### PR TITLE
docs: wrap markdown lines for lint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,8 @@ Details: siehe docs/architekturstruktur.md.
 2) Routing-Matrix „Wohin gehört was?“
 
 Beitragstyp	Zielordner/Datei	Typisches Pattern	Grund (warum dort)
-Neue Seite/Route im UI	apps/web/src/routes/...	+page.svelte, +page.ts, +server.ts	SvelteKit-Routing, SSR/Islands, nahe an UI
+Neue Seite/Route im UI	apps/web/src/routes/...	+page.svelte, +page.ts, +server.ts	SvelteKit-Routing, SSR/Islands,
+			nahe an UI
 UI-Komponente/Store/Util	apps/web/src/lib/...	*.svelte, stores.ts, utils.ts	Wiederverwendung, klare Trennung vom Routing
 Statische Assets	apps/web/static/	manifest.webmanifest, Icons, Fonts	Build-unabhängige Auslieferung
 Neuer API-Endpoint	apps/api/src/routes/...	mod.rs, Handler, Router	HTTP/SSE-Schnittstelle gehört in routes

--- a/README.md
+++ b/README.md
@@ -7,14 +7,16 @@ Struktur und Beiträge: siehe `architekturstruktur.md` und `CONTRIBUTING.md`.
 
 ## Quickstart
 
-> ⚙️ **Preview:** Die folgenden Schritte werden mit Gate C (Infra-light) aktiviert. Solange das Repo Docs-only ist, dienen sie lediglich als Ausblick.
+> ⚙️ **Preview:** Die folgenden Schritte werden mit Gate C (Infra-light) aktiviert.
+> Solange das Repo Docs-only ist, dienen sie lediglich als Ausblick.
 ```bash
 cp .env.example .env
 # docker compose -f infra/compose/compose.core.yml up -d
 # API migrieren (siehe apps/api/README.md), Web starten (apps/web/README.md)
 ```
 
-> **Hinweis:** Aktuell **Docs-only/Clean-Slate** gemäß ADR-0001. Code-Re-Entry erfolgt über die Gates A–D (siehe `docs/process/fahrplan.md`).
+> **Hinweis:** Aktuell **Docs-only/Clean-Slate** gemäß ADR-0001. Code-Re-Entry erfolgt über die Gates A–D (siehe
+> `docs/process/fahrplan.md`).
 
 ## Continuous Integration
 


### PR DESCRIPTION
## Summary
- wrap the routing-matrix table row in `CONTRIBUTING.md` so the "Neue Seite/Route" entry stays within the 120 character markdownlint limit
- break the long preview and Hinweis blockquotes in `README.md` into two lines to satisfy the markdown line-length rule

## Testing
- npx markdownlint-cli2 CONTRIBUTING.md README.md --config .markdownlint.jsonc *(fails because existing tab-indented sections still trigger repository-wide MD010/MD029 violations)*

------
https://chatgpt.com/codex/tasks/task_e_68d8c145f600832ca84f03e8563a72c1