### PR TITLE
Add cargo-deny policy configuration

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,27 @@
+[advisories]
+vulnerability = "deny"
+unmaintained = "deny"
+yanked = "deny"
+notice = "warn"
+ignore = []
+
+[licenses]
+unlicensed = "deny"
+allow = [
+  "MIT", "Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "ISC", "Zlib"
+]
+copyleft = "warn"
+default = "deny"
+confidence-threshold = 0.8
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+deny = []
+skip = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
## Summary
- add a deny.toml configuration file defining advisory, license, ban, and source policies for cargo-deny

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d90a03c150832c99e299a7744e08d5