### PR TITLE
Skip Rust CI job when repo has no Cargo manifests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ jobs:
   rust:
     name: Rust – fmt, clippy, tests, deny
     runs-on: ubuntu-latest
+    # Skip the Rust toolchain job while the repository is docs-only and has no Cargo manifests.
+    if: ${{ hashFiles('**/Cargo.toml') != '' }}
     defaults: { run: { shell: bash } }
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- skip the Rust GitHub Actions job when no Cargo manifests exist so docs-only branches pass CI

## Testing
- not run (CI configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68d9fdeaee5c832cb16343f0c3540382