### PR TITLE
Fix README line lengths

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,6 +1,7 @@
 # Weltgewebe API
 
-The Weltgewebe API is a Rust-based Axum service that powers the platform's backend capabilities. This README provides a quick orientation for running and developing the service locally.
+The Weltgewebe API is a Rust-based Axum service that powers the platform's backend capabilities.
+This README provides a quick orientation for running and developing the service locally.
 
 ## Quickstart
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -16,7 +16,8 @@ npx sv create my-app
 
 ## Developing
 
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
+Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`),
+start a development server:
 
 ```sh
 npm run dev


### PR DESCRIPTION
## Summary
- wrap the long introduction paragraph in the API README to satisfy the MD013 rule
- break the long setup sentence in the web README to conform to the Markdown linter

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da2fedb2a8832c8080b234bb1c1acc