### PR TITLE
Fix markdown lint issues in API README and bash guidelines

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -19,7 +19,6 @@ This README provides a quick orientation for running and developing the service 
 3. **Adjust the required environment variables** (either in `.env` or the shell).
    Values defined in `.env` take precedence over the defaults from Docker Compose when you use the
    local development stack.
-   
    Recommended settings:
    - `API_BIND` &mdash; socket address to bind the API (default `0.0.0.0:8787`)
    - `DATABASE_URL` &mdash; PostgreSQL connection string (e.g. `postgres://user:password@localhost:5432/weltgewebe`)

--- a/docs/process/bash-tooling-guidelines.md
+++ b/docs/process/bash-tooling-guidelines.md
@@ -1,7 +1,8 @@
 # Bash-Tooling-Richtlinien
 
 Diese Richtlinien beschreiben, wie wir Shell-Skripte im Weltgewebe-Projekt entwickeln, prüfen und ausführen.  
-Sie kombinieren generelle Best Practices (Formatierung, Checks) mit projektspezifischen Vorgaben (Devcontainer, CLI-Bootstrap, SemVer).
+Sie kombinieren generelle Best Practices (Formatierung, Checks) mit projektspezifischen Vorgaben
+wie Devcontainer-Setup, CLI-Bootstrap und SemVer.
 
 ## Ziele
 


### PR DESCRIPTION
## Summary
- remove trailing whitespace from the API README to satisfy markdownlint
- wrap the long introductory sentence in the bash tooling guidelines to stay within the line-length limit

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dad176e83c832ca9c57759c29e9b20