### PR TITLE
Add manual triggers and guardrails to CI workflows

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -1,0 +1,26 @@
+name: api
+on:
+  pull_request:
+  push: { branches: [main] }
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: api-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  test-and-lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # - name: cargo-deny (Dependency audit)   # TODO: enable when deny.toml is ready
+      #   run: cargo deny check
+      - run: cargo fmt --all -- --check
+        working-directory: apps/api
+      - run: cargo clippy --all-targets -- -D warnings
+        working-directory: apps/api
+      - run: cargo test --all-features --verbose
+        working-directory: apps/api

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -1,0 +1,19 @@
+name: infra
+on:
+  pull_request:
+  push: { branches: [main] }
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: infra-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  compose-core-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: Core profile is present
+        run: test -f infra/compose/compose.core.yml
+      # - run: test -f infra/compose/compose.observ.yml

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,19 @@
+name: links
+on:
+  pull_request:
+  schedule: [{ cron: "0 4 * * *" }]
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: links-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  lychee:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: lycheeverse/lychee-action@v2
+        with:
+          args: --accept 200,429 --max-redirects 5 --exclude-mail --no-progress "docs/**/*.md"

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1,0 +1,30 @@
+name: web
+on:
+  pull_request:
+  push: { branches: [main] }
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: web-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  budget-and-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: apps/web/package-lock.json
+      - run: |
+          if [ -f package-lock.json ]; then npm ci; else npm install; fi
+        working-directory: apps/web
+      - run: npm run build
+        working-directory: apps/web
+      - name: Check performance budgets
+        run: |
+          test -f ci/budget.json
+          echo "Budget file present (manual enforcement later)."

--- a/.github/workflows/wgx-smoke.yml
+++ b/.github/workflows/wgx-smoke.yml
@@ -1,0 +1,24 @@
+name: wgx-smoke
+on:
+  pull_request:
+  push: { branches: [main] }
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: wgx-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  manifest-doctor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: Ensure manifest exists
+        run: test -f .wgx/profile.yml
+      - name: Dry-run doctor task
+        run: |
+          echo "Simulate 'wgx doctor' until the CLI is vendor-locked."
+          echo "== profile.yml =="
+          sed -n '1,40p' .wgx/profile.yml
+          grep -E "apiVersion:|tasks:" .wgx/profile.yml


### PR DESCRIPTION
## Summary
- add workflow_dispatch triggers and 20-minute timeouts to the API, web, infra, links, and WGX workflows
- reuse setup-node's built-in npm cache for the web workflow
- document a future cargo-deny step in the API workflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daef7b9fd4832c9b824e942117fa52