### PR TITLE
Fix CI tooling configuration issues

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Install rustfmt
+        run: rustup component add rustfmt
       - uses: Swatinem/rust-cache@v2
       # - name: cargo-deny (Dependency audit)   # TODO: enable when deny.toml is ready
       #   run: cargo deny check

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: lycheeverse/lychee-action@v2
         with:
-          args: --accept 200,429 --max-redirects 5 --exclude-mail --no-progress "docs/**/*.md"
+          args: --accept 200,429 --max-redirects 5 --no-progress "docs/**/*.md"

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: apps/web/package-lock.json
       - run: |


### PR DESCRIPTION
## Summary
- install the rustfmt component in the API workflow before running formatting
- drop the unsupported `--exclude-mail` flag from the lychee link check
- upgrade the web workflow to use Node.js 22 as required by the project engines

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db50c86318832cab96454181deef18