### PR TITLE
Handle yamllint config absence

### DIFF
--- a/.github/workflows/policies.yml
+++ b/.github/workflows/policies.yml
@@ -1,0 +1,29 @@
+name: policies
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: policies-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  limits-file-and-yaml:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Ensure limits policy exists
+        run: test -f policies/limits.yaml
+      - name: Lint policies directory with yamllint
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install yamllint
+          if [ -f .yamllint.yml ]; then
+            yamllint -c .yamllint.yml policies
+          else
+            yamllint policies
+          fi

--- a/policies/limits.yaml
+++ b/policies/limits.yaml
@@ -1,0 +1,42 @@
+---
+# Weltgewebe – Soft Limits (v1)
+# Zweck: Leitplanken sichtbar machen. Zunächst nur dokumentarisch; keine harten Gates.
+version: v1
+updated: 2025-09-30
+owner: platform
+
+web:
+  bundle:
+    # Gesamtbudget für alle produktiven JS/CSS-Assets (komprimiert)
+    total_kb: 350
+    note: "Muss zum 'ci/budget.json' passen; später automatische Prüfung."
+  build:
+    max_minutes: 10
+    note: "CI-Build der Web-App soll schnell bleiben; Ziel für Developer-Feedback."
+
+api:
+  latency:
+    p95_ms: 300
+    note: "Lokales/dev-nahes Ziel; Produktions-SLOs stehen in policies/slo.yaml."
+  test:
+    max_minutes: 10
+    note: "Schnelle Rust-Tests, damit PR-Feedback nicht stockt."
+
+ci:
+  max_runtime_minutes:
+    default: 20
+    heavy: 45
+    note: "Deckel pro Job; deckt sich mit aktuellen Timeouts in Workflows."
+
+observability:
+  required:
+    - "compose.core.yml"
+    - "compose.observ.yml"
+  note: "Sobald Observability-Compose landet, wird hier 'compose.observ.yml' Pflicht."
+
+docs:
+  runbooks_required:
+    - "docs/runbooks/README.md"
+    - "docs/runbooks/codespaces-recovery.md"
+    - "docs/runbooks/observability.md"
+  note: "observability.md folgt; zunächst nur als Reminder gelistet."


### PR DESCRIPTION
## Summary
- update the policies workflow to fall back to yamllint defaults when no local configuration file is present

## Testing
- python -m yamllint -c .yamllint.yml policies

------
https://chatgpt.com/codex/tasks/task_e_68db54ca5554832c905bf330523a0d59