### PR TITLE
Ensure clippy component is installed in CI

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install rustfmt
         run: rustup component add rustfmt
+      - name: Ensure clippy is available
+        run: rustup component add clippy
       - uses: Swatinem/rust-cache@v2
       # - name: cargo-deny (Dependency audit)   # TODO: enable when deny.toml is ready
       #   run: cargo deny check


### PR DESCRIPTION
## Summary
- add an explicit step to install the clippy component in the API workflow so clippy runs reliably on clean runners

## Testing
- no tests were run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68db5fe8a764832c882fc473cccd88e7