### PR TITLE
Ensure clippy component installed in CI

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install rustfmt
         run: rustup component add rustfmt
+      - name: Install clippy
+        run: rustup component add clippy
       - uses: Swatinem/rust-cache@v2
       # - name: cargo-deny (Dependency audit)   # TODO: enable when deny.toml is ready
       #   run: cargo deny check


### PR DESCRIPTION
## Summary
- ensure the API workflow installs the clippy component before running linting commands

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db55d83174832cad72a410147aed24