### PR TITLE
Add top-level Cargo workspace manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2467,9 +2467,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,5 @@
+[workspace]
+members = [
+    "apps/api",
+]
+resolver = "2"


### PR DESCRIPTION
## Summary
- add a workspace Cargo.toml at the repository root so cargo commands can run from there
- move the lockfile to the workspace root and refresh dependencies, updating zeroize to 1.8.2

## Testing
- cargo fmt --all
- cargo clippy --all-targets --all-features -q
- cargo test --all --quiet

------
https://chatgpt.com/codex/tasks/task_e_68db9d000ae8832c84081f2dcd14a46b