### PR TITLE
Fix lychee action args

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -20,4 +20,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: lycheeverse/lychee-action@v2
         with:
-          args: --accept 200,429 --max-redirects 5 --exclude-mail --no-progress "docs/**/*.md"
+          args: --accept 200,429 --max-redirects 5 --no-progress "docs/**/*.md"


### PR DESCRIPTION
## Summary
- remove the unsupported `--exclude-mail` flag from the lychee workflow so the action runs successfully

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68dbf085ab94832c839b9b457626f040