### PR TITLE
Limit links workflow to scheduled runs

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,10 +1,5 @@
 name: links
 on:
-  pull_request:
-    branches: [ main ]
-    paths:
-      - "docs/**"
-      - ".github/workflows/links.yml"
   schedule: [{ cron: "0 4 * * *" }]
   workflow_dispatch:
 permissions:


### PR DESCRIPTION
## Summary
- remove the pull request trigger from the link-check workflow since CI already covers it
- keep the workflow available for scheduled and manual runs only

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc074a0ce4832cbdd14dc16ab5c56c