### PR TITLE
Add version endpoint and update smoke probe

### DIFF
--- a/.github/workflows/api-smoke.yml
+++ b/.github/workflows/api-smoke.yml
@@ -55,6 +55,11 @@ jobs:
           curl -fsS -o /dev/null -w "%{http_code}\n" http://127.0.0.1:8787/health/ready | grep -E '^(200|503)$'
           # /metrics darf 200 liefern, Inhalt ist optional; zeigen die ersten Zeilen, falls vorhanden:
           curl -fsS http://127.0.0.1:8787/metrics | head -n 5 || echo "no /metrics yet (ok)"
+      - name: Probe /version (JSON shape)
+        run: |
+          set -euxo pipefail
+          body="$(curl -fsS http://127.0.0.1:8787/version)"
+          echo "$body" | grep -q '"version"' && echo "$body" | grep -q '"commit"' && echo "$body" | grep -q '"build_timestamp"'
       - name: Stop API
         if: always()
         run: |

--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -8,6 +8,7 @@ use anyhow::{anyhow, Context};
 use async_nats::Client as NatsClient;
 use axum::{routing::get, Router};
 use routes::health::health_routes;
+use routes::meta::meta_routes;
 use sqlx::postgres::PgPoolOptions;
 use state::ApiState;
 use telemetry::{metrics_handler, BuildInfo, Metrics, MetricsLayer};
@@ -33,6 +34,7 @@ async fn main() -> anyhow::Result<()> {
 
     let app = Router::new()
         .merge(health_routes())
+        .merge(meta_routes())
         .route("/metrics", get(metrics_handler))
         .layer(MetricsLayer::new(metrics))
         .with_state(state);

--- a/apps/api/src/routes/meta.rs
+++ b/apps/api/src/routes/meta.rs
@@ -1,0 +1,18 @@
+use axum::{routing::get, Json, Router};
+use serde_json::{json, Value};
+
+use crate::state::ApiState;
+use crate::telemetry::BuildInfo;
+
+pub fn meta_routes() -> Router<ApiState> {
+    Router::new().route("/version", get(version))
+}
+
+async fn version() -> Json<Value> {
+    let info = BuildInfo::collect();
+    Json(json!({
+        "version": info.version,
+        "commit": info.commit,
+        "build_timestamp": info.build_timestamp,
+    }))
+}

--- a/apps/api/src/routes/mod.rs
+++ b/apps/api/src/routes/mod.rs
@@ -1,1 +1,2 @@
 pub mod health;
+pub mod meta;


### PR DESCRIPTION
## Summary
- add a `/version` route that exposes the existing build information
- wire the new route into the API router
- extend the smoke workflow to verify the `/version` endpoint returns the expected shape

## Testing
- cargo test -p weltgewebe-api

------
https://chatgpt.com/codex/tasks/task_e_68dc07b2beac832c82c3a37c051d9cbc