### PR TITLE
Document centralized PR link checks

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -2,6 +2,7 @@ name: links
 on:
   schedule: [{ cron: "0 4 * * *" }]
   workflow_dispatch:
+    # Link checks on pull requests are handled in the central CI.
 permissions:
   contents: read
 concurrency:


### PR DESCRIPTION
## Summary
- clarify in the links workflow that PR link checks are handled centrally

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68dc19563218832cafd92970323ac210