### PR TITLE
Ensure database pool survives initial outages

### DIFF
--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -72,17 +72,28 @@ async fn initialise_database_pool() -> (Option<sqlx::PgPool>, bool) {
         Err(_) => return (None, false),
     };
 
-    match PgPoolOptions::new()
+    let pool = match PgPoolOptions::new()
         .max_connections(5)
-        .connect(&database_url)
-        .await
+        .connect_lazy(&database_url)
     {
-        Ok(pool) => (Some(pool), true),
+        Ok(pool) => pool,
         Err(error) => {
-            tracing::warn!(error = %error, "failed to connect to database");
-            (None, true)
+            tracing::warn!(error = %error, "failed to configure database pool");
+            return (None, true);
+        }
+    };
+
+    match pool.acquire().await {
+        Ok(connection) => drop(connection),
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                "database connection unavailable at startup; readiness will keep retrying",
+            );
         }
     }
+
+    (Some(pool), true)
 }
 
 async fn initialise_nats_client() -> (Option<NatsClient>, bool) {


### PR DESCRIPTION
## Summary
- initialise the Postgres pool lazily so it remains available even if the first connection attempt fails
- log the initial acquire failure but keep the pool so readiness checks can recover once the database is up

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68dc2774f160832c8a4043c046572cfb