### PR TITLE
Fix CI workflow permissions for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary
- grant the CI workflow read access to pull requests so it can inspect changed files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcc5cd80f4832c8ca2ef9fda70f90b