### PR TITLE
Document build-time variables in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ Diese Werte werden **zur Compile-Zeit** gesetzt. In CI exportieren die Workflows
 `GIT_COMMIT_SHA` und `BUILD_TIMESTAMP` als Umgebungsvariablen. Lokal sind sie optional
 und fallen auf `"unknown"` zurück. Es ist **nicht nötig**, diese Variablen in `.env` zu pflegen.
 
+### Build-Zeit-Variablen
+
+`GIT_COMMIT_SHA`, `CARGO_PKG_VERSION` und `BUILD_TIMESTAMP` stammen direkt aus dem
+CI bzw. Compiler. Sie werden **nicht** in `.env` oder `.env.example` gepflegt.
+Beim lokalen Build ohne CI-Kontext setzen wir sie automatisch auf `"unknown"`,
+während die Pipelines im CI die echten Werte einspeisen. Es besteht daher kein
+Bedarf, `.env.example` um diese Variablen zu erweitern.
+
 ### Soft-Limits & Policies
 
 Unter `policies/limits.yaml` dokumentieren wir Leitplanken (z. B. Web-Bundle-Budget,


### PR DESCRIPTION
## Summary
- add a README section clarifying how build-time variables are sourced
- note that local builds default to "unknown" while CI injects real values
- explain that .env files do not need the build-time variable entries

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dcd2ceb2f8832c8350f35d9cc566a6