### PR TITLE
Add startup version probe to API smoke test

### DIFF
--- a/.github/workflows/api-smoke.yml
+++ b/.github/workflows/api-smoke.yml
@@ -60,6 +60,13 @@ jobs:
             echo "API process failed to start"
             exit 1
           fi
+      - name: Probe /version (startup)
+        run: |
+          set -euo pipefail
+          body="$(curl --fail-with-body http://127.0.0.1:8787/version)"
+          echo "$body" | grep -q '"version"'
+          echo "$body" | grep -q '"commit"'
+          echo "$body" | grep -q '"build_timestamp"'
       - name: Wait for API health endpoint
         run: |
           ok=0


### PR DESCRIPTION
## Summary
- add a startup probe that curls the /version endpoint with fail-with-body
- verify the payload includes version, commit, and build timestamp to catch regressions early

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dcd34658b0832c92be3d1c7c0281a5