### PR TITLE
Fix metrics layer response type

### DIFF
--- a/apps/api/src/telemetry/mod.rs
+++ b/apps/api/src/telemetry/mod.rs
@@ -152,7 +152,7 @@ where
         Box::pin(async move {
             match future.await {
                 Ok(response) => {
-                    let response = response.into_response();
+                    let response: Response = response.into_response();
                     let status = response.status().as_u16().to_string();
                     metrics
                         .http_requests_total()


### PR DESCRIPTION
## Summary
- ensure the telemetry metrics layer converts service responses into `axum::response::Response` before inspecting their status codes

## Testing
- cargo check -p weltgewebe-api

------
https://chatgpt.com/codex/tasks/task_e_68dcd45efd7c832cb695506f68d7ceb7