### PR TITLE
Run compiled API binary in smoke test

### DIFF
--- a/.github/workflows/api-smoke.yml
+++ b/.github/workflows/api-smoke.yml
@@ -45,7 +45,12 @@ jobs:
           RUST_LOG: info
           RUST_BACKTRACE: 1
         run: |
-          nohup cargo run --locked --release >/tmp/api.log 2>&1 &
+          if [ ! -x ./target/release/weltgewebe-api ]; then
+            echo "compiled API binary missing"
+            ls -al ./target/release || true
+            exit 1
+          fi
+          nohup ./target/release/weltgewebe-api >/tmp/api.log 2>&1 &
           echo $! > /tmp/api.pid
           # Wait up to 5 seconds for the PID file to exist
           for i in {1..10}; do


### PR DESCRIPTION
## Summary
- run the prebuilt `weltgewebe-api` binary in the API smoke workflow instead of spawning `cargo run`
- add a guard that surfaces the release directory when the compiled binary is missing

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dcda57c2c4832c841e2e2307d3b8c1