### PR TITLE
Fix API workflow build and jq parsing

### DIFF
--- a/.github/workflows/api-smoke.yml
+++ b/.github/workflows/api-smoke.yml
@@ -43,7 +43,7 @@ jobs:
           workspaces: |
             apps/api -> target
       - name: Build release (fast start)
-        run: cargo build --locked --release
+        run: cargo build --locked --release --bin weltgewebe-api
       - name: Run API in background
         env:
           API_BIND: 127.0.0.1:8787
@@ -74,6 +74,10 @@ jobs:
         run: |
           set -euo pipefail
           body="$(curl --max-time 10 --fail-with-body http://127.0.0.1:8787/version)"
+          if ! echo "$body" | jq empty >/dev/null 2>&1; then
+            echo "API did not return valid JSON: $body"
+            exit 1
+          fi
           echo "::group::/version body"
           echo "$body"
           echo "::endgroup::"


### PR DESCRIPTION
## Summary
- build the API workflow using the weltgewebe-api binary explicitly
- harden the /version probe against non-JSON responses before invoking jq

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcea5ff284832c875aa8d4d89f8216