### PR TITLE
Adjust links workflow triggers

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,6 +1,7 @@
 name: links
 on:
-  schedule: [{ cron: "0 4 * * *" }]
+  schedule:
+    - cron: "0 4 * * *"
   workflow_dispatch:
     # Link checks on pull requests are handled in the central CI.
 permissions:


### PR DESCRIPTION
## Summary
- ensure the links workflow only runs on the scheduled cron and manual dispatch events
- expand the schedule trigger configuration for clarity

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd47489154832c89843ebcbb2b2fa3