### PR TITLE
Install additional devcontainer tools

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,6 +16,15 @@
     }
   },
   "remoteUser": "vscode",
-  "postCreateCommand": "bash -lc 'set -euxo pipefail; sudo apt-get update; sudo apt-get install -y jq ripgrep vale shfmt hadolint just httpie; npm i -g markdownlint-cli@0.41.0; cargo --version || true; npm -v || true; echo devcontainer ready'",
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
   "postStartCommand": "bash -lc 'set -euxo pipefail; echo Using compose as the single source of truth; just check || true'"
 }
+#!/usr/bin/env bash
+set -euxo pipefail
+
+sudo apt-get update
+sudo apt-get install -y jq ripgrep vale shfmt hadolint just httpie
+npm i -g markdownlint-cli@0.41.0
+cargo --version || true
+npm -v || true
+echo devcontainer ready


### PR DESCRIPTION
## Summary
- install CLI tooling packages during devcontainer creation
- install markdownlint-cli globally via npm for consistent linting

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dd76761448832ca9a59426a95ffd98