### PR TITLE
Add soft Vale documentation style workflow

### DIFF
--- a/.github/workflows/docs-style.yml
+++ b/.github/workflows/docs-style.yml
@@ -50,7 +50,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
       - name: Run Vale (soft; no fail)
         run: |
-          set -euxo pipefail
+          set -uxo pipefail
           if [ -n "${{ steps.changed.outputs.files }}" ]; then
             ./bin/vale --minAlertLevel=suggestion ${{ steps.changed.outputs.files }} || true
           else


### PR DESCRIPTION
## Summary
- add a dedicated docs-style workflow that only runs when documentation or Vale configs change
- ensure the Vale check operates in non-blocking mode and supports manual full sweeps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd81595048832cbc4126524f4c4aef