### PR TITLE
Fix build info metric labels for metrics endpoint

### DIFF
--- a/apps/api/src/telemetry/mod.rs
+++ b/apps/api/src/telemetry/mod.rs
@@ -50,7 +50,8 @@ impl Metrics {
         let http_requests_total = IntCounterVec::new(http_opts, &["method", "path", "status"])?;
 
         let build_opts = Opts::new("build_info", "Build information for the API");
-        let build_info_metric = IntGaugeVec::new(build_opts, &["version", "commit", "built_at"])?;
+        let build_info_metric =
+            IntGaugeVec::new(build_opts, &["version", "commit", "build_timestamp"])?;
 
         let registry = Registry::new();
         registry.register(Box::new(http_requests_total.clone()))?;


### PR DESCRIPTION
## Summary
- rename the build info Prometheus metric label to `build_timestamp`
- keep labels aligned with the `/version` payload and documentation

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68de054617bc832cb4a98e8a54ff8d20