### PR TITLE
Fix jq validation in API smoke test

### DIFF
--- a/.github/workflows/api-smoke.yml
+++ b/.github/workflows/api-smoke.yml
@@ -82,7 +82,7 @@ jobs:
           echo "$body"
           echo "::endgroup::"
           # Validate fields using jq (more robust than grep on strings)
-          echo "$body" | jq -e '.version // empty | .commit // empty | .build_timestamp // empty' >/dev/null
+          echo "$body" | jq -e 'type == "object" and has("version") and has("commit") and has("build_timestamp")' >/dev/null
 
           # Optional: also assert types (string/string/number) – harmless if types differ:
           # echo "$body" | jq -e '(.version|type=="string") and (.commit|type=="string") and (.build_timestamp|type=="number")' >/dev/null


### PR DESCRIPTION
## Summary
- ensure the API smoke workflow verifies the /version payload as an object before checking required fields

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de60158670832cb38dbec194ab23d8