### PR TITLE
Fix missing type for DEFAULT_PATH constant

### DIFF
--- a/apps/api/src/config.rs
+++ b/apps/api/src/config.rs
@@ -12,7 +12,7 @@ pub struct AppConfig {
 }
 
 impl AppConfig {
-    pub const DEFAULT_PATH = "configs/app.defaults.yml";
+    pub const DEFAULT_PATH: &'static str = "configs/app.defaults.yml";
 
     pub fn load() -> Result<Self> {
         let path = env::var("APP_CONFIG_PATH").unwrap_or_else(|_| Self::DEFAULT_PATH.to_string());


### PR DESCRIPTION
## Summary
- add the explicit `&'static str` type annotation to `AppConfig::DEFAULT_PATH`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de9d6d205c832c8dc2898f400d6f1d