### PR TITLE
Fix bare URLs in observability runbook

### DIFF
--- a/docs/runbook.observability.md
+++ b/docs/runbook.observability.md
@@ -5,9 +5,9 @@
 docker compose -f infra/compose/compose.observ.yml up -d
 ```
 
-- Prometheus: http://localhost:9090
-- Grafana:    http://localhost:3001 (anon Viewer)
-- Loki:       http://localhost:3100
-- Tempo:      http://localhost:3200
+- Prometheus: [http://localhost:9090](http://localhost:9090)
+- Grafana:    [http://localhost:3001](http://localhost:3001) (anon Viewer)
+- Loki:       [http://localhost:3100](http://localhost:3100)
+- Tempo:      [http://localhost:3200](http://localhost:3200)
 
 This is purely optional and local, does not block anything – but gives you immediate graphics.


### PR DESCRIPTION
## Summary
- replace bare URLs in the observability runbook with Markdown links to satisfy MD034

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de9d779530832c8302c824f11be547