### PR TITLE
Specify type for AppConfig default path

### DIFF
--- a/apps/api/src/config.rs
+++ b/apps/api/src/config.rs
@@ -12,7 +12,7 @@ pub struct AppConfig {
 }
 
 impl AppConfig {
-    pub const DEFAULT_PATH = "configs/app.defaults.yml";
+    pub const DEFAULT_PATH: &'static str = "configs/app.defaults.yml";
 
     pub fn load() -> Result<Self> {
         let path = env::var("APP_CONFIG_PATH").unwrap_or_else(|_| Self::DEFAULT_PATH.to_string());


### PR DESCRIPTION
## Summary
- specify the type of `AppConfig::DEFAULT_PATH` so the constant satisfies linting requirements

## Testing
- cargo check -p weltgewebe-api *(fails: unable to download crates index due to 403 CONNECT tunnel response)*

------
https://chatgpt.com/codex/tasks/task_e_68dea1624d70832caeef6850b7a1a633