### PR TITLE
Fix markdown spacing for runbook linting

### DIFF
--- a/docs/runbook.observability.md
+++ b/docs/runbook.observability.md
@@ -1,6 +1,7 @@
 # Observability – Local Profile
 
 ## Start
+
 ```bash
 docker compose -f infra/compose/compose.observ.yml up -d
 ```

--- a/docs/runbooks/semantics-intake.md
+++ b/docs/runbooks/semantics-intake.md
@@ -1,4 +1,6 @@
+
 # Semantics Intake (manuell)
+
 1) Von semantAH: `.gewebe/out/nodes.jsonl` und `edges.jsonl` ziehen.
 2) In Weltgewebe ablegen unter `.gewebe/in/*.{nodes,edges}.jsonl`.
 3) PR eröffnen → Workflow `semantics-intake` validiert Format.


### PR DESCRIPTION
## Summary
- add required blank lines around headings and code block in the observability runbook
- ensure the semantics intake runbook headings and list are separated by blank lines

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df573c305c832c8cd434f186e95c91