### PR TITLE
Allow unused ApiState during CI

### DIFF
--- a/apps/api/src/state.rs
+++ b/apps/api/src/state.rs
@@ -2,6 +2,11 @@ use crate::{config::AppConfig, telemetry::Metrics};
 use async_nats::Client as NatsClient;
 use sqlx::PgPool;
 
+// ApiState is constructed for future expansion of the API server state. It is
+// currently unused by the binary, so we explicitly allow dead code here to keep
+// the CI pipeline green while maintaining the transparent intent of the state
+// container.
+#[allow(dead_code)]
 #[derive(Clone)]
 pub struct ApiState {
     pub db_pool: Option<PgPool>,


### PR DESCRIPTION
## Summary
- allow the ApiState struct to compile even though it is currently unused and document the intent

## Testing
- cargo check -p weltgewebe-api

------
https://chatgpt.com/codex/tasks/task_e_68df57fa6a24832cbf76b18fa546832f