### PR TITLE
Fix markdownlint spacing issues

### DIFF
--- a/contracts/semantics/README.md
+++ b/contracts/semantics/README.md
@@ -1,2 +1,3 @@
 # Semantik-Verträge (Upstream: semantAH)
+
 Quelle: externer Ableger `semantAH`. Nicht editieren, nur spiegeln.

--- a/docs/adr/0042-consume-semantah-contracts.md
+++ b/docs/adr/0042-consume-semantah-contracts.md
@@ -1,9 +1,12 @@
 # ADR-0042: semantAH-Contracts konsumieren
+
 Status: accepted
 
 Beschluss:
+
 - Weltgewebe liest JSONL-Dumps (Nodes/Edges) als Infoquelle (read-only).
 - Kein Schreibpfad zurück. Eventuelle Events: getrennte Domain.
 
 Konsequenzen:
+
 - CI validiert nur Formate; Import-Job später.


### PR DESCRIPTION
## Summary
- ensure the semantAH contracts README includes a blank line after the title for markdownlint compliance
- add the missing blank lines around the heading and lists in ADR-0042

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df58b73478832c8f0cd499e6884d59