### PR TITLE
Remove unsupported date-time format from edge schema

### DIFF
--- a/contracts/semantics/edge.schema.json
+++ b/contracts/semantics/edge.schema.json
@@ -1,5 +1,5 @@
 { "$schema":"http://json-schema.org/draft-07/schema#", "title":"SemEdge","type":"object",
   "required":["src","dst","rel"],
   "properties":{"src":{"type":"string"},"dst":{"type":"string"},"rel":{"type":"string"},
-    "weight":{"type":"number"},"why":{"type":"string"},"updated_at":{"type":"string","format":"date-time"}}
+    "weight":{"type":"number"},"why":{"type":"string"},"updated_at":{"type":"string"}}
 }


### PR DESCRIPTION
## Summary
- remove the unsupported `date-time` format from the `updated_at` property in the edge schema to avoid ajv errors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df59e90ec0832c99507308070d4916