### PR TITLE
Fix ajv CLI stdin parameter in semantics intake workflow

### DIFF
--- a/.github/workflows/semantics-intake.yml
+++ b/.github/workflows/semantics-intake.yml
@@ -28,7 +28,7 @@ jobs:
             [ -n "$schema" ] || continue
             found=1
             while IFS= read -r line; do
-              echo "$line" | ajv validate -s "$schema" -d "-" || exit 1
+              echo "$line" | ajv validate -s "$schema" -d - || exit 1
             done < "$f"
           done
           if [ "$found" -eq 0 ]; then


### PR DESCRIPTION
## Summary
- update the semantics intake workflow to pass `-d "-"` so ajv-cli reads from stdin with v5

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df604f26b8832c93e1e03546f5b7e5