### PR TITLE
Replace serde_yaml with manual AppConfig parser

### DIFF
--- a/apps/api/Cargo.toml
+++ b/apps/api/Cargo.toml
@@ -13,7 +13,6 @@ dotenvy = "0.15"
 prometheus = "0.13"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_yaml = "0.9"
 sqlx = { version = "0.7", default-features = false, features = ["runtime-tokio", "postgres"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tower = "0.5"


### PR DESCRIPTION
## Summary
- replace the YAML dependency in the API config loader with a small handwritten parser
- add explicit parsing helpers and restore the environment override tests

## Testing
- cargo fmt --all -- --check
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings *(fails: unable to reach crates.io from the environment)*
- cargo test -p weltgewebe-api --all-features --verbose *(fails: unable to reach crates.io from the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df5ffaca18832cac70c7331c4d8341