### PR TITLE
Fix markdown spacing in Python tools README

### DIFF
--- a/tools/py/README.md
+++ b/tools/py/README.md
@@ -1,6 +1,7 @@
 # Weltgewebe – Python Tools
 
 ## Schnellstart
+
 ```bash
 cd tools/py
 uv sync        # erstellt venv, installiert deps (aktuell leer)


### PR DESCRIPTION
## Summary
- add required blank lines around the "Schnellstart" heading and code block in `tools/py/README.md`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfa2ccc9b0832c9dd62a80c79815a4