### PR TITLE
fix(api): replace bool equality asserts in config tests

### DIFF
--- a/apps/api/src/config.rs
+++ b/apps/api/src/config.rs
@@ -168,7 +168,7 @@ delegation_expire_days: 28
         let cfg = AppConfig::load_from_path(file.path())?;
         assert_eq!(cfg.fade_days, 7);
         assert_eq!(cfg.ron_days, 84);
-        assert_eq!(cfg.anonymize_opt_in, true);
+        assert!(cfg.anonymize_opt_in);
         assert_eq!(cfg.delegation_expire_days, 28);
 
         Ok(())
@@ -188,7 +188,7 @@ delegation_expire_days: 28
         let cfg = AppConfig::load_from_path(file.path())?;
         assert_eq!(cfg.fade_days, 10);
         assert_eq!(cfg.ron_days, 90);
-        assert_eq!(cfg.anonymize_opt_in, false);
+        assert!(!cfg.anonymize_opt_in);
         assert_eq!(cfg.delegation_expire_days, 14);
 
         Ok(())


### PR DESCRIPTION
## Summary
- replace bool equality assertions in the config tests with `assert!` to satisfy clippy's `bool_assert_comparison` lint

## Testing
- cargo test
- cargo clippy --all-targets -- -D warnings

------
https://chatgpt.com/codex/tasks/task_e_68dfa6f35748832c91488903db6885c6