### PR TITLE
Regenerate Cargo.lock for CI compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,19 +1592,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "serial_test"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2200,12 +2187,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2282,7 +2263,6 @@ dependencies = [
  "prometheus",
  "serde",
  "serde_json",
- "serde_yaml",
  "serial_test",
  "sqlx",
  "tempfile",


### PR DESCRIPTION
## Summary
- regenerate the workspace Cargo.lock so it reflects the current dependency graph

## Testing
- cargo check --locked --offline

------
https://chatgpt.com/codex/tasks/task_e_68dfad0da46c832c97338a8f83d42f01