### PR TITLE
Ensure API smoke workflow installs system dependencies

### DIFF
--- a/.github/workflows/api-smoke.yml
+++ b/.github/workflows/api-smoke.yml
@@ -33,6 +33,10 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v4
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libssl-dev libpq-dev
       - name: Inject build metadata (compile-time env)
         run: |
           echo "GIT_COMMIT_SHA=${GITHUB_SHA}" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
- install required system packages before building the API in the smoke workflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfdae915bc832caa185a7699504cfc