### PR TITLE
Fix API smoke test configuration path

### DIFF
--- a/.github/workflows/api-smoke.yml
+++ b/.github/workflows/api-smoke.yml
@@ -53,6 +53,7 @@ jobs:
           API_BIND: 127.0.0.1:8787
           RUST_LOG: info
           RUST_BACKTRACE: 1
+          APP_CONFIG_PATH: ${{ github.workspace }}/configs/app.defaults.yml
         run: |
           if [ ! -x ./target/release/weltgewebe-api ]; then
             echo "compiled API binary missing"


### PR DESCRIPTION
## Summary
- point the API smoke test to the repository config file so the server boots successfully

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dffe097330832ca50e6e582182f6cf