### PR TITLE
Add runbook for uv tooling status and next steps

### DIFF
--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -2,5 +2,6 @@
 
 Anleitungen für wiederkehrende Aufgaben.
 
+- [UV Tooling – Ist-Stand & Ausbauoptionen](uv-tooling.md)
 - [Codespaces Recovery](codespaces-recovery.md)
 - [Zurück zum Doku-Index](../README.md)

--- a/docs/runbooks/uv-tooling.md
+++ b/docs/runbooks/uv-tooling.md
@@ -1,0 +1,40 @@
+# UV Tooling – Ist-Stand & Ausbauoptionen
+
+Dieser Runbook-Eintrag fasst zusammen, wie der Python-Paketmanager
+[uv](https://docs.astral.sh/uv/) heute im Repo eingebunden ist und welche
+Erweiterungen sich anbieten.
+
+## Aktueller Stand
+
+- **Installation im Devcontainer:** `.devcontainer/post-create.sh` installiert `uv`
+  per offizieller Astral-Installroutine und macht das Binary direkt verfügbar.
+- **Dokumentation im Root-README:** Das Getting-Started beschreibt, dass `uv`
+  im Devcontainer bereitgestellt wird und dass Lockfiles (`uv.lock`) eingecheckt
+  werden sollen.
+- **Python-Tooling-Workspace:** Unter `tools/py` liegt ein `pyproject.toml` mit
+  Basiskonfiguration für Python-Helfer; zusätzliche Dependencies würden hier via
+  `uv add` gepflegt.
+
+Damit ist `uv` bereits für Tooling-Aufgaben vorbereitet, benötigt aber aktuell
+noch keine Abhängigkeiten.
+
+## Potenzial für Verbesserungen
+
+1. **Lockfile etablieren:** Sobald der erste Dependency-Eintrag erfolgt, sollte
+   `uv lock` ausgeführt und das entstehende `uv.lock` versioniert werden. Ein
+   leeres Lockfile kann auch jetzt schon erzeugt werden, um den Workflow zu
+   testen und künftige Änderungen leichter reviewen zu können.
+2. **Just-Integration:** Ein `just`-Target (z. B. `just uv-sync`) würde das
+   Synchronisieren des Tooling-Environments standardisieren – sowohl lokal als
+   auch in CI.
+3. **CI-Checks:** Ein optionaler Workflow-Schritt könnte `uv sync --locked`
+   ausführen, um zu prüfen, dass das Lockfile konsistent ist, sobald Python-Tasks
+   relevant werden.
+4. **Fallback für lokale Maschinen:** Außerhalb des Devcontainers sollte das
+   README kurz beschreiben, wie `uv` manuell installiert wird (z. B. per
+   Installscript oder Paketmanager), damit Contributor:innen ohne Devcontainer
+   den gleichen Setup-Pfad nutzen.
+
+Diese Punkte lassen sich unabhängig voneinander umsetzen und sorgen dafür, dass
+`uv` vom vorbereiteten Tooling-Baustein zu einem reproduzierbaren Bestandteil
+von lokalen und CI-Workflows wird.


### PR DESCRIPTION
## Summary
- add a runbook that captures the current uv tooling integration and outlines improvement options
- link the new uv runbook from the runbooks index for discoverability

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e000e49114832c856bbce9be8ea46d