### PR TITLE
Add canonical link handling to web layout

### DIFF
--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -1,11 +1,19 @@
 <script lang="ts">
-	import favicon from '$lib/assets/favicon.svg';
+        import type { Snippet } from 'svelte';
+        import favicon from '$lib/assets/favicon.svg';
 
-	let { children } = $props();
+        type LayoutData = {
+                canonical?: string;
+        };
+
+        let { data, children } = $props<{ data?: LayoutData; children?: Snippet }>();
 </script>
 
 <svelte:head>
-	<link rel="icon" href={favicon} />
+        <link rel="icon" href={favicon} />
+        {#if data?.canonical}
+                <link rel="canonical" href={data.canonical} />
+        {/if}
 </svelte:head>
 
 {@render children?.()}

--- a/apps/web/src/routes/+layout.ts
+++ b/apps/web/src/routes/+layout.ts
@@ -1,0 +1,9 @@
+import type { LayoutLoad } from './$types';
+
+export const load: LayoutLoad = ({ url }) => {
+  const canonical = new URL(url.pathname, url.origin).toString();
+
+  return {
+    canonical
+  };
+};


### PR DESCRIPTION
## Summary
- compute a canonical URL for each request in the web layout load function
- inject the canonical link element into the shared layout head

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68e3bbe66730832c8f1184eee6e8fcc4