### PR TITLE
Add explicit archive link on archive page

### DIFF
--- a/apps/web/src/routes/archive/+page.svelte
+++ b/apps/web/src/routes/archive/+page.svelte
@@ -1,6 +1,4 @@
-<script>
-  // Placeholder content for the archive page
-</script>
-
 <h1>Archiv</h1>
-<p>Hier findest du das Monatsarchiv.</p>
+<p>
+  Hier findest du das Monatsarchiv. Schau dir die <a href="/archive/">Übersicht aller Beiträge</a> an.
+</p>


### PR DESCRIPTION
## Summary
- update the archive page content to include a direct link to `/archive/`
- remove leftover placeholder script from the archive page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3c28783ac832cb8966ac38e378d6b