### PR TITLE
Update wgx metadata for heimgewebe organization

### DIFF
--- a/.wgx/profile.yml
+++ b/.wgx/profile.yml
@@ -1,4 +1,6 @@
 version: 1
+wgx:
+  org: heimgewebe
 repo:
   # Kurzname des Repos (wird automatisch aus git ableitbar sein – hier nur Doku)
   name: auto
@@ -76,7 +78,7 @@ tasks:
         [ -f pyproject.toml ] && grep -q '\[project\]' pyproject.toml || true
 
 meta:
-  owner: "alexdermohr"
+  owner: "heimgewebe"
   conventions:
     gewebedir: ".gewebe"
     version_endpoint: "/version"


### PR DESCRIPTION
## Summary
- declare the heimgewebe organization in the wgx profile metadata
- update the recorded repository owner in the wgx profile to heimgewebe

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4b85cb624832c97ed43b78f85a035