### PR TITLE
Ensure wgx org metadata is validated

### DIFF
--- a/.wgx/profile.yml
+++ b/.wgx/profile.yml
@@ -75,8 +75,11 @@ tasks:
         [ -f Cargo.toml ] && cargo metadata --no-deps > /dev/null || true
         [ -f pyproject.toml ] && grep -q '\[project\]' pyproject.toml || true
 
+wgx:
+  org: "heimgewebe"
+
 meta:
-  owner: "alexdermohr"
+  owner: "heimgewebe"
   conventions:
     gewebedir: ".gewebe"
     version_endpoint: "/version"


### PR DESCRIPTION
## Summary
- move the wgx org declaration ahead of the meta block in the profile for clarity
- teach the profile validator to require a wgx block with a non-empty org
- enforce that meta.owner, when present, matches the declared organization

## Testing
- python ci/scripts/validate_wgx_profile.py *(fails locally: PyYAML not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4cb6911b8832c8c33051477875957