### PR TITLE
Fix markdownlint issues in Gate C quickstart documentation

### DIFF
--- a/docs/quickstart-gate-c.md
+++ b/docs/quickstart-gate-c.md
@@ -10,7 +10,8 @@ make logs
 make down
 ```
 
-**Hinweise**
+## Hinweise
+
 - Frontend nutzt `PUBLIC_API_BASE=/api` (siehe `apps/web/.env.development`).
 - Compose-Profil `dev` schützt vor Verwechslungen mit späteren prod-Stacks.
 - `make smoke` triggert den GitHub-Workflow `compose-smoke` für einen E2E-Boot-Test.


### PR DESCRIPTION
## Summary
- replace the bold "Hinweise" label with a proper heading
- add required spacing after the heading to satisfy markdownlint

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e500e99984832ca509202b03e129df