### PR TITLE
Add landing page metadata for home view

### DIFF
--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -11,6 +11,10 @@
 
   type MapLibreModule = typeof import("maplibre-gl");
 
+  const pageTitle = "Weltgewebe · Home";
+  const pageDescription =
+    "Interaktive Übersicht des Webrats mit Karte, Archiv und Timeline.";
+
   function canInitialise(container: HTMLDivElement | null): container is HTMLDivElement {
     if (typeof window === "undefined") return false;
     if (!container || !container.isConnected) return false;
@@ -86,6 +90,11 @@
     loading = false;
   });
 </script>
+
+<svelte:head>
+  <title>{pageTitle}</title>
+  <meta name="description" content={pageDescription} />
+</svelte:head>
 
 <div style="position:fixed;inset:0;">
   <!-- Map-Fläche -->


### PR DESCRIPTION
## Summary
- add a dedicated title and description to the landing page to satisfy the existing smoke test

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68e4fed10688832c8f3120a0fcf1d822