### PR TITLE
Set explicit toolchain input for API workflow

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
 
       - name: Add rust components
         run: rustup component add rustfmt clippy
@@ -78,6 +80,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
       - name: Install cargo-audit
         run: cargo install cargo-audit --force
       - name: cargo audit


### PR DESCRIPTION
## Summary
- set the `toolchain` input when invoking the Rust toolchain action so the API workflow provides the required value

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e549967b9c832cb60c432f204184c2