### PR TITLE
docs(blueprint): add checkable roadmap to agent operability blueprint

### DIFF
--- a/docs/blueprints/agent-operability-blaupause.md
+++ b/docs/blueprints/agent-operability-blaupause.md
@@ -176,7 +176,7 @@ wgx task run fix_map_submission
 Was passiert intern?
 load task → execute commands sequentially → log results
 
-## Optionale spätere Erweiterungen
+## Optionale spätere Erweiterungen nach Phase 3
 
 Die folgenden Elemente gehören nicht zum zwingenden Minimal-Kern. Sie orientieren sich teilweise an erprobten experimentellen Mustern aus anderen Repos, werden hier aber ausschließlich als optionale, native Erweiterungen für Weltgewebe geführt. Sie sind nicht Voraussetzung für Phase 1–3 der Roadmap und werden nur nach erfolgreicher Basiserprobung relevant, um die Agent-Produktivität gezielt zu erhöhen:
 

--- a/docs/blueprints/agent-operability-blaupause.md
+++ b/docs/blueprints/agent-operability-blaupause.md
@@ -362,6 +362,8 @@ Einsatzregel: Minimal halten.
 - Vollständiger Intelligence Layer (Weltgewebe hat bereits eigene Architektur)
 
 
+Die folgende Roadmap priorisiert ausschließlich den operativen Minimalpfad. Die im vorigen Abschnitt beschriebenen optionalen Erweiterungen gehören nicht zum Initialumfang und werden erst nach erfolgreicher Basiserprobung des Kerns relevant.
+
 ## Roadmap
 
 ### Ausführungsprinzip

--- a/docs/blueprints/agent-operability-blaupause.md
+++ b/docs/blueprints/agent-operability-blaupause.md
@@ -402,12 +402,12 @@ Einsatzregel: Minimal halten.
 - **Stop-Kriterium:** Eindeutiger, nachweisbarer Erfolgsnachweis des gesamten Loops (read -> write -> validate).
 - **Umsetzung (erst danach):**
   - Führe `fix_map_submission` aus.
-  - Wenn belegtes Fehlverhalten oder fehlende Ausführbarkeit vorliegt, passe die betroffenen Commands gezielt an und validiere den gesamten Loop erneut. Die Ursache ist zu dokumentieren.
+  - Wenn belegtes Fehlverhalten oder fehlende Ausführbarkeit vorliegt, passe die betroffenen Commands gezielt an und validiere den gesamten Loop erneut. Die Ursache ist im Runner-Output, Log oder einem zugehörigen Entscheidungsartefakt zu dokumentieren.
 
 ### Phase 4: Erweiterung (Optionales Experiment-Framework)
 
 - **WICHTIG:** NICHT vor erfolgreichem Abschluss von Phase 3 beginnen.
-- **Ziel:** Etablierung des Vibe-Lab Experimentier-Schemas.
+- **Ziel:** Etablierung eines leichtgewichtigen Experiment-Schemas für Weltgewebe.
 - **Diagnose:** Sind die grundlegenden Tasks stabil und verlässlich?
 - **Erwartete Outputs:** Scaffolding für `experiments/`.
 - **Stop-Kriterium:** Valides Schema für `manifest.yml` und `evidence.jsonl` existiert.

--- a/docs/blueprints/agent-operability-blaupause.md
+++ b/docs/blueprints/agent-operability-blaupause.md
@@ -362,6 +362,24 @@ Einsatzregel: Minimal halten.
 - Export-/IR-System (bereits andere Mechaniken vorhanden)
 - Vollständiger Intelligence Layer (Weltgewebe hat bereits eigene Architektur)
 
+
+## Roadmap
+
+- [ ] **Phase 1: Minimaler Kern (Command & Task Definitionen)**
+  - [ ] Erstelle `agent/commands/read_context.yaml`
+  - [ ] Erstelle `agent/commands/write_change.yaml`
+  - [ ] Erstelle `agent/commands/validate_change.yaml`
+  - [ ] Definiere erste Test-Task in `agent/tasks/fix_map_submission.yaml`
+- [ ] **Phase 2: Execution Engine**
+  - [ ] Implementiere Basis-Runner `scripts/run-task` (z.B. in Python oder TS)
+  - [ ] Verbinde Runner mit lokaler Agent-Ausführungsumgebung
+- [ ] **Phase 3: Integration & Erprobung**
+  - [ ] Führe `fix_map_submission` erfolgreich durch den gesamten Loop (read -> write -> validate)
+  - [ ] Überprüfe Ergebnisse und passe Commands ggf. an
+- [ ] **Phase 4: Erweiterung (Optionales Experiment-Framework)**
+  - [ ] Scaffolding für `experiments/` anlegen
+  - [ ] `manifest.yml` und `evidence.jsonl` Schema etablieren
+
 ## Aktivierung
 
 Diese Blaupause wird angewendet, wenn:

--- a/docs/blueprints/agent-operability-blaupause.md
+++ b/docs/blueprints/agent-operability-blaupause.md
@@ -365,20 +365,58 @@ Einsatzregel: Minimal halten.
 
 ## Roadmap
 
-- [ ] **Phase 1: Minimaler Kern (Command & Task Definitionen)**
-  - [ ] Erstelle `agent/commands/read_context.yaml`
-  - [ ] Erstelle `agent/commands/write_change.yaml`
-  - [ ] Erstelle `agent/commands/validate_change.yaml`
-  - [ ] Definiere erste Test-Task in `agent/tasks/fix_map_submission.yaml`
-- [ ] **Phase 2: Execution Engine**
-  - [ ] Implementiere Basis-Runner `scripts/run-task` (z.B. in Python oder TS)
-  - [ ] Verbinde Runner mit lokaler Agent-Ausführungsumgebung
-- [ ] **Phase 3: Integration & Erprobung**
-  - [ ] Führe `fix_map_submission` erfolgreich durch den gesamten Loop (read -> write -> validate)
-  - [ ] Überprüfe Ergebnisse und passe Commands ggf. an
-- [ ] **Phase 4: Erweiterung (Optionales Experiment-Framework)**
-  - [ ] Scaffolding für `experiments/` anlegen
-  - [ ] `manifest.yml` und `evidence.jsonl` Schema etablieren
+### Ausführungsprinzip
+
+- Jede Phase beginnt mit Diagnose (Ist-Zustand erfassen)
+- Keine Implementierung ohne Target-Proof
+- Jede Aktion muss auf konkrete Dateien/Outputs referenzieren
+- Die Roadmap ist kein To-do, sondern ein kontrollierter Ausführungsprozess
+
+### Phase 1: Minimaler Kern (Command & Task Definitionen)
+
+- **Ziel:** Erstellung der ersten drei Commands und einer validen Task.
+- **Diagnose:** Existieren bereits ähnliche Strukturen? Gibt es bestehende Command-Definitionen?
+- **Erwartete Outputs:** Nachweise über den aktuellen Zustand in `agent/commands/` und `agent/tasks/`.
+- **Stop-Kriterium:** Klarheit darüber, wo und wie die YAMLs angelegt werden müssen.
+- **Umsetzung (erst danach):**
+  - Lege Zielpfade fest (z.B. `agent/commands/*.yaml`).
+  - Erstelle `agent/commands/read_context.yaml`.
+  - Erstelle `agent/commands/write_change.yaml`.
+  - Erstelle `agent/commands/validate_change.yaml`.
+  - Definiere erste Test-Task in `agent/tasks/fix_map_submission.yaml`.
+
+### Phase 2: Execution Engine
+
+- **Ziel:** Minimaler Ausführungs-Runner für Agenten-Tasks.
+- **Diagnose:** Gibt es bereits Scripts oder CLI-Strukturen, die genutzt oder erweitert werden können?
+- **Erwartete Outputs:** Entscheidung für ein Tooling (z.B. Python oder TS) inklusive Begründung.
+- **Stop-Kriterium:** Ein konkretes Minimalziel: Der Runner kann genau 1 Task ausführen (kein Framework bauen!).
+- **Umsetzung (erst danach):**
+  - Implementiere Basis-Runner `scripts/run-task`.
+  - Verbinde Runner mit lokaler Agent-Ausführungsumgebung.
+
+### Phase 3: Integration & Erprobung
+
+- **Ziel:** Vollständiger Durchlauf einer Task.
+- **Diagnose:** Ist die Task `fix_map_submission` lauffähig und fehlerfrei definiert?
+- **Erwartete Outputs:**
+  - Welche Logs beweisen den Erfolg?
+  - Welche Dateien wurden durch den Lauf verändert?
+- **Stop-Kriterium:** Eindeutiger Erfolgsnachweis des gesamten Loops (read -> write -> validate).
+- **Umsetzung (erst danach):**
+  - Führe `fix_map_submission` aus.
+  - Überprüfe Ergebnisse und passe Commands ggf. an.
+
+### Phase 4: Erweiterung (Optionales Experiment-Framework)
+
+- **WICHTIG:** NICHT vor erfolgreichem Abschluss von Phase 3 beginnen.
+- **Ziel:** Etablierung des Vibe-Lab Experimentier-Schemas.
+- **Diagnose:** Sind die grundlegenden Tasks stabil und verlässlich?
+- **Erwartete Outputs:** Scaffolding für `experiments/`.
+- **Stop-Kriterium:** Valides Schema für `manifest.yml` und `evidence.jsonl` existiert.
+- **Umsetzung (erst danach):**
+  - Lege Scaffolding für `experiments/` an.
+  - Etabliere Schema für `manifest.yml` und `evidence.jsonl`.
 
 ## Aktivierung
 

--- a/docs/blueprints/agent-operability-blaupause.md
+++ b/docs/blueprints/agent-operability-blaupause.md
@@ -171,15 +171,15 @@ CLI (bewusst simpel):
 wgx task run fix_map_submission
 ```
 
+*(Hinweis: `wgx` dient hier als möglicher CLI-Einstiegspunkt; daraus folgt keine allgemeine Repo-Abhängigkeit des Weltgewebe-Kerns von externen Systemstrukturen. Weltgewebe bleibt eigenständig.)*
+
 Was passiert intern?
 load task → execute commands sequentially → log results
 
-## Experiment-Framework (Extraktion aus vibe-lab)
+## Optionale spätere Erweiterungen
 
-Die folgenden Elemente gehören nicht zum zwingenden Minimal-Kern.
-Sie sind als optionale Erweiterungen für spätere Iterationen gedacht, wenn der minimale Operability-Pfad bereits praktisch funktioniert.
-
-Die folgenden Elemente aus dem vibe-lab Forschungsframework werden übernommen, um die Agent-Produktivität gezielt zu erhöhen:
+Die folgenden Elemente gehören nicht zum zwingenden Minimal-Kern. Sie sind nicht Voraussetzung für Phase 1–3 der Roadmap und werden nur nach erfolgreicher Basiserprobung relevant.
+Sie sind als konzeptionelle Erweiterungen für spätere Iterationen gedacht, um die Agent-Produktivität gezielt zu erhöhen:
 
 ### 1. Experiment-Struktur (Kernmodul)
 
@@ -460,21 +460,21 @@ Fehler 1: Zu viele Commands
 → Es werden drei Commands verwendet.
 
 Fehler 2: Tasks als Text
-→ nein:
+→ ineffektiv:
 
 ```yaml
 steps:
   - "analysiere code"
 ```
 
-→ wertlos
+→ nicht maschinenvalidierbar
 
 Fehler 3: Keine echte Nutzung
 → Erste Task muss echten Bug fixen.
 
 Alternative Sinnachse:
 Statt: „Wir bauen ein Agent-System“
-Zielbild: „Wir bauen ein Makefile für Intelligenz“
+Zielbild: „Wir bauen einen strikten, maschinenlesbaren Ausführungsvertrag“
 
 ## Risiko–Nutzen
 

--- a/docs/blueprints/agent-operability-blaupause.md
+++ b/docs/blueprints/agent-operability-blaupause.md
@@ -403,7 +403,7 @@ Einsatzregel: Minimal halten.
   - Führe `fix_map_submission` aus.
   - Wenn belegtes Fehlverhalten oder fehlende Ausführbarkeit vorliegt, passe die betroffenen Commands gezielt an und validiere den gesamten Loop erneut. Die Ursache ist im Runner-Output, Log oder einem zugehörigen Entscheidungsartefakt zu dokumentieren.
 
-### Phase 4: Erweiterung (Optionales Experiment-Framework)
+### Phase 4: Optionale experimentelle Erweiterungen
 
 - **WICHTIG:** NICHT vor erfolgreichem Abschluss von Phase 3 beginnen.
 - **Ziel:** Etablierung eines leichtgewichtigen Experiment-Schemas für Weltgewebe.

--- a/docs/blueprints/agent-operability-blaupause.md
+++ b/docs/blueprints/agent-operability-blaupause.md
@@ -178,8 +178,7 @@ load task → execute commands sequentially → log results
 
 ## Optionale spätere Erweiterungen
 
-Die folgenden Elemente gehören nicht zum zwingenden Minimal-Kern. Sie sind nicht Voraussetzung für Phase 1–3 der Roadmap und werden nur nach erfolgreicher Basiserprobung relevant.
-Sie sind als konzeptionelle Erweiterungen für spätere Iterationen gedacht, um die Agent-Produktivität gezielt zu erhöhen:
+Die folgenden Elemente gehören nicht zum zwingenden Minimal-Kern. Sie orientieren sich teilweise an erprobten experimentellen Mustern aus anderen Repos, werden hier aber ausschließlich als optionale, native Erweiterungen für Weltgewebe geführt. Sie sind nicht Voraussetzung für Phase 1–3 der Roadmap und werden nur nach erfolgreicher Basiserprobung relevant, um die Agent-Produktivität gezielt zu erhöhen:
 
 ### 1. Experiment-Struktur (Kernmodul)
 

--- a/docs/blueprints/agent-operability-blaupause.md
+++ b/docs/blueprints/agent-operability-blaupause.md
@@ -382,7 +382,7 @@ Einsatzregel: Minimal halten.
   - Erstelle `read_context.yaml` im diagnostisch festgelegten Pfad.
   - Erstelle `write_change.yaml` im diagnostisch festgelegten Pfad.
   - Erstelle `validate_change.yaml` im diagnostisch festgelegten Pfad.
-  - Definiere erste Test-Task (`fix_map_submission.yaml`) im diagnostisch festgelegten Pfad.
+  - Definiere erste Test-Task-Datei `fix_map_submission.yaml` mit der Task-ID `fix_map_submission` im diagnostisch festgelegten Pfad (Task-ID und Dateiname können übereinstimmen, sind aber konzeptionell zu unterscheiden).
 
 ### Phase 2: Execution Engine
 

--- a/docs/blueprints/agent-operability-blaupause.md
+++ b/docs/blueprints/agent-operability-blaupause.md
@@ -375,34 +375,31 @@ Einsatzregel: Minimal halten.
 ### Phase 1: Minimaler Kern (Command & Task Definitionen)
 
 - **Ziel:** Erstellung der ersten drei Commands und einer validen Task.
-- **Diagnose:** Existieren bereits ähnliche Strukturen? Gibt es bestehende Command-Definitionen?
-- **Erwartete Outputs:** Nachweise über den aktuellen Zustand in `agent/commands/` und `agent/tasks/`.
-- **Stop-Kriterium:** Klarheit darüber, wo und wie die YAMLs angelegt werden müssen.
+- **Diagnose:** Existieren bereits `agent/`-Ordner oder analoge Strukturen im Repo? Müssen die vorgeschlagenen Zielpfade neu angelegt werden?
+- **Erwartete Outputs:** Konkrete Nachweise aus Repo-Struktur/Suchtreffern über belegte Pfade oder belegte Nicht-Existenz.
+- **Stop-Kriterium:** Konkret festgelegte und belegte Zielpfade für Commands und Task.
 - **Umsetzung (erst danach):**
-  - Lege Zielpfade fest (z.B. `agent/commands/*.yaml`).
-  - Erstelle `agent/commands/read_context.yaml`.
-  - Erstelle `agent/commands/write_change.yaml`.
-  - Erstelle `agent/commands/validate_change.yaml`.
-  - Definiere erste Test-Task in `agent/tasks/fix_map_submission.yaml`.
+  - Erstelle `read_context.yaml` im diagnostisch festgelegten Pfad.
+  - Erstelle `write_change.yaml` im diagnostisch festgelegten Pfad.
+  - Erstelle `validate_change.yaml` im diagnostisch festgelegten Pfad.
+  - Definiere erste Test-Task (`fix_map_submission.yaml`) im diagnostisch festgelegten Pfad.
 
 ### Phase 2: Execution Engine
 
 - **Ziel:** Minimaler Ausführungs-Runner für Agenten-Tasks.
-- **Diagnose:** Gibt es bereits Scripts oder CLI-Strukturen, die genutzt oder erweitert werden können?
-- **Erwartete Outputs:** Entscheidung für ein Tooling (z.B. Python oder TS) inklusive Begründung.
-- **Stop-Kriterium:** Ein konkretes Minimalziel: Der Runner kann genau 1 Task ausführen (kein Framework bauen!).
+- **Diagnose:** Gibt es bereits bestehende CLI-/Script-Einstiegspunkte, die genutzt werden können?
+- **Erwartete Outputs:** Explizite Entscheidung für eine Sprache (z. B. Python oder TS) und einen Dateipfad.
+- **Stop-Kriterium:** Sprache entschieden, Zielpfad entschieden, Minimalumfang (Runner kann genau 1 Task ausführen) entschieden.
 - **Umsetzung (erst danach):**
-  - Implementiere Basis-Runner `scripts/run-task`.
+  - Implementiere den zuvor festgelegten Basis-Runner im diagnostisch gewählten Zielpfad.
   - Verbinde Runner mit lokaler Agent-Ausführungsumgebung.
 
 ### Phase 3: Integration & Erprobung
 
 - **Ziel:** Vollständiger Durchlauf einer Task.
 - **Diagnose:** Ist die Task `fix_map_submission` lauffähig und fehlerfrei definiert?
-- **Erwartete Outputs:**
-  - Welche Logs beweisen den Erfolg?
-  - Welche Dateien wurden durch den Lauf verändert?
-- **Stop-Kriterium:** Eindeutiger Erfolgsnachweis des gesamten Loops (read -> write -> validate).
+- **Erwartete Outputs:** Konkreter Mindestnachweis (Runner-Output/Exit-Signal, konkret veränderte Dateien, Ergebnis der Validierungsschritte).
+- **Stop-Kriterium:** Eindeutiger, nachweisbarer Erfolgsnachweis des gesamten Loops (read -> write -> validate).
 - **Umsetzung (erst danach):**
   - Führe `fix_map_submission` aus.
   - Überprüfe Ergebnisse und passe Commands ggf. an.

--- a/docs/blueprints/agent-operability-blaupause.md
+++ b/docs/blueprints/agent-operability-blaupause.md
@@ -392,7 +392,7 @@ Einsatzregel: Minimal halten.
 - **Stop-Kriterium:** Sprache entschieden, Zielpfad entschieden, Minimalumfang (Runner kann genau 1 Task ausführen) entschieden.
 - **Umsetzung (erst danach):**
   - Implementiere den zuvor festgelegten Basis-Runner im diagnostisch gewählten Zielpfad.
-  - Verbinde Runner mit lokaler Agent-Ausführungsumgebung.
+  - Dokumentiere die diagnostisch gewählte lokale Ausführungsform und binde den Runner an diese konkrete Ausführungsform an.
 
 ### Phase 3: Integration & Erprobung
 
@@ -402,7 +402,7 @@ Einsatzregel: Minimal halten.
 - **Stop-Kriterium:** Eindeutiger, nachweisbarer Erfolgsnachweis des gesamten Loops (read -> write -> validate).
 - **Umsetzung (erst danach):**
   - Führe `fix_map_submission` aus.
-  - Überprüfe Ergebnisse und passe Commands ggf. an.
+  - Wenn belegtes Fehlverhalten oder fehlende Ausführbarkeit vorliegt, passe die betroffenen Commands gezielt an und validiere den gesamten Loop erneut. Die Ursache ist zu dokumentieren.
 
 ### Phase 4: Erweiterung (Optionales Experiment-Framework)
 

--- a/docs/blueprints/agent-operability-blaupause.md
+++ b/docs/blueprints/agent-operability-blaupause.md
@@ -409,10 +409,10 @@ Einsatzregel: Minimal halten.
 - **WICHTIG:** NICHT vor erfolgreichem Abschluss von Phase 3 beginnen.
 - **Ziel:** Etablierung eines leichtgewichtigen Experiment-Schemas für Weltgewebe.
 - **Diagnose:** Sind die grundlegenden Tasks stabil und verlässlich?
-- **Erwartete Outputs:** Scaffolding für `experiments/`.
-- **Stop-Kriterium:** Valides Schema für `manifest.yml` und `evidence.jsonl` existiert.
+- **Erwartete Outputs:** Diagnostisch begründetes Scaffolding für ein experimentelles Verzeichnis und dessen Kernartefakte.
+- **Stop-Kriterium:** Belegter Zielpfad und valides Schema für `manifest.yml` und `evidence.jsonl` existieren.
 - **Umsetzung (erst danach):**
-  - Lege Scaffolding für `experiments/` an.
+  - Lege minimales Scaffolding im diagnostisch festgelegten Zielpfad an.
   - Etabliere Schema für `manifest.yml` und `evidence.jsonl`.
 
 ## Aktivierung


### PR DESCRIPTION
This PR adds a concrete, checkable roadmap to the `docs/blueprints/agent-operability-blaupause.md` file. The roadmap is structured into 4 phases:
- Phase 1: Minimal Core (Command & Task Definitions)
- Phase 2: Execution Engine
- Phase 3: Integration & Testing
- Phase 4: Expansion (Optional Experiment Framework)

This provides clear next steps for implementing the agent operability blueprint. The markdown document was updated, ensuring valid `markdownlint` syntax throughout.

---
*PR created automatically by Jules for task [15592538603375397967](https://jules.google.com/task/15592538603375397967) started by @alexdermohr*