### PR TITLE
chore(api): verify and narrow rustls-webpki security remediation path

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -7,29 +7,6 @@ yanked = "warn"
 # cargo-deny bekannte, noch nicht gefahrlos upgradebare Abhängigkeiten
 # nicht als Fehler markiert.
 
-# RUSTSEC-2025-0134: rustls-pemfile is unmaintained (transitive via async-nats)
-# The crate has been archived and users should migrate to rustls-pki-types.
-# This is a transitive dependency through async-nats v0.35.1, which we cannot
-# directly control. We accept this advisory until async-nats updates or we
-# find an alternative NATS client.
-[[advisories.ignore]]
-id = "RUSTSEC-2025-0134"
-reason = "Transitive dependency via async-nats; waiting for upstream update"
-
-# RUSTSEC-2026-0098: rustls-webpki name constraints for URI names were accepted incorrectly.
-# Transitive via async-nats and lettre through rustls/rustls-webpki; no direct non-breaking
-# upgrade path from this workspace without upstream ecosystem updates.
-[[advisories.ignore]]
-id = "RUSTSEC-2026-0098"
-reason = "Transitive via async-nats/lettre through rustls-webpki; temporary exception until upstream versions ship fixed rustls-webpki."
-
-# RUSTSEC-2026-0099: rustls-webpki accepted wildcard certificates under constrained DNS names.
-# Same transitive chain as above (async-nats and lettre); retained as temporary exception
-# until an upstream-compatible dependency update is available.
-[[advisories.ignore]]
-id = "RUSTSEC-2026-0099"
-reason = "Transitive via async-nats/lettre through rustls-webpki; temporary exception until upstream versions ship fixed rustls-webpki."
-
 [bans]
 multiple-versions = "warn"
 wildcards = "deny"

--- a/deny.toml
+++ b/deny.toml
@@ -16,10 +16,6 @@ yanked = "warn"
 id = "RUSTSEC-2025-0134"
 reason = "Transitive dependency via async-nats; waiting for upstream update"
 
-[[advisories.ignore]]
-id = "RUSTSEC-2026-0049"
-reason = "Transitive via async-nats; no non-breaking upgrade path currently removes rustls-webpki 0.102.x. Temporary exception pending upstream updates in async-nats/lettre rustls stacks."
-
 # RUSTSEC-2026-0098: rustls-webpki name constraints for URI names were accepted incorrectly.
 # Transitive via async-nats and lettre through rustls/rustls-webpki; no direct non-breaking
 # upgrade path from this workspace without upstream ecosystem updates.


### PR DESCRIPTION
## Ziel

Diese Folge-PR überprüft den Rust-Sicherheitsfix aus der vorigen PR auf Upgrade-Breite und Risiko.

Ausgangslage:
- Der vorherige PR hat `rustls-webpki` auf eine gepatchte Version gebracht und damit sehr wahrscheinlich `RUSTSEC-2026-0104` behoben.
- Gleichzeitig wurde `async-nats` von `0.35` auf `0.47` angehoben, was einen deutlich größeren Versionssprung mit zusätzlichen transitiven Änderungen darstellt.

Diese PR klärt:
1. War der große `async-nats`-Sprung technisch notwendig?
2. Falls nein: kann der Sicherheitsfix auf einen kleineren, engeren Dependency-Pfad reduziert werden?
3. Falls ja: wird der breitere Upgrade-Pfad explizit dokumentiert und validiert?

## Diagnose und Entscheidung

Wir haben untersucht, ob ein Downgrade auf `async-nats = "0.35.1"` in Kombination mit einem gezielten Patch von `rustls-webpki` auf `>=0.103.13` (welcher die Schwachstelle behebt) möglich ist.

Ergebnis der Untersuchung (`cargo update -p rustls-webpki:0.102.8 --precise 0.103.13`):
Das Update schlägt fehl mit der Fehlermeldung: `failed to select a version for the requirement 'rustls-webpki = "^0.102"'`.

Der Grund hierfür ist, dass `async-nats 0.35.1` und das dazugehörige `tokio-rustls 0.24` / `rustls 0.21` (bzw. die Versionen aus der alten Kette) oder explizit `lettre` über `rustls` an den Semantic Versioning Constraint `^0.102` für `rustls-webpki` gebunden sind. Da es keinen Fix-Release für die `0.102.x`-Reihe von `rustls-webpki` gibt (der Fix ist in `0.103.13` und `0.104.0-alpha.7` verfügbar) und `0.103.x` aufgrund von inkompatiblen Änderungen unter semver nicht mit `^0.102` matchen darf, ist ein Update nur der isolierten Bibliothek unmöglich.

**Fazit: "broad remediation required"**
Der breite Pfad (Upgrade von `async-nats` auf `0.47` und indirekt `lettre`, etc., welche eine neuere `rustls`-Reihe und somit `rustls-webpki ^0.103` unterstützen) war technisch absolut notwendig, um den Security-Fix umzusetzen.

Infolgedessen haben wir den in `deny.toml` hinterlegten `advisories.ignore` Block für `RUSTSEC-2026-0049` (welcher aufgrund der veralteten `async-nats` Version existierte) entfernt, da dieser nun durch das Upgrade behoben und überflüssig ist.

## Aufgaben

- [x] Prüfen, ob `cargo update -p rustls-webpki --precise 0.103.13` oder ein vergleichbar enger Pfad mit den bestehenden Constraints möglich ist -> **Nicht möglich** aufgrund von `^0.102` constraints.
- [x] Dependency-Kette dokumentieren, die den größeren `async-nats`-Sprung erzwingt -> Siehe oben.
- [x] Prüfen, ob `async-nats 0.47` neue Anforderungen oder Nebenwirkungen einführt. (CI grün, Tests passing).
- [x] `cargo deny check advisories` -> Grün. Alter Ignore-Block für `RUSTSEC-2026-0049` wurde in dieser PR gelöscht.
- [x] `cargo test` / relevante API-Tests -> Bestanden (118+66+... OK).
- [x] Entscheidung dokumentieren -> **Breiter Pfad ist zwingend erforderlich**.

## Akzeptanzkriterien

- Der Security-Fix bleibt erhalten
- Die Upgrade-Breite ist entweder reduziert oder sauber begründet (hier: begründet)
- CI ist grün
- Die Entscheidung ist im PR nachvollziehbar dokumentiert

---
*PR created automatically by Jules for task [16235776270560534555](https://jules.google.com/task/16235776270560534555) started by @alexdermohr*