### PR TITLE
Validate limit parameter in pagination endpoints

### DIFF
--- a/apps/api/src/routes/accounts.rs
+++ b/apps/api/src/routes/accounts.rs
@@ -1,3 +1,4 @@
+use super::query::parse_usize_param;
 use crate::auth::{accounts::AccountStore, role::Role};
 use crate::state::ApiState;
 use axum::{
@@ -324,8 +325,8 @@ pub async fn list_accounts(
     State(state): State<ApiState>,
     Query(params): Query<HashMap<String, String>>,
 ) -> Result<Json<Vec<AccountPublic>>, StatusCode> {
-    let limit: usize = crate::utils::parse_usize_param(&params, "limit", 100)?;
-    let offset: usize = crate::utils::parse_usize_param(&params, "offset", 0)?;
+    let limit: usize = parse_usize_param(&params, "limit", 100)?;
+    let offset: usize = parse_usize_param(&params, "offset", 0)?;
 
     let accounts = state.accounts.read().await;
 

--- a/apps/api/src/routes/accounts.rs
+++ b/apps/api/src/routes/accounts.rs
@@ -324,14 +324,8 @@ pub async fn list_accounts(
     State(state): State<ApiState>,
     Query(params): Query<HashMap<String, String>>,
 ) -> Result<Json<Vec<AccountPublic>>, StatusCode> {
-    let limit: usize = params
-        .get("limit")
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(100);
-    let offset: usize = match params.get("offset") {
-        Some(raw) => raw.parse().map_err(|_| StatusCode::BAD_REQUEST)?,
-        None => 0,
-    };
+    let limit: usize = crate::utils::parse_usize_param(&params, "limit", 100)?;
+    let offset: usize = crate::utils::parse_usize_param(&params, "offset", 0)?;
 
     let accounts = state.accounts.read().await;
 

--- a/apps/api/src/routes/edges.rs
+++ b/apps/api/src/routes/edges.rs
@@ -1,3 +1,4 @@
+use super::query::parse_usize_param;
 use crate::state::{ApiState, OrderedCache};
 use crate::utils::edges_path;
 use axum::{
@@ -119,8 +120,8 @@ pub async fn list_edges(
 ) -> Result<Json<Vec<Edge>>, StatusCode> {
     let src = params.get("source_id");
     let dst = params.get("target_id");
-    let limit: usize = crate::utils::parse_usize_param(&params, "limit", 250)?.min(MAX_PAGE_SIZE);
-    let offset: usize = crate::utils::parse_usize_param(&params, "offset", 0)?;
+    let limit: usize = parse_usize_param(&params, "limit", 250)?.min(MAX_PAGE_SIZE);
+    let offset: usize = parse_usize_param(&params, "offset", 0)?;
 
     let cache = state.edges.read().await;
 

--- a/apps/api/src/routes/edges.rs
+++ b/apps/api/src/routes/edges.rs
@@ -119,15 +119,8 @@ pub async fn list_edges(
 ) -> Result<Json<Vec<Edge>>, StatusCode> {
     let src = params.get("source_id");
     let dst = params.get("target_id");
-    let limit: usize = params
-        .get("limit")
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(250)
-        .min(MAX_PAGE_SIZE);
-    let offset: usize = match params.get("offset") {
-        Some(raw) => raw.parse().map_err(|_| StatusCode::BAD_REQUEST)?,
-        None => 0,
-    };
+    let limit: usize = crate::utils::parse_usize_param(&params, "limit", 250)?.min(MAX_PAGE_SIZE);
+    let offset: usize = crate::utils::parse_usize_param(&params, "offset", 0)?;
 
     let cache = state.edges.read().await;
 

--- a/apps/api/src/routes/mod.rs
+++ b/apps/api/src/routes/mod.rs
@@ -4,6 +4,7 @@ pub mod edges;
 pub mod health;
 pub mod meta;
 pub mod nodes;
+mod query;
 
 use axum::{
     middleware::from_fn,

--- a/apps/api/src/routes/nodes.rs
+++ b/apps/api/src/routes/nodes.rs
@@ -1,3 +1,4 @@
+use super::query::parse_usize_param;
 use crate::state::{ApiState, OrderedCache};
 use crate::utils::nodes_path;
 use axum::{
@@ -567,8 +568,8 @@ pub async fn list_nodes(
         Some(raw_bbox) => Some(parse_bbox(raw_bbox).ok_or(StatusCode::BAD_REQUEST)?),
         None => None,
     };
-    let limit: usize = crate::utils::parse_usize_param(&params, "limit", 100)?;
-    let offset: usize = crate::utils::parse_usize_param(&params, "offset", 0)?;
+    let limit: usize = parse_usize_param(&params, "limit", 100)?;
+    let offset: usize = parse_usize_param(&params, "offset", 0)?;
 
     let cache = state.nodes.read().await;
 

--- a/apps/api/src/routes/nodes.rs
+++ b/apps/api/src/routes/nodes.rs
@@ -567,14 +567,8 @@ pub async fn list_nodes(
         Some(raw_bbox) => Some(parse_bbox(raw_bbox).ok_or(StatusCode::BAD_REQUEST)?),
         None => None,
     };
-    let limit: usize = params
-        .get("limit")
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(100);
-    let offset: usize = match params.get("offset") {
-        Some(raw) => raw.parse().map_err(|_| StatusCode::BAD_REQUEST)?,
-        None => 0,
-    };
+    let limit: usize = crate::utils::parse_usize_param(&params, "limit", 100)?;
+    let offset: usize = crate::utils::parse_usize_param(&params, "offset", 0)?;
 
     let cache = state.nodes.read().await;
 

--- a/apps/api/src/routes/query.rs
+++ b/apps/api/src/routes/query.rs
@@ -1,0 +1,13 @@
+use axum::http::StatusCode;
+use std::collections::HashMap;
+
+pub fn parse_usize_param(
+    params: &HashMap<String, String>,
+    key: &str,
+    default: usize,
+) -> Result<usize, StatusCode> {
+    match params.get(key) {
+        Some(raw) => raw.parse().map_err(|_| StatusCode::BAD_REQUEST),
+        None => Ok(default),
+    }
+}

--- a/apps/api/src/utils.rs
+++ b/apps/api/src/utils.rs
@@ -1,5 +1,3 @@
-use axum::http::StatusCode;
-use std::collections::HashMap;
 use std::env;
 use std::path::PathBuf;
 
@@ -7,17 +5,6 @@ pub fn in_dir() -> PathBuf {
     env::var("GEWEBE_IN_DIR")
         .map(PathBuf::from)
         .unwrap_or_else(|_| PathBuf::from(".gewebe/in"))
-}
-
-pub fn parse_usize_param(
-    params: &HashMap<String, String>,
-    key: &str,
-    default: usize,
-) -> Result<usize, StatusCode> {
-    match params.get(key) {
-        Some(raw) => raw.parse().map_err(|_| StatusCode::BAD_REQUEST),
-        None => Ok(default),
-    }
 }
 
 pub fn nodes_path() -> PathBuf {

--- a/apps/api/src/utils.rs
+++ b/apps/api/src/utils.rs
@@ -1,3 +1,5 @@
+use axum::http::StatusCode;
+use std::collections::HashMap;
 use std::env;
 use std::path::PathBuf;
 
@@ -5,6 +7,17 @@ pub fn in_dir() -> PathBuf {
     env::var("GEWEBE_IN_DIR")
         .map(PathBuf::from)
         .unwrap_or_else(|_| PathBuf::from(".gewebe/in"))
+}
+
+pub fn parse_usize_param(
+    params: &HashMap<String, String>,
+    key: &str,
+    default: usize,
+) -> Result<usize, StatusCode> {
+    match params.get(key) {
+        Some(raw) => raw.parse().map_err(|_| StatusCode::BAD_REQUEST),
+        None => Ok(default),
+    }
 }
 
 pub fn nodes_path() -> PathBuf {

--- a/apps/api/tests/api_accounts.rs
+++ b/apps/api/tests/api_accounts.rs
@@ -202,3 +202,41 @@ async fn accounts_offset_pagination() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn accounts_invalid_limit() -> Result<()> {
+    let mut state = test_state().await?;
+    let mut accounts = AccountStore::new();
+
+    accounts.insert(AccountInternal {
+        public: AccountPublic {
+            id: "a1".to_string(),
+            kind: "garnrolle".to_string(),
+            title: "Title a1".to_string(),
+            summary: None,
+            public_pos: None,
+            mode: weltgewebe_api::routes::accounts::AccountMode::Ron,
+            radius_m: 0,
+            disabled: false,
+            tags: vec![],
+        },
+        role: Role::Gast,
+        email: None,
+        webauthn_user_id: uuid::Uuid::new_v4(),
+    });
+
+    state.accounts = Arc::new(RwLock::new(accounts));
+    let app = Router::new().merge(api_router()).with_state(state);
+
+    // limit=abc -> 400
+    let req = Request::get("/accounts?limit=abc").body(body::Body::empty())?;
+    let res = app.clone().oneshot(req).await?;
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+
+    // limit=-1 -> 400
+    let req = Request::get("/accounts?limit=-1").body(body::Body::empty())?;
+    let res = app.oneshot(req).await?;
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+
+    Ok(())
+}

--- a/apps/api/tests/api_edges.rs
+++ b/apps/api/tests/api_edges.rs
@@ -208,3 +208,35 @@ async fn edges_offset_pagination() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+#[serial]
+async fn edges_invalid_limit() -> anyhow::Result<()> {
+    let tmp = make_tmp_dir();
+    let in_dir = tmp.path().join("in");
+    let edges_path = in_dir.join("demo.edges.jsonl");
+    let _env = set_gewebe_in_dir(&in_dir);
+
+    write_lines(
+        &edges_path,
+        &[r#"{"id":"e1","source_id":"n1","target_id":"n2","edge_kind":"reference"}"#],
+    );
+
+    let state = test_state().await?;
+    let app = Router::new().merge(api_router()).with_state(state);
+
+    // limit=abc -> 400
+    let res = app
+        .clone()
+        .oneshot(Request::get("/edges?limit=abc").body(body::Body::empty())?)
+        .await?;
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+
+    // limit=-1 -> 400
+    let res = app
+        .oneshot(Request::get("/edges?limit=-1").body(body::Body::empty())?)
+        .await?;
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+
+    Ok(())
+}

--- a/apps/api/tests/api_nodes.rs
+++ b/apps/api/tests/api_nodes.rs
@@ -502,6 +502,34 @@ async fn nodes_offset_pagination() -> anyhow::Result<()> {
 
 #[tokio::test]
 #[serial]
+async fn nodes_invalid_limit() -> anyhow::Result<()> {
+    let tmp = make_tmp_dir();
+    let in_dir = tmp.path().join("in");
+
+    let (app, _env) = app_with_nodes(
+        &in_dir,
+        &[r#"{"id":"n1","location":{"lon":9.9,"lat":53.55},"title":"A"}"#],
+    )
+    .await;
+
+    // limit=abc -> 400
+    let res = app
+        .clone()
+        .oneshot(Request::get("/nodes?limit=abc").body(body::Body::empty())?)
+        .await?;
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+
+    // limit=-1 -> 400
+    let res = app
+        .oneshot(Request::get("/nodes?limit=-1").body(body::Body::empty())?)
+        .await?;
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
 async fn nodes_robustness_with_dirty_data() -> anyhow::Result<()> {
     let tmp = make_tmp_dir();
     let in_dir = tmp.path().join("in");


### PR DESCRIPTION
## Ziel

Einführung einer zentralen Validierungsfunktion für `usize`-Parameter (limit, offset) in Pagination-Endpoints, um konsistent ungültige Werte (nicht-numerisch, negativ) mit HTTP 400 abzulehnen.

## Motivation / Kontext

Bisher wurde der `limit`-Parameter in den Endpoints `/accounts`, `/edges` und `/nodes` mit `.and_then(|s| s.parse().ok()).unwrap_or(default)` verarbeitet. Dies führte dazu, dass ungültige Werte (z.B. `limit=abc` oder `limit=-1`) stillschweigend ignoriert wurden und der Default-Wert verwendet wurde, statt einen Fehler zurückzugeben.

Die Anforderung ist, dass ungültige Pagination-Parameter explizit mit HTTP 400 Bad Request abgelehnt werden.

## Änderungen

- [x] Code

### Implementierung

1. **Neue Utility-Funktion** (`apps/api/src/utils.rs`):
   - `parse_usize_param()`: Zentrale Funktion zur Validierung von `usize`-Parametern
   - Gibt `StatusCode::BAD_REQUEST` zurück, wenn der Parameter nicht geparst werden kann
   - Unterstützt Default-Werte für fehlende Parameter

2. **Refactoring der Endpoints**:
   - `/accounts` (list_accounts): Verwendet neue Validierungsfunktion für `limit` und `offset`
   - `/edges` (list_edges): Verwendet neue Validierungsfunktion für `limit` und `offset`
   - `/nodes` (list_nodes): Verwendet neue Validierungsfunktion für `limit` und `offset`

3. **Tests**:
   - `accounts_invalid_limit()`: Testet `limit=abc` und `limit=-1` → HTTP 400
   - `edges_invalid_limit()`: Testet `limit=abc` und `limit=-1` → HTTP 400
   - `nodes_invalid_limit()`: Testet `limit=abc` und `limit=-1` → HTTP 400

## Risikoabschätzung

**Minimal**: Reine Validierungslogik ohne Geschäftslogik-Änderungen. Bestehende Tests für valide Parameter-Werte bleiben unverändert. Rollback: Einfaches Revert der Änderungen.

## Verifikation

- Neue Tests decken ungültige `limit`-Werte ab (nicht-numerisch, negativ)
- Bestehende Pagination-Tests (`accounts_offset_pagination`, `edges_offset_pagination`, `nodes_offset_pagination`) validieren weiterhin korrekte Behavior mit validen Parametern
- CI-Tests müssen grün sein

## Follow-ups

Keine bekannten Follow-ups.

https://claude.ai/code/session_011Jn8qqgXgg5FP5wkfn8Lku