### PR TITLE
Add operational Optimierungsstatus matrix and link it from reports

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -66,6 +66,7 @@ Kanonische Navigation. Neue UI-Dokumente bestehenden Kategorien zuordnen.
 ### Berichte & Audits
 
 – **Optimierungsbericht:** [reports/optimierungsbericht.md](reports/optimierungsbericht.md) (Schichtenanalyse mit Handlungsempfehlungen)
+– **Optimierungsstatus:** [reports/optimierungsstatus.md](reports/optimierungsstatus.md) (Operative Statusmatrix mit Nachweisen)
 – **Cost Report:** [reports/cost-report.md](reports/cost-report.md)
 
 ### Prozess

--- a/docs/reports/optimierungsbericht.md
+++ b/docs/reports/optimierungsbericht.md
@@ -8,7 +8,8 @@ lang: de
 summary: >
   Umfassende Optimierungsanalyse aller Schichten — API, Frontend, Infrastruktur,
   CI/CD, Dokumentation und Domain-Contracts — mit priorisierten
-  Handlungsempfehlungen und Aufwandsschätzungen.
+  Handlungsempfehlungen; operative Status- und Aufwandspflege erfolgt in
+  docs/reports/optimierungsstatus.md.
 relations:
   - type: relates_to
     target: docs/techstack.md
@@ -16,6 +17,8 @@ relations:
     target: docs/datenmodell.md
   - type: relates_to
     target: docs/policies/agent-reading-protocol.md
+  - type: relates_to
+    target: docs/reports/optimierungsstatus.md
 ---
 
 # Optimierungsbericht Weltgewebe
@@ -24,7 +27,18 @@ relations:
 
 ---
 
-## Gesamtbewertung
+## Statusführung
+
+Dieser Bericht ist die Diagnosequelle, nicht die operative Fortschrittswahrheit.
+Der aktuelle Umsetzungsstand der Maßnahmen wird in
+`docs/reports/optimierungsstatus.md` geführt.
+`done` darf dort nur vergeben werden, wenn Nachweis, reproduzierbarer Test
+und keine Restlücke dokumentiert sind. Ohne Guard-/Schema-Prüfung bleibt die
+Statusmatrix eine operative Orientierung, keine maschinell erzwungene Wahrheit.
+
+---
+
+## Gesamtbewertung (Diagnose, nicht Fortschrittswahrheit)
 
 | Bereich | Score | Einordnung |
 |---------|-------|------------|
@@ -361,17 +375,10 @@ relations:
 
 ---
 
-## Zusammenfassung: Top-10-Prioritäten
+## Zusammenfassung: priorisierte nächste Schritte
 
-| # | Bereich | Maßnahme | Aufwand |
-|---|---------|-----------|---------|
-| 1 | API | Session-Persistenz (Redis/DB) | Mittel |
-| 2 | Frontend | Svelte 5 Runes Migration starten | Hoch |
-| 3 | API | Datenbank-Migrationen einführen | Niedrig |
-| 4 | Contracts | `additionalProperties: false` + String-Constraints | Niedrig |
-| 5 | Infra | Container-Image-Scanning (Trivy) | Niedrig |
-| 6 | API | Paginierung für Listen-Endpunkte | Mittel |
-| 7 | Frontend | Map-Komponente aufteilen (~575 Zeilen) | Mittel |
-| 8 | CI/CD | Workflow-Redundanz reduzieren | Mittel |
-| 9 | Docs | Incident- und Datenbank-Recovery-Runbooks | Niedrig |
-| 10 | Architektur | JSONL zu PostgreSQL Migration planen | Hoch |
+1. Die operative Statusmatrix in `docs/reports/optimierungsstatus.md` pflegen (mit `nachweis`, `test`, `restlücke`, `zuletzt_geprüft`); verbindlich wird sie erst mit Guard-/Schema-Prüfung.
+2. Bereits teilumgesetzte Punkte explizit auf `partial` setzen statt erneut als unqualifiziert „offen“ zu führen.
+3. Kritische offene Risiken zuerst bearbeiten: Session-Persistenz, DB-Migrationen, Produktions-Guards, Runtime-Proofs.
+4. `done` nur mit reproduzierbarem Code-/Test-/Doku-Nachweis vergeben.
+5. Bei fehlender Evidenz den Status als `open` lassen und Lücke explizit benennen (keine stille Interpolation).

--- a/docs/reports/optimierungsstatus.md
+++ b/docs/reports/optimierungsstatus.md
@@ -1,0 +1,59 @@
+---
+id: reports.optimierungsstatus
+title: "Optimierungsstatus Weltgewebe"
+doc_type: status-matrix
+status: active
+created: 2026-04-27
+lang: de
+summary: >
+  Operative Statusmatrix zu den Maßnahmen aus dem Optimierungsbericht.
+  Diese Datei trennt Fortschrittsstand von Diagnose und verlangt konkrete Nachweise.
+relations:
+  - type: depends_on
+    target: docs/reports/optimierungsbericht.md
+  - type: relates_to
+    target: docs/policies/agent-reading-protocol.md
+---
+
+# Optimierungsstatus Weltgewebe
+
+Diese Datei führt den operativen Umsetzungsstand.
+Maßgeblich sind nur belegte Repo-Pfade, Tests und dokumentierte Restlücken.
+Keine stillen Haken.
+Kein `done` ohne reproduzierbaren Nachweis.
+
+## Statuskriterien
+
+| Status | Kriterium |
+|---|---|
+| `open` | Kein positiver überprüfbarer Umsetzungsnachweis vorhanden; ein negativer Ist-Befund kann belegt sein |
+| `partial` | Mindestens ein überprüfbarer Nachweis vorhanden, aber Restlücke bleibt |
+| `done` | Nachweis + reproduzierbarer Test + keine Restlücke |
+| `obsolete` | Maßnahme fachlich überholt; Begründung erforderlich |
+| `contradicted` | Repo-Zustand oder spätere Entscheidung widerspricht der Empfehlung; Begründung erforderlich |
+
+## Befund-Evidenzgrade
+
+| Befund-Evidenzgrad | Bedeutung |
+|---|---|
+| `doc-only` | Der Ist-Befund ist nur dokumentarisch belegt |
+| `code` | Der Ist-Befund ist durch Code belegbar |
+| `code+test` | Der Ist-Befund ist durch Code und Test belegbar |
+| `ci` | Der Ist-Befund ist durch CI-Konfiguration oder CI-Pfad belegbar |
+| `runtime` | Der Ist-Befund ist durch Laufzeit-/Deploy-Nachweis belegbar |
+
+## Matrix
+
+| id | bereich | maßnahme | status | befund_evidenzgrad | risiko | aufwand | priorität | nachweis | test | restlücke | zuletzt_geprüft |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| OPT-API-001 | API | Paginierung Listen-Endpunkte | partial | code+test | mittel | mittel | hoch | `apps/api/src/routes/nodes.rs`, `apps/api/src/routes/edges.rs`, `apps/api/src/routes/accounts.rs` | `apps/api/tests/api_nodes.rs`, `apps/api/tests/api_edges.rs`, `apps/api/tests/api_accounts.rs` | Cursor-Variante, Response-Metadaten und dokumentierter Sortierungsvertrag fehlen | 2026-04-27 |
+| OPT-CON-001 | Contracts | `additionalProperties: false` + String-Constraints | partial | code | mittel | niedrig | hoch | `contracts/domain/node.schema.json`, `contracts/domain/account.schema.json`, `contracts/domain/role.schema.json` | fehlt | Vollständiges Schema-für-Schema-Audit inkl. verbleibender permissiver Felder fehlt | 2026-04-27 |
+| OPT-DOC-001 | Dokumentation | Incident-/DB-Recovery-Runbooks | partial | doc-only | hoch | niedrig | hoch | `docs/runbook.md`, `docs/runbook.observability.md`, `docs/runbooks/README.md` | fehlt | Eigenständige, durchgehende Incident-Response- und DB-Recovery-Abläufe fehlen | 2026-04-27 |
+| OPT-CI-001 | CI/CD | Workflow-Redundanz | partial | ci | mittel | mittel | mittel | `.github/workflows/ci.yml`, `.github/workflows/web.yml`, `.github/workflows/heavy.yml` | fehlt | Konsolidierungskonzept via `workflow_call`, Redundanzkriterien und eigener CI-Strukturcheck fehlen | 2026-04-27 |
+| OPT-MAP-001 | Frontend/Maps | Basemap Runtime Proof | partial | ci | hoch | mittel | hoch | `scripts/guard/basemap-runtime-proof.sh`, `.github/workflows/basemap-runtime-proof.yml`, `apps/web/tests/basemap-client-integration.spec.ts` | `scripts/guard/basemap-runtime-proof.sh`; CI-Pfad: `.github/workflows/basemap-runtime-proof.yml` | Echter CI-Proof mit PMTiles-Artefakt, laufendem Caddy und HTTP-206-Beleg fehlt | 2026-04-27 |
+| OPT-API-002 | API | Session-Persistenz Redis/DB | open | code | hoch | mittel | hoch | `apps/api/src/auth/session.rs` | fehlt | SessionStore ist weiterhin in-memory (`RwLock<HashMap<...>>`), persistenter Adapter fehlt | 2026-04-27 |
+| OPT-API-003 | API | DB-Migrationen | open | code | hoch | niedrig | hoch | `apps/api/src/lib.rs`, `docs/runbook.md` | fehlt | Kein Migrationsverzeichnis `apps/api/migrations/` und kein CI-Pflichtpfad für Migrationen | 2026-04-27 |
+| OPT-FE-001 | Frontend | Svelte-5-Runes-Migration | open | code | mittel | hoch | mittel | `apps/web/src/routes/map/+page.svelte`, `apps/web/src/lib/maplibre/Marker.svelte` | fehlt | Keine belegte Nutzung von `$state`, `$derived`, `$effect` in Kernkomponenten | 2026-04-27 |
+| OPT-FE-002 | Frontend | Map-Aufteilung | open | code | mittel | mittel | mittel | `apps/web/src/routes/map/+page.svelte` | fehlt | Route bleibt monolithisch; Aufteilung in klar getrennte Teilkomponenten fehlt | 2026-04-27 |
+| OPT-INF-001 | Infrastruktur | Trivy Image Scanning | open | ci | mittel | niedrig | mittel | `.github/workflows/security.yml` | fehlt | SBOM mit Syft vorhanden, aber kein Trivy-Container-Scan-Schritt definiert | 2026-04-27 |
+| OPT-ARC-001 | Architektur | JSONL → PostgreSQL | open | code | hoch | hoch | hoch | `apps/api/src/routes/nodes.rs` | fehlt | JSONL ist weiterhin aktive Datenquelle; Migrations- und Cutover-Plan fehlt | 2026-04-27 |


### PR DESCRIPTION
### Motivation

- Separate diagnostic findings from operational progress by introducing an explicit status matrix for tracking implementation evidence and avoiding ambiguous `done` states. 
- Provide a lightweight governance & evidencing model so that each optimization item requires concrete repo paths, tests or runtime proofs before being marked complete. 
- Make the relationship between the high-level Optimierungsbericht and the operational status explicit in the docs index and report metadata. 

### Description

- Add `docs/reports/optimierungsstatus.md` as a new status-matrix document that defines status criteria, evidence grades and a tabular matrix of items with fields such as `status`, `befund_evidenzgrad`, `nachweis`, `test` and `restlücke`. 
- Update `docs/reports/optimierungsbericht.md` to reference the new status file, change the summary to point readers to `docs/reports/optimierungsstatus.md`, and add guidance clarifying that the report is diagnostic while the status file is the operative source of truth. 
- Update `docs/index.md` to include the new **Optimierungsstatus** entry in the Berichte & Audits section so the matrix is discoverable from the main docs index. 
- Populate the new matrix with initial rows that map report recommendations to repo paths and current statuses (e.g. pagination, session persistence, migrations, map runtime proof, CI consolidation). 

### Testing

- No automated tests were added or run for these documentation changes; existing CI/workflows were not modified by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef6a6bf214832ca4d80fd355180473)