### PR TITLE
Optimize rebuild_email_index in AccountStore

### DIFF
--- a/apps/api/src/auth/accounts.rs
+++ b/apps/api/src/auth/accounts.rs
@@ -265,10 +265,10 @@ mod tests {
     #[test]
     fn test_rebuild_email_index_picks_smallest_id_for_duplicate_email() {
         let mut store = AccountStore::new();
-        // Insert in unsorted order
-        store.insert_unindexed(dummy_account("u3", Some("shared@example.com")));
+        // Insert in unsorted order with mixed cases to test normalization
+        store.insert_unindexed(dummy_account("u3", Some("Shared@example.com")));
         store.insert_unindexed(dummy_account("u1", Some("shared@example.com")));
-        store.insert_unindexed(dummy_account("u2", Some("shared@example.com")));
+        store.insert_unindexed(dummy_account("u2", Some("SHARED@example.com")));
 
         store.rebuild_email_index();
 
@@ -278,6 +278,10 @@ mod tests {
         );
         assert_eq!(
             store.get_by_email("SHARED@example.com").unwrap().public.id,
+            "u1"
+        );
+        assert_eq!(
+            store.get_by_email("Shared@example.com").unwrap().public.id,
             "u1"
         );
     }

--- a/apps/api/src/auth/accounts.rs
+++ b/apps/api/src/auth/accounts.rs
@@ -57,34 +57,31 @@ impl AccountStore {
 
     pub(crate) fn rebuild_email_index(&mut self) {
         self.email_index.clear();
+        self.email_index.reserve(self.map.len());
 
-        let mut groups: HashMap<String, (String, usize)> = HashMap::with_capacity(self.map.len());
+        let mut duplicates: HashMap<String, usize> = HashMap::new();
 
-        // BTreeMap.iter() iterates in key order (lexicographically by id)
-        // Since id is already sorted, the first id we encounter for any email
-        // will naturally be the smallest. We track count to emit warnings.
         for (id, acc) in self.map.iter() {
             if let Some(email) = &acc.email {
                 let key = normalize_email_key(email);
-                groups
-                    .entry(key)
-                    .and_modify(|(_, count)| *count += 1)
-                    .or_insert_with(|| (id.clone(), 1));
+                if self.email_index.contains_key(&key) {
+                    *duplicates.entry(key).or_insert(1) += 1;
+                } else {
+                    self.email_index.insert(key, id.clone());
+                }
             }
         }
 
-        self.email_index.reserve(groups.len());
-
-        for (key, (owner_id, count)) in groups {
-            if count > 1 {
+        for (key, extra_count) in duplicates {
+            if let Some(owner_id) = self.email_index.get(&key) {
                 tracing::warn!(
                     event = "account_store.duplicate_email",
                     owner_id = %owner_id,
-                    count = count,
+                    count = extra_count + 1,
                     "Duplicate email detected in AccountStore bulk load. The deterministically smallest ID is chosen as owner."
                 );
+                self.email_index.insert(key, owner_id.clone());
             }
-            self.email_index.insert(key, owner_id);
         }
     }
 

--- a/apps/api/src/auth/accounts.rs
+++ b/apps/api/src/auth/accounts.rs
@@ -1,5 +1,4 @@
 use crate::routes::accounts::AccountInternal;
-use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, HashMap};
 
 #[derive(Clone, Default)]
@@ -60,32 +59,28 @@ impl AccountStore {
         self.email_index.clear();
         self.email_index.reserve(self.map.len());
 
-        let mut duplicates: HashMap<String, usize> = HashMap::new();
+        let mut groups: HashMap<String, (String, usize)> = HashMap::with_capacity(self.map.len());
 
         for (id, acc) in self.map.iter() {
             if let Some(email) = &acc.email {
                 let key = normalize_email_key(email);
-                match self.email_index.entry(key.clone()) {
-                    Entry::Occupied(_) => {
-                        *duplicates.entry(key).or_insert(1) += 1;
-                    }
-                    Entry::Vacant(e) => {
-                        e.insert(id.clone());
-                    }
-                }
+                groups
+                    .entry(key)
+                    .and_modify(|(_, count)| *count += 1)
+                    .or_insert_with(|| (id.clone(), 1));
             }
         }
 
-        for (key, extra_count) in duplicates {
-            if let Some(owner_id) = self.email_index.get(&key) {
+        for (key, (owner_id, count)) in groups {
+            if count > 1 {
                 tracing::warn!(
                     event = "account_store.duplicate_email",
                     owner_id = %owner_id,
-                    count = extra_count + 1,
+                    count = count,
                     "Duplicate email detected in AccountStore bulk load. The deterministically smallest ID is chosen as owner."
                 );
-                self.email_index.insert(key, owner_id.clone());
             }
+            self.email_index.insert(key, owner_id);
         }
     }
 

--- a/apps/api/src/auth/accounts.rs
+++ b/apps/api/src/auth/accounts.rs
@@ -1,4 +1,5 @@
 use crate::routes::accounts::AccountInternal;
+use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, HashMap};
 
 #[derive(Clone, Default)]
@@ -64,10 +65,13 @@ impl AccountStore {
         for (id, acc) in self.map.iter() {
             if let Some(email) = &acc.email {
                 let key = normalize_email_key(email);
-                if self.email_index.contains_key(&key) {
-                    *duplicates.entry(key).or_insert(1) += 1;
-                } else {
-                    self.email_index.insert(key, id.clone());
+                match self.email_index.entry(key.clone()) {
+                    Entry::Occupied(_) => {
+                        *duplicates.entry(key).or_insert(1) += 1;
+                    }
+                    Entry::Vacant(e) => {
+                        e.insert(id.clone());
+                    }
                 }
             }
         }

--- a/apps/api/src/auth/accounts.rs
+++ b/apps/api/src/auth/accounts.rs
@@ -61,6 +61,8 @@ impl AccountStore {
 
         let mut groups: HashMap<String, (String, usize)> = HashMap::with_capacity(self.map.len());
 
+        // self.map is a BTreeMap, so iteration is lexicographic by account ID.
+        // The first ID observed for an email key is therefore the deterministic smallest owner.
         for (id, acc) in self.map.iter() {
             if let Some(email) = &acc.email {
                 let key = normalize_email_key(email);
@@ -259,6 +261,7 @@ mod tests {
             "u1"
         );
     }
+
     #[test]
     fn test_rebuild_email_index_picks_smallest_id_for_duplicate_email() {
         let mut store = AccountStore::new();

--- a/apps/api/src/auth/accounts.rs
+++ b/apps/api/src/auth/accounts.rs
@@ -57,24 +57,30 @@ impl AccountStore {
 
     pub(crate) fn rebuild_email_index(&mut self) {
         self.email_index.clear();
-        let mut groups: HashMap<String, Vec<String>> = HashMap::new();
 
+        let mut groups: HashMap<String, (String, usize)> = HashMap::with_capacity(self.map.len());
+
+        // BTreeMap.iter() iterates in key order (lexicographically by id)
+        // Since id is already sorted, the first id we encounter for any email
+        // will naturally be the smallest. We track count to emit warnings.
         for (id, acc) in self.map.iter() {
             if let Some(email) = &acc.email {
                 let key = normalize_email_key(email);
-                groups.entry(key).or_default().push(id.clone());
+                groups
+                    .entry(key)
+                    .and_modify(|(_, count)| *count += 1)
+                    .or_insert_with(|| (id.clone(), 1));
             }
         }
 
-        for (key, mut ids) in groups {
-            ids.sort(); // Deterministically pick smallest ID
-            let owner_id = ids[0].clone();
+        self.email_index.reserve(groups.len());
 
-            if ids.len() > 1 {
+        for (key, (owner_id, count)) in groups {
+            if count > 1 {
                 tracing::warn!(
                     event = "account_store.duplicate_email",
                     owner_id = %owner_id,
-                    count = ids.len(),
+                    count = count,
                     "Duplicate email detected in AccountStore bulk load. The deterministically smallest ID is chosen as owner."
                 );
             }
@@ -254,6 +260,25 @@ mod tests {
         // new@example.com now points to u1
         assert_eq!(
             store.get_by_email("new@example.com").unwrap().public.id,
+            "u1"
+        );
+    }
+    #[test]
+    fn test_rebuild_email_index_picks_smallest_id_for_duplicate_email() {
+        let mut store = AccountStore::new();
+        // Insert in unsorted order
+        store.insert_unindexed(dummy_account("u3", Some("shared@example.com")));
+        store.insert_unindexed(dummy_account("u1", Some("shared@example.com")));
+        store.insert_unindexed(dummy_account("u2", Some("shared@example.com")));
+
+        store.rebuild_email_index();
+
+        assert_eq!(
+            store.get_by_email("shared@example.com").unwrap().public.id,
+            "u1" // Deterministic fallback to lexicographically smallest ID
+        );
+        assert_eq!(
+            store.get_by_email("SHARED@example.com").unwrap().public.id,
             "u1"
         );
     }


### PR DESCRIPTION
This PR applies the optimization to `rebuild_email_index` to avoid allocations in `HashMap<String, Vec<String>>` and uses `HashMap<String, (String, usize)>` to count elements and preserve the smallest ID.
It also includes a test case `test_rebuild_email_index_picks_smallest_id_for_duplicate_email` to prevent regressions.

---
*PR created automatically by Jules for task [7271745890819683726](https://jules.google.com/task/7271745890819683726) started by @alexdermohr*