### PR TITLE
Add master roadmap (Weltgewebe) coordinating all sub-roadmaps

### DIFF
--- a/docs/_generated/backlinks.md
+++ b/docs/_generated/backlinks.md
@@ -54,6 +54,14 @@ Generated automatically. Do not edit.
 - [relates_to] docs/vision.md
 - [relates_to] docs/zusammenstellung.md
 
+## docs/blueprints/agent-operability-blaupause.md
+
+- [relates_to] docs/roadmap.md
+
+## docs/blueprints/auth-persistence-runtime-proof.md
+
+- [relates_to] docs/roadmap.md
+
 ## docs/blueprints/auth-roadmap.md
 
 - [relates_to] docs/adr/ADR-0006__auth-magic-link-session-passkey.md
@@ -61,13 +69,19 @@ Generated automatically. Do not edit.
 - [relates_to] docs/reports/auth-persistence-next-step.md
 - [relates_to] docs/reports/auth-persistence-readiness.md
 - [relates_to] docs/reports/auth-status-matrix.md
+- [relates_to] docs/roadmap.md
 - [relates_to] docs/specs/auth-blueprint.md
+
+## docs/blueprints/kartenklarheit-phase6.md
+
+- [relates_to] docs/roadmap.md
 
 ## docs/blueprints/kartenklarheit-roadmap.md
 
 - [relates_to] docs/blueprints/kartenklarheit-phase6.md
 - [relates_to] docs/reports/map-architekturkritik.md
 - [relates_to] docs/reports/map-status-matrix.md
+- [relates_to] docs/roadmap.md
 
 ## docs/blueprints/kartenklarheit.md
 
@@ -82,6 +96,7 @@ Generated automatically. Do not edit.
 
 - [relates_to] docs/blueprints/kartenklarheit.md
 - [relates_to] docs/blueprints/map-blaupause.md
+- [relates_to] docs/roadmap.md
 
 ## docs/blueprints/ui-blaupause.md
 
@@ -93,6 +108,7 @@ Generated automatically. Do not edit.
 
 - [relates_to] docs/blueprints/ui-blaupause.md
 - [relates_to] docs/blueprints/ui-state-machine.md
+- [relates_to] docs/roadmap.md
 
 ## docs/blueprints/ui-state-machine.md
 
@@ -102,6 +118,7 @@ Generated automatically. Do not edit.
 ## docs/blueprints/versionierungs-blaupause.md
 
 - [relates_to] docs/blueprints/versionierungs-statusgrundlage.md
+- [relates_to] docs/roadmap.md
 
 ## docs/blueprints/versionierungs-statusgrundlage.md
 
@@ -237,6 +254,7 @@ Generated automatically. Do not edit.
 - [relates_to] docs/adr/ADR-0004__fahrplan-verweis.md
 - [relates_to] docs/process/README.md
 - [relates_to] docs/quickstart-gate-c.md
+- [relates_to] docs/roadmap.md
 
 ## docs/process/sprache.md
 
@@ -264,6 +282,7 @@ Generated automatically. Do not edit.
 
 - [relates_to] docs/adr/ADR-0006__auth-magic-link-session-passkey.md
 - [relates_to] docs/blueprints/auth-roadmap.md
+- [relates_to] docs/roadmap.md
 
 ## docs/reports/map-architekturkritik.md
 
@@ -279,6 +298,7 @@ Generated automatically. Do not edit.
 - [relates_to] docs/blueprints/kartenklarheit.md
 - [relates_to] docs/blueprints/map-roadmap.md
 - [relates_to] docs/reports/map-architekturkritik.md
+- [relates_to] docs/roadmap.md
 
 ## docs/reports/optimierungsbericht.md
 
@@ -287,6 +307,7 @@ Generated automatically. Do not edit.
 ## docs/reports/optimierungsstatus.md
 
 - [relates_to] docs/reports/optimierungsbericht.md
+- [relates_to] docs/roadmap.md
 
 ## docs/runbook.md
 

--- a/docs/_generated/backlinks.md
+++ b/docs/_generated/backlinks.md
@@ -56,11 +56,11 @@ Generated automatically. Do not edit.
 
 ## docs/blueprints/agent-operability-blaupause.md
 
-- [relates_to] docs/roadmap.md
+- [depends_on] docs/roadmap.md
 
 ## docs/blueprints/auth-persistence-runtime-proof.md
 
-- [relates_to] docs/roadmap.md
+- [depends_on] docs/roadmap.md
 
 ## docs/blueprints/auth-roadmap.md
 
@@ -69,19 +69,19 @@ Generated automatically. Do not edit.
 - [relates_to] docs/reports/auth-persistence-next-step.md
 - [relates_to] docs/reports/auth-persistence-readiness.md
 - [relates_to] docs/reports/auth-status-matrix.md
-- [relates_to] docs/roadmap.md
+- [depends_on] docs/roadmap.md
 - [relates_to] docs/specs/auth-blueprint.md
 
 ## docs/blueprints/kartenklarheit-phase6.md
 
-- [relates_to] docs/roadmap.md
+- [depends_on] docs/roadmap.md
 
 ## docs/blueprints/kartenklarheit-roadmap.md
 
 - [relates_to] docs/blueprints/kartenklarheit-phase6.md
 - [relates_to] docs/reports/map-architekturkritik.md
 - [relates_to] docs/reports/map-status-matrix.md
-- [relates_to] docs/roadmap.md
+- [depends_on] docs/roadmap.md
 
 ## docs/blueprints/kartenklarheit.md
 
@@ -96,7 +96,7 @@ Generated automatically. Do not edit.
 
 - [relates_to] docs/blueprints/kartenklarheit.md
 - [relates_to] docs/blueprints/map-blaupause.md
-- [relates_to] docs/roadmap.md
+- [depends_on] docs/roadmap.md
 
 ## docs/blueprints/ui-blaupause.md
 
@@ -108,7 +108,7 @@ Generated automatically. Do not edit.
 
 - [relates_to] docs/blueprints/ui-blaupause.md
 - [relates_to] docs/blueprints/ui-state-machine.md
-- [relates_to] docs/roadmap.md
+- [depends_on] docs/roadmap.md
 
 ## docs/blueprints/ui-state-machine.md
 
@@ -118,7 +118,7 @@ Generated automatically. Do not edit.
 ## docs/blueprints/versionierungs-blaupause.md
 
 - [relates_to] docs/blueprints/versionierungs-statusgrundlage.md
-- [relates_to] docs/roadmap.md
+- [depends_on] docs/roadmap.md
 
 ## docs/blueprints/versionierungs-statusgrundlage.md
 
@@ -254,7 +254,7 @@ Generated automatically. Do not edit.
 - [relates_to] docs/adr/ADR-0004__fahrplan-verweis.md
 - [relates_to] docs/process/README.md
 - [relates_to] docs/quickstart-gate-c.md
-- [relates_to] docs/roadmap.md
+- [depends_on] docs/roadmap.md
 
 ## docs/process/sprache.md
 
@@ -282,7 +282,7 @@ Generated automatically. Do not edit.
 
 - [relates_to] docs/adr/ADR-0006__auth-magic-link-session-passkey.md
 - [relates_to] docs/blueprints/auth-roadmap.md
-- [relates_to] docs/roadmap.md
+- [depends_on] docs/roadmap.md
 
 ## docs/reports/map-architekturkritik.md
 
@@ -298,7 +298,7 @@ Generated automatically. Do not edit.
 - [relates_to] docs/blueprints/kartenklarheit.md
 - [relates_to] docs/blueprints/map-roadmap.md
 - [relates_to] docs/reports/map-architekturkritik.md
-- [relates_to] docs/roadmap.md
+- [depends_on] docs/roadmap.md
 
 ## docs/reports/optimierungsbericht.md
 
@@ -307,7 +307,7 @@ Generated automatically. Do not edit.
 ## docs/reports/optimierungsstatus.md
 
 - [relates_to] docs/reports/optimierungsbericht.md
-- [relates_to] docs/roadmap.md
+- [depends_on] docs/roadmap.md
 
 ## docs/runbook.md
 

--- a/docs/_generated/backlinks.md
+++ b/docs/_generated/backlinks.md
@@ -35,8 +35,11 @@ Generated automatically. Do not edit.
 ## docs/adr/ADR-0006__auth-magic-link-session-passkey.md
 
 - [relates_to] docs/adr/ADR-0005-auth.md
+- [relates_to] docs/blueprints/auth-persistence-runtime-proof.md
 - [relates_to] docs/blueprints/auth-roadmap.md
 - [relates_to] docs/blueprints/weltgewebe.auth-and-ui-routing.md
+- [relates_to] docs/reports/auth-persistence-next-step.md
+- [relates_to] docs/reports/auth-persistence-readiness.md
 - [relates_to] docs/reports/auth-status-matrix.md
 - [relates_to] docs/specs/auth-api.md
 - [relates_to] docs/specs/auth-blueprint.md
@@ -54,6 +57,9 @@ Generated automatically. Do not edit.
 ## docs/blueprints/auth-roadmap.md
 
 - [relates_to] docs/adr/ADR-0006__auth-magic-link-session-passkey.md
+- [relates_to] docs/blueprints/auth-persistence-runtime-proof.md
+- [relates_to] docs/reports/auth-persistence-next-step.md
+- [relates_to] docs/reports/auth-persistence-readiness.md
 - [relates_to] docs/reports/auth-status-matrix.md
 - [relates_to] docs/specs/auth-blueprint.md
 
@@ -106,6 +112,7 @@ Generated automatically. Do not edit.
 - [relates_to] docs/adr/0043-edge-vs-conversation.md
 - [relates_to] docs/architekturstruktur.md
 - [relates_to] docs/domain/vocabulary.md
+- [relates_to] docs/reports/optimierungsbericht.md
 - [relates_to] docs/specs/contract.md
 - [relates_to] docs/techstack.md
 
@@ -207,6 +214,8 @@ Generated automatically. Do not edit.
 - [relates_to] docs/blueprints/agent-operability-blaupause.md
 - [relates_to] docs/policies/architecture-critique.md
 - [relates_to] docs/reports/agent-readiness-audit.md
+- [relates_to] docs/reports/optimierungsbericht.md
+- [relates_to] docs/reports/optimierungsstatus.md
 
 ## docs/policies/orientierung.md
 
@@ -241,6 +250,16 @@ Generated automatically. Do not edit.
 
 - [relates_to] docs/blueprints/agent-operability-blaupause.md
 
+## docs/reports/auth-persistence-next-step.md
+
+- [relates_to] docs/blueprints/auth-persistence-runtime-proof.md
+
+## docs/reports/auth-persistence-readiness.md
+
+- [relates_to] docs/blueprints/auth-persistence-runtime-proof.md
+- [updates] docs/reports/auth-persistence-next-step.md
+- [relates_to] docs/reports/optimierungsstatus.md
+
 ## docs/reports/auth-status-matrix.md
 
 - [relates_to] docs/adr/ADR-0006__auth-magic-link-session-passkey.md
@@ -260,6 +279,14 @@ Generated automatically. Do not edit.
 - [relates_to] docs/blueprints/kartenklarheit.md
 - [relates_to] docs/blueprints/map-roadmap.md
 - [relates_to] docs/reports/map-architekturkritik.md
+
+## docs/reports/optimierungsbericht.md
+
+- [depends_on] docs/reports/optimierungsstatus.md
+
+## docs/reports/optimierungsstatus.md
+
+- [relates_to] docs/reports/optimierungsbericht.md
 
 ## docs/runbook.md
 
@@ -292,6 +319,9 @@ Generated automatically. Do not edit.
 
 ## docs/specs/auth-api.md
 
+- [relates_to] docs/blueprints/auth-persistence-runtime-proof.md
+- [relates_to] docs/reports/auth-persistence-next-step.md
+- [relates_to] docs/reports/auth-persistence-readiness.md
 - [relates_to] docs/specs/auth-state-machine.md
 - [relates_to] docs/specs/auth-ui.md
 
@@ -326,6 +356,7 @@ Generated automatically. Do not edit.
 
 - [relates_to] docs/architekturstruktur.md
 - [relates_to] docs/datenmodell.md
+- [relates_to] docs/reports/optimierungsbericht.md
 
 ## docs/vision.md
 

--- a/docs/_generated/doc-coverage.md
+++ b/docs/_generated/doc-coverage.md
@@ -15,6 +15,7 @@ Generated automatically. Do not edit.
 | Component Type | Coverage | Total | Documented |
 | --- | --- | --- | --- |
 | Config | 66% | 3 | 2 |
+| Guard | 100% | 1 | 1 |
 | Schema | 0% | 1 | 0 |
 | Service | 0% | 2 | 0 |
 | Workflow | 50% | 2 | 1 |

--- a/docs/_generated/doc-index.md
+++ b/docs/_generated/doc-index.md
@@ -47,6 +47,7 @@ Generated automatically. Do not edit.
 | docs.policies.agent-reading-protocol | Agent Reading Protocol | policy | canonical | docs/policies/agent-reading-protocol.md |
 | docs.policies.architecture-critique | Architekturkritik-Skill: weltgewebe.architecture.critique | policy | canonical | docs/policies/architecture-critique.md |
 | docs.reports.agent-readiness-audit | Agent Readiness Audit | documentation | active | docs/reports/agent-readiness-audit.md |
+| docs.roadmap | Weltgewebe — Master-Umsetzungsroadmap | roadmap | active | docs/roadmap.md |
 | docs.runbook | Runbook | runbook | active | docs/runbook.md |
 | docs.runbook.observability | Observability Runbook | runbook | active | docs/runbook.observability.md |
 | docs.techstack | Techstack | architecture | active | docs/techstack.md |

--- a/docs/_generated/doc-index.md
+++ b/docs/_generated/doc-index.md
@@ -20,6 +20,7 @@ Generated automatically. Do not edit.
 | adr.ADR-0004__fahrplan-verweis | ADR-0004 — Fahrplan-Verweis | reference | active | docs/adr/ADR-0004__fahrplan-verweis.md |
 | adr.ADR-0005-auth | ADR-0005 — Auth (Cookie-basierte Sessions) | reference | active | docs/adr/ADR-0005-auth.md |
 | adr.ADR-0006-auth-magic-link-session-passkey | ADR-0006 — Auth: Magic Link, Session und optionaler Passkey | reference | active | docs/adr/ADR-0006__auth-magic-link-session-passkey.md |
+| blueprints.auth-persistence-runtime-proof | Auth-Persistenz — Runtime-Proof-Blaupause | blueprint | active | docs/blueprints/auth-persistence-runtime-proof.md |
 | blueprints.auth-roadmap | Auth Roadmap | roadmap | active | docs/blueprints/auth-roadmap.md |
 | blueprints.weltgewebe.auth-and-ui-routing | Auth und UI-Routing | reference | active | docs/blueprints/weltgewebe.auth-and-ui-routing.md |
 | blueprints.weltgewebe.config.diff | Config Diff | reference | active | docs/blueprints/weltgewebe.config.diff.md |
@@ -70,8 +71,12 @@ Generated automatically. Do not edit.
 | process.sprache | Sprache | reference | active | docs/process/sprache.md |
 | quickstart-gate-c | Quickstart Gate C | reference | active | docs/quickstart-gate-c.md |
 | reference.glossar | Glossar | reference | active | docs/reference/glossar.md |
+| reports.auth-persistence-next-step | Auth-Persistenz — Nächster Schritt | report | active | docs/reports/auth-persistence-next-step.md |
+| reports.auth-persistence-readiness | Auth-Persistenzbereitschaft — OPT-API-002 | report | active | docs/reports/auth-persistence-readiness.md |
 | reports.auth-status-matrix | Auth Status Matrix | reference | active | docs/reports/auth-status-matrix.md |
 | reports.cost-report | Cost Report | reference | active | docs/reports/cost-report.md |
+| reports.optimierungsbericht | Optimierungsbericht Weltgewebe | report | active | docs/reports/optimierungsbericht.md |
+| reports.optimierungsstatus | Optimierungsstatus Weltgewebe | status-matrix | active | docs/reports/optimierungsstatus.md |
 | runbooks.README | Runbooks-Übersicht | reference | active | docs/runbooks/README.md |
 | runbooks.codespaces-recovery | Codespaces Recovery | reference | active | docs/runbooks/codespaces-recovery.md |
 | runbooks.ops.runbook.weltgewebe-selfhost-deploy | Selfhost-Deploy Runbook | reference | active | docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md |

--- a/docs/_generated/implicit-dependencies.md
+++ b/docs/_generated/implicit-dependencies.md
@@ -14,27 +14,31 @@ Generated automatically. Do not edit.
 
 | Source | Inferred Dependency | Evidence | Documented |
 | --- | --- | --- | --- |
-| Makefile (docs-guard) | unittest | `python3 -m unittest discover scripts/docmeta/tests/` | *unclear* |
-| Makefile (docs-guard) | scripts.docmeta.validate_schema | `python3 -m scripts.docmeta.validate_schema` | *unclear* |
-| Makefile (docs-guard) | scripts.docmeta.validate_relations | `python3 -m scripts.docmeta.validate_relations` | *unclear* |
-| Makefile (docs-guard) | scripts.docmeta.check_repo_index_consistency | `python3 -m scripts.docmeta.check_repo_index_consistency` | *unclear* |
-| Makefile (docs-guard) | scripts.docmeta.check_doc_review_age | `python3 -m scripts.docmeta.check_doc_review_age` | *unclear* |
-| Makefile (docs-guard) | scripts.docmeta.review_impact | `python3 -m scripts.docmeta.review_impact` | *unclear* |
-| Makefile (docs-guard) | scripts.docmeta.export_docs_index | `python3 -m scripts.docmeta.export_docs_index` | *unclear* |
-| Makefile (docs-guard) | scripts.docmeta.generate_audit_gaps | `python3 -m scripts.docmeta.generate_audit_gaps` | *unclear* |
-| Makefile (docs-guard) | scripts.docmeta.check_links | `python3 -m scripts.docmeta.check_links` | *unclear* |
-| Makefile (docs-guard) | scripts/docmeta/generate-doc-index.sh | `bash scripts/docmeta/generate-doc-index.sh` | *unclear* |
-| Makefile (docs-guard) | scripts.docmeta.generate_backlinks | `python3 -m scripts.docmeta.generate_backlinks` | *unclear* |
-| Makefile (docs-guard) | scripts/docmeta/generate-impl-index.sh | `bash scripts/docmeta/generate-impl-index.sh` | *unclear* |
-| Makefile (docs-guard) | scripts.docmeta.generate_orphans | `python3 -m scripts.docmeta.generate_orphans` | *unclear* |
-| Makefile (docs-guard) | scripts.docmeta.generate_supersession_map | `python3 -m scripts.docmeta.generate_supersession_map` | *unclear* |
-| Makefile (docs-guard) | scripts.docmeta.generate_system_map | `python3 -m scripts.docmeta.generate_system_map` | *unclear* |
-| Makefile (docs-guard) | scripts.docmeta.generate_architecture_drift | `python3 -m scripts.docmeta.generate_architecture_drift` | *unclear* |
-| Makefile (docs-guard) | scripts.docmeta.generate_doc_coverage | `python3 -m scripts.docmeta.generate_doc_coverage` | *unclear* |
-| Makefile (docs-guard) | scripts.docmeta.generate_knowledge_gaps | `python3 -m scripts.docmeta.generate_knowledge_gaps` | *unclear* |
-| Makefile (docs-guard) | scripts.docmeta.generate_implicit_dependencies | `python3 -m scripts.docmeta.generate_implicit_dependencies` | *unclear* |
-| Makefile (docs-guard) | scripts.docmeta.generate_change_resonance | `python3 -m scripts.docmeta.generate_change_resonance` | *unclear* |
-| Makefile (docs-guard) | scripts.docmeta.generate_staleness_report | `python3 -m scripts.docmeta.generate_staleness_report` | *unclear* |
-| Makefile (docs-guard) | scripts.docmeta.generate_agent_readiness | `python3 -m scripts.docmeta.generate_agent_readiness` | *unclear* |
-| Makefile (docs-guard) | scripts.docmeta.generate_relations_analysis | `python3 -m scripts.docmeta.generate_relations_analysis` | *unclear* |
-| Makefile (docs-guard) | scripts.docmeta.generate_relates_to_audit | `python3 -m scripts.docmeta.generate_relates_to_audit` | *unclear* |
+| Makefile (validate-tests) | unittest | `python3 -m unittest discover scripts/docmeta/tests/` | *unclear* |
+| Makefile (validate-core) | scripts.docmeta.validate_schema | `python3 -m scripts.docmeta.validate_schema` | *unclear* |
+| Makefile (validate-core) | scripts.docmeta.validate_relations | `python3 -m scripts.docmeta.validate_relations` | *unclear* |
+| Makefile (validate-core) | scripts.docmeta.check_repo_index_consistency | `python3 -m scripts.docmeta.check_repo_index_consistency` | *unclear* |
+| Makefile (validate-core) | scripts.docmeta.check_doc_review_age | `python3 -m scripts.docmeta.check_doc_review_age` | *unclear* |
+| Makefile (validate-core) | scripts.docmeta.review_impact | `python3 -m scripts.docmeta.review_impact` | *unclear* |
+| Makefile (validate-core) | scripts.docmeta.export_docs_index | `python3 -m scripts.docmeta.export_docs_index` | *unclear* |
+| Makefile (validate-core) | scripts.docmeta.generate_audit_gaps | `python3 -m scripts.docmeta.generate_audit_gaps` | *unclear* |
+| Makefile (validate-core) | scripts.docmeta.check_links | `python3 -m scripts.docmeta.check_links` | *unclear* |
+| Makefile (validate-guards) | scripts/docmeta/repo-structure-guard.sh | `bash scripts/docmeta/repo-structure-guard.sh` | *unclear* |
+| Makefile (validate-guards) | scripts/docmeta/docs-relations-guard.sh | `bash scripts/docmeta/docs-relations-guard.sh` | *unclear* |
+| Makefile (validate-guards) | scripts/docmeta/generated-files-guard.sh | `bash scripts/docmeta/generated-files-guard.sh` | *unclear* |
+| Makefile (validate-guards) | scripts/docmeta/coverage-guard.sh | `bash scripts/docmeta/coverage-guard.sh` | *unclear* |
+| Makefile (generate) | scripts/docmeta/generate-doc-index.sh | `bash scripts/docmeta/generate-doc-index.sh` | *unclear* |
+| Makefile (generate) | scripts.docmeta.generate_backlinks | `python3 -m scripts.docmeta.generate_backlinks` | *unclear* |
+| Makefile (generate) | scripts/docmeta/generate-impl-index.sh | `bash scripts/docmeta/generate-impl-index.sh` | *unclear* |
+| Makefile (generate) | scripts.docmeta.generate_orphans | `python3 -m scripts.docmeta.generate_orphans` | *unclear* |
+| Makefile (generate) | scripts.docmeta.generate_supersession_map | `python3 -m scripts.docmeta.generate_supersession_map` | *unclear* |
+| Makefile (generate) | scripts.docmeta.generate_system_map | `python3 -m scripts.docmeta.generate_system_map` | *unclear* |
+| Makefile (generate) | scripts.docmeta.generate_architecture_drift | `python3 -m scripts.docmeta.generate_architecture_drift` | *unclear* |
+| Makefile (generate) | scripts.docmeta.generate_doc_coverage | `python3 -m scripts.docmeta.generate_doc_coverage` | *unclear* |
+| Makefile (generate) | scripts.docmeta.generate_knowledge_gaps | `python3 -m scripts.docmeta.generate_knowledge_gaps` | *unclear* |
+| Makefile (generate) | scripts.docmeta.generate_implicit_dependencies | `python3 -m scripts.docmeta.generate_implicit_dependencies` | *unclear* |
+| Makefile (generate) | scripts.docmeta.generate_change_resonance | `python3 -m scripts.docmeta.generate_change_resonance` | *unclear* |
+| Makefile (generate) | scripts.docmeta.generate_staleness_report | `python3 -m scripts.docmeta.generate_staleness_report` | *unclear* |
+| Makefile (generate) | scripts.docmeta.generate_agent_readiness | `python3 -m scripts.docmeta.generate_agent_readiness` | *unclear* |
+| Makefile (generate) | scripts.docmeta.generate_relations_analysis | `python3 -m scripts.docmeta.generate_relations_analysis` | *unclear* |
+| Makefile (generate) | scripts.docmeta.generate_relates_to_audit | `python3 -m scripts.docmeta.generate_relates_to_audit` | *unclear* |

--- a/docs/_generated/relates-to-audit.md
+++ b/docs/_generated/relates-to-audit.md
@@ -14,9 +14,9 @@ Generated automatically. Do not edit.
 
 | Metrik | Wert |
 | --- | --- |
-| Relationen gesamt | 185 |
+| Relationen gesamt | 197 |
 | — depends_on | 1 |
-| — relates_to | 182 |
+| — relates_to | 194 |
 | — supersedes | 1 |
 | — updates | 1 |
 | relates_to Anteil | 98% |
@@ -31,26 +31,50 @@ _Keine Lücken erkannt._
 
 > Zusammenhängende Gruppen im relates_to-Graphen.
 
-**Cluster 1** (46 Dokumente):
+**Cluster 1** (84 Dokumente):
 
 - `AGENTS.md`
 - `agent-policy.yaml`
 - `docs/adr/0043-edge-vs-conversation.md`
 - `docs/adr/ADR-0001__clean-slate-docs-monorepo.md`
+- `docs/adr/ADR-0002__reentry-kriterien.md`
 - `docs/adr/ADR-0003__privacy-ungenauigkeitsradius-ron.md`
+- `docs/adr/ADR-0004__fahrplan-verweis.md`
 - `docs/adr/ADR-0005-auth.md`
 - `docs/adr/ADR-0006__auth-magic-link-session-passkey.md`
 - `docs/architekturstruktur.md`
 - `docs/blueprints/agent-operability-blaupause.md`
 - `docs/blueprints/auth-persistence-runtime-proof.md`
 - `docs/blueprints/auth-roadmap.md`
+- `docs/blueprints/kartenklarheit-phase6.md`
+- `docs/blueprints/kartenklarheit-roadmap.md`
+- `docs/blueprints/kartenklarheit.md`
+- `docs/blueprints/map-blaupause.md`
+- `docs/blueprints/map-roadmap.md`
 - `docs/blueprints/ui-blaupause.md`
 - `docs/blueprints/ui-roadmap.md`
 - `docs/blueprints/ui-state-machine.md`
+- `docs/blueprints/versionierungs-blaupause.md`
+- `docs/blueprints/versionierungs-statusgrundlage.md`
 - `docs/blueprints/weltgewebe.auth-and-ui-routing.md`
+- `docs/blueprints/weltgewebe.config.diff.md`
+- `docs/blueprints/weltgewebe.deploy.plan.md`
 - `docs/datenmodell.md`
+- `docs/deploy/CHANGELOG.md`
+- `docs/deploy/DRIFT_POLICY.md`
+- `docs/deploy/README.md`
+- `docs/deploy/heim-first-phase0.md`
+- `docs/deploy/heimserver.deployment.md`
+- `docs/deploy/heimserver.integration.md`
+- `docs/deploy/security.md`
+- `docs/deploy/vps.md`
+- `docs/deploy/weltgewebe.naming.md`
+- `docs/deployment.md`
+- `docs/deployment_governance.md`
+- `docs/dev/codespaces.md`
 - `docs/domain/modules.md`
 - `docs/domain/vocabulary.md`
+- `docs/edge/systemd/README.md`
 - `docs/geist-und-plan.md`
 - `docs/inhalt.md`
 - `docs/konzepte/garnrolle-und-verortung.md`
@@ -60,13 +84,27 @@ _Keine Lücken erkannt._
 - `docs/policies/agent-reading-protocol.md`
 - `docs/policies/architecture-critique.md`
 - `docs/policies/orientierung.md`
+- `docs/process/README.md`
+- `docs/process/bash-tooling-guidelines.md`
+- `docs/process/fahrplan.md`
+- `docs/process/sprache.md`
+- `docs/quickstart-gate-c.md`
 - `docs/reference/glossar.md`
 - `docs/reports/agent-readiness-audit.md`
 - `docs/reports/auth-persistence-next-step.md`
 - `docs/reports/auth-persistence-readiness.md`
 - `docs/reports/auth-status-matrix.md`
+- `docs/reports/map-architekturkritik.md`
+- `docs/reports/map-status-matrix.md`
 - `docs/reports/optimierungsbericht.md`
 - `docs/reports/optimierungsstatus.md`
+- `docs/roadmap.md`
+- `docs/runbook.md`
+- `docs/runbook.observability.md`
+- `docs/runbooks/README.md`
+- `docs/runbooks/codespaces-recovery.md`
+- `docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md`
+- `docs/runbooks/uv-tooling.md`
 - `docs/specs/auth-api.md`
 - `docs/specs/auth-blueprint.md`
 - `docs/specs/auth-state-machine.md`
@@ -80,50 +118,7 @@ _Keine Lücken erkannt._
 - `docs/zusammenstellung.md`
 - `repo.meta.yaml`
 
-**Cluster 2** (30 Dokumente):
-
-- `docs/adr/ADR-0002__reentry-kriterien.md`
-- `docs/adr/ADR-0004__fahrplan-verweis.md`
-- `docs/blueprints/versionierungs-blaupause.md`
-- `docs/blueprints/versionierungs-statusgrundlage.md`
-- `docs/blueprints/weltgewebe.config.diff.md`
-- `docs/blueprints/weltgewebe.deploy.plan.md`
-- `docs/deploy/CHANGELOG.md`
-- `docs/deploy/DRIFT_POLICY.md`
-- `docs/deploy/README.md`
-- `docs/deploy/heim-first-phase0.md`
-- `docs/deploy/heimserver.deployment.md`
-- `docs/deploy/heimserver.integration.md`
-- `docs/deploy/security.md`
-- `docs/deploy/vps.md`
-- `docs/deploy/weltgewebe.naming.md`
-- `docs/deployment.md`
-- `docs/deployment_governance.md`
-- `docs/dev/codespaces.md`
-- `docs/edge/systemd/README.md`
-- `docs/process/README.md`
-- `docs/process/bash-tooling-guidelines.md`
-- `docs/process/fahrplan.md`
-- `docs/process/sprache.md`
-- `docs/quickstart-gate-c.md`
-- `docs/runbook.md`
-- `docs/runbook.observability.md`
-- `docs/runbooks/README.md`
-- `docs/runbooks/codespaces-recovery.md`
-- `docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md`
-- `docs/runbooks/uv-tooling.md`
-
-**Cluster 3** (7 Dokumente):
-
-- `docs/blueprints/kartenklarheit-phase6.md`
-- `docs/blueprints/kartenklarheit-roadmap.md`
-- `docs/blueprints/kartenklarheit.md`
-- `docs/blueprints/map-blaupause.md`
-- `docs/blueprints/map-roadmap.md`
-- `docs/reports/map-architekturkritik.md`
-- `docs/reports/map-status-matrix.md`
-
-**Cluster 4** (3 Dokumente):
+**Cluster 2** (3 Dokumente):
 
 - `docs/adr/0042-consume-semantah-contracts.md`
 - `docs/x-repo/peers-learnings.md`
@@ -132,6 +127,21 @@ _Keine Lücken erkannt._
 ### Konkrete Beispiele zur Prüfung
 
 > Dokumente mit den meisten relates_to-Zielen und ihren konkreten Relationen.
+
+**`docs/roadmap.md`**:
+
+- relates_to → `docs/blueprints/agent-operability-blaupause.md`
+- relates_to → `docs/blueprints/auth-persistence-runtime-proof.md`
+- relates_to → `docs/blueprints/auth-roadmap.md`
+- relates_to → `docs/blueprints/kartenklarheit-phase6.md`
+- relates_to → `docs/blueprints/kartenklarheit-roadmap.md`
+- relates_to → `docs/blueprints/map-roadmap.md`
+- relates_to → `docs/blueprints/ui-roadmap.md`
+- relates_to → `docs/blueprints/versionierungs-blaupause.md`
+- relates_to → `docs/process/fahrplan.md`
+- relates_to → `docs/reports/auth-status-matrix.md`
+- relates_to → `docs/reports/map-status-matrix.md`
+- relates_to → `docs/reports/optimierungsstatus.md`
 
 **`docs/blueprints/auth-persistence-runtime-proof.md`**:
 
@@ -148,13 +158,6 @@ _Keine Lücken erkannt._
 - relates_to → `docs/deploy/security.md`
 - relates_to → `docs/deployment.md`
 - relates_to → `docs/deployment_governance.md`
-
-**`docs/adr/ADR-0006__auth-magic-link-session-passkey.md`**:
-
-- relates_to → `docs/adr/ADR-0005-auth.md`
-- relates_to → `docs/blueprints/auth-roadmap.md`
-- relates_to → `docs/reports/auth-status-matrix.md`
-- relates_to → `docs/specs/auth-blueprint.md`
 
 ### Hinweise
 

--- a/docs/_generated/relates-to-audit.md
+++ b/docs/_generated/relates-to-audit.md
@@ -14,10 +14,12 @@ Generated automatically. Do not edit.
 
 | Metrik | Wert |
 | --- | --- |
-| Relationen gesamt | 168 |
-| — relates_to | 167 |
+| Relationen gesamt | 185 |
+| — depends_on | 1 |
+| — relates_to | 182 |
 | — supersedes | 1 |
-| relates_to Anteil | 99% |
+| — updates | 1 |
+| relates_to Anteil | 98% |
 
 ### Mögliche supersedes-Lücken
 
@@ -29,20 +31,23 @@ _Keine Lücken erkannt._
 
 > Zusammenhängende Gruppen im relates_to-Graphen.
 
-**Cluster 1** (36 Dokumente):
+**Cluster 1** (46 Dokumente):
 
 - `AGENTS.md`
 - `agent-policy.yaml`
 - `docs/adr/0043-edge-vs-conversation.md`
 - `docs/adr/ADR-0001__clean-slate-docs-monorepo.md`
 - `docs/adr/ADR-0003__privacy-ungenauigkeitsradius-ron.md`
+- `docs/adr/ADR-0005-auth.md`
+- `docs/adr/ADR-0006__auth-magic-link-session-passkey.md`
 - `docs/architekturstruktur.md`
 - `docs/blueprints/agent-operability-blaupause.md`
-- `docs/blueprints/kartenklarheit-phase6.md`
-- `docs/blueprints/kartenklarheit-roadmap.md`
-- `docs/blueprints/kartenklarheit.md`
-- `docs/blueprints/map-blaupause.md`
-- `docs/blueprints/map-roadmap.md`
+- `docs/blueprints/auth-persistence-runtime-proof.md`
+- `docs/blueprints/auth-roadmap.md`
+- `docs/blueprints/ui-blaupause.md`
+- `docs/blueprints/ui-roadmap.md`
+- `docs/blueprints/ui-state-machine.md`
+- `docs/blueprints/weltgewebe.auth-and-ui-routing.md`
 - `docs/datenmodell.md`
 - `docs/domain/modules.md`
 - `docs/domain/vocabulary.md`
@@ -57,8 +62,15 @@ _Keine Lücken erkannt._
 - `docs/policies/orientierung.md`
 - `docs/reference/glossar.md`
 - `docs/reports/agent-readiness-audit.md`
-- `docs/reports/map-architekturkritik.md`
-- `docs/reports/map-status-matrix.md`
+- `docs/reports/auth-persistence-next-step.md`
+- `docs/reports/auth-persistence-readiness.md`
+- `docs/reports/auth-status-matrix.md`
+- `docs/reports/optimierungsbericht.md`
+- `docs/reports/optimierungsstatus.md`
+- `docs/specs/auth-api.md`
+- `docs/specs/auth-blueprint.md`
+- `docs/specs/auth-state-machine.md`
+- `docs/specs/auth-ui.md`
 - `docs/specs/contract.md`
 - `docs/specs/privacy-api.md`
 - `docs/specs/privacy-ui.md`
@@ -101,20 +113,15 @@ _Keine Lücken erkannt._
 - `docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md`
 - `docs/runbooks/uv-tooling.md`
 
-**Cluster 3** (12 Dokumente):
+**Cluster 3** (7 Dokumente):
 
-- `docs/adr/ADR-0005-auth.md`
-- `docs/adr/ADR-0006__auth-magic-link-session-passkey.md`
-- `docs/blueprints/auth-roadmap.md`
-- `docs/blueprints/ui-blaupause.md`
-- `docs/blueprints/ui-roadmap.md`
-- `docs/blueprints/ui-state-machine.md`
-- `docs/blueprints/weltgewebe.auth-and-ui-routing.md`
-- `docs/reports/auth-status-matrix.md`
-- `docs/specs/auth-api.md`
-- `docs/specs/auth-blueprint.md`
-- `docs/specs/auth-state-machine.md`
-- `docs/specs/auth-ui.md`
+- `docs/blueprints/kartenklarheit-phase6.md`
+- `docs/blueprints/kartenklarheit-roadmap.md`
+- `docs/blueprints/kartenklarheit.md`
+- `docs/blueprints/map-blaupause.md`
+- `docs/blueprints/map-roadmap.md`
+- `docs/reports/map-architekturkritik.md`
+- `docs/reports/map-status-matrix.md`
 
 **Cluster 4** (3 Dokumente):
 
@@ -125,6 +132,14 @@ _Keine Lücken erkannt._
 ### Konkrete Beispiele zur Prüfung
 
 > Dokumente mit den meisten relates_to-Zielen und ihren konkreten Relationen.
+
+**`docs/blueprints/auth-persistence-runtime-proof.md`**:
+
+- relates_to → `docs/adr/ADR-0006__auth-magic-link-session-passkey.md`
+- relates_to → `docs/blueprints/auth-roadmap.md`
+- relates_to → `docs/reports/auth-persistence-next-step.md`
+- relates_to → `docs/reports/auth-persistence-readiness.md`
+- relates_to → `docs/specs/auth-api.md`
 
 **`docs/deploy/README.md`**:
 
@@ -140,13 +155,6 @@ _Keine Lücken erkannt._
 - relates_to → `docs/blueprints/auth-roadmap.md`
 - relates_to → `docs/reports/auth-status-matrix.md`
 - relates_to → `docs/specs/auth-blueprint.md`
-
-**`docs/blueprints/agent-operability-blaupause.md`**:
-
-- relates_to → `AGENTS.md`
-- relates_to → `agent-policy.yaml`
-- relates_to → `docs/policies/agent-reading-protocol.md`
-- relates_to → `docs/reports/agent-readiness-audit.md`
 
 ### Hinweise
 

--- a/docs/_generated/relates-to-audit.md
+++ b/docs/_generated/relates-to-audit.md
@@ -15,11 +15,11 @@ Generated automatically. Do not edit.
 | Metrik | Wert |
 | --- | --- |
 | Relationen gesamt | 197 |
-| — depends_on | 1 |
-| — relates_to | 194 |
+| — depends_on | 13 |
+| — relates_to | 182 |
 | — supersedes | 1 |
 | — updates | 1 |
-| relates_to Anteil | 98% |
+| relates_to Anteil | 92% |
 
 ### Mögliche supersedes-Lücken
 
@@ -31,50 +31,26 @@ _Keine Lücken erkannt._
 
 > Zusammenhängende Gruppen im relates_to-Graphen.
 
-**Cluster 1** (84 Dokumente):
+**Cluster 1** (46 Dokumente):
 
 - `AGENTS.md`
 - `agent-policy.yaml`
 - `docs/adr/0043-edge-vs-conversation.md`
 - `docs/adr/ADR-0001__clean-slate-docs-monorepo.md`
-- `docs/adr/ADR-0002__reentry-kriterien.md`
 - `docs/adr/ADR-0003__privacy-ungenauigkeitsradius-ron.md`
-- `docs/adr/ADR-0004__fahrplan-verweis.md`
 - `docs/adr/ADR-0005-auth.md`
 - `docs/adr/ADR-0006__auth-magic-link-session-passkey.md`
 - `docs/architekturstruktur.md`
 - `docs/blueprints/agent-operability-blaupause.md`
 - `docs/blueprints/auth-persistence-runtime-proof.md`
 - `docs/blueprints/auth-roadmap.md`
-- `docs/blueprints/kartenklarheit-phase6.md`
-- `docs/blueprints/kartenklarheit-roadmap.md`
-- `docs/blueprints/kartenklarheit.md`
-- `docs/blueprints/map-blaupause.md`
-- `docs/blueprints/map-roadmap.md`
 - `docs/blueprints/ui-blaupause.md`
 - `docs/blueprints/ui-roadmap.md`
 - `docs/blueprints/ui-state-machine.md`
-- `docs/blueprints/versionierungs-blaupause.md`
-- `docs/blueprints/versionierungs-statusgrundlage.md`
 - `docs/blueprints/weltgewebe.auth-and-ui-routing.md`
-- `docs/blueprints/weltgewebe.config.diff.md`
-- `docs/blueprints/weltgewebe.deploy.plan.md`
 - `docs/datenmodell.md`
-- `docs/deploy/CHANGELOG.md`
-- `docs/deploy/DRIFT_POLICY.md`
-- `docs/deploy/README.md`
-- `docs/deploy/heim-first-phase0.md`
-- `docs/deploy/heimserver.deployment.md`
-- `docs/deploy/heimserver.integration.md`
-- `docs/deploy/security.md`
-- `docs/deploy/vps.md`
-- `docs/deploy/weltgewebe.naming.md`
-- `docs/deployment.md`
-- `docs/deployment_governance.md`
-- `docs/dev/codespaces.md`
 - `docs/domain/modules.md`
 - `docs/domain/vocabulary.md`
-- `docs/edge/systemd/README.md`
 - `docs/geist-und-plan.md`
 - `docs/inhalt.md`
 - `docs/konzepte/garnrolle-und-verortung.md`
@@ -84,27 +60,13 @@ _Keine Lücken erkannt._
 - `docs/policies/agent-reading-protocol.md`
 - `docs/policies/architecture-critique.md`
 - `docs/policies/orientierung.md`
-- `docs/process/README.md`
-- `docs/process/bash-tooling-guidelines.md`
-- `docs/process/fahrplan.md`
-- `docs/process/sprache.md`
-- `docs/quickstart-gate-c.md`
 - `docs/reference/glossar.md`
 - `docs/reports/agent-readiness-audit.md`
 - `docs/reports/auth-persistence-next-step.md`
 - `docs/reports/auth-persistence-readiness.md`
 - `docs/reports/auth-status-matrix.md`
-- `docs/reports/map-architekturkritik.md`
-- `docs/reports/map-status-matrix.md`
 - `docs/reports/optimierungsbericht.md`
 - `docs/reports/optimierungsstatus.md`
-- `docs/roadmap.md`
-- `docs/runbook.md`
-- `docs/runbook.observability.md`
-- `docs/runbooks/README.md`
-- `docs/runbooks/codespaces-recovery.md`
-- `docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md`
-- `docs/runbooks/uv-tooling.md`
 - `docs/specs/auth-api.md`
 - `docs/specs/auth-blueprint.md`
 - `docs/specs/auth-state-machine.md`
@@ -118,7 +80,50 @@ _Keine Lücken erkannt._
 - `docs/zusammenstellung.md`
 - `repo.meta.yaml`
 
-**Cluster 2** (3 Dokumente):
+**Cluster 2** (30 Dokumente):
+
+- `docs/adr/ADR-0002__reentry-kriterien.md`
+- `docs/adr/ADR-0004__fahrplan-verweis.md`
+- `docs/blueprints/versionierungs-blaupause.md`
+- `docs/blueprints/versionierungs-statusgrundlage.md`
+- `docs/blueprints/weltgewebe.config.diff.md`
+- `docs/blueprints/weltgewebe.deploy.plan.md`
+- `docs/deploy/CHANGELOG.md`
+- `docs/deploy/DRIFT_POLICY.md`
+- `docs/deploy/README.md`
+- `docs/deploy/heim-first-phase0.md`
+- `docs/deploy/heimserver.deployment.md`
+- `docs/deploy/heimserver.integration.md`
+- `docs/deploy/security.md`
+- `docs/deploy/vps.md`
+- `docs/deploy/weltgewebe.naming.md`
+- `docs/deployment.md`
+- `docs/deployment_governance.md`
+- `docs/dev/codespaces.md`
+- `docs/edge/systemd/README.md`
+- `docs/process/README.md`
+- `docs/process/bash-tooling-guidelines.md`
+- `docs/process/fahrplan.md`
+- `docs/process/sprache.md`
+- `docs/quickstart-gate-c.md`
+- `docs/runbook.md`
+- `docs/runbook.observability.md`
+- `docs/runbooks/README.md`
+- `docs/runbooks/codespaces-recovery.md`
+- `docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md`
+- `docs/runbooks/uv-tooling.md`
+
+**Cluster 3** (7 Dokumente):
+
+- `docs/blueprints/kartenklarheit-phase6.md`
+- `docs/blueprints/kartenklarheit-roadmap.md`
+- `docs/blueprints/kartenklarheit.md`
+- `docs/blueprints/map-blaupause.md`
+- `docs/blueprints/map-roadmap.md`
+- `docs/reports/map-architekturkritik.md`
+- `docs/reports/map-status-matrix.md`
+
+**Cluster 4** (3 Dokumente):
 
 - `docs/adr/0042-consume-semantah-contracts.md`
 - `docs/x-repo/peers-learnings.md`
@@ -127,21 +132,6 @@ _Keine Lücken erkannt._
 ### Konkrete Beispiele zur Prüfung
 
 > Dokumente mit den meisten relates_to-Zielen und ihren konkreten Relationen.
-
-**`docs/roadmap.md`**:
-
-- relates_to → `docs/blueprints/agent-operability-blaupause.md`
-- relates_to → `docs/blueprints/auth-persistence-runtime-proof.md`
-- relates_to → `docs/blueprints/auth-roadmap.md`
-- relates_to → `docs/blueprints/kartenklarheit-phase6.md`
-- relates_to → `docs/blueprints/kartenklarheit-roadmap.md`
-- relates_to → `docs/blueprints/map-roadmap.md`
-- relates_to → `docs/blueprints/ui-roadmap.md`
-- relates_to → `docs/blueprints/versionierungs-blaupause.md`
-- relates_to → `docs/process/fahrplan.md`
-- relates_to → `docs/reports/auth-status-matrix.md`
-- relates_to → `docs/reports/map-status-matrix.md`
-- relates_to → `docs/reports/optimierungsstatus.md`
 
 **`docs/blueprints/auth-persistence-runtime-proof.md`**:
 
@@ -158,6 +148,13 @@ _Keine Lücken erkannt._
 - relates_to → `docs/deploy/security.md`
 - relates_to → `docs/deployment.md`
 - relates_to → `docs/deployment_governance.md`
+
+**`docs/adr/ADR-0006__auth-magic-link-session-passkey.md`**:
+
+- relates_to → `docs/adr/ADR-0005-auth.md`
+- relates_to → `docs/blueprints/auth-roadmap.md`
+- relates_to → `docs/reports/auth-status-matrix.md`
+- relates_to → `docs/specs/auth-blueprint.md`
 
 ### Hinweise
 

--- a/docs/_generated/relations-analysis.md
+++ b/docs/_generated/relations-analysis.md
@@ -14,12 +14,14 @@ Generated automatically. Do not edit.
 
 | Metrik | Wert |
 | --- | --- |
-| Dokumente gesamt | 80 |
-| Dokumente mit ausgehenden Relationen | 77 |
-| Dokumente als Ziel referenziert | 60 |
-| Relationen gesamt | 168 |
-| — relates_to | 167 |
+| Dokumente gesamt | 85 |
+| Dokumente mit ausgehenden Relationen | 83 |
+| Dokumente als Ziel referenziert | 63 |
+| Relationen gesamt | 185 |
+| — depends_on | 1 |
+| — relates_to | 182 |
 | — supersedes | 1 |
+| — updates | 1 |
 | Isolierte Dokumente | 1 |
 | depends_on Zyklen | 0 |
 
@@ -28,6 +30,7 @@ Generated automatically. Do not edit.
 > Heuristische Hinweise — keine CI-Fehler. Zyklen deuten auf zirkuläre Abhängigkeiten, hohe Vernetzung auf zentrale Dokumente, die bei Änderungen besondere Aufmerksamkeit erfordern.
 
 - ⚠️ High inbound count (13): `docs/deploy/README.md` — central dependency, review carefully
+- ⚠️ High inbound count (11): `docs/adr/ADR-0006__auth-magic-link-session-passkey.md` — central dependency, review carefully
 - ⚠️ High inbound count (11): `docs/deployment.md` — central dependency, review carefully
 
 ### Zyklen (depends_on)
@@ -39,6 +42,7 @@ _Keine Zyklen gefunden._
 **Eingehend (inbound):**
 
 - `docs/deploy/README.md` — 13 eingehende Relationen
+- `docs/adr/ADR-0006__auth-magic-link-session-passkey.md` — 11 eingehende Relationen
 - `docs/deployment.md` — 11 eingehende Relationen
 
 ### Isolierte Dokumente

--- a/docs/_generated/relations-analysis.md
+++ b/docs/_generated/relations-analysis.md
@@ -14,12 +14,12 @@ Generated automatically. Do not edit.
 
 | Metrik | Wert |
 | --- | --- |
-| Dokumente gesamt | 85 |
-| Dokumente mit ausgehenden Relationen | 83 |
-| Dokumente als Ziel referenziert | 63 |
-| Relationen gesamt | 185 |
+| Dokumente gesamt | 86 |
+| Dokumente mit ausgehenden Relationen | 84 |
+| Dokumente als Ziel referenziert | 66 |
+| Relationen gesamt | 197 |
 | — depends_on | 1 |
-| — relates_to | 182 |
+| — relates_to | 194 |
 | — supersedes | 1 |
 | — updates | 1 |
 | Isolierte Dokumente | 1 |
@@ -29,6 +29,7 @@ Generated automatically. Do not edit.
 
 > Heuristische Hinweise — keine CI-Fehler. Zyklen deuten auf zirkuläre Abhängigkeiten, hohe Vernetzung auf zentrale Dokumente, die bei Änderungen besondere Aufmerksamkeit erfordern.
 
+- ⚠️ High outbound count (12): `docs/roadmap.md` — possible over-linking
 - ⚠️ High inbound count (13): `docs/deploy/README.md` — central dependency, review carefully
 - ⚠️ High inbound count (11): `docs/adr/ADR-0006__auth-magic-link-session-passkey.md` — central dependency, review carefully
 - ⚠️ High inbound count (11): `docs/deployment.md` — central dependency, review carefully
@@ -38,6 +39,10 @@ Generated automatically. Do not edit.
 _Keine Zyklen gefunden._
 
 ### Hubs (hohe Vernetzung)
+
+**Ausgehend (outbound):**
+
+- `docs/roadmap.md` — 12 ausgehende Relationen
 
 **Eingehend (inbound):**
 

--- a/docs/_generated/relations-analysis.md
+++ b/docs/_generated/relations-analysis.md
@@ -18,8 +18,8 @@ Generated automatically. Do not edit.
 | Dokumente mit ausgehenden Relationen | 84 |
 | Dokumente als Ziel referenziert | 66 |
 | Relationen gesamt | 197 |
-| — depends_on | 1 |
-| — relates_to | 194 |
+| — depends_on | 13 |
+| — relates_to | 182 |
 | — supersedes | 1 |
 | — updates | 1 |
 | Isolierte Dokumente | 1 |

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,10 @@ NOTE:
 Kanonische Navigation. Neue UI-Dokumente bestehenden Kategorien zuordnen.
 -->
 
+### Master-Umsetzungsroadmap
+
+– **Master-Roadmap:** [roadmap.md](roadmap.md) (Koordinations-Index über alle thematischen Sub-Roadmaps)
+
 ### System
 
 – **Start:** [architekturstruktur.md](architekturstruktur.md)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -69,6 +69,14 @@ Haken hier sind verdichtete Repräsentationen, keine Eigenwahrheiten.
 4. **Reihenfolge vor Vollständigkeit.** Diese Datei priorisiert
    Abhängigkeiten zwischen Themen, nicht die Themen-internen Phasen.
 
+## Relations-Hinweis
+
+Diese Roadmap hat bewusst viele ausgehende `depends_on`-Relationen, weil sie
+als Koordinations-Index aus Sub-Roadmaps und Statusmatrizen abgeleitet ist.
+Ein hoher Outbound-Wert ist hier erwartet und kein eigenständiger Architektur-Hub.
+Neue Relationen dürfen nur ergänzt werden, wenn ein Dokument wirklich als
+Status- oder Reihenfolgequelle für die Master-Roadmap dient.
+
 ## Themen-Übersicht
 
 | Thema | Sub-Roadmap | Statusbeleg |
@@ -117,13 +125,13 @@ Reihenfolge: Daten-/Szenenklarheit → Souveräne Basemap-Pipeline → Runtime-P
 
 ## Strang Agent-Operability
 
-- [~] Minimaler Action-Layer · [agent-operability-blaupause.md](blueprints/agent-operability-blaupause.md)
+- [?] Minimaler Action-Layer · Zielbild dokumentiert, Implementierungsstand prüfen · [agent-operability-blaupause.md](blueprints/agent-operability-blaupause.md)
 - [?] Agent-Readiness vollständig grün · [agent-readiness-audit.md](reports/agent-readiness-audit.md)
 
 ## Strang Versionierung
 
-- [?] Versionierungsmodell festziehen · [versionierungs-blaupause.md](blueprints/versionierungs-blaupause.md)
-- [?] Statusgrundlage gegen Repo prüfen · [versionierungs-statusgrundlage.md](blueprints/versionierungs-statusgrundlage.md)
+- [?] Versionierungsmodell festziehen · Blueprint ist draft · [versionierungs-blaupause.md](blueprints/versionierungs-blaupause.md)
+- [?] Statusgrundlage gegen Repo prüfen · Statusgrundlage ist active, aber Master-Status bleibt nur aus Sub-Beleg ableitbar · [versionierungs-statusgrundlage.md](blueprints/versionierungs-statusgrundlage.md)
 
 ## Strang Optimierungsfront
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -116,7 +116,8 @@ Reihenfolge: Kanonisierung → Step-up → Persistenz-Runtime-Proof → DbSessio
 
 Reihenfolge: Daten-/Szenenklarheit → Souveräne Basemap-Pipeline → Runtime-Proof.
 
-- [x] Kartenklarheit Phasen 0–4 — Ist sichern, Datenquelle, Szenengrenzen, Regressionen · [kartenklarheit-roadmap.md](blueprints/kartenklarheit-roadmap.md)
+- [x] Kartenklarheit Phasen 0–3 — Ist sichern, Datenquelle, Szenengrenzen · [kartenklarheit-roadmap.md](blueprints/kartenklarheit-roadmap.md)
+- [~] Kartenklarheit Phase 4 — Regressionen teilweise; Keyboard-/Query-Parameter-Navigation offen · [kartenklarheit-roadmap.md](blueprints/kartenklarheit-roadmap.md)
 - [~] Kartenklarheit Phase 5 — Souveräne Basemap-Infrastruktur · [kartenklarheit-roadmap §155](blueprints/kartenklarheit-roadmap.md)
 - [~] Basemap-Roadmap Phasen 1–3 — Pipeline, Style, Runtime-Integration · [map-roadmap.md](blueprints/map-roadmap.md)
 - [ ] Basemap-Roadmap Phase 4 — Betrieb & Versionierung

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,152 @@
+---
+id: docs.roadmap
+title: Weltgewebe — Master-Umsetzungsroadmap
+doc_type: roadmap
+status: active
+created: 2026-05-08
+lang: de
+summary: >
+  Koordinations-Roadmap, die alle thematischen Sub-Roadmaps (Auth, UI, Map,
+  Agent-Operability, Versionierung) ordnet und Meilensteine abhakbar macht.
+  Sie ersetzt keine Sub-Roadmap und keinen Statusbericht, sondern verknüpft sie.
+relations:
+  - type: relates_to
+    target: docs/process/fahrplan.md
+  - type: relates_to
+    target: docs/blueprints/auth-roadmap.md
+  - type: relates_to
+    target: docs/blueprints/auth-persistence-runtime-proof.md
+  - type: relates_to
+    target: docs/blueprints/ui-roadmap.md
+  - type: relates_to
+    target: docs/blueprints/map-roadmap.md
+  - type: relates_to
+    target: docs/blueprints/kartenklarheit-roadmap.md
+  - type: relates_to
+    target: docs/blueprints/kartenklarheit-phase6.md
+  - type: relates_to
+    target: docs/blueprints/agent-operability-blaupause.md
+  - type: relates_to
+    target: docs/blueprints/versionierungs-blaupause.md
+  - type: relates_to
+    target: docs/reports/optimierungsstatus.md
+  - type: relates_to
+    target: docs/reports/auth-status-matrix.md
+  - type: relates_to
+    target: docs/reports/map-status-matrix.md
+---
+
+# Weltgewebe — Master-Umsetzungsroadmap
+
+> **Zweck.** Diese Roadmap ist der **Koordinations-Index** über alle
+> thematischen Sub-Roadmaps. Sie ordnet, verknüpft und macht Meilensteine
+> abhakbar — sie ist **keine** neue Architekturentscheidung und **kein**
+> neuer Plan.
+>
+> **Abgrenzung.** `docs/process/fahrplan.md` ordnet die infrastrukturellen
+> Gates A–D. Diese Datei ordnet die thematischen Stränge.
+> `docs/reports/optimierungsstatus.md` führt den belegten Statusbeweis.
+> Hier: Reihenfolge & Verlinkung. Dort: Statusmessung mit Nachweisen.
+
+## Statuslegende
+
+- `[ ]` offen
+- `[~]` in Arbeit
+- `[x]` erledigt (Beleg im Sub-Dokument oder Statusmatrix)
+- `[?]` Status unklar — erfordert Belegung in der jeweiligen Statusmatrix
+
+Der eigentliche Wahrheitsbeweis lebt in den Sub-Roadmaps und Statusmatrizen.
+Haken hier sind verdichtete Repräsentationen, keine Eigenwahrheiten.
+
+## Leitprinzipien
+
+1. **Kein Haken ohne Beleg.** Verweise auf konkrete Sub-Tasks oder
+   Statuszeilen. Kein stilles Glätten.
+2. **Sub-Roadmap führt.** Wenn diese Datei und eine Sub-Roadmap divergieren,
+   führt die Sub-Roadmap. Diese Datei ist abhängig.
+3. **Klein schneiden.** Aufnahme nur dort, wo Koordinationsbedarf zwischen
+   Themen besteht. Themen-interne Schritte bleiben in der Sub-Roadmap.
+4. **Reihenfolge vor Vollständigkeit.** Diese Datei priorisiert
+   Abhängigkeiten zwischen Themen, nicht die Themen-internen Phasen.
+
+## Themen-Übersicht
+
+| Thema | Sub-Roadmap | Statusbeleg |
+|---|---|---|
+| Auth | [auth-roadmap.md](blueprints/auth-roadmap.md) | [auth-status-matrix.md](reports/auth-status-matrix.md) |
+| Auth-Persistenz (Runtime-Proof) | [auth-persistence-runtime-proof.md](blueprints/auth-persistence-runtime-proof.md) | [auth-persistence-readiness.md](reports/auth-persistence-readiness.md), [auth-persistence-next-step.md](reports/auth-persistence-next-step.md) |
+| UI | [ui-roadmap.md](blueprints/ui-roadmap.md) | (UI-State-Machine-Tests) |
+| Basemap | [map-roadmap.md](blueprints/map-roadmap.md) | [map-status-matrix.md](reports/map-status-matrix.md) |
+| Kartenklarheit | [kartenklarheit-roadmap.md](blueprints/kartenklarheit-roadmap.md) | [map-architekturkritik.md](reports/map-architekturkritik.md) |
+| Kartenklarheit Phase 6 (Wahrheitsbeweis) | [kartenklarheit-phase6.md](blueprints/kartenklarheit-phase6.md) | [map-status-matrix.md](reports/map-status-matrix.md) |
+| Agent-Operability | [agent-operability-blaupause.md](blueprints/agent-operability-blaupause.md) | [agent-readiness-audit.md](reports/agent-readiness-audit.md) |
+| Versionierung | [versionierungs-blaupause.md](blueprints/versionierungs-blaupause.md) | [versionierungs-statusgrundlage.md](blueprints/versionierungs-statusgrundlage.md) |
+| Optimierungsfront | (kein Sub-Plan) | [optimierungsstatus.md](reports/optimierungsstatus.md), [optimierungsbericht.md](reports/optimierungsbericht.md) |
+
+## Strang Auth
+
+Reihenfolge: Kanonisierung → Step-up → Persistenz-Runtime-Proof → DbSessionStore.
+
+- [x] Phase 0 — Kanonisierung & Drift-Stopp · [auth-roadmap §4](blueprints/auth-roadmap.md)
+- [x] Phase 1 — Ist-vs-Ziel-Beweis · [auth-roadmap §5](blueprints/auth-roadmap.md)
+- [x] Phase 2 — Session-/Device-Modell vervollständigen · [auth-roadmap §6](blueprints/auth-roadmap.md)
+- [~] Phase 3 — Step-up Auth · Passkey-Pfad offen · [auth-roadmap §7](blueprints/auth-roadmap.md)
+- [ ] Phase 4 — Auth-Persistenz Runtime-Proof (SQLx + PgBouncer) · [auth-persistence-runtime-proof.md](blueprints/auth-persistence-runtime-proof.md)
+- [ ] Phase 5 — `DbSessionStore` / `SessionBackend`-Abstraktion · folgt aus Runtime-Proof
+- [ ] Phase 6 — Auth-Statusmatrix vollständig grün · [auth-status-matrix.md](reports/auth-status-matrix.md)
+
+## Strang UI
+
+- [x] Phase 1 — Kompositionseditor vollenden · [ui-roadmap Phase 1](blueprints/ui-roadmap.md)
+- [x] Phase 2 — Zustandsdurchsetzung härten · [ui-roadmap Phase 2](blueprints/ui-roadmap.md)
+- [x] Phase 3 — Fokus-Panels (Node/Account/Edge) · [ui-roadmap Phase 3](blueprints/ui-roadmap.md)
+- [x] Phase 4 — Suche, Filter, A11y · [ui-roadmap Phase 4](blueprints/ui-roadmap.md)
+- [x] Phase 5 — Doku-/Strukturpflege · [ui-roadmap Phase 5](blueprints/ui-roadmap.md)
+- [ ] Auth-UI-Integration: Step-up-Consume + Passkey-Eintragspunkt · folgt aus Auth-Phase 3
+
+## Strang Karte (Basemap + Kartenklarheit)
+
+Reihenfolge: Daten-/Szenenklarheit → Souveräne Basemap-Pipeline → Runtime-Proof.
+
+- [x] Kartenklarheit Phasen 0–4 — Ist sichern, Datenquelle, Szenengrenzen, Regressionen · [kartenklarheit-roadmap.md](blueprints/kartenklarheit-roadmap.md)
+- [~] Kartenklarheit Phase 5 — Souveräne Basemap-Infrastruktur · [kartenklarheit-roadmap §155](blueprints/kartenklarheit-roadmap.md)
+- [~] Basemap-Roadmap Phasen 1–3 — Pipeline, Style, Runtime-Integration · [map-roadmap.md](blueprints/map-roadmap.md)
+- [ ] Basemap-Roadmap Phase 4 — Betrieb & Versionierung
+- [ ] Basemap-Roadmap Phase 5 — Ausbau (Faden-Dichte)
+- [ ] Kartenklarheit Phase 6 — Wahrheitsbeweis (Runtime, E2E, visuelle Abnahme, CI) · [kartenklarheit-phase6.md](blueprints/kartenklarheit-phase6.md)
+
+## Strang Agent-Operability
+
+- [~] Minimaler Action-Layer · [agent-operability-blaupause.md](blueprints/agent-operability-blaupause.md)
+- [?] Agent-Readiness vollständig grün · [agent-readiness-audit.md](reports/agent-readiness-audit.md)
+
+## Strang Versionierung
+
+- [?] Versionierungsmodell festziehen · [versionierungs-blaupause.md](blueprints/versionierungs-blaupause.md)
+- [?] Statusgrundlage gegen Repo prüfen · [versionierungs-statusgrundlage.md](blueprints/versionierungs-statusgrundlage.md)
+
+## Strang Optimierungsfront
+
+- Verfolgt direkt in [optimierungsstatus.md](reports/optimierungsstatus.md). Diese Roadmap dupliziert die Tickets nicht.
+
+## Themenübergreifende Reihenfolge (Was vor Was)
+
+1. **Auth-Persistenz Runtime-Proof** vor `DbSessionStore`.
+2. **Auth-Phase 3 (Step-up)** vor **UI Auth-Integration**.
+3. **Kartenklarheit Phase 5 (souveräne Pipeline)** vor **Phase 6 (Wahrheitsbeweis)**.
+4. **Basemap-Roadmap Phase 3 (Runtime-Integration)** überlappt mit
+   **Kartenklarheit Phase 5/6** — gemeinsame Schnittmenge: PMTiles-Auslieferung
+   über Caddy mit reproduzierbarem Artefakt.
+5. **Versionierungs-Statusgrundlage** vor jedem Feature, das semver-relevante
+   Schemata berührt (Domain-Contracts).
+
+## Pflege-Regeln
+
+- Diese Datei ist nur dann anzupassen, wenn eine Sub-Roadmap einen Phasen-
+  oder Reihenfolge-Wechsel bekommt. Themen-interne Detail-Tasks gehören
+  **nicht** hierher.
+- Statuswechsel hier nur, wenn die zugehörige Sub-Roadmap oder Statusmatrix
+  den Wechsel bereits belegt.
+- Bei Drift zwischen dieser Datei und einer Sub-Roadmap: Sub-Roadmap führt;
+  diese Datei nachziehen oder einen Drift-Eintrag in
+  [optimierungsstatus.md](reports/optimierungsstatus.md) anlegen.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,29 +10,29 @@ summary: >
   Agent-Operability, Versionierung) ordnet und Meilensteine abhakbar macht.
   Sie ersetzt keine Sub-Roadmap und keinen Statusbericht, sondern verknüpft sie.
 relations:
-  - type: relates_to
+  - type: depends_on
     target: docs/process/fahrplan.md
-  - type: relates_to
+  - type: depends_on
     target: docs/blueprints/auth-roadmap.md
-  - type: relates_to
+  - type: depends_on
     target: docs/blueprints/auth-persistence-runtime-proof.md
-  - type: relates_to
+  - type: depends_on
     target: docs/blueprints/ui-roadmap.md
-  - type: relates_to
+  - type: depends_on
     target: docs/blueprints/map-roadmap.md
-  - type: relates_to
+  - type: depends_on
     target: docs/blueprints/kartenklarheit-roadmap.md
-  - type: relates_to
+  - type: depends_on
     target: docs/blueprints/kartenklarheit-phase6.md
-  - type: relates_to
+  - type: depends_on
     target: docs/blueprints/agent-operability-blaupause.md
-  - type: relates_to
+  - type: depends_on
     target: docs/blueprints/versionierungs-blaupause.md
-  - type: relates_to
+  - type: depends_on
     target: docs/reports/optimierungsstatus.md
-  - type: relates_to
+  - type: depends_on
     target: docs/reports/auth-status-matrix.md
-  - type: relates_to
+  - type: depends_on
     target: docs/reports/map-status-matrix.md
 ---
 


### PR DESCRIPTION
## Ziel

Neue Master-Umsetzungsroadmap (`docs/roadmap.md`) als Koordinations-Index über alle thematischen Sub-Roadmaps (Auth, UI, Karte, Agent-Operability, Versionierung). Macht Meilensteine abhakbar und ordnet Reihenfolge-Abhängigkeiten zwischen Themen.

## Motivation / Kontext

Bisher existieren Sub-Roadmaps für einzelne Themen, aber kein übergeordneter Koordinations-Punkt, der:
- Reihenfolge-Abhängigkeiten zwischen Themen sichtbar macht (z.B. Auth-Phase 3 vor UI Auth-Integration)
- Meilensteine zentral abhakbar macht
- Auf Sub-Roadmaps und Statusmatrizen verweist, ohne sie zu duplizieren

Diese Roadmap schließt diese Lücke und ersetzt nicht die Sub-Roadmaps oder Statusberichte, sondern verknüpft sie.

## Änderungen

- [x] Docs

### Neue Datei: `docs/roadmap.md`

- **Zweck:** Koordinations-Index über Auth, UI, Karte (Basemap + Kartenklarheit), Agent-Operability, Versionierung und Optimierungsfront
- **Struktur:**
  - Statuslegende und Leitprinzipien (kein Haken ohne Beleg, Sub-Roadmap führt)
  - Themen-Übersicht mit Links zu Sub-Roadmaps und Statusmatrizen
  - Pro Thema: Phasen mit Status und Verweise auf konkrete Sub-Dokumente
  - Themenübergreifende Reihenfolge (Was vor Was)
  - Pflege-Regeln und Relations-Hinweis (begründet den hohen Outbound-Wert)
- **Relationen:** 12 `depends_on`-Kanten auf Sub-Roadmaps, Statusmatrizen und `docs/process/fahrplan.md`. Der Mechanismus ist `relations[]` mit `type: depends_on` gemäß Docmeta-Contract; eine Umstellung auf Top-Level-`depends_on` wäre eine separate Docmeta-Harmonisierung und ist hier bewusst out of scope.

### Automatisch aktualisierte Generated Files

- `docs/_generated/relates-to-audit.md`: Cluster-Analyse zeigt `docs/roadmap.md` mit 12 ausgehenden Relationen (möglicher Over-Linking-Hinweis vom Generator, aber als Koordinations-Hub beabsichtigt; im Dokument selbst unter „Relations-Hinweis" erklärt)
- `docs/_generated/backlinks.md`: Alle Sub-Roadmaps und Statusmatrizen zeigen jetzt Backlinks zu `docs/roadmap.md`
- `docs/_generated/relations-analysis.md`: Neue Metriken (depends_on: 13, keine Zyklen)
- `docs/_generated/doc-index.md`: Neue Einträge für `docs/roadmap.md` und `docs/blueprints/auth-persistence-runtime-proof.md`
- `docs/index.md`: Neue Sektion „Master-Umsetzungsroadmap" mit Link zu `roadmap.md`
- `docs/_generated/implicit-dependencies.md`, `docs/_generated/doc-coverage.md`: Folge-Updates aus `make generate`

## Review-Antworten

- **Codex (Kartenklarheit-Haken):** fixed in 3f755f1 — Phasen 0–4 [x] aufgesplittet in Phasen 0–3 [x] + Phase 4 [~], weil die Quell-Roadmap Phase 4 explizit mit offenem Arbeitspaket (Tastatur-/Query-Parameter-Navigation) und Stop-Kriterium [~] führt.
- **Copilot (PR-Beschreibung):** fixed — `12 depends_on`-Kanten statt fälschlich „12 relates_to-Links".
- **Copilot (Top-Level `depends_on`):** nicht in diesem PR. Der aktuelle Docmeta-Contract konsumiert `relations[]` und zählt die Einträge korrekt als `depends_on` ohne Zyklen. Eine Verschiebung in Top-Level-`depends_on` wäre eine breitere Docmeta-Semantik-Bereinigung und gehört in einen separaten Cleanup-PR.

## Risikoabschätzung

**Keine Risiken:**
- Reine Dokumentation, keine Code-Änderungen
- Verweist auf existierende Sub-Roadmaps und Statusmatrizen
- Keine neuen Abhängigkeiten oder Prozessänderungen

**Wartung:**
- Roadmap muss nachgezogen werden, wenn Sub-Roadmaps Phasen-/Reihenfolge-Wechsel bekommen
- Drift-Regel: Sub-Roadmap führt; diese Datei ist abhängig

## Verifikation

- Alle generierten Dateien wurden durch `make generate` aktualisiert
- Schema- und Link-Checks grün; vorbestehender Validation-Error in `docs/reports/auth-persistence-next-step.md` (relation type `updates`) liegt bereits auf `main` und ist out of scope dieses PRs

https://claude.ai/code/session_01BFdebWaYKVYkNJ7J1QkkTe