### PR TITLE
docs(auth): canonize direct Postgres as production auth-persistence path

### DIFF
--- a/docs/adr/ADR-0007__auth-persistence-production-db-path.md
+++ b/docs/adr/ADR-0007__auth-persistence-production-db-path.md
@@ -5,7 +5,7 @@ doc_type: reference
 status: accepted
 summary: >
   Kanonisiert den Produktionspfad für Auth-Persistenz: direkter PostgreSQL-Zugriff
-  via DATABASE_URL. PgBouncer bleibt Dev-/Proof-/Spezialpfad und ist kein
+  via DATABASE_URL. PgBouncer bleibt Dev-/Spezialpfad und ist kein
   Produktions-Gate für DbSessionStore.
 relations:
   - type: relates_to
@@ -38,9 +38,11 @@ accepted
 
 ## Entscheidung
 
-Production auth persistence uses direct PostgreSQL via `DATABASE_URL`.
+Die produktive Auth-Persistenz nutzt direkten PostgreSQL-Zugriff über
+`DATABASE_URL`.
 
-PgBouncer is development/proof infrastructure and not a required production path.
+PgBouncer ist Dev-/Spezialinfrastruktur und kein erforderlicher
+Produktionspfad.
 
 ## Begründung
 

--- a/docs/adr/ADR-0007__auth-persistence-production-db-path.md
+++ b/docs/adr/ADR-0007__auth-persistence-production-db-path.md
@@ -1,0 +1,65 @@
+---
+id: adr.ADR-0007-auth-persistence-production-db-path
+title: "ADR-0007 — Auth-Persistenz Produktionspfad: Direkter PostgreSQL-Zugriff statt PgBouncer"
+doc_type: reference
+status: accepted
+summary: >
+  Kanonisiert den Produktionspfad für Auth-Persistenz: direkter PostgreSQL-Zugriff
+  via DATABASE_URL. PgBouncer bleibt Dev-/Proof-/Spezialpfad und ist kein
+  Produktions-Gate für DbSessionStore.
+relations:
+  - type: relates_to
+    target: docs/adr/ADR-0006__auth-magic-link-session-passkey.md
+  - type: relates_to
+    target: docs/blueprints/auth-roadmap.md
+  - type: relates_to
+    target: docs/reports/auth-persistence-runtime-target-reconciliation.md
+  - type: relates_to
+    target: docs/reports/auth-persistence-runtime-proof.md
+  - type: relates_to
+    target: docs/proofs/sqlx-pgbouncer-session-crud-proof.md
+---
+
+# ADR-0007 — Auth-Persistenz Produktionspfad: Direkter PostgreSQL-Zugriff statt PgBouncer
+
+## Status
+
+accepted
+
+## Kontext
+
+- Der Dev-Stack enthält PgBouncer (`compose.core.yml`, Port 6432, transaction mode).
+- Der Prod-Stack enthält keinen PgBouncer (`compose.prod.yml`).
+- Die Heimserver-Runtime zeigt keinen PgBouncer-Service.
+- `.env.example` setzt `DATABASE_URL` auf direkten Postgres-Port 5432.
+- Die API liest ausschließlich `DATABASE_URL`.
+- Der SQLx/PgBouncer-Test ist nur `READY_FOR_PROOF` und kein Runtime-Beweis.
+- PgBouncer als Prod-Gate ist dokumentarisch angenommen, aber runtime-seitig nicht kanonisch.
+
+## Entscheidung
+
+Production auth persistence uses direct PostgreSQL via `DATABASE_URL`.
+
+PgBouncer is development/proof infrastructure and not a required production path.
+
+## Begründung
+
+- Geringere Betriebs- und Debug-Komplexität.
+- Weniger Failure Surfaces.
+- Der bestehende Prod-Stack entspricht bereits diesem Modell.
+- Kein nachgewiesener Lastdruck für Connection-Pooling.
+- PgBouncer transaction mode erzeugt zusätzliche SQLx-/Prepared-Statement-Komplexität.
+
+## Konsequenzen
+
+- `DbSessionStore` darf gegen den direkten PostgreSQL-Pfad geplant werden.
+- Der PgBouncer-SQLx-Proof ist ein optionaler Spezialpfad, kein Persistenz-Gate.
+- Dokumentation muss Dev-vs-Prod sauber trennen.
+- Eine spätere Rückkehr zu PgBouncer als Produktionspfad erfordert ein neues ADR.
+
+## Nicht-Ziele
+
+- Keine Compose-Änderung.
+- Kein Runtime-Proof.
+- Kein CI-PgBouncer-Job.
+- Keine Persistenzimplementierung.

--- a/docs/blueprints/auth-persistence-runtime-proof.md
+++ b/docs/blueprints/auth-persistence-runtime-proof.md
@@ -6,15 +6,17 @@ status: active
 created: 2026-05-06
 lang: de
 summary: >
-  Blueprint für sichere und schlanke Auth-Session-Persistenz: erst SQLx-,
-  PostgreSQL- und PgBouncer-Runtime-Pfad beweisen, danach DbSessionStore oder
-  SessionBackend-Abstraktion implementieren.
+  Blueprint für sichere und schlanke Auth-Session-Persistenz: erst den direkten
+  SQLx/PostgreSQL-Produktionspfad beweisen, danach DbSessionStore oder
+  SessionBackend-Abstraktion implementieren. PgBouncer bleibt nach ADR-0007
+  optionaler Dev-/Proof-/Spezialpfad.
 depends_on:
   - docs/adr/ADR-0006__auth-magic-link-session-passkey.md
   - docs/blueprints/auth-roadmap.md
   - docs/reports/auth-persistence-readiness.md
   - docs/reports/auth-persistence-next-step.md
   - docs/reports/optimierungsstatus.md
+  - docs/adr/ADR-0007__auth-persistence-production-db-path.md
 relations:
   - type: relates_to
     target: docs/adr/ADR-0006__auth-magic-link-session-passkey.md
@@ -26,6 +28,8 @@ relations:
     target: docs/reports/auth-persistence-readiness.md
   - type: relates_to
     target: docs/reports/auth-persistence-next-step.md
+  - type: relates_to
+    target: docs/adr/ADR-0007__auth-persistence-production-db-path.md
 ---
 
 # Auth-Persistenz — Runtime-Proof-Blaupause
@@ -40,13 +44,14 @@ relations:
 ### These
 
 `SessionStore` soll persistent werden. PostgreSQL ist der naheliegende Zielpfad,
-weil bereits `sqlx`, `PgPool`, PostgreSQL, PgBouncer und eine `sessions`-Migration
-im Repo vorhanden sind.
+weil bereits `sqlx`, `PgPool`, PostgreSQL und eine `sessions`-Migration im Repo
+vorhanden sind. PgBouncer ist zusätzlich im Dev-Stack vorhanden, aber nach ADR-0007
+kein Produktionspfad.
 
 ### Antithese
 
-Direkt `DbSessionStore` zu bauen ist riskant, solange SQLx, PostgreSQL,
-PgBouncer und Migrationen im echten Runtime-Pfad nicht bewiesen sind. Ein
+Direkt `DbSessionStore` zu bauen ist riskant, solange SQLx, PostgreSQL und
+Migrationen im direkten Produktionspfad nicht bewiesen sind. Ein
 Feature-PR ohne Runtime-Beleg würde Auth-Code, async-Abstraktion und
 Infrastruktur-Risiken vermischen.
 
@@ -55,7 +60,7 @@ Infrastruktur-Risiken vermischen.
 Runtime-Proof zuerst, danach adaptive Implementierung. Der Idealfall besteht aus
 zwei PRs:
 
-1. Runtime-Proof gegen PostgreSQL und, falls im aktiven Stack vorgesehen, PgBouncer.
+1. Runtime-Proof gegen direkten PostgreSQL-Zugriff via `DATABASE_URL`; PgBouncer nur optional, falls im aktiven Dev-/Spezialstack vorgesehen.
 2. Persistenz-Implementierung mit kleinem Scope: entweder direkt `DbSessionStore`
    oder zuerst eine `SessionBackend`-/`SessionOps`-Abstraktion.
 
@@ -72,7 +77,8 @@ Ergebnisziel:
 - Sessions überleben API-Neustarts.
 - Serverseitiger Widerruf bleibt möglich.
 - Offline-Tests ohne Datenbank bleiben grün.
-- Runtime-Pfad mit PostgreSQL und, sofern Stack-Ziel, PgBouncer ist belegt.
+- Produktionspfad mit direktem PostgreSQL-Zugriff via `DATABASE_URL` ist belegt.
+- PgBouncer ist nur für Dev-/Proof-/Spezialpfade relevant und kein Produktions-Gate.
 
 ---
 
@@ -131,7 +137,7 @@ weil es in großen Codebasen langsam ist.
 
 | Schritt | PR | Zweck |
 |---|---|---|
-| 1 | `chore(db): prove SQLx migration and PgBouncer runtime path` | Runtime-Pfad belegen, keine Auth-Feature-Arbeit |
+| 1 | `chore(db): prove direct SQLx/Postgres session path` | Direkten Produktionspfad belegen, keine Auth-Feature-Arbeit; PgBouncer nur optional, wenn im aktiven Dev-/Spezialstack vorgesehen |
 | 2 | `feat(auth): implement Postgres-backed sessions` oder `refactor(auth): introduce SessionBackend abstraction` | Persistenz oder vorbereitende Abstraktion |
 
 Regel: Mehr Phasen nur, wenn PR 1 echte Hindernisse zeigt.
@@ -142,12 +148,12 @@ Regel: Mehr Phasen nur, wenn PR 1 echte Hindernisse zeigt.
 
 ### Titel
 
-`chore(db): prove SQLx migration and PgBouncer runtime path`
+`chore(db): prove direct SQLx/Postgres session path`
 
 ### Ziel
 
 Beweisen, dass die vorhandene `sessions`-Migration und ein minimaler SQLx-Zugriff
-gegen den echten DB-Pfad funktionieren.
+gegen den direkten PostgreSQL-Produktionspfad funktionieren.
 
 ### Nicht tun
 
@@ -211,7 +217,7 @@ sqlx migrate run --source apps/api/migrations
 
 ### Migration gegen PgBouncer
 
-Nur ausführen, wenn PgBouncer im Stack aktiv ist. Zuerst Ziel-DB-Klasse
+Optionaler Dev-/Spezialpfad nach ADR-0007. Nur ausführen, wenn PgBouncer im aktiven Stack vorgesehen ist. Zuerst Ziel-DB-Klasse
 dokumentieren.
 
 Variante A — nur für `disposable-local`:
@@ -254,8 +260,8 @@ cargo test --locked -p weltgewebe-api
 
 | Ergebnis | Folge |
 |---|---|
-| PostgreSQL + PgBouncer + CRUD grün | Weiter zu PR 2 |
-| PostgreSQL grün, PgBouncer scheitert | Gezielte Mitigation |
+| Direkter PostgreSQL-SQLx-Pfad + CRUD grün | Weiter zu PR 2 |
+| PostgreSQL grün, PgBouncer scheitert | Prod-Pfad nicht blockiert; gezielte Mitigation nur für Dev-/Spezialpfad |
 | CRUD scheitert | Ursache isolieren |
 | DB nicht verfügbar | Umgebung herstellen oder Nebenpfad dokumentieren |
 | Offline-Tests scheitern | Stoppen, kein Auth-Umbau |
@@ -277,7 +283,7 @@ Nur anwenden, wenn PgBouncer-/Prepared-Statement-Fehler belegt sind.
 
 ### Option C — API direkt gegen PostgreSQL
 
-Nur wählen, wenn PgBouncer bewusst nicht Zielpfad ist.
+Nach ADR-0007 ist dies der Produktionszielpfad.
 
 Regel: Keine Infrastrukturänderung ohne reproduzierten Fehler.
 
@@ -409,9 +415,11 @@ Erst bei geschlossenem Runtime-, CI-, Deploy- und Restlückenbeweis:
 
 ## 12. Alternativpfade
 
-### Wenn DB/PgBouncer blockiert
+### Wenn DB blockiert
 
 `OPT-INF-001`: Trivy Image Scanning.
+
+Ein blockierter PgBouncer-Proof blockiert nur Dev-/Spezialpfade, nicht den Produktionspfad nach ADR-0007.
 
 ### Wenn Runtime-Proof blockiert, aber Code-Fortschritt nötig ist
 
@@ -427,12 +435,13 @@ Arbeite diagnose-first. Ziel ist ein Runtime-Proof-PR, kein Auth-Feature.
 
 PR-Titel:
 
-`chore(db): prove SQLx migration and PgBouncer runtime path`
+`chore(db): prove direct SQLx/Postgres session path`
 
 Aufgabe:
 
 Beweise, dass die bestehende `sessions`-Migration und ein minimaler SQLx-CRUD-Pfad
-gegen PostgreSQL und, falls im Stack vorgesehen, gegen PgBouncer funktionieren.
+gegen den direkten PostgreSQL-Produktionspfad funktionieren. PgBouncer nur optional
+prüfen, wenn er im aktiven Dev-/Spezialstack vorgesehen ist.
 
 Nicht tun:
 
@@ -479,7 +488,7 @@ Hebel: Erst DB-Runtime beweisen, dann Auth umbauen.
 Entscheidung: Zwei PRs: Runtime-Proof → Persistenz.
 
 Nächste Aktion: Agentenauftrag für
-`chore(db): prove SQLx migration and PgBouncer runtime path`.
+`chore(db): prove direct SQLx/Postgres session path`.
 
 Unsicherheitsgrad: `0.12` — lokale Runtime-Ausgaben fehlen.
 

--- a/docs/blueprints/auth-persistence-runtime-proof.md
+++ b/docs/blueprints/auth-persistence-runtime-proof.md
@@ -9,7 +9,7 @@ summary: >
   Blueprint für sichere und schlanke Auth-Session-Persistenz: erst den direkten
   SQLx/PostgreSQL-Produktionspfad beweisen, danach DbSessionStore oder
   SessionBackend-Abstraktion implementieren. PgBouncer bleibt nach ADR-0007
-  optionaler Dev-/Proof-/Spezialpfad.
+  optionaler Dev-/Spezialpfad.
 depends_on:
   - docs/adr/ADR-0006__auth-magic-link-session-passkey.md
   - docs/blueprints/auth-roadmap.md
@@ -78,7 +78,7 @@ Ergebnisziel:
 - Serverseitiger Widerruf bleibt möglich.
 - Offline-Tests ohne Datenbank bleiben grün.
 - Produktionspfad mit direktem PostgreSQL-Zugriff via `DATABASE_URL` ist belegt.
-- PgBouncer ist nur für Dev-/Proof-/Spezialpfade relevant und kein Produktions-Gate.
+- PgBouncer ist nur für Dev-/Spezialpfade relevant und kein Produktions-Gate.
 
 ---
 

--- a/docs/blueprints/auth-roadmap.md
+++ b/docs/blueprints/auth-roadmap.md
@@ -10,6 +10,8 @@ relations:
   - type: relates_to
     target: docs/adr/ADR-0006__auth-magic-link-session-passkey.md
   - type: relates_to
+    target: docs/adr/ADR-0007__auth-persistence-production-db-path.md
+  - type: relates_to
     target: docs/reports/auth-status-matrix.md
   - type: relates_to
     target: docs/specs/auth-blueprint.md
@@ -44,6 +46,7 @@ Diese Roadmap dient zugleich als:
 Diese Dokumente definieren den kanonischen Zielzustand:
 
 - `docs/adr/ADR-0006__auth-magic-link-session-passkey.md`
+- `docs/adr/ADR-0007__auth-persistence-production-db-path.md`
 - `docs/specs/auth-api.md`
 - `docs/specs/auth-state-machine.md`
 - `docs/specs/auth-ui.md`
@@ -213,6 +216,18 @@ Jeder relevante Bereich ist entweder:
 - `ApiState` enthält bereits ein optionales `db_pool: Option<PgPool>` als generelle DB-Infrastruktur; eine Session-spezifische Anbindung existiert noch nicht.
 - Die `SessionStore`-Schnittstelle (`create`, `get`, `delete`, `list_by_account`, `delete_by_device`, `delete_all_by_account`) ist abstrakt genug, um ohne Route-Änderungen auf einen persistenten Adapter umgestellt zu werden.
 - Challenge- und Token-Stores unterliegen derselben Einschätzung: kurzlebig (5 min TTL), sicherheitsunkritisch bei Verlust durch Restart.
+
+### Produktionspfad für persistenten Store
+
+**Entscheidung:** ADR-0007 legt den Produktionspfad für Auth-Persistenz auf direkten
+PostgreSQL-Zugriff via `DATABASE_URL` fest.
+
+**Folgen:**
+
+- `DbSessionStore` / `SessionBackend` wird gegen den direkten SQLx/Postgres-Pfad geplant.
+- PgBouncer bleibt Dev-/Proof-/Spezialpfad und ist kein Produktions-Gate.
+- Kein `DbSessionStore` ohne direkten SQLx/Postgres-Persistenzpfad-Nachweis.
+- Eine spätere Rückkehr zu PgBouncer als Produktionspfad erfordert ein neues ADR.
 
 **Trigger für Migration auf persistenten Store:**
 

--- a/docs/blueprints/auth-roadmap.md
+++ b/docs/blueprints/auth-roadmap.md
@@ -225,7 +225,7 @@ PostgreSQL-Zugriff via `DATABASE_URL` fest.
 **Folgen:**
 
 - `DbSessionStore` / `SessionBackend` wird gegen den direkten SQLx/Postgres-Pfad geplant.
-- PgBouncer bleibt Dev-/Proof-/Spezialpfad und ist kein Produktions-Gate.
+- PgBouncer bleibt Dev-/Spezialpfad und ist kein Produktions-Gate.
 - Kein `DbSessionStore` ohne direkten SQLx/Postgres-Persistenzpfad-Nachweis.
 - Eine spätere Rückkehr zu PgBouncer als Produktionspfad erfordert ein neues ADR.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,6 +52,7 @@ Kanonische Navigation. Neue UI-Dokumente bestehenden Kategorien zuordnen.
 ### Auth-Architektur (Kanonisch)
 
 – **ADR-0006:** [adr/ADR-0006__auth-magic-link-session-passkey.md](adr/ADR-0006__auth-magic-link-session-passkey.md) (Führendes Zielbild)
+– **ADR-0007:** [adr/ADR-0007__auth-persistence-production-db-path.md](adr/ADR-0007__auth-persistence-production-db-path.md) (Auth-Persistenz Produktionspfad: direkter PostgreSQL-Zugriff)
 – **Auth Roadmap:** [blueprints/auth-roadmap.md](blueprints/auth-roadmap.md) (Umsetzungspfad)
 – **Auth-Persistenz Runtime-Proof:** [blueprints/auth-persistence-runtime-proof.md](blueprints/auth-persistence-runtime-proof.md) (Blaupause)
 – **Auth Status Matrix:** [reports/auth-status-matrix.md](reports/auth-status-matrix.md) (Aktueller Repo-Beweis)
@@ -73,7 +74,7 @@ Kanonische Navigation. Neue UI-Dokumente bestehenden Kategorien zuordnen.
 – **Optimierungsbericht:** [reports/optimierungsbericht.md](reports/optimierungsbericht.md) (Schichtenanalyse mit Handlungsempfehlungen)
 – **Optimierungsstatus:** [reports/optimierungsstatus.md](reports/optimierungsstatus.md) (Operative Statusmatrix mit Nachweisen)
 – **Auth-Persistenzbereitschaft:** [reports/auth-persistence-readiness.md](reports/auth-persistence-readiness.md) (Diagnose zu OPT-API-002)
-– **Auth-Persistenz Zielarchitektur-Abgleich:** [reports/auth-persistence-runtime-target-reconciliation.md](reports/auth-persistence-runtime-target-reconciliation.md) (PgBouncer vs. direkter Postgres — OPEN_DECISION)
+– **Auth-Persistenz Zielarchitektur-Abgleich:** [reports/auth-persistence-runtime-target-reconciliation.md](reports/auth-persistence-runtime-target-reconciliation.md) (ADR-0007: Produktion direkter Postgres; PgBouncer Dev-/Spezialpfad)
 – **Passkey Register-Verify Vorbereitung:** [reports/passkey-register-verify-prep.md](reports/passkey-register-verify-prep.md) (Diagnose und Folge-PR-Entscheidung)
 – **Cost Report:** [reports/cost-report.md](reports/cost-report.md)
 

--- a/docs/proofs/sqlx-pgbouncer-session-crud-proof.md
+++ b/docs/proofs/sqlx-pgbouncer-session-crud-proof.md
@@ -7,8 +7,9 @@ created: 2026-05-13
 lang: de
 summary: >
   Rust/SQLx CRUD-Integrationstest gegen PgBouncer (transaction mode) → Postgres auf
-  der sessions-Tabelle. Bereitet den Beweis des produktionsnahen Verbindungspfads mit
-  statement_cache_capacity(0) als Mitigation vor (READY_FOR_PROOF). Kein chrono-Feature
+  der sessions-Tabelle. Bereitet einen optionalen Dev-/Spezialpfad mit
+  statement_cache_capacity(0) als Mitigation vor (READY_FOR_PROOF). Nach ADR-0007
+  ist dieser Proof kein Produktions-Gate für DbSessionStore. Kein chrono-Feature
   in sqlx, kein DbSessionStore, kein Auth-Umbau.
 depends_on:
   - docs/reports/auth-persistence-runtime-proof.md
@@ -20,6 +21,8 @@ relations:
     target: docs/reports/auth-persistence-next-step.md
   - type: relates_to
     target: docs/blueprints/auth-roadmap.md
+  - type: relates_to
+    target: docs/adr/ADR-0007__auth-persistence-production-db-path.md
 ---
 
 # SQLx → PgBouncer → Postgres — Session-CRUD-Proof
@@ -30,6 +33,8 @@ relations:
 > Der Proof wird erst vollständig, wenn jemand mit Stack + PgBouncer
 > `PGBOUNCER_URL=... cargo test -- sqlx_pgbouncer --include-ignored` lädt.
 > Eine Heimserver-/Produktiv-Runtime ist dadurch nicht automatisch eine Proof-Umgebung.
+> Nach ADR-0007 ist dieser Proof ein optionaler Dev-/Spezialpfad und kein
+> Produktions-Gate für `DbSessionStore`.
 >
 > Ziel dieses PRs: belegter Rust-SQLx-CRUD-Code gegen ein **sessions-spaltenkompatibles Proof-Fixture**
 > durch PgBouncer im transaction mode (syntax + semantik geprüft; Runtime-Beweis noch ausstehend).
@@ -38,11 +43,13 @@ relations:
 
 ## 1. Was genau bewiesen wurde (bzw. vorbereitet)
 
-Dieser PR bereitet den Beweis der zwei offenen NOT_PROVEN-Items aus
+Dieser PR bereitet den Beweis des PgBouncer-spezifischen NOT_PROVEN-Items aus
 `docs/reports/auth-persistence-runtime-proof.md`, Abschnitt 5, vor:
 
-> SQLx/Rust-API CRUD direkt Postgres — NOT_PROVEN
 > SQLx/Rust-API CRUD via PgBouncer transaction mode — NOT_PROVEN
+
+Das direkte SQLx/Postgres-Item bleibt separat nachzuweisen und ist nach ADR-0007
+relevant für den Produktionspfad.
 
 Der Integrationstest `apps/api/tests/sqlx_pgbouncer_session_crud.rs` ist:
 
@@ -205,18 +212,19 @@ Proof-Lauf. Der Test darf deshalb weiterhin **nicht** still skippen.
 
 ---
 
-## 7. Warum dieser PR das korrekte Gate vor dem Persistenz-PR ist
+## 7. Warum dieser PR kein Produktions-Gate mehr ist
 
-Aus `docs/reports/auth-persistence-runtime-proof.md`, Abschnitt 8:
+ADR-0007 entscheidet den Produktionspfad für Auth-Persistenz auf direkten
+PostgreSQL-Zugriff via `DATABASE_URL`. Damit ist dieser PgBouncer-Proof kein
+Blocker für einen produktiven `DbSessionStore`, der gegen den direkten
+SQLx/Postgres-Pfad geplant und belegt wird.
 
-> **Stop-Regel:** Wenn SQLx über PgBouncer scheitert, keine Session-Persistenz
-> verdrahten — erst Ursache isolieren und Mitigation belegen.
-
-Dieser PR liefert den **ausführbaren Beweisaufbau** für `sqlx::PgPool` mit
-`statement_cache_capacity(0)` über PgBouncer im transaction mode. Der eigentliche
-Runtime-Beweis ist erst erbracht, wenn der ignorierte Test mit `PGBOUNCER_URL`
-gegen den aktiven Stack erfolgreich ausgeführt wurde. Erst danach ist der
-`DbSessionStore`-PR architektonisch abgesichert.
+Dieser PR liefert weiterhin einen **ausführbaren Beweisaufbau** für `sqlx::PgPool`
+mit `statement_cache_capacity(0)` über PgBouncer im transaction mode. Der eigentliche
+PgBouncer-Runtime-Beweis ist erst erbracht, wenn der ignorierte Test mit
+`PGBOUNCER_URL` gegen den aktiven Stack erfolgreich ausgeführt wurde. Das Ergebnis
+ist relevant für Dev-/Proof-/Spezialbetriebe mit PgBouncer, aber nicht für die
+Produktionsentscheidung nach ADR-0007.
 
 ---
 
@@ -242,7 +250,7 @@ Nicht verändert: `apps/api/src/`, Migrations, Auth-Middleware, SessionStore, Ro
 | Cargo.lock: unverändert | ✅ PROVEN | kein `"chrono"`-Feature, keine neuen Dependencies |
 | Kein Auth-Verhalten geändert | ✅ PROVEN | Keine Code-Änderungen außerhalb `tests/` und `docs/proofs/` |
 | SQLx/Rust-API CRUD via PgBouncer transaction mode | ⚪ READY_FOR_PROOF | Test bereit; Ausführung erfordert `PGBOUNCER_URL` + aktiven Stack + `cargo test -- sqlx_pgbouncer --include-ignored` |
-| SQLx/Rust-API CRUD direkt Postgres | ⚪ NOT_CLAIMED | Test kann technisch gegen Postgres Port 5432 laufen, aber Scope ist PgBouncer |
+| SQLx/Rust-API CRUD direkt Postgres | ⚪ NOT_CLAIMED | Separater Produktionspfad nach ADR-0007; dieser Test hat bewusst PgBouncer-Scope |
 | `sqlx::migrate!` / sqlx-cli Migration | ❌ NOT_PROVEN | Separate Aufgabe; Test nutzt Fixture nicht sqlx-cli |
 
 **Wichtig:** Der Proof-Test beweist seine Hypothese erst durch tatsächliche Ausführung
@@ -265,5 +273,6 @@ PGBOUNCER_URL=postgres://... cargo test -p weltgewebe-api -- sqlx_pgbouncer --in
 ```
 
 Bis ein solcher Lauf tatsächlich erfolgreich belegt ist, bleibt dieser PR bewusst
-bei **READY_FOR_PROOF**. Die Stop-Regel bleibt bestehen: kein `DbSessionStore`
-ohne ausgeführten SQLx/PgBouncer-Proof.
+bei **READY_FOR_PROOF**. Nach ADR-0007 ist das ein optionaler Dev-/Spezialpfad:
+kein produktiver `DbSessionStore` gegen direkten PostgreSQL-Zugriff wird durch
+den fehlenden SQLx/PgBouncer-Proof blockiert.

--- a/docs/proofs/sqlx-pgbouncer-session-crud-proof.md
+++ b/docs/proofs/sqlx-pgbouncer-session-crud-proof.md
@@ -223,7 +223,7 @@ Dieser PR liefert weiterhin einen **ausführbaren Beweisaufbau** für `sqlx::PgP
 mit `statement_cache_capacity(0)` über PgBouncer im transaction mode. Der eigentliche
 PgBouncer-Runtime-Beweis ist erst erbracht, wenn der ignorierte Test mit
 `PGBOUNCER_URL` gegen den aktiven Stack erfolgreich ausgeführt wurde. Das Ergebnis
-ist relevant für Dev-/Proof-/Spezialbetriebe mit PgBouncer, aber nicht für die
+ist relevant für Dev-/Spezialbetriebe mit PgBouncer, aber nicht für die
 Produktionsentscheidung nach ADR-0007.
 
 ---

--- a/docs/reports/auth-persistence-next-step.md
+++ b/docs/reports/auth-persistence-next-step.md
@@ -447,4 +447,4 @@ isoliert sein, damit der bestehende Offline-Testpfad erhalten bleibt.
 | Strategie Postgres vs. Redis vs. Hybrid? | **strategisch gestützt** | PostgreSQL durch Doku und Diagnose als nächster Pfad gestützt; Redis/Hybrid ohne belegten Zusatznutzen; Runtime-Proof noch offen |
 | Was fehlt für Implementierung? | **belegt** | async-Abstraktion, `DbSessionStore`, Startup-Migration, CI-Gate |
 | PgBouncer-Kompatibilität? | **optionaler Spezialpfad** | SQLx prepared statements + statement cache + PgBouncer `transaction` mode (`edoburu/pgbouncer:1.20`) sind nicht belastbar kompatibel; nach ADR-0007 aber kein Produktions-Gate |
-| Weiterer vorgelagerter Diagnose-PR nötig? | **nein** | Kein weiterer Diagnose-PR nötig, sofern der Folge-PR die offenen Target-Proofs enthält: direkte `sqlx`-Migration/CRUD gegen PostgreSQL, `DbSessionStore`-CRUD-Integrationstest, weiterhin grüner Offline-Testpfad |
+| Weiterer vorgelagerter Diagnose-PR nötig? | **nein** | Kein weiterer Diagnose-PR nötig; vor produktivem `DbSessionStore` ist jedoch ein separater Nachweis des direkten SQLx/Postgres-Persistenzpfads zwingend (inkl. weiterhin grünem Offline-Testpfad). |

--- a/docs/reports/auth-persistence-next-step.md
+++ b/docs/reports/auth-persistence-next-step.md
@@ -55,7 +55,7 @@ Was fehlt bis zur vollständigen Session-Persistenz:
 2. Async-Abstraktion für `SessionStore` (Trait oder Enum-Dispatch)
 3. Startup-Migration in `apps/api/src/lib.rs`
 4. CI-Migrations-Step in `.github/workflows/api.yml`
-5. PgBouncer-Kompatibilitätsprüfung (`transaction` mode)
+5. Direkter SQLx/Postgres-Persistenzpfad-Nachweis; PgBouncer-Kompatibilitätsprüfung nur für optionale Dev-/Spezialpfade
 
 Prämissencheck zur Aufgabenstellung:
 
@@ -64,7 +64,7 @@ Prämissencheck zur Aufgabenstellung:
 | Auth-State ist mindestens teilweise flüchtig | **Bestätigt** | Fünf transiente Auth-Stores sind in-memory: Sessions, Tokens, StepUpTokens, Challenges und PasskeyRegistrations. Account-Stammdaten sind ein separates JSONL-Thema. |
 | Doku markiert Persistenz als Restlücke | **Bestätigt** | OPT-API-002 in `optimierungsstatus.md` = open; README-Note aktiv. |
 | Keine belastbare Entscheidung Postgres vs. Redis vs. Hybrid | **Teilweise falsch** | Die Doku stützt DB-first als nächsten Pfad; Runtime-Proof und Implementierungsdetails fehlen noch. |
-| Direkter Implementierungs-PR wäre zu annahmenreich | **Teilweise wahr** | PgBouncer-Modus, async-Abstraktion und CI-Gate sind noch ungeklärt. |
+| Direkter Implementierungs-PR wäre zu annahmenreich | **Teilweise wahr** | Direkter SQLx/Postgres-Nachweis, async-Abstraktion und CI-Gate fehlen noch. PgBouncer ist nach ADR-0007 kein Produktions-Gate. |
 
 ---
 
@@ -151,8 +151,9 @@ Divergenz zu `auth-persistence-readiness.md`: Dieses Vorgängerdokument stellte
 fest, dass kein Migrationsverzeichnis existiert. Das ist seit dem Schema-PR nicht mehr
 korrekt. Der aktuelle Ist-Zustand enthält ein Migrationsverzeichnis mit einer
 plausiblen `sessions`-Tabellendefinition. Runtime-Funktion noch nicht belegt:
-`sqlx migrate run` gegen PostgreSQL/PgBouncer und Query-Kompatibilität eines
-späteren `DbSessionStore` sind noch zu prüfen.
+`sqlx migrate run` und Query-Kompatibilität gegen direkten PostgreSQL-Zugriff sind
+für einen späteren `DbSessionStore` noch zu prüfen. PgBouncer bleibt nach ADR-0007
+optionaler Dev-/Spezialpfad.
 
 ### 2.3 DB-Pool (vorhanden, für Auth ungenutzt)
 
@@ -175,7 +176,7 @@ apps/api/src/routes/health.rs:164:    match state.db_pool.as_ref() {
 `db_pool` ist verdrahtet, aber **ausschließlich für den Health-Check** genutzt.
 Kein Auth-Handler liest oder schreibt über den Pool.
 
-### 2.4 PgBouncer-Konfiguration (belegt)
+### 2.4 PgBouncer-Konfiguration (belegt; optionaler Dev-/Spezialpfad nach ADR-0007)
 
 Kommando:
 
@@ -192,14 +193,14 @@ infra/compose/compose.core.yml:90:      POOL_MODE: transaction
 infra/compose/compose.core.yml:42:      DATABASE_URL: postgres://welt:gewebe@pgbouncer:6432/weltgewebe
 ```
 
-PgBouncer läuft im `transaction` mode und laut Compose-Befund aktuell mit Image
-`edoburu/pgbouncer:1.20`. Für einen künftigen `DbSessionStore` ist die Kompatibilität
-mit dem aktuellen Stack nicht belastbar abgesichert. `sqlx` verwendet prepared
-statements und transparentes Statement-Caching (`PgConnectOptions::statement_cache_capacity`,
-Default 100); ohne explizite Mitigation kann das auch bei einfachen CRUD-Operationen
-unter PgBouncer im `transaction` mode scheitern. Die Aussage „grundsätzlich kompatibel"
-wäre daher zu stark. Ein Folge-PR muss eine explizite PgBouncer/sqlx-Strategie wählen
-und empirisch prüfen.
+PgBouncer läuft im Dev-Stack im `transaction` mode und laut Compose-Befund aktuell
+mit Image `edoburu/pgbouncer:1.20`. Nach ADR-0007 ist PgBouncer kein Produktionspfad
+für Auth-Persistenz. Für Dev-/Spezialbetriebe bleibt die SQLx-Kompatibilität trotzdem
+nicht belastbar abgesichert: `sqlx` verwendet prepared statements und transparentes
+Statement-Caching (`PgConnectOptions::statement_cache_capacity`, Default 100); ohne
+explizite Mitigation kann das auch bei einfachen CRUD-Operationen unter PgBouncer im
+`transaction` mode scheitern. Eine PgBouncer/sqlx-Strategie ist daher nur für diese
+optionalen Pfade empirisch zu prüfen.
 
 ### 2.5 Redis-Status (belegt: nicht im Stack)
 
@@ -313,7 +314,7 @@ eigenständiger PR-Scope.
 | Option | Pro | Contra | Bewertung |
 |---|---|---|---|
 | **In-Memory belassen** | kein Aufwand, aktueller Zustand | Restart = Logout aller Nutzer; kein Multi-Instance | nur für PoC/Dev ohne SLA |
-| **PostgreSQL** | Stack vorhanden; Migration vorhanden; `db_pool` verdrahtet; keine neue Abhängigkeit | async-Abstraktion nötig; CI-Gate fehlt; PgBouncer-Modus zu prüfen | **empfohlen** (strategisch gestützt; Runtime-Proof offen) |
+| **PostgreSQL** | Stack vorhanden; Migration vorhanden; `db_pool` verdrahtet; keine neue Abhängigkeit; ADR-0007 legt direkten Produktionspfad fest | async-Abstraktion nötig; CI-Gate fehlt; direkter SQLx/Postgres-Proof fehlt | **empfohlen** (strategisch gestützt; Runtime-Proof offen) |
 | **Redis** | schnell für TTL-basierte Keys; kein Schema nötig | nicht im Stack; neue Abhängigkeit; kein Mehrwert für diesen Use-Case | nicht empfohlen |
 | **Hybrid** | kurzlebige Stores in Redis, Sessions in PG | komplexer Stack; zwei Systeme für dasselbe Problem | nicht empfohlen für aktuellen Scope |
 
@@ -339,9 +340,9 @@ vorwegzunehmen.
 ### Was müsste wahr sein, damit Postgres genügt?
 
 - **Belegt:** `db_pool` ist in `ApiState` vorhanden und `DATABASE_URL` konfiguriert.
-- **Belegt:** Eine `sessions`-Migration existiert und definiert die benötigten Kernspalten und Indizes. Runtime-Migrationsbeweis gegen PostgreSQL/PgBouncer und Query-Kompatibilität des späteren `DbSessionStore` stehen noch aus.
+- **Belegt:** Eine `sessions`-Migration existiert und definiert die benötigten Kernspalten und Indizes. Runtime-Migrationsbeweis gegen direkten PostgreSQL-Zugriff und Query-Kompatibilität des späteren `DbSessionStore` stehen noch aus.
 - **Belegt:** `sqlx` v0.8.1 ist als Abhängigkeit vorhanden.
-- **Offen (Risiko):** PgBouncer `transaction` mode ist ein explizites Kompatibilitätsrisiko. Der aktuelle PgBouncer-Stand (`edoburu/pgbouncer:1.20`) und die SQLx-Prepared-Statement-/Statement-Cache-Nutzung müssen im Folge-PR entweder konfigurationsseitig entschärft (z. B. Statement-Cache deaktivieren, PgBouncer-Upgrade mit `max_prepared_statements`) oder durch eine andere Pooling-/Verbindungsstrategie ersetzt werden. Der CRUD-Pfad muss gegen PostgreSQL/PgBouncer getestet werden.
+- **Entschieden:** ADR-0007 macht direkten PostgreSQL-Zugriff via `DATABASE_URL` zum Produktionspfad; PgBouncer `transaction` mode bleibt optionales Kompatibilitätsrisiko für Dev-/Spezialpfade.
 - **Offen:** Startup-Migration (`sqlx::migrate!`) muss sicher sein bei nicht-konfiguriertem Pool (bestehende Tests nutzen `db_pool: None`).
 - **Offen:** CI-Gate muss Migrations- und Integrationstests ohne Datenbankverbindung weiterhin erlauben (aktueller In-Memory-Pfad muss erhalten bleiben).
 
@@ -430,7 +431,7 @@ isoliert sein, damit der bestehende Offline-Testpfad erhalten bleibt.
 
 1. **Async-Abstraktion:** `SessionOps`-Trait mit `async_trait` oder `SessionBackend`-Enum mit `match`-Dispatch? Beides ist möglich. Enum-Dispatch hat weniger Indirektion; Trait ist erweiterbar. Entscheidung im PR-Review.
 
-2. **PgBouncer `transaction` mode:** Muss verifiziert werden, dass `sqlx::PgPool`-CRUD ohne Prepared-Statement-/Statement-Cache-Probleme läuft. `sqlx::query!`-Makros sind hierfür keine Abhilfe: Auch sie verwenden prepared statements und lösen das PgBouncer-Grundproblem nicht; zusätzlich setzen sie `cargo sqlx prepare` / eingecheckte `.sqlx`-Datei oder eine Live-Datenbank beim Compile voraus. Der Folge-PR muss eine explizite Mitigation wählen und testen — z. B. Statement-Cache auf 0 setzen (`PgConnectOptions::statement_cache_capacity(0)`), PgBouncer-Upgrade auf ≥ 1.21 mit `max_prepared_statements > 0`, Session-Pooling für die API, oder direkte Postgres-Verbindung ohne PgBouncer. Keine dieser Optionen gilt ohne Integrationstest als bewiesen.
+2. **Direkter SQLx/Postgres-Pfad:** Nach ADR-0007 muss der Folge-PR verifizieren, dass `sqlx::PgPool`-CRUD gegen direkten PostgreSQL-Zugriff über `DATABASE_URL` funktioniert. PgBouncer-Varianten (Statement-Cache auf 0, PgBouncer-Upgrade auf ≥ 1.21 mit `max_prepared_statements > 0`, Session-Pooling) sind optionale Dev-/Spezialpfade und keine Produktionsvoraussetzung.
 
 3. **Startup-Fehlerverhalten:** Wenn `db_pool_configured = true` und Pool nicht verfügbar, soll die API nicht still auf In-Memory fallen — expliziter Fehler ist korrekt (bereits in `auth-persistence-readiness.md` definiert).
 
@@ -445,5 +446,5 @@ isoliert sein, damit der bestehende Offline-Testpfad erhalten bleibt.
 | Migrations-Schema vorhanden? | **belegt** | Ja, seit 2026-04-28 — aber nicht in Startup aktiviert |
 | Strategie Postgres vs. Redis vs. Hybrid? | **strategisch gestützt** | PostgreSQL durch Doku und Diagnose als nächster Pfad gestützt; Redis/Hybrid ohne belegten Zusatznutzen; Runtime-Proof noch offen |
 | Was fehlt für Implementierung? | **belegt** | async-Abstraktion, `DbSessionStore`, Startup-Migration, CI-Gate |
-| PgBouncer-Kompatibilität? | **offenes Risiko** | SQLx prepared statements + statement cache + PgBouncer `transaction` mode (`edoburu/pgbouncer:1.20`) sind nicht belastbar kompatibel; Mitigation und Integrationstest sind Pflicht im Folge-PR |
-| Weiterer vorgelagerter Diagnose-PR nötig? | **nein** | Kein weiterer Diagnose-PR nötig, sofern der Folge-PR die offenen Target-Proofs enthält: `sqlx`-Migration gegen PostgreSQL/PgBouncer, `DbSessionStore`-CRUD-Integrationstest, weiterhin grüner Offline-Testpfad |
+| PgBouncer-Kompatibilität? | **optionaler Spezialpfad** | SQLx prepared statements + statement cache + PgBouncer `transaction` mode (`edoburu/pgbouncer:1.20`) sind nicht belastbar kompatibel; nach ADR-0007 aber kein Produktions-Gate |
+| Weiterer vorgelagerter Diagnose-PR nötig? | **nein** | Kein weiterer Diagnose-PR nötig, sofern der Folge-PR die offenen Target-Proofs enthält: direkte `sqlx`-Migration/CRUD gegen PostgreSQL, `DbSessionStore`-CRUD-Integrationstest, weiterhin grüner Offline-Testpfad |

--- a/docs/reports/auth-persistence-readiness.md
+++ b/docs/reports/auth-persistence-readiness.md
@@ -212,8 +212,9 @@ reiner In-Memory-Zugriff, keine Datenbankabfrage.
 - `db_pool: Option<PgPool>` ist bereits in `ApiState` verdrahtet —
   Infrastruktur vorhanden, nur nicht für Auth genutzt.
 - PostgreSQL ist in den betrachteten Dev-/Prod-Basisstacks vorhanden und wird
-  von der API über `DATABASE_URL` adressiert; Profil-Parität und PgBouncer-Policy
-  bleiben separat zu prüfen.
+  von der API über `DATABASE_URL` adressiert; nach ADR-0007 ist direkter
+  PostgreSQL-Zugriff der Produktionspfad. PgBouncer bleibt optionaler
+  Dev-/Spezialpfad.
 - Die DB-Extensions `uuid-ossp` und `pgcrypto` sind bereits aktiv
   (`infra/compose/sql/init/00_extensions.sql`).
 - `SessionStore`-Methodenoberfläche deckt alle nötigen Operationen ab;
@@ -391,7 +392,7 @@ mit gleicher Schnittstelle parallel für beide Backends bestehen.
 | Risiko | Schwere | Wahrscheinlichkeit | Maßnahme |
 |---|---|---|---|
 | API-Neustart löscht alle Sessions (Ist-Zustand) | hoch | bei jedem Deploy | `sessions`-Tabelle einführen |
-| DB-Ausfall bei persistentem Store → alle Auth-Ops fehlerhaft | hoch | kontextabhängig / nicht abschließend belegt | Klar scheitern statt In-Memory-Fallback; Readiness/Health muss DB-Ausfall sichtbar machen; PgBouncer-Parität für Dev/Prod separat prüfen |
+| DB-Ausfall bei persistentem Store → alle Auth-Ops fehlerhaft | hoch | kontextabhängig / nicht abschließend belegt | Klar scheitern statt In-Memory-Fallback; Readiness/Health muss DB-Ausfall sichtbar machen; direkter Postgres-Produktionspfad muss nachgewiesen werden |
 | Migration läuft nicht idempotent → CI-Bruch | mittel | niedrig | Keine `IF NOT EXISTS`-Kaschierung in der Up-Migration; die Migration soll bei unerwartetem Vorzustand scheitern. Das sqlx-Migrationsprotokoll verhindert reguläre Doppelausführung. |
 | `DbSessionStore` verdrängt `SessionStore` → In-Memory-Testharness bricht | niedrig | niedrig | `test_state()` nutzt `db_pool: None` → bleibt in-memory |
 | Falsche Indexwahl → Performance bei hoher Session-Zahl | niedrig | niedrig | `sessions_account_id` + `sessions_expires_at` decken alle Abfragen ab |

--- a/docs/reports/auth-persistence-runtime-proof.md
+++ b/docs/reports/auth-persistence-runtime-proof.md
@@ -10,7 +10,9 @@ summary: >
   Gesamtergebnis: PARTIAL_PROVEN. psql-basierter Migrations- und CRUD-Smoke
   gegen disposable-local PostgreSQL und PgBouncer (transaction mode) sind belegt.
   SQLx/Rust-API-CRUD gegen PgBouncer, sqlx-cli-Migration und exaktes
-  Stack-PgBouncer-Image bleiben NOT_PROVEN.
+  Stack-PgBouncer-Image bleiben NOT_PROVEN. ADR-0007 schränkt PgBouncer auf
+  Dev-/Proof-/Spezialpfade ein; der Produktionspfad ist DATABASE_URL → direkter
+  PostgreSQL-Zugriff.
 depends_on:
   - docs/blueprints/auth-persistence-runtime-proof.md
   - docs/reports/auth-persistence-next-step.md
@@ -23,6 +25,8 @@ relations:
     target: docs/blueprints/auth-roadmap.md
   - type: relates_to
     target: docs/adr/ADR-0006__auth-magic-link-session-passkey.md
+  - type: relates_to
+    target: docs/adr/ADR-0007__auth-persistence-production-db-path.md
 ---
 
 # Auth-Persistenz — Runtime-Proof
@@ -30,7 +34,9 @@ relations:
 > **Zweck:** Beweis-PR. Kein Auth-Umbau, kein `DbSessionStore`, keine
 > `SessionBackend`-Abstraktion. Kein register/verify.
 > Ziel: belegter Runtime-Pfad für die vorhandene `sessions`-Migration mit psql
-> und PgBouncer gegen eine wegwerfbare lokale Datenbank.
+> und PgBouncer gegen eine wegwerfbare lokale Datenbank. Nach ADR-0007 ist dieser
+> PgBouncer-Pfad ein Dev-/Proof-/Spezialpfad; Produktion nutzt `DATABASE_URL` für
+> direkten PostgreSQL-Zugriff.
 >
 > Blueprint: `docs/blueprints/auth-persistence-runtime-proof.md`
 
@@ -60,7 +66,7 @@ Beweisen, dass:
 | Down-Migration | `apps/api/migrations/20260428000000_create_sessions.down.sql` vorhanden — `DROP TABLE sessions` |
 | SQLx | Cargo.toml: `sqlx = { version = "0.8.1", features = ["runtime-tokio", "postgres"] }` |
 | PgBouncer im Stack | `infra/compose/compose.core.yml`: `edoburu/pgbouncer:1.20`, `POOL_MODE: transaction`, Port 6432 |
-| API-Verbindung | API-Container verbindet über PgBouncer (Port 6432), nicht direkt gegen Postgres |
+| API-Verbindung | Dev-Stack: API-Container verbindet über PgBouncer (Port 6432). Produktion nach ADR-0007: `DATABASE_URL` → direkter PostgreSQL-Zugriff. |
 | `db_pool` in ApiState | vorhanden, aber ausschließlich für Health-Check verdrahtet — kein Auth-Pfad nutzt die DB |
 | `sqlx-cli` | **nicht** in der CI-Umgebung installiert; Justfile dokumentiert Install-Befehl |
 | SessionStore | in-memory, kein Auth-Umbau in diesem PR |
@@ -283,9 +289,11 @@ git diff --check
 ### Gesamtergebnis: PARTIAL_PROVEN
 
 Der psql-basierte Migrations- und CRUD-Pfad gegen PostgreSQL und PgBouncer
-(transaction mode) ist reproduzierbar belegt. Der kritische SQLx/Rust-API-Pfad
-gegen PgBouncer transaction mode — der tatsächliche Runtime-Pfad der API — ist
-noch nicht bewiesen. `psql`-CRUD ist nicht äquivalent zu SQLx-Runtime.
+(transaction mode) ist reproduzierbar belegt. Der SQLx/Rust-API-Pfad gegen
+PgBouncer transaction mode bleibt für Dev-/Proof-/Spezialfälle unbewiesen.
+Nach ADR-0007 ist dies kein Produktions-Gate: Der Produktionspfad für Auth-
+Persistenz ist `DATABASE_URL` → direkter PostgreSQL-Zugriff. `psql`-CRUD ist
+nicht äquivalent zu SQLx-Runtime.
 
 ---
 
@@ -293,7 +301,7 @@ noch nicht bewiesen. `psql`-CRUD ist nicht äquivalent zu SQLx-Runtime.
 
 ### Restlücke 1: SQLx Prepared Statements gegen PgBouncer (Rust-API-Ebene)
 
-#### Status: offen
+#### Status: offen für Dev-/Proof-/Spezialpfad; kein Produktions-Gate nach ADR-0007
 
 Alle CRUD-Operationen wurden über den `psql`-Client ausgeführt, der keine
 Prepared Statements im SQLx-Sinne verwendet. SQLx nutzt standardmäßig
@@ -348,29 +356,27 @@ des Stacks bleibt unverändert.
 
 ## 8. Entscheidungsempfehlung: nächster sicherer Schritt
 
-**Empfehlung: `test(db): prove SQLx session CRUD through PgBouncer`**
+**Empfehlung: `test(db): prove direct SQLx/Postgres session CRUD`**
 
-Der psql-basierte Proof ist bestanden, aber der kritische SQLx/Rust-API-Pfad
-gegen PgBouncer transaction mode ist noch nicht belegt. Bevor `DbSessionStore`
-gebaut wird, muss dieser Pfad bewiesen sein.
+Der psql-basierte Proof ist bestanden, aber der produktive SQLx/Rust-API-Pfad
+gegen direkten PostgreSQL-Zugriff ist noch nicht belegt. Nach ADR-0007 ist dieser
+direkte Pfad das Gate vor produktiver Auth-Persistenz.
 
 Vorgehen für den nächsten PR:
 
 1. Rust-Integrationstest schreiben, der via `sqlx::PgPool` gegen eine
-   disposable-local Datenbank hinter PgBouncer (transaction mode) arbeitet.
-2. `PgConnectOptions::statement_cache_capacity(0)` beim Pool-Setup aktivieren
-   und im Test explizit belegen, dass der getestete SQLx-CRUD-Pfad mit
-   `POOL_MODE=transaction` und deaktiviertem Statement-Cache erfolgreich läuft
-   (INSERT / SELECT / UPDATE / DELETE via SQLx gegen PgBouncer ohne Fehler).
-3. INSERT / SELECT / UPDATE / DELETE gegen `sessions` via SQLx/Rust — nicht via psql.
+   disposable-local PostgreSQL-Datenbank arbeitet.
+2. INSERT / SELECT / UPDATE / DELETE gegen `sessions` via SQLx/Rust — nicht via psql.
+3. Belegen, dass der getestete Pool aus `DATABASE_URL` direkt PostgreSQL adressiert.
 4. Offline-Tests müssen weiterhin grün bleiben.
 
-**Stop-Regel:** Wenn SQLx über PgBouncer scheitert, keine Session-Persistenz
-verdrahten — erst Ursache isolieren und Mitigation belegen.
+**Stop-Regel:** Kein `DbSessionStore` ohne belegten direkten SQLx/Postgres-
+Persistenzpfad.
 
-**Alternative:** `DbSessionStore` darf direkt im nächsten PR begonnen werden,
-aber nur wenn derselbe PR den SQLx/PgBouncer-Proof mit `statement_cache_capacity(0)`
-und Rust-Integrationstest enthält. Kein `DbSessionStore` ohne belegten SQLx/PgBouncer-Pfad.
+Optionaler Spezialpfad: Der SQLx/PgBouncer-Proof mit `statement_cache_capacity(0)`
+kann weiterhin ausgeführt werden, wenn ein Dev-/Spezialbetrieb PgBouncer nutzt.
+Er ist aber kein Produktions-Gate und blockiert `DbSessionStore` gegen direkten
+PostgreSQL-Zugriff nicht.
 
 Zweite Alternative: erst `refactor(auth): introduce SessionBackend abstraction`
 als eigenen PR, wenn die Änderungsfläche nach erster Messung breit erscheint

--- a/docs/reports/auth-persistence-runtime-proof.md
+++ b/docs/reports/auth-persistence-runtime-proof.md
@@ -11,7 +11,7 @@ summary: >
   gegen disposable-local PostgreSQL und PgBouncer (transaction mode) sind belegt.
   SQLx/Rust-API-CRUD gegen PgBouncer, sqlx-cli-Migration und exaktes
   Stack-PgBouncer-Image bleiben NOT_PROVEN. ADR-0007 schränkt PgBouncer auf
-  Dev-/Proof-/Spezialpfade ein; der Produktionspfad ist DATABASE_URL → direkter
+  Dev-/Spezialpfade ein; der Produktionspfad ist DATABASE_URL → direkter
   PostgreSQL-Zugriff.
 depends_on:
   - docs/blueprints/auth-persistence-runtime-proof.md
@@ -35,7 +35,7 @@ relations:
 > `SessionBackend`-Abstraktion. Kein register/verify.
 > Ziel: belegter Runtime-Pfad für die vorhandene `sessions`-Migration mit psql
 > und PgBouncer gegen eine wegwerfbare lokale Datenbank. Nach ADR-0007 ist dieser
-> PgBouncer-Pfad ein Dev-/Proof-/Spezialpfad; Produktion nutzt `DATABASE_URL` für
+> PgBouncer-Pfad ein Dev-/Spezialpfad; Produktion nutzt `DATABASE_URL` für
 > direkten PostgreSQL-Zugriff.
 >
 > Blueprint: `docs/blueprints/auth-persistence-runtime-proof.md`
@@ -290,7 +290,7 @@ git diff --check
 
 Der psql-basierte Migrations- und CRUD-Pfad gegen PostgreSQL und PgBouncer
 (transaction mode) ist reproduzierbar belegt. Der SQLx/Rust-API-Pfad gegen
-PgBouncer transaction mode bleibt für Dev-/Proof-/Spezialfälle unbewiesen.
+PgBouncer transaction mode bleibt für Dev-/Spezialfälle unbewiesen.
 Nach ADR-0007 ist dies kein Produktions-Gate: Der Produktionspfad für Auth-
 Persistenz ist `DATABASE_URL` → direkter PostgreSQL-Zugriff. `psql`-CRUD ist
 nicht äquivalent zu SQLx-Runtime.
@@ -301,7 +301,7 @@ nicht äquivalent zu SQLx-Runtime.
 
 ### Restlücke 1: SQLx Prepared Statements gegen PgBouncer (Rust-API-Ebene)
 
-#### Status: offen für Dev-/Proof-/Spezialpfad; kein Produktions-Gate nach ADR-0007
+#### Status: offen für Dev-/Spezialpfad; kein Produktions-Gate nach ADR-0007
 
 Alle CRUD-Operationen wurden über den `psql`-Client ausgeführt, der keine
 Prepared Statements im SQLx-Sinne verwendet. SQLx nutzt standardmäßig

--- a/docs/reports/auth-persistence-runtime-target-reconciliation.md
+++ b/docs/reports/auth-persistence-runtime-target-reconciliation.md
@@ -6,14 +6,17 @@ status: active
 created: 2026-05-13
 lang: de
 summary: >
-  Diagnose- und Kanonisierungsbericht. Klärt, ob PgBouncer im Auth-Persistenzpfad
-  weiterhin kanonische Zielarchitektur ist oder ob der belegte Runtime-Zustand davon
-  abweicht. Befundmatrix, Kontrastprüfung, offene Entscheidung und Stop-Regeln.
+  Diagnose- und Kanonisierungsbericht. Klärt den Auth-Persistenzpfad für
+  Produktion: direkter PostgreSQL-Zugriff via DATABASE_URL ist durch ADR-0007
+  entschieden. PgBouncer bleibt Dev-/Proof-/Spezialpfad und kein Produktions-Gate.
   Keine Implementierung.
 depends_on:
+  - docs/adr/ADR-0007__auth-persistence-production-db-path.md
   - docs/reports/auth-persistence-runtime-proof.md
   - docs/proofs/sqlx-pgbouncer-session-crud-proof.md
 relations:
+  - type: relates_to
+    target: docs/adr/ADR-0007__auth-persistence-production-db-path.md
   - type: relates_to
     target: docs/reports/auth-persistence-runtime-proof.md
   - type: relates_to
@@ -26,12 +29,16 @@ relations:
 
 # Auth-Persistenz — Runtime-Zielarchitektur-Abgleich
 
-> **Zweck:** Diagnose und Kanonisierung. Klärt, ob `API → PgBouncer → Postgres`
-> wirklich Zielarchitektur ist oder ob PgBouncer nur noch Doku-/Config-Rest ist.
+> **Zweck:** Diagnose und Kanonisierung. Dieses Dokument hält den Abgleich zwischen
+> Dev-Stack, Prod-Stack, Runtime-Befund und Proof-Dokumenten fest.
+>
+> **Ergebnis:** ADR-0007 entscheidet den Produktionspfad: Auth-Persistenz läuft in
+> Produktion direkt über PostgreSQL via `DATABASE_URL`. PgBouncer ist Dev-/Proof-/
+> Spezialpfad und kein Produktions-Gate für `DbSessionStore`.
 >
 > **Kein Produktionscode. Kein CI-Job. Keine Session-Persistenz. Keine Compose-Änderung.**
 >
-> Alle Aussagen sind als **PROVEN / NOT_PROVEN / CONFLICT / OPEN_DECISION** markiert.
+> Aussagen sind als **PROVEN / NOT_PROVEN / CONFLICT_RESOLVED / DECIDED** markiert.
 
 ---
 
@@ -42,11 +49,13 @@ ist als `READY_FOR_PROOF` markiert — compiliertes Testgerüst, kein ausgeführ
 Runtime-Beweis. Der belegte Heimserver-Zustand zeigt: API und Postgres laufen,
 aber kein PgBouncer-Service, keine Rust/Cargo-Toolchain auf dem Runtime-Host.
 
-Damit ist offen: Ist `API → PgBouncer → Postgres` wirklich der Zielpfad für
-Auth-Persistenz in der Produktion — oder ist PgBouncer nur Dev-Infrastruktur?
+Die vormals offene Frage war: Soll Auth-Persistenz produktiv über
+`API → PgBouncer → Postgres` laufen, oder ist PgBouncer nur Dev-/Proof-
+Infrastruktur?
 
-Diese Frage entscheidet, ob der nächste Schritt ein CI-PgBouncer-Proof ist
-oder ob der Persistenzpfad direkt auf Postgres geht.
+**Antwort:** ADR-0007 entscheidet den Produktionspfad auf direkten PostgreSQL-Zugriff
+via `DATABASE_URL`. Der nächste Architekturpfad für `DbSessionStore` ist daher der
+direkte SQLx/Postgres-Persistenzpfad, nicht ein PgBouncer-Produktions-Gate.
 
 ---
 
@@ -58,13 +67,13 @@ oder ob der Persistenzpfad direkt auf Postgres geht.
 | `infra/compose/compose.prod.yml` | Kein PgBouncer-Service. API nutzt `DATABASE_URL: ${DATABASE_URL}` (env-injected). | **PROVEN** | Produktionsdefinition enthält keinen PgBouncer-Service. |
 | `infra/compose/compose.prod.override.yml` | Kein PgBouncer. Nur API- und Caddy-Overrides. | **PROVEN** | Prod-Override ergänzt keinen PgBouncer. |
 | `infra/compose/compose.heimserver.override.yml` | Kein PgBouncer. Nur API-Seed und Caddy-Overrides. | **PROVEN** | Heimserver-Override ergänzt keinen PgBouncer. |
-| `.env.example` | `DATABASE_URL` → Port 5432 (direkt). `PGBOUNCER_URL` existiert als separater Eintrag, wird aber nicht als `DATABASE_URL` gesetzt. | **CONFLICT** | `.env.example` dokumentiert PgBouncer-URL, setzt aber `DATABASE_URL` auf direkten Postgres. |
-| `apps/api/src/lib.rs` + `state.rs` | API liest `DATABASE_URL` und erstellt `sqlx::PgPool`. Kein expliziter PgBouncer-Pfad im Produktionscode. `db_pool` wird aktuell nur für Health-Checks genutzt. | **PROVEN** | API verbindet gegen was auch immer in `DATABASE_URL` steht. Kein Auth-Pfad nutzt den Pool. |
-| Runtime-Dump Heimserver (externe Evidenz) | `docker compose ps`: `weltgewebe-api-1` healthy, `weltgewebe-db-1` healthy, `weltgewebe-nats-1` healthy — **kein PgBouncer-Service**. Port 6432 nicht sichtbar. Kein `rustc`, kein `cargo` im API-Container. | **PROVEN** | Produktiver Heimserver läuft ohne PgBouncer. |
-| `docs/reports/auth-persistence-runtime-proof.md` §2 | „API-Container verbindet über PgBouncer (Port 6432), nicht direkt gegen Postgres" | **CONFLICT** | Diese Aussage gilt für den Dev-Stack (`compose.core.yml`). Für den Prod-Stack ist sie falsch. Die Quelle dokumentiert einen Dev-Befund, nicht den Prod-Zustand. |
-| `docs/blueprints/auth-persistence-runtime-proof.md` §5 | Behandelt PgBouncer als Ziel des Runtime-Proof-PR. | **NOT_PROVEN** | PgBouncer ist im Blueprint als Proof-Ziel gesetzt, ohne dass Prod-Stack diesen Pfad enthält. |
-| `docs/proofs/sqlx-pgbouncer-session-crud-proof.md` | Test ist `#[ignore]`, Status `READY_FOR_PROOF`. Kein Runtime-Beweis. | **PROVEN** | Proof-Harness vorhanden; Runtime-Ausführung ausstehend. |
-| `docs/roadmap.md` Phase 4 | „SQLx/PgBouncer-CRUD-Smoke belegt; SQLx-via-PgBouncer-Rust-Proof offen" | **CONFLICT** | Phase 4 spiegelt nicht wider, dass die PgBouncer-Zielentscheidung für Produktion offen ist. |
+| `.env.example` | `DATABASE_URL` → Port 5432 (direkt). `PGBOUNCER_URL` existiert als separater Eintrag, wird aber nicht als `DATABASE_URL` gesetzt. | **PROVEN** | Beispielkonfiguration trennt direkten Produktionspfad und optionalen PgBouncer-Pfad. |
+| `apps/api/src/lib.rs` + `state.rs` | API liest `DATABASE_URL` und erstellt `sqlx::PgPool`. Kein expliziter PgBouncer-Pfad im Produktionscode. `db_pool` wird aktuell nur für Health-Checks genutzt. | **PROVEN** | API verbindet gegen was auch immer in `DATABASE_URL` steht; ADR-0007 legt für Produktion den direkten Postgres-Zielwert fest. |
+| Runtime-Dump Heimserver (externe Evidenz) | `docker compose ps`: `weltgewebe-api-1` healthy, `weltgewebe-db-1` healthy, `weltgewebe-nats-1` healthy — kein PgBouncer-Service. Port 6432 nicht sichtbar. Kein `rustc`, kein `cargo` im API-Container. | **PROVEN** | Produktiver Heimserver läuft ohne PgBouncer. |
+| `docs/reports/auth-persistence-runtime-proof.md` §2 | „API-Container verbindet über PgBouncer (Port 6432), nicht direkt gegen Postgres" | **CONFLICT_RESOLVED** | Diese Aussage wird auf den Dev-Stack (`compose.core.yml`) eingeschränkt. Für Produktion gilt ADR-0007: `DATABASE_URL` → direkter PostgreSQL-Zugriff. |
+| `docs/blueprints/auth-persistence-runtime-proof.md` | Behandelt PgBouncer als Proof-Ziel, wenn im aktiven Stack vorgesehen. | **CONFLICT_RESOLVED** | PgBouncer-Proofs bleiben optionaler Dev-/Spezialpfad; sie sind kein Produktions-Gate. |
+| `docs/proofs/sqlx-pgbouncer-session-crud-proof.md` | Test ist `#[ignore]`, Status `READY_FOR_PROOF`. Kein Runtime-Beweis. | **PROVEN** | Proof-Harness vorhanden; Runtime-Ausführung optional und nicht blockierend für Produktions-`DbSessionStore`. |
+| `docs/adr/ADR-0007__auth-persistence-production-db-path.md` | Production auth persistence uses direct PostgreSQL via `DATABASE_URL`; PgBouncer is not a required production path. | **DECIDED** | Die Zielarchitekturentscheidung ist geschlossen. |
 
 ---
 
@@ -76,7 +85,7 @@ oder ob der Persistenzpfad direkt auf Postgres geht.
 
 - `compose.core.yml` (dev) verdrahtet PgBouncer explizit und konfiguriert `POOL_MODE: transaction`.
 - `.env.example` enthält `PGBOUNCER_URL` als separaten dokumentierten Eintrag.
-- Mehrere Docs (Blueprint, Runtime-Proof-Report, Proof-Doku) behandeln PgBouncer als Ziel.
+- Ältere Docs (Blueprint, Runtime-Proof-Report, Proof-Doku) behandelten PgBouncer als Proof-Ziel.
 - SQLx/PgBouncer-Testgerüst (`sqlx_pgbouncer_session_crud.rs`) ist vorbereitet.
 
 **Belege dagegen:**
@@ -87,8 +96,9 @@ oder ob der Persistenzpfad direkt auf Postgres geht.
 - `.env.example` setzt `DATABASE_URL` auf direkten Postgres (5432), nicht auf Port 6432.
 - Heimserver-Runtime zeigt keinen PgBouncer — konsistent mit Prod-Compose-Definition.
 - Kein Deploy-Runbook oder CI-Workflow richtet PgBouncer für Produktion ein.
+- ADR-0007 lehnt PgBouncer als Produktionsvoraussetzung für Auth-Persistenz ab.
 
-### Deutung B: Direkter Postgres-Pfad ist faktische Runtime-Architektur für Produktion
+### Deutung B: Direkter Postgres-Pfad ist Produktionsarchitektur
 
 **Belege dafür:**
 
@@ -97,87 +107,76 @@ oder ob der Persistenzpfad direkt auf Postgres geht.
 - Runtime-Dump: kein PgBouncer-Service, kein Port 6432.
 - API-Code (`lib.rs`, `state.rs`): verbindet gegen `DATABASE_URL`, kein PgBouncer-spezifischer Pfad.
 - PgBouncer in `compose.core.yml` ist in `profiles: ["dev"]` — explizit als Dev-Werkzeug markiert.
+- ADR-0007 kanonisiert diesen Pfad.
 
 **Belege dagegen:**
 
-- Mehrere Docs behandeln PgBouncer als Zielarchitektur und wurden nie zurückgezogen.
-- `PGBOUNCER_URL` in `.env.example` deutet auf zumindest geplante Nutzung hin.
-- Blueprint und Proof-Dokumente wurden aufgebaut, ohne dass ihre Prämissen (PgBouncer in Prod) formell abgelehnt wurden.
+- Vor ADR-0007 behandelten mehrere Dokumente PgBouncer als Ziel- oder Gate-Annahme.
+- `PGBOUNCER_URL` in `.env.example` bleibt als optionaler Spezialpfad dokumentiert.
 
 ### Gewichtung
 
-Die **Runtime-Konfiguration** (Compose-Dateien, .env.example, Heimserver-Dump) spricht
-konsistent für Deutung B: Prod läuft ohne PgBouncer. Die **Dokumentation** spricht für
-Deutung A, aber sie wurde auf Basis von Dev-Stack-Beobachtungen geschrieben und spiegelt
-den Prod-Stack nicht korrekt wider.
+Die **Runtime-Konfiguration** (Compose-Dateien, `.env.example`, Heimserver-Dump) spricht
+konsistent für den direkten PostgreSQL-Produktionspfad. Die frühere **Dokumentation**
+sprach teilweise für PgBouncer als Ziel, beruhte aber auf Dev-Stack-Beobachtungen und
+spiegelte den Prod-Stack nicht korrekt wider.
 
-Für diese konkrete Runtime-Frage haben Compose-Konfigurationen, `.env.example`,
-API-Code und der Heimserver-Dump höhere Beweiskraft als ältere Reports, weil sie den
-aktuell ausführbaren bzw. konfigurierten Verbindungspfad beschreiben. Die Reports
-bleiben wichtig als Absichtsdokumente, sind hier aber teilweise mit dem belegten
-Prod-/Heimserver-Zustand im Konflikt.
+ADR-0007 löst diese Divergenz formal auf: Für Produktion ist der direkte PostgreSQL-Pfad
+kanonisch. PgBouncer bleibt als Dev-/Proof-/Spezialpfad zulässig, aber nicht als
+Voraussetzung für produktive Auth-Persistenz.
 
 ---
 
-## 4. Entscheidungspunkt
+## 4. Entscheidung
 
-> **OPEN_DECISION:** Soll Auth-Persistenz produktiv über PgBouncer transaction mode laufen?
+> **DECIDED:** Auth-Persistenz läuft produktiv über direkten PostgreSQL-Zugriff via
+> `DATABASE_URL`.
 
-Diese Frage ist im Repo weder explizit entschieden noch durch einen ADR abgedeckt.
-
-**Auswirkung der Entscheidung:**
+Diese Entscheidung ist in `docs/adr/ADR-0007__auth-persistence-production-db-path.md`
+formal akzeptiert.
 
 | Entscheidung | Konsequenz |
 |---|---|
-| **JA: PgBouncer in Produktion** | PgBouncer muss in `compose.prod.yml` ergänzt werden. `DATABASE_URL` in Prod muss auf Port 6432 zeigen. Erst dann ist ein CI-/Runtime-Proof mit PgBouncer sinnvoll. SQLx/PgBouncer-Test kann danach ausgeführt werden. |
-| **NEIN: Direkter Postgres-Pfad** | Prod-Compose und `.env.example` bleiben wie sie sind. `DATABASE_URL` → direkter Postgres. SQLx/PgBouncer-Proof wird als optionaler Spezialpfad markiert (oder archiviert). `DbSessionStore` wird gegen direkten Postgres geplant. Roadmap/Reports korrigieren. |
+| Direkter PostgreSQL-Pfad in Produktion | Prod-Compose und `.env.example` bleiben in ihrer Grundrichtung unverändert: `DATABASE_URL` zeigt für Produktion auf PostgreSQL. `DbSessionStore` wird gegen diesen direkten SQLx/Postgres-Pfad geplant. |
+| PgBouncer als Dev-/Proof-/Spezialpfad | SQLx/PgBouncer-Proofs bleiben möglich, sind aber optional und kein Persistenz-Gate für Produktion. |
+| Rückkehr zu PgBouncer als Produktionspfad | Nur über neues ADR zulässig; dann wären Prod-Compose, Deployment, `DATABASE_URL` und Proof-Gates neu zu entscheiden. |
 
 ---
 
-## 5. Empfohlener nächster Schritt nach Entscheidung
+## 5. Abgeschlossener Folgepfad
 
-### Wenn JA — PgBouncer bleibt Ziel
-
-1. PgBouncer in `compose.prod.yml` als kanonischen Service ergänzen.
-2. `DATABASE_URL` in `.env.example` auf Port 6432 umstellen (oder `PGBOUNCER_URL` als
-   primäre DB-URL im Prod-Stack dokumentieren).
-3. Heimserver-Deployment anpassen: PgBouncer-Service starten.
-4. Erst danach: SQLx/PgBouncer-Test mit `--include-ignored` ausführen (Runtime-Proof).
-5. Erst nach bestandenem Runtime-Proof: `DbSessionStore` gegen PgBouncer-Pfad planen.
-
-### Wenn NEIN — direkter Postgres-Pfad
-
-1. `docs/blueprints/auth-persistence-runtime-proof.md` — PgBouncer-Pfad als
-   Dev-only / optional kennzeichnen.
-2. `docs/reports/auth-persistence-runtime-proof.md` §2 — Klarstellung ergänzen:
-   Dev-Stack nutzt PgBouncer, Prod-Stack verbindet direkt gegen Postgres.
-3. `docs/proofs/sqlx-pgbouncer-session-crud-proof.md` — Status auf `optional`
-   oder `archived` setzen; Scope auf „Dev-/Spezialpfad" eingrenzen.
-4. `DbSessionStore` gegen direkten Postgres-Pfad planen (`DATABASE_URL` → Port 5432).
-5. Roadmap Phase 4 aktualisieren: PgBouncer-Proof als Dev-Pfad, nicht als
-   Prod-Gate.
+1. `docs/reports/auth-persistence-runtime-proof.md` schränkt die Aussage
+   „API verbindet über PgBouncer" auf den Dev-Stack ein.
+2. `docs/proofs/sqlx-pgbouncer-session-crud-proof.md` markiert den Proof als
+   optionalen Dev-/Spezialpfad.
+3. `docs/roadmap.md` und `docs/blueprints/auth-roadmap.md` vermerken die
+   geschlossene Zielarchitekturentscheidung.
+4. Der nächste Architekturpfad für Auth-Persistenz ist ein direkter
+   SQLx/Postgres-Nachweis und danach `DbSessionStore` / `SessionBackend` gegen
+   den direkten PostgreSQL-Pfad.
 
 ---
 
 ## 6. Stop-Regeln
 
-**Kein `DbSessionStore`**, solange diese OPEN_DECISION nicht explizit aufgelöst ist.
+**Kein `DbSessionStore`** ohne direkten SQLx/Postgres-Persistenzpfad-Nachweis.
 
-**Kein CI-PgBouncer-Proof**, solange PgBouncer nicht als Prod-Zielarchitektur
-bestätigt und in `compose.prod.yml` kanonisch eingetragen ist.
+**Kein CI-PgBouncer-Proof** als Produktions-Gate, solange PgBouncer nicht durch ein
+neues ADR als Produktionsziel reaktiviert ist.
 
 **Kein weiterer Proof-PR**, der PgBouncer als Prod-Prämisse voraussetzt, solange
-der Prod-Stack keinen PgBouncer-Service enthält.
+der Prod-Stack keinen PgBouncer-Service enthält und ADR-0007 gilt.
 
 ---
 
 ## 7. Konfliktdokumentation
 
-Die folgenden Stellen in bestehenden Dokumenten sind inhaltlich ungenau und
-müssen nach Entscheidung korrigiert werden:
+Die folgenden Stellen in bestehenden Dokumenten wurden oder werden inhaltlich
+präzisiert:
 
-| Dokument | Stelle | Problem |
+| Dokument | Stelle | Korrektur |
 |---|---|---|
-| `docs/reports/auth-persistence-runtime-proof.md` §2 | „API-Container verbindet über PgBouncer (Port 6432)" | Gilt nur für Dev-Stack (`compose.core.yml`). Prod-Stack (`compose.prod.yml`) hat keinen PgBouncer. |
-| `docs/blueprints/auth-persistence-runtime-proof.md` | Gesamtblaupause behandelt PgBouncer als Prod-Proof-Ziel | Prod-Stack enthält PgBouncer nicht. Blueprint wurde auf Basis von Dev-Stack-Beobachtungen geschrieben. |
-| `docs/roadmap.md` Phase 4 | „SQLx/PgBouncer-CRUD-Smoke belegt" als Gate für `DbSessionStore` | CRUD-Smoke ist belegt, aber Prod-Zielarchitektur für PgBouncer ist OPEN_DECISION. |
+| `docs/reports/auth-persistence-runtime-proof.md` §2 | „API-Container verbindet über PgBouncer (Port 6432)" | Gilt nur für Dev-Stack (`compose.core.yml`). Prod-Stack (`compose.prod.yml`) hat keinen PgBouncer; Produktionspfad ist `DATABASE_URL` → direkter PostgreSQL-Zugriff. |
+| `docs/blueprints/auth-persistence-runtime-proof.md` | Proof-Ziel PgBouncer | PgBouncer-Proof nur, wenn im aktiven Stack vorgesehen; kein Produktions-Gate. |
+| `docs/proofs/sqlx-pgbouncer-session-crud-proof.md` | Gate-Formulierungen vor `DbSessionStore` | Optionaler Dev-/Spezialpfad; kein Blocker für produktiven `DbSessionStore` gegen direkten Postgres. |
+| `docs/roadmap.md` Phase 4/5 | Offene Entscheidung | Geschlossen: direkter PostgreSQL-Produktionspfad; Phase 5 folgt gegen direkten Pfad. |

--- a/docs/reports/auth-persistence-runtime-target-reconciliation.md
+++ b/docs/reports/auth-persistence-runtime-target-reconciliation.md
@@ -8,7 +8,7 @@ lang: de
 summary: >
   Diagnose- und Kanonisierungsbericht. Klärt den Auth-Persistenzpfad für
   Produktion: direkter PostgreSQL-Zugriff via DATABASE_URL ist durch ADR-0007
-  entschieden. PgBouncer bleibt Dev-/Proof-/Spezialpfad und kein Produktions-Gate.
+  entschieden. PgBouncer bleibt Dev-/Spezialpfad und kein Produktions-Gate.
   Keine Implementierung.
 depends_on:
   - docs/adr/ADR-0007__auth-persistence-production-db-path.md
@@ -33,8 +33,8 @@ relations:
 > Dev-Stack, Prod-Stack, Runtime-Befund und Proof-Dokumenten fest.
 >
 > **Ergebnis:** ADR-0007 entscheidet den Produktionspfad: Auth-Persistenz läuft in
-> Produktion direkt über PostgreSQL via `DATABASE_URL`. PgBouncer ist Dev-/Proof-/
-> Spezialpfad und kein Produktions-Gate für `DbSessionStore`.
+> Produktion direkt über PostgreSQL via `DATABASE_URL`. PgBouncer ist
+> Dev-/Spezialpfad und kein Produktions-Gate für `DbSessionStore`.
 >
 > **Kein Produktionscode. Kein CI-Job. Keine Session-Persistenz. Keine Compose-Änderung.**
 >
@@ -50,7 +50,7 @@ Runtime-Beweis. Der belegte Heimserver-Zustand zeigt: API und Postgres laufen,
 aber kein PgBouncer-Service, keine Rust/Cargo-Toolchain auf dem Runtime-Host.
 
 Die vormals offene Frage war: Soll Auth-Persistenz produktiv über
-`API → PgBouncer → Postgres` laufen, oder ist PgBouncer nur Dev-/Proof-
+`API → PgBouncer → Postgres` laufen, oder ist PgBouncer nur Dev-/Spezial-
 Infrastruktur?
 
 **Antwort:** ADR-0007 entscheidet den Produktionspfad auf direkten PostgreSQL-Zugriff
@@ -73,7 +73,7 @@ direkte SQLx/Postgres-Persistenzpfad, nicht ein PgBouncer-Produktions-Gate.
 | `docs/reports/auth-persistence-runtime-proof.md` §2 | „API-Container verbindet über PgBouncer (Port 6432), nicht direkt gegen Postgres" | **CONFLICT_RESOLVED** | Diese Aussage wird auf den Dev-Stack (`compose.core.yml`) eingeschränkt. Für Produktion gilt ADR-0007: `DATABASE_URL` → direkter PostgreSQL-Zugriff. |
 | `docs/blueprints/auth-persistence-runtime-proof.md` | Behandelt PgBouncer als Proof-Ziel, wenn im aktiven Stack vorgesehen. | **CONFLICT_RESOLVED** | PgBouncer-Proofs bleiben optionaler Dev-/Spezialpfad; sie sind kein Produktions-Gate. |
 | `docs/proofs/sqlx-pgbouncer-session-crud-proof.md` | Test ist `#[ignore]`, Status `READY_FOR_PROOF`. Kein Runtime-Beweis. | **PROVEN** | Proof-Harness vorhanden; Runtime-Ausführung optional und nicht blockierend für Produktions-`DbSessionStore`. |
-| `docs/adr/ADR-0007__auth-persistence-production-db-path.md` | Production auth persistence uses direct PostgreSQL via `DATABASE_URL`; PgBouncer is not a required production path. | **DECIDED** | Die Zielarchitekturentscheidung ist geschlossen. |
+| `docs/adr/ADR-0007__auth-persistence-production-db-path.md` | Die produktive Auth-Persistenz nutzt direkten PostgreSQL-Zugriff über `DATABASE_URL`; PgBouncer ist Dev-/Spezialinfrastruktur und kein erforderlicher Produktionspfad. | **DECIDED** | Die Zielarchitekturentscheidung ist geschlossen. |
 
 ---
 
@@ -122,7 +122,7 @@ sprach teilweise für PgBouncer als Ziel, beruhte aber auf Dev-Stack-Beobachtung
 spiegelte den Prod-Stack nicht korrekt wider.
 
 ADR-0007 löst diese Divergenz formal auf: Für Produktion ist der direkte PostgreSQL-Pfad
-kanonisch. PgBouncer bleibt als Dev-/Proof-/Spezialpfad zulässig, aber nicht als
+kanonisch. PgBouncer bleibt als Dev-/Spezialpfad zulässig, aber nicht als
 Voraussetzung für produktive Auth-Persistenz.
 
 ---
@@ -138,7 +138,7 @@ formal akzeptiert.
 | Entscheidung | Konsequenz |
 |---|---|
 | Direkter PostgreSQL-Pfad in Produktion | Prod-Compose und `.env.example` bleiben in ihrer Grundrichtung unverändert: `DATABASE_URL` zeigt für Produktion auf PostgreSQL. `DbSessionStore` wird gegen diesen direkten SQLx/Postgres-Pfad geplant. |
-| PgBouncer als Dev-/Proof-/Spezialpfad | SQLx/PgBouncer-Proofs bleiben möglich, sind aber optional und kein Persistenz-Gate für Produktion. |
+| PgBouncer als Dev-/Spezialpfad | SQLx/PgBouncer-Proofs bleiben möglich, sind aber optional und kein Persistenz-Gate für Produktion. |
 | Rückkehr zu PgBouncer als Produktionspfad | Nur über neues ADR zulässig; dann wären Prod-Compose, Deployment, `DATABASE_URL` und Proof-Gates neu zu entscheiden. |
 
 ---

--- a/docs/reports/auth-status-matrix.json
+++ b/docs/reports/auth-status-matrix.json
@@ -1,6 +1,7 @@
 {
   "generated_from": [
     "docs/adr/ADR-0006__auth-magic-link-session-passkey.md",
+    "docs/adr/ADR-0007__auth-persistence-production-db-path.md",
     "docs/specs/auth-api.md",
     "docs/specs/auth-state-machine.md",
     "docs/specs/auth-ui.md",
@@ -34,9 +35,10 @@
     },
     "session": {
       "soll": "GET /auth/session, Cookie, belastbares Persistenzmodell",
-      "ist": "GET /auth/session implementiert (inkl. expires_at und device_id), durch API-Tests belegt. In-Memory SessionStore als bewusste Architekturentscheidung für Single-Instance-Betrieb dokumentiert (auth-roadmap.md, Phase 2 Persistenzentscheidung). SessionStore-Schnittstelle erlaubt Migration auf persistenten Adapter ohne Route-Änderungen. Cookie-Transport aktiv; httpOnly und SameSite=Lax bedingungslos gesetzt; Secure standardmäßig aktiv, konfigurierbar über AUTH_COOKIE_SECURE.",
+      "ist": "GET /auth/session implementiert (inkl. expires_at und device_id), durch API-Tests belegt. In-Memory SessionStore als bewusste Architekturentscheidung für Single-Instance-Betrieb dokumentiert (auth-roadmap.md, Phase 2 Persistenzentscheidung). ADR-0007 legt für die produktive Auth-Persistenz den direkten PostgreSQL-Zugriff über DATABASE_URL fest; PgBouncer ist optionaler Dev-/Spezialpfad und kein Produktions-Gate. SessionStore-Schnittstelle erlaubt Migration auf persistenten Adapter ohne Route-Änderungen. Cookie-Transport aktiv; httpOnly und SameSite=Lax bedingungslos gesetzt; Secure standardmäßig aktiv, konfigurierbar über AUTH_COOKIE_SECURE.",
       "status": "Teil",
       "documentation_evidence": [
+        "docs/adr/ADR-0007__auth-persistence-production-db-path.md",
         "docs/blueprints/auth-roadmap.md",
         "docs/specs/auth-blueprint.md",
         "docs/blueprints/weltgewebe.auth-and-ui-routing.md"

--- a/docs/reports/auth-status-matrix.md
+++ b/docs/reports/auth-status-matrix.md
@@ -8,6 +8,8 @@ relations:
   - type: relates_to
     target: docs/adr/ADR-0006__auth-magic-link-session-passkey.md
   - type: relates_to
+    target: docs/adr/ADR-0007__auth-persistence-production-db-path.md
+  - type: relates_to
     target: docs/blueprints/auth-roadmap.md
 ---
 
@@ -31,6 +33,7 @@ Pflegeregel: Diese Matrix ist bei jedem Auth-bezogenen PR zu aktualisieren, der 
 Diese Dokumente beschreiben die finale Architektur, auf die hingearbeitet wird:
 
 - `docs/adr/ADR-0006__auth-magic-link-session-passkey.md`
+- `docs/adr/ADR-0007__auth-persistence-production-db-path.md`
 - `docs/specs/auth-api.md`
 - `docs/specs/auth-state-machine.md`
 - `docs/specs/auth-ui.md`
@@ -93,7 +96,7 @@ Ein Bereich erhält den Status `Teil` auch dann, wenn ein funktional verwandter 
 ### 2.2 Session
 
 **Soll:** GET `/auth/session`, Session Cookie (secure, httpOnly), belastbares Persistenzmodell.
-**Ist:** `GET /auth/session` ist implementiert (inkl. `expires_at` und `device_id`) und durch API-Tests belegt. In-Memory `SessionStore` ist als bewusste Architekturentscheidung für Single-Instance-Betrieb dokumentiert (`auth-roadmap.md`, Phase 2 Persistenzentscheidung). Die `SessionStore`-Schnittstelle erlaubt Migration auf persistenten Adapter ohne Route-Änderungen. Cookie-Transport aktiv; `httpOnly` und `SameSite=Lax` bedingungslos gesetzt; `Secure` standardmäßig aktiv, konfigurierbar über `AUTH_COOKIE_SECURE`.
+**Ist:** `GET /auth/session` ist implementiert (inkl. `expires_at` und `device_id`) und durch API-Tests belegt. In-Memory `SessionStore` ist als bewusste Architekturentscheidung für Single-Instance-Betrieb dokumentiert (`auth-roadmap.md`, Phase 2 Persistenzentscheidung). ADR-0007 legt für die produktive Auth-Persistenz den direkten PostgreSQL-Zugriff über `DATABASE_URL` fest; PgBouncer ist optionaler Dev-/Spezialpfad und kein Produktions-Gate. Die `SessionStore`-Schnittstelle erlaubt Migration auf persistenten Adapter ohne Route-Änderungen. Cookie-Transport aktiv; `httpOnly` und `SameSite=Lax` bedingungslos gesetzt; `Secure` standardmäßig aktiv, konfigurierbar über `AUTH_COOKIE_SECURE`.
 **Dokumentationsbelege:** `docs/blueprints/auth-roadmap.md` (Persistenzentscheidung), `docs/specs/auth-blueprint.md`, `docs/blueprints/weltgewebe.auth-and-ui-routing.md`
 **Code-, Test- und Verifikationsbelege:** `apps/api/src/routes/auth.rs`, `apps/api/src/routes/mod.rs`, `apps/api/src/middleware/auth.rs`, `apps/api/src/middleware/authz.rs`, `apps/api/tests/api_auth.rs`, `apps/api/src/auth/session.rs`
 **Fehlende Belege:** Vollumfängliche Cookie-Sicherheits-Verifikation (z.B. Rotation/Leak-Tests), E2E-Nachweis.

--- a/docs/reports/auth-status-matrix.md
+++ b/docs/reports/auth-status-matrix.md
@@ -97,7 +97,7 @@ Ein Bereich erhält den Status `Teil` auch dann, wenn ein funktional verwandter 
 
 **Soll:** GET `/auth/session`, Session Cookie (secure, httpOnly), belastbares Persistenzmodell.
 **Ist:** `GET /auth/session` ist implementiert (inkl. `expires_at` und `device_id`) und durch API-Tests belegt. In-Memory `SessionStore` ist als bewusste Architekturentscheidung für Single-Instance-Betrieb dokumentiert (`auth-roadmap.md`, Phase 2 Persistenzentscheidung). ADR-0007 legt für die produktive Auth-Persistenz den direkten PostgreSQL-Zugriff über `DATABASE_URL` fest; PgBouncer ist optionaler Dev-/Spezialpfad und kein Produktions-Gate. Die `SessionStore`-Schnittstelle erlaubt Migration auf persistenten Adapter ohne Route-Änderungen. Cookie-Transport aktiv; `httpOnly` und `SameSite=Lax` bedingungslos gesetzt; `Secure` standardmäßig aktiv, konfigurierbar über `AUTH_COOKIE_SECURE`.
-**Dokumentationsbelege:** `docs/blueprints/auth-roadmap.md` (Persistenzentscheidung), `docs/specs/auth-blueprint.md`, `docs/blueprints/weltgewebe.auth-and-ui-routing.md`
+**Dokumentationsbelege:** `docs/adr/ADR-0007__auth-persistence-production-db-path.md`, `docs/blueprints/auth-roadmap.md` (Persistenzentscheidung), `docs/specs/auth-blueprint.md`, `docs/blueprints/weltgewebe.auth-and-ui-routing.md`
 **Code-, Test- und Verifikationsbelege:** `apps/api/src/routes/auth.rs`, `apps/api/src/routes/mod.rs`, `apps/api/src/middleware/auth.rs`, `apps/api/src/middleware/authz.rs`, `apps/api/tests/api_auth.rs`, `apps/api/src/auth/session.rs`
 **Fehlende Belege:** Vollumfängliche Cookie-Sicherheits-Verifikation (z.B. Rotation/Leak-Tests), E2E-Nachweis.
 **Status:** Teil

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -101,13 +101,13 @@ Reihenfolge: Kanonisierung → Step-up → Persistenz-Runtime-Proof → DbSessio
 - [~] Phase 3 — Step-up Auth · Passkey-Register-Grant-Handoff belegt; Register-Verify und UI-E2E offen · [auth-roadmap §7/§8](blueprints/auth-roadmap.md)
 - [~] Phase 4 — Auth-Persistenz Runtime-Proof
   - SQL/psql-Migration + psql-basierter PgBouncer-CRUD-Smoke belegt
-  - SQLx/PgBouncer-Rust-Proof als Testgerüst vorbereitet (READY_FOR_PROOF, nicht ausgeführt)
-  - **OPEN_DECISION:** Ob Auth-Persistenz produktiv via PgBouncer oder direkten Postgres-Pfad
-    laufen soll, ist ungeklärt. Prod-Stack enthält keinen PgBouncer; Dev-Stack enthält PgBouncer.
-  - Belege: [auth-persistence-runtime-proof.md](blueprints/auth-persistence-runtime-proof.md),
+  - SQLx/PgBouncer-Rust-Proof als Testgerüst vorbereitet (READY_FOR_PROOF, nicht ausgeführt), aber nach ADR-0007 optionaler Dev-/Spezialpfad
+  - Zielarchitekturentscheidung geschlossen: Produktion nutzt direkten PostgreSQL-Zugriff via `DATABASE_URL`; PgBouncer ist kein Produktions-Gate
+  - Belege: [ADR-0007](adr/ADR-0007__auth-persistence-production-db-path.md),
+    [auth-persistence-runtime-proof.md](blueprints/auth-persistence-runtime-proof.md),
     [Report](reports/auth-persistence-runtime-proof.md),
     [Zielarchitektur-Abgleich](reports/auth-persistence-runtime-target-reconciliation.md)
-- [ ] Phase 5 — `DbSessionStore` / `SessionBackend`-Abstraktion · folgt aus Runtime-Proof
+- [ ] Phase 5 — `DbSessionStore` / `SessionBackend`-Abstraktion · nächster Architekturpfad gegen direkten SQLx/PostgreSQL-Persistenzpfad
 - [ ] Phase 6 — Auth-Statusmatrix vollständig grün · [auth-status-matrix.md](reports/auth-status-matrix.md)
 
 ## Strang UI
@@ -147,7 +147,7 @@ Reihenfolge: Daten-/Szenenklarheit → Souveräne Basemap-Pipeline → Runtime-P
 
 ## Themenübergreifende Reihenfolge (Was vor Was)
 
-1. **Auth-Persistenz Runtime-Proof** vor `DbSessionStore`.
+1. **Direkter SQLx/Postgres-Persistenzpfad-Nachweis** vor produktivem `DbSessionStore`; PgBouncer-Proofs sind nach ADR-0007 optionaler Dev-/Spezialpfad.
 2. **Auth-Phase 3 (Step-up)** vor **UI Auth-Integration**.
 3. **Kartenklarheit Phase 5 (souveräne Pipeline)** vor **Phase 6 (Wahrheitsbeweis)**.
 4. **Basemap-Roadmap Phase 3 (Runtime-Integration)** überlappt mit


### PR DESCRIPTION
### Motivation

- Close the open documentation/architecture drift about whether production auth persistence must go through PgBouncer or direct Postgres and make the production path explicit and canonical.  
- Keep PgBouncer available as a Dev/Proof/Special path but remove it as a production gate for planning `DbSessionStore`.  
- Make subsequent implementation work (e.g. `DbSessionStore`) unblocked by a missing PgBouncer runtime proof and require a direct SQLx/Postgres proof for production readiness.

### Description

- Add a new ADR file `docs/adr/ADR-0007__auth-persistence-production-db-path.md` that records the decision: production auth persistence uses direct PostgreSQL via `DATABASE_URL`, and PgBouncer is a Dev/Proof/Special path (status: `accepted`).
- Update reconciliation, blueprint and proof docs to reflect the decision and scope PgBouncer-related artifacts as optional Dev/Proof paths rather than production gates, including edits to `docs/reports/auth-persistence-runtime-target-reconciliation.md`, `docs/reports/auth-persistence-runtime-proof.md`, `docs/proofs/sqlx-pgbouncer-session-crud-proof.md`, and `docs/blueprints/auth-persistence-runtime-proof.md`.
- Update coordination/navigation surfaces so the roadmaps and indexes reference the ADR and the new production-path rules, including `docs/roadmap.md`, `docs/index.md`, and `docs/blueprints/auth-roadmap.md` and adjust the next-step/readiness guidance (`docs/reports/auth-persistence-next-step.md`, `docs/reports/auth-persistence-readiness.md`).
- All changes are documentation-only: no runtime code, compose, migrations, CI jobs, or `DbSessionStore` implementations were added or modified.

### Testing

- Ran the docs validation suite: `make docs-guard`, which completed successfully (docmeta checks, relations, generated-files and coverage guards passed).  
- Ran `git diff --check` to ensure no whitespace/errors (no issues reported).  
- Searched docs for remaining `OPEN_DECISION` occurrences with `rg 'OPEN_DECISION' docs/` to confirm the previous open decision was resolved (no blocking occurrences remain).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a048466221c832c8ef59f6d1df50241)