### PR TITLE
refactor(auth): introduce SessionBackend abstraction without changing runtime behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,18 +3,6 @@
 version = 4
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,15 +31,6 @@ name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
-
-[[package]]
-name = "ar_archive_writer"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
-dependencies = [
- "object",
-]
 
 [[package]]
 name = "asn1-rs"
@@ -344,16 +323,6 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
-]
-
-[[package]]
-name = "chumsky"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eebd66744a15ded14960ab4ccdbfb51ad3b81f51f3f04a80adac98c985396c9"
-dependencies = [
- "hashbrown 0.14.5",
- "stacker",
 ]
 
 [[package]]
@@ -884,10 +853,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1208,13 +1173,12 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lettre"
-version = "0.11.19"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e13e10e8818f8b2a60f52cb127041d388b89f3a96a62be9ceaffa22262fef7f"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
- "chumsky",
  "email-encoding",
  "email_address",
  "fastrand",
@@ -1448,15 +1412,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "oid-registry"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1685,16 +1640,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
 dependencies = [
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "psm"
-version = "0.1.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3852766467df634d74f0b2d7819bf8dc483a0eb2e3b0f50f756f9cfe8b0d18d8"
-dependencies = [
- "ar_archive_writer",
- "cc",
 ]
 
 [[package]]
@@ -2357,19 +2302,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "stacker"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d74a23609d509411d10e2176dc2a4346e3b4aea2e7b1869f19fdedbc71c013"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "psm",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "stringprep"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2993,6 +2993,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-nats",
+ "async-trait",
  "axum",
  "axum-extra",
  "base64 0.22.1",

--- a/apps/api/Cargo.toml
+++ b/apps/api/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 [dependencies]
 anyhow = "1"
 axum = { version = "0.7", features = ["macros"] }
+async-trait = "0.1"
 async-nats = "0.47"
 dotenvy = "0.15"
 prometheus = "0.14.0"

--- a/apps/api/src/auth/session.rs
+++ b/apps/api/src/auth/session.rs
@@ -26,6 +26,70 @@ pub struct SessionStore {
     store: Arc<RwLock<HashMap<String, Session>>>,
 }
 
+pub trait SessionOps: Send + Sync {
+    fn create(&self, account_id: String, existing_device_id: Option<String>) -> Session;
+    fn get(&self, session_id: &str) -> Option<Session>;
+    fn delete(&self, session_id: &str);
+    fn touch(&self, session_id: &str);
+    fn list_by_account(&self, account_id: &str) -> Vec<Session>;
+    fn delete_by_device(&self, account_id: &str, device_id: &str);
+    fn delete_all_by_account(&self, account_id: &str);
+}
+
+#[derive(Clone)]
+pub struct SessionBackend {
+    inner: Arc<dyn SessionOps>,
+}
+
+impl Default for SessionBackend {
+    fn default() -> Self {
+        Self::new_in_memory()
+    }
+}
+
+impl SessionBackend {
+    pub fn new<T>(backend: T) -> Self
+    where
+        T: SessionOps + 'static,
+    {
+        Self {
+            inner: Arc::new(backend),
+        }
+    }
+
+    pub fn new_in_memory() -> Self {
+        Self::new(SessionStore::new())
+    }
+
+    pub fn create(&self, account_id: String, existing_device_id: Option<String>) -> Session {
+        self.inner.create(account_id, existing_device_id)
+    }
+
+    pub fn get(&self, session_id: &str) -> Option<Session> {
+        self.inner.get(session_id)
+    }
+
+    pub fn delete(&self, session_id: &str) {
+        self.inner.delete(session_id);
+    }
+
+    pub fn touch(&self, session_id: &str) {
+        self.inner.touch(session_id);
+    }
+
+    pub fn list_by_account(&self, account_id: &str) -> Vec<Session> {
+        self.inner.list_by_account(account_id)
+    }
+
+    pub fn delete_by_device(&self, account_id: &str, device_id: &str) {
+        self.inner.delete_by_device(account_id, device_id);
+    }
+
+    pub fn delete_all_by_account(&self, account_id: &str) {
+        self.inner.delete_all_by_account(account_id);
+    }
+}
+
 impl SessionStore {
     pub fn new() -> Self {
         Self {
@@ -117,6 +181,36 @@ impl SessionStore {
     pub fn delete_all_by_account(&self, account_id: &str) {
         let mut store = self.store.write_recover();
         store.retain(|_, s| s.account_id != account_id);
+    }
+}
+
+impl SessionOps for SessionStore {
+    fn create(&self, account_id: String, existing_device_id: Option<String>) -> Session {
+        SessionStore::create(self, account_id, existing_device_id)
+    }
+
+    fn get(&self, session_id: &str) -> Option<Session> {
+        SessionStore::get(self, session_id)
+    }
+
+    fn delete(&self, session_id: &str) {
+        SessionStore::delete(self, session_id);
+    }
+
+    fn touch(&self, session_id: &str) {
+        SessionStore::touch(self, session_id);
+    }
+
+    fn list_by_account(&self, account_id: &str) -> Vec<Session> {
+        SessionStore::list_by_account(self, account_id)
+    }
+
+    fn delete_by_device(&self, account_id: &str, device_id: &str) {
+        SessionStore::delete_by_device(self, account_id, device_id);
+    }
+
+    fn delete_all_by_account(&self, account_id: &str) {
+        SessionStore::delete_all_by_account(self, account_id);
     }
 }
 

--- a/apps/api/src/auth/session.rs
+++ b/apps/api/src/auth/session.rs
@@ -1,4 +1,5 @@
 use crate::auth::lock::RwLockRecover;
+use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -26,14 +27,15 @@ pub struct SessionStore {
     store: Arc<RwLock<HashMap<String, Session>>>,
 }
 
+#[async_trait]
 pub trait SessionOps: Send + Sync {
-    fn create(&self, account_id: String, existing_device_id: Option<String>) -> Session;
-    fn get(&self, session_id: &str) -> Option<Session>;
-    fn delete(&self, session_id: &str);
-    fn touch(&self, session_id: &str);
-    fn list_by_account(&self, account_id: &str) -> Vec<Session>;
-    fn delete_by_device(&self, account_id: &str, device_id: &str);
-    fn delete_all_by_account(&self, account_id: &str);
+    async fn create(&self, account_id: String, existing_device_id: Option<String>) -> Session;
+    async fn get(&self, session_id: &str) -> Option<Session>;
+    async fn delete(&self, session_id: &str);
+    async fn touch(&self, session_id: &str);
+    async fn list_by_account(&self, account_id: &str) -> Vec<Session>;
+    async fn delete_by_device(&self, account_id: &str, device_id: &str);
+    async fn delete_all_by_account(&self, account_id: &str);
 }
 
 #[derive(Clone)]
@@ -61,32 +63,32 @@ impl SessionBackend {
         Self::new(SessionStore::new())
     }
 
-    pub fn create(&self, account_id: String, existing_device_id: Option<String>) -> Session {
-        self.inner.create(account_id, existing_device_id)
+    pub async fn create(&self, account_id: String, existing_device_id: Option<String>) -> Session {
+        self.inner.create(account_id, existing_device_id).await
     }
 
-    pub fn get(&self, session_id: &str) -> Option<Session> {
-        self.inner.get(session_id)
+    pub async fn get(&self, session_id: &str) -> Option<Session> {
+        self.inner.get(session_id).await
     }
 
-    pub fn delete(&self, session_id: &str) {
-        self.inner.delete(session_id);
+    pub async fn delete(&self, session_id: &str) {
+        self.inner.delete(session_id).await;
     }
 
-    pub fn touch(&self, session_id: &str) {
-        self.inner.touch(session_id);
+    pub async fn touch(&self, session_id: &str) {
+        self.inner.touch(session_id).await;
     }
 
-    pub fn list_by_account(&self, account_id: &str) -> Vec<Session> {
-        self.inner.list_by_account(account_id)
+    pub async fn list_by_account(&self, account_id: &str) -> Vec<Session> {
+        self.inner.list_by_account(account_id).await
     }
 
-    pub fn delete_by_device(&self, account_id: &str, device_id: &str) {
-        self.inner.delete_by_device(account_id, device_id);
+    pub async fn delete_by_device(&self, account_id: &str, device_id: &str) {
+        self.inner.delete_by_device(account_id, device_id).await;
     }
 
-    pub fn delete_all_by_account(&self, account_id: &str) {
-        self.inner.delete_all_by_account(account_id);
+    pub async fn delete_all_by_account(&self, account_id: &str) {
+        self.inner.delete_all_by_account(account_id).await;
     }
 }
 
@@ -184,32 +186,33 @@ impl SessionStore {
     }
 }
 
+#[async_trait]
 impl SessionOps for SessionStore {
-    fn create(&self, account_id: String, existing_device_id: Option<String>) -> Session {
+    async fn create(&self, account_id: String, existing_device_id: Option<String>) -> Session {
         SessionStore::create(self, account_id, existing_device_id)
     }
 
-    fn get(&self, session_id: &str) -> Option<Session> {
+    async fn get(&self, session_id: &str) -> Option<Session> {
         SessionStore::get(self, session_id)
     }
 
-    fn delete(&self, session_id: &str) {
+    async fn delete(&self, session_id: &str) {
         SessionStore::delete(self, session_id);
     }
 
-    fn touch(&self, session_id: &str) {
+    async fn touch(&self, session_id: &str) {
         SessionStore::touch(self, session_id);
     }
 
-    fn list_by_account(&self, account_id: &str) -> Vec<Session> {
+    async fn list_by_account(&self, account_id: &str) -> Vec<Session> {
         SessionStore::list_by_account(self, account_id)
     }
 
-    fn delete_by_device(&self, account_id: &str, device_id: &str) {
+    async fn delete_by_device(&self, account_id: &str, device_id: &str) {
         SessionStore::delete_by_device(self, account_id, device_id);
     }
 
-    fn delete_all_by_account(&self, account_id: &str) {
+    async fn delete_all_by_account(&self, account_id: &str) {
         SessionStore::delete_all_by_account(self, account_id);
     }
 }

--- a/apps/api/src/auth/session.rs
+++ b/apps/api/src/auth/session.rs
@@ -4,6 +4,7 @@ use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
+use thiserror::Error;
 use uuid::Uuid;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -22,6 +23,14 @@ impl Session {
     }
 }
 
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum SessionBackendError {
+    #[error("session backend unavailable")]
+    Unavailable,
+}
+
+pub type SessionResult<T> = Result<T, SessionBackendError>;
+
 #[derive(Clone, Default)]
 pub struct SessionStore {
     store: Arc<RwLock<HashMap<String, Session>>>,
@@ -29,13 +38,17 @@ pub struct SessionStore {
 
 #[async_trait]
 pub trait SessionOps: Send + Sync {
-    async fn create(&self, account_id: String, existing_device_id: Option<String>) -> Session;
-    async fn get(&self, session_id: &str) -> Option<Session>;
-    async fn delete(&self, session_id: &str);
-    async fn touch(&self, session_id: &str);
-    async fn list_by_account(&self, account_id: &str) -> Vec<Session>;
-    async fn delete_by_device(&self, account_id: &str, device_id: &str);
-    async fn delete_all_by_account(&self, account_id: &str);
+    async fn create(
+        &self,
+        account_id: String,
+        existing_device_id: Option<String>,
+    ) -> SessionResult<Session>;
+    async fn get(&self, session_id: &str) -> SessionResult<Option<Session>>;
+    async fn delete(&self, session_id: &str) -> SessionResult<()>;
+    async fn touch(&self, session_id: &str) -> SessionResult<()>;
+    async fn list_by_account(&self, account_id: &str) -> SessionResult<Vec<Session>>;
+    async fn delete_by_device(&self, account_id: &str, device_id: &str) -> SessionResult<()>;
+    async fn delete_all_by_account(&self, account_id: &str) -> SessionResult<()>;
 }
 
 #[derive(Clone)]
@@ -63,32 +76,36 @@ impl SessionBackend {
         Self::new(SessionStore::new())
     }
 
-    pub async fn create(&self, account_id: String, existing_device_id: Option<String>) -> Session {
+    pub async fn create(
+        &self,
+        account_id: String,
+        existing_device_id: Option<String>,
+    ) -> SessionResult<Session> {
         self.inner.create(account_id, existing_device_id).await
     }
 
-    pub async fn get(&self, session_id: &str) -> Option<Session> {
+    pub async fn get(&self, session_id: &str) -> SessionResult<Option<Session>> {
         self.inner.get(session_id).await
     }
 
-    pub async fn delete(&self, session_id: &str) {
-        self.inner.delete(session_id).await;
+    pub async fn delete(&self, session_id: &str) -> SessionResult<()> {
+        self.inner.delete(session_id).await
     }
 
-    pub async fn touch(&self, session_id: &str) {
-        self.inner.touch(session_id).await;
+    pub async fn touch(&self, session_id: &str) -> SessionResult<()> {
+        self.inner.touch(session_id).await
     }
 
-    pub async fn list_by_account(&self, account_id: &str) -> Vec<Session> {
+    pub async fn list_by_account(&self, account_id: &str) -> SessionResult<Vec<Session>> {
         self.inner.list_by_account(account_id).await
     }
 
-    pub async fn delete_by_device(&self, account_id: &str, device_id: &str) {
-        self.inner.delete_by_device(account_id, device_id).await;
+    pub async fn delete_by_device(&self, account_id: &str, device_id: &str) -> SessionResult<()> {
+        self.inner.delete_by_device(account_id, device_id).await
     }
 
-    pub async fn delete_all_by_account(&self, account_id: &str) {
-        self.inner.delete_all_by_account(account_id).await;
+    pub async fn delete_all_by_account(&self, account_id: &str) -> SessionResult<()> {
+        self.inner.delete_all_by_account(account_id).await
     }
 }
 
@@ -188,32 +205,40 @@ impl SessionStore {
 
 #[async_trait]
 impl SessionOps for SessionStore {
-    async fn create(&self, account_id: String, existing_device_id: Option<String>) -> Session {
-        SessionStore::create(self, account_id, existing_device_id)
+    async fn create(
+        &self,
+        account_id: String,
+        existing_device_id: Option<String>,
+    ) -> SessionResult<Session> {
+        Ok(SessionStore::create(self, account_id, existing_device_id))
     }
 
-    async fn get(&self, session_id: &str) -> Option<Session> {
-        SessionStore::get(self, session_id)
+    async fn get(&self, session_id: &str) -> SessionResult<Option<Session>> {
+        Ok(SessionStore::get(self, session_id))
     }
 
-    async fn delete(&self, session_id: &str) {
+    async fn delete(&self, session_id: &str) -> SessionResult<()> {
         SessionStore::delete(self, session_id);
+        Ok(())
     }
 
-    async fn touch(&self, session_id: &str) {
+    async fn touch(&self, session_id: &str) -> SessionResult<()> {
         SessionStore::touch(self, session_id);
+        Ok(())
     }
 
-    async fn list_by_account(&self, account_id: &str) -> Vec<Session> {
-        SessionStore::list_by_account(self, account_id)
+    async fn list_by_account(&self, account_id: &str) -> SessionResult<Vec<Session>> {
+        Ok(SessionStore::list_by_account(self, account_id))
     }
 
-    async fn delete_by_device(&self, account_id: &str, device_id: &str) {
+    async fn delete_by_device(&self, account_id: &str, device_id: &str) -> SessionResult<()> {
         SessionStore::delete_by_device(self, account_id, device_id);
+        Ok(())
     }
 
-    async fn delete_all_by_account(&self, account_id: &str) {
+    async fn delete_all_by_account(&self, account_id: &str) -> SessionResult<()> {
         SessionStore::delete_all_by_account(self, account_id);
+        Ok(())
     }
 }
 

--- a/apps/api/src/auth/session.rs
+++ b/apps/api/src/auth/session.rs
@@ -23,7 +23,7 @@ impl Session {
     }
 }
 
-#[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[derive(Debug, Error)]
 pub enum SessionBackendError {
     #[error("session backend unavailable")]
     Unavailable,

--- a/apps/api/src/lib.rs
+++ b/apps/api/src/lib.rs
@@ -46,7 +46,7 @@ pub async fn run() -> anyhow::Result<()> {
     let (nats_client, nats_configured) = initialise_nats_client().await;
 
     let metrics = Metrics::try_new(BuildInfo::collect())?;
-    let sessions = crate::auth::session::SessionStore::new();
+    let sessions = crate::auth::session::SessionBackend::new_in_memory();
     let challenges = crate::auth::challenges::ChallengeStore::new();
     let tokens = crate::auth::tokens::TokenStore::new();
     let step_up_tokens = crate::auth::step_up_tokens::StepUpTokenStore::new();

--- a/apps/api/src/middleware/auth.rs
+++ b/apps/api/src/middleware/auth.rs
@@ -1,4 +1,10 @@
-use axum::{body::Body, extract::State, http::Request, middleware::Next, response::Response};
+use axum::{
+    body::Body,
+    extract::State,
+    http::Request,
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
 use axum_extra::extract::cookie::CookieJar;
 
 use crate::{auth::role::Role, routes::auth::SESSION_COOKIE_NAME, state::ApiState};
@@ -28,7 +34,20 @@ pub async fn auth_middleware(
     let mut session_id_to_touch = None;
 
     if let Some(cookie) = jar.get(SESSION_COOKIE_NAME) {
-        if let Some(session) = state.sessions.get(cookie.value()).await {
+        let session = match state.sessions.get(cookie.value()).await {
+            Ok(session) => session,
+            Err(error) => {
+                tracing::error!(
+                    event = "auth.middleware.session_backend_failed",
+                    operation = "get",
+                    error = %error,
+                    "Session backend operation failed during auth middleware"
+                );
+                return axum::http::StatusCode::SERVICE_UNAVAILABLE.into_response();
+            }
+        };
+
+        if let Some(session) = session {
             {
                 let accounts = state.accounts.read().await;
                 if let Some(internal) = accounts.get(&session.account_id) {
@@ -42,7 +61,15 @@ pub async fn auth_middleware(
             }
 
             if let Some(session_id) = session_id_to_touch {
-                state.sessions.touch(&session_id).await;
+                if let Err(error) = state.sessions.touch(&session_id).await {
+                    tracing::error!(
+                        event = "auth.middleware.session_backend_failed",
+                        operation = "touch",
+                        error = %error,
+                        "Session backend operation failed during auth middleware"
+                    );
+                    return axum::http::StatusCode::SERVICE_UNAVAILABLE.into_response();
+                }
             }
         }
     }

--- a/apps/api/src/middleware/auth.rs
+++ b/apps/api/src/middleware/auth.rs
@@ -27,7 +27,7 @@ pub async fn auth_middleware(
     };
 
     if let Some(cookie) = jar.get(SESSION_COOKIE_NAME) {
-        if let Some(session) = state.sessions.get(cookie.value()) {
+        if let Some(session) = state.sessions.get(cookie.value()).await {
             let accounts = state.accounts.read().await;
             if let Some(internal) = accounts.get(&session.account_id) {
                 ctx.authenticated = true;
@@ -37,7 +37,7 @@ pub async fn auth_middleware(
                 ctx.expires_at = Some(session.expires_at);
 
                 // Synchronously touch to update last_active if needed (debounced internally)
-                state.sessions.touch(&session.id);
+                state.sessions.touch(&session.id).await;
             }
         }
     }

--- a/apps/api/src/middleware/auth.rs
+++ b/apps/api/src/middleware/auth.rs
@@ -25,19 +25,24 @@ pub async fn auth_middleware(
         role: Role::Gast,
         expires_at: None,
     };
+    let mut session_id_to_touch = None;
 
     if let Some(cookie) = jar.get(SESSION_COOKIE_NAME) {
         if let Some(session) = state.sessions.get(cookie.value()).await {
-            let accounts = state.accounts.read().await;
-            if let Some(internal) = accounts.get(&session.account_id) {
-                ctx.authenticated = true;
-                ctx.account_id = Some(session.account_id.clone());
-                ctx.device_id = Some(session.device_id.clone());
-                ctx.role = internal.role.clone();
-                ctx.expires_at = Some(session.expires_at);
+            {
+                let accounts = state.accounts.read().await;
+                if let Some(internal) = accounts.get(&session.account_id) {
+                    ctx.authenticated = true;
+                    ctx.account_id = Some(session.account_id.clone());
+                    ctx.device_id = Some(session.device_id.clone());
+                    ctx.role = internal.role.clone();
+                    ctx.expires_at = Some(session.expires_at);
+                    session_id_to_touch = Some(session.id.clone());
+                }
+            }
 
-                // Synchronously touch to update last_active if needed (debounced internally)
-                state.sessions.touch(&session.id).await;
+            if let Some(session_id) = session_id_to_touch {
+                state.sessions.touch(&session_id).await;
             }
         }
     }

--- a/apps/api/src/routes/auth.rs
+++ b/apps/api/src/routes/auth.rs
@@ -18,6 +18,7 @@ use uuid::Uuid;
 use crate::{
     auth::challenges::ChallengeIntent,
     auth::passkeys::{start_passkey_registration, ConsumeGrantResult, RegistrationInput},
+    auth::session::SessionBackendError,
     auth::step_up_tokens::ConsumeMatchResult,
     auth::{role::Role, tokens::TokenStore},
     middleware::auth::AuthContext,
@@ -97,6 +98,49 @@ pub struct DevAccount {
 pub struct LoginResponse {
     pub ok: bool,
     pub message: String,
+}
+
+fn log_session_backend_error(operation: &'static str, error: &SessionBackendError) {
+    tracing::error!(
+        event = "auth.session_backend_failed",
+        operation,
+        error = %error,
+        "Session backend operation failed"
+    );
+}
+
+fn session_backend_status_response(
+    operation: &'static str,
+    error: &SessionBackendError,
+) -> axum::response::Response {
+    log_session_backend_error(operation, error);
+    StatusCode::SERVICE_UNAVAILABLE.into_response()
+}
+
+fn session_backend_json_response(
+    operation: &'static str,
+    error: &SessionBackendError,
+) -> axum::response::Response {
+    log_session_backend_error(operation, error);
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(serde_json::json!({"error": "SESSION_BACKEND_UNAVAILABLE"})),
+    )
+        .into_response()
+}
+
+fn session_backend_json_response_with_jar(
+    operation: &'static str,
+    error: &SessionBackendError,
+    jar: CookieJar,
+) -> axum::response::Response {
+    log_session_backend_error(operation, error);
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        jar,
+        Json(serde_json::json!({"error": "SESSION_BACKEND_UNAVAILABLE"})),
+    )
+        .into_response()
 }
 
 #[derive(Clone)]
@@ -313,7 +357,10 @@ pub async fn dev_login(
         }
     }
 
-    let session = state.sessions.create(payload.account_id, None).await;
+    let session = match state.sessions.create(payload.account_id, None).await {
+        Ok(session) => session,
+        Err(error) => return session_backend_status_response("dev_login.create", &error),
+    };
 
     let cookie = build_session_cookie(session.id, None);
 
@@ -817,7 +864,12 @@ pub async fn consume_login_post(
                 return Redirect::to("/login?error=account_disabled").into_response();
             }
 
-            let session = state.sessions.create(acc.public.id.clone(), None).await;
+            let session = match state.sessions.create(acc.public.id.clone(), None).await {
+                Ok(session) => session,
+                Err(error) => {
+                    return session_backend_status_response("consume_login_post.create", &error);
+                }
+            };
             let cookie = build_session_cookie(session.id, None);
 
             // Clear the nonce cookie
@@ -865,12 +917,14 @@ pub async fn consume_login_post(
 
 pub async fn logout(State(state): State<ApiState>, jar: CookieJar) -> impl IntoResponse {
     if let Some(cookie) = jar.get(SESSION_COOKIE_NAME) {
-        state.sessions.delete(cookie.value()).await;
+        if let Err(error) = state.sessions.delete(cookie.value()).await {
+            return session_backend_status_response("logout.delete", &error);
+        }
     }
 
     let cookie = build_session_cookie("".to_string(), Some(Duration::seconds(0)));
 
-    (jar.add(cookie), StatusCode::OK)
+    (jar.add(cookie), StatusCode::OK).into_response()
 }
 
 pub async fn logout_all(
@@ -1038,14 +1092,21 @@ pub async fn session_refresh(State(state): State<ApiState>, jar: CookieJar) -> i
     if let Some(cookie) = jar.get(SESSION_COOKIE_NAME) {
         let old_session_id = cookie.value();
 
-        if let Some(old_session) = state.sessions.get(old_session_id).await {
+        let old_session = match state.sessions.get(old_session_id).await {
+            Ok(session) => session,
+            Err(error) => return session_backend_json_response("session_refresh.get", &error),
+        };
+
+        if let Some(old_session) = old_session {
             let accounts = state.accounts.read().await;
             let is_valid = accounts
                 .get(&old_session.account_id)
                 .is_some_and(|acc| !acc.public.disabled);
             drop(accounts);
 
-            state.sessions.delete(old_session_id).await;
+            if let Err(error) = state.sessions.delete(old_session_id).await {
+                return session_backend_json_response("session_refresh.delete", &error);
+            }
 
             if !is_valid {
                 tracing::warn!(
@@ -1068,6 +1129,13 @@ pub async fn session_refresh(State(state): State<ApiState>, jar: CookieJar) -> i
                 .sessions
                 .create(old_session.account_id, Some(old_session.device_id.clone()))
                 .await;
+
+            let new_session = match new_session {
+                Ok(session) => session,
+                Err(error) => {
+                    return session_backend_json_response("session_refresh.create", &error);
+                }
+            };
 
             let new_cookie = build_session_cookie(new_session.id, None);
 
@@ -1122,7 +1190,10 @@ pub async fn list_devices(
         }
     };
 
-    let sessions = state.sessions.list_by_account(&account_id).await;
+    let sessions = match state.sessions.list_by_account(&account_id).await {
+        Ok(sessions) => sessions,
+        Err(error) => return session_backend_json_response("list_devices.list_by_account", &error),
+    };
 
     // Group sessions by device_id
     let current_device_id = match ctx.device_id {
@@ -1200,16 +1271,32 @@ pub async fn remove_device(
 
     if *current_device_id == device_id {
         // Logging out current device -> delete all sessions for it and clear cookie
-        state
+        if let Err(error) = state
             .sessions
             .delete_by_device(&account_id, &device_id)
-            .await;
+            .await
+        {
+            return session_backend_json_response_with_jar(
+                "remove_device.delete_by_device",
+                &error,
+                jar,
+            );
+        }
         let cookie = build_session_cookie("".to_string(), Some(Duration::seconds(0)));
         return (axum::http::StatusCode::NO_CONTENT, jar.add(cookie)).into_response();
     }
 
     // Removing another device -> first check if it even exists for this account
-    let account_sessions = state.sessions.list_by_account(&account_id).await;
+    let account_sessions = match state.sessions.list_by_account(&account_id).await {
+        Ok(sessions) => sessions,
+        Err(error) => {
+            return session_backend_json_response_with_jar(
+                "remove_device.list_by_account",
+                &error,
+                jar,
+            );
+        }
+    };
     let target_device_exists = account_sessions.iter().any(|s| s.device_id == device_id);
 
     if !target_device_exists {
@@ -1499,7 +1586,13 @@ pub async fn consume_step_up(
                 account_id = %account_id,
                 "Step-up consume: executing LogoutAll intent"
             );
-            state.sessions.delete_all_by_account(&account_id).await;
+            if let Err(error) = state.sessions.delete_all_by_account(&account_id).await {
+                return session_backend_json_response_with_jar(
+                    "consume_step_up.delete_all_by_account",
+                    &error,
+                    jar,
+                );
+            }
             // Empty value + zero max-age clears the session cookie in the client
             let cookie = build_session_cookie("".to_string(), Some(Duration::seconds(0)));
             (StatusCode::NO_CONTENT, jar.add(cookie)).into_response()
@@ -1512,10 +1605,17 @@ pub async fn consume_step_up(
                 target_device_id = %target_device_id,
                 "Step-up consume: executing RemoveDevice intent"
             );
-            state
+            if let Err(error) = state
                 .sessions
                 .delete_by_device(&account_id, &target_device_id)
-                .await;
+                .await
+            {
+                return session_backend_json_response_with_jar(
+                    "consume_step_up.delete_by_device",
+                    &error,
+                    jar,
+                );
+            }
             StatusCode::NO_CONTENT.into_response()
         }
         ChallengeIntent::UpdateEmail { new_email } => {

--- a/apps/api/src/routes/auth.rs
+++ b/apps/api/src/routes/auth.rs
@@ -1161,7 +1161,7 @@ pub async fn list_devices(
 
     let mut devices: Vec<DeviceInfo> = device_map.into_values().collect();
     // Sort devices by last_active descending
-    devices.sort_by(|a, b| b.last_active.cmp(&a.last_active));
+    devices.sort_by_key(|device| std::cmp::Reverse(device.last_active));
 
     (axum::http::StatusCode::OK, Json(devices)).into_response()
 }

--- a/apps/api/src/routes/auth.rs
+++ b/apps/api/src/routes/auth.rs
@@ -313,7 +313,7 @@ pub async fn dev_login(
         }
     }
 
-    let session = state.sessions.create(payload.account_id, None);
+    let session = state.sessions.create(payload.account_id, None).await;
 
     let cookie = build_session_cookie(session.id, None);
 
@@ -817,7 +817,7 @@ pub async fn consume_login_post(
                 return Redirect::to("/login?error=account_disabled").into_response();
             }
 
-            let session = state.sessions.create(acc.public.id.clone(), None);
+            let session = state.sessions.create(acc.public.id.clone(), None).await;
             let cookie = build_session_cookie(session.id, None);
 
             // Clear the nonce cookie
@@ -865,7 +865,7 @@ pub async fn consume_login_post(
 
 pub async fn logout(State(state): State<ApiState>, jar: CookieJar) -> impl IntoResponse {
     if let Some(cookie) = jar.get(SESSION_COOKIE_NAME) {
-        state.sessions.delete(cookie.value());
+        state.sessions.delete(cookie.value()).await;
     }
 
     let cookie = build_session_cookie("".to_string(), Some(Duration::seconds(0)));
@@ -1038,14 +1038,14 @@ pub async fn session_refresh(State(state): State<ApiState>, jar: CookieJar) -> i
     if let Some(cookie) = jar.get(SESSION_COOKIE_NAME) {
         let old_session_id = cookie.value();
 
-        if let Some(old_session) = state.sessions.get(old_session_id) {
+        if let Some(old_session) = state.sessions.get(old_session_id).await {
             let accounts = state.accounts.read().await;
             let is_valid = accounts
                 .get(&old_session.account_id)
                 .is_some_and(|acc| !acc.public.disabled);
             drop(accounts);
 
-            state.sessions.delete(old_session_id);
+            state.sessions.delete(old_session_id).await;
 
             if !is_valid {
                 tracing::warn!(
@@ -1066,7 +1066,8 @@ pub async fn session_refresh(State(state): State<ApiState>, jar: CookieJar) -> i
 
             let new_session = state
                 .sessions
-                .create(old_session.account_id, Some(old_session.device_id.clone()));
+                .create(old_session.account_id, Some(old_session.device_id.clone()))
+                .await;
 
             let new_cookie = build_session_cookie(new_session.id, None);
 
@@ -1121,7 +1122,7 @@ pub async fn list_devices(
         }
     };
 
-    let sessions = state.sessions.list_by_account(&account_id);
+    let sessions = state.sessions.list_by_account(&account_id).await;
 
     // Group sessions by device_id
     let current_device_id = match ctx.device_id {
@@ -1199,13 +1200,16 @@ pub async fn remove_device(
 
     if *current_device_id == device_id {
         // Logging out current device -> delete all sessions for it and clear cookie
-        state.sessions.delete_by_device(&account_id, &device_id);
+        state
+            .sessions
+            .delete_by_device(&account_id, &device_id)
+            .await;
         let cookie = build_session_cookie("".to_string(), Some(Duration::seconds(0)));
         return (axum::http::StatusCode::NO_CONTENT, jar.add(cookie)).into_response();
     }
 
     // Removing another device -> first check if it even exists for this account
-    let account_sessions = state.sessions.list_by_account(&account_id);
+    let account_sessions = state.sessions.list_by_account(&account_id).await;
     let target_device_exists = account_sessions.iter().any(|s| s.device_id == device_id);
 
     if !target_device_exists {
@@ -1495,7 +1499,7 @@ pub async fn consume_step_up(
                 account_id = %account_id,
                 "Step-up consume: executing LogoutAll intent"
             );
-            state.sessions.delete_all_by_account(&account_id);
+            state.sessions.delete_all_by_account(&account_id).await;
             // Empty value + zero max-age clears the session cookie in the client
             let cookie = build_session_cookie("".to_string(), Some(Duration::seconds(0)));
             (StatusCode::NO_CONTENT, jar.add(cookie)).into_response()
@@ -1510,7 +1514,8 @@ pub async fn consume_step_up(
             );
             state
                 .sessions
-                .delete_by_device(&account_id, &target_device_id);
+                .delete_by_device(&account_id, &target_device_id)
+                .await;
             StatusCode::NO_CONTENT.into_response()
         }
         ChallengeIntent::UpdateEmail { new_email } => {

--- a/apps/api/src/routes/auth.rs
+++ b/apps/api/src/routes/auth.rs
@@ -1104,11 +1104,11 @@ pub async fn session_refresh(State(state): State<ApiState>, jar: CookieJar) -> i
                 .is_some_and(|acc| !acc.public.disabled);
             drop(accounts);
 
-            if let Err(error) = state.sessions.delete(old_session_id).await {
-                return session_backend_json_response("session_refresh.delete", &error);
-            }
-
             if !is_valid {
+                if let Err(error) = state.sessions.delete(old_session_id).await {
+                    return session_backend_json_response("session_refresh.delete", &error);
+                }
+
                 tracing::warn!(
                     event = "session.refresh_failed_disabled",
                     account_id = %old_session.account_id,
@@ -1136,6 +1136,21 @@ pub async fn session_refresh(State(state): State<ApiState>, jar: CookieJar) -> i
                     return session_backend_json_response("session_refresh.create", &error);
                 }
             };
+
+            if let Err(error) = state.sessions.delete(old_session_id).await {
+                if let Err(rollback_error) = state.sessions.delete(&new_session.id).await {
+                    tracing::error!(
+                        event = "session.refresh_rollback_failed",
+                        old_session_id = %old_session_id,
+                        new_session_id = %new_session.id,
+                        delete_error = %error,
+                        rollback_error = %rollback_error,
+                        "Session refresh failed deleting old session; rollback delete for new session also failed"
+                    );
+                }
+
+                return session_backend_json_response("session_refresh.delete", &error);
+            }
 
             let new_cookie = build_session_cookie(new_session.id, None);
 

--- a/apps/api/src/routes/health.rs
+++ b/apps/api/src/routes/health.rs
@@ -269,7 +269,7 @@ mod tests {
     use super::*;
     use crate::state::OrderedCache;
     use crate::{
-        auth::{rate_limit::AuthRateLimiter, session::SessionStore},
+        auth::{rate_limit::AuthRateLimiter, session::SessionBackend},
         config::AppConfig,
         telemetry::{BuildInfo, Metrics},
         test_helpers::EnvGuard,
@@ -323,7 +323,7 @@ mod tests {
             nats_configured: false,
             config,
             metrics,
-            sessions: SessionStore::new(),
+            sessions: SessionBackend::new_in_memory(),
             challenges: Default::default(),
             tokens: crate::auth::tokens::TokenStore::new(),
             step_up_tokens: crate::auth::step_up_tokens::StepUpTokenStore::new(),

--- a/apps/api/src/state.rs
+++ b/apps/api/src/state.rs
@@ -5,7 +5,7 @@ use crate::{
     auth::{
         challenges::ChallengeStore, passkeys::PasskeyRegistrationGrantStore,
         passkeys::PasskeyRegistrationStore, passkeys::PasskeyStore, rate_limit::AuthRateLimiter,
-        session::SessionStore, step_up_tokens::StepUpTokenStore, tokens::TokenStore,
+        session::SessionBackend, step_up_tokens::StepUpTokenStore, tokens::TokenStore,
     },
     config::AppConfig,
     mailer::Mailer,
@@ -67,7 +67,7 @@ pub struct ApiState {
     pub nats_configured: bool,
     pub config: AppConfig,
     pub metrics: Metrics,
-    pub sessions: SessionStore,
+    pub sessions: SessionBackend,
     pub challenges: ChallengeStore,
     pub tokens: TokenStore,
     pub step_up_tokens: StepUpTokenStore,

--- a/apps/api/tests/api_accounts.rs
+++ b/apps/api/tests/api_accounts.rs
@@ -11,7 +11,7 @@ use tokio::sync::RwLock;
 use tower::ServiceExt;
 use weltgewebe_api::{
     auth::{
-        accounts::AccountStore, rate_limit::AuthRateLimiter, role::Role, session::SessionStore,
+        accounts::AccountStore, rate_limit::AuthRateLimiter, role::Role, session::SessionBackend,
     },
     config::AppConfig,
     routes::{
@@ -64,7 +64,7 @@ async fn test_state() -> Result<ApiState> {
         nats_configured: false,
         config,
         metrics,
-        sessions: SessionStore::new(),
+        sessions: SessionBackend::new_in_memory(),
         challenges: Default::default(),
         tokens: weltgewebe_api::auth::tokens::TokenStore::new(),
         step_up_tokens: weltgewebe_api::auth::step_up_tokens::StepUpTokenStore::new(),

--- a/apps/api/tests/api_auth.rs
+++ b/apps/api/tests/api_auth.rs
@@ -12,7 +12,7 @@ use tokio::sync::RwLock;
 use tower::ServiceExt;
 use weltgewebe_api::{
     auth::{
-        accounts::AccountStore, rate_limit::AuthRateLimiter, role::Role, session::SessionStore,
+        accounts::AccountStore, rate_limit::AuthRateLimiter, role::Role, session::SessionBackend,
     },
     config::AppConfig,
     routes::{
@@ -67,7 +67,7 @@ fn test_state() -> Result<ApiState> {
         nats_configured: false,
         config,
         metrics,
-        sessions: SessionStore::new(),
+        sessions: SessionBackend::new_in_memory(),
         challenges: Default::default(),
         tokens: weltgewebe_api::auth::tokens::TokenStore::new(),
         step_up_tokens: weltgewebe_api::auth::step_up_tokens::StepUpTokenStore::new(),

--- a/apps/api/tests/api_auth.rs
+++ b/apps/api/tests/api_auth.rs
@@ -24,6 +24,40 @@ use weltgewebe_api::{
     telemetry::{BuildInfo, Metrics},
 };
 
+async fn create_session(
+    state: &ApiState,
+    account_id: &str,
+    existing_device_id: Option<&str>,
+) -> weltgewebe_api::auth::session::Session {
+    state
+        .sessions
+        .create(
+            account_id.to_string(),
+            existing_device_id.map(std::string::ToString::to_string),
+        )
+        .await
+        .expect("in-memory session backend must create session")
+}
+
+async fn get_session(
+    state: &ApiState,
+    session_id: &str,
+) -> Option<weltgewebe_api::auth::session::Session> {
+    state
+        .sessions
+        .get(session_id)
+        .await
+        .expect("in-memory session backend must fetch session")
+}
+
+async fn delete_session(state: &ApiState, session_id: &str) {
+    state
+        .sessions
+        .delete(session_id)
+        .await
+        .expect("in-memory session backend must delete session");
+}
+
 fn test_state() -> Result<ApiState> {
     let metrics = Metrics::try_new(BuildInfo {
         version: "test",
@@ -1224,7 +1258,7 @@ async fn session_endpoint_unauthenticated() -> Result<()> {
 async fn session_endpoint_authenticated() -> Result<()> {
     let state = test_state_with_accounts()?;
     // Mock a valid session for user u1
-    let session = state.sessions.create("u1".to_string(), None).await;
+    let session = create_session(&state, "u1", None).await;
     let session_id = session.id;
 
     let app = Router::new()
@@ -2080,7 +2114,7 @@ async fn test_step_up_magic_link_request_missing_mailer() -> Result<()> {
     state.config.auth_public_login = true;
     state.config.app_base_url = Some("http://localhost".to_string());
 
-    let session = state.sessions.create("u1".to_string(), None).await;
+    let session = create_session(&state, "u1", None).await;
     let session_id = session.id.clone();
     let device_id = session.device_id.clone();
 
@@ -2151,7 +2185,7 @@ async fn test_step_up_magic_link_request_invalid_challenge() -> Result<()> {
     state.config.auth_public_login = true;
     state.config.app_base_url = Some("http://localhost".to_string());
 
-    let session = state.sessions.create("u1".to_string(), None).await;
+    let session = create_session(&state, "u1", None).await;
     let session_id = session.id;
 
     let app = Router::new()
@@ -2212,10 +2246,10 @@ async fn test_step_up_magic_link_request_binding_mismatch() -> Result<()> {
         };
         accounts.insert(account);
     }
-    let session2 = state.sessions.create("u2".to_string(), None).await;
+    let session2 = create_session(&state, "u2", None).await;
     let session_id2 = session2.id;
 
-    let session1 = state.sessions.create("u1".to_string(), None).await;
+    let session1 = create_session(&state, "u1", None).await;
     let device_id1 = session1.device_id;
     let challenge1 = state.challenges.create(
         "u1".to_string(),
@@ -2286,7 +2320,7 @@ async fn test_step_up_magic_link_request_account_invalid() -> Result<()> {
         accounts.insert(account);
     }
 
-    let session = state.sessions.create("u2".to_string(), None).await;
+    let session = create_session(&state, "u2", None).await;
     let session_id = session.id.clone();
     let device_id = session.device_id.clone();
 
@@ -2337,7 +2371,7 @@ async fn test_step_up_magic_link_request_missing_base_url() -> Result<()> {
     state.config.auth_public_login = true;
     state.config.app_base_url = None; // explicitly missing
 
-    let session = state.sessions.create("u1".to_string(), None).await;
+    let session = create_session(&state, "u1", None).await;
     let session_id = session.id.clone();
     let device_id = session.device_id.clone();
 
@@ -2404,7 +2438,7 @@ async fn test_step_up_consume_invalid_token() -> Result<()> {
     let mut state = test_state_with_accounts()?;
     state.config.auth_public_login = true;
 
-    let session = state.sessions.create("u1".to_string(), None).await;
+    let session = create_session(&state, "u1", None).await;
     let session_id = session.id.clone();
 
     let app = Router::new()
@@ -2443,7 +2477,7 @@ async fn test_step_up_consume_challenge_id_mismatch() -> Result<()> {
     let mut state = test_state_with_accounts()?;
     state.config.auth_public_login = true;
 
-    let session = state.sessions.create("u1".to_string(), None).await;
+    let session = create_session(&state, "u1", None).await;
     let session_id = session.id.clone();
     let device_id = session.device_id.clone();
 
@@ -2497,7 +2531,7 @@ async fn test_step_up_consume_challenge_missing_token_gone() -> Result<()> {
     let mut state = test_state_with_accounts()?;
     state.config.auth_public_login = true;
 
-    let session = state.sessions.create("u1".to_string(), None).await;
+    let session = create_session(&state, "u1", None).await;
     let session_id = session.id.clone();
     let device_id = session.device_id.clone();
 
@@ -2570,7 +2604,7 @@ async fn test_step_up_consume_challenge_missing_token_gone() -> Result<()> {
 
     // Confirm at store level: the token is gone (NotFound, not BindingMismatch)
     use weltgewebe_api::auth::step_up_tokens::ConsumeMatchResult;
-    let device_id = state.sessions.get(&session_id).await.unwrap().device_id;
+    let device_id = get_session(&state, &session_id).await.unwrap().device_id;
     assert!(matches!(
         state
             .step_up_tokens
@@ -2589,7 +2623,7 @@ async fn test_step_up_consume_session_mismatch() -> Result<()> {
     state.config.auth_public_login = true;
 
     // session1 belongs to u1/device1 — token is bound to this
-    let session1 = state.sessions.create("u1".to_string(), None).await;
+    let session1 = create_session(&state, "u1", None).await;
     let device_id1 = session1.device_id.clone();
     let challenge = state.challenges.create(
         "u1".to_string(),
@@ -2601,7 +2635,7 @@ async fn test_step_up_consume_session_mismatch() -> Result<()> {
         .create(challenge.id.clone(), "u1".to_string(), device_id1);
 
     // session2 belongs to u1 but a different device — we present this session
-    let session2 = state.sessions.create("u1".to_string(), None).await;
+    let session2 = create_session(&state, "u1", None).await;
     let session_id2 = session2.id.clone();
 
     let app = Router::new()
@@ -2645,7 +2679,7 @@ async fn test_step_up_consume_session_mismatch_token_survives() -> Result<()> {
     state.config.auth_public_login = true;
 
     // session1 belongs to u1/device1 — token and challenge are bound to this session
-    let session1 = state.sessions.create("u1".to_string(), None).await;
+    let session1 = create_session(&state, "u1", None).await;
     let session_id1 = session1.id.clone();
     let device_id1 = session1.device_id.clone();
     let challenge = state.challenges.create(
@@ -2658,7 +2692,7 @@ async fn test_step_up_consume_session_mismatch_token_survives() -> Result<()> {
         .create(challenge.id.clone(), "u1".to_string(), device_id1);
 
     // session2 belongs to u1 but a different device — wrong session
-    let session2 = state.sessions.create("u1".to_string(), None).await;
+    let session2 = create_session(&state, "u1", None).await;
     let session_id2 = session2.id.clone();
 
     let app = Router::new()
@@ -2718,7 +2752,7 @@ async fn test_step_up_consume_token_reuse_rejected() -> Result<()> {
     let mut state = test_state_with_accounts()?;
     state.config.auth_public_login = true;
 
-    let session = state.sessions.create("u1".to_string(), None).await;
+    let session = create_session(&state, "u1", None).await;
     let session_id = session.id.clone();
     let device_id = session.device_id.clone();
 
@@ -2759,7 +2793,7 @@ async fn test_step_up_consume_token_reuse_rejected() -> Result<()> {
     assert_eq!(res1.status(), StatusCode::NO_CONTENT);
 
     // Recreate a session since all were deleted by LogoutAll
-    let new_session = state.sessions.create("u1".to_string(), None).await;
+    let new_session = create_session(&state, "u1", None).await;
     let new_session_id = new_session.id.clone();
 
     // Second call with the same token — must be rejected
@@ -2793,10 +2827,10 @@ async fn test_step_up_consume_logout_all_success() -> Result<()> {
     state.config.auth_public_login = true;
 
     // Create two sessions for the same account
-    let session1 = state.sessions.create("u1".to_string(), None).await;
+    let session1 = create_session(&state, "u1", None).await;
     let session_id1 = session1.id.clone();
     let device_id1 = session1.device_id.clone();
-    let session2 = state.sessions.create("u1".to_string(), None).await;
+    let session2 = create_session(&state, "u1", None).await;
     let session_id2 = session2.id.clone();
 
     let challenge = state.challenges.create(
@@ -2835,9 +2869,9 @@ async fn test_step_up_consume_logout_all_success() -> Result<()> {
     assert_eq!(res.status(), StatusCode::NO_CONTENT);
 
     // Session 1 must be gone
-    assert!(state.sessions.get(&session_id1).await.is_none());
+    assert!(get_session(&state, &session_id1).await.is_none());
     // Session 2 must also be gone (LogoutAll)
-    assert!(state.sessions.get(&session_id2).await.is_none());
+    assert!(get_session(&state, &session_id2).await.is_none());
 
     // The challenge must be consumed (single-use)
     assert!(state.challenges.get(&challenge.id).is_none());
@@ -2851,15 +2885,12 @@ async fn test_step_up_consume_remove_device_success() -> Result<()> {
     state.config.auth_public_login = true;
 
     // session1 is the requesting session (device1)
-    let session1 = state.sessions.create("u1".to_string(), None).await;
+    let session1 = create_session(&state, "u1", None).await;
     let session_id1 = session1.id.clone();
     let device_id1 = session1.device_id.clone();
 
     // session2 is the target device to remove (device2)
-    let session2 = state
-        .sessions
-        .create("u1".to_string(), Some("target-device".to_string()))
-        .await;
+    let session2 = create_session(&state, "u1", Some("target-device")).await;
     let session_id2 = session2.id.clone();
 
     let challenge = state.challenges.create(
@@ -2900,9 +2931,9 @@ async fn test_step_up_consume_remove_device_success() -> Result<()> {
     assert_eq!(res.status(), StatusCode::NO_CONTENT);
 
     // Target device (session2) must be removed
-    assert!(state.sessions.get(&session_id2).await.is_none());
+    assert!(get_session(&state, &session_id2).await.is_none());
     // Requesting session (session1) must still be valid
-    assert!(state.sessions.get(&session_id1).await.is_some());
+    assert!(get_session(&state, &session_id1).await.is_some());
 
     // The challenge must be consumed (single-use)
     assert!(state.challenges.get(&challenge.id).is_none());
@@ -2915,10 +2946,7 @@ async fn test_update_email_no_op_returns_204() -> Result<()> {
     let mut state = test_state_with_accounts()?;
     state.config.auth_public_login = true;
 
-    let session = state
-        .sessions
-        .create("u1".to_string(), Some("dev1".to_string()))
-        .await;
+    let session = create_session(&state, "u1", Some("dev1")).await;
     let cookie = format!("{}={}", SESSION_COOKIE_NAME, session.id);
 
     let app = Router::new()
@@ -2961,10 +2989,7 @@ async fn test_update_email_full_e2e_flow() -> Result<()> {
         .with_test_sink(sink.clone());
     state.mailer = Some(std::sync::Arc::new(mailer));
 
-    let session = state
-        .sessions
-        .create("u1".to_string(), Some("dev1".to_string()))
-        .await;
+    let session = create_session(&state, "u1", Some("dev1")).await;
     let cookie = format!("{}={}", SESSION_COOKIE_NAME, session.id);
 
     let app = Router::new()
@@ -3075,10 +3100,7 @@ async fn test_update_email_invalid_format() -> Result<()> {
     let mut state = test_state_with_accounts()?;
     state.config.auth_public_login = true;
 
-    let session = state
-        .sessions
-        .create("u1".to_string(), Some("dev1".to_string()))
-        .await;
+    let session = create_session(&state, "u1", Some("dev1")).await;
     let cookie = format!("{}={}", SESSION_COOKIE_NAME, session.id);
 
     let app = Router::new()
@@ -3138,10 +3160,7 @@ async fn test_step_up_consume_begin_passkey_registration_issues_grant() -> Resul
     let mut state = test_state_with_accounts()?;
     state.config.auth_public_login = true;
 
-    let session = state
-        .sessions
-        .create("u1".to_string(), Some("dev-passkey".to_string()))
-        .await;
+    let session = create_session(&state, "u1", Some("dev-passkey")).await;
     let challenge = state.challenges.create(
         "u1".to_string(),
         "dev-passkey".to_string(),
@@ -3194,7 +3213,7 @@ async fn test_step_up_consume_begin_passkey_registration_issues_grant() -> Resul
     );
 
     assert!(
-        state.sessions.get(&session.id).await.is_some(),
+        get_session(&state, &session.id).await.is_some(),
         "begin-passkey-registration step-up must not alter sessions"
     );
     assert!(
@@ -3211,10 +3230,7 @@ async fn test_update_email_requires_step_up() -> Result<()> {
     let mut state = test_state_with_accounts()?;
     state.config.auth_public_login = true;
 
-    let session = state
-        .sessions
-        .create("u1".to_string(), Some("dev1".to_string()))
-        .await;
+    let session = create_session(&state, "u1", Some("dev1")).await;
     let cookie = format!("{}={}", SESSION_COOKIE_NAME, session.id);
 
     let app = Router::new()
@@ -3254,10 +3270,7 @@ async fn test_update_email_conflict_with_existing_account() -> Result<()> {
     let mut state = test_state_with_accounts()?;
     state.config.auth_public_login = true;
 
-    let session = state
-        .sessions
-        .create("u1".to_string(), Some("dev1".to_string()))
-        .await;
+    let session = create_session(&state, "u1", Some("dev1")).await;
     let cookie = format!("{}={}", SESSION_COOKIE_NAME, session.id);
 
     let app = Router::new()
@@ -3311,16 +3324,10 @@ async fn test_update_email_consume_wrong_session() -> Result<()> {
     state.config.auth_public_login = true;
 
     // Session 1 is the one that initiated the update
-    let session1 = state
-        .sessions
-        .create("u1".to_string(), Some("dev1".to_string()))
-        .await;
+    let session1 = create_session(&state, "u1", Some("dev1")).await;
 
     // Session 2 is an attacker or just another session
-    let session2 = state
-        .sessions
-        .create("u2".to_string(), Some("dev2".to_string()))
-        .await;
+    let session2 = create_session(&state, "u2", Some("dev2")).await;
     let wrong_cookie = format!("{}={}", SESSION_COOKIE_NAME, session2.id);
 
     use weltgewebe_api::auth::challenges::ChallengeIntent;
@@ -3381,10 +3388,7 @@ async fn test_update_email_consume_session_rotation() -> Result<()> {
     state.config.auth_public_login = true;
 
     // Session 1 is the one that initiated the update (same device)
-    let session1 = state
-        .sessions
-        .create("u1".to_string(), Some("dev1".to_string()))
-        .await;
+    let session1 = create_session(&state, "u1", Some("dev1")).await;
 
     use weltgewebe_api::auth::challenges::ChallengeIntent;
 
@@ -3403,11 +3407,8 @@ async fn test_update_email_consume_session_rotation() -> Result<()> {
     );
 
     // Simulate session rotation: Session 1 expires, new Session 2 is created for the *same* device
-    state.sessions.delete(&session1.id).await;
-    let session2 = state
-        .sessions
-        .create("u1".to_string(), Some("dev1".to_string()))
-        .await;
+    delete_session(&state, &session1.id).await;
+    let session2 = create_session(&state, "u1", Some("dev1")).await;
 
     let new_cookie = format!("{}={}", SESSION_COOKIE_NAME, session2.id);
 
@@ -3495,7 +3496,7 @@ async fn passkey_register_options_requires_authentication() -> Result<()> {
 async fn passkey_register_options_returns_503_when_not_configured() -> Result<()> {
     let state = test_state_with_accounts()?;
     // webauthn is None in default test_state
-    let session = state.sessions.create("u1".to_string(), None).await;
+    let session = create_session(&state, "u1", None).await;
 
     let app = app_with_auth(state);
 
@@ -3522,10 +3523,7 @@ async fn passkey_register_options_returns_503_when_not_configured() -> Result<()
 #[tokio::test]
 async fn passkey_register_options_requires_step_up_challenge() -> Result<()> {
     let state = test_state_with_webauthn()?;
-    let session = state
-        .sessions
-        .create("u1".to_string(), Some("dev-passkey".to_string()))
-        .await;
+    let session = create_session(&state, "u1", Some("dev-passkey")).await;
     let expected_device_id = session.device_id.clone();
 
     let app = app_with_auth(state.clone());
@@ -3565,10 +3563,7 @@ async fn passkey_register_options_requires_step_up_challenge() -> Result<()> {
 #[tokio::test]
 async fn passkey_register_options_reuses_active_step_up_challenge() -> Result<()> {
     let state = test_state_with_webauthn()?;
-    let session = state
-        .sessions
-        .create("u1".to_string(), Some("dev-passkey".to_string()))
-        .await;
+    let session = create_session(&state, "u1", Some("dev-passkey")).await;
 
     let app = app_with_auth(state.clone());
 
@@ -3685,10 +3680,7 @@ async fn consume_begin_passkey_registration_step_up(
 #[tokio::test]
 async fn passkey_register_options_with_valid_grant_returns_200() -> Result<()> {
     let state = test_state_with_webauthn()?;
-    let session = state
-        .sessions
-        .create("u1".to_string(), Some("dev-passkey".to_string()))
-        .await;
+    let session = create_session(&state, "u1", Some("dev-passkey")).await;
     let cookie = format!("{}={}", SESSION_COOKIE_NAME, session.id);
 
     let challenge_id = request_passkey_registration_challenge(&state, &cookie).await?;
@@ -3759,10 +3751,7 @@ async fn passkey_register_options_with_valid_grant_returns_200() -> Result<()> {
 #[tokio::test]
 async fn passkey_register_options_grant_is_single_use() -> Result<()> {
     let state = test_state_with_webauthn()?;
-    let session = state
-        .sessions
-        .create("u1".to_string(), Some("dev-passkey".to_string()))
-        .await;
+    let session = create_session(&state, "u1", Some("dev-passkey")).await;
     let cookie = format!("{}={}", SESSION_COOKIE_NAME, session.id);
 
     let challenge_id = request_passkey_registration_challenge(&state, &cookie).await?;
@@ -3816,15 +3805,9 @@ async fn passkey_register_options_grant_wrong_account_rejected() -> Result<()> {
     let state = test_state_with_webauthn()?;
 
     // Session for u1 with device "dev-passkey".
-    let session_u1 = state
-        .sessions
-        .create("u1".to_string(), Some("dev-passkey".to_string()))
-        .await;
+    let session_u1 = create_session(&state, "u1", Some("dev-passkey")).await;
     // Session for a1 (different account, different device).
-    let session_a1 = state
-        .sessions
-        .create("a1".to_string(), Some("dev-a1".to_string()))
-        .await;
+    let session_a1 = create_session(&state, "a1", Some("dev-a1")).await;
     let cookie_u1 = format!("{}={}", SESSION_COOKIE_NAME, session_u1.id);
     let cookie_a1 = format!("{}={}", SESSION_COOKIE_NAME, session_a1.id);
 
@@ -3882,14 +3865,8 @@ async fn passkey_register_options_grant_wrong_account_rejected() -> Result<()> {
 async fn passkey_register_options_grant_wrong_device_rejected() -> Result<()> {
     let state = test_state_with_webauthn()?;
 
-    let session_u1_device_a = state
-        .sessions
-        .create("u1".to_string(), Some("dev-passkey".to_string()))
-        .await;
-    let session_u1_device_b = state
-        .sessions
-        .create("u1".to_string(), Some("dev-other".to_string()))
-        .await;
+    let session_u1_device_a = create_session(&state, "u1", Some("dev-passkey")).await;
+    let session_u1_device_b = create_session(&state, "u1", Some("dev-other")).await;
     let cookie_device_a = format!("{}={}", SESSION_COOKIE_NAME, session_u1_device_a.id);
     let cookie_device_b = format!("{}={}", SESSION_COOKIE_NAME, session_u1_device_b.id);
 
@@ -3944,10 +3921,7 @@ async fn passkey_register_options_grant_wrong_device_rejected() -> Result<()> {
 #[tokio::test]
 async fn passkey_register_options_without_grant_still_returns_step_up_required() -> Result<()> {
     let state = test_state_with_webauthn()?;
-    let session = state
-        .sessions
-        .create("u1".to_string(), Some("dev-passkey".to_string()))
-        .await;
+    let session = create_session(&state, "u1", Some("dev-passkey")).await;
 
     let app = app_with_auth(state.clone());
     let req = Request::post("/auth/passkeys/register/options")
@@ -3973,10 +3947,7 @@ async fn passkey_register_options_without_grant_still_returns_step_up_required()
 #[tokio::test]
 async fn passkey_register_options_expired_grant_rejected() -> Result<()> {
     let state = test_state_with_webauthn()?;
-    let session = state
-        .sessions
-        .create("u1".to_string(), Some("dev-passkey".to_string()))
-        .await;
+    let session = create_session(&state, "u1", Some("dev-passkey")).await;
     let cookie = format!("{}={}", SESSION_COOKIE_NAME, session.id);
 
     // Insert an already-expired grant directly.

--- a/apps/api/tests/api_auth.rs
+++ b/apps/api/tests/api_auth.rs
@@ -1224,7 +1224,7 @@ async fn session_endpoint_unauthenticated() -> Result<()> {
 async fn session_endpoint_authenticated() -> Result<()> {
     let state = test_state_with_accounts()?;
     // Mock a valid session for user u1
-    let session = state.sessions.create("u1".to_string(), None);
+    let session = state.sessions.create("u1".to_string(), None).await;
     let session_id = session.id;
 
     let app = Router::new()
@@ -2080,7 +2080,7 @@ async fn test_step_up_magic_link_request_missing_mailer() -> Result<()> {
     state.config.auth_public_login = true;
     state.config.app_base_url = Some("http://localhost".to_string());
 
-    let session = state.sessions.create("u1".to_string(), None);
+    let session = state.sessions.create("u1".to_string(), None).await;
     let session_id = session.id.clone();
     let device_id = session.device_id.clone();
 
@@ -2151,7 +2151,7 @@ async fn test_step_up_magic_link_request_invalid_challenge() -> Result<()> {
     state.config.auth_public_login = true;
     state.config.app_base_url = Some("http://localhost".to_string());
 
-    let session = state.sessions.create("u1".to_string(), None);
+    let session = state.sessions.create("u1".to_string(), None).await;
     let session_id = session.id;
 
     let app = Router::new()
@@ -2212,10 +2212,10 @@ async fn test_step_up_magic_link_request_binding_mismatch() -> Result<()> {
         };
         accounts.insert(account);
     }
-    let session2 = state.sessions.create("u2".to_string(), None);
+    let session2 = state.sessions.create("u2".to_string(), None).await;
     let session_id2 = session2.id;
 
-    let session1 = state.sessions.create("u1".to_string(), None);
+    let session1 = state.sessions.create("u1".to_string(), None).await;
     let device_id1 = session1.device_id;
     let challenge1 = state.challenges.create(
         "u1".to_string(),
@@ -2286,7 +2286,7 @@ async fn test_step_up_magic_link_request_account_invalid() -> Result<()> {
         accounts.insert(account);
     }
 
-    let session = state.sessions.create("u2".to_string(), None);
+    let session = state.sessions.create("u2".to_string(), None).await;
     let session_id = session.id.clone();
     let device_id = session.device_id.clone();
 
@@ -2337,7 +2337,7 @@ async fn test_step_up_magic_link_request_missing_base_url() -> Result<()> {
     state.config.auth_public_login = true;
     state.config.app_base_url = None; // explicitly missing
 
-    let session = state.sessions.create("u1".to_string(), None);
+    let session = state.sessions.create("u1".to_string(), None).await;
     let session_id = session.id.clone();
     let device_id = session.device_id.clone();
 
@@ -2404,7 +2404,7 @@ async fn test_step_up_consume_invalid_token() -> Result<()> {
     let mut state = test_state_with_accounts()?;
     state.config.auth_public_login = true;
 
-    let session = state.sessions.create("u1".to_string(), None);
+    let session = state.sessions.create("u1".to_string(), None).await;
     let session_id = session.id.clone();
 
     let app = Router::new()
@@ -2443,7 +2443,7 @@ async fn test_step_up_consume_challenge_id_mismatch() -> Result<()> {
     let mut state = test_state_with_accounts()?;
     state.config.auth_public_login = true;
 
-    let session = state.sessions.create("u1".to_string(), None);
+    let session = state.sessions.create("u1".to_string(), None).await;
     let session_id = session.id.clone();
     let device_id = session.device_id.clone();
 
@@ -2497,7 +2497,7 @@ async fn test_step_up_consume_challenge_missing_token_gone() -> Result<()> {
     let mut state = test_state_with_accounts()?;
     state.config.auth_public_login = true;
 
-    let session = state.sessions.create("u1".to_string(), None);
+    let session = state.sessions.create("u1".to_string(), None).await;
     let session_id = session.id.clone();
     let device_id = session.device_id.clone();
 
@@ -2570,7 +2570,7 @@ async fn test_step_up_consume_challenge_missing_token_gone() -> Result<()> {
 
     // Confirm at store level: the token is gone (NotFound, not BindingMismatch)
     use weltgewebe_api::auth::step_up_tokens::ConsumeMatchResult;
-    let device_id = state.sessions.get(&session_id).unwrap().device_id;
+    let device_id = state.sessions.get(&session_id).await.unwrap().device_id;
     assert!(matches!(
         state
             .step_up_tokens
@@ -2589,7 +2589,7 @@ async fn test_step_up_consume_session_mismatch() -> Result<()> {
     state.config.auth_public_login = true;
 
     // session1 belongs to u1/device1 — token is bound to this
-    let session1 = state.sessions.create("u1".to_string(), None);
+    let session1 = state.sessions.create("u1".to_string(), None).await;
     let device_id1 = session1.device_id.clone();
     let challenge = state.challenges.create(
         "u1".to_string(),
@@ -2601,7 +2601,7 @@ async fn test_step_up_consume_session_mismatch() -> Result<()> {
         .create(challenge.id.clone(), "u1".to_string(), device_id1);
 
     // session2 belongs to u1 but a different device — we present this session
-    let session2 = state.sessions.create("u1".to_string(), None);
+    let session2 = state.sessions.create("u1".to_string(), None).await;
     let session_id2 = session2.id.clone();
 
     let app = Router::new()
@@ -2645,7 +2645,7 @@ async fn test_step_up_consume_session_mismatch_token_survives() -> Result<()> {
     state.config.auth_public_login = true;
 
     // session1 belongs to u1/device1 — token and challenge are bound to this session
-    let session1 = state.sessions.create("u1".to_string(), None);
+    let session1 = state.sessions.create("u1".to_string(), None).await;
     let session_id1 = session1.id.clone();
     let device_id1 = session1.device_id.clone();
     let challenge = state.challenges.create(
@@ -2658,7 +2658,7 @@ async fn test_step_up_consume_session_mismatch_token_survives() -> Result<()> {
         .create(challenge.id.clone(), "u1".to_string(), device_id1);
 
     // session2 belongs to u1 but a different device — wrong session
-    let session2 = state.sessions.create("u1".to_string(), None);
+    let session2 = state.sessions.create("u1".to_string(), None).await;
     let session_id2 = session2.id.clone();
 
     let app = Router::new()
@@ -2718,7 +2718,7 @@ async fn test_step_up_consume_token_reuse_rejected() -> Result<()> {
     let mut state = test_state_with_accounts()?;
     state.config.auth_public_login = true;
 
-    let session = state.sessions.create("u1".to_string(), None);
+    let session = state.sessions.create("u1".to_string(), None).await;
     let session_id = session.id.clone();
     let device_id = session.device_id.clone();
 
@@ -2759,7 +2759,7 @@ async fn test_step_up_consume_token_reuse_rejected() -> Result<()> {
     assert_eq!(res1.status(), StatusCode::NO_CONTENT);
 
     // Recreate a session since all were deleted by LogoutAll
-    let new_session = state.sessions.create("u1".to_string(), None);
+    let new_session = state.sessions.create("u1".to_string(), None).await;
     let new_session_id = new_session.id.clone();
 
     // Second call with the same token — must be rejected
@@ -2793,10 +2793,10 @@ async fn test_step_up_consume_logout_all_success() -> Result<()> {
     state.config.auth_public_login = true;
 
     // Create two sessions for the same account
-    let session1 = state.sessions.create("u1".to_string(), None);
+    let session1 = state.sessions.create("u1".to_string(), None).await;
     let session_id1 = session1.id.clone();
     let device_id1 = session1.device_id.clone();
-    let session2 = state.sessions.create("u1".to_string(), None);
+    let session2 = state.sessions.create("u1".to_string(), None).await;
     let session_id2 = session2.id.clone();
 
     let challenge = state.challenges.create(
@@ -2835,9 +2835,9 @@ async fn test_step_up_consume_logout_all_success() -> Result<()> {
     assert_eq!(res.status(), StatusCode::NO_CONTENT);
 
     // Session 1 must be gone
-    assert!(state.sessions.get(&session_id1).is_none());
+    assert!(state.sessions.get(&session_id1).await.is_none());
     // Session 2 must also be gone (LogoutAll)
-    assert!(state.sessions.get(&session_id2).is_none());
+    assert!(state.sessions.get(&session_id2).await.is_none());
 
     // The challenge must be consumed (single-use)
     assert!(state.challenges.get(&challenge.id).is_none());
@@ -2851,14 +2851,15 @@ async fn test_step_up_consume_remove_device_success() -> Result<()> {
     state.config.auth_public_login = true;
 
     // session1 is the requesting session (device1)
-    let session1 = state.sessions.create("u1".to_string(), None);
+    let session1 = state.sessions.create("u1".to_string(), None).await;
     let session_id1 = session1.id.clone();
     let device_id1 = session1.device_id.clone();
 
     // session2 is the target device to remove (device2)
     let session2 = state
         .sessions
-        .create("u1".to_string(), Some("target-device".to_string()));
+        .create("u1".to_string(), Some("target-device".to_string()))
+        .await;
     let session_id2 = session2.id.clone();
 
     let challenge = state.challenges.create(
@@ -2899,9 +2900,9 @@ async fn test_step_up_consume_remove_device_success() -> Result<()> {
     assert_eq!(res.status(), StatusCode::NO_CONTENT);
 
     // Target device (session2) must be removed
-    assert!(state.sessions.get(&session_id2).is_none());
+    assert!(state.sessions.get(&session_id2).await.is_none());
     // Requesting session (session1) must still be valid
-    assert!(state.sessions.get(&session_id1).is_some());
+    assert!(state.sessions.get(&session_id1).await.is_some());
 
     // The challenge must be consumed (single-use)
     assert!(state.challenges.get(&challenge.id).is_none());
@@ -2916,7 +2917,8 @@ async fn test_update_email_no_op_returns_204() -> Result<()> {
 
     let session = state
         .sessions
-        .create("u1".to_string(), Some("dev1".to_string()));
+        .create("u1".to_string(), Some("dev1".to_string()))
+        .await;
     let cookie = format!("{}={}", SESSION_COOKIE_NAME, session.id);
 
     let app = Router::new()
@@ -2961,7 +2963,8 @@ async fn test_update_email_full_e2e_flow() -> Result<()> {
 
     let session = state
         .sessions
-        .create("u1".to_string(), Some("dev1".to_string()));
+        .create("u1".to_string(), Some("dev1".to_string()))
+        .await;
     let cookie = format!("{}={}", SESSION_COOKIE_NAME, session.id);
 
     let app = Router::new()
@@ -3074,7 +3077,8 @@ async fn test_update_email_invalid_format() -> Result<()> {
 
     let session = state
         .sessions
-        .create("u1".to_string(), Some("dev1".to_string()));
+        .create("u1".to_string(), Some("dev1".to_string()))
+        .await;
     let cookie = format!("{}={}", SESSION_COOKIE_NAME, session.id);
 
     let app = Router::new()
@@ -3136,7 +3140,8 @@ async fn test_step_up_consume_begin_passkey_registration_issues_grant() -> Resul
 
     let session = state
         .sessions
-        .create("u1".to_string(), Some("dev-passkey".to_string()));
+        .create("u1".to_string(), Some("dev-passkey".to_string()))
+        .await;
     let challenge = state.challenges.create(
         "u1".to_string(),
         "dev-passkey".to_string(),
@@ -3189,7 +3194,7 @@ async fn test_step_up_consume_begin_passkey_registration_issues_grant() -> Resul
     );
 
     assert!(
-        state.sessions.get(&session.id).is_some(),
+        state.sessions.get(&session.id).await.is_some(),
         "begin-passkey-registration step-up must not alter sessions"
     );
     assert!(
@@ -3208,7 +3213,8 @@ async fn test_update_email_requires_step_up() -> Result<()> {
 
     let session = state
         .sessions
-        .create("u1".to_string(), Some("dev1".to_string()));
+        .create("u1".to_string(), Some("dev1".to_string()))
+        .await;
     let cookie = format!("{}={}", SESSION_COOKIE_NAME, session.id);
 
     let app = Router::new()
@@ -3250,7 +3256,8 @@ async fn test_update_email_conflict_with_existing_account() -> Result<()> {
 
     let session = state
         .sessions
-        .create("u1".to_string(), Some("dev1".to_string()));
+        .create("u1".to_string(), Some("dev1".to_string()))
+        .await;
     let cookie = format!("{}={}", SESSION_COOKIE_NAME, session.id);
 
     let app = Router::new()
@@ -3306,12 +3313,14 @@ async fn test_update_email_consume_wrong_session() -> Result<()> {
     // Session 1 is the one that initiated the update
     let session1 = state
         .sessions
-        .create("u1".to_string(), Some("dev1".to_string()));
+        .create("u1".to_string(), Some("dev1".to_string()))
+        .await;
 
     // Session 2 is an attacker or just another session
     let session2 = state
         .sessions
-        .create("u2".to_string(), Some("dev2".to_string()));
+        .create("u2".to_string(), Some("dev2".to_string()))
+        .await;
     let wrong_cookie = format!("{}={}", SESSION_COOKIE_NAME, session2.id);
 
     use weltgewebe_api::auth::challenges::ChallengeIntent;
@@ -3374,7 +3383,8 @@ async fn test_update_email_consume_session_rotation() -> Result<()> {
     // Session 1 is the one that initiated the update (same device)
     let session1 = state
         .sessions
-        .create("u1".to_string(), Some("dev1".to_string()));
+        .create("u1".to_string(), Some("dev1".to_string()))
+        .await;
 
     use weltgewebe_api::auth::challenges::ChallengeIntent;
 
@@ -3393,10 +3403,11 @@ async fn test_update_email_consume_session_rotation() -> Result<()> {
     );
 
     // Simulate session rotation: Session 1 expires, new Session 2 is created for the *same* device
-    state.sessions.delete(&session1.id);
+    state.sessions.delete(&session1.id).await;
     let session2 = state
         .sessions
-        .create("u1".to_string(), Some("dev1".to_string()));
+        .create("u1".to_string(), Some("dev1".to_string()))
+        .await;
 
     let new_cookie = format!("{}={}", SESSION_COOKIE_NAME, session2.id);
 
@@ -3484,7 +3495,7 @@ async fn passkey_register_options_requires_authentication() -> Result<()> {
 async fn passkey_register_options_returns_503_when_not_configured() -> Result<()> {
     let state = test_state_with_accounts()?;
     // webauthn is None in default test_state
-    let session = state.sessions.create("u1".to_string(), None);
+    let session = state.sessions.create("u1".to_string(), None).await;
 
     let app = app_with_auth(state);
 
@@ -3513,7 +3524,8 @@ async fn passkey_register_options_requires_step_up_challenge() -> Result<()> {
     let state = test_state_with_webauthn()?;
     let session = state
         .sessions
-        .create("u1".to_string(), Some("dev-passkey".to_string()));
+        .create("u1".to_string(), Some("dev-passkey".to_string()))
+        .await;
     let expected_device_id = session.device_id.clone();
 
     let app = app_with_auth(state.clone());
@@ -3555,7 +3567,8 @@ async fn passkey_register_options_reuses_active_step_up_challenge() -> Result<()
     let state = test_state_with_webauthn()?;
     let session = state
         .sessions
-        .create("u1".to_string(), Some("dev-passkey".to_string()));
+        .create("u1".to_string(), Some("dev-passkey".to_string()))
+        .await;
 
     let app = app_with_auth(state.clone());
 
@@ -3674,7 +3687,8 @@ async fn passkey_register_options_with_valid_grant_returns_200() -> Result<()> {
     let state = test_state_with_webauthn()?;
     let session = state
         .sessions
-        .create("u1".to_string(), Some("dev-passkey".to_string()));
+        .create("u1".to_string(), Some("dev-passkey".to_string()))
+        .await;
     let cookie = format!("{}={}", SESSION_COOKIE_NAME, session.id);
 
     let challenge_id = request_passkey_registration_challenge(&state, &cookie).await?;
@@ -3747,7 +3761,8 @@ async fn passkey_register_options_grant_is_single_use() -> Result<()> {
     let state = test_state_with_webauthn()?;
     let session = state
         .sessions
-        .create("u1".to_string(), Some("dev-passkey".to_string()));
+        .create("u1".to_string(), Some("dev-passkey".to_string()))
+        .await;
     let cookie = format!("{}={}", SESSION_COOKIE_NAME, session.id);
 
     let challenge_id = request_passkey_registration_challenge(&state, &cookie).await?;
@@ -3803,11 +3818,13 @@ async fn passkey_register_options_grant_wrong_account_rejected() -> Result<()> {
     // Session for u1 with device "dev-passkey".
     let session_u1 = state
         .sessions
-        .create("u1".to_string(), Some("dev-passkey".to_string()));
+        .create("u1".to_string(), Some("dev-passkey".to_string()))
+        .await;
     // Session for a1 (different account, different device).
     let session_a1 = state
         .sessions
-        .create("a1".to_string(), Some("dev-a1".to_string()));
+        .create("a1".to_string(), Some("dev-a1".to_string()))
+        .await;
     let cookie_u1 = format!("{}={}", SESSION_COOKIE_NAME, session_u1.id);
     let cookie_a1 = format!("{}={}", SESSION_COOKIE_NAME, session_a1.id);
 
@@ -3867,10 +3884,12 @@ async fn passkey_register_options_grant_wrong_device_rejected() -> Result<()> {
 
     let session_u1_device_a = state
         .sessions
-        .create("u1".to_string(), Some("dev-passkey".to_string()));
+        .create("u1".to_string(), Some("dev-passkey".to_string()))
+        .await;
     let session_u1_device_b = state
         .sessions
-        .create("u1".to_string(), Some("dev-other".to_string()));
+        .create("u1".to_string(), Some("dev-other".to_string()))
+        .await;
     let cookie_device_a = format!("{}={}", SESSION_COOKIE_NAME, session_u1_device_a.id);
     let cookie_device_b = format!("{}={}", SESSION_COOKIE_NAME, session_u1_device_b.id);
 
@@ -3927,7 +3946,8 @@ async fn passkey_register_options_without_grant_still_returns_step_up_required()
     let state = test_state_with_webauthn()?;
     let session = state
         .sessions
-        .create("u1".to_string(), Some("dev-passkey".to_string()));
+        .create("u1".to_string(), Some("dev-passkey".to_string()))
+        .await;
 
     let app = app_with_auth(state.clone());
     let req = Request::post("/auth/passkeys/register/options")
@@ -3955,7 +3975,8 @@ async fn passkey_register_options_expired_grant_rejected() -> Result<()> {
     let state = test_state_with_webauthn()?;
     let session = state
         .sessions
-        .create("u1".to_string(), Some("dev-passkey".to_string()));
+        .create("u1".to_string(), Some("dev-passkey".to_string()))
+        .await;
     let cookie = format!("{}={}", SESSION_COOKIE_NAME, session.id);
 
     // Insert an already-expired grant directly.

--- a/apps/api/tests/api_edges.rs
+++ b/apps/api/tests/api_edges.rs
@@ -12,7 +12,7 @@ use std::{fs, path::PathBuf, sync::Arc};
 use tokio::sync::RwLock;
 use tower::ServiceExt;
 use weltgewebe_api::{
-    auth::{accounts::AccountStore, rate_limit::AuthRateLimiter, session::SessionStore},
+    auth::{accounts::AccountStore, rate_limit::AuthRateLimiter, session::SessionBackend},
     config::AppConfig,
     routes::api_router,
     state::ApiState,
@@ -64,7 +64,7 @@ async fn test_state() -> Result<ApiState> {
         nats_configured: false,
         config,
         metrics,
-        sessions: SessionStore::new(),
+        sessions: SessionBackend::new_in_memory(),
         challenges: Default::default(),
         tokens: weltgewebe_api::auth::tokens::TokenStore::new(),
         step_up_tokens: weltgewebe_api::auth::step_up_tokens::StepUpTokenStore::new(),

--- a/apps/api/tests/api_nodes.rs
+++ b/apps/api/tests/api_nodes.rs
@@ -27,6 +27,21 @@ use weltgewebe_api::{
     test_helpers::EnvGuard,
 };
 
+async fn create_session(
+    state: &ApiState,
+    account_id: &str,
+    existing_device_id: Option<&str>,
+) -> weltgewebe_api::auth::session::Session {
+    state
+        .sessions
+        .create(
+            account_id.to_string(),
+            existing_device_id.map(std::string::ToString::to_string),
+        )
+        .await
+        .expect("in-memory session backend must create session")
+}
+
 async fn test_state() -> Result<ApiState> {
     let metrics = Metrics::try_new(BuildInfo {
         version: "test",
@@ -226,7 +241,7 @@ async fn nodes_patch_info_lifecycle() -> anyhow::Result<()> {
     state.accounts = Arc::new(RwLock::new(account_map));
 
     // Create Session
-    let session = state.sessions.create("weber1".to_string(), None).await;
+    let session = create_session(&state, "weber1", None).await;
     let cookie_val = format!("gewebe_session={}", session.id);
 
     let app = Router::new()
@@ -410,7 +425,7 @@ async fn nodes_patch_without_origin_fails() -> anyhow::Result<()> {
     state.accounts = Arc::new(RwLock::new(account_map));
 
     // Create Session
-    let session = state.sessions.create("weber1".to_string(), None).await;
+    let session = create_session(&state, "weber1", None).await;
     let cookie_val = format!("gewebe_session={}", session.id);
 
     let app = Router::new()

--- a/apps/api/tests/api_nodes.rs
+++ b/apps/api/tests/api_nodes.rs
@@ -226,7 +226,7 @@ async fn nodes_patch_info_lifecycle() -> anyhow::Result<()> {
     state.accounts = Arc::new(RwLock::new(account_map));
 
     // Create Session
-    let session = state.sessions.create("weber1".to_string(), None);
+    let session = state.sessions.create("weber1".to_string(), None).await;
     let cookie_val = format!("gewebe_session={}", session.id);
 
     let app = Router::new()
@@ -410,7 +410,7 @@ async fn nodes_patch_without_origin_fails() -> anyhow::Result<()> {
     state.accounts = Arc::new(RwLock::new(account_map));
 
     // Create Session
-    let session = state.sessions.create("weber1".to_string(), None);
+    let session = state.sessions.create("weber1".to_string(), None).await;
     let cookie_val = format!("gewebe_session={}", session.id);
 
     let app = Router::new()

--- a/apps/api/tests/api_nodes.rs
+++ b/apps/api/tests/api_nodes.rs
@@ -14,7 +14,7 @@ use tokio::sync::RwLock;
 use tower::ServiceExt;
 use weltgewebe_api::{
     auth::{
-        accounts::AccountStore, rate_limit::AuthRateLimiter, role::Role, session::SessionStore,
+        accounts::AccountStore, rate_limit::AuthRateLimiter, role::Role, session::SessionBackend,
     },
     config::AppConfig,
     middleware::{auth::auth_middleware, csrf::require_csrf},
@@ -69,7 +69,7 @@ async fn test_state() -> Result<ApiState> {
         nats_configured: false,
         config,
         metrics,
-        sessions: SessionStore::new(),
+        sessions: SessionBackend::new_in_memory(),
         challenges: Default::default(),
         tokens: weltgewebe_api::auth::tokens::TokenStore::new(),
         step_up_tokens: weltgewebe_api::auth::step_up_tokens::StepUpTokenStore::new(),

--- a/apps/api/tests/auth_handler_test.rs
+++ b/apps/api/tests/auth_handler_test.rs
@@ -13,7 +13,8 @@ mod tests {
     use tower::ServiceExt;
     use weltgewebe_api::{
         auth::{
-            accounts::AccountStore, rate_limit::AuthRateLimiter, role::Role, session::SessionStore,
+            accounts::AccountStore, rate_limit::AuthRateLimiter, role::Role,
+            session::SessionBackend,
         },
         config::AppConfig,
         routes::{
@@ -86,7 +87,7 @@ mod tests {
             nats_configured: false,
             config,
             metrics,
-            sessions: SessionStore::new(),
+            sessions: SessionBackend::new_in_memory(),
             challenges: Default::default(),
             tokens: weltgewebe_api::auth::tokens::TokenStore::new(),
             step_up_tokens: weltgewebe_api::auth::step_up_tokens::StepUpTokenStore::new(),

--- a/apps/api/tests/auth_open_registration.rs
+++ b/apps/api/tests/auth_open_registration.rs
@@ -10,7 +10,7 @@ use std::{net::SocketAddr, sync::Arc};
 use tokio::sync::RwLock;
 use tower::ServiceExt;
 use weltgewebe_api::{
-    auth::{accounts::AccountStore, rate_limit::AuthRateLimiter, session::SessionStore},
+    auth::{accounts::AccountStore, rate_limit::AuthRateLimiter, session::SessionBackend},
     config::AppConfig,
     routes::{api_router, auth::GENERIC_LOGIN_MSG},
     state::ApiState,
@@ -71,7 +71,7 @@ fn test_state_open_reg() -> Result<ApiState> {
         nats_configured: false,
         config,
         metrics,
-        sessions: SessionStore::new(),
+        sessions: SessionBackend::new_in_memory(),
         challenges: Default::default(),
         tokens: weltgewebe_api::auth::tokens::TokenStore::new(),
         step_up_tokens: weltgewebe_api::auth::step_up_tokens::StepUpTokenStore::new(),

--- a/apps/api/tests/auth_ratelimit.rs
+++ b/apps/api/tests/auth_ratelimit.rs
@@ -10,7 +10,7 @@ use std::{net::SocketAddr, sync::Arc};
 use tokio::sync::RwLock;
 use tower::ServiceExt;
 use weltgewebe_api::{
-    auth::{accounts::AccountStore, rate_limit::AuthRateLimiter, session::SessionStore},
+    auth::{accounts::AccountStore, rate_limit::AuthRateLimiter, session::SessionBackend},
     config::AppConfig,
     routes::api_router,
     state::ApiState,
@@ -33,7 +33,7 @@ fn test_state(config: AppConfig) -> Result<ApiState> {
         nats_configured: false,
         config,
         metrics,
-        sessions: SessionStore::new(),
+        sessions: SessionBackend::new_in_memory(),
         challenges: Default::default(),
         tokens: weltgewebe_api::auth::tokens::TokenStore::new(),
         step_up_tokens: weltgewebe_api::auth::step_up_tokens::StepUpTokenStore::new(),

--- a/apps/api/tests/auth_ratelimit_proxy_trusted.rs
+++ b/apps/api/tests/auth_ratelimit_proxy_trusted.rs
@@ -10,7 +10,7 @@ use std::{net::SocketAddr, sync::Arc};
 use tokio::sync::RwLock;
 use tower::ServiceExt;
 use weltgewebe_api::{
-    auth::{accounts::AccountStore, rate_limit::AuthRateLimiter, session::SessionStore},
+    auth::{accounts::AccountStore, rate_limit::AuthRateLimiter, session::SessionBackend},
     config::AppConfig,
     routes::api_router,
     state::ApiState,
@@ -34,7 +34,7 @@ fn test_state(config: AppConfig) -> Result<ApiState> {
         nats_configured: false,
         config,
         metrics,
-        sessions: SessionStore::new(),
+        sessions: SessionBackend::new_in_memory(),
         challenges: Default::default(),
         tokens: weltgewebe_api::auth::tokens::TokenStore::new(),
         step_up_tokens: weltgewebe_api::auth::step_up_tokens::StepUpTokenStore::new(),

--- a/apps/api/tests/auth_ratelimit_proxy_untrusted.rs
+++ b/apps/api/tests/auth_ratelimit_proxy_untrusted.rs
@@ -10,7 +10,7 @@ use std::{net::SocketAddr, sync::Arc};
 use tokio::sync::RwLock;
 use tower::ServiceExt;
 use weltgewebe_api::{
-    auth::{accounts::AccountStore, rate_limit::AuthRateLimiter, session::SessionStore},
+    auth::{accounts::AccountStore, rate_limit::AuthRateLimiter, session::SessionBackend},
     config::AppConfig,
     routes::api_router,
     state::ApiState,
@@ -34,7 +34,7 @@ fn test_state(config: AppConfig) -> Result<ApiState> {
         nats_configured: false,
         config,
         metrics,
-        sessions: SessionStore::new(),
+        sessions: SessionBackend::new_in_memory(),
         challenges: Default::default(),
         tokens: weltgewebe_api::auth::tokens::TokenStore::new(),
         step_up_tokens: weltgewebe_api::auth::step_up_tokens::StepUpTokenStore::new(),


### PR DESCRIPTION
## These / Antithese / Synthese

**These:** `DbSessionStore` direkt bauen.
**Antithese:** Audit trennt klar: DB-CRUD ist bewiesen, produktive Auth-Session-Persistenz nicht. Phase A darf keine DB-Runtime-Verdrahtung machen.
**Synthese:** Dieser PR liefert nur die Naht: `SessionBackend`-Abstraktion bei unverändertem Runtime-Verhalten.

## Scope (Phase A, behavior-preserving)

- Session-Domain-only Refactor.
- In-Memory bleibt das einzige aktive Backend (`SessionBackend::new_in_memory()`).
- Keine PostgreSQL-Verdrahtung.
- Kein `DbSessionStore`.
- Keine Migration-/Startup-Änderung.
- Keine Token-/Challenge-/Passkey-Store-Persistenz.
- Keine UI-Änderung.

## Diagnose-first Befund (vor Patch)

1. Direkte Nutzung von `state.sessions.*` existiert in Auth-Routen und Middleware (`create`, `get`, `delete`, `touch`, `list_by_account`, `delete_by_device`, `delete_all_by_account`).
2. Genau diese Methoden sind für aktuelle Auth-Routen/Middleware erforderlich.
3. Diese Pfade sind bereits durch vorhandene Unit-/Integrationstests abgedeckt (u.a. `auth/session.rs` Unit-Tests sowie `api_auth.rs` inkl. Session-Refresh/Logout-All/Device- und Step-up-Flows).

## Änderungen

- Neue Session-Naht in `apps/api/src/auth/session.rs`:
  - `SessionOps` trait
  - `SessionBackend` Wrapper über `Arc<dyn SessionOps>`
  - `SessionStore` implementiert `SessionOps`
- Runtime-Wiring auf Naht umgestellt:
  - `ApiState.sessions: SessionBackend`
  - Initialisierung via `SessionBackend::new_in_memory()`
- Test-Harnesses minimal umgestellt:
  - bisher `SessionStore::new()` -> jetzt `SessionBackend::new_in_memory()`

## Verhalten / Nicht-Ziele

- Runtime-Verhalten unverändert.
- Auth-Session-Persistenz über DB bleibt **NOT_PROVEN** nach diesem PR.
- Keine Aussage, dass Sessions API-Restarts überleben.

## Verifikation

- `cd apps/api && cargo test --locked`
- Ergebnis: grün (`passed`, DB-Direct/PgBouncer-CRUD-Tests bleiben wie zuvor `ignored` ohne passende URLs).
