### PR TITLE
fix(devcontainer): prevent host UID drift

### DIFF
--- a/.devcontainer/Dockerfile.extended
+++ b/.devcontainer/Dockerfile.extended
@@ -8,10 +8,9 @@ ENV DEBIAN_FRONTEND=noninteractive \
 # --- Ensure expected devcontainer user exists (the CLI assumes "vscode") ---
 # Idempotent: nur anlegen, wenn er fehlt (manche Base-Images liefern ihn nicht).
 #
-# Robustere Logik: vermeide feste UID/GID, wenn die gewünschte UID bereits belegt ist.
-# Falls ${USERNAME} bereits existiert, passiert nichts. Falls die gewünschte UID
-# frei ist, wird sie verwendet; sonst wird der User ohne feste UID angelegt, um
-# "UID ... is not unique"-Fehler während des Image-Builds zu vermeiden.
+# Hard invariant: if the requested UID is already owned by a different user, fail
+# fast instead of renaming the foreign user. The devcontainer CLI is responsible
+# for synchronizing the runtime UID/GID when updateRemoteUserUID is enabled.
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=${USER_UID}
@@ -19,8 +18,6 @@ RUN set -eux; \
    requested_uid="${USER_UID}"; \
    requested_gid="${USER_GID}"; \
    uid_owner="$(getent passwd "${requested_uid}" | cut -d: -f1 || true)"; \
-   # Hard invariant: ${USERNAME} must end up with ${USER_UID}. \
-   # Silent fallback to a different UID corrupts bind-mounted host repos. \
    if getent passwd "${USERNAME}" >/dev/null 2>&1; then \
      current_uid="$(id -u "${USERNAME}")"; \
      if [ "${current_uid}" != "${requested_uid}" ]; then \
@@ -31,12 +28,9 @@ RUN set -eux; \
        usermod --uid "${requested_uid}" "${USERNAME}"; \
      fi; \
    else \
-     if [ -n "${uid_owner}" ]; then \
-       old_home="$(getent passwd "${uid_owner}" | cut -d: -f6)"; \
-       usermod -l "${USERNAME}" "${uid_owner}"; \
-       if [ "${old_home}" != "/home/${USERNAME}" ]; then \
-         usermod -d "/home/${USERNAME}" -m "${USERNAME}" || true; \
-       fi; \
+     if [ -n "${uid_owner}" ] && [ "${uid_owner}" != "${USERNAME}" ]; then \
+       echo "ERROR: requested UID ${requested_uid} is already used by ${uid_owner}; refusing to create ${USERNAME}" >&2; \
+       exit 42; \
      else \
        if getent group "${requested_gid}" >/dev/null 2>&1; then \
          target_group="$(getent group "${requested_gid}" | cut -d: -f1)"; \

--- a/.devcontainer/Dockerfile.extended
+++ b/.devcontainer/Dockerfile.extended
@@ -5,13 +5,13 @@ ENV DEBIAN_FRONTEND=noninteractive \
     LANG=C.UTF-8 \
     LC_ALL=C.UTF-8
 
-# --- Ensure expected devcontainer user exists (the CLI assumes "vscode") ---
-# Idempotent: nur anlegen, wenn er fehlt (manche Base-Images liefern ihn nicht).
-#
+# --- Use base image user (node) to avoid UID conflicts ---
+# The base image mcr.microsoft.com/devcontainers/javascript-node:22
+# already provides the `node` user with UID 1000.
 # Hard invariant: if the requested UID is already owned by a different user, fail
 # fast instead of renaming the foreign user. The devcontainer CLI is responsible
 # for synchronizing the runtime UID/GID when updateRemoteUserUID is enabled.
-ARG USERNAME=vscode
+ARG USERNAME=node
 ARG USER_UID=1000
 ARG USER_GID=${USER_UID}
 RUN set -eux; \

--- a/.devcontainer/Dockerfile.extended
+++ b/.devcontainer/Dockerfile.extended
@@ -16,21 +16,43 @@ ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=${USER_UID}
 RUN set -eux; \
-    # ensure group exists (try with requested GID, fall back to name-only)
-    if ! getent group "${USERNAME}" >/dev/null 2>&1; then \
-      groupadd --gid "${USER_GID}" "${USERNAME}" || groupadd "${USERNAME}"; \
-    fi; \
-    # create user only if missing
-    if ! getent passwd "${USERNAME}" >/dev/null 2>&1; then \
-      # if the requested UID is free, create with that UID; otherwise create
-      # the user without forcing UID to avoid conflicts with existing users
-      if ! getent passwd "${USER_UID}" >/dev/null 2>&1; then \
-        useradd --uid "${USER_UID}" --gid "${USERNAME}" -m -s /bin/bash "${USERNAME}"; \
-      else \
-        useradd -m -s /bin/bash -g "${USERNAME}" "${USERNAME}" || useradd -m -s /bin/bash "${USERNAME}"; \
-      fi; \
-    fi; \
-    mkdir -p /home/"${USERNAME}"/.ssh && chown -R "${USERNAME}:${USERNAME}" /home/"${USERNAME}"
+   requested_uid="${USER_UID}"; \
+   requested_gid="${USER_GID}"; \
+   uid_owner="$(getent passwd "${requested_uid}" | cut -d: -f1 || true)"; \
+   # Hard invariant: ${USERNAME} must end up with ${USER_UID}. \
+   # Silent fallback to a different UID corrupts bind-mounted host repos. \
+   if getent passwd "${USERNAME}" >/dev/null 2>&1; then \
+     current_uid="$(id -u "${USERNAME}")"; \
+     if [ "${current_uid}" != "${requested_uid}" ]; then \
+       if [ -n "${uid_owner}" ] && [ "${uid_owner}" != "${USERNAME}" ]; then \
+         echo "ERROR: requested UID ${requested_uid} is already used by ${uid_owner}; refusing UID drift for ${USERNAME}" >&2; \
+         exit 42; \
+       fi; \
+       usermod --uid "${requested_uid}" "${USERNAME}"; \
+     fi; \
+   else \
+     if [ -n "${uid_owner}" ]; then \
+       old_home="$(getent passwd "${uid_owner}" | cut -d: -f6)"; \
+       usermod -l "${USERNAME}" "${uid_owner}"; \
+       if [ "${old_home}" != "/home/${USERNAME}" ]; then \
+         usermod -d "/home/${USERNAME}" -m "${USERNAME}" || true; \
+       fi; \
+     else \
+       if getent group "${requested_gid}" >/dev/null 2>&1; then \
+         target_group="$(getent group "${requested_gid}" | cut -d: -f1)"; \
+       else \
+         groupadd --gid "${requested_gid}" "${USERNAME}"; \
+         target_group="${USERNAME}"; \
+       fi; \
+       useradd --uid "${requested_uid}" --gid "${target_group}" -m -s /bin/bash "${USERNAME}"; \
+     fi; \
+   fi; \
+   if getent group "${requested_gid}" >/dev/null 2>&1; then \
+     target_group="$(getent group "${requested_gid}" | cut -d: -f1)"; \
+     usermod --gid "${target_group}" "${USERNAME}" || true; \
+   fi; \
+   mkdir -p /home/"${USERNAME}"/.ssh; \
+   chown -R "${USERNAME}:$(id -gn "${USERNAME}")" /home/"${USERNAME}"
 
 # Optional: Standard-Tools/Qualität der Life-in-Container-Experience
 # + sudo installieren und passwortlosen sudo für die Gruppe sudo erlauben,

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,7 @@
 {
   "name": "weltgewebe-dev",
   "build": {
-    "dockerfile": "Dockerfile.extended",
-    "args": {
-      "USERNAME": "vscode",
-      "USER_UID": "1000",
-      "USER_GID": "1000"
-    }
+    "dockerfile": "Dockerfile.extended"
   },
   "features": {
     "ghcr.io/devcontainers/features/git:1": {},
@@ -46,8 +41,8 @@
     "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD": "1",
     "PUPPETEER_SKIP_DOWNLOAD": "true"
   },
-  "remoteUser": "vscode",
-  "updateRemoteUserUID": false,
+  "remoteUser": "node",
+  "updateRemoteUserUID": true,
   "init": true,
   "postCreateCommand": "bash -lc 'set -e; .devcontainer/uid-guard.sh; bash .devcontainer/post-create.sh'",
   "postAttachCommand": "bash -lc 'set -e; .devcontainer/uid-guard.sh; corepack enable || true; cd apps/web && ([ -d node_modules ] || pnpm install)'",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,55 +1,55 @@
 {
- "name": "weltgewebe-dev",
- "build": {
-  "dockerfile": "Dockerfile.extended",
-  "args": {
-   "USERNAME": "vscode",
-   "USER_UID": "1000",
-   "USER_GID": "1000"
-  }
- },
- "features": {
-  "ghcr.io/devcontainers/features/git:1": {},
-  "ghcr.io/devcontainers/features/github-cli:1": {},
-  "ghcr.io/devcontainers/features/rust:1": {},
-  "ghcr.io/devcontainers/features/node:1": {
-   "version": "20"
-  }
- },
- "customizations": {
-  "vscode": {
-   "extensions": [
-    "rust-lang.rust-analyzer",
-    "timonwong.shellcheck",
-    "streetsidesoftware.code-spell-checker",
-    "yzhang.markdown-all-in-one",
-    "DavidAnson.vscode-markdownlint",
-    "bierner.markdown-preview-github-styles"
-   ]
-  }
- },
- "forwardPorts": [
-  5173,
-  3000
- ],
- "portsAttributes": {
-  "5173": {
-   "label": "Vite Dev Server",
-   "onAutoForward": "openBrowser"
+  "name": "weltgewebe-dev",
+  "build": {
+    "dockerfile": "Dockerfile.extended",
+    "args": {
+      "USERNAME": "vscode",
+      "USER_UID": "1000",
+      "USER_GID": "1000"
+    }
   },
-  "3000": {
-   "label": "API / Preview",
-   "onAutoForward": "notify"
-  }
- },
- "containerEnv": {
-  "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD": "1",
-  "PUPPETEER_SKIP_DOWNLOAD": "true"
- },
- "remoteUser": "vscode",
- "updateRemoteUserUID": false,
- "init": true,
- "postCreateCommand": "bash -lc 'set -e; .devcontainer/uid-guard.sh; bash .devcontainer/post-create.sh'",
- "postAttachCommand": "bash -lc 'set -e; .devcontainer/uid-guard.sh; corepack enable || true; cd apps/web && ([ -d node_modules ] || pnpm install)'",
- "postStartCommand": "bash -lc 'set -e; .devcontainer/uid-guard.sh; set -uxo pipefail; echo Using compose as the single source of truth; just check || true'"
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/rust:1": {},
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "timonwong.shellcheck",
+        "streetsidesoftware.code-spell-checker",
+        "yzhang.markdown-all-in-one",
+        "DavidAnson.vscode-markdownlint",
+        "bierner.markdown-preview-github-styles"
+      ]
+    }
+  },
+  "forwardPorts": [
+    5173,
+    3000
+  ],
+  "portsAttributes": {
+    "5173": {
+      "label": "Vite Dev Server",
+      "onAutoForward": "openBrowser"
+    },
+    "3000": {
+      "label": "API / Preview",
+      "onAutoForward": "notify"
+    }
+  },
+  "containerEnv": {
+    "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD": "1",
+    "PUPPETEER_SKIP_DOWNLOAD": "true"
+  },
+  "remoteUser": "vscode",
+  "updateRemoteUserUID": false,
+  "init": true,
+  "postCreateCommand": "bash -lc 'set -e; .devcontainer/uid-guard.sh; bash .devcontainer/post-create.sh'",
+  "postAttachCommand": "bash -lc 'set -e; .devcontainer/uid-guard.sh; corepack enable || true; cd apps/web && ([ -d node_modules ] || pnpm install)'",
+  "postStartCommand": "bash -lc 'set -e; .devcontainer/uid-guard.sh; set -uxo pipefail; echo Using compose as the single source of truth; just check || true'"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,47 +1,55 @@
 {
-  "name": "weltgewebe-dev",
-  "build": {
-    "dockerfile": "Dockerfile.extended"
+ "name": "weltgewebe-dev",
+ "build": {
+  "dockerfile": "Dockerfile.extended",
+  "args": {
+   "USERNAME": "vscode",
+   "USER_UID": "1000",
+   "USER_GID": "1000"
+  }
+ },
+ "features": {
+  "ghcr.io/devcontainers/features/git:1": {},
+  "ghcr.io/devcontainers/features/github-cli:1": {},
+  "ghcr.io/devcontainers/features/rust:1": {},
+  "ghcr.io/devcontainers/features/node:1": {
+   "version": "20"
+  }
+ },
+ "customizations": {
+  "vscode": {
+   "extensions": [
+    "rust-lang.rust-analyzer",
+    "timonwong.shellcheck",
+    "streetsidesoftware.code-spell-checker",
+    "yzhang.markdown-all-in-one",
+    "DavidAnson.vscode-markdownlint",
+    "bierner.markdown-preview-github-styles"
+   ]
+  }
+ },
+ "forwardPorts": [
+  5173,
+  3000
+ ],
+ "portsAttributes": {
+  "5173": {
+   "label": "Vite Dev Server",
+   "onAutoForward": "openBrowser"
   },
-  "features": {
-    "ghcr.io/devcontainers/features/git:1": {},
-    "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/devcontainers/features/rust:1": {},
-    "ghcr.io/devcontainers/features/node:1": {
-      "version": "20"
-    }
-  },
-  "customizations": {
-    "vscode": {
-      "extensions": [
-        "rust-lang.rust-analyzer",
-        "timonwong.shellcheck",
-        "streetsidesoftware.code-spell-checker",
-        "yzhang.markdown-all-in-one",
-        "DavidAnson.vscode-markdownlint",
-        "bierner.markdown-preview-github-styles"
-      ]
-    }
-  },
-  "forwardPorts": [5173, 3000],
-  "portsAttributes": {
-    "5173": {
-      "label": "Vite Dev Server",
-      "onAutoForward": "openBrowser"
-    },
-    "3000": {
-      "label": "API / Preview",
-      "onAutoForward": "notify"
-    }
-  },
-  "containerEnv": {
-    "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD": "1",
-    "PUPPETEER_SKIP_DOWNLOAD": "true"
-  },
-  "remoteUser": "vscode",
-  "updateRemoteUserUID": true,
-  "init": true,
-  "postCreateCommand": "bash .devcontainer/post-create.sh",
-  "postAttachCommand": "bash -lc 'corepack enable || true; cd apps/web && [ -d node_modules ] || pnpm install'",
-  "postStartCommand": "bash -lc 'set -euxo pipefail; echo Using compose as the single source of truth; just check || true'"
+  "3000": {
+   "label": "API / Preview",
+   "onAutoForward": "notify"
+  }
+ },
+ "containerEnv": {
+  "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD": "1",
+  "PUPPETEER_SKIP_DOWNLOAD": "true"
+ },
+ "remoteUser": "vscode",
+ "updateRemoteUserUID": false,
+ "init": true,
+ "postCreateCommand": "bash -lc 'set -e; .devcontainer/uid-guard.sh; bash .devcontainer/post-create.sh'",
+ "postAttachCommand": "bash -lc 'set -e; .devcontainer/uid-guard.sh; corepack enable || true; cd apps/web && ([ -d node_modules ] || pnpm install)'",
+ "postStartCommand": "bash -lc 'set -e; .devcontainer/uid-guard.sh; set -uxo pipefail; echo Using compose as the single source of truth; just check || true'"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,9 @@
   "build": {
     "dockerfile": "Dockerfile.extended",
     "args": {
-      "USERNAME": "vscode"
+      "USERNAME": "vscode",
+      "USER_UID": "1000",
+      "USER_GID": "1000"
     }
   },
   "features": {
@@ -45,7 +47,7 @@
     "PUPPETEER_SKIP_DOWNLOAD": "true"
   },
   "remoteUser": "vscode",
-  "updateRemoteUserUID": true,
+  "updateRemoteUserUID": false,
   "init": true,
   "postCreateCommand": "bash -lc 'set -e; .devcontainer/uid-guard.sh; bash .devcontainer/post-create.sh'",
   "postAttachCommand": "bash -lc 'set -e; .devcontainer/uid-guard.sh; corepack enable || true; cd apps/web && ([ -d node_modules ] || pnpm install)'",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,9 +3,7 @@
   "build": {
     "dockerfile": "Dockerfile.extended",
     "args": {
-      "USERNAME": "vscode",
-      "USER_UID": "1000",
-      "USER_GID": "1000"
+      "USERNAME": "vscode"
     }
   },
   "features": {
@@ -47,7 +45,7 @@
     "PUPPETEER_SKIP_DOWNLOAD": "true"
   },
   "remoteUser": "vscode",
-  "updateRemoteUserUID": false,
+  "updateRemoteUserUID": true,
   "init": true,
   "postCreateCommand": "bash -lc 'set -e; .devcontainer/uid-guard.sh; bash .devcontainer/post-create.sh'",
   "postAttachCommand": "bash -lc 'set -e; .devcontainer/uid-guard.sh; corepack enable || true; cd apps/web && ([ -d node_modules ] || pnpm install)'",

--- a/.devcontainer/uid-guard.sh
+++ b/.devcontainer/uid-guard.sh
@@ -13,7 +13,7 @@ workspace_gid="$(stat -c '%g' "$repo")"
 current_uid="$(id -u)"
 current_gid="$(id -g)"
 
-if [ "$current_uid" != "$workspace_uid" ]; then
+if [ "$current_uid" != "$workspace_uid" ] || [ "$current_gid" != "$workspace_gid" ]; then
   cat >&2 <<EOF
 UID-GUARD: mismatch detected.
 container uid/gid: ${current_uid}:${current_gid}
@@ -21,7 +21,7 @@ workspace uid/gid: ${workspace_uid}:${workspace_gid}
 workspace: ${repo}
 
 Refusing to run devcontainer lifecycle command because this would create host files
-owned by the wrong UID and break host-side git/omnipull.
+owned by the wrong UID/GID and break host-side git/omnipull.
 EOF
   exit 67
 fi

--- a/.devcontainer/uid-guard.sh
+++ b/.devcontainer/uid-guard.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${DEVCONTAINER_WORKSPACE:-/workspaces/weltgewebe}"
+
+if [ ! -d "$repo" ]; then
+  echo "UID-GUARD: workspace not found: $repo" >&2
+  exit 66
+fi
+
+workspace_uid="$(stat -c '%u' "$repo")"
+workspace_gid="$(stat -c '%g' "$repo")"
+current_uid="$(id -u)"
+current_gid="$(id -g)"
+
+if [ "$current_uid" != "$workspace_uid" ]; then
+  cat >&2 <<EOF
+UID-GUARD: mismatch detected.
+container uid/gid: ${current_uid}:${current_gid}
+workspace uid/gid: ${workspace_uid}:${workspace_gid}
+workspace: ${repo}
+
+Refusing to run devcontainer lifecycle command because this would create host files
+owned by the wrong UID and break host-side git/omnipull.
+EOF
+  exit 67
+fi
+
+echo "UID-GUARD: ok uid/gid=${current_uid}:${current_gid} workspace=${repo}"


### PR DESCRIPTION
## Ziel

Verhindert, dass der Devcontainer mit falscher UID/GID in das bind-gemountete Host-Repo schreibt und dadurch `.git` oder Arbeitsdateien für den Host-User unbeschreibbar macht.

## Kontext

Auf dem Host trat UID-Drift auf:

- Host-Repo gehört `alex:alex` / UID:GID 1000:1000
- Devcontainer-Lifecycle konnte mit abweichender Identität Dateien erzeugen
- Folge: `git fetch` / `omnipull` konnten an `.git/FETCH_HEAD` oder ähnlichen Dateien scheitern

## Änderung

- nutzt den im Base-Image vorhandenen User `node` statt einen konkurrierenden `vscode`-User zu erzwingen
- lässt `updateRemoteUserUID: true` aktiv, damit Nicht-1000-Linux-Hosts weiterhin vom Devcontainer-UID-Sync profitieren
- ergänzt `.devcontainer/uid-guard.sh`
- Guard prüft UID und GID gegen den Workspace
- Guard läuft vor `postCreateCommand`, `postAttachCommand` und `postStartCommand`
- Dockerfile schlägt sichtbar fehl, wenn der gewünschte Build-User nicht sauber zur angeforderten UID passt

## Proof

Erforderlicher lokaler Proof:

```text
python3 -m json.tool .devcontainer/devcontainer.json
bash -n .devcontainer/uid-guard.sh
git diff --check
devcontainer up --workspace-folder /home/alex/repos/weltgewebe
devcontainer exec --workspace-folder /home/alex/repos/weltgewebe ...

Erwartete Kernaussagen:

whoami = node
UID-GUARD: ok uid/gid=1000:1000 workspace=/workspaces/weltgewebe
cargo vorhanden
node vorhanden
pnpm vorhanden
host foreign owners after proof: leer
Risiko

Strengerer Lifecycle: Wenn Container-User und Workspace-Owner nicht zusammenpassen, bricht der Guard ab. Das ist beabsichtigt, weil stilles Weitermachen Host-Git und Omnipull beschädigen kann.
