### PR TITLE
chore(gitignore): ignore local pnpm store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ apps/web/src/lib/generated/
 # Ignore downloaded basemap assets to avoid polluting the git history with binary blobs
 map-style/glyphs/*/*.pbf
 map-style/glyphs/*/.complete
+
+# Local pnpm content-addressable store; not repository content.
+.pnpm-store/


### PR DESCRIPTION
## Ziel

Verhindert, dass ein lokal erzeugter pnpm Content-Store erneut Git-Status und repoLens-Dumps kontaminiert.

## Befund

`.pnpm-store` war untracked, lag aber im Repo-Baum und dominierte den letzten Dump semantisch.

## Änderung

- `.pnpm-store/` in `.gitignore`

## Proof

- `.pnpm-store` nicht getrackt
- lokaler Cache entfernt
- kein foreign owner im Repo
- Devcontainer UID-Guard bleibt grün

## Risiko

Niedrig. Lokaler pnpm-Cache ist regenerierbar.