### PR TITLE
proof(auth): direct sqlx postgres session path

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -86,6 +86,13 @@ db-wait:    # wait for database to be ready
 db-migrate:    # run database migrations (requires sqlx-cli 0.8.1: cargo install sqlx-cli --version 0.8.1 --locked --no-default-features --features native-tls,postgres)
 	sqlx migrate run --source apps/api/migrations
 
+proof-auth-session-sqlx-direct:    # run ignored SQLx direct-Postgres session CRUD proof test
+	if [ -z "${PG_DIRECT_URL:-${DATABASE_URL:-}}" ]; then \
+		echo "Set PG_DIRECT_URL or DATABASE_URL to direct PostgreSQL (not PgBouncer)." >&2; \
+		exit 1; \
+	fi
+	cargo test --locked -p weltgewebe-api --test sqlx_postgres_direct_session_crud -- --include-ignored
+
 seed:          # seed database with initial data
 	cargo run -p api -- seed
 default: lint

--- a/Justfile
+++ b/Justfile
@@ -87,11 +87,11 @@ db-migrate:    # run database migrations (requires sqlx-cli 0.8.1: cargo install
 	sqlx migrate run --source apps/api/migrations
 
 proof-auth-session-sqlx-direct:    # run ignored SQLx direct-Postgres session CRUD proof test
-	if [ -z "${PG_DIRECT_URL:-${DATABASE_URL:-}}" ]; then \
-		echo "Set PG_DIRECT_URL or DATABASE_URL to direct PostgreSQL (not PgBouncer)." >&2; \
+	if [ -z "${PG_DIRECT_URL:-}" ]; then \
+		echo "Set PG_DIRECT_URL to direct PostgreSQL (not PgBouncer)." >&2; \
 		exit 1; \
 	fi
-	cargo test --locked -p weltgewebe-api --test sqlx_postgres_direct_session_crud -- --include-ignored
+	DATABASE_URL="${PG_DIRECT_URL}" PG_DIRECT_URL="${PG_DIRECT_URL}" cargo test --locked -p weltgewebe-api --test sqlx_postgres_direct_session_crud -- --include-ignored
 
 seed:          # seed database with initial data
 	cargo run -p api -- seed

--- a/docs/reports/auth-persistence-next-step.md
+++ b/docs/reports/auth-persistence-next-step.md
@@ -42,7 +42,8 @@ relations:
 Die vorhandene Dokumentation und der aktualisierte Ist-Zustand stützen **PostgreSQL (DB-first)**
 als nächsten Implementierungspfad für Session-Persistenz. Redis und Hybrid haben im aktuellen
 Befund keinen belegten Zusatznutzen. Strategisch gestützt durch `docs/reports/auth-persistence-readiness.md`
-und `docs/blueprints/auth-roadmap.md`; noch nicht runtime-bewiesen.
+und `docs/blueprints/auth-roadmap.md`; der direkte SQLx/Postgres-CRUD-Proof ist
+mittlerweile belegt, die produktive `DbSessionStore`-Integration bleibt offen.
 
 Seit dem Readiness-Report hat ein Migrations-Schema-PR die `sessions`-Tabellendefinition
 eingeführt (`apps/api/migrations/20260428000000_create_sessions.up.sql`). Der aktuelle
@@ -55,7 +56,7 @@ Was fehlt bis zur vollständigen Session-Persistenz:
 2. Async-Abstraktion für `SessionStore` (Trait oder Enum-Dispatch)
 3. Startup-Migration in `apps/api/src/lib.rs`
 4. CI-Migrations-Step in `.github/workflows/api.yml`
-5. Direkter SQLx/Postgres-Persistenzpfad-Nachweis; PgBouncer-Kompatibilitätsprüfung nur für optionale Dev-/Spezialpfade
+5. Produktive Persistenzverdrahtung (`DbSessionStore`) mit weiterhin grünem Offline-Testpfad; PgBouncer-Kompatibilitätsprüfung nur für optionale Dev-/Spezialpfade
 
 Prämissencheck zur Aufgabenstellung:
 
@@ -63,8 +64,8 @@ Prämissencheck zur Aufgabenstellung:
 |---|---|---|
 | Auth-State ist mindestens teilweise flüchtig | **Bestätigt** | Fünf transiente Auth-Stores sind in-memory: Sessions, Tokens, StepUpTokens, Challenges und PasskeyRegistrations. Account-Stammdaten sind ein separates JSONL-Thema. |
 | Doku markiert Persistenz als Restlücke | **Bestätigt** | OPT-API-002 in `optimierungsstatus.md` = open; README-Note aktiv. |
-| Keine belastbare Entscheidung Postgres vs. Redis vs. Hybrid | **Teilweise falsch** | Die Doku stützt DB-first als nächsten Pfad; Runtime-Proof und Implementierungsdetails fehlen noch. |
-| Direkter Implementierungs-PR wäre zu annahmenreich | **Teilweise wahr** | Direkter SQLx/Postgres-Nachweis, async-Abstraktion und CI-Gate fehlen noch. PgBouncer ist nach ADR-0007 kein Produktions-Gate. |
+| Keine belastbare Entscheidung Postgres vs. Redis vs. Hybrid | **Teilweise falsch** | Die Doku stützt DB-first als nächsten Pfad; der direkte SQLx/Postgres-CRUD-Proof ist belegt, Implementierungsdetails fehlen noch. |
+| Direkter Implementierungs-PR wäre zu annahmenreich | **Teilweise wahr** | Direkter SQLx/Postgres-Nachweis ist belegt; async-Abstraktion und CI-Gate fehlen noch. PgBouncer ist nach ADR-0007 kein Produktions-Gate. |
 
 ---
 
@@ -150,10 +151,10 @@ CREATE INDEX sessions_expires_at ON sessions (expires_at);
 Divergenz zu `auth-persistence-readiness.md`: Dieses Vorgängerdokument stellte
 fest, dass kein Migrationsverzeichnis existiert. Das ist seit dem Schema-PR nicht mehr
 korrekt. Der aktuelle Ist-Zustand enthält ein Migrationsverzeichnis mit einer
-plausiblen `sessions`-Tabellendefinition. Runtime-Funktion noch nicht belegt:
-`sqlx migrate run` und Query-Kompatibilität gegen direkten PostgreSQL-Zugriff sind
-für einen späteren `DbSessionStore` noch zu prüfen. PgBouncer bleibt nach ADR-0007
-optionaler Dev-/Spezialpfad.
+plausiblen `sessions`-Tabellendefinition. Der direkte SQLx/Postgres-CRUD-Pfad ist
+mittlerweile per separatem Proof belegt. Offen bleiben `sqlx migrate run` im CI-
+Pfad und die produktive Query-Verdrahtung des späteren `DbSessionStore`.
+PgBouncer bleibt nach ADR-0007 optionaler Dev-/Spezialpfad.
 
 ### 2.3 DB-Pool (vorhanden, für Auth ungenutzt)
 
@@ -314,7 +315,7 @@ eigenständiger PR-Scope.
 | Option | Pro | Contra | Bewertung |
 |---|---|---|---|
 | **In-Memory belassen** | kein Aufwand, aktueller Zustand | Restart = Logout aller Nutzer; kein Multi-Instance | nur für PoC/Dev ohne SLA |
-| **PostgreSQL** | Stack vorhanden; Migration vorhanden; `db_pool` verdrahtet; keine neue Abhängigkeit; ADR-0007 legt direkten Produktionspfad fest | async-Abstraktion nötig; CI-Gate fehlt; direkter SQLx/Postgres-Proof fehlt | **empfohlen** (strategisch gestützt; Runtime-Proof offen) |
+| **PostgreSQL** | Stack vorhanden; Migration vorhanden; `db_pool` verdrahtet; keine neue Abhängigkeit; ADR-0007 legt direkten Produktionspfad fest | async-Abstraktion nötig; CI-Gate fehlt | **empfohlen** (strategisch gestützt; direkter SQLx/Postgres-CRUD-Proof belegt) |
 | **Redis** | schnell für TTL-basierte Keys; kein Schema nötig | nicht im Stack; neue Abhängigkeit; kein Mehrwert für diesen Use-Case | nicht empfohlen |
 | **Hybrid** | kurzlebige Stores in Redis, Sessions in PG | komplexer Stack; zwei Systeme für dasselbe Problem | nicht empfohlen für aktuellen Scope |
 
@@ -334,13 +335,13 @@ eigenständiger PR-Scope.
 
 Diese Strategie ist durch `auth-persistence-readiness.md` und `auth-roadmap.md`
 vorgezeichnet. Dieses Dokument bestätigt PostgreSQL als naheliegenden nächsten
-Implementierungspfad auf Basis des aktualisierten Ist-Zustands, ohne den Runtime-Proof
-vorwegzunehmen.
+Implementierungspfad auf Basis des aktualisierten Ist-Zustands; der direkte
+SQLx/Postgres-CRUD-Proof ist inzwischen separat belegt.
 
 ### Was müsste wahr sein, damit Postgres genügt?
 
 - **Belegt:** `db_pool` ist in `ApiState` vorhanden und `DATABASE_URL` konfiguriert.
-- **Belegt:** Eine `sessions`-Migration existiert und definiert die benötigten Kernspalten und Indizes. Runtime-Migrationsbeweis gegen direkten PostgreSQL-Zugriff und Query-Kompatibilität des späteren `DbSessionStore` stehen noch aus.
+- **Belegt:** Eine `sessions`-Migration existiert und definiert die benötigten Kernspalten und Indizes. Der direkte SQLx/Postgres-CRUD-Proof ist belegt; offen stehen Runtime-Migrationsbeweis via `sqlx migrate run` und die Query-Kompatibilität des späteren `DbSessionStore` in produktiver Verdrahtung.
 - **Belegt:** `sqlx` v0.8.1 ist als Abhängigkeit vorhanden.
 - **Entschieden:** ADR-0007 macht direkten PostgreSQL-Zugriff via `DATABASE_URL` zum Produktionspfad; PgBouncer `transaction` mode bleibt optionales Kompatibilitätsrisiko für Dev-/Spezialpfade.
 - **Offen:** Startup-Migration (`sqlx::migrate!`) muss sicher sein bei nicht-konfiguriertem Pool (bestehende Tests nutzen `db_pool: None`).
@@ -431,7 +432,7 @@ isoliert sein, damit der bestehende Offline-Testpfad erhalten bleibt.
 
 1. **Async-Abstraktion:** `SessionOps`-Trait mit `async_trait` oder `SessionBackend`-Enum mit `match`-Dispatch? Beides ist möglich. Enum-Dispatch hat weniger Indirektion; Trait ist erweiterbar. Entscheidung im PR-Review.
 
-2. **Direkter SQLx/Postgres-Pfad:** Nach ADR-0007 muss der Folge-PR verifizieren, dass `sqlx::PgPool`-CRUD gegen direkten PostgreSQL-Zugriff über `DATABASE_URL` funktioniert. PgBouncer-Varianten (Statement-Cache auf 0, PgBouncer-Upgrade auf ≥ 1.21 mit `max_prepared_statements > 0`, Session-Pooling) sind optionale Dev-/Spezialpfade und keine Produktionsvoraussetzung.
+2. **Direkter SQLx/Postgres-Pfad:** Nach ADR-0007 ist der SQLx/Postgres-CRUD-Proof gegen den direkten Pfad belegt. Der Folge-PR muss diese Pfadwahl in der produktiven `DbSessionStore`-Verdrahtung beibehalten. PgBouncer-Varianten (Statement-Cache auf 0, PgBouncer-Upgrade auf ≥ 1.21 mit `max_prepared_statements > 0`, Session-Pooling) sind optionale Dev-/Spezialpfade und keine Produktionsvoraussetzung.
 
 3. **Startup-Fehlerverhalten:** Wenn `db_pool_configured = true` und Pool nicht verfügbar, soll die API nicht still auf In-Memory fallen — expliziter Fehler ist korrekt (bereits in `auth-persistence-readiness.md` definiert).
 
@@ -444,7 +445,7 @@ isoliert sein, damit der bestehende Offline-Testpfad erhalten bleibt.
 | Welche Stores sind in-memory? | **belegt** | Alle 5: Sessions, Tokens, StepUpTokens, Challenges, PasskeyRegistrations |
 | Was ist kritisch? | **belegt** | Nur `SessionStore` (24h TTL, Restart = Logout aller Nutzer) |
 | Migrations-Schema vorhanden? | **belegt** | Ja, seit 2026-04-28 — aber nicht in Startup aktiviert |
-| Strategie Postgres vs. Redis vs. Hybrid? | **strategisch gestützt** | PostgreSQL durch Doku und Diagnose als nächster Pfad gestützt; Redis/Hybrid ohne belegten Zusatznutzen; Runtime-Proof noch offen |
+| Strategie Postgres vs. Redis vs. Hybrid? | **strategisch gestützt** | PostgreSQL durch Doku und Diagnose als nächster Pfad gestützt; Redis/Hybrid ohne belegten Zusatznutzen; direkter SQLx/Postgres-CRUD-Proof belegt |
 | Was fehlt für Implementierung? | **belegt** | async-Abstraktion, `DbSessionStore`, Startup-Migration, CI-Gate |
 | PgBouncer-Kompatibilität? | **optionaler Spezialpfad** | SQLx prepared statements + statement cache + PgBouncer `transaction` mode (`edoburu/pgbouncer:1.20`) sind nicht belastbar kompatibel; nach ADR-0007 aber kein Produktions-Gate |
-| Weiterer vorgelagerter Diagnose-PR nötig? | **nein** | Kein weiterer Diagnose-PR nötig; vor produktivem `DbSessionStore` ist jedoch ein separater Nachweis des direkten SQLx/Postgres-Persistenzpfads zwingend (inkl. weiterhin grünem Offline-Testpfad). |
+| Weiterer vorgelagerter Diagnose-PR nötig? | **nein** | Kein weiterer Diagnose-PR nötig; der direkte SQLx/Postgres-Proof ist belegt. Nächster Schritt ist die produktive `DbSessionStore`-Implementierung bei weiterhin grünem Offline-Testpfad. |

--- a/docs/reports/auth-persistence-next-step.md
+++ b/docs/reports/auth-persistence-next-step.md
@@ -53,10 +53,10 @@ verzeichnis vorfand.
 Was fehlt bis zur vollständigen Session-Persistenz:
 
 1. `DbSessionStore`-Implementierung (async, `PgPool`)
-2. Async-Abstraktion für `SessionStore` (Trait oder Enum-Dispatch)
+2. Produktive Verdrahtung über die vorhandene `SessionBackend`/`SessionOps`-Naht
 3. Startup-Migration in `apps/api/src/lib.rs`
 4. CI-Migrations-Step in `.github/workflows/api.yml`
-5. Produktive Persistenzverdrahtung (`DbSessionStore`) mit weiterhin grünem Offline-Testpfad; PgBouncer-Kompatibilitätsprüfung nur für optionale Dev-/Spezialpfade
+5. Weiterhin grüner Offline-Testpfad; PgBouncer-Kompatibilitätsprüfung nur für optionale Dev-/Spezialpfade
 
 Prämissencheck zur Aufgabenstellung:
 
@@ -65,7 +65,7 @@ Prämissencheck zur Aufgabenstellung:
 | Auth-State ist mindestens teilweise flüchtig | **Bestätigt** | Fünf transiente Auth-Stores sind in-memory: Sessions, Tokens, StepUpTokens, Challenges und PasskeyRegistrations. Account-Stammdaten sind ein separates JSONL-Thema. |
 | Doku markiert Persistenz als Restlücke | **Bestätigt** | OPT-API-002 in `optimierungsstatus.md` = open; README-Note aktiv. |
 | Keine belastbare Entscheidung Postgres vs. Redis vs. Hybrid | **Teilweise falsch** | Die Doku stützt DB-first als nächsten Pfad; der direkte SQLx/Postgres-CRUD-Proof ist belegt, Implementierungsdetails fehlen noch. |
-| Direkter Implementierungs-PR wäre zu annahmenreich | **Teilweise wahr** | Direkter SQLx/Postgres-Nachweis ist belegt; async-Abstraktion und CI-Gate fehlen noch. PgBouncer ist nach ADR-0007 kein Produktions-Gate. |
+| Direkter Implementierungs-PR wäre zu annahmenreich | **Teilweise wahr** | Direkter SQLx/Postgres-Nachweis und SessionBackend-Abstraktion sind belegt; `DbSessionStore`, produktive Verdrahtung und CI-Gate fehlen noch. PgBouncer ist nach ADR-0007 kein Produktions-Gate. |
 
 ---
 
@@ -315,7 +315,7 @@ eigenständiger PR-Scope.
 | Option | Pro | Contra | Bewertung |
 |---|---|---|---|
 | **In-Memory belassen** | kein Aufwand, aktueller Zustand | Restart = Logout aller Nutzer; kein Multi-Instance | nur für PoC/Dev ohne SLA |
-| **PostgreSQL** | Stack vorhanden; Migration vorhanden; `db_pool` verdrahtet; keine neue Abhängigkeit; ADR-0007 legt direkten Produktionspfad fest | async-Abstraktion nötig; CI-Gate fehlt | **empfohlen** (strategisch gestützt; direkter SQLx/Postgres-CRUD-Proof belegt) |
+| **PostgreSQL** | Stack vorhanden; Migration vorhanden; `db_pool` verdrahtet; `SessionBackend`/`SessionOps` vorhanden; keine neue Abhängigkeit; ADR-0007 legt direkten Produktionspfad fest | `DbSessionStore`, produktive Verdrahtung und CI-Gate fehlen | **empfohlen** (strategisch gestützt; direkter SQLx/Postgres-CRUD-Proof belegt) |
 | **Redis** | schnell für TTL-basierte Keys; kein Schema nötig | nicht im Stack; neue Abhängigkeit; kein Mehrwert für diesen Use-Case | nicht empfohlen |
 | **Hybrid** | kurzlebige Stores in Redis, Sessions in PG | komplexer Stack; zwei Systeme für dasselbe Problem | nicht empfohlen für aktuellen Scope |
 
@@ -430,7 +430,7 @@ isoliert sein, damit der bestehende Offline-Testpfad erhalten bleibt.
 
 ### Offene Implementierungsfragen (zu klären im PR)
 
-1. **Async-Abstraktion:** `SessionOps`-Trait mit `async_trait` oder `SessionBackend`-Enum mit `match`-Dispatch? Beides ist möglich. Enum-Dispatch hat weniger Indirektion; Trait ist erweiterbar. Entscheidung im PR-Review.
+1. **SessionBackend-Naht:** `SessionBackend`/`SessionOps` ist vorhanden. Der Folge-PR soll diese Naht nutzen und den produktiven `DbSessionStore` dahinter verdrahten, ohne erneut über Trait-vs.-Enum zu entscheiden.
 
 2. **Direkter SQLx/Postgres-Pfad:** Nach ADR-0007 ist der SQLx/Postgres-CRUD-Proof gegen den direkten Pfad belegt. Der Folge-PR muss diese Pfadwahl in der produktiven `DbSessionStore`-Verdrahtung beibehalten. PgBouncer-Varianten (Statement-Cache auf 0, PgBouncer-Upgrade auf ≥ 1.21 mit `max_prepared_statements > 0`, Session-Pooling) sind optionale Dev-/Spezialpfade und keine Produktionsvoraussetzung.
 
@@ -446,6 +446,6 @@ isoliert sein, damit der bestehende Offline-Testpfad erhalten bleibt.
 | Was ist kritisch? | **belegt** | Nur `SessionStore` (24h TTL, Restart = Logout aller Nutzer) |
 | Migrations-Schema vorhanden? | **belegt** | Ja, seit 2026-04-28 — aber nicht in Startup aktiviert |
 | Strategie Postgres vs. Redis vs. Hybrid? | **strategisch gestützt** | PostgreSQL durch Doku und Diagnose als nächster Pfad gestützt; Redis/Hybrid ohne belegten Zusatznutzen; direkter SQLx/Postgres-CRUD-Proof belegt |
-| Was fehlt für Implementierung? | **belegt** | async-Abstraktion, `DbSessionStore`, Startup-Migration, CI-Gate |
+| Was fehlt für Implementierung? | **belegt** | `DbSessionStore`, produktive Verdrahtung, Startup-Migration, CI-Gate |
 | PgBouncer-Kompatibilität? | **optionaler Spezialpfad** | SQLx prepared statements + statement cache + PgBouncer `transaction` mode (`edoburu/pgbouncer:1.20`) sind nicht belastbar kompatibel; nach ADR-0007 aber kein Produktions-Gate |
 | Weiterer vorgelagerter Diagnose-PR nötig? | **nein** | Kein weiterer Diagnose-PR nötig; der direkte SQLx/Postgres-Proof ist belegt. Nächster Schritt ist die produktive `DbSessionStore`-Implementierung bei weiterhin grünem Offline-Testpfad. |

--- a/docs/reports/auth-persistence-runtime-proof.md
+++ b/docs/reports/auth-persistence-runtime-proof.md
@@ -411,9 +411,9 @@ als eigenen PR, wenn die Änderungsfläche nach erster Messung breit erscheint
 |---|---|
 | `cargo test --locked -p weltgewebe-api` | ✅ 240 passed, lokal ausgeführt |
 | `git diff --check` | ✅ clean |
-| `cargo fmt -- --check` | nicht ausgeführt (kein Rust-Code verändert) |
-| `cargo clippy -- -D warnings` | nicht ausgeführt (kein Rust-Code verändert) |
+| `cargo fmt --check` | ✅ ausgeführt |
+| `cargo clippy -p weltgewebe-api --all-targets --all-features -- -D warnings` | ✅ ausgeführt |
 | `pnpm lint` (Web) | nicht betroffen |
 
-Dieser PR enthält ausschließlich einen neuen Report (`docs/reports/`).
+Dieser Sync-PR enthält Änderungen in `docs/reports/` und im `Justfile`.
 Keine Produktionscode-Änderungen.

--- a/docs/reports/auth-persistence-runtime-proof.md
+++ b/docs/reports/auth-persistence-runtime-proof.md
@@ -18,11 +18,14 @@ summary: >
 depends_on:
   - docs/blueprints/auth-persistence-runtime-proof.md
   - docs/reports/auth-persistence-next-step.md
+  - docs/proofs/sqlx-postgres-direct-session-crud-proof.md
 relations:
   - type: relates_to
     target: docs/blueprints/auth-persistence-runtime-proof.md
   - type: relates_to
     target: docs/reports/auth-persistence-next-step.md
+  - type: relates_to
+    target: docs/proofs/sqlx-postgres-direct-session-crud-proof.md
   - type: relates_to
     target: docs/blueprints/auth-roadmap.md
   - type: relates_to

--- a/docs/reports/auth-persistence-runtime-proof.md
+++ b/docs/reports/auth-persistence-runtime-proof.md
@@ -291,8 +291,8 @@ git diff --check
 ### Gesamtergebnis: PARTIAL_PROVEN
 
 Der psql-basierte Migrations- und CRUD-Pfad gegen PostgreSQL und PgBouncer
-(transaction mode) ist reproduzierbar belegt. Der produktive SQLx/Rust-API-
-Pfad gegen direkten PostgreSQL-Zugriff ist ebenfalls belegt (separater
+(transaction mode) ist reproduzierbar belegt. Der direkte SQLx/Rust-CRUD-
+Pfad gegen die Session-Tabelle in PostgreSQL ist ebenfalls belegt (separater
 Proof-Report: `docs/proofs/sqlx-postgres-direct-session-crud-proof.md`).
 Offen bleibt der SQLx/Rust-API-Pfad gegen PgBouncer transaction mode für
 Dev-/Spezialfälle. Nach ADR-0007 ist PgBouncer kein Produktions-Gate.
@@ -301,7 +301,7 @@ Dev-/Spezialfälle. Nach ADR-0007 ist PgBouncer kein Produktions-Gate.
 
 PROVEN:
 
-- SQLx/Rust-CRUD gegen direkten PostgreSQL-Pfad (`DATABASE_URL`/`PG_DIRECT_URL`)
+- SQLx/Rust-CRUD gegen direkten PostgreSQL-Pfad (`PG_DIRECT_URL`, im Test als `DATABASE_URL` exportiert)
 - psql-Migrations- und CRUD-Pfad gegen disposable-local PostgreSQL
 - psql-CRUD über PgBouncer transaction mode
 
@@ -381,7 +381,7 @@ des Stacks bleibt unverändert.
 
 **Empfehlung: `feat(auth): implement DbSessionStore against direct PostgreSQL path`**
 
-Der direkte SQLx/PostgreSQL-Persistenzpfad ist jetzt als Proof belegt. Damit ist
+Der direkte SQLx/PostgreSQL-CRUD-Pfad gegen die Session-Tabelle ist jetzt als Proof belegt. Damit ist
 die zentrale Vorbedingung aus ADR-0007 für den nächsten Implementierungsschritt
 erfüllt.
 

--- a/docs/reports/auth-persistence-runtime-proof.md
+++ b/docs/reports/auth-persistence-runtime-proof.md
@@ -9,6 +9,8 @@ summary: >
   Runtime-Proof-Bericht für den Auth-Persistenz-Pfad (OPT-API-002/003).
   Gesamtergebnis: PARTIAL_PROVEN. psql-basierter Migrations- und CRUD-Smoke
   gegen disposable-local PostgreSQL und PgBouncer (transaction mode) sind belegt.
+  SQLx/Rust-API-CRUD gegen direkten PostgreSQL-Zugriff ist ebenfalls belegt
+  (siehe docs/proofs/sqlx-postgres-direct-session-crud-proof.md).
   SQLx/Rust-API-CRUD gegen PgBouncer, sqlx-cli-Migration und exaktes
   Stack-PgBouncer-Image bleiben NOT_PROVEN. ADR-0007 schränkt PgBouncer auf
   Dev-/Spezialpfade ein; der Produktionspfad ist DATABASE_URL → direkter
@@ -281,7 +283,7 @@ git diff --check
 | CRUD via PgBouncer transaction mode (psql) | ✅ PROVEN |
 | Offline-Tests grün | ✅ PROVEN |
 | Kein Auth-Verhalten geändert | ✅ PROVEN |
-| SQLx/Rust-API CRUD direkt Postgres | ❌ NOT_PROVEN |
+| SQLx/Rust-API CRUD direkt Postgres | ✅ PROVEN |
 | SQLx/Rust-API CRUD via PgBouncer transaction mode | ❌ NOT_PROVEN |
 | `sqlx migrate run` via sqlx-cli | ❌ NOT_PROVEN |
 | Exaktes Stack-Image `edoburu/pgbouncer:1.20` | ❌ NOT_PROVEN |
@@ -289,11 +291,32 @@ git diff --check
 ### Gesamtergebnis: PARTIAL_PROVEN
 
 Der psql-basierte Migrations- und CRUD-Pfad gegen PostgreSQL und PgBouncer
-(transaction mode) ist reproduzierbar belegt. Der SQLx/Rust-API-Pfad gegen
-PgBouncer transaction mode bleibt für Dev-/Spezialfälle unbewiesen.
-Nach ADR-0007 ist dies kein Produktions-Gate: Der Produktionspfad für Auth-
-Persistenz ist `DATABASE_URL` → direkter PostgreSQL-Zugriff. `psql`-CRUD ist
-nicht äquivalent zu SQLx-Runtime.
+(transaction mode) ist reproduzierbar belegt. Der produktive SQLx/Rust-API-
+Pfad gegen direkten PostgreSQL-Zugriff ist ebenfalls belegt (separater
+Proof-Report: `docs/proofs/sqlx-postgres-direct-session-crud-proof.md`).
+Offen bleibt der SQLx/Rust-API-Pfad gegen PgBouncer transaction mode für
+Dev-/Spezialfälle. Nach ADR-0007 ist PgBouncer kein Produktions-Gate.
+
+### 5.1 Scope-Abgrenzung (kurz)
+
+PROVEN:
+
+- SQLx/Rust-CRUD gegen direkten PostgreSQL-Pfad (`DATABASE_URL`/`PG_DIRECT_URL`)
+- psql-Migrations- und CRUD-Pfad gegen disposable-local PostgreSQL
+- psql-CRUD über PgBouncer transaction mode
+
+NOT_PROVEN:
+
+- SQLx/Rust-CRUD über PgBouncer transaction mode
+- `sqlx migrate run` via sqlx-cli im CI-Kontext
+- Exaktes Stack-Image `edoburu/pgbouncer:1.20` im Runtime-Proof
+
+Warum `DbSessionStore` nicht Teil dieses PR ist:
+
+- Dieser PR ist ein Runtime-Proof-Scope ohne Auth-Router-Umbau.
+- Das Ziel ist Nachweisbarkeit des Persistenzpfads, nicht produktive
+  Store-Einführung.
+- `DbSessionStore` bleibt der nächste, separate Implementierungs-PR.
 
 ---
 
@@ -356,22 +379,20 @@ des Stacks bleibt unverändert.
 
 ## 8. Entscheidungsempfehlung: nächster sicherer Schritt
 
-**Empfehlung: `test(db): prove direct SQLx/Postgres session CRUD`**
+**Empfehlung: `feat(auth): implement DbSessionStore against direct PostgreSQL path`**
 
-Der psql-basierte Proof ist bestanden, aber der produktive SQLx/Rust-API-Pfad
-gegen direkten PostgreSQL-Zugriff ist noch nicht belegt. Nach ADR-0007 ist dieser
-direkte Pfad das Gate vor produktiver Auth-Persistenz.
+Der direkte SQLx/PostgreSQL-Persistenzpfad ist jetzt als Proof belegt. Damit ist
+die zentrale Vorbedingung aus ADR-0007 für den nächsten Implementierungsschritt
+erfüllt.
 
 Vorgehen für den nächsten PR:
 
-1. Rust-Integrationstest schreiben, der via `sqlx::PgPool` gegen eine
-   disposable-local PostgreSQL-Datenbank arbeitet.
-2. INSERT / SELECT / UPDATE / DELETE gegen `sessions` via SQLx/Rust — nicht via psql.
-3. Belegen, dass der getestete Pool aus `DATABASE_URL` direkt PostgreSQL adressiert.
-4. Offline-Tests müssen weiterhin grün bleiben.
+1. `DbSessionStore` gegen direkten PostgreSQL-Zugriff implementieren.
+2. `SessionBackend`/`SessionOps`-Wiring nur soweit anpassen, wie für Persistenz nötig.
+3. Login/Logout/Refresh-Verhalten unverändert halten.
+4. Offline-Testpfad weiterhin grün halten.
 
-**Stop-Regel:** Kein `DbSessionStore` ohne belegten direkten SQLx/Postgres-
-Persistenzpfad.
+**Stop-Regel:** Kein PgBouncer-spezifischer Umbau als Produktions-Gate.
 
 Optionaler Spezialpfad: Der SQLx/PgBouncer-Proof mit `statement_cache_capacity(0)`
 kann weiterhin ausgeführt werden, wenn ein Dev-/Spezialbetrieb PgBouncer nutzt.

--- a/docs/reports/auth-persistence-runtime-proof.md
+++ b/docs/reports/auth-persistence-runtime-proof.md
@@ -9,7 +9,7 @@ summary: >
   Runtime-Proof-Bericht für den Auth-Persistenz-Pfad (OPT-API-002/003).
   Gesamtergebnis: PARTIAL_PROVEN. psql-basierter Migrations- und CRUD-Smoke
   gegen disposable-local PostgreSQL und PgBouncer (transaction mode) sind belegt.
-  SQLx/Rust-API-CRUD gegen direkten PostgreSQL-Zugriff ist ebenfalls belegt
+  SQLx/Rust-CRUD gegen die Session-Tabelle im direkten PostgreSQL-Pfad ist ebenfalls belegt
   (siehe docs/proofs/sqlx-postgres-direct-session-crud-proof.md).
   SQLx/Rust-API-CRUD gegen PgBouncer, sqlx-cli-Migration und exaktes
   Stack-PgBouncer-Image bleiben NOT_PROVEN. ADR-0007 schränkt PgBouncer auf
@@ -286,8 +286,8 @@ git diff --check
 | CRUD via PgBouncer transaction mode (psql) | ✅ PROVEN |
 | Offline-Tests grün | ✅ PROVEN |
 | Kein Auth-Verhalten geändert | ✅ PROVEN |
-| SQLx/Rust-API CRUD direkt Postgres | ✅ PROVEN |
-| SQLx/Rust-API CRUD via PgBouncer transaction mode | ❌ NOT_PROVEN |
+| SQLx/Rust CRUD gegen Session-Tabelle direkt Postgres | ✅ PROVEN |
+| SQLx/Rust CRUD via PgBouncer transaction mode | ❌ NOT_PROVEN |
 | `sqlx migrate run` via sqlx-cli | ❌ NOT_PROVEN |
 | Exaktes Stack-Image `edoburu/pgbouncer:1.20` | ❌ NOT_PROVEN |
 

--- a/docs/reports/auth-persistence-runtime-proof.md
+++ b/docs/reports/auth-persistence-runtime-proof.md
@@ -11,7 +11,7 @@ summary: >
   gegen disposable-local PostgreSQL und PgBouncer (transaction mode) sind belegt.
   SQLx/Rust-CRUD gegen die Session-Tabelle im direkten PostgreSQL-Pfad ist ebenfalls belegt
   (siehe docs/proofs/sqlx-postgres-direct-session-crud-proof.md).
-  SQLx/Rust-API-CRUD gegen PgBouncer, sqlx-cli-Migration und exaktes
+  SQLx/Rust-CRUD gegen PgBouncer, sqlx-cli-Migration und exaktes
   Stack-PgBouncer-Image bleiben NOT_PROVEN. ADR-0007 schränkt PgBouncer auf
   Dev-/Spezialpfade ein; der Produktionspfad ist DATABASE_URL → direkter
   PostgreSQL-Zugriff.
@@ -297,7 +297,7 @@ Der psql-basierte Migrations- und CRUD-Pfad gegen PostgreSQL und PgBouncer
 (transaction mode) ist reproduzierbar belegt. Der direkte SQLx/Rust-CRUD-
 Pfad gegen die Session-Tabelle in PostgreSQL ist ebenfalls belegt (separater
 Proof-Report: `docs/proofs/sqlx-postgres-direct-session-crud-proof.md`).
-Offen bleibt der SQLx/Rust-API-Pfad gegen PgBouncer transaction mode für
+Offen bleibt der SQLx/Rust-Pfad gegen PgBouncer transaction mode für
 Dev-/Spezialfälle. Nach ADR-0007 ist PgBouncer kein Produktions-Gate.
 
 ### 5.1 Scope-Abgrenzung (kurz)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -101,11 +101,13 @@ Reihenfolge: Kanonisierung → Step-up → Persistenz-Runtime-Proof → DbSessio
 - [~] Phase 3 — Step-up Auth · Passkey-Register-Grant-Handoff belegt; Register-Verify und UI-E2E offen · [auth-roadmap §7/§8](blueprints/auth-roadmap.md)
 - [~] Phase 4 — Auth-Persistenz Runtime-Proof
   - SQL/psql-Migration + psql-basierter PgBouncer-CRUD-Smoke belegt
-  - SQLx/PgBouncer-Rust-Proof als Testgerüst vorbereitet (READY_FOR_PROOF, nicht ausgeführt), aber nach ADR-0007 optionaler Dev-/Spezialpfad
+  - SQLx/Rust-CRUD gegen direkten PostgreSQL-Pfad ist belegt (PROVEN; Session-Tabellen-CRUD-Primitive)
+  - SQLx/PgBouncer-Rust-Proof bleibt optionaler Dev-/Spezialpfad und weiterhin nicht belegt (NOT_PROVEN / READY_FOR_PROOF)
   - Zielarchitekturentscheidung geschlossen: Produktion nutzt direkten PostgreSQL-Zugriff via `DATABASE_URL`; PgBouncer ist kein Produktions-Gate
   - Belege: [ADR-0007](adr/ADR-0007__auth-persistence-production-db-path.md),
     [auth-persistence-runtime-proof.md](blueprints/auth-persistence-runtime-proof.md),
     [Report](reports/auth-persistence-runtime-proof.md),
+    [Direct-SQLx-Proof](proofs/sqlx-postgres-direct-session-crud-proof.md),
     [Zielarchitektur-Abgleich](reports/auth-persistence-runtime-target-reconciliation.md)
 - [ ] Phase 5 — `DbSessionStore` / `SessionBackend`-Abstraktion · nächster Architekturpfad gegen direkten SQLx/PostgreSQL-Persistenzpfad
 - [ ] Phase 6 — Auth-Statusmatrix vollständig grün · [auth-status-matrix.md](reports/auth-status-matrix.md)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -109,7 +109,7 @@ Reihenfolge: Kanonisierung → Step-up → Persistenz-Runtime-Proof → DbSessio
     [Report](reports/auth-persistence-runtime-proof.md),
     [Direct-SQLx-Proof](proofs/sqlx-postgres-direct-session-crud-proof.md),
     [Zielarchitektur-Abgleich](reports/auth-persistence-runtime-target-reconciliation.md)
-- [ ] Phase 5 — `DbSessionStore` / `SessionBackend`-Abstraktion · nächster Architekturpfad gegen direkten SQLx/PostgreSQL-Persistenzpfad
+- [ ] Phase 5 — `DbSessionStore`-Verdrahtung über vorhandene `SessionBackend`/`SessionOps`-Abstraktion · nächster Implementierungspfad gegen direkten SQLx/PostgreSQL-Persistenzpfad
 - [ ] Phase 6 — Auth-Statusmatrix vollständig grün · [auth-status-matrix.md](reports/auth-status-matrix.md)
 
 ## Strang UI


### PR DESCRIPTION
## Ziel

Proof-PR für den direkten SQLX/Postgres-Session-Persistenzpfad.

## Kontext

Dieser PR dokumentiert und synchronisiert den Stand des Runtime-Proofs für den direkten SQLX/Postgres-Session-Pfad. Ziel ist nicht die produktive DB-Verdrahtung, sondern die belastbare Trennung zwischen:

- PROVEN / NOT_PROVEN
- Runtime-Proof
- SessionStore-Abgrenzung
- späterer produktiver Session-Persistenz

## Änderung

- Runtime-Proof-Status synchronisiert
- CI-/Validierungsnotizen an aktuellen Stand angepasst
- Dokumentation auf den direkten SQLX/Postgres-Pfad ausgerichtet

## Nicht-Ziel

- Kein DbSessionStore
- Keine produktive Auth-Session-Migration
- Keine Änderung am aktiven In-Memory-Sessionpfad
- Keine neue DB-Verkabelung im Runtime-Code

## Prüfstatus

Lokaler Branch ist auf aktuellem `origin/main` aufgebaut. Weitere CI-Validierung erfolgt im PR.
