### PR TITLE
chore(basemap-proof): harden trigger paths, image tag, and endpoint explicitness

### DIFF
--- a/.github/workflows/basemap-runtime-proof.yml
+++ b/.github/workflows/basemap-runtime-proof.yml
@@ -194,7 +194,8 @@ jobs:
         id: proof
         run: |
           set -euo pipefail
-          scripts/guard/basemap-runtime-proof.sh 2>&1 | tee /tmp/proof-output.txt
+          BASEMAP_ENDPOINT_PATH="/local-basemap/${ARTEFACT_NAME}" \
+            scripts/guard/basemap-runtime-proof.sh 2>&1 | tee /tmp/proof-output.txt
 
       - name: Capture raw 206 evidence for the audit trail
         if: always()

--- a/docs/deploy/CHANGELOG.md
+++ b/docs/deploy/CHANGELOG.md
@@ -288,7 +288,7 @@ und schließender Klammer auskommentiert wurde.
 docker compose -f infra/compose/compose.prod.yml config
 # Sollte ohne Fehler durchlaufen
 
-docker run --rm -v "$PWD/infra/caddy/Caddyfile.prod:/etc/caddy/Caddyfile:ro" caddy:2 caddy validate --config /etc/caddy/Caddyfile
+docker run --rm -v "$PWD/infra/caddy/Caddyfile.prod:/etc/caddy/Caddyfile:ro" caddy:2.7 caddy validate --config /etc/caddy/Caddyfile
 # Sollte "Valid configuration" ausgeben
 ```
 


### PR DESCRIPTION
## These / Antithese / Synthese

**These:** Der Basemap-Range-Delivery-Proof-PR trennt Range-Auslieferung korrekt von PMTiles-Inhaltsvalidität und vermeidet den „HTTP 206 = Karte bewiesen"-Kurzschluss.
**Antithese:** Er kann durch Doku-/Workflow-Drift geschwächt werden, wenn Image-Bezeichnungen oder Endpunkt-Pfade implizit bleiben.
**Synthese:** Minimale Härtung — keine neue Funktionalität, kein Scope-Ausweitung.

---

## Befund vor diesem PR

### Was bereits korrekt war

- `on.paths` deckt `infra/caddy/**` (deckt `Caddyfile.proof`), `scripts/guard/basemap-runtime-proof.sh` und `.github/workflows/basemap-runtime-proof.yml` ab. Kein Trigger-Gap.
- Alle geprüften Docs (`kartenklarheit-phase6.md`, `kartenklarheit-roadmap.md`, `map-architekturkritik.md`, `map-status-matrix.md`, `map-status-matrix.json`) verwenden bereits `caddy:2.7`.
- Beweisstatus ist korrekt: PROVEN mit CI-Lauf 25970466659 (Commit 14feefd6). Kein Übergrünen nötig.

### Was gefehlt hat

1. **Image-Drift in `docs/deploy/CHANGELOG.md`**: Ein historischer Rate-Limiting-Eintrag (2026-03-20) nutzte `caddy:2` in einem `docker run`-Validierungsbeispiel — abweichend von `caddy:2.7` in Workflow und allen anderen Docs.

2. **Impliziter Endpunkt im Guard-Aufruf**: Der CI-Schritt `Run basemap runtime proof guard` rief das Script ohne `BASEMAP_ENDPOINT_PATH` auf; der Guard ermittelte den Pfad via Auto-Detection aus `BASEMAP_ARTIFACT_DIR`. Korrekt, aber epistemisch schwächer als ein explizit benannter Pfad.

---

## Änderungen

### `docs/deploy/CHANGELOG.md`

```diff
-docker run --rm -v "$PWD/infra/caddy/Caddyfile.prod:/etc/caddy/Caddyfile:ro" caddy:2 caddy validate --config /etc/caddy/Caddyfile
+docker run --rm -v "$PWD/infra/caddy/Caddyfile.prod:/etc/caddy/Caddyfile:ro" caddy:2.7 caddy validate --config /etc/caddy/Caddyfile
```

Kanonische Version laut `infra/compose/compose.core.yml` und Workflow ist `caddy:2.7`.

### `.github/workflows/basemap-runtime-proof.yml`

```diff
-          scripts/guard/basemap-runtime-proof.sh 2>&1 | tee /tmp/proof-output.txt
+          BASEMAP_ENDPOINT_PATH="/local-basemap/${ARTEFACT_NAME}" \
+            scripts/guard/basemap-runtime-proof.sh 2>&1 | tee /tmp/proof-output.txt
```

Der Guard-Aufruf benennt jetzt explizit, welches Artefakt geprüft wird. `ARTEFACT_NAME` ist `proof-range-delivery.pmtiles` (job-level env). Kein Rätselraten mehr.

---

## Verifikation

- `bash -n scripts/guard/basemap-runtime-proof.sh` → `syntax OK`
- `git diff --check` → clean

---

## Restlücken (explizit)

- `on.paths` triggert auf `infra/caddy/**` (gesamter Unterordner), nicht nur `Caddyfile.proof`. Breadth ist akzeptabel — jede Caddy-Konfig-Änderung soll den Proof triggern.
- PMTiles-Magic-Bytes-Validierung via HTTP-Range durch Caddy (also `curl Range bytes=0-6` gegen den laufenden Container statt lokaler `dd`-Prüfung) ist noch offen. Dies ist ein bewusst getrennter nächster Schritt.
- `caddy:2.7` ist nicht auf einen Digest gepinnt. Eine Digest-Pinning würde stärkere Reproduzierbarkeit bieten, geht aber über den Scope dieser Härtung hinaus.

---

## Dateien geändert

| Datei | Änderung |
|---|---|
| `.github/workflows/basemap-runtime-proof.yml` | `BASEMAP_ENDPOINT_PATH` explizit im Guard-Aufruf |
| `docs/deploy/CHANGELOG.md` | `caddy:2` → `caddy:2.7` (Image-Drift-Fix) |