### PR TITLE
chore(deploy): configurable Cargo build parallelism in API Dockerfile

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -23,7 +23,10 @@ COPY . .
 
 # 4) Build the API binary in release mode
 # Build against the checked-in lockfile for deterministic dependency resolution.
-RUN cargo build --release --locked --bin weltgewebe-api
+ARG CARGO_BUILD_JOBS=2
+# Default to a conservative job count for Heimserver stability.
+# CI or larger builders may override with --build-arg CARGO_BUILD_JOBS=<n>.
+RUN CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS}" cargo build --release --locked --bin weltgewebe-api
 
 # Runner stage
 FROM debian:bookworm-slim

--- a/docs/deploy/CHANGELOG.md
+++ b/docs/deploy/CHANGELOG.md
@@ -10,6 +10,23 @@ relations:
 ---
 # Deployment-Änderungsprotokoll
 
+## 2026-05-23 - API-Dockerfile: konfigurierbare Cargo-Build-Parallelität
+
+**Geänderte Dateien:**
+
+- `apps/api/Dockerfile`
+
+**Beschreibung:**
+
+Das API-Dockerfile nutzt jetzt `CARGO_BUILD_JOBS` als explizites Build-Arg,
+um die Cargo-Build-Parallelität stabil und nachvollziehbar zu steuern.
+Der Default ist auf `2` gesetzt, um die Build-Last auf dem Heimserver zu glätten
+und harte Abbrüche bei `docker compose up --build` zu reduzieren.
+Auf CI oder größeren Buildern kann der Wert gezielt per
+`--build-arg CARGO_BUILD_JOBS=<n>` überschrieben werden.
+
+**Risiko:** Build kann länger dauern; dafür stabilerer Heimserver-Deploy.
+
 ## 2026-05-23 - `weltgewebe-up` Deploy-Branch-Vertrag explizit gemacht
 
 **Geänderte Dateien:**


### PR DESCRIPTION
## Summary
- add `ARG CARGO_BUILD_JOBS=2` to `apps/api/Dockerfile`
- build API binary with `CARGO_BUILD_JOBS` applied to `cargo build --release --locked --bin weltgewebe-api`
- document the change and risk/benefit in `docs/deploy/CHANGELOG.md`

## Why
- smooth Heimserver build pressure during `docker compose up --build`
- keep behavior explicit, canonical, and overrideable via `--build-arg CARGO_BUILD_JOBS=<n>`

## Scope
- no Compose service logic changes
- no Caddy/Edge/Basemap changes
- no DB/volume changes
- no dependency version changes
- no API application logic changes

## Checks
- `git diff --check` ✅
- `docker build --progress=plain -f apps/api/Dockerfile -t weltgewebe-api:jobs2-test .` ⚠️ not runnable in this dev container (`docker: command not found`)
- `docker run --rm --entrypoint /bin/sh weltgewebe-api:jobs2-test -lc 'ldd /app/weltgewebe-api | grep -E "ssl|crypto|not found" || true'` ⚠️ not runnable here for same reason