### PR TITLE
harden(csp): restrict repo local-sovereign basemap sources

### DIFF
--- a/docs/deploy/CHANGELOG.md
+++ b/docs/deploy/CHANGELOG.md
@@ -10,6 +10,27 @@ relations:
 ---
 # Deployment-Änderungsprotokoll
 
+
+## 2026-05-24 - CSP-Härtung für repo-interne local-sovereign Caddyfiles
+
+**Geänderte Dateien:**
+
+- `infra/caddy/Caddyfile`
+- `infra/caddy/Caddyfile.dev`
+
+**Beschreibung:**
+
+Die repo-internen Caddy-Konfigurationen entfernen externe CARTO-Tile-Provider
+aus `connect-src` und `img-src`. WebSocket-Quellen (`ws:`/`wss:`) bleiben für
+Dev-/Proxy-Betrieb erlaubt; Basemap-Bild- und Tile-Quellen bleiben lokal.
+
+Die operative Heimserver-Edge-Caddyfile kann extern unter
+`/opt/heimgewebe/edge/Caddyfile` liegen und wird durch `weltgewebe-up`
+bevorzugt, wenn vorhanden. Diese Änderung härtet die repo-internen
+Referenz-/Dev-Caddyfiles und verhindert künftige CSP-Drift, ersetzt aber nicht
+den Live-Edge-Abgleich.
+
+
 ## 2026-05-23 - CARTO-freies local-sovereign-Bundle via Build-Time-Generator
 
 **Geänderte Dateien:**

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -39,9 +39,8 @@
   }
   reverse_proxy /* web:5173
   header {
-    # Dev-CSP: HMR/WebSocket & Dev-Assets erlauben; bei Bedarf später härten
-    # Für externe Tiles ggf. ergänzen, z.B.:
-    #   img-src 'self' data: blob: https://tile.openstreetmap.org https://*.tile.openstreetmap.org;
+    # Local-sovereign CSP: WebSocket-Schemes bleiben fuer Dev/Proxy erlaubt;
+    # externe Tile-/Bildquellen bleiben in diesem Caddy-Pfad bewusst gesperrt.
     Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss:; img-src 'self' data: blob:; worker-src 'self' blob:; object-src 'none';"
     X-Frame-Options "DENY"
     Referrer-Policy "no-referrer"

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -42,7 +42,7 @@
     # Dev-CSP: HMR/WebSocket & Dev-Assets erlauben; bei Bedarf später härten
     # Für externe Tiles ggf. ergänzen, z.B.:
     #   img-src 'self' data: blob: https://tile.openstreetmap.org https://*.tile.openstreetmap.org;
-    Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss: https://basemaps.cartocdn.com; img-src 'self' data: blob: https://basemaps.cartocdn.com; worker-src 'self' blob:; object-src 'none';"
+    Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss:; img-src 'self' data: blob:; worker-src 'self' blob:; object-src 'none';"
     X-Frame-Options "DENY"
     Referrer-Policy "no-referrer"
     # Optional diagnostic header. Deploy can set WELTGEWEBE_BUILD to the canonical

--- a/infra/caddy/Caddyfile.dev
+++ b/infra/caddy/Caddyfile.dev
@@ -41,7 +41,7 @@
     # Dev-CSP: HMR/WebSocket & Dev-Assets erlauben; bei Bedarf später härten
     # Für externe Tiles ggf. ergänzen, z.B.:
     #   img-src 'self' data: blob: https://tile.openstreetmap.org https://*.tile.openstreetmap.org;
-    Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss: https://basemaps.cartocdn.com; img-src 'self' data: blob: https://basemaps.cartocdn.com; worker-src 'self' blob:; object-src 'none';"
+    Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss:; img-src 'self' data: blob:; worker-src 'self' blob:; object-src 'none';"
     X-Frame-Options "DENY"
     Referrer-Policy "no-referrer"
     # Optional diagnostic header. Deploy can set WELTGEWEBE_BUILD to the canonical

--- a/infra/caddy/Caddyfile.dev
+++ b/infra/caddy/Caddyfile.dev
@@ -38,9 +38,8 @@
   }
   reverse_proxy /* web:5173
   header {
-    # Dev-CSP: HMR/WebSocket & Dev-Assets erlauben; bei Bedarf später härten
-    # Für externe Tiles ggf. ergänzen, z.B.:
-    #   img-src 'self' data: blob: https://tile.openstreetmap.org https://*.tile.openstreetmap.org;
+    # Local-sovereign CSP: WebSocket-Schemes bleiben fuer Dev/Proxy erlaubt;
+    # externe Tile-/Bildquellen bleiben in diesem Caddy-Pfad bewusst gesperrt.
     Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss:; img-src 'self' data: blob:; worker-src 'self' blob:; object-src 'none';"
     X-Frame-Options "DENY"
     Referrer-Policy "no-referrer"


### PR DESCRIPTION
## Summary

Harden repo-internal Caddy CSPs for the local-sovereign basemap path by removing external CARTO tile sources from `connect-src` and `img-src`.

The live Heimserver edge CSP was already fixed separately in `/opt/heimgewebe/edge/Caddyfile`; this PR prevents repo/reference drift in `infra/caddy/Caddyfile` and `infra/caddy/Caddyfile.dev`.

## Proof

- `git diff --check`
- `bash scripts/preflight/csp_contract_static.sh`
- `bash scripts/tests/test_csp_contract_static.sh`
- `bash scripts/guard/caddy-basemap-route-guard.sh`
- `pnpm exec playwright test --config=playwright.proof.config.ts basemap-real-hamburg-visual.proof.ts --reporter=line`

## Non-goals

- No PMTiles rebuild
- No map-style changes
- No glyph changes
- No app basemap mode logic changes