### PR TITLE
Basemap Runtime Proof: pmtiles-content CI Scope mit echtem Artefakt

### DIFF
--- a/.github/workflows/basemap-runtime-proof.yml
+++ b/.github/workflows/basemap-runtime-proof.yml
@@ -1,7 +1,7 @@
 ---
 name: Basemap Runtime Proof
 
-# This workflow runs two jobs:
+# This workflow runs three jobs:
 #
 #   1. basemap-runtime-proof  (Pfad 1 — epistemischer Dry-Run, nicht blockierend)
 #      Runs the guard in skip mode with no Caddy and no artefact. Reports
@@ -12,6 +12,12 @@ name: Basemap Runtime Proof
 #      under /local-basemap/* and runs the guard in require mode with
 #      scope=range-delivery. The guard issues a Range request via curl and
 #      asserts HTTP 206 plus Accept-Ranges/Content-Range. Failure fails the job.
+#
+#   3. basemap-pmtiles-content-proof (Pfad 3 — echter Content-Proof, blockierend)
+#      Builds a real PMTiles artefact via scripts/basemap/build-hamburg-pmtiles.sh,
+#      serves it through Caddy, and runs the guard with scope=pmtiles-content.
+#      The guard verifies endpoint/range delivery (HTTP 206), the PMTiles magic
+#      bytes "PMTiles" and an optional SHA256 match from the generated metadata.
 #
 # Scope distinction:
 #   Pfad 2 proves Caddy HTTP Range delivery against a .pmtiles file. It does
@@ -28,12 +34,14 @@ name: Basemap Runtime Proof
     branches: [main]
     paths:
       - "infra/caddy/**"
+      - "scripts/basemap/build-hamburg-pmtiles.sh"
       - "scripts/guard/basemap-runtime-proof.sh"
       - ".github/workflows/basemap-runtime-proof.yml"
   push:
     branches: [main]
     paths:
       - "infra/caddy/**"
+      - "scripts/basemap/build-hamburg-pmtiles.sh"
       - "scripts/guard/basemap-runtime-proof.sh"
       - ".github/workflows/basemap-runtime-proof.yml"
   workflow_dispatch: {}
@@ -279,5 +287,152 @@ jobs:
             cat "${HDR_FILE}" >> "${GITHUB_STEP_SUMMARY}"
           else
             printf 'No response headers captured.\n' >> "${GITHUB_STEP_SUMMARY}"
+          fi
+          printf '```\n\n</details>\n' >> "${GITHUB_STEP_SUMMARY}"
+
+  basemap-pmtiles-content-proof:
+    name: basemap-pmtiles-content-proof
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      BASEMAP_PROOF_MODE: require
+      BASEMAP_PROOF_SCOPE: pmtiles-content
+      BASEMAP_CADDY_URL: http://localhost:8081
+      SOURCE_DATE_EPOCH: "1704067200"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify Docker availability
+        run: |
+          set -euo pipefail
+          docker --version
+          docker info >/dev/null
+
+      - name: Build real PMTiles artefact (Hamburg)
+        run: |
+          set -euo pipefail
+          bash scripts/basemap/build-hamburg-pmtiles.sh
+
+          ARTEFACT_NAME="basemap-hamburg-v0.1.0.pmtiles"
+          ARTEFACT_PATH="build/basemap/${ARTEFACT_NAME}"
+          META_PATH="build/basemap/basemap-hamburg-v0.1.0.meta.json"
+
+          test -s "${ARTEFACT_PATH}"
+          test -s "${META_PATH}"
+
+          EXPECTED_SHA256="$(python3 - <<'PY'
+          import json
+          with open('build/basemap/basemap-hamburg-v0.1.0.meta.json', 'r', encoding='utf-8') as f:
+              meta = json.load(f)
+          value = meta.get('sha256', '')
+          if not value:
+              raise SystemExit('missing sha256 in metadata')
+          print(value)
+          PY
+          )"
+
+          FILE_SIZE="$(wc -c < "${ARTEFACT_PATH}" | tr -d '[:space:]')"
+
+          printf 'ARTEFACT_NAME=%s\n' "${ARTEFACT_NAME}" >> "${GITHUB_ENV}"
+          printf 'ARTEFACT_PATH=%s\n' "${ARTEFACT_PATH}" >> "${GITHUB_ENV}"
+          printf 'META_PATH=%s\n' "${META_PATH}" >> "${GITHUB_ENV}"
+          printf 'EXPECTED_SHA256=%s\n' "${EXPECTED_SHA256}" >> "${GITHUB_ENV}"
+          printf 'ARTEFACT_SIZE=%s\n' "${FILE_SIZE}" >> "${GITHUB_ENV}"
+
+      - name: Start Caddy serving /local-basemap/ from artefact directory
+        run: |
+          set -euo pipefail
+          docker run -d --name caddy-proof-content \
+            -p 8081:8081 \
+            -v "${PWD}/infra/caddy/Caddyfile.proof:/etc/caddy/Caddyfile:ro" \
+            -v "${PWD}/build/basemap:/srv/weltgewebe-basemap:ro" \
+            caddy:2.7 caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
+          for i in $(seq 1 30); do
+            if curl -sf -o /dev/null --max-time 2 "${BASEMAP_CADDY_URL}/"; then
+              echo "caddy ready after ${i} attempts"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "ERROR: caddy did not become ready in 30s" >&2
+          docker logs caddy-proof-content || true
+          exit 1
+
+      - name: Run basemap runtime proof guard (require + pmtiles-content)
+        id: proof
+        run: |
+          set -euo pipefail
+          BASEMAP_ENDPOINT_PATH="/local-basemap/${ARTEFACT_NAME}" \
+          BASEMAP_PMTILES_PATH="${PWD}/${ARTEFACT_PATH}" \
+          BASEMAP_EXPECTED_SHA256="${EXPECTED_SHA256}" \
+            scripts/guard/basemap-runtime-proof.sh 2>&1 | tee /tmp/proof-output.txt
+
+      - name: Capture raw PMTiles magic bytes and 206 headers
+        if: always()
+        run: |
+          set -euo pipefail
+          xxd -l 16 -g 1 "${ARTEFACT_PATH}" > /tmp/magic-bytes.txt
+          curl -sS -D /tmp/response-headers.txt -o /dev/null \
+            -H 'Range: bytes=0-511' \
+            "${BASEMAP_CADDY_URL}/local-basemap/${ARTEFACT_NAME}" || true
+
+      - name: Collect caddy logs
+        if: always()
+        run: |
+          docker logs caddy-proof-content > /tmp/caddy.log 2>&1 || true
+          tail -n 100 /tmp/caddy.log || true
+
+      - name: Tear down Caddy container
+        if: always()
+        run: docker rm -f caddy-proof-content || true
+
+      - name: Upload proof evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: basemap-pmtiles-content-proof-evidence
+          path: |
+            /tmp/proof-output.txt
+            /tmp/magic-bytes.txt
+            /tmp/response-headers.txt
+            /tmp/caddy.log
+            ${{ env.ARTEFACT_PATH }}
+            ${{ env.META_PATH }}
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Write job summary
+        if: always()
+        run: |
+          set -euo pipefail
+          OUTPUT_FILE="/tmp/proof-output.txt"
+
+          printf '## Basemap PMTiles Content Proof\n\n' >> "${GITHUB_STEP_SUMMARY}"
+
+          if [[ -f "${OUTPUT_FILE}" ]] && grep -q '^PROVEN: Caddy PMTiles content verified (scope=pmtiles-content)$' "${OUTPUT_FILE}"; then
+            printf '%s\n\n' '✅ **PROVEN (scope=pmtiles-content)** — Caddy endpoint, HTTP 206 range, PMTiles magic bytes, and SHA256 verified' \
+              >> "${GITHUB_STEP_SUMMARY}"
+            printf '%s\n\n' 'Artefact provenance: built in CI via scripts/basemap/build-hamburg-pmtiles.sh (Planetiler pinned digest + pinned OSM snapshot hash).' \
+              >> "${GITHUB_STEP_SUMMARY}"
+            printf 'Artefact: %s (%s bytes)\n' "${ARTEFACT_NAME}" "${ARTEFACT_SIZE}" >> "${GITHUB_STEP_SUMMARY}"
+            printf 'SHA256: %s\n\n' "${EXPECTED_SHA256}" >> "${GITHUB_STEP_SUMMARY}"
+          else
+            printf '%s\n\n' '❌ **FAILED** — guard did not report pmtiles-content as PROVEN' \
+              >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+          printf '<details><summary>Guard output</summary>\n\n```\n' >> "${GITHUB_STEP_SUMMARY}"
+          if [[ -f "${OUTPUT_FILE}" ]]; then
+            cat "${OUTPUT_FILE}" >> "${GITHUB_STEP_SUMMARY}"
+          else
+            printf 'No guard output captured.\n' >> "${GITHUB_STEP_SUMMARY}"
+          fi
+          printf '```\n\n</details>\n\n' >> "${GITHUB_STEP_SUMMARY}"
+
+          printf '<details><summary>PMTiles magic bytes (first 16)</summary>\n\n```\n' >> "${GITHUB_STEP_SUMMARY}"
+          if [[ -f /tmp/magic-bytes.txt ]]; then
+            cat /tmp/magic-bytes.txt >> "${GITHUB_STEP_SUMMARY}"
+          else
+            printf 'No magic-byte capture found.\n' >> "${GITHUB_STEP_SUMMARY}"
           fi
           printf '```\n\n</details>\n' >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/basemap-runtime-proof.yml
+++ b/.github/workflows/basemap-runtime-proof.yml
@@ -420,15 +420,24 @@ jobs:
 
           printf '## Basemap PMTiles Content Proof\n\n' >> "${GITHUB_STEP_SUMMARY}"
 
-          if [[ -f "${OUTPUT_FILE}" ]] && grep -q '^PROVEN: Caddy PMTiles content verified (scope=pmtiles-content)$' "${OUTPUT_FILE}"; then
-            printf '%s\n\n' '✅ **PROVEN (scope=pmtiles-content)** — Caddy endpoint, HTTP 206 range, PMTiles magic bytes, and SHA256 verified' \
-              >> "${GITHUB_STEP_SUMMARY}"
-            printf '%s\n\n' 'Artefact provenance: built in CI via scripts/basemap/build-hamburg-pmtiles.sh (Planetiler pinned digest + pinned OSM snapshot hash).' \
-              >> "${GITHUB_STEP_SUMMARY}"
-            printf 'Artefact: %s (%s bytes)\n' "${artefact_name}" "${artefact_size}" >> "${GITHUB_STEP_SUMMARY}"
-            printf 'PMTiles-Artefakt-SHA256 (from build/basemap/basemap-hamburg-v0.1.0.meta.json): %s\n\n' "${expected_sha256}" >> "${GITHUB_STEP_SUMMARY}"
+          PROVEN_PATTERN='^PROVEN: Caddy PMTiles content verified (scope=pmtiles-content)$'
+          if [[ -f "${OUTPUT_FILE}" ]] && grep -q "${PROVEN_PATTERN}" "${OUTPUT_FILE}"; then
+            _msg='✅ **PROVEN (scope=pmtiles-content)**'
+            _msg="${_msg} — Caddy endpoint, HTTP 206 range, PMTiles magic bytes, and"
+            _msg="${_msg} SHA256 verified"
+            printf '%s\n\n' "${_msg}" >> "${GITHUB_STEP_SUMMARY}"
+            _prov='Artefact provenance: built in CI via'
+            _prov="${_prov} scripts/basemap/build-hamburg-pmtiles.sh (Planetiler pinned"
+            _prov="${_prov} digest + pinned OSM snapshot hash)."
+            printf '%s\n\n' "${_prov}" >> "${GITHUB_STEP_SUMMARY}"
+            printf 'Artefact: %s (%s bytes)\n' \
+              "${artefact_name}" "${artefact_size}" >> "${GITHUB_STEP_SUMMARY}"
+            printf 'PMTiles-Artefakt-SHA256 (from build/basemap/' >> "${GITHUB_STEP_SUMMARY}"
+            printf 'basemap-hamburg-v0.1.0.meta.json): %s\n\n' \
+              "${expected_sha256}" >> "${GITHUB_STEP_SUMMARY}"
           else
-            printf '%s\n\n' '❌ **FAILED** — guard did not report pmtiles-content as PROVEN' \
+            printf '%s\n\n' \
+              '❌ **FAILED** — guard did not report pmtiles-content as PROVEN' \
               >> "${GITHUB_STEP_SUMMARY}"
           fi
 

--- a/.github/workflows/basemap-runtime-proof.yml
+++ b/.github/workflows/basemap-runtime-proof.yml
@@ -371,10 +371,18 @@ jobs:
         if: always()
         run: |
           set -euo pipefail
-          xxd -l 16 -g 1 "${ARTEFACT_PATH}" > /tmp/magic-bytes.txt
-          curl -sS -D /tmp/response-headers.txt -o /dev/null \
-            -H 'Range: bytes=0-511' \
-            "${BASEMAP_CADDY_URL}/local-basemap/${ARTEFACT_NAME}" || true
+          artefact_path="${ARTEFACT_PATH:-}"
+          artefact_name="${ARTEFACT_NAME:-}"
+          if [[ -n "${artefact_path}" && -f "${artefact_path}" ]]; then
+            xxd -l 16 -g 1 "${artefact_path}" > /tmp/magic-bytes.txt
+          else
+            printf 'No PMTiles artefact available for magic-byte capture.\n' > /tmp/magic-bytes.txt
+          fi
+          if [[ -n "${artefact_name}" ]]; then
+            curl -sS -D /tmp/response-headers.txt -o /dev/null \
+              -H 'Range: bytes=0-511' \
+              "${BASEMAP_CADDY_URL}/local-basemap/${artefact_name}" || true
+          fi
 
       - name: Collect caddy logs
         if: always()
@@ -396,8 +404,8 @@ jobs:
             /tmp/magic-bytes.txt
             /tmp/response-headers.txt
             /tmp/caddy.log
-            ${{ env.ARTEFACT_PATH }}
-            ${{ env.META_PATH }}
+            ${{ env.ARTEFACT_PATH || '' }}
+            ${{ env.META_PATH || '' }}
           if-no-files-found: warn
           retention-days: 14
 
@@ -406,6 +414,9 @@ jobs:
         run: |
           set -euo pipefail
           OUTPUT_FILE="/tmp/proof-output.txt"
+          artefact_name="${ARTEFACT_NAME:-<unset>}"
+          artefact_size="${ARTEFACT_SIZE:-<unset>}"
+          expected_sha256="${EXPECTED_SHA256:-<unset>}"
 
           printf '## Basemap PMTiles Content Proof\n\n' >> "${GITHUB_STEP_SUMMARY}"
 
@@ -414,8 +425,8 @@ jobs:
               >> "${GITHUB_STEP_SUMMARY}"
             printf '%s\n\n' 'Artefact provenance: built in CI via scripts/basemap/build-hamburg-pmtiles.sh (Planetiler pinned digest + pinned OSM snapshot hash).' \
               >> "${GITHUB_STEP_SUMMARY}"
-            printf 'Artefact: %s (%s bytes)\n' "${ARTEFACT_NAME}" "${ARTEFACT_SIZE}" >> "${GITHUB_STEP_SUMMARY}"
-            printf 'SHA256: %s\n\n' "${EXPECTED_SHA256}" >> "${GITHUB_STEP_SUMMARY}"
+            printf 'Artefact: %s (%s bytes)\n' "${artefact_name}" "${artefact_size}" >> "${GITHUB_STEP_SUMMARY}"
+            printf 'PMTiles-Artefakt-SHA256 (from build/basemap/basemap-hamburg-v0.1.0.meta.json): %s\n\n' "${expected_sha256}" >> "${GITHUB_STEP_SUMMARY}"
           else
             printf '%s\n\n' '❌ **FAILED** — guard did not report pmtiles-content as PROVEN' \
               >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/basemap-runtime-proof.yml
+++ b/.github/workflows/basemap-runtime-proof.yml
@@ -404,8 +404,8 @@ jobs:
             /tmp/magic-bytes.txt
             /tmp/response-headers.txt
             /tmp/caddy.log
-            ${{ env.ARTEFACT_PATH || '' }}
-            ${{ env.META_PATH || '' }}
+            build/basemap/basemap-hamburg-v0.1.0.pmtiles
+            build/basemap/basemap-hamburg-v0.1.0.meta.json
           if-no-files-found: warn
           retention-days: 14
 

--- a/docs/reports/map-status-matrix.json
+++ b/docs/reports/map-status-matrix.json
@@ -107,13 +107,14 @@
     },
     "runtime_integration": {
       "soll": "Echter HTTP-206-Nachweis der Caddy PMTiles Range-Auslieferung gegen reales Artefakt",
-      "ist": "Der CI-Workflow betreibt drei Jobs: 'basemap-runtime-proof' meldet im skip-Modus weiterhin NOT_PROVEN ohne Caddy; 'basemap-range-delivery-proof' startet einen realen caddy:2.7-Container gegen ein deterministisches .pmtiles-Testartefakt, fuehrt einen Range-GET (bytes=0-511) aus und schlaegt bei abweichendem Status hart fehl; 'basemap-pmtiles-content-proof' erzeugt ein echtes PMTiles-Artefakt ueber scripts/basemap/build-hamburg-pmtiles.sh (Planetiler gepinnt, OSM-Snapshot mit SHA256 verifiziert), startet Caddy und prueft Scope pmtiles-content inklusive Endpoint, HTTP 206, 7-Byte-Magic 'PMTiles' und optionaler SHA256. PROVEN (scope=range-delivery): CI-Lauf #25970466659, Commit 14feefd6, Guard-Output 'PROVEN: Caddy PMTiles Range delivery verified (scope=range-delivery)', Response-Header 'HTTP/1.1 206 Partial Content'. PROVEN (scope=pmtiles-content): CI-Lauf #26445893660, Commit ae9e2362, Job basemap-pmtiles-content-proof erfolgreich.",
+      "ist": "Der CI-Workflow betreibt drei Jobs: 'basemap-runtime-proof' meldet im skip-Modus weiterhin NOT_PROVEN ohne Caddy; 'basemap-range-delivery-proof' startet einen realen caddy:2.7-Container gegen ein deterministisches .pmtiles-Testartefakt, fuehrt einen Range-GET (bytes=0-511) aus und schlaegt bei abweichendem Status hart fehl; 'basemap-pmtiles-content-proof' erzeugt ein echtes PMTiles-Artefakt ueber scripts/basemap/build-hamburg-pmtiles.sh (Planetiler gepinnt, OSM-Snapshot mit SHA256 verifiziert), startet Caddy und prueft Scope pmtiles-content inklusive Endpoint, HTTP 206, 7-Byte-Magic 'PMTiles' und optionaler SHA256. PROVEN (scope=range-delivery): CI-Lauf #25970466659, Commit 14feefd6, Guard-Output 'PROVEN: Caddy PMTiles Range delivery verified (scope=range-delivery)', Response-Header 'HTTP/1.1 206 Partial Content'. pmtiles-content HTTP-served Magic proof implemented, pending CI proof.",
       "status": "Teil",
       "documentation_evidence": [
         "docs/blueprints/kartenklarheit-roadmap.md",
         "docs/blueprints/kartenklarheit-phase6.md"
       ],
       "missing_evidence": [
+        "Erfolgreicher GitHub-Actions-Lauf nach HTTP-served-Magic-Fix",
         "Visuelle Abnahme der gerenderten Karte",
         "Tile-Directory- und strukturelle PMTiles-Validierung"
       ],
@@ -130,13 +131,12 @@
         "scripts/guard/caddy-basemap-route-guard.sh (statischer Konfigurations-Check, kein Runtime-Beweis)"
       ],
       "proven": [
-        "HTTP-206-Range-Delivery via Caddy gegen .pmtiles-Endpoint unter /local-basemap/* (Scope range-delivery) — PROVEN: CI-Lauf https://github.com/heimgewebe/weltgewebe/actions/runs/25970466659, Commit 14feefd6, Guard-Output 'PROVEN: Caddy PMTiles Range delivery verified (scope=range-delivery)', Response HTTP/1.1 206 Partial Content",
-        "PMTiles-Content-Proof via GitHub Actions ist PROVEN: CI-Lauf https://github.com/heimgewebe/weltgewebe/actions/runs/26445893660, Job https://github.com/heimgewebe/weltgewebe/actions/runs/26445893660/job/77852013272, Commit ae9e2362, Guard-Output 'PROVEN: Caddy PMTiles content verified (scope=pmtiles-content)', PMTiles-Artefakt: basemap-hamburg-v0.1.0.pmtiles, sha256: f0734f0137c69b345ea81ed865519402d96f226fe15bc6c976134d9ed1f28a8e (aus build/basemap/basemap-hamburg-v0.1.0.meta.json, Feld sha256), Evidence-Upload-Digest: sha256:b618ff7c7b84db7c6d8b42a8f80deca538c5bd1c1b18fdade09622488215c8d4"
+        "HTTP-206-Range-Delivery via Caddy gegen .pmtiles-Endpoint unter /local-basemap/* (Scope range-delivery) — PROVEN: CI-Lauf https://github.com/heimgewebe/weltgewebe/actions/runs/25970466659, Commit 14feefd6, Guard-Output 'PROVEN: Caddy PMTiles Range delivery verified (scope=range-delivery)', Response HTTP/1.1 206 Partial Content"
       ]
     }
   },
   "open_architectural_decisions": {
     "Basemap_Strategie": "Offen: remote-style als Produktionsdefault bewusst beibehalten oder local-sovereign produktiv erzwingen.",
-    "Deploy_Artefakt": "PROVEN (range-delivery): blockierender Job basemap-range-delivery-proof hat HTTP 206 via Caddy bewiesen (CI-Lauf #25970466659, Commit 14feefd6). PROVEN (pmtiles-content): basemap-pmtiles-content-proof ist erfolgreich gelaufen (CI-Lauf #26445893660, Commit ae9e2362). Offen: visuelle Runtime-Abnahme in GitHub Actions und tiefe PMTiles-Strukturvalidierung."
+    "Deploy_Artefakt": "PROVEN (range-delivery): blockierender Job basemap-range-delivery-proof hat HTTP 206 via Caddy bewiesen (CI-Lauf #25970466659, Commit 14feefd6). pmtiles-content HTTP-served Magic proof implemented, pending CI proof. Offen: visuelle Runtime-Abnahme in GitHub Actions und tiefe PMTiles-Strukturvalidierung."
   }
 }

--- a/docs/reports/map-status-matrix.json
+++ b/docs/reports/map-status-matrix.json
@@ -131,7 +131,7 @@
       ],
       "proven": [
         "HTTP-206-Range-Delivery via Caddy gegen .pmtiles-Endpoint unter /local-basemap/* (Scope range-delivery) — PROVEN: CI-Lauf https://github.com/heimgewebe/weltgewebe/actions/runs/25970466659, Commit 14feefd6, Guard-Output 'PROVEN: Caddy PMTiles Range delivery verified (scope=range-delivery)', Response HTTP/1.1 206 Partial Content",
-        "PMTiles-Content-Proof via GitHub Actions ist PROVEN: CI-Lauf https://github.com/heimgewebe/weltgewebe/actions/runs/26445893660, Job https://github.com/heimgewebe/weltgewebe/actions/runs/26445893660/job/77852013272, Commit ae9e2362, Guard-Output 'PROVEN: Caddy PMTiles content verified (scope=pmtiles-content)', Artefaktname basemap-hamburg-v0.1.0.pmtiles, Evidence-Artefakt-Digest sha256:b618ff7c7b84db7c6d8b42a8f80deca538c5bd1c1b18fdade09622488215c8d4"
+        "PMTiles-Content-Proof via GitHub Actions ist PROVEN: CI-Lauf https://github.com/heimgewebe/weltgewebe/actions/runs/26445893660, Job https://github.com/heimgewebe/weltgewebe/actions/runs/26445893660/job/77852013272, Commit ae9e2362, Guard-Output 'PROVEN: Caddy PMTiles content verified (scope=pmtiles-content)', PMTiles-Artefakt: basemap-hamburg-v0.1.0.pmtiles, sha256: f0734f0137c69b345ea81ed865519402d96f226fe15bc6c976134d9ed1f28a8e (aus build/basemap/basemap-hamburg-v0.1.0.meta.json, Feld sha256), Evidence-Upload-Digest: sha256:b618ff7c7b84db7c6d8b42a8f80deca538c5bd1c1b18fdade09622488215c8d4"
       ]
     }
   },

--- a/docs/reports/map-status-matrix.json
+++ b/docs/reports/map-status-matrix.json
@@ -107,16 +107,15 @@
     },
     "runtime_integration": {
       "soll": "Echter HTTP-206-Nachweis der Caddy PMTiles Range-Auslieferung gegen reales Artefakt",
-      "ist": "Der CI-Workflow betreibt zwei Jobs: 'basemap-runtime-proof' meldet im skip-Modus weiterhin NOT_PROVEN ohne Caddy, und 'basemap-range-delivery-proof' startet einen realen caddy:2.7-Container gegen ein deterministisches .pmtiles-Testartefakt, fuehrt einen Range-GET (bytes=0-511) aus und schlaegt bei abweichendem Status hart fehl. Der Guard kennt die Scopes 'range-delivery' (HTTP-206-Beweis, im CI aktiv) und 'pmtiles-content' (Magic-Byte-Check der ersten 7 Bytes 'PMTiles' — kein vollstaendiger Struktur-Check, fuer ein echtes Artefakt vorbereitet). PROVEN (scope=range-delivery): CI-Lauf #25970466659, Commit 14feefd6, Guard-Output 'PROVEN: Caddy PMTiles Range delivery verified (scope=range-delivery)', Response-Header 'HTTP/1.1 206 Partial Content'. Artifact: basemap-range-delivery-proof-evidence (ID 7035995961).",
+      "ist": "Der CI-Workflow betreibt drei Jobs: 'basemap-runtime-proof' meldet im skip-Modus weiterhin NOT_PROVEN ohne Caddy; 'basemap-range-delivery-proof' startet einen realen caddy:2.7-Container gegen ein deterministisches .pmtiles-Testartefakt, fuehrt einen Range-GET (bytes=0-511) aus und schlaegt bei abweichendem Status hart fehl; 'basemap-pmtiles-content-proof' erzeugt ein echtes PMTiles-Artefakt ueber scripts/basemap/build-hamburg-pmtiles.sh (Planetiler gepinnt, OSM-Snapshot mit SHA256 verifiziert), startet Caddy und prueft Scope pmtiles-content inklusive Endpoint, HTTP 206, 7-Byte-Magic 'PMTiles' und optionaler SHA256. PROVEN (scope=range-delivery): CI-Lauf #25970466659, Commit 14feefd6, Guard-Output 'PROVEN: Caddy PMTiles Range delivery verified (scope=range-delivery)', Response-Header 'HTTP/1.1 206 Partial Content'.",
       "status": "Teil",
       "documentation_evidence": [
         "docs/blueprints/kartenklarheit-roadmap.md",
         "docs/blueprints/kartenklarheit-phase6.md"
       ],
       "missing_evidence": [
-        "Echtes PMTiles-Artefakt im CI-Stack",
-        "PMTiles-Magic-Byte-Check (Scope pmtiles-content, 7-Byte-Prefix) gegen reales Artefakt",
-        "Visuelle Abnahme der gerenderten Karte"
+        "Visuelle Abnahme der gerenderten Karte",
+        "Tile-Directory- und strukturelle PMTiles-Validierung"
       ],
       "risk": "mittel",
       "code_runtime_evidence": [
@@ -131,12 +130,13 @@
         "scripts/guard/caddy-basemap-route-guard.sh (statischer Konfigurations-Check, kein Runtime-Beweis)"
       ],
       "proven": [
-        "HTTP-206-Range-Delivery via Caddy gegen .pmtiles-Endpoint unter /local-basemap/* (Scope range-delivery) — PROVEN: CI-Lauf https://github.com/heimgewebe/weltgewebe/actions/runs/25970466659, Commit 14feefd6, Guard-Output 'PROVEN: Caddy PMTiles Range delivery verified (scope=range-delivery)', Response HTTP/1.1 206 Partial Content"
+        "HTTP-206-Range-Delivery via Caddy gegen .pmtiles-Endpoint unter /local-basemap/* (Scope range-delivery) — PROVEN: CI-Lauf https://github.com/heimgewebe/weltgewebe/actions/runs/25970466659, Commit 14feefd6, Guard-Output 'PROVEN: Caddy PMTiles Range delivery verified (scope=range-delivery)', Response HTTP/1.1 206 Partial Content",
+        "CI-Pfad fuer PMTiles-Content-Proof ist als eigener blockierender Scope umgesetzt: basemap-pmtiles-content-proof baut ein echtes PMTiles-Artefakt und prueft per Guard Endpoint + HTTP 206 + Magic-Byte + optionale SHA256 (scope=pmtiles-content)"
       ]
     }
   },
   "open_architectural_decisions": {
     "Basemap_Strategie": "Offen: remote-style als Produktionsdefault bewusst beibehalten oder local-sovereign produktiv erzwingen.",
-    "Deploy_Artefakt": "PROVEN (range-delivery): blockierender Job basemap-range-delivery-proof hat HTTP 206 via Caddy bewiesen (CI-Lauf #25970466659, Commit 14feefd6). Offen: reproduzierbare Bereitstellung eines echten PMTiles-Artefakts im CI fuer den Scope pmtiles-content (Magic-Byte-Check der ersten 7 Bytes)."
+    "Deploy_Artefakt": "PROVEN (range-delivery): blockierender Job basemap-range-delivery-proof hat HTTP 206 via Caddy bewiesen (CI-Lauf #25970466659, Commit 14feefd6). PMTiles-Content-Proof ist als eigener blockierender Scope in GitHub Actions implementiert (basemap-pmtiles-content-proof mit echtem Artefakt + Magic-Byte/SHA256-Check). Offen: visuelle Runtime-Abnahme in GitHub Actions und tiefe PMTiles-Strukturvalidierung."
   }
 }

--- a/docs/reports/map-status-matrix.json
+++ b/docs/reports/map-status-matrix.json
@@ -107,7 +107,7 @@
     },
     "runtime_integration": {
       "soll": "Echter HTTP-206-Nachweis der Caddy PMTiles Range-Auslieferung gegen reales Artefakt",
-      "ist": "Der CI-Workflow betreibt drei Jobs: 'basemap-runtime-proof' meldet im skip-Modus weiterhin NOT_PROVEN ohne Caddy; 'basemap-range-delivery-proof' startet einen realen caddy:2.7-Container gegen ein deterministisches .pmtiles-Testartefakt, fuehrt einen Range-GET (bytes=0-511) aus und schlaegt bei abweichendem Status hart fehl; 'basemap-pmtiles-content-proof' erzeugt ein echtes PMTiles-Artefakt ueber scripts/basemap/build-hamburg-pmtiles.sh (Planetiler gepinnt, OSM-Snapshot mit SHA256 verifiziert), startet Caddy und prueft Scope pmtiles-content inklusive Endpoint, HTTP 206, 7-Byte-Magic 'PMTiles' und optionaler SHA256. PROVEN (scope=range-delivery): CI-Lauf #25970466659, Commit 14feefd6, Guard-Output 'PROVEN: Caddy PMTiles Range delivery verified (scope=range-delivery)', Response-Header 'HTTP/1.1 206 Partial Content'.",
+      "ist": "Der CI-Workflow betreibt drei Jobs: 'basemap-runtime-proof' meldet im skip-Modus weiterhin NOT_PROVEN ohne Caddy; 'basemap-range-delivery-proof' startet einen realen caddy:2.7-Container gegen ein deterministisches .pmtiles-Testartefakt, fuehrt einen Range-GET (bytes=0-511) aus und schlaegt bei abweichendem Status hart fehl; 'basemap-pmtiles-content-proof' erzeugt ein echtes PMTiles-Artefakt ueber scripts/basemap/build-hamburg-pmtiles.sh (Planetiler gepinnt, OSM-Snapshot mit SHA256 verifiziert), startet Caddy und prueft Scope pmtiles-content inklusive Endpoint, HTTP 206, 7-Byte-Magic 'PMTiles' und optionaler SHA256. PROVEN (scope=range-delivery): CI-Lauf #25970466659, Commit 14feefd6, Guard-Output 'PROVEN: Caddy PMTiles Range delivery verified (scope=range-delivery)', Response-Header 'HTTP/1.1 206 Partial Content'. PROVEN (scope=pmtiles-content): CI-Lauf #26445893660, Commit ae9e2362, Job basemap-pmtiles-content-proof erfolgreich.",
       "status": "Teil",
       "documentation_evidence": [
         "docs/blueprints/kartenklarheit-roadmap.md",
@@ -131,12 +131,12 @@
       ],
       "proven": [
         "HTTP-206-Range-Delivery via Caddy gegen .pmtiles-Endpoint unter /local-basemap/* (Scope range-delivery) — PROVEN: CI-Lauf https://github.com/heimgewebe/weltgewebe/actions/runs/25970466659, Commit 14feefd6, Guard-Output 'PROVEN: Caddy PMTiles Range delivery verified (scope=range-delivery)', Response HTTP/1.1 206 Partial Content",
-        "CI-Pfad fuer PMTiles-Content-Proof ist als eigener blockierender Scope umgesetzt: basemap-pmtiles-content-proof baut ein echtes PMTiles-Artefakt und prueft per Guard Endpoint + HTTP 206 + Magic-Byte + optionale SHA256 (scope=pmtiles-content)"
+        "PMTiles-Content-Proof via GitHub Actions ist PROVEN: CI-Lauf https://github.com/heimgewebe/weltgewebe/actions/runs/26445893660, Job https://github.com/heimgewebe/weltgewebe/actions/runs/26445893660/job/77852013272, Commit ae9e2362, Guard-Output 'PROVEN: Caddy PMTiles content verified (scope=pmtiles-content)', Artefaktname basemap-hamburg-v0.1.0.pmtiles, Evidence-Artefakt-Digest sha256:b618ff7c7b84db7c6d8b42a8f80deca538c5bd1c1b18fdade09622488215c8d4"
       ]
     }
   },
   "open_architectural_decisions": {
     "Basemap_Strategie": "Offen: remote-style als Produktionsdefault bewusst beibehalten oder local-sovereign produktiv erzwingen.",
-    "Deploy_Artefakt": "PROVEN (range-delivery): blockierender Job basemap-range-delivery-proof hat HTTP 206 via Caddy bewiesen (CI-Lauf #25970466659, Commit 14feefd6). PMTiles-Content-Proof ist als eigener blockierender Scope in GitHub Actions implementiert (basemap-pmtiles-content-proof mit echtem Artefakt + Magic-Byte/SHA256-Check). Offen: visuelle Runtime-Abnahme in GitHub Actions und tiefe PMTiles-Strukturvalidierung."
+    "Deploy_Artefakt": "PROVEN (range-delivery): blockierender Job basemap-range-delivery-proof hat HTTP 206 via Caddy bewiesen (CI-Lauf #25970466659, Commit 14feefd6). PROVEN (pmtiles-content): basemap-pmtiles-content-proof ist erfolgreich gelaufen (CI-Lauf #26445893660, Commit ae9e2362). Offen: visuelle Runtime-Abnahme in GitHub Actions und tiefe PMTiles-Strukturvalidierung."
   }
 }

--- a/docs/reports/map-status-matrix.md
+++ b/docs/reports/map-status-matrix.md
@@ -78,7 +78,10 @@ HTTP-206-Range, 7-Byte-Magic `PMTiles` und optionale SHA256 gegen ein echtes
 in CI erzeugtes Artefakt. CI-Nachweis: [CI-Lauf 26445893660](https://github.com/heimgewebe/weltgewebe/actions/runs/26445893660)
 (Commit ae9e2362), Job [basemap-pmtiles-content-proof](https://github.com/heimgewebe/weltgewebe/actions/runs/26445893660/job/77852013272),
 Guard-Zeile `PROVEN: Caddy PMTiles content verified (scope=pmtiles-content)`,
-Artefaktname `basemap-hamburg-v0.1.0.pmtiles`, Evidence-Artefakt-Digest
+PMTiles-Artefakt: `basemap-hamburg-v0.1.0.pmtiles`, sha256:
+`f0734f0137c69b345ea81ed865519402d96f226fe15bc6c976134d9ed1f28a8e`
+(aus `build/basemap/basemap-hamburg-v0.1.0.meta.json`, Feld `sha256`),
+Evidence-Upload-Digest:
 `sha256:b618ff7c7b84db7c6d8b42a8f80deca538c5bd1c1b18fdade09622488215c8d4`.
 Offen bleiben die Produktionsentscheidung fuer den
 Basemap-Modus und die visuelle Kartenabnahme in GitHub Actions.

--- a/docs/reports/map-status-matrix.md
+++ b/docs/reports/map-status-matrix.md
@@ -56,12 +56,10 @@ Repo-Stand tatsaechlich vorhanden sind.
 ## 6. Runtime-Integration
 
 - **Soll**: Echter HTTP-206-Nachweis, dass Caddy ein reales PMTiles-Artefakt per Range-Request korrekt ausliefert.
-- **Ist**: `basemap-client-integration.spec.ts` und `basemap-sovereignty-testbuild.spec.ts` belegen den lokalen clientseitigen Basemap-Pfad im Testkontext. Das Guard-Script `scripts/guard/basemap-runtime-proof.sh` prueft den echten Live-Pfad gegen Caddy plus `.pmtiles`-Datei und unterscheidet explizit zwischen PROVEN und NOT_PROVEN. Der Guard kennt zwei Scopes: `range-delivery` (HTTP-206-Beweis) und `pmtiles-content` (zusaetzliche Magic-Byte-Validierung). Der CI-Workflow betreibt zwei Jobs: `basemap-runtime-proof` (skip-Modus, Diagnose) und `basemap-range-delivery-proof` (require-Modus + Scope `range-delivery`) — letzterer startet einen realen `caddy:2.7`-Container gegen ein deterministisches `.pmtiles`-Testartefakt und schlaegt bei abweichendem HTTP-Status hart fehl.
-- **Status**: Teil (HTTP-206-Range-Delivery: PROVEN — CI-Lauf #25970466659, Commit 14feefd6, Guard-Output `PROVEN: Caddy PMTiles Range delivery verified (scope=range-delivery)`, Response `HTTP/1.1 206 Partial Content`; PMTiles-Magic-Byte-Check offen)
+- **Ist**: `basemap-client-integration.spec.ts` und `basemap-sovereignty-testbuild.spec.ts` belegen den lokalen clientseitigen Basemap-Pfad im Testkontext. Das Guard-Script `scripts/guard/basemap-runtime-proof.sh` prueft den echten Live-Pfad gegen Caddy plus `.pmtiles`-Datei und unterscheidet explizit zwischen PROVEN und NOT_PROVEN. Der Guard kennt zwei Scopes: `range-delivery` (HTTP-206-Beweis) und `pmtiles-content` (Endpoint + HTTP-206-Range + 7-Byte-Magic `PMTiles` + optionale SHA256-Validierung). Der CI-Workflow betreibt drei Jobs: `basemap-runtime-proof` (skip-Modus, Diagnose), `basemap-range-delivery-proof` (require-Modus + Scope `range-delivery`) und `basemap-pmtiles-content-proof` (require-Modus + Scope `pmtiles-content`). Der Content-Job erzeugt ein echtes PMTiles-Artefakt ueber `scripts/basemap/build-hamburg-pmtiles.sh` (Planetiler-Pinning + verifizierter OSM-Snapshot), startet Caddy und laesst den Guard hart fehlschlagen, sobald Endpoint/206/Magic/SHA nicht stimmen.
+- **Status**: Teil (HTTP-206-Range-Delivery: PROVEN — CI-Lauf #25970466659, Commit 14feefd6, Guard-Output `PROVEN: Caddy PMTiles Range delivery verified (scope=range-delivery)`, Response `HTTP/1.1 206 Partial Content`; PMTiles-Content-Proof in GitHub Actions als eigener blockierender Job umgesetzt, visuelle Abnahme weiterhin getrennt)
 - **Nachweis**: `apps/web/tests/basemap-client-integration.spec.ts`, `apps/web/tests/basemap-sovereignty-testbuild.spec.ts`, `scripts/guard/basemap-runtime-proof.sh`, `.github/workflows/basemap-runtime-proof.yml`, `infra/caddy/Caddyfile.proof`
-- **Fehlend**: PMTiles-Magic-Byte-Check (7-Byte-Prefix) im CI; `BASEMAP_PROOF_SCOPE=pmtiles-content`
-  ist vorbereitet, der Job benoetigt aber ein echtes Artefakt. Tile-Directory- und
-  strukturelle PMTiles-Validierung bleiben Future Work.
+- **Fehlend**: Tile-Directory- und strukturelle PMTiles-Validierung bleiben Future Work.
   **Visueller Beweis differenzieren**: Lokale Ausführung (Heimserver, `basemap-real-hamburg-visual.proof.ts`) PROVEN
   (Canvas 1280×720, style_loaded true, direct_range_status 206, zero remote_violations).
   CI-Ausführung des visuellen Proofs: NOT_PROVEN (noch nicht in GitHub Actions). Map-Interaktion und clientseite Fehlerbehandlung sind belegt.
@@ -73,5 +71,9 @@ Die Karte besitzt einen expliziten Loader-Contract, ein Szenenmodell und belegte
 Der blockierende CI-Job `basemap-range-delivery-proof` fuer HTTP-206-Range-Delivery
 ist PROVEN: [CI-Lauf 25970466659](https://github.com/heimgewebe/weltgewebe/actions/runs/25970466659)
 (Commit 14feefd6), Guard-Output `PROVEN: Caddy PMTiles Range delivery verified
-(scope=range-delivery)`, Response-Header `HTTP/1.1 206 Partial Content`. Offen bleiben die Produktionsentscheidung fuer den
-Basemap-Modus, den PMTiles-Magic-Byte-Check im CI und die visuelle Kartenabnahme.
+(scope=range-delivery)`, Response-Header `HTTP/1.1 206 Partial Content`.
+Der Scope `pmtiles-content` ist im selben Workflow als eigener blockierender
+Proof-Job hinterlegt (`basemap-pmtiles-content-proof`) und prueft Endpoint,
+HTTP-206-Range, 7-Byte-Magic `PMTiles` und optionale SHA256 gegen ein echtes
+in CI erzeugtes Artefakt. Offen bleiben die Produktionsentscheidung fuer den
+Basemap-Modus und die visuelle Kartenabnahme in GitHub Actions.

--- a/docs/reports/map-status-matrix.md
+++ b/docs/reports/map-status-matrix.md
@@ -57,9 +57,9 @@ Repo-Stand tatsaechlich vorhanden sind.
 
 - **Soll**: Echter HTTP-206-Nachweis, dass Caddy ein reales PMTiles-Artefakt per Range-Request korrekt ausliefert.
 - **Ist**: `basemap-client-integration.spec.ts` und `basemap-sovereignty-testbuild.spec.ts` belegen den lokalen clientseitigen Basemap-Pfad im Testkontext. Das Guard-Script `scripts/guard/basemap-runtime-proof.sh` prueft den echten Live-Pfad gegen Caddy plus `.pmtiles`-Datei und unterscheidet explizit zwischen PROVEN und NOT_PROVEN. Der Guard kennt zwei Scopes: `range-delivery` (HTTP-206-Beweis) und `pmtiles-content` (Endpoint + HTTP-206-Range + 7-Byte-Magic `PMTiles` + optionale SHA256-Validierung). Der CI-Workflow betreibt drei Jobs: `basemap-runtime-proof` (skip-Modus, Diagnose), `basemap-range-delivery-proof` (require-Modus + Scope `range-delivery`) und `basemap-pmtiles-content-proof` (require-Modus + Scope `pmtiles-content`). Der Content-Job erzeugt ein echtes PMTiles-Artefakt ueber `scripts/basemap/build-hamburg-pmtiles.sh` (Planetiler-Pinning + verifizierter OSM-Snapshot), startet Caddy und laesst den Guard hart fehlschlagen, sobald Endpoint/206/Magic/SHA nicht stimmen.
-- **Status**: Teil (HTTP-206-Range-Delivery: PROVEN — CI-Lauf #25970466659, Commit 14feefd6, Guard-Output `PROVEN: Caddy PMTiles Range delivery verified (scope=range-delivery)`, Response `HTTP/1.1 206 Partial Content`; PMTiles-Content-Proof: PROVEN — CI-Lauf #26445893660, Commit ae9e2362, Job `basemap-pmtiles-content-proof` erfolgreich)
+- **Status**: Teil (HTTP-206-Range-Delivery: PROVEN — CI-Lauf #25970466659, Commit 14feefd6, Guard-Output `PROVEN: Caddy PMTiles Range delivery verified (scope=range-delivery)`, Response `HTTP/1.1 206 Partial Content`; pmtiles-content HTTP-served Magic proof implemented, pending CI proof)
 - **Nachweis**: `apps/web/tests/basemap-client-integration.spec.ts`, `apps/web/tests/basemap-sovereignty-testbuild.spec.ts`, `scripts/guard/basemap-runtime-proof.sh`, `.github/workflows/basemap-runtime-proof.yml`, `infra/caddy/Caddyfile.proof`
-- **Fehlend**: Tile-Directory- und strukturelle PMTiles-Validierung bleiben Future Work.
+- **Fehlend**: Tile-Directory- und strukturelle PMTiles-Validierung bleiben Future Work. Erfolgreicher GitHub-Actions-Lauf nach HTTP-served-Magic-Fix.
   **Visueller Beweis differenzieren**: Lokale Ausführung (Heimserver, `basemap-real-hamburg-visual.proof.ts`) PROVEN
   (Canvas 1280×720, style_loaded true, direct_range_status 206, zero remote_violations).
   CI-Ausführung des visuellen Proofs: NOT_PROVEN (noch nicht in GitHub Actions). Map-Interaktion und clientseite Fehlerbehandlung sind belegt.
@@ -75,13 +75,9 @@ ist PROVEN: [CI-Lauf 25970466659](https://github.com/heimgewebe/weltgewebe/actio
 Der Scope `pmtiles-content` ist im selben Workflow als eigener blockierender
 Proof-Job hinterlegt (`basemap-pmtiles-content-proof`) und prueft Endpoint,
 HTTP-206-Range, 7-Byte-Magic `PMTiles` und optionale SHA256 gegen ein echtes
-in CI erzeugtes Artefakt. CI-Nachweis: [CI-Lauf 26445893660](https://github.com/heimgewebe/weltgewebe/actions/runs/26445893660)
-(Commit ae9e2362), Job [basemap-pmtiles-content-proof](https://github.com/heimgewebe/weltgewebe/actions/runs/26445893660/job/77852013272),
-Guard-Zeile `PROVEN: Caddy PMTiles content verified (scope=pmtiles-content)`,
-PMTiles-Artefakt: `basemap-hamburg-v0.1.0.pmtiles`, sha256:
-`f0734f0137c69b345ea81ed865519402d96f226fe15bc6c976134d9ed1f28a8e`
-(aus `build/basemap/basemap-hamburg-v0.1.0.meta.json`, Feld `sha256`),
-Evidence-Upload-Digest:
-`sha256:b618ff7c7b84db7c6d8b42a8f80deca538c5bd1c1b18fdade09622488215c8d4`.
+in CI erzeugtes Artefakt. Der Guard ist fachlich erweitert um
+`PROVEN: HTTP-served PMTiles Magic verified`; die Statusmatrix wartet aber noch
+auf einen neuen GitHub-Actions-Lauf nach diesem Fix, damit die stärkere Semantik
+gegen den richtigen Run belegt ist.
 Offen bleiben die Produktionsentscheidung fuer den
 Basemap-Modus und die visuelle Kartenabnahme in GitHub Actions.

--- a/docs/reports/map-status-matrix.md
+++ b/docs/reports/map-status-matrix.md
@@ -57,7 +57,7 @@ Repo-Stand tatsaechlich vorhanden sind.
 
 - **Soll**: Echter HTTP-206-Nachweis, dass Caddy ein reales PMTiles-Artefakt per Range-Request korrekt ausliefert.
 - **Ist**: `basemap-client-integration.spec.ts` und `basemap-sovereignty-testbuild.spec.ts` belegen den lokalen clientseitigen Basemap-Pfad im Testkontext. Das Guard-Script `scripts/guard/basemap-runtime-proof.sh` prueft den echten Live-Pfad gegen Caddy plus `.pmtiles`-Datei und unterscheidet explizit zwischen PROVEN und NOT_PROVEN. Der Guard kennt zwei Scopes: `range-delivery` (HTTP-206-Beweis) und `pmtiles-content` (Endpoint + HTTP-206-Range + 7-Byte-Magic `PMTiles` + optionale SHA256-Validierung). Der CI-Workflow betreibt drei Jobs: `basemap-runtime-proof` (skip-Modus, Diagnose), `basemap-range-delivery-proof` (require-Modus + Scope `range-delivery`) und `basemap-pmtiles-content-proof` (require-Modus + Scope `pmtiles-content`). Der Content-Job erzeugt ein echtes PMTiles-Artefakt ueber `scripts/basemap/build-hamburg-pmtiles.sh` (Planetiler-Pinning + verifizierter OSM-Snapshot), startet Caddy und laesst den Guard hart fehlschlagen, sobald Endpoint/206/Magic/SHA nicht stimmen.
-- **Status**: Teil (HTTP-206-Range-Delivery: PROVEN — CI-Lauf #25970466659, Commit 14feefd6, Guard-Output `PROVEN: Caddy PMTiles Range delivery verified (scope=range-delivery)`, Response `HTTP/1.1 206 Partial Content`; PMTiles-Content-Proof in GitHub Actions als eigener blockierender Job umgesetzt, visuelle Abnahme weiterhin getrennt)
+- **Status**: Teil (HTTP-206-Range-Delivery: PROVEN — CI-Lauf #25970466659, Commit 14feefd6, Guard-Output `PROVEN: Caddy PMTiles Range delivery verified (scope=range-delivery)`, Response `HTTP/1.1 206 Partial Content`; PMTiles-Content-Proof: PROVEN — CI-Lauf #26445893660, Commit ae9e2362, Job `basemap-pmtiles-content-proof` erfolgreich)
 - **Nachweis**: `apps/web/tests/basemap-client-integration.spec.ts`, `apps/web/tests/basemap-sovereignty-testbuild.spec.ts`, `scripts/guard/basemap-runtime-proof.sh`, `.github/workflows/basemap-runtime-proof.yml`, `infra/caddy/Caddyfile.proof`
 - **Fehlend**: Tile-Directory- und strukturelle PMTiles-Validierung bleiben Future Work.
   **Visueller Beweis differenzieren**: Lokale Ausführung (Heimserver, `basemap-real-hamburg-visual.proof.ts`) PROVEN
@@ -75,5 +75,10 @@ ist PROVEN: [CI-Lauf 25970466659](https://github.com/heimgewebe/weltgewebe/actio
 Der Scope `pmtiles-content` ist im selben Workflow als eigener blockierender
 Proof-Job hinterlegt (`basemap-pmtiles-content-proof`) und prueft Endpoint,
 HTTP-206-Range, 7-Byte-Magic `PMTiles` und optionale SHA256 gegen ein echtes
-in CI erzeugtes Artefakt. Offen bleiben die Produktionsentscheidung fuer den
+in CI erzeugtes Artefakt. CI-Nachweis: [CI-Lauf 26445893660](https://github.com/heimgewebe/weltgewebe/actions/runs/26445893660)
+(Commit ae9e2362), Job [basemap-pmtiles-content-proof](https://github.com/heimgewebe/weltgewebe/actions/runs/26445893660/job/77852013272),
+Guard-Zeile `PROVEN: Caddy PMTiles content verified (scope=pmtiles-content)`,
+Artefaktname `basemap-hamburg-v0.1.0.pmtiles`, Evidence-Artefakt-Digest
+`sha256:b618ff7c7b84db7c6d8b42a8f80deca538c5bd1c1b18fdade09622488215c8d4`.
+Offen bleiben die Produktionsentscheidung fuer den
 Basemap-Modus und die visuelle Kartenabnahme in GitHub Actions.

--- a/scripts/guard/basemap-runtime-proof.sh
+++ b/scripts/guard/basemap-runtime-proof.sh
@@ -58,6 +58,76 @@ REPO_ROOT="${REPO_ROOT:-$(cd -- "${SCRIPT_DIR}/../.." >/dev/null 2>&1 && pwd)}"
 BASEMAP_PROOF_SCOPE="${BASEMAP_PROOF_SCOPE:-range-delivery}"
 BASEMAP_PROOF_MODE="${BASEMAP_PROOF_MODE:-require}"
 
+require_http_range_proof() {
+  local full_url="$1"
+  local header_tmp=""
+  local http_status=""
+  local has_accept_ranges=0
+  local has_content_range=0
+
+  header_tmp="$(mktemp)"
+
+  http_status="$({
+    curl --silent \
+         --max-time 10 \
+         --header 'Range: bytes=0-511' \
+         --output /dev/null \
+         --dump-header "${header_tmp}" \
+         --write-out '%{http_code}' \
+         "${full_url}" 2>/dev/null
+  })" || {
+    rm -f "${header_tmp}"
+    printf 'ERROR: curl request to %s failed\n' "${full_url}" >&2
+    return 1
+  }
+
+  if [[ "${http_status}" == "200" ]]; then
+    rm -f "${header_tmp}"
+    printf 'ERROR: Caddy returned HTTP 200 for a Range request — Range delivery is inactive\n' >&2
+    printf '  URL:    %s\n' "${full_url}" >&2
+    printf '  Status: 200 OK (expected 206 Partial Content)\n' >&2
+    printf '  A 200 response to a Range request means the server ignores Range headers.\n' >&2
+    return 1
+  fi
+
+  if [[ "${http_status}" != "206" ]]; then
+    rm -f "${header_tmp}"
+    printf 'ERROR: Unexpected HTTP status %s for Range request\n' "${http_status}" >&2
+    printf '  URL:      %s\n' "${full_url}" >&2
+    printf '  Expected: 206 Partial Content\n' >&2
+    return 1
+  fi
+
+  if grep -qi '^accept-ranges:' "${header_tmp}"; then
+    has_accept_ranges=1
+  fi
+  if grep -qi '^content-range:' "${header_tmp}"; then
+    has_content_range=1
+  fi
+
+  if [[ "${has_accept_ranges}" -eq 0 && "${has_content_range}" -eq 0 ]]; then
+    rm -f "${header_tmp}"
+    printf 'ERROR: Neither Accept-Ranges nor Content-Range header present in response\n' >&2
+    printf '  URL: %s\n' "${full_url}" >&2
+    return 1
+  fi
+
+  printf 'HTTP status: %s (206 Partial Content confirmed)\n' "${http_status}"
+
+  if [[ "${has_accept_ranges}" -eq 1 ]]; then
+    local accept_ranges_val=""
+    accept_ranges_val="$(grep -i '^accept-ranges:' "${header_tmp}" | head -1 | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r')"
+    printf 'Accept-Ranges: %s (confirmed)\n' "${accept_ranges_val}"
+  fi
+  if [[ "${has_content_range}" -eq 1 ]]; then
+    local content_range_val=""
+    content_range_val="$(grep -i '^content-range:' "${header_tmp}" | head -1 | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r')"
+    printf 'Content-Range: %s (confirmed)\n' "${content_range_val}"
+  fi
+
+  rm -f "${header_tmp}"
+}
+
 # Validate BASEMAP_PROOF_SCOPE
 if [[ "${BASEMAP_PROOF_SCOPE}" != "range-delivery" && "${BASEMAP_PROOF_SCOPE}" != "pmtiles-content" ]]; then
   printf 'ERROR: BASEMAP_PROOF_SCOPE must be "range-delivery" or "pmtiles-content", got: %s\n' "${BASEMAP_PROOF_SCOPE}" >&2
@@ -81,7 +151,9 @@ if [[ "${BASEMAP_PROOF_SCOPE}" == "pmtiles-content" ]]; then
   printf 'Proof scope: pmtiles-content (Magic/Header/Hash — not deep structure)\n'
 
   BASEMAP_ARTIFACT_DIR="${BASEMAP_ARTIFACT_DIR:-${REPO_ROOT}/build/basemap}"
+  BASEMAP_CADDY_URL="${BASEMAP_CADDY_URL:-http://localhost:8081}"
   BASEMAP_PMTILES_PATH="${BASEMAP_PMTILES_PATH:-}"
+  BASEMAP_ENDPOINT_PATH="${BASEMAP_ENDPOINT_PATH:-}"
   BASEMAP_EXPECTED_SHA256="${BASEMAP_EXPECTED_SHA256:-}"
 
   # Resolve file path
@@ -146,11 +218,26 @@ if [[ "${BASEMAP_PROOF_SCOPE}" == "pmtiles-content" ]]; then
     SHA256_STATUS="PROVEN"
   fi
 
+  if [[ -z "${BASEMAP_ENDPOINT_PATH}" ]]; then
+    BASEMAP_ENDPOINT_PATH="/local-basemap/$(basename "${PMTILES_FILE}")"
+  fi
+
+  if [[ "${BASEMAP_ENDPOINT_PATH}" != /* ]]; then
+    printf 'ERROR: BASEMAP_ENDPOINT_PATH must start with "/", got: %s\n' "${BASEMAP_ENDPOINT_PATH}" >&2
+    exit 1
+  fi
+
+  FULL_URL="${BASEMAP_CADDY_URL}${BASEMAP_ENDPOINT_PATH}"
+  printf 'Issuing Range GET request: %s (Range: bytes=0-511)\n' "${FULL_URL}"
+  require_http_range_proof "${FULL_URL}"
+
   printf '\n'
-  printf 'PROVEN: PMTiles Magic/Header verified\n'
+  printf 'PROVEN: Caddy PMTiles content verified (scope=pmtiles-content)\n'
   printf '  File:         %s\n' "${PMTILES_FILE}"
   printf '  Size:         %s bytes\n' "${FILE_SIZE}"
   printf '  Magic header: "%s" at offset 0\n' "${MAGIC_ACTUAL}"
+  printf '  Endpoint:     %s\n' "${FULL_URL}"
+  printf '  HTTP status:  206 Partial Content\n'
   printf '  SHA256 check: %s\n' "${SHA256_STATUS}"
   printf '\n'
   printf 'NOT_PROVEN: Deep PMTiles structure validation (tile index, directory, metadata integrity)\n'
@@ -172,18 +259,6 @@ if [[ -n "${BASEMAP_ENDPOINT_PATH:-}" && "${BASEMAP_ENDPOINT_PATH}" != /* ]]; th
   printf 'ERROR: BASEMAP_ENDPOINT_PATH must start with "/", got: %s\n' "${BASEMAP_ENDPOINT_PATH}" >&2
   exit 1
 fi
-
-# ---------------------------------------------------------------------------
-# Cleanup
-# ---------------------------------------------------------------------------
-
-HEADER_TMP=""
-cleanup() {
-  if [[ -n "${HEADER_TMP}" && -f "${HEADER_TMP}" ]]; then
-    rm -f "${HEADER_TMP}"
-  fi
-}
-trap cleanup EXIT
 
 # ---------------------------------------------------------------------------
 # Step 1: Locate PMTiles artefact
@@ -230,79 +305,13 @@ FULL_URL="${BASEMAP_CADDY_URL}${ENDPOINT_PATH}"
 # ---------------------------------------------------------------------------
 
 printf 'Issuing Range GET request: %s (Range: bytes=0-511)\n' "${FULL_URL}"
-
-HEADER_TMP="$(mktemp)"
-
-HTTP_STATUS="$(
-  curl --silent \
-       --max-time 10 \
-       --header 'Range: bytes=0-511' \
-       --output /dev/null \
-       --dump-header "${HEADER_TMP}" \
-       --write-out '%{http_code}' \
-       "${FULL_URL}" 2>/dev/null
-)" || {
-  printf 'ERROR: curl request to %s failed\n' "${FULL_URL}" >&2
-  exit 1
-}
-
-# ---------------------------------------------------------------------------
-# Step 3: Validate HTTP 206 — reject silent 200 OK on Range requests
-# ---------------------------------------------------------------------------
-
-if [[ "${HTTP_STATUS}" == "200" ]]; then
-  printf 'ERROR: Caddy returned HTTP 200 for a Range request — Range delivery is inactive\n' >&2
-  printf '  URL:    %s\n' "${FULL_URL}" >&2
-  printf '  Status: 200 OK (expected 206 Partial Content)\n' >&2
-  printf '  A 200 response to a Range request means the server ignores Range headers.\n' >&2
-  printf '  PMTiles clients rely on byte-range streaming; a 200 here breaks tile loading.\n' >&2
-  exit 1
-fi
-
-if [[ "${HTTP_STATUS}" != "206" ]]; then
-  printf 'ERROR: Unexpected HTTP status %s for Range request\n' "${HTTP_STATUS}" >&2
-  printf '  URL:      %s\n' "${FULL_URL}" >&2
-  printf '  Expected: 206 Partial Content\n' >&2
-  exit 1
-fi
-
-printf 'HTTP status: %s (206 Partial Content confirmed)\n' "${HTTP_STATUS}"
-
-# ---------------------------------------------------------------------------
-# Step 4: Verify Accept-Ranges or Content-Range header is present
-# ---------------------------------------------------------------------------
-
-HAS_ACCEPT_RANGES=0
-HAS_CONTENT_RANGE=0
-
-if grep -qi '^accept-ranges:' "${HEADER_TMP}"; then
-  HAS_ACCEPT_RANGES=1
-fi
-if grep -qi '^content-range:' "${HEADER_TMP}"; then
-  HAS_CONTENT_RANGE=1
-fi
-
-if [[ "${HAS_ACCEPT_RANGES}" -eq 0 && "${HAS_CONTENT_RANGE}" -eq 0 ]]; then
-  printf 'ERROR: Neither Accept-Ranges nor Content-Range header present in response\n' >&2
-  printf '  URL: %s\n' "${FULL_URL}" >&2
-  printf '  Without these headers PMTiles clients cannot reliably stream byte ranges.\n' >&2
-  exit 1
-fi
-
-if [[ "${HAS_ACCEPT_RANGES}" -eq 1 ]]; then
-  ACCEPT_RANGES_VAL="$(grep -i '^accept-ranges:' "${HEADER_TMP}" | head -1 | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r')"
-  printf 'Accept-Ranges: %s (confirmed)\n' "${ACCEPT_RANGES_VAL}"
-fi
-if [[ "${HAS_CONTENT_RANGE}" -eq 1 ]]; then
-  CONTENT_RANGE_VAL="$(grep -i '^content-range:' "${HEADER_TMP}" | head -1 | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r')"
-  printf 'Content-Range: %s (confirmed)\n' "${CONTENT_RANGE_VAL}"
-fi
+require_http_range_proof "${FULL_URL}"
 
 # ---------------------------------------------------------------------------
 # Proof confirmed
 # ---------------------------------------------------------------------------
 
-printf '\nPROVEN: Caddy PMTiles Range delivery verified\n'
+printf '\nPROVEN: Caddy PMTiles Range delivery verified (scope=range-delivery)\n'
 printf '  Endpoint:      %s\n' "${FULL_URL}"
 printf '  HTTP status:   206 Partial Content\n'
 printf '  Range headers: present\n'

--- a/scripts/guard/basemap-runtime-proof.sh
+++ b/scripts/guard/basemap-runtime-proof.sh
@@ -150,7 +150,7 @@ fi
 # ---------------------------------------------------------------------------
 
 if [[ "${BASEMAP_PROOF_SCOPE}" == "pmtiles-content" ]]; then
-  printf 'Proof scope: pmtiles-content (Magic/Header/Hash — not deep structure)\n'
+  printf 'Proof scope: pmtiles-content (local Magic/SHA + Caddy HTTP 206 + HTTP-served Magic; not deep structure)\n'
 
   BASEMAP_ARTIFACT_DIR="${BASEMAP_ARTIFACT_DIR:-${REPO_ROOT}/build/basemap}"
   BASEMAP_CADDY_URL="${BASEMAP_CADDY_URL:-http://localhost:8081}"

--- a/scripts/guard/basemap-runtime-proof.sh
+++ b/scripts/guard/basemap-runtime-proof.sh
@@ -11,8 +11,9 @@ set -euo pipefail
 #     headers present.  Does NOT validate the artefact content itself.
 #
 #   pmtiles-content
-#     Proves that the local artefact exists, is non-empty, and carries the exact
-#     PMTiles magic header at byte offset 0 ("PMTiles", 7 bytes).
+#     Proves that the local artefact exists, is non-empty, carries the exact
+#     PMTiles magic header at byte offset 0 ("PMTiles", 7 bytes), and that
+#     Caddy delivers the same magic bytes 0-6 via HTTP Range request.
 #     Optionally verifies SHA256 when BASEMAP_EXPECTED_SHA256 is set.
 #     Explicitly NOT a deep PMTiles structure validation.
 #
@@ -143,7 +144,8 @@ fi
 # ---------------------------------------------------------------------------
 # Scope: pmtiles-content
 # Proves: local file exists, non-empty, PMTiles magic header at offset 0,
-#         optional SHA256 checksum.
+#         optional SHA256 checksum, and Caddy delivers the same magic bytes
+#         via HTTP Range request (bytes 0-6).
 # Explicitly NOT: deep PMTiles structure validation.
 # ---------------------------------------------------------------------------
 
@@ -228,17 +230,60 @@ if [[ "${BASEMAP_PROOF_SCOPE}" == "pmtiles-content" ]]; then
   fi
 
   FULL_URL="${BASEMAP_CADDY_URL}${BASEMAP_ENDPOINT_PATH}"
-  printf 'Issuing Range GET request: %s (Range: bytes=0-511)\n' "${FULL_URL}"
+  printf 'Issuing HTTP Range requests to: %s\n' "${FULL_URL}"
+
+  # Step 1: Verify HTTP-served PMTiles magic bytes (0-6)
+  printf 'Step 1: Verifying HTTP magic bytes (Range: bytes=0-6)...\n'
+  http_magic_tmp="$(mktemp)"
+  http_magic_status="$({ \
+    curl --silent \
+         --max-time 10 \
+         --range 0-6 \
+         --output "${http_magic_tmp}" \
+         --write-out '%{http_code}' \
+         "${FULL_URL}" 2>/dev/null; \
+  })"
+  http_magic_exit=$?
+  if [[ ${http_magic_exit} -ne 0 ]]; then
+    rm -f "${http_magic_tmp}"
+    printf 'ERROR: curl request to fetch HTTP magic bytes failed (exit: %d)\n' ${http_magic_exit} >&2
+    printf '  URL: %s\n' "${FULL_URL}" >&2
+    exit 1
+  fi
+
+  if [[ "${http_magic_status}" != "206" ]]; then
+    rm -f "${http_magic_tmp}"
+    printf 'ERROR: Expected HTTP 206 for PMTiles magic range, got %s\n' "${http_magic_status}" >&2
+    printf '  URL:      %s\n' "${FULL_URL}" >&2
+    printf '  Expected: 206 Partial Content\n' >&2
+    exit 1
+  fi
+
+  http_magic="$(cat "${http_magic_tmp}" 2>/dev/null | tr -d '\0')"
+  rm -f "${http_magic_tmp}"
+
+  if [[ "${http_magic}" != "PMTiles" ]]; then
+    printf 'ERROR: HTTP-served PMTiles magic bytes mismatch\n' >&2
+    printf '  Expected: PMTiles\n' >&2
+    printf '  Got:      %s\n' "${http_magic}" >&2
+    exit 1
+  fi
+  printf 'HTTP magic bytes (0-6): "%s" confirmed\n' "${http_magic}"
+
+  # Step 2: Verify HTTP Range delivery (206 + headers for bytes 0-511)
+  printf 'Step 2: Verifying HTTP Range delivery (Range: bytes=0-511)...\n'
   require_http_range_proof "${FULL_URL}"
 
   printf '\n'
+  printf 'PROVEN: HTTP-served PMTiles Magic verified\n'
   printf 'PROVEN: Caddy PMTiles content verified (scope=pmtiles-content)\n'
-  printf '  File:         %s\n' "${PMTILES_FILE}"
-  printf '  Size:         %s bytes\n' "${FILE_SIZE}"
-  printf '  Magic header: "%s" at offset 0\n' "${MAGIC_ACTUAL}"
-  printf '  Endpoint:     %s\n' "${FULL_URL}"
-  printf '  HTTP status:  206 Partial Content\n'
-  printf '  SHA256 check: %s\n' "${SHA256_STATUS}"
+  printf '  Local file:     %s\n' "${PMTILES_FILE}"
+  printf '  File size:      %s bytes\n' "${FILE_SIZE}"
+  printf '  Local magic:    "%s" at offset 0\n' "${MAGIC_ACTUAL}"
+  printf '  HTTP endpoint:  %s\n' "${FULL_URL}"
+  printf '  HTTP magic:     "%s" (bytes 0-6)\n' "${http_magic}"
+  printf '  HTTP status:    206 Partial Content\n'
+  printf '  SHA256 check:   %s\n' "${SHA256_STATUS}"
   printf '\n'
   printf 'NOT_PROVEN: Deep PMTiles structure validation (tile index, directory, metadata integrity)\n'
   printf '  This scope validates magic/header/hash only — full structure proof not implemented.\n'


### PR DESCRIPTION
## These / Antithese / Synthese

**These:** Dieser PR bleibt eng im Basemap-Strang und schließt nur den Beweiszustand für `pmtiles-content`.

**Antithese:** Ein reiner Prefix-Stub (`PMTiles` in eine Dummy-Datei schreiben) wäre ein Scheinbeweis.

**Synthese:** Der PR ergänzt einen CI-fähigen `pmtiles-content`-Proof mit echtem PMTiles-Artefakt-Build, getrennt von `range-delivery`; visuelle Abnahme bleibt außerhalb dieses PR.

## Scope dieses PR

Bewiesen (nach erfolgreichem Actions-Lauf dieses PR):
- `range-delivery` (bestehender Scope, unverändert)
- `pmtiles-content` (neu als eigener blockierender Scope)

Nicht bewiesen (explizit außerhalb dieses PR):
- visuelle Render-Abnahme in GitHub Actions
- tiefe PMTiles-Strukturvalidierung (Tile-Directory etc.)

## Was geändert wurde

1. Guard erweitert in `scripts/guard/basemap-runtime-proof.sh`
- Scope `range-delivery` bleibt getrennt und unverändert im Zweck.
- Scope `pmtiles-content` prüft jetzt:
  - lokales `.pmtiles`-Artefakt vorhanden und nicht leer,
  - HTTP-Range-Request gegen `/local-basemap/*.pmtiles` via Caddy,
  - HTTP `206` plus Range-Header,
  - erste 7 Bytes exakt `PMTiles`,
  - optional SHA256-Match, wenn gesetzt.
- Eindeutige Scope-Ausgaben:
  - `PROVEN: Caddy PMTiles Range delivery verified (scope=range-delivery)`
  - `PROVEN: Caddy PMTiles content verified (scope=pmtiles-content)`

2. Workflow erweitert in `.github/workflows/basemap-runtime-proof.yml`
- Neuer blockierender Job `basemap-pmtiles-content-proof`.
- Erzeugt ein echtes PMTiles-Artefakt über `scripts/basemap/build-hamburg-pmtiles.sh` (Planetiler-Digest gepinnt, OSM-Snapshot + SHA256 verifiziert).
- Startet Caddy (`infra/caddy/Caddyfile.proof`) und führt den Guard mit `BASEMAP_PROOF_SCOPE=pmtiles-content` aus.
- Beweisartefakte werden hochgeladen (Guard-Output, Header, Magic-Bytes, Artefakt + Meta).

3. Statusdokumente präzisiert
- `docs/reports/map-status-matrix.md`
- `docs/reports/map-status-matrix.json`
- `range-delivery` bleibt PROVEN.
- `visual-rendering` bleibt offen/NOT_PROVEN.
- `pmtiles-content` als neuer separater CI-Proof-Pfad dokumentiert.

## Nachweis (lokal)

Ausgeführt:

bash -n scripts/guard/basemap-runtime-proof.sh

Output:

bash -n OK

## Warum das PMTiles-Artefakt kein Fake-Prefix ist

Der neue CI-Job verwendet keine synthetische Header-Datei, sondern erzeugt ein echtes PMTiles-Artefakt mit dem bestehenden Build-Skript `scripts/basemap/build-hamburg-pmtiles.sh` (Planetiler-Container mit gepinntem Digest, verifizierter OSM-Input inkl. SHA256). Zusätzlich prüft der Guard im selben Scope Magic-Bytes + optional SHA256.

## Erwartete PR-Checks

Bitte im erfolgreichen Actions-Lauf prüfen:
- Guard-Output für `scope=pmtiles-content`
- relevanter Header-Ausschnitt mit HTTP `206`
- evidenzierte Magic-Bytes (`PMTiles`) im Upload-Artefakt
