### PR TITLE
docs(map): set pmtiles-content status back to PROVEN with fresh CI evidence

### DIFF
--- a/docs/reports/map-status-matrix.json
+++ b/docs/reports/map-status-matrix.json
@@ -107,15 +107,14 @@
     },
     "runtime_integration": {
       "soll": "Echter HTTP-206-Nachweis der Caddy PMTiles Range-Auslieferung gegen reales Artefakt",
-      "ist": "Der CI-Workflow betreibt drei Jobs: 'basemap-runtime-proof' meldet im skip-Modus weiterhin NOT_PROVEN ohne Caddy; 'basemap-range-delivery-proof' startet einen realen caddy:2.7-Container gegen ein deterministisches .pmtiles-Testartefakt, fuehrt einen Range-GET (bytes=0-511) aus und schlaegt bei abweichendem Status hart fehl; 'basemap-pmtiles-content-proof' erzeugt ein echtes PMTiles-Artefakt ueber scripts/basemap/build-hamburg-pmtiles.sh (Planetiler gepinnt, OSM-Snapshot mit SHA256 verifiziert), startet Caddy und prueft Scope pmtiles-content inklusive Endpoint, HTTP 206, 7-Byte-Magic 'PMTiles' und optionaler SHA256. PROVEN (scope=range-delivery): CI-Lauf #25970466659, Commit 14feefd6, Guard-Output 'PROVEN: Caddy PMTiles Range delivery verified (scope=range-delivery)', Response-Header 'HTTP/1.1 206 Partial Content'. pmtiles-content HTTP-served Magic proof implemented, pending CI proof.",
+      "ist": "Der CI-Workflow betreibt drei Jobs: 'basemap-runtime-proof' meldet im skip-Modus weiterhin NOT_PROVEN ohne Caddy; 'basemap-range-delivery-proof' startet einen realen caddy:2.7-Container gegen ein deterministisches .pmtiles-Testartefakt, fuehrt einen Range-GET (bytes=0-511) aus und schlaegt bei abweichendem Status hart fehl; 'basemap-pmtiles-content-proof' erzeugt ein echtes PMTiles-Artefakt ueber scripts/basemap/build-hamburg-pmtiles.sh (Planetiler gepinnt, OSM-Snapshot mit SHA256 verifiziert), startet Caddy und prueft Scope pmtiles-content inklusive Endpoint, HTTP 206, 7-Byte-Magic 'PMTiles' und optionaler SHA256. PROVEN (scope=range-delivery): CI-Lauf #25970466659, Commit 14feefd6, Guard-Output 'PROVEN: Caddy PMTiles Range delivery verified (scope=range-delivery)', Response-Header 'HTTP/1.1 206 Partial Content'. PROVEN (scope=pmtiles-content): CI-Lauf #26447341921, Job basemap-pmtiles-content-proof (#77857000606), Commit 3410c872964669fa27bfee958169ad9ce95594ae, Guard-Output 'PROVEN: HTTP-served PMTiles Magic verified' und 'PROVEN: Caddy PMTiles content verified (scope=pmtiles-content)', Artefakt basemap-hamburg-v0.1.0.pmtiles, SHA256 3eea9946f90a1cca425916c5b3272692ae8a1030bf22e700b67908cfafee8eab, Groesse 23948909 Bytes.",
       "status": "Teil",
       "documentation_evidence": [
         "docs/blueprints/kartenklarheit-roadmap.md",
         "docs/blueprints/kartenklarheit-phase6.md"
       ],
       "missing_evidence": [
-        "Erfolgreicher GitHub-Actions-Lauf nach HTTP-served-Magic-Fix",
-        "Visuelle Abnahme der gerenderten Karte",
+        "Visuelle Abnahme der gerenderten Karte in GitHub Actions",
         "Tile-Directory- und strukturelle PMTiles-Validierung"
       ],
       "risk": "mittel",
@@ -130,13 +129,42 @@
         "apps/web/tests/basemap-client-integration.spec.ts (clientseitiger Mock-Test, kein Live-Caddy-Beweis)",
         "scripts/guard/caddy-basemap-route-guard.sh (statischer Konfigurations-Check, kein Runtime-Beweis)"
       ],
+      "scope_status": {
+        "range-delivery": "proven",
+        "pmtiles-content": "proven"
+      },
+      "evidence": {
+        "workflow": "Basemap Runtime Proof",
+        "run_id": 26447341921,
+        "run_url": "https://github.com/heimgewebe/weltgewebe/actions/runs/26447341921",
+        "event": "pull_request",
+        "branch": "chore/api-dockerfile-cargo-build-jobs",
+        "head_sha": "3410c872964669fa27bfee958169ad9ce95594ae",
+        "job": "basemap-pmtiles-content-proof",
+        "job_id": 77857000606,
+        "job_url": "https://github.com/heimgewebe/weltgewebe/actions/runs/26447341921/job/77857000606",
+        "conclusion": "success",
+        "guard_output": [
+          "PROVEN: HTTP-served PMTiles Magic verified",
+          "PROVEN: Caddy PMTiles content verified (scope=pmtiles-content)"
+        ],
+        "artifact": {
+          "name": "basemap-hamburg-v0.1.0.pmtiles",
+          "sha256": "3eea9946f90a1cca425916c5b3272692ae8a1030bf22e700b67908cfafee8eab",
+          "size_bytes": 23948909,
+          "generator": "planetiler",
+          "planetiler_image_digest": "ghcr.io/onthegomap/planetiler@sha256:10e4d6850664bd2ad7a223623383c48281e7d87fb427360838b13342cac012bb",
+          "input_sha256": "e9beba6f27594a3abe571dd632e752fb43c8a136b2517fa162988fd641f8cdc9"
+        }
+      },
       "proven": [
-        "HTTP-206-Range-Delivery via Caddy gegen .pmtiles-Endpoint unter /local-basemap/* (Scope range-delivery) — PROVEN: CI-Lauf https://github.com/heimgewebe/weltgewebe/actions/runs/25970466659, Commit 14feefd6, Guard-Output 'PROVEN: Caddy PMTiles Range delivery verified (scope=range-delivery)', Response HTTP/1.1 206 Partial Content"
+        "HTTP-206-Range-Delivery via Caddy gegen .pmtiles-Endpoint unter /local-basemap/* (Scope range-delivery) — PROVEN: CI-Lauf https://github.com/heimgewebe/weltgewebe/actions/runs/25970466659, Commit 14feefd6, Guard-Output 'PROVEN: Caddy PMTiles Range delivery verified (scope=range-delivery)', Response HTTP/1.1 206 Partial Content",
+        "PMTiles-Content-Proof via Caddy gegen echtes CI-Artefakt (Scope pmtiles-content) — PROVEN: CI-Lauf https://github.com/heimgewebe/weltgewebe/actions/runs/26447341921, Job https://github.com/heimgewebe/weltgewebe/actions/runs/26447341921/job/77857000606, Commit 3410c872964669fa27bfee958169ad9ce95594ae, Guard-Output 'PROVEN: HTTP-served PMTiles Magic verified' und 'PROVEN: Caddy PMTiles content verified (scope=pmtiles-content)', Artefakt basemap-hamburg-v0.1.0.pmtiles, SHA256 3eea9946f90a1cca425916c5b3272692ae8a1030bf22e700b67908cfafee8eab, Groesse 23948909 Bytes"
       ]
     }
   },
   "open_architectural_decisions": {
     "Basemap_Strategie": "Offen: remote-style als Produktionsdefault bewusst beibehalten oder local-sovereign produktiv erzwingen.",
-    "Deploy_Artefakt": "PROVEN (range-delivery): blockierender Job basemap-range-delivery-proof hat HTTP 206 via Caddy bewiesen (CI-Lauf #25970466659, Commit 14feefd6). pmtiles-content HTTP-served Magic proof implemented, pending CI proof. Offen: visuelle Runtime-Abnahme in GitHub Actions und tiefe PMTiles-Strukturvalidierung."
+    "Deploy_Artefakt": "PROVEN (scope=range-delivery und scope=pmtiles-content): blockierende Jobs basemap-range-delivery-proof und basemap-pmtiles-content-proof haben HTTP 206 via Caddy sowie HTTP-served PMTiles-Magic gegen ein echtes CI-Artefakt belegt (Runs #25970466659 und #26447341921, Commit 3410c872964669fa27bfee958169ad9ce95594ae fuer pmtiles-content). Offen: visuelle Runtime-Abnahme in GitHub Actions und tiefe PMTiles-Strukturvalidierung."
   }
 }

--- a/docs/reports/map-status-matrix.json
+++ b/docs/reports/map-status-matrix.json
@@ -165,6 +165,6 @@
   },
   "open_architectural_decisions": {
     "Basemap_Strategie": "Offen: remote-style als Produktionsdefault bewusst beibehalten oder local-sovereign produktiv erzwingen.",
-    "Deploy_Artefakt": "PROVEN (scope=range-delivery und scope=pmtiles-content): blockierende Jobs basemap-range-delivery-proof und basemap-pmtiles-content-proof haben HTTP 206 via Caddy sowie HTTP-served PMTiles-Magic gegen ein echtes CI-Artefakt belegt (Runs #25970466659 und #26447341921, Commit 3410c872964669fa27bfee958169ad9ce95594ae fuer pmtiles-content). Offen: visuelle Runtime-Abnahme in GitHub Actions und tiefe PMTiles-Strukturvalidierung."
+    "Deploy_Artefakt": "PROVEN (scope=range-delivery und scope=pmtiles-content): blockierende Jobs basemap-range-delivery-proof und basemap-pmtiles-content-proof haben HTTP 206 via Caddy sowie HTTP-served PMTiles-Magic gegen ein echtes CI-Artefakt belegt (range-delivery: Run #25970466659, Commit 14feefd6; pmtiles-content: Run #26447341921, Commit 3410c872964669fa27bfee958169ad9ce95594ae). Offen: visuelle Runtime-Abnahme in GitHub Actions und tiefe PMTiles-Strukturvalidierung."
   }
 }

--- a/docs/reports/map-status-matrix.md
+++ b/docs/reports/map-status-matrix.md
@@ -57,13 +57,19 @@ Repo-Stand tatsaechlich vorhanden sind.
 
 - **Soll**: Echter HTTP-206-Nachweis, dass Caddy ein reales PMTiles-Artefakt per Range-Request korrekt ausliefert.
 - **Ist**: `basemap-client-integration.spec.ts` und `basemap-sovereignty-testbuild.spec.ts` belegen den lokalen clientseitigen Basemap-Pfad im Testkontext. Das Guard-Script `scripts/guard/basemap-runtime-proof.sh` prueft den echten Live-Pfad gegen Caddy plus `.pmtiles`-Datei und unterscheidet explizit zwischen PROVEN und NOT_PROVEN. Der Guard kennt zwei Scopes: `range-delivery` (HTTP-206-Beweis) und `pmtiles-content` (Endpoint + HTTP-206-Range + 7-Byte-Magic `PMTiles` + optionale SHA256-Validierung). Der CI-Workflow betreibt drei Jobs: `basemap-runtime-proof` (skip-Modus, Diagnose), `basemap-range-delivery-proof` (require-Modus + Scope `range-delivery`) und `basemap-pmtiles-content-proof` (require-Modus + Scope `pmtiles-content`). Der Content-Job erzeugt ein echtes PMTiles-Artefakt ueber `scripts/basemap/build-hamburg-pmtiles.sh` (Planetiler-Pinning + verifizierter OSM-Snapshot), startet Caddy und laesst den Guard hart fehlschlagen, sobald Endpoint/206/Magic/SHA nicht stimmen.
-- **Status**: Teil (HTTP-206-Range-Delivery: PROVEN — CI-Lauf #25970466659, Commit 14feefd6, Guard-Output `PROVEN: Caddy PMTiles Range delivery verified (scope=range-delivery)`, Response `HTTP/1.1 206 Partial Content`; pmtiles-content HTTP-served Magic proof implemented, pending CI proof)
+- **Status**: Teil (HTTP-206-Range-Delivery: PROVEN — CI-Lauf #25970466659, Commit 14feefd6, Guard-Output `PROVEN: Caddy PMTiles Range delivery verified (scope=range-delivery)`, Response `HTTP/1.1 206 Partial Content`; pmtiles-content: PROVEN (scope=pmtiles-content) — CI-Lauf #26447341921, Job `basemap-pmtiles-content-proof` (#77857000606), Commit 3410c872964669fa27bfee958169ad9ce95594ae, Guard-Output `PROVEN: HTTP-served PMTiles Magic verified` und `PROVEN: Caddy PMTiles content verified (scope=pmtiles-content)`, Artefakt `basemap-hamburg-v0.1.0.pmtiles`, SHA256 `3eea9946f90a1cca425916c5b3272692ae8a1030bf22e700b67908cfafee8eab`, Groesse `23948909` Bytes)
 - **Nachweis**: `apps/web/tests/basemap-client-integration.spec.ts`, `apps/web/tests/basemap-sovereignty-testbuild.spec.ts`, `scripts/guard/basemap-runtime-proof.sh`, `.github/workflows/basemap-runtime-proof.yml`, `infra/caddy/Caddyfile.proof`
-- **Fehlend**: Tile-Directory- und strukturelle PMTiles-Validierung bleiben Future Work. Erfolgreicher GitHub-Actions-Lauf nach HTTP-served-Magic-Fix.
+- **Fehlend**: Tile-Directory- und strukturelle PMTiles-Validierung bleiben Future Work.
   **Visueller Beweis differenzieren**: Lokale Ausführung (Heimserver, `basemap-real-hamburg-visual.proof.ts`) PROVEN
   (Canvas 1280×720, style_loaded true, direct_range_status 206, zero remote_violations).
   CI-Ausführung des visuellen Proofs: NOT_PROVEN (noch nicht in GitHub Actions). Map-Interaktion und clientseite Fehlerbehandlung sind belegt.
   Produktentscheidung (remote-style vs. local-sovereign im Produktionsbetrieb): ausstehend.
+
+  **Fresh CI-Evidence pmtiles-content**:
+  Run-URL: `https://github.com/heimgewebe/weltgewebe/actions/runs/26447341921`
+  Job-URL: `https://github.com/heimgewebe/weltgewebe/actions/runs/26447341921/job/77857000606`
+  Event: `pull_request`
+  Branch: `chore/api-dockerfile-cargo-build-jobs`
 
 ## Essenz
 
@@ -76,8 +82,14 @@ Der Scope `pmtiles-content` ist im selben Workflow als eigener blockierender
 Proof-Job hinterlegt (`basemap-pmtiles-content-proof`) und prueft Endpoint,
 HTTP-206-Range, 7-Byte-Magic `PMTiles` und optionale SHA256 gegen ein echtes
 in CI erzeugtes Artefakt. Der Guard ist fachlich erweitert um
-`PROVEN: HTTP-served PMTiles Magic verified`; die Statusmatrix wartet aber noch
-auf einen neuen GitHub-Actions-Lauf nach diesem Fix, damit die stärkere Semantik
-gegen den richtigen Run belegt ist.
+`PROVEN: HTTP-served PMTiles Magic verified`.
+Fuer Scope `pmtiles-content` ist der Proof jetzt PROVEN: [CI-Lauf 26447341921](https://github.com/heimgewebe/weltgewebe/actions/runs/26447341921)
+(Job `basemap-pmtiles-content-proof`, [Job 77857000606](https://github.com/heimgewebe/weltgewebe/actions/runs/26447341921/job/77857000606),
+Commit 3410c872964669fa27bfee958169ad9ce95594ae), Guard-Output
+`PROVEN: HTTP-served PMTiles Magic verified` und
+`PROVEN: Caddy PMTiles content verified (scope=pmtiles-content)`, Artefakt
+`basemap-hamburg-v0.1.0.pmtiles` mit SHA256
+`3eea9946f90a1cca425916c5b3272692ae8a1030bf22e700b67908cfafee8eab` und
+Groesse `23948909` Bytes.
 Offen bleiben die Produktionsentscheidung fuer den
 Basemap-Modus und die visuelle Kartenabnahme in GitHub Actions.


### PR DESCRIPTION
## These / Antithese / Synthese

**These:** Der fehlende Artefakt-Beleg liegt jetzt vor: `basemap-hamburg-v0.1.0.pmtiles`, SHA256 `3eea9946f90a1cca425916c5b3272692ae8a1030bf22e700b67908cfafee8eab`, Größe `23948909` Bytes.

**Antithese:** Der Status darf trotzdem nicht „Basemap vollständig bewiesen“ sagen. Bewiesen ist nur der Scope `pmtiles-content`: echtes Artefakt gebaut, über Caddy per Range ausgeliefert, HTTP-served Magic geprüft.

**Synthese:** Die Statusmatrix ist gezielt auf **PROVEN (scope=pmtiles-content)** angehoben, ohne Vollständigkeitsbehauptung.

## Belegdaten

- Workflow: `Basemap Runtime Proof`
- Run-ID: `26447341921`
- Run-URL: https://github.com/heimgewebe/weltgewebe/actions/runs/26447341921
- Event: `pull_request`
- Branch: `chore/api-dockerfile-cargo-build-jobs`
- Commit/headSha: `3410c872964669fa27bfee958169ad9ce95594ae`
- Job: `basemap-pmtiles-content-proof`
- Job-ID: `77857000606`
- Job-URL: https://github.com/heimgewebe/weltgewebe/actions/runs/26447341921/job/77857000606
- Conclusion: `success`

Guard-Output:

- `PROVEN: HTTP-served PMTiles Magic verified`
- `PROVEN: Caddy PMTiles content verified (scope=pmtiles-content)`

PMTiles-Artefakt aus `basemap-hamburg-v0.1.0.meta.json`:

- Artifact: `basemap-hamburg-v0.1.0.pmtiles`
- SHA256: `3eea9946f90a1cca425916c5b3272692ae8a1030bf22e700b67908cfafee8eab`
- Size: `23948909`
- Generator: `planetiler`
- Planetiler image digest: `ghcr.io/onthegomap/planetiler@sha256:10e4d6850664bd2ad7a223623383c48281e7d87fb427360838b13342cac012bb`
- Input SHA256: `e9beba6f27594a3abe571dd632e752fb43c8a136b2517fa162988fd641f8cdc9`

## Geänderte Dateien

- `docs/reports/map-status-matrix.md`
- `docs/reports/map-status-matrix.json`

## Scope / Nicht-Scope

- **Scope:** `pmtiles-content` auf PROVEN mit synchronisierter Evidence in MD/JSON.
- **Nicht-Scope:** Keine Aussage „Basemap vollständig bewiesen“.
- **Weiter offen:** visuelle Render-Abnahme in GitHub Actions; tiefe PMTiles-Strukturvalidierung.

## Validierung

```bash
python3 -m json.tool docs/reports/map-status-matrix.json >/dev/null
rg "26445893660|ae9e2362|pending fresh CI proof|PROVEN: HTTP-served PMTiles Magic verified|3eea9946f90a1cca425916c5b3272692ae8a1030bf22e700b67908cfafee8eab" \
  docs/reports/map-status-matrix.md \
  docs/reports/map-status-matrix.json

git diff -- docs/reports/map-status-matrix.md docs/reports/map-status-matrix.json
```

Hinweis: Evidence-Upload-Digest wurde nicht eingetragen, weil `gh api` lokal ohne Auth (`gh auth login`/`GH_TOKEN`) nicht ausführbar war.