### PR TITLE
Auth Phase 6: Dedicated Cookie-Proof CI job

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -90,10 +90,20 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Run phase 6 cookie/session proof tests
-        run: >-
-          cargo test --locked -p weltgewebe-api
-          --test api_auth session_cookie_
-          -- --test-threads=1
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo test --locked -p weltgewebe-api \
+            --test api_auth session_cookie_ \
+            -- --test-threads=1 | tee /tmp/cookie-session-proof.log
+
+          if grep -Eq "running 0 tests|0 passed; 0 failed" /tmp/cookie-session-proof.log; then
+            echo "ERROR: cookie/session proof matched zero tests" >&2
+            exit 1
+          fi
+
+          grep -Eq "test result: ok\." /tmp/cookie-session-proof.log
+          echo "PROVEN: cookie/session proof tests passed (phase 6)"
 
   db-session-persistence-proof:
     name: db session persistence proof (direct postgres)

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -76,7 +76,7 @@ jobs:
     name: cookie session proof (phase 6)
     runs-on: ubuntu-latest
     env:
-      CARGO_TERM_COLOR: always
+      CARGO_TERM_COLOR: never
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -95,13 +95,14 @@ jobs:
           set -euo pipefail
           cargo test --locked -p weltgewebe-api \
             --test api_auth session_cookie_ \
-            -- --test-threads=1 | tee /tmp/cookie-session-proof.log
+            -- --test-threads=1 --color never | tee /tmp/cookie-session-proof.log
 
           if grep -Eq "running 0 tests|0 passed; 0 failed" /tmp/cookie-session-proof.log; then
             echo "ERROR: cookie/session proof matched zero tests" >&2
             exit 1
           fi
 
+          grep -Eq "running [1-9][0-9]* tests" /tmp/cookie-session-proof.log
           grep -Eq "test result: ok\." /tmp/cookie-session-proof.log
           echo "PROVEN: cookie/session proof tests passed (phase 6)"
 

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -72,6 +72,29 @@ jobs:
         working-directory: apps/api
         run: cargo test --all-features --verbose
 
+  cookie-session-proof:
+    name: cookie session proof (phase 6)
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: "1.89.0"
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run phase 6 cookie/session proof tests
+        run: >-
+          cargo test --locked -p weltgewebe-api
+          --test api_auth session_cookie_
+          -- --test-threads=1
+
   db-session-persistence-proof:
     name: db session persistence proof (direct postgres)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Kontext
Phase 5b ist bereits CI-proven (Run 26394569642 / Job 77692063785, direct PostgreSQL 5432, db_session_store_persistence ok, 6 passed; 0 failed).

Die Statusmatrix trennt korrekt:
- Phase 5 DbSessionStore CI proof PROVEN
- Phase 6 Cookie-Proof CI pending

## Diagnose
- Phase-6-Cookie-Proof-Testlogik ist bereits vorhanden in apps/api/tests/api_auth.rs:
  - session_cookie_has_secure_attributes_on_magic_link_consume
  - session_cookie_insecure_when_auth_cookie_secure_disabled
- Diese Tests liefen bisher nur implizit im breiten test-and-lint-Job.
- Für einen engen, eindeutigen CI-Proof fehlte ein dedizierter Job.

## Änderung
- Ergänzt in .github/workflows/api.yml:
  - Neuer Job cookie-session-proof
  - Führt ausschließlich die Phase-6-Cookie-Tests aus:
    - cargo test --locked -p weltgewebe-api --test api_auth session_cookie_ -- --test-threads=1
- Kein Passkey-Register-Verify
- Kein UI
- Kein PgBouncer
- Kein Umbau des Session-Backends

## Lokaler Proof
Der neue Job-Command wurde lokal ausgeführt und ist grün:
- 2 passed; 0 failed

## Statusdokumente
Nicht angepasst. Bleiben pending, bis der neue CI-Job auf GitHub grün belegt ist.
