### PR TITLE
proof(map): add and harden visual CI proof for local basemap runtime

### DIFF
--- a/.github/workflows/basemap-runtime-proof.yml
+++ b/.github/workflows/basemap-runtime-proof.yml
@@ -50,6 +50,7 @@ name: Basemap Runtime Proof
       - "scripts/basemap/publish-basemap.sh"
       - "scripts/guard/basemap-runtime-proof.sh"
       - "apps/web/tests/proofs/**"
+      - "apps/web/package.json"
       - "apps/web/playwright.proof.config.ts"
       - "apps/web/vite.config.ts"
       - "map-style/**"
@@ -62,6 +63,7 @@ name: Basemap Runtime Proof
       - "scripts/basemap/publish-basemap.sh"
       - "scripts/guard/basemap-runtime-proof.sh"
       - "apps/web/tests/proofs/**"
+      - "apps/web/package.json"
       - "apps/web/playwright.proof.config.ts"
       - "apps/web/vite.config.ts"
       - "map-style/**"
@@ -506,6 +508,8 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 9.11.0
 
       - name: Setup Node
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b
@@ -622,4 +626,5 @@ jobs:
             printf '%s\n\n' \
               '❌ **FAILED** — no proof summary found (Playwright test may not have run to completion)' \
               >> "${GITHUB_STEP_SUMMARY}"
+            exit 1
           fi

--- a/.github/workflows/basemap-runtime-proof.yml
+++ b/.github/workflows/basemap-runtime-proof.yml
@@ -1,7 +1,7 @@
 ---
 name: Basemap Runtime Proof
 
-# This workflow runs three jobs:
+# This workflow runs four jobs:
 #
 #   1. basemap-runtime-proof  (Pfad 1 — epistemischer Dry-Run, nicht blockierend)
 #      Runs the guard in skip mode with no Caddy and no artefact. Reports
@@ -19,11 +19,22 @@ name: Basemap Runtime Proof
 #      The guard verifies endpoint/range delivery (HTTP 206), the PMTiles magic
 #      bytes "PMTiles" and an optional SHA256 match from the generated metadata.
 #
+#   4. basemap-visual-proof  (Pfad 4 — visueller End-to-End-Proof, blockierend)
+#      Builds a real Hamburg PMTiles artefact, publishes the stable alias
+#      (basemap-hamburg.pmtiles), starts the Vite preview server with the
+#      local-basemap-serve middleware, and runs the Playwright visual proof
+#      (apps/web/tests/proofs/basemap-real-hamburg-visual.proof.ts) against it.
+#      Proves: Browser → Vite middleware → PMTiles alias → HTTP 206 Range delivery
+#      → MapLibre canvas visible + isStyleLoaded() → zero remote tile violations.
+#      Failure fails the job. Uploads screenshot, trace, and proof summary.
+#
 # Scope distinction:
 #   Pfad 2 proves Caddy HTTP Range delivery against a .pmtiles file. It does
 #   NOT validate PMTiles content beyond the delivery chain. The pmtiles-content
 #   scope (when used against a real artefact) adds a 7-byte magic-byte prefix
 #   check only; tile-directory and structural PMTiles validation remain future work.
+#   Pfad 4 proves the browser-side visual pipeline using the Vite middleware (not
+#   Caddy); it is a different proof path from Pfad 2/3, not a substitute.
 #
 # What is NOT a substitute for either proof:
 #   - basemap-client-integration.spec.ts (mocked MapLibre protocol handler)
@@ -35,14 +46,24 @@ name: Basemap Runtime Proof
     paths:
       - "infra/caddy/**"
       - "scripts/basemap/build-hamburg-pmtiles.sh"
+      - "scripts/basemap/publish-basemap.sh"
       - "scripts/guard/basemap-runtime-proof.sh"
+      - "apps/web/tests/proofs/**"
+      - "apps/web/playwright.proof.config.ts"
+      - "apps/web/vite.config.ts"
+      - "map-style/**"
       - ".github/workflows/basemap-runtime-proof.yml"
   push:
     branches: [main]
     paths:
       - "infra/caddy/**"
       - "scripts/basemap/build-hamburg-pmtiles.sh"
+      - "scripts/basemap/publish-basemap.sh"
       - "scripts/guard/basemap-runtime-proof.sh"
+      - "apps/web/tests/proofs/**"
+      - "apps/web/playwright.proof.config.ts"
+      - "apps/web/vite.config.ts"
+      - "map-style/**"
       - ".github/workflows/basemap-runtime-proof.yml"
   workflow_dispatch: {}
 
@@ -456,3 +477,126 @@ jobs:
             printf 'No magic-byte capture found.\n' >> "${GITHUB_STEP_SUMMARY}"
           fi
           printf '```\n\n</details>\n' >> "${GITHUB_STEP_SUMMARY}"
+
+  basemap-visual-proof:
+    name: basemap-visual-proof
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      PUBLIC_BASEMAP_MODE: local-sovereign
+      PLAYWRIGHT_HTML_REPORT_OPEN: never
+      PUPPETEER_SKIP_DOWNLOAD: "true"
+      NPM_CONFIG_AUDIT: "false"
+      NPM_CONFIG_FUND: "false"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b
+        with:
+          node-version-file: '.node-version'
+          cache: 'pnpm'
+          cache-dependency-path: apps/web/pnpm-lock.yaml
+
+      - name: Install web dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: apps/web
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+        working-directory: apps/web
+
+      - name: Verify Docker availability
+        run: |
+          set -euo pipefail
+          docker --version
+          docker info >/dev/null
+
+      - name: Build Hamburg PMTiles artefact
+        run: bash scripts/basemap/build-hamburg-pmtiles.sh
+
+      - name: Publish basemap (create stable alias basemap-hamburg.pmtiles)
+        run: |
+          set -euo pipefail
+          bash scripts/basemap/publish-basemap.sh \
+            build/basemap/basemap-hamburg-v0.1.0.pmtiles \
+            build/basemap/basemap-hamburg-v0.1.0.meta.json \
+            build/basemap/
+          test -e build/basemap/basemap-hamburg.pmtiles
+          printf 'Alias verified: build/basemap/basemap-hamburg.pmtiles\n'
+          ls -la build/basemap/
+
+      - name: Run Playwright visual basemap proof
+        id: visual-proof
+        run: pnpm test:proof:basemap-real
+        working-directory: apps/web
+
+      - name: Upload visual proof screenshot and summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: basemap-visual-proof-screenshot
+          path: |
+            build/proofs/basemap-visual/screenshot.png
+            build/proofs/basemap-visual/proof-summary.json
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Upload visual proof trace and test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: basemap-visual-proof-trace
+          path: |
+            apps/web/test-results/
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Upload Playwright HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: basemap-visual-proof-report
+          path: |
+            apps/web/playwright-report/
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Write job summary
+        if: always()
+        run: |
+          set -euo pipefail
+          SUMMARY_FILE="build/proofs/basemap-visual/proof-summary.json"
+          printf '## Basemap Visual Proof\n\n' >> "${GITHUB_STEP_SUMMARY}"
+          if [[ -f "${SUMMARY_FILE}" ]]; then
+            VERDICT="$(python3 -c "
+          import json, sys
+          try:
+              d = json.load(open('${SUMMARY_FILE}'))
+              print(d.get('verdict', 'UNKNOWN'))
+          except Exception:
+              print('UNKNOWN')
+          " 2>/dev/null || echo 'UNKNOWN')"
+            if [[ "${VERDICT}" == "PROVEN" ]]; then
+              _msg='✅ **PROVEN** — MapLibre canvas visible, isStyleLoaded() true,'
+              _msg="${_msg} HTTP 206 Range delivery confirmed, zero remote violations"
+              printf '%s\n\n' "${_msg}" >> "${GITHUB_STEP_SUMMARY}"
+              printf '%s\n\n' \
+                'Chain: Browser → Vite middleware → basemap-hamburg.pmtiles → HTTP 206 → MapLibre rendered' \
+                >> "${GITHUB_STEP_SUMMARY}"
+            else
+              printf '%s\n\n' \
+                '❌ **NOT PROVEN** — see test results for details' \
+                >> "${GITHUB_STEP_SUMMARY}"
+            fi
+            printf '<details><summary>Proof summary</summary>\n\n```json\n' >> "${GITHUB_STEP_SUMMARY}"
+            cat "${SUMMARY_FILE}" >> "${GITHUB_STEP_SUMMARY}"
+            printf '\n```\n\n</details>\n' >> "${GITHUB_STEP_SUMMARY}"
+          else
+            printf '%s\n\n' \
+              '❌ **FAILED** — no proof summary found (Playwright test may not have run to completion)' \
+              >> "${GITHUB_STEP_SUMMARY}"
+          fi

--- a/.github/workflows/basemap-runtime-proof.yml
+++ b/.github/workflows/basemap-runtime-proof.yml
@@ -22,8 +22,7 @@ name: Basemap Runtime Proof
 #   4. basemap-visual-proof  (Pfad 4 — visueller End-to-End-Proof, blockierend)
 #      Reuses the real Hamburg PMTiles artefact from Pfad 3, publishes the
 #      stable alias (basemap-hamburg.pmtiles), starts the Vite preview server
-#      with the
-#      local-basemap-serve middleware, and runs the Playwright visual proof
+#      with the local-basemap-serve middleware, and runs the Playwright visual proof
 #      (apps/web/tests/proofs/basemap-real-hamburg-visual.proof.ts) against it.
 #      Proves: Browser → Vite middleware → PMTiles alias → HTTP 206 Range delivery
 #      → MapLibre canvas visible + isStyleLoaded() → zero remote tile violations.

--- a/.github/workflows/basemap-runtime-proof.yml
+++ b/.github/workflows/basemap-runtime-proof.yml
@@ -535,8 +535,10 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p build/basemap
-          ARTEFACT_SRC="$(find /tmp/basemap-visual-proof-input -type f -name 'basemap-hamburg-v0.1.0.pmtiles' | head -n 1)"
-          META_SRC="$(find /tmp/basemap-visual-proof-input -type f -name 'basemap-hamburg-v0.1.0.meta.json' | head -n 1)"
+          ARTEFACT_SRC="$(find /tmp/basemap-visual-proof-input -type f \
+            -name 'basemap-hamburg-v0.1.0.pmtiles' | head -n 1)"
+          META_SRC="$(find /tmp/basemap-visual-proof-input -type f \
+            -name 'basemap-hamburg-v0.1.0.meta.json' | head -n 1)"
           test -n "${ARTEFACT_SRC}"
           test -n "${META_SRC}"
           cp "${ARTEFACT_SRC}" build/basemap/basemap-hamburg-v0.1.0.pmtiles
@@ -599,7 +601,8 @@ jobs:
           printf '## Basemap Visual Proof\n\n' >> "${GITHUB_STEP_SUMMARY}"
           if [[ -f "${SUMMARY_FILE}" ]]; then
             VERDICT="$(
-              python3 -c 'import json, sys; print(json.load(open(sys.argv[1], encoding="utf-8")).get("verdict", "UNKNOWN"))' \
+              python3 -c \
+                'import json, sys; print(json.load(open(sys.argv[1], encoding="utf-8")).get("verdict", "UNKNOWN"))' \
                 "${SUMMARY_FILE}" 2>/dev/null || echo 'UNKNOWN'
             )"
             if [[ "${VERDICT}" == "PROVEN" ]]; then

--- a/.github/workflows/basemap-runtime-proof.yml
+++ b/.github/workflows/basemap-runtime-proof.yml
@@ -20,8 +20,9 @@ name: Basemap Runtime Proof
 #      bytes "PMTiles" and an optional SHA256 match from the generated metadata.
 #
 #   4. basemap-visual-proof  (Pfad 4 — visueller End-to-End-Proof, blockierend)
-#      Builds a real Hamburg PMTiles artefact, publishes the stable alias
-#      (basemap-hamburg.pmtiles), starts the Vite preview server with the
+#      Reuses the real Hamburg PMTiles artefact from Pfad 3, publishes the
+#      stable alias (basemap-hamburg.pmtiles), starts the Vite preview server
+#      with the
 #      local-basemap-serve middleware, and runs the Playwright visual proof
 #      (apps/web/tests/proofs/basemap-real-hamburg-visual.proof.ts) against it.
 #      Proves: Browser → Vite middleware → PMTiles alias → HTTP 206 Range delivery
@@ -430,6 +431,17 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+      - name: Upload reusable visual proof input artefact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: basemap-visual-proof-input
+          path: |
+            build/basemap/basemap-hamburg-v0.1.0.pmtiles
+            build/basemap/basemap-hamburg-v0.1.0.meta.json
+          if-no-files-found: error
+          retention-days: 14
+
       - name: Write job summary
         if: always()
         run: |
@@ -480,6 +492,7 @@ jobs:
 
   basemap-visual-proof:
     name: basemap-visual-proof
+    needs: [basemap-pmtiles-content-proof]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -509,14 +522,24 @@ jobs:
         run: pnpm exec playwright install --with-deps chromium
         working-directory: apps/web
 
-      - name: Verify Docker availability
+      - name: Download reusable PMTiles artefact from content proof
+        uses: actions/download-artifact@v4
+        with:
+          name: basemap-visual-proof-input
+          path: /tmp/basemap-visual-proof-input
+
+      - name: Materialize PMTiles artefact for visual proof
         run: |
           set -euo pipefail
-          docker --version
-          docker info >/dev/null
-
-      - name: Build Hamburg PMTiles artefact
-        run: bash scripts/basemap/build-hamburg-pmtiles.sh
+          mkdir -p build/basemap
+          ARTEFACT_SRC="$(find /tmp/basemap-visual-proof-input -type f -name 'basemap-hamburg-v0.1.0.pmtiles' | head -n 1)"
+          META_SRC="$(find /tmp/basemap-visual-proof-input -type f -name 'basemap-hamburg-v0.1.0.meta.json' | head -n 1)"
+          test -n "${ARTEFACT_SRC}"
+          test -n "${META_SRC}"
+          cp "${ARTEFACT_SRC}" build/basemap/basemap-hamburg-v0.1.0.pmtiles
+          cp "${META_SRC}" build/basemap/basemap-hamburg-v0.1.0.meta.json
+          test -s build/basemap/basemap-hamburg-v0.1.0.pmtiles
+          test -s build/basemap/basemap-hamburg-v0.1.0.meta.json
 
       - name: Publish basemap (create stable alias basemap-hamburg.pmtiles)
         run: |

--- a/.github/workflows/basemap-runtime-proof.yml
+++ b/.github/workflows/basemap-runtime-proof.yml
@@ -598,14 +598,10 @@ jobs:
           SUMMARY_FILE="build/proofs/basemap-visual/proof-summary.json"
           printf '## Basemap Visual Proof\n\n' >> "${GITHUB_STEP_SUMMARY}"
           if [[ -f "${SUMMARY_FILE}" ]]; then
-            VERDICT="$(python3 -c "
-          import json, sys
-          try:
-              d = json.load(open('${SUMMARY_FILE}'))
-              print(d.get('verdict', 'UNKNOWN'))
-          except Exception:
-              print('UNKNOWN')
-          " 2>/dev/null || echo 'UNKNOWN')"
+            VERDICT="$(
+              python3 -c 'import json, sys; print(json.load(open(sys.argv[1], encoding="utf-8")).get("verdict", "UNKNOWN"))' \
+                "${SUMMARY_FILE}" 2>/dev/null || echo 'UNKNOWN'
+            )"
             if [[ "${VERDICT}" == "PROVEN" ]]; then
               _msg='✅ **PROVEN** — MapLibre canvas visible, isStyleLoaded() true,'
               _msg="${_msg} HTTP 206 Range delivery confirmed, zero remote violations"

--- a/docs/blueprints/kartenklarheit-phase6.md
+++ b/docs/blueprints/kartenklarheit-phase6.md
@@ -165,6 +165,9 @@ curl -I http://localhost:8081/basemap/hamburg.pmtiles
   bleiben heavy und laufen nur via `workflow_dispatch`.
 - [ ] **Visuelle Abnahme.** Karte rendert ohne Fallback nach realem Tile-Load —
   separater Schritt, nicht durch den Range-Delivery-Proof gedeckt.
+  READY_FOR_CI_PROOF: Job `basemap-visual-proof` in `.github/workflows/basemap-runtime-proof.yml`
+  eingerichtet (Browser → Vite-Middleware → PMTiles-Alias → HTTP 206 → MapLibre canvas + isStyleLoaded()).
+  Kein grüner GitHub-Actions-Lauf liegt noch vor → Status bleibt NOT_PROVEN.
 
 ---
 

--- a/docs/reports/map-status-matrix.json
+++ b/docs/reports/map-status-matrix.json
@@ -114,7 +114,7 @@
         "docs/blueprints/kartenklarheit-phase6.md"
       ],
       "missing_evidence": [
-        "Visuelle Abnahme der gerenderten Karte in GitHub Actions",
+        "Gruener GitHub-Actions-Lauf fuer Job basemap-visual-proof (READY_FOR_CI_PROOF, nicht PROVEN)",
         "Tile-Directory- und strukturelle PMTiles-Validierung"
       ],
       "risk": "mittel",

--- a/docs/reports/map-status-matrix.md
+++ b/docs/reports/map-status-matrix.md
@@ -62,7 +62,9 @@ Repo-Stand tatsaechlich vorhanden sind.
 - **Fehlend**: Tile-Directory- und strukturelle PMTiles-Validierung bleiben Future Work.
   **Visueller Beweis differenzieren**: Lokale Ausführung (Heimserver, `basemap-real-hamburg-visual.proof.ts`) PROVEN
   (Canvas 1280×720, style_loaded true, direct_range_status 206, zero remote_violations).
-  CI-Ausführung des visuellen Proofs: NOT_PROVEN (noch nicht in GitHub Actions). Map-Interaktion und clientseite Fehlerbehandlung sind belegt.
+  CI-Ausführung des visuellen Proofs: READY_FOR_CI_PROOF — Job `basemap-visual-proof` in
+  `.github/workflows/basemap-runtime-proof.yml` eingerichtet; kein grüner GitHub-Actions-Lauf liegt noch vor.
+  Map-Interaktion und clientseitige Fehlerbehandlung sind belegt.
   Produktentscheidung (remote-style vs. local-sovereign im Produktionsbetrieb): ausstehend.
 
   **Fresh CI-Evidence pmtiles-content**:


### PR DESCRIPTION
## Diagnose: Was war vorher belegt?

**PROVEN (vor diesem PR):**
- `scope=range-delivery`: CI-Lauf <a href="https://github.com/heimgewebe/weltgewebe/actions/runs/25970466659">#25970466659</a> (Commit 14feefd6) — HTTP 206 via Caddy ✓
- `scope=pmtiles-content`: CI-Lauf <a href="https://github.com/heimgewebe/weltgewebe/actions/runs/26447341921">#26447341921</a> (Commit 3410c872) — Magic-Bytes + SHA256 via Caddy ✓
- Lokale visuelle Abnahme (Heimserver): `basemap-real-hamburg-visual.proof.ts` PROVEN — Canvas 1280×720, style_loaded true, direct_range_status 206, zero remote_violations

**NOT_PROVEN (vor diesem PR):**
- Visuelle CI-Abnahme in GitHub Actions: kein Job dafür existierte
- Tiefe PMTiles-Strukturvalidierung: Future Work (bleibt NOT_PROVEN)
- Produktionsentscheidung remote-style vs. local-sovereign: ausstehend (nicht angetastet)

## Welche Lücke wird geschlossen?

Job `basemap-visual-proof` fehlt im Workflow. Der Playwright-Test `basemap-real-hamburg-visual.proof.ts` existiert und ist lokal bewiesen, läuft aber nicht in GitHub Actions. Das ist die einzige verbleibende Proof-Lücke für Phase 6.

Zusätzlich wurde der CI-Pfad nach Review gehärtet:
- kein doppelter PMTiles-Build mehr im Visual-Job
- dedizierte Artefaktkette vom Content-Proof zum Visual-Proof
- strengere Job-Hygiene (Trigger/Tool-Pin/Fail-fast bei fehlender Summary)

## Geänderte Dateien

- **`.github/workflows/basemap-runtime-proof.yml`**
  - neuer Job `basemap-visual-proof`
  - Artefakt-Wiederverwendung: `basemap-visual-proof` nutzt `needs: [basemap-pmtiles-content-proof]` und lädt `basemap-visual-proof-input` per `actions/download-artifact`
  - Trigger-Pfade erweitert, inkl. `apps/web/package.json`
  - `pnpm/action-setup@v4` im Visual-Job explizit gepinnt auf `9.11.0`
  - Summary-Step im Visual-Job schlägt bei fehlender `proof-summary.json` jetzt hart fehl (`exit 1`)
- **`docs/reports/map-status-matrix.md`** — Status visueller Beweis: `NOT_PROVEN` → `READY_FOR_CI_PROOF`
- **`docs/reports/map-status-matrix.json`** — `missing_evidence` aktualisiert
- **`docs/blueprints/kartenklarheit-phase6.md`** — Notiz `READY_FOR_CI_PROOF` unter visuelle Abnahme

## Lokale Checks

```
git status --short       → sauber nach Commit
git diff --check         → keine Whitespace-Fehler
bash -n scripts/guard/basemap-runtime-proof.sh    → OK
bash -n scripts/guard/caddy-basemap-route-guard.sh → OK
python3 yaml.safe_load(workflow)  → YAML valide, 4 Jobs, kein continue-on-error
make validate            → OK
```

**Nicht lokal ausführbar:**
- `pnpm test:proof:basemap-real` — kein `build/basemap/basemap-hamburg.pmtiles` lokal vorhanden (kein PMTiles-Build lokal gelaufen); CI ist der Zielbeweis
- Docker/Caddy für PMTiles-Build: lokal verfügbar, aber 30-min-Download für Hamburg-OSM-Snapshot bewusst nicht ausgeführt

## Welche CI-Jobs müssen grün werden?

- `basemap-visual-proof` — blockierender Job, kein `continue-on-error`
- Die drei bestehenden Jobs (`basemap-runtime-proof`, `basemap-range-delivery-proof`, `basemap-pmtiles-content-proof`) bleiben unverändert und müssen weiterhin grün bleiben

## Welche Artefakte beweisen den visuellen Runtime-Pfad?

- `basemap-visual-proof-screenshot` — `build/proofs/basemap-visual/screenshot.png` + `proof-summary.json`
- `basemap-visual-proof-trace` — `apps/web/test-results/` (Playwright-Traces)
- `basemap-visual-proof-report` — `apps/web/playwright-report/` (HTML-Report)

Der Proof-Pfad: Browser → Vite-Middleware → `basemap-hamburg.pmtiles` (Alias via `publish-basemap.sh`) → HTTP 206 Range → MapLibre canvas sichtbar + `isStyleLoaded()` → zero remote violations.

## Was bleibt ausdrücklich NOT_PROVEN / Future Work?

- **Visuelle CI-Abnahme**: READY_FOR_CI_PROOF — kein grüner Lauf liegt noch vor → Status bleibt NOT_PROVEN bis CI grün
- **Tiefe PMTiles-Strukturvalidierung** (Tile-Directory, Index): Future Work, explizit NOT_PROVEN
- **Produktionsentscheidung** remote-style vs. local-sovereign: ausstehend, nicht angetastet

## Status-Dokumentation

- `map-status-matrix.md` und `map-status-matrix.json`: `READY_FOR_CI_PROOF` (nicht `PROVEN`)
- Nach grünem CI-Lauf mit Run-ID → separater PR mit `PROVEN` + Beleg-Details