### PR TITLE
feat(auth): implement passkey register verify endpoint

### DIFF
--- a/apps/api/src/auth/accounts.rs
+++ b/apps/api/src/auth/accounts.rs
@@ -135,6 +135,16 @@ impl AccountStore {
     pub fn is_empty(&self) -> bool {
         self.map.is_empty()
     }
+
+    pub fn remove(&mut self, account_id: &str) -> bool {
+        let removed = self.map.remove(account_id);
+        if let Some(account) = &removed {
+            if let Some(email) = &account.email {
+                self.recompute_email_index_for_key(&normalize_email_key(email));
+            }
+        }
+        removed.is_some()
+    }
 }
 
 #[cfg(test)]

--- a/apps/api/src/auth/passkeys.rs
+++ b/apps/api/src/auth/passkeys.rs
@@ -12,9 +12,9 @@
 //!   internal account semantics and protects against future migration pain.
 //!   **Persistence status:** the value is read from the account data source when
 //!   present and generated fresh (lazy backfill) when absent. It is stable for
-//!   the lifetime of the running process. Across restarts it is only stable once
-//!   the value has been written back to the account data source. This writeback
-//!   is performed by the `register/verify` handler upon successful registration.
+//!   the lifetime of the running process. The `register/verify` handler writes
+//!   the value back into the current `AccountStore` on successful registration;
+//!   cross-restart stability still requires a persistent account data source.
 //! * **`rp_id` / `rp_origin`** come from `AppConfig` (env overrides supported).
 //!   No hardcoded defaults — missing values cause an explicit startup error when
 //!   passkeys are enabled.

--- a/apps/api/src/auth/passkeys.rs
+++ b/apps/api/src/auth/passkeys.rs
@@ -13,8 +13,8 @@
 //!   **Persistence status:** the value is read from the account data source when
 //!   present and generated fresh (lazy backfill) when absent. It is stable for
 //!   the lifetime of the running process. Across restarts it is only stable once
-//!   the value has been written back to the account data source — which is a
-//!   prerequisite for `register/verify` and is NOT yet implemented.
+//!   the value has been written back to the account data source. This writeback
+//!   is performed by the `register/verify` handler upon successful registration.
 //! * **`rp_id` / `rp_origin`** come from `AppConfig` (env overrides supported).
 //!   No hardcoded defaults — missing values cause an explicit startup error when
 //!   passkeys are enabled.

--- a/apps/api/src/routes/auth.rs
+++ b/apps/api/src/routes/auth.rs
@@ -17,7 +17,9 @@ use uuid::Uuid;
 
 use crate::{
     auth::challenges::ChallengeIntent,
-    auth::passkeys::{start_passkey_registration, ConsumeGrantResult, RegistrationInput},
+    auth::passkeys::{
+        start_passkey_registration, ConsumeGrantResult, PasskeyStoreInsertError, RegistrationInput,
+    },
     auth::session::SessionBackendError,
     auth::step_up_tokens::ConsumeMatchResult,
     auth::{role::Role, tokens::TokenStore},
@@ -25,6 +27,7 @@ use crate::{
     routes::accounts::{AccountInternal, AccountPublic},
     state::ApiState,
 };
+use webauthn_rs::prelude::RegisterPublicKeyCredential;
 
 pub const SESSION_COOKIE_NAME: &str = "gewebe_session";
 pub const NONCE_COOKIE_NAME: &str = "auth_nonce";
@@ -1894,6 +1897,143 @@ pub async fn passkey_register_options(
             (StatusCode::OK, Json(body)).into_response()
         }
     }
+}
+
+// ── Passkey Registration Verify ───────────────────────────────────────────
+
+#[derive(serde::Deserialize)]
+pub struct PasskeyRegisterVerifyPayload {
+    pub registration_id: String,
+    pub credential: RegisterPublicKeyCredential,
+}
+
+/// POST /auth/passkeys/register/verify
+///
+/// Completes the WebAuthn registration ceremony started by
+/// `POST /auth/passkeys/register/options`.
+///
+/// The handler performs a real cryptographic verification via
+/// `webauthn.finish_passkey_registration` — no shortcuts. On success the
+/// resulting credential is stored in `PasskeyStore` (account-bound, duplicate
+/// detection enforced) and the lazily generated `webauthn_user_id` is written
+/// back through `AccountStore::update_webauthn_user_id`, so the account binding
+/// survives a future persistent store.
+///
+/// The endpoint never establishes a session and never sets a cookie.
+pub async fn passkey_register_verify(
+    State(state): State<ApiState>,
+    Extension(ctx): Extension<AuthContext>,
+    headers: HeaderMap,
+    Json(payload): Json<PasskeyRegisterVerifyPayload>,
+) -> impl IntoResponse {
+    let request_id = get_request_id(&headers);
+
+    let account_id = match &ctx.account_id {
+        Some(id) => id.clone(),
+        None => {
+            let err = serde_json::json!({
+                "error": "UNAUTHORIZED",
+                "message": "Authentication required"
+            });
+            return (StatusCode::UNAUTHORIZED, Json(err)).into_response();
+        }
+    };
+
+    let webauthn = match state.webauthn.as_ref() {
+        Some(w) => w,
+        None => {
+            tracing::warn!(
+                event = "auth.passkey.register_verify.not_configured",
+                request_id = %request_id,
+                "Passkey register-verify called but WebAuthn is not configured"
+            );
+            let err = serde_json::json!({
+                "error": "PASSKEYS_NOT_CONFIGURED",
+                "message": "Passkey support is not enabled on this server"
+            });
+            return (StatusCode::SERVICE_UNAVAILABLE, Json(err)).into_response();
+        }
+    };
+
+    let reg_state = match state
+        .passkey_registrations
+        .consume(&payload.registration_id, &account_id)
+        .await
+    {
+        Some(state) => state,
+        None => {
+            tracing::warn!(
+                event = "auth.passkey.register_verify.registration_invalid",
+                request_id = %request_id,
+                account_id = %account_id,
+                "Passkey register-verify: registration_id unknown, expired, or bound to a different account"
+            );
+            let err = serde_json::json!({"error": "REGISTRATION_INVALID"});
+            return (StatusCode::BAD_REQUEST, Json(err)).into_response();
+        }
+    };
+
+    let passkey = match webauthn.finish_passkey_registration(&payload.credential, &reg_state) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(
+                event = "auth.passkey.register_verify.webauthn_error",
+                request_id = %request_id,
+                account_id = %account_id,
+                error = %e,
+                "WebAuthn finish_passkey_registration rejected the credential"
+            );
+            let err = serde_json::json!({"error": "CREDENTIAL_INVALID"});
+            return (StatusCode::BAD_REQUEST, Json(err)).into_response();
+        }
+    };
+
+    if let Err(PasskeyStoreInsertError::DuplicateCredentialId) =
+        state.passkeys.insert(account_id.clone(), passkey)
+    {
+        tracing::warn!(
+            event = "auth.passkey.register_verify.duplicate_credential",
+            request_id = %request_id,
+            account_id = %account_id,
+            "Passkey register-verify: credential already registered"
+        );
+        let err = serde_json::json!({"error": "CREDENTIAL_ALREADY_REGISTERED"});
+        return (StatusCode::CONFLICT, Json(err)).into_response();
+    }
+
+    let webauthn_user_id = {
+        let accounts = state.accounts.read().await;
+        accounts.get(&account_id).map(|a| a.webauthn_user_id)
+    };
+    if let Some(webauthn_user_id) = webauthn_user_id {
+        let mut accounts = state.accounts.write().await;
+        let updated = accounts.update_webauthn_user_id(&account_id, webauthn_user_id);
+        if !updated {
+            tracing::warn!(
+                event = "auth.passkey.register_verify.account_writeback_missing",
+                request_id = %request_id,
+                account_id = %account_id,
+                "Account disappeared between credential storage and webauthn_user_id writeback"
+            );
+        }
+    } else {
+        tracing::warn!(
+            event = "auth.passkey.register_verify.account_writeback_missing",
+            request_id = %request_id,
+            account_id = %account_id,
+            "Account missing during webauthn_user_id writeback after successful registration"
+        );
+    }
+
+    tracing::info!(
+        event = "auth.passkey.register_verify.ok",
+        request_id = %request_id,
+        account_id = %account_id,
+        "Passkey registration verified and credential stored"
+    );
+
+    let body = serde_json::json!({"ok": true});
+    (StatusCode::OK, Json(body)).into_response()
 }
 
 #[cfg(test)]

--- a/apps/api/src/routes/auth.rs
+++ b/apps/api/src/routes/auth.rs
@@ -1955,6 +1955,24 @@ pub async fn passkey_register_verify(
         }
     };
 
+    let webauthn_user_id = {
+        let accounts = state.accounts.read().await;
+        match accounts.get(&account_id) {
+            Some(a) => a.webauthn_user_id,
+            None => {
+                tracing::error!(
+                    event = "auth.passkey.register_verify.account_not_found",
+                    request_id = %request_id,
+                    account_id = %account_id,
+                    "Session references non-existent account"
+                );
+                let err =
+                    serde_json::json!({"error": "ACCOUNT_INVALID", "message": "Account not found"});
+                return (StatusCode::BAD_REQUEST, Json(err)).into_response();
+            }
+        }
+    };
+
     let reg_state = match state
         .passkey_registrations
         .consume(&payload.registration_id, &account_id)
@@ -1988,24 +2006,21 @@ pub async fn passkey_register_verify(
         }
     };
 
-    if let Err(PasskeyStoreInsertError::DuplicateCredentialId) =
-        state.passkeys.insert(account_id.clone(), passkey)
-    {
-        tracing::warn!(
-            event = "auth.passkey.register_verify.duplicate_credential",
-            request_id = %request_id,
-            account_id = %account_id,
-            "Passkey register-verify: credential already registered"
-        );
-        let err = serde_json::json!({"error": "CREDENTIAL_ALREADY_REGISTERED"});
-        return (StatusCode::CONFLICT, Json(err)).into_response();
+    match state.passkeys.insert(account_id.clone(), passkey) {
+        Ok(()) => {}
+        Err(PasskeyStoreInsertError::DuplicateCredentialId) => {
+            tracing::warn!(
+                event = "auth.passkey.register_verify.duplicate_credential",
+                request_id = %request_id,
+                account_id = %account_id,
+                "Passkey register-verify: credential already registered"
+            );
+            let err = serde_json::json!({"error": "CREDENTIAL_ALREADY_REGISTERED"});
+            return (StatusCode::CONFLICT, Json(err)).into_response();
+        }
     }
 
-    let webauthn_user_id = {
-        let accounts = state.accounts.read().await;
-        accounts.get(&account_id).map(|a| a.webauthn_user_id)
-    };
-    if let Some(webauthn_user_id) = webauthn_user_id {
+    {
         let mut accounts = state.accounts.write().await;
         let updated = accounts.update_webauthn_user_id(&account_id, webauthn_user_id);
         if !updated {
@@ -2013,16 +2028,9 @@ pub async fn passkey_register_verify(
                 event = "auth.passkey.register_verify.account_writeback_missing",
                 request_id = %request_id,
                 account_id = %account_id,
-                "Account disappeared between credential storage and webauthn_user_id writeback"
+                "Account disappeared between account guard and webauthn_user_id writeback"
             );
         }
-    } else {
-        tracing::warn!(
-            event = "auth.passkey.register_verify.account_writeback_missing",
-            request_id = %request_id,
-            account_id = %account_id,
-            "Account missing during webauthn_user_id writeback after successful registration"
-        );
     }
 
     tracing::info!(

--- a/apps/api/src/routes/mod.rs
+++ b/apps/api/src/routes/mod.rs
@@ -19,8 +19,8 @@ use self::{
     accounts::{create_account, get_account, list_accounts},
     auth::{
         consume_login_get, consume_login_post, consume_step_up, dev_login, list_dev_accounts,
-        list_devices, logout, logout_all, me, passkey_register_options, remove_device,
-        request_login, request_step_up, session, session_refresh, update_email,
+        list_devices, logout, logout_all, me, passkey_register_options, passkey_register_verify,
+        remove_device, request_login, request_step_up, session, session_refresh, update_email,
     },
     edges::{get_edge, list_edges},
     nodes::{get_node, list_nodes, patch_node},
@@ -64,5 +64,9 @@ pub fn api_router() -> Router<ApiState> {
         .route(
             "/auth/passkeys/register/options",
             post(passkey_register_options),
+        )
+        .route(
+            "/auth/passkeys/register/verify",
+            post(passkey_register_verify),
         )
 }

--- a/apps/api/tests/api_auth.rs
+++ b/apps/api/tests/api_auth.rs
@@ -4211,7 +4211,7 @@ async fn passkey_register_verify_wrong_account_rejected_and_non_destructive() ->
     // a1 tries to verify u1's registration — must fail with 400.
     let app = app_with_auth(state.clone());
     let body_payload = serde_json::json!({
-        "registration_id": registration_id,
+        "registration_id": registration_id.as_str(),
         "credential": bogus_register_credential(),
     });
     let req = Request::post("/auth/passkeys/register/verify")
@@ -4258,7 +4258,7 @@ async fn passkey_register_verify_invalid_credential_returns_400_and_consumes_reg
     // First attempt: structurally valid but cryptographically bogus credential.
     let app = app_with_auth(state.clone());
     let body_payload = serde_json::json!({
-        "registration_id": registration_id,
+        "registration_id": registration_id.as_str(),
         "credential": bogus_register_credential(),
     });
     let req = Request::post("/auth/passkeys/register/verify")
@@ -4302,7 +4302,7 @@ async fn passkey_register_verify_invalid_credential_returns_400_and_consumes_reg
     // consumed before WebAuthn verification (consume-first semantics).
     let app2 = app_with_auth(state.clone());
     let body_payload2 = serde_json::json!({
-        "registration_id": registration_id,
+        "registration_id": registration_id.as_str(),
         "credential": bogus_register_credential(),
     });
     let req2 = Request::post("/auth/passkeys/register/verify")
@@ -4351,7 +4351,7 @@ async fn passkey_register_verify_deleted_account_returns_401_and_does_not_consum
 
     let app = app_with_auth(state.clone());
     let body_payload = serde_json::json!({
-        "registration_id": registration_id,
+        "registration_id": registration_id.as_str(),
         "credential": bogus_register_credential(),
     });
     let req = Request::post("/auth/passkeys/register/verify")

--- a/apps/api/tests/api_auth.rs
+++ b/apps/api/tests/api_auth.rs
@@ -4039,6 +4039,291 @@ async fn passkey_register_options_expired_grant_rejected() -> Result<()> {
     Ok(())
 }
 
+// ── Passkey Register-Verify ───────────────────────────────────────────────
+//
+// These tests cover the negative paths and structural guarantees of
+// `POST /auth/passkeys/register/verify`. A reproducible positive proof
+// (success path with a real Passkey from `navigator.credentials.create()`)
+// requires either a browser E2E test or a soft-authenticator crate
+// (e.g. `webauthn-authenticator-rs`); neither is part of this repository's
+// current dependency set. See `docs/reports/passkey-register-verify-prep.md`.
+//
+// The structurally-valid but cryptographically-bogus credential used below
+// matches the `RegisterPublicKeyCredential` shape defined in
+// `webauthn-rs-proto::attest::RegisterPublicKeyCredential` so that the JSON
+// deserialiser accepts it; `webauthn.finish_passkey_registration` then
+// rejects it during the real cryptographic checks.
+
+fn bogus_register_credential() -> serde_json::Value {
+    serde_json::json!({
+        "id": "AAAA",
+        "rawId": "AAAA",
+        "response": {
+            "attestationObject": "AAAA",
+            "clientDataJSON": "AAAA"
+        },
+        "type": "public-key"
+    })
+}
+
+async fn obtain_registration_id_via_api(
+    state: &ApiState,
+    session_cookie: &str,
+    account_id: &str,
+    device_id: &str,
+) -> Result<String> {
+    let challenge_id = request_passkey_registration_challenge(state, session_cookie).await?;
+    let grant_id = consume_begin_passkey_registration_step_up(
+        state,
+        session_cookie,
+        &challenge_id,
+        account_id,
+        device_id,
+    )
+    .await?;
+
+    let app = app_with_auth(state.clone());
+    let req = Request::post("/auth/passkeys/register/options")
+        .header("Host", "localhost")
+        .header("Origin", "http://localhost:3000")
+        .header("Content-Type", "application/json")
+        .header("Cookie", session_cookie.to_string())
+        .body(body::Body::from(
+            serde_json::json!({"registration_grant_id": grant_id}).to_string(),
+        ))?;
+    let res = app.oneshot(req).await?;
+    assert_eq!(
+        res.status(),
+        StatusCode::OK,
+        "register/options must succeed with valid grant"
+    );
+    let bytes = body::to_bytes(res.into_body(), usize::MAX).await?;
+    let body: serde_json::Value = serde_json::from_slice(&bytes)?;
+    let registration_id = body["registration_id"]
+        .as_str()
+        .context("response must contain registration_id")?
+        .to_string();
+    Ok(registration_id)
+}
+
+#[tokio::test]
+async fn passkey_register_verify_requires_authentication() -> Result<()> {
+    let state = test_state_with_webauthn()?;
+    let app = app_with_auth(state);
+
+    let body_payload = serde_json::json!({
+        "registration_id": "any-id",
+        "credential": bogus_register_credential(),
+    });
+    let req = Request::post("/auth/passkeys/register/verify")
+        .header("Host", "localhost")
+        .header("Origin", "http://localhost:3000")
+        .header("Content-Type", "application/json")
+        .body(body::Body::from(body_payload.to_string()))?;
+
+    let res = app.oneshot(req).await?;
+    assert_eq!(
+        res.status(),
+        StatusCode::UNAUTHORIZED,
+        "unauthenticated register-verify must be rejected"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn passkey_register_verify_returns_503_when_not_configured() -> Result<()> {
+    let state = test_state_with_accounts()?;
+    let session = create_session(&state, "u1", None).await;
+    let app = app_with_auth(state);
+
+    let body_payload = serde_json::json!({
+        "registration_id": "any-id",
+        "credential": bogus_register_credential(),
+    });
+    let req = Request::post("/auth/passkeys/register/verify")
+        .header("Host", "localhost")
+        .header("Origin", "http://localhost")
+        .header("Content-Type", "application/json")
+        .header("Cookie", format!("{}={}", SESSION_COOKIE_NAME, session.id))
+        .body(body::Body::from(body_payload.to_string()))?;
+
+    let res = app.oneshot(req).await?;
+    assert_eq!(
+        res.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "register-verify must fail closed when WebAuthn is not configured"
+    );
+    let bytes = body::to_bytes(res.into_body(), usize::MAX).await?;
+    let body: serde_json::Value = serde_json::from_slice(&bytes)?;
+    assert_eq!(body["error"], "PASSKEYS_NOT_CONFIGURED");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn passkey_register_verify_unknown_registration_id_returns_400() -> Result<()> {
+    let state = test_state_with_webauthn()?;
+    let session = create_session(&state, "u1", Some("dev-passkey")).await;
+    let cookie = format!("{}={}", SESSION_COOKIE_NAME, session.id);
+
+    let app = app_with_auth(state);
+    let body_payload = serde_json::json!({
+        "registration_id": "not-a-real-registration",
+        "credential": bogus_register_credential(),
+    });
+    let req = Request::post("/auth/passkeys/register/verify")
+        .header("Host", "localhost")
+        .header("Origin", "http://localhost:3000")
+        .header("Content-Type", "application/json")
+        .header("Cookie", &cookie)
+        .body(body::Body::from(body_payload.to_string()))?;
+
+    let res = app.oneshot(req).await?;
+    assert_eq!(
+        res.status(),
+        StatusCode::BAD_REQUEST,
+        "unknown registration_id must yield 400"
+    );
+    let bytes = body::to_bytes(res.into_body(), usize::MAX).await?;
+    let body: serde_json::Value = serde_json::from_slice(&bytes)?;
+    assert_eq!(body["error"], "REGISTRATION_INVALID");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn passkey_register_verify_wrong_account_rejected_and_non_destructive() -> Result<()> {
+    let state = test_state_with_webauthn()?;
+    let session_u1 = create_session(&state, "u1", Some("dev-passkey")).await;
+    let session_a1 = create_session(&state, "a1", Some("dev-a1")).await;
+    let cookie_u1 = format!("{}={}", SESSION_COOKIE_NAME, session_u1.id);
+    let cookie_a1 = format!("{}={}", SESSION_COOKIE_NAME, session_a1.id);
+
+    let registration_id = obtain_registration_id_via_api(
+        &state,
+        &cookie_u1,
+        &session_u1.account_id,
+        &session_u1.device_id,
+    )
+    .await?;
+
+    // a1 tries to verify u1's registration — must fail with 400.
+    let app = app_with_auth(state.clone());
+    let body_payload = serde_json::json!({
+        "registration_id": registration_id,
+        "credential": bogus_register_credential(),
+    });
+    let req = Request::post("/auth/passkeys/register/verify")
+        .header("Host", "localhost")
+        .header("Origin", "http://localhost:3000")
+        .header("Content-Type", "application/json")
+        .header("Cookie", &cookie_a1)
+        .body(body::Body::from(body_payload.to_string()))?;
+    let res = app.oneshot(req).await?;
+    assert_eq!(
+        res.status(),
+        StatusCode::BAD_REQUEST,
+        "verify with mismatching account must be rejected"
+    );
+    let bytes = body::to_bytes(res.into_body(), usize::MAX).await?;
+    let body: serde_json::Value = serde_json::from_slice(&bytes)?;
+    assert_eq!(body["error"], "REGISTRATION_INVALID");
+
+    // The registration must still be consumable by the legitimate owner u1
+    // (PasskeyRegistrationStore::consume is non-destructive on wrong account).
+    let still_there = state
+        .passkey_registrations
+        .consume(&registration_id, &session_u1.account_id)
+        .await;
+    assert!(
+        still_there.is_some(),
+        "wrong-account verify must not burn the registration for the legitimate owner"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn passkey_register_verify_invalid_credential_returns_400_and_consumes_registration(
+) -> Result<()> {
+    let state = test_state_with_webauthn()?;
+    let session = create_session(&state, "u1", Some("dev-passkey")).await;
+    let cookie = format!("{}={}", SESSION_COOKIE_NAME, session.id);
+
+    let registration_id =
+        obtain_registration_id_via_api(&state, &cookie, &session.account_id, &session.device_id)
+            .await?;
+
+    // First attempt: structurally valid but cryptographically bogus credential.
+    let app = app_with_auth(state.clone());
+    let body_payload = serde_json::json!({
+        "registration_id": registration_id,
+        "credential": bogus_register_credential(),
+    });
+    let req = Request::post("/auth/passkeys/register/verify")
+        .header("Host", "localhost")
+        .header("Origin", "http://localhost:3000")
+        .header("Content-Type", "application/json")
+        .header("Cookie", &cookie)
+        .body(body::Body::from(body_payload.to_string()))?;
+    let res = app.oneshot(req).await?;
+    assert_eq!(
+        res.status(),
+        StatusCode::BAD_REQUEST,
+        "invalid credential must be rejected by WebAuthn verification"
+    );
+    // Snapshot Set-Cookie headers before consuming the body — register/verify
+    // never establishes a session, even on the happy path, and must not set a
+    // session cookie on the failure path either.
+    let res_cookies_str: Vec<String> = res
+        .headers()
+        .get_all("set-cookie")
+        .iter()
+        .filter_map(|v| v.to_str().ok().map(str::to_string))
+        .collect();
+    let bytes = body::to_bytes(res.into_body(), usize::MAX).await?;
+    let body: serde_json::Value = serde_json::from_slice(&bytes)?;
+    // The error code differentiates from REGISTRATION_INVALID so that the
+    // caller can tell "your registration_id is gone" from "your credential
+    // failed verification".
+    assert_eq!(body["error"], "CREDENTIAL_INVALID");
+
+    assert!(
+        res_cookies_str
+            .iter()
+            .all(|c| !c.starts_with(&format!("{}=", SESSION_COOKIE_NAME))),
+        "register/verify must not set a session cookie; got: {:?}",
+        res_cookies_str
+    );
+
+    // Second attempt with the same registration_id must now fail with
+    // REGISTRATION_INVALID — the registration_id is single-use and was
+    // consumed before WebAuthn verification (consume-first semantics).
+    let app2 = app_with_auth(state.clone());
+    let body_payload2 = serde_json::json!({
+        "registration_id": registration_id,
+        "credential": bogus_register_credential(),
+    });
+    let req2 = Request::post("/auth/passkeys/register/verify")
+        .header("Host", "localhost")
+        .header("Origin", "http://localhost:3000")
+        .header("Content-Type", "application/json")
+        .header("Cookie", &cookie)
+        .body(body::Body::from(body_payload2.to_string()))?;
+    let res2 = app2.oneshot(req2).await?;
+    assert_eq!(
+        res2.status(),
+        StatusCode::BAD_REQUEST,
+        "second verify with the same registration_id must be rejected"
+    );
+    let bytes2 = body::to_bytes(res2.into_body(), usize::MAX).await?;
+    let body2: serde_json::Value = serde_json::from_slice(&bytes2)?;
+    assert_eq!(body2["error"], "REGISTRATION_INVALID");
+
+    Ok(())
+}
+
 // Phase 6 API-level Proof: Session Cookie Security Attributes
 //
 // This test proves that:

--- a/apps/api/tests/api_auth.rs
+++ b/apps/api/tests/api_auth.rs
@@ -4324,6 +4324,64 @@ async fn passkey_register_verify_invalid_credential_returns_400_and_consumes_reg
     Ok(())
 }
 
+#[tokio::test]
+#[serial]
+async fn passkey_register_verify_deleted_account_returns_401_and_does_not_consume_registration(
+) -> Result<()> {
+    // Defense-in-depth layering: `auth_middleware` checks account existence and
+    // only populates `AuthContext.account_id` when the account is in state. If
+    // the account is deleted after session creation, the middleware returns 401
+    // before the handler executes — so the handler's inner ACCOUNT_INVALID guard
+    // never fires in practice. This test proves the middleware layer holds and
+    // that no registration_id is consumed.
+    let state = test_state_with_webauthn()?;
+    let session = create_session(&state, "u1", Some("dev-passkey")).await;
+    let cookie = format!("{}={}", SESSION_COOKIE_NAME, session.id);
+    let account_id = session.account_id.clone();
+
+    let registration_id =
+        obtain_registration_id_via_api(&state, &cookie, &account_id, &session.device_id).await?;
+
+    // Remove the account from the store to simulate a deleted/ghost account.
+    {
+        let mut accounts = state.accounts.write().await;
+        let removed = accounts.remove(&account_id);
+        assert!(removed, "account must be present before removal");
+    }
+
+    let app = app_with_auth(state.clone());
+    let body_payload = serde_json::json!({
+        "registration_id": registration_id,
+        "credential": bogus_register_credential(),
+    });
+    let req = Request::post("/auth/passkeys/register/verify")
+        .header("Host", "localhost")
+        .header("Origin", "http://localhost:3000")
+        .header("Content-Type", "application/json")
+        .header("Cookie", &cookie)
+        .body(body::Body::from(body_payload.to_string()))?;
+    let res = app.oneshot(req).await?;
+    // `auth_middleware` fires first: no account in state → ctx.account_id = None → 401.
+    assert_eq!(
+        res.status(),
+        StatusCode::UNAUTHORIZED,
+        "deleted account: middleware must return 401 before handler executes"
+    );
+
+    // The registration_id must NOT have been consumed — the request was rejected
+    // before the consume step.
+    let reg_state = state
+        .passkey_registrations
+        .consume(&registration_id, &account_id)
+        .await;
+    assert!(
+        reg_state.is_some(),
+        "registration_id must not be consumed when middleware rejects the request"
+    );
+
+    Ok(())
+}
+
 // Phase 6 API-level Proof: Session Cookie Security Attributes
 //
 // This test proves that:

--- a/apps/api/tests/auth_security_invariants.rs
+++ b/apps/api/tests/auth_security_invariants.rs
@@ -359,6 +359,7 @@ const CSRF_COVERED_MUTATING_ROUTES: &[(&str, &str)] = &[
     ("POST", "/auth/step-up/magic-link/request"),
     ("POST", "/auth/step-up/magic-link/consume"),
     ("POST", "/auth/passkeys/register/options"),
+    ("POST", "/auth/passkeys/register/verify"),
     ("PATCH", "/nodes/:id"),
     ("POST", "/accounts"),
 ];

--- a/docs/blueprints/auth-roadmap.md
+++ b/docs/blueprints/auth-roadmap.md
@@ -285,7 +285,7 @@ Step-up bleibt aktionsgebunden und session-neutral.
 
 1. [x] Statusbeweis: Was existiert bereits?
 2. [x] Register-Options (`POST /auth/passkeys/register/options`) — Endpunkt, Step-up-403, Grant-Handoff implementiert; `BeginPasskeyRegistration`-Consume erzeugt `registration_grant_id`; `register/options` konsumiert Grant und startet WebAuthn-Ceremony
-3. [ ] Register-Verify — Vorbereitungsbericht: [reports/passkey-register-verify-prep.md](../reports/passkey-register-verify-prep.md)
+3. [~] Register-Verify (`POST /auth/passkeys/register/verify`) — API-seitig implementiert mit echter `webauthn.finish_passkey_registration(...)`-Verifikation, single-use-Consume der `registration_id`, Credential-Speicherung über `PasskeyStore` (Duplicate-Detection → `409 CONFLICT`), `webauthn_user_id`-Writeback und session-neutralem Erfolgspfad (`200 OK`, kein Cookie). Negativpfade (401, 503, 400 unknown/mismatch/invalid credential, kein Set-Cookie) sind getestet. **Offen:** positiver Verify-Pfad mit echter WebAuthn-Antwort (Browser-/Authenticator-Beleg)
 4. [x] Voraussetzungen für Register-Verify — PasskeyStore + Writeback-Mutation implementiert; `register/options` vollständiger Grant-Handoff implementiert
 5. [ ] Auth-Options
 6. [ ] Auth-Verify
@@ -295,18 +295,19 @@ Step-up bleibt aktionsgebunden und session-neutral.
 
 ### Aktueller Stand
 
-- `webauthn_user_id` als dediziertes Feld am Account-Modell eingeführt (Lazy Backfill, prozessstabil; persistenzpflichtig ab register/verify)
+- `webauthn_user_id` als dediziertes Feld am Account-Modell eingeführt (Lazy Backfill, prozessstabil; Writeback im Verify-Pfad implementiert, Datenquellen-Persistenz folgt mit persistenter Account-Ablage)
 - WebAuthn-Konfiguration (`rp_id`, `rp_origin`, optional `rp_name`) aus `AppConfig` mit Validierung
 - `Webauthn`-Instanz wird beim Start einmalig gebaut (optional, nur wenn konfiguriert)
 - `PasskeyRegistrationGrantStore` (In-Memory, TTL 5 Min, single-use, account- und device-gebunden) eingeführt
 - Register-Options-Endpunkt: ohne Grant fail-closed `403 STEP_UP_REQUIRED` mit `challenge_id`; mit gültigem Grant wird die WebAuthn-Ceremony gestartet (`200 OK` mit `registration_id` + `options`)
+- Register-Verify-Endpunkt: prüft Session/Konfiguration, konsumiert `registration_id` single-use, verifiziert die Credential-Antwort über `webauthn.finish_passkey_registration(...)` (echte Krypto, kein Mock), legt das `Passkey` über `PasskeyStore.insert(...)` mit Duplicate-Detection ab, schreibt `webauthn_user_id` zurück und antwortet session-neutral mit `200 OK {"ok": true}` — kein Cookie, kein neuer Session-Token
 - `BeginPasskeyRegistration`-Consume erzeugt einen kurzlebigen `registration_grant_id` (TTL 5 Min)
 - In-Memory-Store für laufende Registrierungen (`PasskeyRegistrationStore`, TTL 5 Min) wird nach Grant-Consume aktiv genutzt
 - Langlebiger In-Memory-`PasskeyStore` (account-gebunden, duplicate detection, list/find/remove)
-- `AccountStore.update_webauthn_user_id(account_id, uuid)` für gezielten Writeback vorbereitet
+- `AccountStore.update_webauthn_user_id(account_id, uuid)` für gezielten Writeback vorbereitet und im Verify-Pfad aktiv aufgerufen
 - Step-up-Intent `BeginPasskeyRegistration` ergänzt (vollständiger Handoff mit Grant-Erzeugung und -Konsum)
-- Unit- und Integrationstests belegen PasskeyStore, AccountStore-Writeback-Mutation, Grant-Handoff, fail-closed `register/options` ohne Grant und erfolgreichen Ceremony-Start mit Grant
-- **Offen:** Register-Verify (inkl. tatsächlichem Datenquellen-Writeback), Auth-Optionen/Verify, Passkey-Login/Management, UI
+- Unit- und Integrationstests belegen PasskeyStore, AccountStore-Writeback-Mutation, Grant-Handoff, fail-closed `register/options` ohne Grant, erfolgreichen Ceremony-Start mit Grant sowie alle dokumentierten Negativpfade von `register/verify` (401, 503, 400 unknown/mismatch/invalid credential, kein Session-Cookie); CSRF-Drift-Guard erfasst die neue Route
+- **Offen:** Positiver Verify-Pfad mit echter WebAuthn-Antwort (Browser-/Authenticator-Beleg — `webauthn-rs 0.5` enthält keinen Soft-Authenticator), persistente Account-Datenquelle für den `webauthn_user_id`-Writeback, Auth-Optionen/Verify, Passkey-Login/Management, UI
 
 ### Voraussetzungen
 

--- a/docs/reports/auth-status-matrix.md
+++ b/docs/reports/auth-status-matrix.md
@@ -76,7 +76,7 @@ Ein Bereich erhält den Status `Teil` auch dann, wenn ein funktional verwandter 
 | Logout All            | required    | Challenge belegt, Consume implementiert (LogoutAll-Intent via Step-up-Consume), kein E2E-Email-Flow-Test | Teil   | mittel  |
 | Devices               | required    | API aktiv (Liste, Self-Delete), RemoveDevice-Intent via Step-up-Consume implementiert, kein E2E-Email-Flow-Test | Teil   | mittel  |
 | Step-up Auth          | required    | Challenge-Store, Request, Consume für Magic-Link implementiert; `BeginPasskeyRegistration`-Consume erzeugt jetzt `registration_grant_id` (TTL 5 Min, single-use, account/device-gebunden); Handoff vollständig | Teil   | mittel  |
-| Passkeys              | optional    | Register-Options mit Grant-Handoff: Step-up erzeugt Grant, `register/options` konsumiert Grant und startet WebAuthn-Ceremony; PasskeyStore + `webauthn_user_id`-Writeback-Mutation vorhanden; register/verify und Login-/Management-Pfade offen | Teil  | mittel  |
+| Passkeys              | optional    | Register-Options mit Grant-Handoff: Step-up erzeugt Grant, `register/options` konsumiert Grant und startet WebAuthn-Ceremony; PasskeyStore + `webauthn_user_id`-Writeback-Mutation vorhanden; `register/verify` API-seitig implementiert (echte `finish_passkey_registration`, single-use, Duplicate-Detection, Writeback) — Negativpfade getestet, positiver Verify-Pfad braucht weiterhin Browser-/Authenticator-Beleg; Login-/Management-Pfade offen | Teil  | mittel  |
 | Sicherheitsinvarianten| required    | Codepfade für alle fünf Aspekte implementiert; Anti-Enumeration-Parität und systematische CSRF-Abdeckung aller aktuell gelisteten CSRF-pflichtigen mutierenden Endpunkte reproduzierbar belegt (Phase 7), ergänzt um eine quelltextbasierte CSRF-Routen-Drift-Prüfung gegen neue unklassifizierte Mutationsrouten; CI-Prüfung für den Runtime-Smoke des E-Mail-Rate-Limits bei `/auth/magic-link/request` hinzugefügt (READY_FOR_CI_PROOF), IP-Rate-Limit-Runtime-Beweis und End-to-End-Token-Leak-Test offen | Teil   | mittel  |
 
 ---
@@ -160,25 +160,27 @@ Ein Bereich erhält den Status `Teil` auch dann, wenn ein funktional verwandter 
 **Soll:** register (options + verify), auth (options + verify), list/remove.
 **Ist:**
 
-- `webauthn_user_id` als dedizierte UUID pro Account eingeführt (nicht aus `account_id` abgeleitet); wenn in der Datenquelle vorhanden: dauerhaft stabil; sonst: lazy-backfill/prozessstabil (Writeback-Persistenz ist Voraussetzung für Register-Verify, noch offen)
+- `webauthn_user_id` als dedizierte UUID pro Account eingeführt (nicht aus `account_id` abgeleitet); wenn in der Datenquelle vorhanden: dauerhaft stabil; sonst: lazy-backfill/prozessstabil. Writeback im Verify-Pfad implementiert (siehe unten); reale Datenquellen-Persistenz folgt mit persistenter Account-Ablage.
 - WebAuthn-Konfiguration (`rp_id`, `rp_origin`) aus `AppConfig` mit Validierung und Env-Override
 - `POST /auth/passkeys/register/options` implementiert: ohne `registration_grant_id` fail-closed mit `STEP_UP_REQUIRED` + `challenge_id`; mit gültigem Grant wird die WebAuthn-Ceremony gestartet und `registration_id` + `options` zurückgegeben
+- `POST /auth/passkeys/register/verify` API-seitig implementiert: prüft Session, fail-closed bei fehlender WebAuthn-Konfiguration (`503 PASSKEYS_NOT_CONFIGURED`), konsumiert `registration_id` single-use über `PasskeyRegistrationStore.consume(...)` (non-destructive bei Account-Mismatch), ruft `webauthn.finish_passkey_registration(...)` mit echter Kryptoprüfung auf, legt das resultierende `Passkey` über `PasskeyStore.insert(...)` ab (Duplicate-Detection → `409 CONFLICT`), schreibt `webauthn_user_id` via `AccountStore.update_webauthn_user_id(...)` zurück. Erfolg liefert `200 OK` mit `{"ok": true}` — keine Session, kein Cookie. Negativpfade (401, 503, 400 unknown/mismatch, 400 invalid credential, kein Session-Cookie) sind durch Integrationstests in `apps/api/tests/api_auth.rs` belegt; ein positiver Verify-Pfad mit echter Browser-/Authenticator-Antwort ist als Folgearbeit dokumentiert.
 - `PasskeyRegistrationGrantStore` (In-Memory, TTL 5 Min, single-use, account- und device-gebunden) eingeführt; Consume für `BeginPasskeyRegistration` erzeugt einen Grant
 - `PasskeyRegistrationStore` für laufende Registrierungen (In-Memory, TTL 5 Min) aktiv genutzt (nach Grant-Consume)
 - Langlebiger `PasskeyStore` für registrierte Credentials (In-Memory, account-gebunden, duplicate detection, list/find/remove)
 - `AccountStore.update_webauthn_user_id(account_id, uuid)` als Writeback-Mutation implementiert
-- **Offen:** Register-Verify, Auth-Options, Auth-Verify, Passkey-Login/-Management, UI
+- **Offen:** Positiver Verify-Pfad mit echter WebAuthn-Antwort (Browser-/Authenticator-Beleg), Auth-Options, Auth-Verify, Passkey-Login/-Management, persistente Ablage über Neustart, UI
 
 **Dokumentationsbelege:** auth-roadmap.md (Phase 4 aktualisiert), [reports/passkey-register-verify-prep.md](passkey-register-verify-prep.md) (Vorbereitungsbericht Register-Verify)
 **Code-, Test- und Verifikationsbelege:**
 
 - `apps/api/src/auth/passkeys.rs` — Modul mit Builder, Store, Registrierung
-- `apps/api/src/routes/auth.rs` — `passkey_register_options` Endpunkt
+- `apps/api/src/routes/auth.rs` — `passkey_register_options`- und `passkey_register_verify`-Endpunkte
+- `apps/api/src/routes/mod.rs` — Router-Eintrag `POST /auth/passkeys/register/verify`
 - `apps/api/src/config.rs` — `webauthn_rp_id`, `webauthn_rp_origin`, `webauthn_rp_name`
 - `apps/api/src/routes/accounts.rs` — `webauthn_user_id` am Account-Modell
-- Unit-Tests in `apps/api/src/auth/passkeys.rs` und `apps/api/src/auth/accounts.rs`; Integrationstests in `apps/api/tests/api_auth.rs`
+- Unit-Tests in `apps/api/src/auth/passkeys.rs` und `apps/api/src/auth/accounts.rs`; Integrationstests in `apps/api/tests/api_auth.rs` (inkl. `passkey_register_verify_*`-Negativpfade) und `apps/api/tests/auth_security_invariants.rs` (CSRF-Drift-Guard erfasst `POST /auth/passkeys/register/verify`)
 
-**Fehlende Belege:** Register-Verify, Auth-Flow, persistente Ablage über Neustart, E2E-UI
+**Fehlende Belege:** Positiver `register/verify`-Pfad mit echter WebAuthn-Antwort (Browser- oder Soft-Authenticator-Beleg — `webauthn-rs 0.5` enthält keinen integrierten Soft-Authenticator); Auth-Flow (Options/Verify); persistente Ablage über Neustart; E2E-UI
 **Status:** Teil
 **Risiko:** mittel
 

--- a/docs/reports/passkey-register-verify-prep.md
+++ b/docs/reports/passkey-register-verify-prep.md
@@ -301,8 +301,10 @@ Pfad C ist nachgelagert — sinnvoll als Teil des Folge-PR, nicht als separater 
 **Pfad B ist umgesetzt.** Damit ist Pfad A jetzt gangbar. Der nächste sinnvolle Schritt ist:
 
 ```text
-feat(auth): implement passkey register verify
+feat(auth): implement passkey register verify endpoint
 ```
+
+**Status:** Umgesetzt durch den genannten Folge-PR. Endpunkt `POST /auth/passkeys/register/verify` ist registriert, ruft `webauthn.finish_passkey_registration(...)` mit echter Kryptoprüfung auf, konsumiert die `registration_id` single-use, legt das Credential im `PasskeyStore` ab (mit Duplicate-Detection → `409 CONFLICT`) und schreibt `webauthn_user_id` zurück. Erfolg liefert `200 OK {"ok": true}` ohne Session/Cookie. Negativpfade (T2 401, T4/T6/T7 400, T8 503) sind getestet. T1 (positiver Pfad) und T9 (Duplicate-Detection auf API-Ebene) bleiben offen, weil sie eine echte WebAuthn-Antwort erfordern — siehe Restlücken.
 
 ---
 
@@ -386,9 +388,9 @@ Der `validate_relations`-Fehler ist **pre-existing** und nicht durch diesen PR v
 
 | Lücke | Konsequenz |
 |---|---|
-| Finaler Step-up-Handoff vor `register/options` fehlt | Der Intent ist ergänzt, aber die Ceremony-Übergabe ist noch nicht end-to-end geschlossen |
-| Kein persistenter Passkey-Store | In-Memory-Store ist vorhanden, verliert Daten bei Neustart |
-| Datenquellen-Writeback für `webauthn_user_id` im Register-Verify-Pfad fehlt | Mutation existiert, aber der echte Persistenzpunkt wird erst mit `register/verify` umgesetzt |
-| Test-Fixtures für `finish_passkey_registration` | `webauthn_rs` benötigt kryptografisch korrekte Antworten; Strategie für realistische Tests im Folge-PR festlegen |
-| `excludeCredentials` im `register/options` | Grundsätzlich an `PasskeyStore` angebunden; reale Wirkung erst nach Register-Verify und tatsächlicher Credential-Ablage |
-| E2E-Test für vollständige Register-Ceremony | Folgt aus Implementierung, nicht Vorbereitung |
+| Finaler Step-up-Handoff vor `register/options` fehlt | Geschlossen — `BeginPasskeyRegistration`-Consume erzeugt `registration_grant_id`; `register/options` konsumiert den Grant und startet die Ceremony |
+| Kein persistenter Passkey-Store | In-Memory-Store ist vorhanden, verliert Daten bei Neustart — `register/verify` legt Credentials ab, aber persistente Ablage bleibt offen |
+| Datenquellen-Writeback für `webauthn_user_id` im Register-Verify-Pfad fehlt | Mutation wird im Verify-Pfad aktiv aufgerufen; reale Datenquellen-Persistenz folgt mit persistenter Account-Ablage |
+| Test-Fixtures für `finish_passkey_registration` | `webauthn-rs 0.5.4` enthält keinen Soft-Authenticator (kein `softpasskey`-Modul, kein `SoftToken`); eine seriöse positive Verifikation benötigt entweder einen Browser-E2E oder eine separate Authenticator-Crate (z.B. `webauthn-authenticator-rs`) — beides ist nicht Teil des Folge-PR. Negativpfade nutzen strukturell gültige aber kryptografisch ungültige `RegisterPublicKeyCredential`-JSON-Payloads und treffen `finish_passkey_registration` echt. |
+| `excludeCredentials` im `register/options` | Grundsätzlich an `PasskeyStore` angebunden; reale Wirkung greift erst, sobald positiv verifizierte Credentials abgelegt sind |
+| E2E-Test für vollständige Register-Ceremony | Folgt aus Browser-/Authenticator-Beleg — bleibt offene Folgearbeit |

--- a/docs/specs/auth-api.md
+++ b/docs/specs/auth-api.md
@@ -248,6 +248,62 @@ device-gebunden). Ohne Grant liefert der Endpunkt `403 STEP_UP_REQUIRED` mit
 
 `POST /auth/passkeys/register/verify`
 
+**Voraussetzung:** Aktive authentifizierte Session und eine zuvor aus
+`POST /auth/passkeys/register/options` erhaltene `registration_id`.
+
+**Zweck:** Schließt die WebAuthn-Registrierung ab. Der Server verifiziert die vom
+Client gelieferte `RegisterPublicKeyCredential` echt kryptographisch über
+`webauthn.finish_passkey_registration(...)`. Bei Erfolg wird das `Passkey` im
+account-gebundenen Credential-Store abgelegt; eine vorhandene `webauthn_user_id`
+des Accounts wird in die Datenquelle zurückgeschrieben. Der Endpunkt etabliert
+**keine neue Session** und setzt **keine Cookies**.
+
+**Request-Body:**
+
+```json
+{
+  "registration_id": "<uuid aus register/options>",
+  "credential": { }
+}
+```
+
+- `registration_id`: Opaque UUID aus dem `register/options`-Response. Single-use
+  und account-gebunden. Wird vor der WebAuthn-Verifikation konsumiert, sodass
+  jeder Verify-Versuch — auch ein kryptographisch fehlgeschlagener — die
+  `registration_id` verbraucht. Erneute Aufrufe mit derselben ID schlagen mit
+  `REGISTRATION_INVALID` fehl; der Client muss eine neue Ceremony starten.
+- `credential`: Vollständige `RegisterPublicKeyCredential` aus
+  `navigator.credentials.create()`. Die Shape entspricht dem webauthn-rs-Protokoll.
+
+**Response `200 OK`:**
+
+```json
+{ "ok": true }
+```
+
+**Fehlerfälle:**
+
+| HTTP-Status | `error`-Code                   | Ursache                                                              |
+|-------------|--------------------------------|----------------------------------------------------------------------|
+| `401`       | `UNAUTHORIZED`                 | Keine aktive Session                                                 |
+| `503`       | `PASSKEYS_NOT_CONFIGURED`      | WebAuthn ist auf diesem Server nicht konfiguriert                    |
+| `400`       | `REGISTRATION_INVALID`         | `registration_id` unbekannt, abgelaufen oder gehört zu anderem Account |
+| `400`       | `CREDENTIAL_INVALID`           | WebAuthn-Verifikation der Credential-Antwort fehlgeschlagen          |
+| `409`       | `CREDENTIAL_ALREADY_REGISTERED`| Credential-ID ist bereits an einen Account gebunden                  |
+
+**Architekturanmerkungen:**
+
+- Account-Mismatch (`registration_id` gehört einem anderen Account) ist
+  non-destructive: die Registrierung bleibt für den rechtmäßigen Account
+  konsumierbar (`PasskeyRegistrationStore`-Semantik).
+- Eine fehlgeschlagene Credential-Verifikation verbrennt die `registration_id`
+  trotzdem (consume-first-Semantik). Das ist beabsichtigt: WebAuthn-Ceremonies
+  sind single-use; ein zweiter Versuch mit demselben Server-State wäre
+  semantisch ungültig.
+- Persistente Credential-Ablage über Neustart und ein Datenquellen-Writeback der
+  `webauthn_user_id` setzen eine persistente Account-/Passkey-Datenquelle
+  voraus, die in dieser Phase noch nicht existiert.
+
 ### Login starten
 
 `POST /auth/passkeys/auth/options`


### PR DESCRIPTION
Closes the gap identified in auth-status-matrix.md §2.8 and the register-verify prep report: register/options was implemented, but register/verify was missing, so the WebAuthn registration ceremony could not be completed.

Changes:
- apps/api/src/routes/auth.rs: new `passkey_register_verify` handler. Checks session (401), WebAuthn configuration (503), consumes the `registration_id` single-use via `PasskeyRegistrationStore.consume` (non-destructive on account mismatch; consume-first means a failed verification still burns the registration), calls `webauthn.finish_passkey_registration(&credential, &reg_state)` with real cryptographic verification (no mock, no bypass), stores the resulting `Passkey` in `PasskeyStore` (duplicate credential IDs → 409 CREDENTIAL_ALREADY_REGISTERED), and writes the account's `webauthn_user_id` back via `AccountStore.update_webauthn_user_id`. Success returns 200 OK with `{"ok": true}` — no session, no cookie.
- apps/api/src/routes/mod.rs: register the new route `POST /auth/passkeys/register/verify`.
- apps/api/tests/api_auth.rs: five new integration tests covering the negative paths — unauthenticated (401), not configured (503), unknown registration_id (400 REGISTRATION_INVALID), wrong-account rejection with non-destructive proof that the legitimate owner can still consume the registration, and invalid credential (400 CREDENTIAL_INVALID) including a single-use proof on the second attempt and a guard that no session cookie is set on failure. The invalid-credential path uses a structurally valid but cryptographically bogus `RegisterPublicKeyCredential` JSON so `finish_passkey_registration` runs the real crypto checks.
- apps/api/tests/auth_security_invariants.rs: add the new route to `CSRF_COVERED_MUTATING_ROUTES` so the drift guard passes; the existing `csrf_blocks_all_mutating_endpoints_without_origin` test now also covers register/verify.
- docs/specs/auth-api.md: fill in the register/verify contract (request body, 200 OK response, full error matrix incl. 409 CREDENTIAL_ALREADY_REGISTERED, consume-first semantics, no session, no cookie).
- docs/blueprints/auth-roadmap.md: mark Phase 4 register/verify as in-progress (~). API path implemented; positive verify path with a real WebAuthn response remains open because webauthn-rs 0.5 ships no soft authenticator and no browser/authenticator-driven proof is part of this PR.
- docs/reports/auth-status-matrix.md: update §2.8 with the new endpoint and explicitly keep the missing-evidence list (positive verify proof, persistent storage, auth flow, UI).
- docs/reports/passkey-register-verify-prep.md: mark the follow-up PR as implemented; update §11 restlücken to reflect what shifted and what stays open (soft-authenticator gap, persistent passkey store, account data-source writeback).

Not in scope (kept open intentionally):
- POST /auth/passkeys/auth/options, /auth/verify
- GET /auth/passkeys, DELETE /auth/passkeys/:id
- UI activation of the passkey CTA
- Browser E2E
- Persistent passkey/account data source
- SessionBackend / DbSessionStore changes

Verified:
- `cargo fmt --check` clean
- `cargo clippy --locked --tests -- -D warnings` clean
- `cargo test --locked -p weltgewebe-api` green (146 unit, 80 api_auth, 4 auth_security_invariants — including the CSRF drift guard — plus all other suites)
- `git diff --check` clean

https://claude.ai/code/session_017jncgsbW5yLChnYJtWk5kr