### PR TITLE
Add Task-Control blueprint, roadmap, and examples; update docs index and master roadmap

### DIFF
--- a/docs/blueprints/doc-structure-task-control-examples.md
+++ b/docs/blueprints/doc-structure-task-control-examples.md
@@ -1,0 +1,381 @@
+---
+id: blueprint-doc-structure-task-control-examples
+title: Dokumentationsstruktur und Task-Steuerung Beispiele
+doc_type: reference
+status: draft
+summary: >
+  Beispielhafte JSON-, Markdown-, YAML- und Workflow-Skizzen für die spätere
+  Umsetzung der Task-Control-Schicht.
+relations:
+  - type: depends_on
+    target: docs/blueprints/doc-structure-task-control.md
+  - type: relates_to
+    target: docs/blueprints/doc-structure-task-control-roadmap.md
+---
+
+# Beispiele: Dokumentationsstruktur und Task-Steuerung
+
+## 0. Rolle
+
+Diese Datei sammelt Beispiele. Sie ist **keine** Umsetzung. Beispiele dürfen
+nicht als existierende Repo-Struktur gelesen werden, solange die genannten
+Dateien nicht tatsächlich angelegt und validiert sind.
+
+## 1. README-Schnellzugriff
+
+```markdown
+## Schnellzugriff
+
+- [Dokumentationsindex](docs/index.md)
+- [Beitragen](CONTRIBUTING.md)
+- [Agenten-Leitfaden](AGENTS.md)
+- [Task-Board](docs/tasks/board.md)
+- [Optimierungsstatus](docs/reports/optimierungsstatus.md)
+- [Deploy-Änderungsprotokoll](docs/deploy/CHANGELOG.md)
+- [Dokumentenindex](docs/_generated/doc-index.md)
+- [Implementierungsindex](docs/_generated/impl-index.md)
+```
+
+Akzeptanz:
+
+- Alle Links existieren.
+- README erklärt Einstieg, Wahrheit, Diagnose und Task-Steuerung getrennt.
+
+## 2. Task-Board
+
+```markdown
+# Task Board
+
+## Aktive Prioritäten
+
+| ID | Bereich | Status | Priorität | Evidenz | Nächste Aktion |
+|---|---|---|---|---|---|
+
+## Blocker
+
+| ID | Blocker | Fehlt | Folge |
+|---|---|---|---|
+
+## Nächste PR-Kandidaten
+
+| ID | PR-Schnitt | Akzeptanzkriterium |
+|---|---|---|
+
+## Links
+
+- Optimierungsstatus: ../reports/optimierungsstatus.md
+- Maschinenindex: index.json
+- Agent Readiness: ../_generated/agent-readiness.md
+```
+
+Akzeptanz:
+
+- Jedes offene High-Priority-Paket hat eine nächste Aktion.
+- Keine Aufgabe ohne Evidenz-Link oder explizite Leerstelle.
+
+## 3. Task-Index JSON
+
+```json
+{
+  "schema_version": "1.0.0",
+  "generated_at": "2026-05-28T00:00:00Z",
+  "source_files": [
+    "docs/reports/optimierungsstatus.md",
+    "docs/reports/auth-status-matrix.json",
+    "docs/reports/map-status-matrix.json"
+  ],
+  "tasks": [
+    {
+      "id": "OPT-DOC-001",
+      "title": "README als Einstiegskarte neu schneiden",
+      "area": "docs",
+      "status": "open",
+      "priority": "high",
+      "effort": "S",
+      "risk": "low",
+      "owner": "unknown",
+      "evidence": [
+        "README.md",
+        "docs/index.md"
+      ],
+      "missing_evidence": [],
+      "acceptance": [
+        "README enthält Schnellzugriff",
+        "Alle Links existieren",
+        "README erklärt Navigation vs Wahrheit"
+      ],
+      "links": {
+        "issues": [],
+        "prs": [],
+        "docs": [
+          "README.md",
+          "docs/index.md"
+        ]
+      },
+      "updated_at": "2026-05-28"
+    }
+  ]
+}
+```
+
+Akzeptanz:
+
+- Jede Task-ID ist eindeutig.
+- Jeder Pfad existiert oder wird als fehlend markiert.
+- High-Priority-Tasks ohne Akzeptanzkriterien schlagen fehl.
+
+## 4. Optimierungsstatus JSON
+
+```json
+{
+  "schema_version": "1.0.0",
+  "source_markdown": "docs/reports/optimierungsstatus.md",
+  "items": [
+    {
+      "id": "OPT-DOC-001",
+      "area": "docs",
+      "status": "open",
+      "priority": "high",
+      "evidence_status": "partial",
+      "evidence": [],
+      "missing_evidence": [
+        "maschinenlesbarer Statuszwilling fehlt"
+      ],
+      "next_action": "optimierungsstatus.json einführen",
+      "risk": "medium",
+      "updated_at": "2026-05-28"
+    }
+  ]
+}
+```
+
+Akzeptanz:
+
+- Enthält alle `OPT-*`-Einträge aus `optimierungsstatus.md`.
+- Kein Statuswechsel ohne Evidenz.
+- Wird durch CI validiert.
+
+## 5. Issue Form für Arbeitspakete
+
+```yaml
+name: Arbeitspaket
+description: Strukturiertes Task-Issue für Repo, Doku und CI
+title: "[Task]: "
+labels: ["kind:task", "status:triage"]
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Bereich
+      options:
+        - docs
+        - ci
+        - api
+        - web
+        - infra
+        - release
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priorität
+      options:
+        - high
+        - medium
+        - low
+    validations:
+      required: true
+
+  - type: input
+    id: task_id
+    attributes:
+      label: Interne Task-ID
+      placeholder: OPT-DOC-001
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Was ist konkret unklar, gebrochen oder unverbunden?
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Akzeptanzkriterien
+      description: Ein Kriterium pro Zeile.
+    validations:
+      required: true
+
+  - type: textarea
+    id: docs_paths
+    attributes:
+      label: Relevante Dokumentpfade
+      placeholder: |
+        README.md
+        docs/index.md
+        docs/reports/optimierungsstatus.md
+    validations:
+      required: true
+```
+
+## 6. PR-Meta-Template
+
+```markdown
+<!-- .github/pull_request_template.md -->
+
+## Kontext
+- related-task:
+- related-docs:
+- related-issue:
+
+## Änderung
+- Was wurde verändert?
+- Warum hier?
+- Welche Pfade sind betroffen?
+
+## Nachweis
+- Tests:
+- Doku aktualisiert:
+- Restlücken:
+
+## Release-Hinweis
+- [ ] release-note:feature
+- [ ] release-note:fix
+- [ ] release-note:docs
+- [ ] chore/no-release
+```
+
+## 7. Label-Taxonomie
+
+```text
+area:docs
+area:ci
+area:api
+area:web
+area:infra
+area:release
+
+kind:task
+kind:bug
+kind:doc-drift
+kind:decision
+kind:proof
+kind:refactor
+
+prio:high
+prio:medium
+prio:low
+
+status:triage
+status:ready
+status:blocked
+status:in-progress
+status:needs-review
+
+needs-doc
+needs-proof
+blocked
+
+release-note:feature
+release-note:fix
+release-note:docs
+chore/no-release
+```
+
+## 8. Release-Kategorien
+
+```yaml
+changelog:
+  categories:
+    - title: Features
+      labels:
+        - release-note:feature
+    - title: Fixes
+      labels:
+        - release-note:fix
+    - title: Documentation
+      labels:
+        - release-note:docs
+    - title: Maintenance
+      labels:
+        - chore
+  exclude:
+    labels:
+      - chore/no-release
+```
+
+## 9. Task-Index Workflow
+
+```yaml
+name: task-index
+
+on:
+  pull_request:
+    paths:
+      - "README.md"
+      - "CONTRIBUTING.md"
+      - "docs/**"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/workflows/task-index.yml"
+      - "scripts/docmeta/**"
+  workflow_dispatch: {}
+  schedule:
+    - cron: "17 3 * * *"
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  validate-task-index:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate task index
+        run: python3 scripts/docmeta/generate_task_index.py --check
+      - name: Validate task index
+        run: python3 scripts/docmeta/validate_task_index.py docs/tasks/index.json
+```
+
+Wichtig: PR-Checks sollen prüfen, nicht still schreiben. Automatische Commits
+gehören in separate Bot-PRs.
+
+## 10. Agenten-Prompts
+
+### Dok-Drift-Auditor
+
+```text
+Vergleiche README.md, CONTRIBUTING.md, docs/index.md, repo.meta.yaml,
+audit/impl-registry.yaml und docs/_generated/*.md.
+
+Liste nur belegte Inkonsistenzen.
+Prüfe jeden referenzierten Pfad auf Existenz.
+Unterscheide Navigation, Diagnose, Wahrheit und Arbeitspaket.
+Erzeuge keine stillen Umdeutungen.
+```
+
+### Task-Reconciler
+
+```text
+Lies docs/tasks/index.json, docs/reports/optimierungsstatus.json,
+offene Issues mit kind:task, Project-Felder und audit/impl-registry.yaml.
+
+Melde alle Maßnahmen ohne Owner, ohne Akzeptanzkriterien,
+ohne Evidenz-Link oder mit nicht existierenden Pfaden.
+```
+
+### Release-Notes-Kurator
+
+```text
+Gruppiere gemergte PRs nach release-note:* Labels.
+Verlinke relevante Dokuänderungen.
+Ignoriere chore/no-release.
+Markiere PRs ohne Release-Kategorie als review_needed.
+```

--- a/docs/blueprints/doc-structure-task-control-roadmap.md
+++ b/docs/blueprints/doc-structure-task-control-roadmap.md
@@ -1,0 +1,212 @@
+---
+id: blueprint-doc-structure-task-control-roadmap
+title: Dokumentationsstruktur und Task-Steuerung Roadmap
+doc_type: roadmap
+status: draft
+summary: >
+  Phasenplan und PR-Schnitte für die Einführung einer Task-Control-Schicht
+  zwischen Navigation, Statusmatrizen, Task-Artefakten und GitHub-Umlauf.
+relations:
+  - type: depends_on
+    target: docs/blueprints/doc-structure-task-control.md
+  - type: relates_to
+    target: docs/reports/optimierungsstatus.md
+  - type: relates_to
+    target: docs/blueprints/doc-structure-task-control-examples.md
+---
+
+# Roadmap: Dokumentationsstruktur und Task-Steuerung
+
+## 0. Rolle
+
+Diese Roadmap ist der operative Begleitplan zur
+[Blaupause](doc-structure-task-control.md). Sie ist **draft** und wird erst zur
+stabilen Statusquelle, wenn die ersten Task-Artefakte implementiert und durch
+Guards validiert sind.
+
+Die Master-Roadmap darf auf dieses Dokument als thematischen Arbeitsstrang
+verweisen. Die fachliche Begründung bleibt in der Blaupause; belegte
+Umsetzungsstände bleiben in Statusmatrizen und PR-Nachweisen.
+
+## Phase 0: Diagnose-Gate
+
+Ziel: Belegen, was aktuell fehlt, bevor neue Struktur eingeführt wird.
+
+Checks:
+
+```bash
+test -f docs/tasks/board.md || echo "missing docs/tasks/board.md"
+test -f docs/tasks/index.json || echo "missing docs/tasks/index.json"
+test -f docs/reports/optimierungsstatus.json || echo "missing optimierungsstatus.json"
+test -d .github/ISSUE_TEMPLATE || echo "missing issue templates"
+test -f .github/pull_request_template.md || echo "missing PR template"
+test -f .github/release.yml || echo "missing release categories"
+```
+
+Stop-Kriterium:
+
+- Fehlende Dateien sind eindeutig benannt.
+- Kein Patch vor belegtem Ist-Zustand.
+
+## Phase 1: Einstieg und Navigation stabilisieren
+
+Scope:
+
+```text
+README.md
+CONTRIBUTING.md
+docs/index.md
+repo.meta.yaml
+```
+
+Änderungen:
+
+- README Quicklinks ergänzen.
+- README-Pfade korrigieren.
+- `CONTRIBUTING.md` an reale Repo-Struktur anpassen.
+- `docs/index.md` um relevante Diagnoseartefakte ergänzen.
+- `repo.meta.yaml` nur ändern, wenn neue Artefakte tatsächlich eingeführt
+  werden und ihre Rolle geklärt ist.
+
+Akzeptanz:
+
+- Alle Links existieren.
+- Keine Verweise auf nicht vorhandene Pfade.
+- `docs/index.md` erklärt Navigation vs Wahrheit.
+- `repo.meta.yaml` und `docs/index.md` widersprechen sich nicht.
+
+## Phase 2: Task-Control-Schicht einführen
+
+Scope:
+
+```text
+docs/tasks/README.md
+docs/tasks/board.md
+docs/tasks/index.json
+docs/tasks/schema.json
+docs/reports/optimierungsstatus.json
+```
+
+Änderungen:
+
+- Menschliches Task-Board anlegen.
+- JSON-Task-Index und Schema anlegen.
+- Maschinenlesbaren Zwilling für `optimierungsstatus.md` einführen.
+- Pflege- und Generierungsstatus der JSON-Artefakte explizit dokumentieren.
+
+Akzeptanz:
+
+- Alle offenen Top-Prioritäten erscheinen im Board.
+- JSON ist valide.
+- Jede Task-ID ist eindeutig.
+- High-Priority-Tasks haben Akzeptanzkriterien.
+- Geschlossene Tasks haben Evidenz.
+
+## Phase 3: GitHub-native Arbeitsobjekte anbinden
+
+Scope:
+
+```text
+.github/ISSUE_TEMPLATE/*.yml
+.github/pull_request_template.md
+.github/release.yml
+docs/process/labels.md
+```
+
+Änderungen:
+
+- Issue Forms einführen.
+- Leichtes PR-Meta-Template einführen.
+- Label-Taxonomie dokumentieren.
+- Optional GitHub Project v2 konfigurieren, aber nur nach Klärung von Rechten
+  und Ownern.
+
+Akzeptanz:
+
+- Neue Arbeitspakete enthalten Task-ID, Bereich, Priorität und
+  Akzeptanzkriterien.
+- PRs verweisen auf Tasks, Docs oder Issues.
+- Labels folgen derselben Taxonomie wie Issue Forms und Release Notes.
+- Das Template bleibt kurz genug, damit keine Formularlyrik entsteht.
+
+## Phase 4: Generator und Guard integrieren
+
+Scope:
+
+```text
+scripts/docmeta/generate_task_index.py
+scripts/docmeta/validate_task_index.py
+.github/workflows/task-index.yml
+.github/workflows/docs-guard.yml
+```
+
+Änderungen:
+
+- Task-Index deterministisch erzeugen oder im Check-Modus validieren.
+- Pfade, Statuswerte, Akzeptanzkriterien und Evidenz prüfen.
+- PR-Checks prüfen, aber schreiben nicht still in den Branch.
+
+Akzeptanz:
+
+- PR-Checks erkennen Drift.
+- Task-Index wird deterministisch erzeugt.
+- Generated-Files-Regel wird respektiert.
+- Fehlende Evidenz wird nicht geglättet, sondern gemeldet.
+
+## Phase 5: Implementierungs-Mapping schließen
+
+Scope:
+
+```text
+audit/impl-registry.yaml
+docs/_generated/impl-index.md
+docs/_generated/doc-coverage.md
+```
+
+Änderungen:
+
+- `audit/impl-registry.yaml` für Kernpfade mit `documented_by` und
+  `verified_by` füllen.
+- `docs/_generated/impl-index.md` als Gate-Signal nutzen, nicht manuell
+  ändern.
+- Kernbereiche API, Web, CI, Compose und Contracts priorisieren.
+
+Akzeptanz:
+
+- Kernimplementierungen sind nicht mehr „undocumented“.
+- Jede Kernimplementierung hat mindestens ein Doku- und ein Prüfartefakt.
+- Agents können von Task → Implementierung → Proof navigieren.
+
+## PR-Schnitte
+
+| PR | Fokus | Dateien | Akzeptanz |
+|---|---|---|---|
+| PR 1 | Navigation reparieren | `README.md`, `CONTRIBUTING.md`, `docs/index.md`, `repo.meta.yaml` | Links korrekt, reale Topologie, Rollen erklärt |
+| PR 2 | Task-Artefakte | `docs/tasks/*`, `docs/reports/optimierungsstatus.json` | JSON valide, Top-Prioritäten sichtbar |
+| PR 3 | GitHub-Struktur | Issue Forms, PR-Template, Release-Konfig, Labels-Doku | strukturierte Issues und Release-Kategorien |
+| PR 4 | Generator und CI | Docmeta-Skripte, Task-Index-Workflow | deterministische Prüfung, Drift-Erkennung |
+| PR 5 | Implementierungs-Mapping | `audit/impl-registry.yaml`, generierte Diagnosen | Kernpfade verknüpft und belegbar |
+
+## Messbare Erfolgskriterien
+
+Nach Umsetzung sollte gelten:
+
+```text
+README broken links: 0
+CONTRIBUTING non-existing path references: 0
+High-priority tasks without acceptance: 0
+Closed tasks without evidence: 0
+Duplicate task IDs: 0
+Generated docs missing from docs/index.md: 0
+Generated docs missing from repo.meta.yaml: 0
+Task JSON schema validation: pass
+Docs guard: pass
+```
+
+Optional:
+
+```text
+Open GitHub issues without task_id: 0 for kind:task
+PRs without related-task or related-docs: warning
+Release PRs without release-note label: warning
+```

--- a/docs/blueprints/doc-structure-task-control.md
+++ b/docs/blueprints/doc-structure-task-control.md
@@ -1,0 +1,326 @@
+---
+id: blueprint-doc-structure-task-control
+title: Weltgewebe Dokumentationsstruktur und Task-Steuerung
+doc_type: blueprint
+status: draft
+summary: >
+  Zielbild für eine schmale Task-Control-Schicht, die Navigation,
+  Optimierungsstatus, maschinenlesbare Task-Artefakte und GitHub-Arbeitsobjekte
+  verbindet, ohne eine neue Wahrheitsschicht einzuführen.
+relations:
+  - type: relates_to
+    target: docs/reports/optimierungsstatus.md
+  - type: relates_to
+    target: docs/blueprints/agent-operability-blaupause.md
+  - type: relates_to
+    target: docs/blueprints/doc-structure-task-control-roadmap.md
+  - type: relates_to
+    target: docs/blueprints/doc-structure-task-control-examples.md
+---
+
+# Blaupause: Dokumentationsstruktur und Task-Steuerung für Weltgewebe
+
+## 0. Status und Grenze
+
+Dieses Dokument ist ein **Zielbild**, keine Umsetzung und keine neue
+Wahrheitsschicht. Es beschreibt, welche operative Task-Control-Schicht später
+entstehen soll. Verbindliche Statuswechsel bleiben bei den vorhandenen
+Statusmatrizen und belegten Repo-Artefakten.
+
+Die operative Reihenfolge lebt in
+[doc-structure-task-control-roadmap.md](doc-structure-task-control-roadmap.md).
+Konkrete YAML-, JSON- und Workflow-Beispiele leben in
+[doc-structure-task-control-examples.md](doc-structure-task-control-examples.md).
+
+## 1. Kurzfassung
+
+Weltgewebe besitzt bereits eine starke Dokumentationsmaschine. Es fehlen nicht
+primär weitere Dokumente, sondern eine klarere Arbeitsumlaufbahn zwischen
+Orientierung, Nachweis und Arbeitspaket:
+
+```text
+README.md
+→ docs/index.md
+→ docs/tasks/
+→ docs/reports/optimierungsstatus.{md,json}
+→ GitHub Issues / Projects / PRs / Release Labels
+```
+
+Ziel ist weniger Kontextverlust zwischen Navigation, belegtem Status und
+konkreter Arbeit. Das Repo hat ein Gedächtnis; die Task-Control-Schicht soll
+das Kurzzeitgedächtnis ergänzen.
+
+## 2. These / Antithese / Synthese
+
+### These
+
+Das Repo ist bereits ungewöhnlich agenten- und dokumentationsorientiert.
+Vorhanden sind unter anderem:
+
+- Frontmatter und Docmeta-Struktur,
+- `AGENTS.md` als agentischer Leseleitfaden,
+- `repo.meta.yaml` als Truth-Model- und Precedence-Schicht,
+- generierte Diagnoseartefakte unter `docs/_generated/`,
+- Statusmatrizen für einzelne Bereiche,
+- Dokumenten-Relations- und Coverage-Mechanismen.
+
+### Antithese
+
+Die vorhandene Stärke ist fragmentiert. Aufgaben, Nachweise und
+Navigationspunkte liegen verteilt in README, Fahrplan, Reports, generierten
+Diagnosen und Statusmatrizen. GitHub-native Arbeitsobjekte wie Issues,
+Project-Felder, Issue Forms und Labels sind noch nicht ausreichend als
+Steuerungsschicht angebunden.
+
+### Synthese
+
+Die bestehende Dokumentationsintelligenz bleibt erhalten, wird aber durch eine
+schmale, maschinenlesbare Task-Control-Schicht ergänzt:
+
+- `docs/tasks/board.md` für Menschen,
+- `docs/tasks/index.json` für Agents,
+- `docs/reports/optimierungsstatus.json` als maschinenlesbarer Zwilling,
+- Issue Forms für strukturierte Arbeitspakete,
+- leichtes PR-Meta-Template,
+- Label-Taxonomie,
+- Generator und Guard für Task-Index, Konsistenz und Drift.
+
+## 3. Ziele
+
+Menschen sollen schneller erkennen:
+
+- was offen ist,
+- was priorisiert ist,
+- wo Nachweise liegen,
+- welche Datei autoritativ ist,
+- was nur Navigation oder Diagnose ist.
+
+Agents sollen zuverlässiger:
+
+- To-dos erkennen,
+- Status und Evidenz auswerten,
+- Pfade prüfen,
+- fehlende Akzeptanzkriterien melden,
+- GitHub-Issues, PRs und Dokumente miteinander verbinden.
+
+Das Repo soll vermeiden:
+
+- doppelte Task-Wahrheiten,
+- veraltete Navigationspfade,
+- Markdown-only-Steuerung,
+- „optimiert, aber nicht nachweisbar“,
+- Agenten-Halluzination durch veraltete Pfade.
+
+## 4. Nicht-Ziele
+
+Diese Blaupause ist ausdrücklich nicht:
+
+- ein vollständiger Umbau der Dokumentation,
+- eine Ablösung von `docs/` durch GitHub Projects,
+- ein schweres PR-Bürokratieformular,
+- eine Einführung von Agents als Default-Branch-Schreiber,
+- eine neue Wahrheitsschicht neben bestehenden Dokumenten.
+
+GitHub-Issues und Projects sind Arbeitsobjekte, nicht Wahrheit. Markdown und
+JSON bleiben repo-lokale Artefakte. Die Arbeitsebene bekommt nur bessere
+Umlaufbahnen.
+
+## 5. Grundprinzipien
+
+### 5.1 Navigation ≠ Wahrheit
+
+`docs/index.md`, `docs/tasks/board.md` und generierte `_generated`-Artefakte
+sind Navigation, Diagnose oder Arbeitssteuerung. Sie dürfen auf Wahrheit
+verweisen, aber nicht still Wahrheit ersetzen.
+
+### 5.2 Markdown für Menschen, JSON für Maschinen
+
+Jede operative Statusfläche mit längerfristiger Steuerungsfunktion braucht
+einen maschinenlesbaren Zwilling. Bestehende Muster wie
+`auth-status-matrix.{md,json}` und `map-status-matrix.{md,json}` werden dafür
+als Strukturvorbild genutzt, nicht als automatische Wahrheitserweiterung.
+
+### 5.3 Task-ID vor Freitext
+
+Jedes relevante Arbeitspaket bekommt eine stabile ID, zum Beispiel:
+
+```text
+OPT-DOC-001
+OPT-TASK-002
+OPT-AGENT-003
+AUTH-PERSIST-004
+MAP-VIS-005
+```
+
+Diese ID verbindet Markdown-Abschnitt, JSON-Eintrag, Issue, PR,
+Implementierung, Nachweis und Restlücke.
+
+### 5.4 Diagnose darf laut sein
+
+Generated Reports wie `impl-index`, `doc-coverage`, `orphans`,
+`knowledge-gaps`, `staleness-report`, `relations-analysis` und
+`relates-to-audit` sollen nicht versteckt bleiben. Sie gehören in die vordere
+Navigation, bleiben aber Diagnose.
+
+### 5.5 Agents schreiben Vorschläge, keine Wahrheit
+
+Agents dürfen lesen, prüfen, indizieren, Drift melden, PRs vorbereiten und
+Task-Vorschläge erzeugen. Sie dürfen keinen erledigten Status ohne Evidenz
+setzen, Markdown-Lücken nicht interpretativ glätten und nicht vorhandene Pfade
+nicht als Zielpfade verwenden.
+
+## 6. Zielartefakte
+
+Die Task-Control-Schicht besteht aus schmalen, getrennten Artefakten:
+
+| Artefakt | Rolle | Wahrheitsstatus |
+|---|---|---|
+| `docs/tasks/README.md` | Einstieg in Task-Control | Orientierung |
+| `docs/tasks/board.md` | Menschliche Arbeitskarte | Arbeitssteuerung, keine Wahrheit |
+| `docs/tasks/index.json` | Maschinenlesbarer Task-Index | abgeleitet / validiert |
+| `docs/tasks/schema.json` | Schema für Task-Index | Validierungsvertrag |
+| `docs/reports/optimierungsstatus.json` | Maschinenlesbarer Zwilling des Markdown-Status | abgeleitet aus Statusmatrix |
+| Issue Forms | GitHub-native Eingabe strukturierter Tasks | Arbeitsobjekte |
+| PR-Template | leichter Review-Kontext | Arbeitsobjekt |
+| Label-Taxonomie | Triage- und Release-Sprache | Prozesskonvention |
+| Generator/Guard | Drift-Abwehr | Prüfmechanismus |
+
+Wichtig: Sobald `docs/tasks/index.json` oder
+`docs/reports/optimierungsstatus.json` eingeführt werden, muss explizit
+entschieden werden, ob sie generiert, kuratiert oder hybrid gepflegt werden.
+Sie dürfen nicht unmarkiert als zweite Wahrheit entstehen.
+
+## 7. Vorgeschlagene Zielstruktur
+
+```text
+README.md
+CONTRIBUTING.md
+AGENTS.md
+repo.meta.yaml
+
+docs/
+  index.md
+  tasks/
+    README.md
+    board.md
+    index.json
+    schema.json
+  reports/
+    optimierungsstatus.md
+    optimierungsstatus.json
+    auth-status-matrix.md
+    auth-status-matrix.json
+    map-status-matrix.md
+    map-status-matrix.json
+
+.github/
+  ISSUE_TEMPLATE/
+    task.yml
+    bug.yml
+    doc-drift.yml
+    decision.yml
+  pull_request_template.md
+  release.yml
+  workflows/
+    task-index.yml
+
+scripts/docmeta/
+  generate_task_index.py
+  validate_task_index.py
+  sync_optimierungsstatus_json.py
+```
+
+## 8. Governance-Schnitt
+
+### 8.1 Einstieg und Navigation
+
+README und `docs/index.md` sollen schneller erklären:
+
+- wo Orientierung beginnt,
+- welche Dokumente Wahrheit tragen,
+- welche Artefakte Diagnose sind,
+- wo aktive Arbeitspakete liegen.
+
+### 8.2 Task-Control
+
+`docs/tasks/board.md` ist die menschliche Arbeitskarte.
+`docs/tasks/index.json` ist die maschinenlesbare Sicht. Beide dürfen nur dann
+Status verdichten, wenn Evidenz oder eine explizite Leerstelle benannt ist.
+
+### 8.3 GitHub-Umlauf
+
+Issues, PRs, Labels und Release Notes bilden den Umlauf für Kollaboration und
+Review. Sie ersetzen keine repo-lokale Wahrheit.
+
+### 8.4 Generator und Guard
+
+Generatoren dürfen Indizes schreiben oder prüfen. PR-Checks sollen Drift
+melden; automatische Commits gehören in separate Bot-PRs, nicht in stille
+PR-Checks.
+
+## 9. Entscheidungslogik
+
+Diese Blaupause gilt, wenn folgende Prämissen stimmen:
+
+1. Weltgewebe soll langfristig agentenlesbar bleiben.
+2. Offene Aufgaben sollen nicht nur im Fließtext existieren.
+3. GitHub Issues/PRs/Projects sollen Arbeitsumlauf sein, nicht Wahrheitsschicht.
+4. Generated Artefacts sollen Diagnose liefern, aber nicht manuell gepflegt werden.
+5. Statusänderungen brauchen Evidenz.
+
+Wenn diese Prämissen nicht stimmen, ist ein anderer Pfad sinnvoll.
+
+## 10. Alternativen
+
+### Pfad A: GitHub-first
+
+Alles wird über Issues und Projects gesteuert; Markdown verweist nur noch.
+Das verbessert UI und Verantwortlichkeit, schwächt aber repo-lokale Analyse und
+Offline-Fähigkeit.
+
+### Pfad B: Docs-only
+
+Alles bleibt in Markdown/JSON. Das ist dumpbar und plattformarm, aber schwächer
+für Triage, Review und Verantwortlichkeit.
+
+### Empfohlener Pfad: Hybrid
+
+Markdown/JSON bleibt Quelle für Struktur und Nachweis. GitHub liefert Umlauf,
+Review und Kollaboration. Das passt am besten zu einem bereits
+dokumentationszentrierten Repo, das Arbeitssteuerung braucht.
+
+## 11. Risiken
+
+| Risiko | Folge | Gegenmaßnahme |
+|---|---|---|
+| Bürokratisierung | Templates werden mechanisch gefüllt. | Templates minimal halten. |
+| Zweite Wahrheit | JSON und Markdown driften auseinander. | Generator + CI-Check. |
+| CI-Reibung | PRs scheitern an zu strengen Guards. | Erst warnend, dann blocking. |
+| falsche Kanonizität | Task-Board wird als Wahrheit gelesen. | Rollen klar markieren. |
+| Owner-Leere | Aufgaben sind strukturiert, aber herrenlos. | `owner: unknown` explizit erlauben und reporten. |
+| Tokenrisiko | Project API braucht zusätzliche Rechte. | Least privilege, GitHub App, kein breit gesetzter PAT. |
+
+## 12. Epistemische Leerstellen
+
+Für die endgültige Betriebsentscheidung fehlen:
+
+1. GitHub Project v2 Status: Board, Felder, Privatheit und Aktivität sind nicht
+   verifiziert.
+2. Owner-Matrix: Verantwortliche für Docs, CI, Release und Statusschluss sind
+   nicht festgelegt.
+3. Automationsgrad: nur prüfen, Bot-PRs erzeugen oder Project-Felder setzen ist
+   offen.
+
+Diese Leerstellen müssen vor Phase 3 und Phase 4 der Roadmap geschlossen oder
+als explizite Lücken markiert werden.
+
+## 13. Essenz
+
+Hebel: Eine schmale Task-Control-Schicht verbindet bestehende Doku mit
+GitHub-Arbeitsobjekten.
+
+Entscheidung: Hybrid statt GitHub-only oder Docs-only.
+
+Nächste Aktion: Mit dem operativen Schnitt in
+[doc-structure-task-control-roadmap.md](doc-structure-task-control-roadmap.md)
+beginnen, ohne den Blueprint als erledigte Implementierung zu lesen.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,10 @@ summary: >
 
 ## Canonical Knowledge
 
+> Dieser Index ist kanonische Navigation, keine eigenständige Wahrheitsschicht.
+> Bei Konflikten führen Spezifikationen, ADRs, Policies, Statusmatrizen und
+> Code gemäß `repo.meta.yaml`.
+
 <!--
 NOTE:
 Kanonische Navigation. Neue UI-Dokumente bestehenden Kategorien zuordnen.
@@ -27,7 +31,13 @@ Kanonische Navigation. Neue UI-Dokumente bestehenden Kategorien zuordnen.
 – **Techstack:** [techstack.md](techstack.md)
 – **Datenmodell:** [datenmodell.md](datenmodell.md)
 – **Vision:** [vision.md](vision.md)
+
+### Agenten & Arbeitssteuerung
+
 – **Agent Operability:** [blueprints/agent-operability-blaupause.md](blueprints/agent-operability-blaupause.md) (Blueprint)
+– **Dokumentationsstruktur & Task-Steuerung:** [blueprints/doc-structure-task-control.md](blueprints/doc-structure-task-control.md) (Blueprint)
+– **Task-Control Roadmap:** [blueprints/doc-structure-task-control-roadmap.md](blueprints/doc-structure-task-control-roadmap.md) (Roadmap)
+– **Task-Control Beispiele:** [blueprints/doc-structure-task-control-examples.md](blueprints/doc-structure-task-control-examples.md) (Referenz)
 
 ### Domäne
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -90,7 +90,7 @@ Status- oder Reihenfolgequelle für die Master-Roadmap dient.
 | Kartenklarheit | [kartenklarheit-roadmap.md](blueprints/kartenklarheit-roadmap.md) | [map-architekturkritik.md](reports/map-architekturkritik.md) |
 | Kartenklarheit Phase 6 (Wahrheitsbeweis) | [kartenklarheit-phase6.md](blueprints/kartenklarheit-phase6.md) | [map-status-matrix.md](reports/map-status-matrix.md) |
 | Agent-Operability | [agent-operability-blaupause.md](blueprints/agent-operability-blaupause.md) | [agent-readiness-audit.md](reports/agent-readiness-audit.md) |
-| Dokumentationsstruktur & Task-Steuerung | [doc-structure-task-control-roadmap.md](blueprints/doc-structure-task-control-roadmap.md), [Blueprint](blueprints/doc-structure-task-control.md) | [optimierungsstatus.md](reports/optimierungsstatus.md) |
+| Dokumentationsstruktur & Task-Steuerung | [doc-structure-task-control-roadmap.md](blueprints/doc-structure-task-control-roadmap.md), [Blueprint](blueprints/doc-structure-task-control.md) | Statusbeleg ausstehend — noch kein Eintrag in `reports/optimierungsstatus.md` |
 | Versionierung | [versionierungs-blaupause.md](blueprints/versionierungs-blaupause.md) | [versionierungs-statusgrundlage.md](blueprints/versionierungs-statusgrundlage.md) |
 | Optimierungsfront | (kein Sub-Plan) | [optimierungsstatus.md](reports/optimierungsstatus.md), [optimierungsbericht.md](reports/optimierungsbericht.md) |
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -27,6 +27,8 @@ relations:
   - type: depends_on
     target: docs/blueprints/agent-operability-blaupause.md
   - type: depends_on
+    target: docs/blueprints/doc-structure-task-control-roadmap.md
+  - type: depends_on
     target: docs/blueprints/versionierungs-blaupause.md
   - type: depends_on
     target: docs/reports/optimierungsstatus.md
@@ -88,6 +90,7 @@ Status- oder Reihenfolgequelle für die Master-Roadmap dient.
 | Kartenklarheit | [kartenklarheit-roadmap.md](blueprints/kartenklarheit-roadmap.md) | [map-architekturkritik.md](reports/map-architekturkritik.md) |
 | Kartenklarheit Phase 6 (Wahrheitsbeweis) | [kartenklarheit-phase6.md](blueprints/kartenklarheit-phase6.md) | [map-status-matrix.md](reports/map-status-matrix.md) |
 | Agent-Operability | [agent-operability-blaupause.md](blueprints/agent-operability-blaupause.md) | [agent-readiness-audit.md](reports/agent-readiness-audit.md) |
+| Dokumentationsstruktur & Task-Steuerung | [doc-structure-task-control-roadmap.md](blueprints/doc-structure-task-control-roadmap.md), [Blueprint](blueprints/doc-structure-task-control.md) | [optimierungsstatus.md](reports/optimierungsstatus.md) |
 | Versionierung | [versionierungs-blaupause.md](blueprints/versionierungs-blaupause.md) | [versionierungs-statusgrundlage.md](blueprints/versionierungs-statusgrundlage.md) |
 | Optimierungsfront | (kein Sub-Plan) | [optimierungsstatus.md](reports/optimierungsstatus.md), [optimierungsbericht.md](reports/optimierungsbericht.md) |
 


### PR DESCRIPTION
### Motivation

- Introduce a scoping blueprint for a slim Task-Control layer to connect navigation, status matrices, machine-readable task artifacts and GitHub work objects.
- Provide an operative roadmap and concrete examples to guide phased implementation and CI integration without creating a second truth layer.

### Description

- Add `docs/blueprints/doc-structure-task-control.md` as the blueprint describing goals, principles, artifacts and governance for the Task-Control layer.
- Add `docs/blueprints/doc-structure-task-control-roadmap.md` containing a phased rollout plan, PR-cut suggestions and measurable acceptance criteria.
- Add `docs/blueprints/doc-structure-task-control-examples.md` with JSON/YAML/Markdown/workflow examples, IssueForm and agent prompts for later implementation.
- Update `docs/index.md` to surface the new Task-Control blueprint and roadmap under the "Agenten & Arbeitssteuerung" section by adding links to the new files.
- Update `docs/roadmap.md` to add a `depends_on` relation to the new roadmap and include the Task-Control strand in the master roadmap table.

### Testing

- No automated tests were executed as part of this change; these are documentation additions and roadmap artifacts only.
- CI/docs-build and link-check steps are expected to validate the new pages in subsequent runs but were not run with this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a185967305c832c9b658c2f3d7a33b5)