### PR TITLE
Streamline CONTRIBUTING.md and README.md for clarity and agent guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,25 +21,28 @@ Kurzprinzip: **„Richtig routen, klein schneiden, sauber messen."**
 
 ## 1. Reale Repo-Topographie
 
+**Auszug der Hauptverzeichnisse** (vollständige Discovery-Liste siehe [`repo.meta.yaml:discovery_roots`](repo.meta.yaml)):
+
 ```text
+.github/
+  workflows/           # CI/CD
 apps/
   api/                 # Rust/Axum HTTP-API
   web/                 # SvelteKit-Frontend
+architecture/          # Architektur-Notizen
+audit/                 # impl-registry.yaml — Implementierungs-Mapping
+configs/               # App-Defaults (app.defaults.yml)
 contracts/
   domain/              # JSON-Schema-Domain-Contracts (höchste Wahrheits-Präzedenz)
+docs/                  # ADRs, Blueprints, Specs, Reports, Policies, _generated/
 infra/
   caddy/               # Reverse Proxy
   compose/             # Docker-Compose-Profile
-docs/                  # ADRs, Blueprints, Specs, Reports, Policies, _generated/
-ci/                    # Budgets, Smoke-Tests
-scripts/               # Tooling, insb. scripts/docmeta/ für Doku-Indexer und Guards
-.github/
-  workflows/           # CI/CD
-audit/                 # impl-registry.yaml — Implementierungs-Mapping
 policies/              # Soft-Limits (limits.yaml, perf.json, retention.yml, slo.yaml ...)
-configs/               # App-Defaults (app.defaults.yml)
-architecture/          # Architektur-Notizen
-runbooks/              # Operative Runbooks
+scripts/               # Tooling, insb. scripts/docmeta/ für Doku-Indexer und Guards
+src/                   # Gemeinsame Sources
+tools/                 # Development Tools
+ci/                    # Budgets, Smoke-Tests
 Root                   # Justfile, Makefile, repo.meta.yaml, AGENTS.md, README.md, Lizenz
 ```
 
@@ -88,7 +91,7 @@ Outbox-Projektoren (Timeline, Search), DSGVO-/DR-Rebuilder und Search-Adapter ha
 | `docs/reports/*` | Diagnostische Berichte und Statusmatrizen mit Evidenz | guarded |
 | `docs/index.md` | Navigation, **keine** Wahrheit | guarded |
 | `docs/_generated/*` | Diagnose, automatisch generiert | **forbidden** für manuelle Edits |
-| `audit/impl-registry.yaml` | Implementations-Mapping | guarded |
+| `audit/impl-registry.yaml` | Implementations-Mapping | siehe `repo.meta.yaml` / `agent-policy.yaml` (nicht als guarded geführt) |
 | `docs/tasks/*` | Geplante Task-Control-Schicht (Roadmap) | noch nicht eingeführt — nicht ohne Roadmap-Phase 2 anlegen |
 | `secrets/`, `snapshots/` | Sensitive Daten / Snapshots | **forbidden** |
 
@@ -99,9 +102,10 @@ Vollständige bindende Pfadliste siehe [`agent-policy.yaml`](agent-policy.yaml).
 - Branch-Strategie: kurzes Feature-Branching gegen `main`. Kleine, thematisch fokussierte Pull Requests.
 - Commit-Präfixe: `feat(web): …`, `feat(api): …`, `feat(infra): …`, `fix(...)`, `chore(...)`, `refactor(...)`, `docs(adr|runbook|...)`.
 - PR-Prozess:
-  1. Lokal: Lints, Tests und Budgets ausführen (`just check`).
-  2. PR klein halten; Zweck und „Wie getestet" kurz erläutern.
-  3. Bei Architektur- oder Sicherheitsauswirkungen: ADR oder Runbook-Update beilegen oder verlinken.
+  1. Lokal: `just check` für schnelle Hygiene-Checks (Rust fmt/clippy/test, Demo-Daten, Domain-Contracts, `cargo deny`).
+  2. Bei Änderungen unter `apps/web/`: zusätzlich `just ci` oder spezifische Web-Checks in `apps/web/` ausführen (Web-Install, Sync, Build, `pnpm run ci`).
+  3. PR klein halten; Zweck und „Wie getestet" kurz erläutern.
+  4. Bei Architektur- oder Sicherheitsauswirkungen: ADR oder Runbook-Update beilegen oder verlinken.
 - CI-Gates (brechen Builds):
   - Frontend-Budget aus `ci/budget.json` (Initial-JS ≤ 60 KB, TTI ≤ 2000 ms).
   - Lints/Formatter: Web (ESLint/Prettier, `max-warnings=0`), Rust (`cargo fmt`, `cargo clippy -D warnings`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,11 +54,13 @@ Nur reale Zielordner. Was nicht existiert, wird hier nicht aufgelistet.
 - **Neue Seite oder Route im UI:** `apps/web/src/routes/...` (`+page.svelte`, `+page.ts`, `+server.ts`).
 - **UI-Komponente, Store, Util:** `apps/web/src/lib/...`.
 - **Statische Assets:** `apps/web/static/`.
-- **Neuer API-Endpoint:** `apps/api/src/routes/...`.
-- **Geschäftslogik / Service:** `apps/api/src/domain/...`.
-- **DB-Zugriff (PostgreSQL):** `apps/api/src/repo/...` (sqlx).
-- **Events / Outbox-Publizierer:** `apps/api/src/events/...`.
+- **Neuer API-Endpoint:** `apps/api/src/routes/...`; reale Route-Module: `accounts`, `auth`, `edges`, `health`, `meta`, `nodes`, `query`.
+- **Auth-Logik:** `apps/api/src/auth/...` (Sessions, Passkeys, Tokens, Rate-Limiting, Rollen).
+- **Middleware:** `apps/api/src/middleware/...` (Auth, AuthZ, CSRF).
+- **Querschnitt:** `apps/api/src/{config,state,mailer,utils}.rs`, `apps/api/src/telemetry/...`.
 - **DB-Migrationen:** `apps/api/migrations/` (`YYYYMMDDHHMM__beschreibung.sql`).
+
+Fachliche Trennungen wie `apps/api/src/domain/`, `apps/api/src/repo/` oder `apps/api/src/events/` sind **Zielbild**, aber aktuell nicht vorhanden. Neue Unterordner erst nach eigenem Architektur- oder Refactoring-PR einführen — nicht als freie Routing-Entscheidung.
 - **Compose-Profile:** `infra/compose/*.yml`.
 - **Proxy, Headers, CSP:** `infra/caddy/`.
 - **CI-Workflow:** `.github/workflows/*.yml`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,7 @@ Nur reale Zielordner. Was nicht existiert, wird hier nicht aufgelistet.
 - **DB-Migrationen:** `apps/api/migrations/` (`YYYYMMDDHHMM__beschreibung.sql`).
 
 Fachliche Trennungen wie `apps/api/src/domain/`, `apps/api/src/repo/` oder `apps/api/src/events/` sind **Zielbild**, aber aktuell nicht vorhanden. Neue Unterordner erst nach eigenem Architektur- oder Refactoring-PR einführen — nicht als freie Routing-Entscheidung.
+
 - **Compose-Profile:** `infra/compose/*.yml`.
 - **Proxy, Headers, CSP:** `infra/caddy/`.
 - **CI-Workflow:** `.github/workflows/*.yml`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,199 +1,125 @@
-Hier ist das finale CONTRIBUTING.md – optimiert, konsistent mit docs/architekturstruktur.md, und so
-geschrieben, dass Menschen
-und KIs sofort wissen, was wohin gehört, warum, und wie gearbeitet wird.
+# CONTRIBUTING
 
-⸻
+Wie im Weltgewebe-Repository gearbeitet wird: Orientierung, Routing, Workflow, Qualität.
 
-# CONTRIBUTING.md
+Verbindliche Grundlagen vor jedem Patch:
 
-## Weltgewebe – Beiträge, Qualität, Wegeführung
+- [`repo.meta.yaml`](repo.meta.yaml) — Truth Model und Konfliktauflösung.
+- [`AGENTS.md`](AGENTS.md) — Agentenleitfaden und Coding Guidelines.
+- [`agent-policy.yaml`](agent-policy.yaml) — Schreibrechte und Required Checks.
+- [`docs/policies/agent-reading-protocol.md`](docs/policies/agent-reading-protocol.md) — bindendes Lese- und Abbruchprotokoll.
 
-Dieses Dokument erklärt, wie im Weltgewebe-Repository gearbeitet wird: Ordner-Orientierung,
-Workflows, Qualitätsmaßstäbe und
-Entscheidungswege.
+Weitere Referenzen:
 
-Es baut auf folgenden Dateien auf:
+- [`docs/architekturstruktur.md`](docs/architekturstruktur.md) — Repo-Architekturüberblick.
+- [`docs/techstack.md`](docs/techstack.md) — Stack-Referenz (SvelteKit, Rust/Axum, Postgres + Outbox, JetStream, Caddy).
+- [`docs/runbook.md`](docs/runbook.md) — Betrieb, DR/DSGVO-Drills.
+- [`docs/datenmodell.md`](docs/datenmodell.md) — Tabellen, Projektionen, Events.
+- [`ci/budget.json`](ci/budget.json) — Performance-Budgets.
 
-- docs/architekturstruktur.md – verbindliche Repo-Struktur (Ordner, Inhalte, Zweck).
-- docs/techstack.md – Stack-Referenz (SvelteKit, Rust/Axum, Postgres+Outbox, JetStream, Caddy,
-  Observability).
-- ci/budget.json – Performance-Budgets (Frontend).
-- docs/runbook.md – Woche-1/2, DR/DSGVO-Drills.
-- docs/datenmodell.md – Tabellen, Projektionen, Events.
+Kurzprinzip: **„Richtig routen, klein schneiden, sauber messen."**
 
-Kurzprinzip: „Richtig routen, klein schneiden, sauber messen.“ Beiträge landen im richtigen Ordner,
-klein und testbar, mit
-Metriken und Budgets im Blick.
+## 1. Reale Repo-Topographie
 
-⸻
+```text
+apps/
+  api/                 # Rust/Axum HTTP-API
+  web/                 # SvelteKit-Frontend
+contracts/
+  domain/              # JSON-Schema-Domain-Contracts (höchste Wahrheits-Präzedenz)
+infra/
+  caddy/               # Reverse Proxy
+  compose/             # Docker-Compose-Profile
+docs/                  # ADRs, Blueprints, Specs, Reports, Policies, _generated/
+ci/                    # Budgets, Smoke-Tests
+scripts/               # Tooling, insb. scripts/docmeta/ für Doku-Indexer und Guards
+.github/
+  workflows/           # CI/CD
+audit/                 # impl-registry.yaml — Implementierungs-Mapping
+policies/              # Soft-Limits (limits.yaml, perf.json, retention.yml, slo.yaml ...)
+configs/               # App-Defaults (app.defaults.yml)
+architecture/          # Architektur-Notizen
+runbooks/              # Operative Runbooks
+Root                   # Justfile, Makefile, repo.meta.yaml, AGENTS.md, README.md, Lizenz
+```
 
-## 1. Repo-Topographie in 30 Sekunden
+Noch nicht im Repo, aber im Zielbild vorgesehen: `apps/worker/` (Outbox-Projektoren, DSGVO-/DR-Rebuilder), `apps/search/` (Search-Adapter), gemeinsame Library-Pakete unter `packages/`. Patches dürfen diese Strukturen **nicht erfinden**; sie entstehen erst, wenn die jeweilige Gate-Phase erreicht ist.
 
-- apps/ – Business-Code (Web-Frontend, API, Worker, optionale Search-Adapter).
-- packages/ – gemeinsame Libraries/SDKs (optional).
-- infra/ – Compose-Profile, Proxy (Caddy), DB-Init, Monitoring, optional Nomad/K8s.
-- docs/ – ADRs, Architektur-Poster, Datenmodell, Runbook.
-- ci/ – GitHub-Workflows, Skripte, Performance-Budgets.
-- Root – .env.example, Editor/Git-Konfig, Lizenz, README.
+Details: siehe [`docs/architekturstruktur.md`](docs/architekturstruktur.md).
 
-Details: siehe docs/architekturstruktur.md.
+## 2. Routing-Matrix „Wohin gehört was?"
 
-⸻
+Nur reale Zielordner. Was nicht existiert, wird hier nicht aufgelistet.
 
-## 2. Routing-Matrix „Wohin gehört was?“
+- **Neue Seite oder Route im UI:** `apps/web/src/routes/...` (`+page.svelte`, `+page.ts`, `+server.ts`).
+- **UI-Komponente, Store, Util:** `apps/web/src/lib/...`.
+- **Statische Assets:** `apps/web/static/`.
+- **Neuer API-Endpoint:** `apps/api/src/routes/...`.
+- **Geschäftslogik / Service:** `apps/api/src/domain/...`.
+- **DB-Zugriff (PostgreSQL):** `apps/api/src/repo/...` (sqlx).
+- **Events / Outbox-Publizierer:** `apps/api/src/events/...`.
+- **DB-Migrationen:** `apps/api/migrations/` (`YYYYMMDDHHMM__beschreibung.sql`).
+- **Compose-Profile:** `infra/compose/*.yml`.
+- **Proxy, Headers, CSP:** `infra/caddy/`.
+- **CI-Workflow:** `.github/workflows/*.yml`.
+- **Performance-Budget:** `ci/budget.json`.
+- **Soft-Limits / SLOs:** `policies/`.
+- **App-Defaults:** `configs/app.defaults.yml`.
+- **Architektur-Entscheidung:** `docs/adr/ADR-xxx__<slug>.md`.
+- **Architektur-Blaupause:** `docs/blueprints/<slug>.md`.
+- **Spezifikation:** `docs/specs/<slug>.md`.
+- **Statusbericht / Diagnose:** `docs/reports/<slug>.md` (Markdown plus optional `.json`-Zwilling, dokumentiert).
+- **Runbook:** `docs/runbook.md` oder `docs/runbooks/<slug>.md`.
+- **Domain-Contract:** `contracts/domain/<entity>.schema.json`.
+- **Doku-Indexer / Relations-Skript:** `scripts/docmeta/`.
 
-- Neue Seite oder Route im UI
-  - Zielordner/Datei: apps/web/src/routes/...
-  - Typisches Pattern: +page.svelte, +page.ts, +server.ts.
-  - Grund: SvelteKit-Routing, SSR/Islands, nahe an UI.
+Outbox-Projektoren (Timeline, Search), DSGVO-/DR-Rebuilder und Search-Adapter haben noch keinen realen Zielordner und entstehen erst mit der entsprechenden Gate-Phase.
 
-- UI-Komponente, Store oder Util
-  - Zielordner/Datei: apps/web/src/lib/...
-  - Typisches Pattern: *.svelte, stores.ts, utils.ts.
-  - Grund: Wiederverwendung, klare Trennung vom Routing.
+## 3. Doku-Rollen und Schreibgrenzen
 
-- Statische Assets
-  - Zielordner/Datei: apps/web/static/.
-  - Typisches Pattern: manifest.webmanifest, Icons, Fonts.
-  - Grund: Build-unabhängige Auslieferung.
+| Pfad | Rolle | Schreibstatus |
+|---|---|---|
+| `repo.meta.yaml`, `AGENTS.md`, `agent-policy.yaml`, `docs/policies/*` | Kanonische Wahrheits- und Steuerungsschicht | guarded |
+| `contracts/domain/*.schema.json` | Höchste Wahrheits-Präzedenz | guarded, erfordert `contracts-domain-check` |
+| `docs/adr/*`, `docs/specs/*`, `docs/blueprints/*` | Normative Spezifikation und Architekturplanung | guarded |
+| `docs/reports/*` | Diagnostische Berichte und Statusmatrizen mit Evidenz | guarded |
+| `docs/index.md` | Navigation, **keine** Wahrheit | guarded |
+| `docs/_generated/*` | Diagnose, automatisch generiert | **forbidden** für manuelle Edits |
+| `audit/impl-registry.yaml` | Implementations-Mapping | guarded |
+| `docs/tasks/*` | Geplante Task-Control-Schicht (Roadmap) | noch nicht eingeführt — nicht ohne Roadmap-Phase 2 anlegen |
+| `secrets/`, `snapshots/` | Sensitive Daten / Snapshots | **forbidden** |
 
-- Neuer API-Endpoint
-  - Zielordner/Datei: apps/api/src/routes/...
-  - Typisches Pattern: mod.rs, Handler, Router.
-  - Grund: HTTP/SSE-Schnittstelle gehört in routes.
+Vollständige bindende Pfadliste siehe [`agent-policy.yaml`](agent-policy.yaml).
 
-- Geschäftslogik oder Service
-  - Zielordner/Datei: apps/api/src/domain/...
-  - Typisches Pattern: Use-Case-Funktionen.
-  - Grund: Fachlogik von I/O trennen.
+## 4. Arbeitsweise und Workflow
 
-- DB-Zugriff (nur PostgreSQL)
-  - Zielordner/Datei: apps/api/src/repo/...
-  - Typisches Pattern: sqlx-Queries, Mappings.
-  - Grund: Konsistente Datenzugriffe.
+- Branch-Strategie: kurzes Feature-Branching gegen `main`. Kleine, thematisch fokussierte Pull Requests.
+- Commit-Präfixe: `feat(web): …`, `feat(api): …`, `feat(infra): …`, `fix(...)`, `chore(...)`, `refactor(...)`, `docs(adr|runbook|...)`.
+- PR-Prozess:
+  1. Lokal: Lints, Tests und Budgets ausführen (`just check`).
+  2. PR klein halten; Zweck und „Wie getestet" kurz erläutern.
+  3. Bei Architektur- oder Sicherheitsauswirkungen: ADR oder Runbook-Update beilegen oder verlinken.
+- CI-Gates (brechen Builds):
+  - Frontend-Budget aus `ci/budget.json` (Initial-JS ≤ 60 KB, TTI ≤ 2000 ms).
+  - Lints/Formatter: Web (ESLint/Prettier, `max-warnings=0`), Rust (`cargo fmt`, `cargo clippy -D warnings`).
+  - Tests (`pnpm test`, `cargo test --locked`).
+  - Sicherheits- und Konsistenzchecks (`cargo deny`, Workflow `docs-guard.yml`, Compose-Smoke).
 
-- Outbox-Publizierer oder Eventtypen
-  - Zielordner/Datei: apps/api/src/events/...
-  - Typisches Pattern: publish_*, Event-Schema.
-  - Grund: Transaktionale Events am System of Truth.
+Generierte Dateien unter `docs/_generated/` sind abgeleitete Diagnoseartefakte und werden nicht manuell editiert. CI regeneriert sie für Beobachtbarkeit; Drift wird gemeldet und soll zeitnah behoben oder bewusst dokumentiert werden.
 
-- DB-Migrationen
-  - Zielordner/Datei: apps/api/migrations/.
-  - Typisches Pattern: YYYYMMDDHHMM__beschreibung.sql.
-  - Grund: Änderungsverfolgung am Schema.
+Blockierende Doku-Validierung läuft deterministisch über `make ci-validate` (Alias zu `make validate`).
 
-- Timeline-Projektor
-  - Zielordner/Datei: apps/worker/src/projector_timeline.rs.
-  - Typisches Pattern: Outbox → Timeline.
-  - Grund: Read-Model separat, idempotent.
+## 5. Domain-Contracts lokal validieren
 
-- Search-Projektor
-  - Zielordner/Datei: apps/worker/src/projector_search.rs.
-  - Typisches Pattern: Outbox → Typesense/Meili.
-  - Grund: Indexing asynchron.
+JSON-Schemas und Beispiele unter `contracts/domain/` prüfen:
 
-- DSGVO- oder DR-Rebuilder
-  - Zielordner/Datei: apps/worker/src/replayer.rs.
-  - Typisches Pattern: Replay/Shadow-Rebuild.
-  - Grund: Audit- und Forget-Pfad.
-
-- Search-Adapter oder SDK
-  - Zielordner/Datei: apps/search/adapters/...
-  - Typisches Pattern: typesense.ts, meili.ts.
-  - Grund: Client-Adapter gekapselt.
-
-- Compose-Profile
-  - Zielordner/Datei: infra/compose/*.yml.
-  - Typisches Pattern: compose.core.yml usw.
-  - Grund: Start- und Betriebsprofile.
-
-- Proxy, Headers, CSP
-  - Zielordner/Datei: infra/caddy/Caddyfile.
-  - Typisches Pattern: HTTP/3, TLS, CSP.
-  - Grund: Auslieferung & Sicherheit.
-
-- DB-Init und Partitionierung
-  - Zielordner/Datei: infra/db/{init,partman}/.
-  - Typisches Pattern: Extensions, Partman.
-  - Grund: Basis-Setup für PostgreSQL.
-
-- Monitoring
-  - Zielordner/Datei: infra/monitoring/...
-  - Typisches Pattern: prometheus.yml, Dashboards, Alerts.
-  - Grund: Metriken, SLO-Wächter.
-
-- Architektur-Entscheidung
-  - Zielordner/Datei: docs/adr/ADR-xxx.md.
-  - Typisches Pattern: Datum- oder Nummernschema.
-  - Grund: Nachvollziehbarkeit.
-
-- Runbook
-  - Zielordner/Datei: docs/runbook.md.
-  - Typisches Pattern: Woche-1/2, DR/DSGVO.
-  - Grund: Betrieb in der Praxis.
-
-- Datenmodell
-  - Zielordner/Datei: docs/datenmodell.md.
-  - Typisches Pattern: Tabellen/Projektionen.
-  - Grund: Referenz für API/Worker.
-
-⸻
-
-## 3. Arbeitsweise / Workflow
-
-Branch-Strategie: kurzes Feature-Branching gegen main.
-Kleine, thematisch fokussierte Pull Requests.
-
-Commit-Präfixe:
-
-- feat(web): … | feat(api): … | feat(worker): … | feat(infra): …
-- fix(...) | chore(...) | refactor(...) | docs(adr|runbook|...)
-
-PR-Prozess:
-
-1. Lokal: Lints, Tests und Budgets laufen lassen.
-2. PR klein halten, Zweck und „Wie getestet“ kurz erläutern.
-3. Bei Architektur- oder Sicherheitsauswirkungen: ADR oder Runbook-Update beilegen oder verlinken.
-
-CI-Gates (brechen Builds):
-
-- Frontend-Budget aus ci/budget.json (Initial-JS ≤ 60 KB, TTI ≤ 2000 ms).
-- Lints/Formatter (Web: ESLint/Prettier; API/Worker: cargo fmt, cargo clippy -D).
-- Tests (npm test, cargo test).
-- Sicherheitschecks (cargo audit/deny), Konfiglint (Prometheus, Caddy).
-
-Generierte Dateien sind abgeleitete Diagnoseartefakte. Sie sind nicht erforderlich für die Commit-Validität. CI regeneriert ausgewählte Diagnosen für die Beobachtbarkeit, und Drift in generierten Dateien wird nicht-blockierend berichtet.
-
-Blockierende Docs-Validierung ist zwischen lokal und CI deterministisch über `make ci-validate` (Alias zu `make validate`).
-Bei gemeldetem Drift in den Diagnoseartefakten soll der Drift zeitnah behoben oder bewusst dokumentiert werden. CI macht den Drift zusätzlich über Warning-Hinweise und Artefakt-Upload sichtbar.
-
-### Domain-Contracts lokal validieren
-
-Um die JSON-Schemas und Beispiele unter `contracts/domain/` lokal zu prüfen und sicherzustellen, dass sie
-mit der CI übereinstimmen, kann ein Validierungsskript ausgeführt werden.
-
-**Voraussetzungen:**
-
-- Node.js ≥ 20
-- `ajv-cli` und `ajv-formats` global installiert (z.B. mit `pnpm install -g ajv-cli ajv-formats`)
-
-**Ausführung:**
-
-- `just contracts-domain-check`
-- oder `npm run contracts:domain:check`
+- Voraussetzungen: Node.js ≥ 20, `ajv-cli` und `ajv-formats` (z. B. `pnpm install -g ajv-cli ajv-formats`).
+- Ausführung: `just contracts-domain-check` oder `npm run contracts:domain:check`.
 
 Das Skript kompiliert alle Schemas und validiert die Beispiel-Instanzen dagegen.
 
-## 4. Tooling-Differenzierung (Lokal vs. CI)
+## 6. Tooling-Differenzierung (Lokal vs. CI)
 
-- **`scripts/tools/yq-pin.sh`** – lokaler Installer für eine reproduzierbare Umgebung (ohne sudo).
-  Erkennt Download-Ziele, lädt mit Wiederholungen (`curl --retry*`), prüft Checksums und legt
-  alles unter `~/.local/bin` ab (inkl. PATH-Hinzufügung).
-
-- **CI-Workflows (`.github/workflows/ci.yml`)** – nutzen einen eigenen `yq`-Installer (gepinnte Version,
-  direkter Download), da Runner root-Rechte und ein frisches Dateisystem haben. So bleibt der
-  Workflow ohne Dotfiles/Cache deterministisch.
-
-- **Link-Prüfung:** Im CI läuft `lychee` mit strengen Parametern (`--retry`, niedrige Parallelität),
-  um Flakes zu vermeiden. Der nächtliche Workflow (`links.yml`) dient als Watchdog mit
-  reduziertem Profil und ist kein hartes Qualitäts-Gate.
+- **`scripts/tools/yq-pin.sh`** — lokaler Installer für reproduzierbare Umgebung (ohne sudo). Lädt `yq` mit Wiederholungen, prüft Checksums, legt das Binary unter `~/.local/bin` ab (inkl. PATH-Hinzufügung).
+- **CI-Workflows (`.github/workflows/ci.yml`)** — eigener gepinnter `yq`-Installer, da Runner root-Rechte und frisches Dateisystem haben.
+- **Link-Prüfung:** Im CI läuft `lychee` mit strengen Parametern (`--retry`, niedrige Parallelität). Der nächtliche Workflow (`links.yml`) ist Watchdog mit reduziertem Profil, kein hartes Qualitäts-Gate.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,10 @@ just down
 
 ### Build- und Konfigurationsdetails
 
-- Die API liefert `/version` mit Build-Metadaten. `GIT_COMMIT_SHA`, `CARGO_PKG_VERSION` und `BUILD_TIMESTAMP` werden vom CI gesetzt; ohne CI-Kontext fallen sie auf `"unknown"` zurück. Sie werden **nicht** in `.env` gepflegt.
+- Die API liefert `/version` mit Build-Metadaten:
+  - `version` kommt aus `env!("CARGO_PKG_VERSION")` (Cargo-Paketmetadaten; **kein Fallback** auf `"unknown"`).
+  - `GIT_COMMIT_SHA` und `BUILD_TIMESTAMP` sind optional; sie fallen über `option_env!(...).unwrap_or("unknown")` auf `"unknown"` zurück, wenn nicht vom CI gesetzt.
+  - Diese Werte werden **nicht** in `.env` gepflegt.
 - Defaults: [`configs/app.defaults.yml`](configs/app.defaults.yml). Overrides via Env-Variablen `HA_FADE_DAYS`, `HA_RON_DAYS`, `HA_ANONYMIZE_OPT_IN`, `HA_DELEGATION_EXPIRE_DAYS` oder `APP_CONFIG_PATH`.
 - Policies-Pfad-Override: `POLICY_LIMITS_PATH=/pfad/zur/limits.yaml`.
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ just down
 ## Entwicklung und Qualität
 
 - Beitragsregeln und Routing: [`CONTRIBUTING.md`](CONTRIBUTING.md)
-- Lokaler Komplett-Check: `just check`
+- Schneller lokaler Hygiene-Check: `just check` (Rust/API-Grundchecks, Demo-Daten, Domain-Contracts, `cargo deny`)
+- Breiterer CI-Spiegel bei Web/API-Änderungen: `just ci`
 - Frontend-/Gate-A-Prototyp: [`apps/web/README.md`](apps/web/README.md)
 - Web-E2E (Playwright): siehe Workflow [`.github/workflows/web-e2e.yml`](.github/workflows/web-e2e.yml); lokal in `apps/web/` mit `pnpm test:setup` (einmalig) und `pnpm test`.
 - Performance-Budgets: [`ci/budget.json`](ci/budget.json); Soft-Limits in [`policies/`](policies/).

--- a/README.md
+++ b/README.md
@@ -1,219 +1,103 @@
 <!-- "Docs-only" ist ein formaler Gate-Status (ADR-0001). Das Repo ENTHÄLT operativen Code in apps/ und infra/. Diese Runtime-Artefakte sind Teil der Wahrheitsschicht und müssen gemäß dem definierten Truth Model (repo.meta.yaml) berücksichtigt werden. -->
 <!-- Docs-only (ADR-0001 Clean-Slate) • Re-Entry via Gates A–D -->
+
 # Weltgewebe
 
-Mobile-first Webprojekt mit SvelteKit (Web), Rust/Axum (API), Postgres+Outbox, JetStream und Caddy.
-Struktur und Beiträge: siehe `architekturstruktur.md` und `CONTRIBUTING.md`.
+Mobile-first Webprojekt mit SvelteKit (Web), Rust/Axum (API), Postgres + Outbox, NATS JetStream und Caddy.
 
-Weitere Informationen befinden sich in [AGENTS.md](AGENTS.md) und [docs/index.md](docs/index.md).
+## Status des Repos
 
-> **Hinweis zur Eigenständigkeit:** Weltgewebe ist ein eigenständiges Projekt. Repositories wie
-> `heimgewebe/contracts`, `wgx` oder `hauski` sind optionale Quellen und Werkzeuge, aber keine
-> monolithische Codebasis.
+- Weltgewebe ist ein **eigenständiges Projekt**. Repositories wie `heimgewebe/contracts`, `wgx` oder `hauski` sind optionale Quellen und Werkzeuge, keine monolithische Codebasis.
+- Formaler **Docs-only/Clean-Slate**-Status nach ADR-0001. Gleichzeitig enthält das Repo operative Artefakte unter `apps/` und `infra/`, die Teil der Wahrheitsschicht sind.
+- Code-Re-Entry erfolgt über die **Gates A–D**; siehe [`docs/process/fahrplan.md`](docs/process/fahrplan.md).
+- Wahrheit und Konfliktauflösung folgen strikt [`repo.meta.yaml`](repo.meta.yaml) und dem [Agent Reading Protocol](docs/policies/agent-reading-protocol.md). `docs/index.md` ist Navigation, keine Wahrheitsschicht. `docs/_generated/*` ist Diagnose, nicht Ursprung.
 
-## Landing
+## Schnellzugriff
 
-Für einen schnellen Einstieg in Ethik, UX und Projektkontext:
+- [Dokumentationsindex](docs/index.md)
+- [Repo-Architektur](docs/architekturstruktur.md)
+- [Agenten-Leitfaden](AGENTS.md)
+- [Beitragen](CONTRIBUTING.md)
+- [Master-Roadmap](docs/roadmap.md)
+- [Optimierungsstatus](docs/reports/optimierungsstatus.md)
+- [Task-Control-Blaupause](docs/blueprints/doc-structure-task-control.md)
+- [Task-Control-Roadmap](docs/blueprints/doc-structure-task-control-roadmap.md)
+- [Deployment-Übersicht](docs/deploy/README.md)
+- [Gate-Fahrplan](docs/process/fahrplan.md)
 
-- [Vision & Leitidee](docs/vision.md)
-- [Einführung: Ethik- & UX-First-Startpunkt](docs/overview/inhalt.md)
-- [Systematik & Strukturüberblick](docs/overview/zusammenstellung.md)
+## Für Agents
 
-> **Hinweis / Scope**
->
-> - **Kein** Teilnahme-/Freigabeprozess für Fleet-Rollouts oder operativen Leitstandbetrieb.
-> - Optionales Dashboard-Widget liest **ausschließlich** über das Leitstand-REST/Gateway,
->   **kein Direktzugriff** auf JSONL-Dateien.
-> - Entspricht ADR-0001 (Docs-only) und bleibt kompatibel mit den Gates A–D.
+Verbindliche Leseordnung vor jedem Patch:
 
-## Getting started
+1. [`repo.meta.yaml`](repo.meta.yaml)
+2. [`AGENTS.md`](AGENTS.md)
+3. [`agent-policy.yaml`](agent-policy.yaml)
+4. [`docs/policies/agent-reading-protocol.md`](docs/policies/agent-reading-protocol.md)
+5. [`docs/index.md`](docs/index.md) — nur Navigation
+6. betroffene Blueprint-, Report-, Spec- oder Codepfade
 
-> ⚙️ **Preview:** Die folgenden Schritte werden mit Gate C (Infra-light) aktiviert.
-> Solange das Repo Docs-only ist, dienen sie lediglich als Ausblick.
+Interpolation ist verboten. Bei nicht auflösbaren Widersprüchen oder fehlenden Zielnachweisen MUSS abgebrochen werden.
 
-### Frontend schnell starten (Codespaces)
+## Lokal starten
 
-1. **Dev-Server starten**
+Voraussetzungen: Docker, Docker Compose und `just` (alternativ `make`).
 
-   [▶ Frontend in Codespaces starten](command:workbench.action.tasks.runTask?%5B%22Web%3A%20Devserver%20(Codespaces)%22%5D)
-
-2. **Frontend im Browser öffnen**
-
-   [🌍 Karte öffnen](http://localhost:5173/map)
-
-### Development Quickstart
-
-1. **Voraussetzungen:** Docker, Docker Compose und `just` müssen installiert sein.
-   Alternativ zu `just` kann `make` verwendet werden.
-
-2. **.env erstellen:** Kopiere die Vorlage `.env.example` nach `.env`.
-   Für den lokalen Start sind in der Regel keine Änderungen nötig.
-
-    ```bash
-    cp .env.example .env
-    ```
-
-3. **Dev-Stack starten:**
-
-    ```bash
-    just up
-    ```
-
-    Der Befehl `make up` ist ein Alias und macht dasselbe.
-    *Hinweis: Der erste Start kann einige Minuten dauern, da Docker-Images gebaut werden.*
-
-4. **Erfolg prüfen:**
-    - **Frontend:** Öffne [http://localhost:8081](http://localhost:8081) im Browser.
-    - **API-Healthcheck:** Rufe [http://localhost:8081/api/health/live](http://localhost:8081/api/health/live) auf.
-
-5. **Stack anhalten:**
-
-    ```bash
-    just down
-    ```
-
-- Für weitere Details siehe `docs/quickstart-gate-c.md`.
-- Um Code-Qualität lokal zu prüfen, nutze `just check`.
-
-- Im VS Code Devcontainer richtet `.devcontainer/post-create.sh` die benötigten Tools
-  (u. a. `just`, `uv`, `vale`) automatisch ein. Python-Helfer über `uv` stehen
-  danach sofort zur Verfügung (`uv -V`).
-- Falls du Python-Tools in Unterordnern verwaltest (z. B. `tools/py/`), achte darauf,
-  das entstehende `uv.lock` mit einzuchecken – es landet standardmäßig im jeweiligen
-  Projektstamm (Root oder Unterordner).
-- Außerhalb des Devcontainers stellst du die gewünschte `uv`-Version mit
-  `scripts/tools/uv-pin.sh ensure` sicher (optional via `UV_VERSION=<ziel>`).
-
-- CI enforces: `cargo fmt --check`, `clippy -D warnings`, `cargo deny check`.
-- Performance-Budgets & SLOs leben in `policies/` und werden in Docs & Dashboards referenziert.
-- Für lokale Web-E2E-Tests installierst du die Playwright-Browser einmalig
-  (Details im Abschnitt [Web-E2E-Quickstart](#web-e2e-quickstart-preview)):
-  `pnpm exec playwright install --with-deps`
-
-> **Hinweis:** Aktuell formaler **Docs-only/Clean-Slate** Gate-Status gemäß ADR-0001, ABER `apps/` und `infra/` enthalten operative Laufzeitumgebungen. Deren Relevanz und Bindung für Agentenentscheidungen ergibt sich strikt aus dem Truth Model in `repo.meta.yaml` und dem Agent Reading Protocol.
-> Code-Re-Entry erfolgt über die Gates A–D (siehe [docs/process/fahrplan.md](docs/process/fahrplan.md)).
-> Dort sind die Gate-Checklisten (A–D) als To-dos dokumentiert.
-
-### Web-E2E-Quickstart (Preview)
-
-Abgeleitet aus dem manuellen CI-Workflow (siehe `.github/workflows/web-e2e.yml`).
-Damit Playwright lokal zuverlässig läuft, orientiere dich an den folgenden
-Schritten – zusätzliche Details findest du bei Bedarf in der Workflowdatei:
-
-1. Voraussetzungen: Node.js (siehe `.node-version` für die aktuelle Version).
-
-    ```bash
-    corepack enable
-    ```
-
-2. Dependencies installieren (nutzt das pnpm-Lockfile):
-
-    ```bash
-    cd apps/web
-    pnpm install --frozen-lockfile
-    ```
-
-3. Playwright-Browser nachrüsten (**einmalig pro Maschine**):
-
-    ```bash
-    pnpm exec playwright install --with-deps
-    # alternativ: pnpm test:setup
-    ```
-
-4. App builden, damit `pnpm preview` die statischen Assets servieren kann:
-
-    ```bash
-    pnpm build
-    ```
-
-5. Tests headless ausführen (startet automatisch einen Preview-Server):
-
-    ```bash
-    pnpm test
-    # CI-Spiegel: pnpm test:ci
-    ```
-
-Optional kannst du `PLAYWRIGHT_SKIP_WEBSERVER=1` setzen, wenn bereits ein lokaler
-`pnpm preview` läuft. **Wichtig:** Für externe Previews muss der Test-Server
-zuvor explizit via `pnpm run build:e2e` gebaut werden, damit die Map-Instanz für die Tests
-korrekt bereitgestellt wird. Den HTML-Report findest du nach den Läufen unter
-`apps/web/playwright-report/`.
-
-### Build-Zeit-Metadaten (Version/Commit/Zeitstempel)
-
-Die API stellt unter `/version` Build-Infos bereit:
-
-```json
-{
-  "version": "0.1.0",
-  "commit": "<git sha>",
-  "build_timestamp": "<UTC ISO8601>"
-}
+```bash
+cp .env.example .env
+just up
 ```
 
-Diese Werte werden zur Compile-Zeit gesetzt. In CI exportieren die Workflows `GIT_COMMIT_SHA`
-und `BUILD_TIMESTAMP` als Umgebungsvariablen. Lokal sind sie optional und fallen auf
-`"unknown"` zurück. Es ist **nicht nötig**, diese Variablen in `.env` zu pflegen.
+Prüfen:
 
-### Build-Zeit-Variablen
+- Frontend: <http://localhost:8081>
+- API Healthcheck: <http://localhost:8081/api/health/live>
 
-`GIT_COMMIT_SHA`, `CARGO_PKG_VERSION` und `BUILD_TIMESTAMP` stammen direkt aus dem CI
-bzw. Compiler. Sie werden **nicht** in `.env` oder `.env.example` gepflegt.
-Beim lokalen Build ohne CI-Kontext setzen wir sie automatisch auf `"unknown"`, während
-die Pipelines im CI die echten Werte einspeisen.
+Stoppen:
 
-### Policies-Pfad (Override)
+```bash
+just down
+```
 
-Standardmäßig sucht die API die Datei `policies/limits.yaml`. Für abweichende Layouts
-kannst du den Pfad via `POLICY_LIMITS_PATH=/pfad/zur/limits.yaml` setzen.
+> ⚙️ Der vollständig betriebsbereite Dev-Stack ist Teil von **Gate C** (Infra-light). Für Detailschritte siehe [`docs/quickstart-gate-c.md`](docs/quickstart-gate-c.md). Im VS-Code-Devcontainer richtet `.devcontainer/post-create.sh` Tools wie `just`, `uv` und `vale` automatisch ein.
 
-### Konfigurations-Overrides (HA_*)
+## Entwicklung und Qualität
 
-Die API liest Standardwerte aus `configs/app.defaults.yml`. Für Deployments können
-wir diese Defaults über folgende Umgebungsvariablen anpassen:
+- Beitragsregeln und Routing: [`CONTRIBUTING.md`](CONTRIBUTING.md)
+- Lokaler Komplett-Check: `just check`
+- Frontend-/Gate-A-Prototyp: [`apps/web/README.md`](apps/web/README.md)
+- Web-E2E (Playwright): siehe Workflow [`.github/workflows/web-e2e.yml`](.github/workflows/web-e2e.yml); lokal in `apps/web/` mit `pnpm test:setup` (einmalig) und `pnpm test`.
+- Performance-Budgets: [`ci/budget.json`](ci/budget.json); Soft-Limits in [`policies/`](policies/).
+- Doku- und Relations-Checks: Skripte unter `scripts/docmeta/` plus CI-Workflow `docs-guard.yml`.
+- Domain-Contracts lokal validieren: `just contracts-domain-check`.
 
-- `HA_FADE_DAYS`
-- `HA_RON_DAYS`
-- `HA_ANONYMIZE_OPT_IN`
-- `HA_DELEGATION_EXPIRE_DAYS`
+### Build- und Konfigurationsdetails
 
-Optional kann `APP_CONFIG_PATH` auf eine alternative YAML-Datei zeigen.
+- Die API liefert `/version` mit Build-Metadaten. `GIT_COMMIT_SHA`, `CARGO_PKG_VERSION` und `BUILD_TIMESTAMP` werden vom CI gesetzt; ohne CI-Kontext fallen sie auf `"unknown"` zurück. Sie werden **nicht** in `.env` gepflegt.
+- Defaults: [`configs/app.defaults.yml`](configs/app.defaults.yml). Overrides via Env-Variablen `HA_FADE_DAYS`, `HA_RON_DAYS`, `HA_ANONYMIZE_OPT_IN`, `HA_DELEGATION_EXPIRE_DAYS` oder `APP_CONFIG_PATH`.
+- Policies-Pfad-Override: `POLICY_LIMITS_PATH=/pfad/zur/limits.yaml`.
 
-### Soft-Limits & Policies
+## Deployment und Betrieb
 
-- Zweck: **Frühwarnung, kein Hard-Fail.**
-- Hinweis: **Werden nach und nach automatisiert in CI erzwungen.**
+- Übersicht: [`docs/deploy/README.md`](docs/deploy/README.md)
+- Heimserver als Referenz-Integration: [`docs/deploy/heimserver.integration.md`](docs/deploy/heimserver.integration.md)
+- Security: [`docs/deploy/security.md`](docs/deploy/security.md)
+- Drift-Policy: [`docs/deploy/DRIFT_POLICY.md`](docs/deploy/DRIFT_POLICY.md)
+- Runbook: [`docs/runbook.md`](docs/runbook.md); Observability: [`docs/runbook.observability.md`](docs/runbook.observability.md)
 
-Unter `policies/limits.yaml` dokumentieren wir Leitplanken (z. B. Web-Bundle-Budget, CI-Laufzeiten).
-Sie sind zunächst informativ und werden derzeit über Kommentare in der CI gespiegelt. Abweichungen
-dienen als Diskussionsgrundlage im Review.
+> **Hinweis:** Das Heimserver-Deployment ist Referenz-Implementierung des Integration-Contracts. Die langfristige Produktionsumgebung kann abweichen, der Contract bleibt gültig.
 
-## Semantik (Optionale zukünftige Integration – derzeit inaktiv)
+## Roadmap und offene Arbeit
 
-- Ursprünglicher Plan: `semantAH`-Integration (siehe ADR-0042).
-- Status: Vorerst ausgesetzt, Contracts und CI-Jobs entfernt.
-- Eine Reaktivierung würde eine neue ADR erfordern.
+- [Master-Roadmap](docs/roadmap.md)
+- [Optimierungsstatus](docs/reports/optimierungsstatus.md)
+- [Task-Control-Roadmap](docs/blueprints/doc-structure-task-control-roadmap.md)
 
-## Continuous Integration
+Task-Control-Artefakte wie `docs/tasks/index.json`, `docs/tasks/board.md` und `docs/reports/optimierungsstatus.json` sind in der Roadmap geplant, in diesem PR aber **noch nicht umgesetzt**. Verweise auf sie müssen entsprechend als geplant gekennzeichnet werden.
 
-Docs-Only-CI aktiv mit den Checks Markdown-Lint, Link-Check,
-YAML/JSON-Lint und Budget-Stub (ci/budget.json).
+## Semantik (ausgesetzt)
 
-## Deployment (Heimserver)
+Die ursprünglich geplante `semantAH`-Integration (ADR-0042) ist ausgesetzt; Contracts und CI-Jobs wurden entfernt. Eine Reaktivierung würde eine neue ADR erfordern.
 
-See: `docs/deploy/heimserver.integration.md`
-
-> **Hinweis:** Das Deployment auf dem Heimserver ist Teil der aktuellen Entwicklungs- und Integrationsphase.
-> Es dient als Referenz-Implementierung des Integrations-Contracts.
-> Die langfristige Produktionsumgebung kann abweichen, der definierte Contract bleibt jedoch gültig.
-
-## Gate-Fahrplan & Gate A – UX Click-Dummy
-
-- **Gate-Checklisten:** [docs/process/fahrplan.md](docs/process/fahrplan.md)
-  (Gates A–D mit konkreten Prüfpunkten)
-- **Gate A (Preview/Docs):** [apps/web/README.md](apps/web/README.md)
-  (Frontend-Prototyp für Karte · Kontextpanel · Aktionsleiste · Ethik-UI)
-
-## Beiträge & Docs
+## Beiträge und Doku-Style
 
 Stilprüfung via Vale läuft automatisch bei Doku-PRs; lokal `vale docs/` für Hinweise.


### PR DESCRIPTION
## Summary

Restructured and significantly condensed `CONTRIBUTING.md` and `README.md` to prioritize canonical sources, clarify repo topology, and provide explicit guidance for agents and contributors. Both documents now front-load references to `repo.meta.yaml`, `AGENTS.md`, `agent-policy.yaml`, and the Agent Reading Protocol as mandatory reading before any patch.

## Key Changes

### CONTRIBUTING.md
- **Removed:** Lengthy preamble and redundant explanations; moved focus to canonical sources.
- **Added:** Explicit mandatory reading order (repo.meta.yaml → AGENTS.md → agent-policy.yaml → agent-reading-protocol.md).
- **Clarified:** Repo-topography section now lists only *real* directories (no speculative future structures like `apps/worker/` or `apps/search/`).
- **Introduced:** Doku-Rollen und Schreibgrenzen (Documentation Roles and Write Boundaries) table mapping paths to guardianship status.
- **Condensed:** Workflow, CI-gates, and tooling sections to essential points; removed verbose explanations.
- **Preserved:** Domain-contract validation instructions and local tooling differentiation (yq, lychee).

### README.md
- **Removed:** Verbose "Getting started" sections, redundant quickstart instructions, and speculative Gate C details.
- **Restructured:** Moved core info to top: status, quick links, mandatory agent reading order.
- **Added:** "Schnellzugriff" (Quick Access) section with direct links to key docs.
- **Clarified:** Explicit statement that Weltgewebe is standalone; operative artefacts in `apps/` and `infra/` are part of the truth layer per `repo.meta.yaml`.
- **Condensed:** Development, deployment, and roadmap sections to links and brief descriptions.
- **Preserved:** Local startup instructions, build-time metadata, and policy overrides.

## Notable Implementation Details

- Both documents now treat `docs/index.md` as navigation only, not truth.
- `docs/_generated/*` is explicitly marked as diagnostic and forbidden for manual edits.
- Routing matrix in CONTRIBUTING.md now includes only paths that exist in the current repo state.
- Write-permission table in CONTRIBUTING.md provides clear guardianship status for all major paths.
- Agent reading protocol is now the first reference point for conflict resolution and decision-making.

## Rationale

These changes align with the canonical truth model defined in `repo.meta.yaml` and the Agent Reading Protocol. By front-loading mandatory sources and removing speculative content, both documents now serve as clear entry points for contributors and agents, reducing ambiguity and supporting deterministic decision-making.

https://claude.ai/code/session_01GERbP2HytAuAR4mPWQebXT