### PR TITLE
docs: add task-control phase 2 artifacts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,7 @@ Kein Status in `docs/tasks/index.json` oder `docs/reports/optimierungsstatus.jso
 Validator lokal ausführen:
 
 ```bash
-python3 scripts/docmeta/validate_task_index.py docs/tasks/index.json
+python3 -m scripts.docmeta.validate_task_index docs/tasks/index.json
 ```
 
 Noch offen für Folge-PRs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,6 +164,29 @@ CI-Gates (brechen Builds):
 
 Generierte Dateien sind abgeleitete Diagnoseartefakte. Sie sind nicht erforderlich für die Commit-Validität. CI regeneriert ausgewählte Diagnosen für die Beobachtbarkeit, und Drift in generierten Dateien wird nicht-blockierend berichtet.
 
+### Task-Control-Artefakte
+
+`docs/tasks/` ist die Arbeitssteuerungs-Schicht:
+
+- `docs/tasks/board.md` ist eine **menschliche Arbeitskarte**, keine Wahrheitsschicht.
+- `docs/tasks/index.json` ist ein **maschinenlesbarer Task-Index**.
+  Manuelle Änderungen sind erlaubt, solange `curation` klar als `"manual_phase2_seed"` oder `"manual"` gesetzt ist.
+  Sobald ein Generator eingeführt wird (Phase 4), muss der Schreibstatus neu bewertet werden.
+- `docs/tasks/schema.json` ist der **Validierungsvertrag** – Änderungen brauchen einen begründeten PR.
+- `docs/reports/optimierungsstatus.md` bleibt die **Wahrheitsquelle** für OPT-* Einträge.
+  `docs/reports/optimierungsstatus.json` ist deren maschinenlesbarer Zwilling, kein eigenständiger Statusträger.
+
+Kein Status in `index.json` oder `optimierungsstatus.json` darf dem Markdown widersprechen.
+Stille Status-Upgrades sind verboten. `done` erfordert Evidenz in der Statusmatrix.
+
+Validator lokal ausführen:
+
+```bash
+python3 scripts/docmeta/validate_task_index.py docs/tasks/index.json
+```
+
+Noch nicht umgesetzt (Folge-PRs): GitHub Issue Forms, PR-Template, Release-Konfig, Generator/CI-Guard.
+
 Blockierende Docs-Validierung ist zwischen lokal und CI deterministisch über `make ci-validate` (Alias zu `make validate`).
 Bei gemeldetem Drift in den Diagnoseartefakten soll der Drift zeitnah behoben oder bewusst dokumentiert werden. CI macht den Drift zusätzlich über Warning-Hinweise und Artefakt-Upload sichtbar.
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,9 @@ just down
 - [Optimierungsstatus](docs/reports/optimierungsstatus.md)
 - [Task-Control-Roadmap](docs/blueprints/doc-structure-task-control-roadmap.md)
 
-Task-Control-Artefakte wie `docs/tasks/index.json`, `docs/tasks/board.md` und `docs/reports/optimierungsstatus.json` sind in der Roadmap geplant, in diesem PR aber **noch nicht umgesetzt**. Verweise auf sie müssen entsprechend als geplant gekennzeichnet werden.
+Task-Control Phase 2 ist eingeführt. Die Arbeitssteuerung liegt jetzt unter `docs/tasks/`; der maschinenlesbare Optimierungsstatus liegt unter `docs/reports/optimierungsstatus.json`.
+
+Offen bleiben Folgephasen: GitHub Issue Forms, PR-Template, Release-Konfig, Task-Index-Generator, CI-Guard und Implementierungs-Mapping.
 
 ## Semantik (ausgesetzt)
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Die operative Arbeitssteuerung liegt in `docs/tasks/`:
 Noch nicht umgesetzt (Folge-PRs): GitHub Issue Forms, PR-Template, Release-Konfig, Generator und CI-Guard.
 
 ```bash
-python3 scripts/docmeta/validate_task_index.py docs/tasks/index.json
+python3 -m scripts.docmeta.validate_task_index docs/tasks/index.json
 ```
 
 ## Beiträge & Docs

--- a/README.md
+++ b/README.md
@@ -214,6 +214,24 @@ See: `docs/deploy/heimserver.integration.md`
 - **Gate A (Preview/Docs):** [apps/web/README.md](apps/web/README.md)
   (Frontend-Prototyp für Karte · Kontextpanel · Aktionsleiste · Ethik-UI)
 
+## Task-Control
+
+Die operative Arbeitssteuerung liegt in `docs/tasks/`:
+
+| Datei | Zweck |
+|---|---|
+| `docs/tasks/board.md` | Menschliche Arbeitskarte (aktive Prioritäten, Blocker) |
+| `docs/tasks/index.json` | Maschinenlesbarer Task-Index (Phase-2-Seed: manuell) |
+| `docs/tasks/schema.json` | Validierungsvertrag |
+| `docs/reports/optimierungsstatus.md` | Maßgebliche Statusmatrix (Wahrheitsquelle für OPT-* Einträge) |
+| `docs/reports/optimierungsstatus.json` | Maschinenlesbarer Zwilling der Statusmatrix |
+
+Noch nicht umgesetzt (Folge-PRs): GitHub Issue Forms, PR-Template, Release-Konfig, Generator und CI-Guard.
+
+```bash
+python3 scripts/docmeta/validate_task_index.py docs/tasks/index.json
+```
+
 ## Beiträge & Docs
 
 Stilprüfung via Vale läuft automatisch bei Doku-PRs; lokal `vale docs/` für Hinweise.

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,10 +69,17 @@ Kanonische Navigation. Neue UI-Dokumente bestehenden Kategorien zuordnen.
 – **Runbook:** [runbook.md](runbook.md)
 – **Observability:** [runbook.observability.md](runbook.observability.md)
 
+### Task-Control
+
+– **Task-Control Einstieg:** [tasks/README.md](tasks/README.md) (Rollenklärung und Phase-Stand)
+– **Task Board:** [tasks/board.md](tasks/board.md) (Menschliche Arbeitskarte – aktive Prioritäten, Blocker, nächste PR-Kandidaten)
+– **Task Index:** [tasks/index.json](tasks/index.json) (Maschinenlesbarer Task-Index – Phase-2-Seed, manuell gepflegt)
+– **Optimierungsstatus JSON:** [reports/optimierungsstatus.json](reports/optimierungsstatus.json) (Maschinenlesbarer Zwilling der OPT-Statusmatrix)
+
 ### Berichte & Audits
 
 – **Optimierungsbericht:** [reports/optimierungsbericht.md](reports/optimierungsbericht.md) (Schichtenanalyse mit Handlungsempfehlungen)
-– **Optimierungsstatus:** [reports/optimierungsstatus.md](reports/optimierungsstatus.md) (Operative Statusmatrix mit Nachweisen)
+– **Optimierungsstatus:** [reports/optimierungsstatus.md](reports/optimierungsstatus.md) (Operative Statusmatrix mit Nachweisen – Wahrheitsquelle für OPT-* Einträge)
 – **Auth-Persistenzbereitschaft:** [reports/auth-persistence-readiness.md](reports/auth-persistence-readiness.md) (Diagnose zu OPT-API-002)
 – **Auth-Persistenz Zielarchitektur-Abgleich:** [reports/auth-persistence-runtime-target-reconciliation.md](reports/auth-persistence-runtime-target-reconciliation.md) (ADR-0007: Produktion direkter Postgres; PgBouncer Dev-/Spezialpfad)
 – **Passkey Register-Verify Vorbereitung:** [reports/passkey-register-verify-prep.md](reports/passkey-register-verify-prep.md) (Diagnose und Folge-PR-Entscheidung)

--- a/docs/reports/optimierungsstatus.json
+++ b/docs/reports/optimierungsstatus.json
@@ -1,0 +1,365 @@
+{
+  "schema_version": "1.0.0",
+  "source_markdown": "docs/reports/optimierungsstatus.md",
+  "curation": "manual_phase2_seed",
+  "generated_at": null,
+  "items": [
+    {
+      "id": "OPT-API-001",
+      "area": "API",
+      "title": "Paginierung Listen-Endpunkte",
+      "status": "partial",
+      "priority": "high",
+      "risk": "medium",
+      "effort": "medium",
+      "evidence_status": "code+test",
+      "evidence": [
+        "apps/api/src/routes/nodes.rs",
+        "apps/api/src/routes/edges.rs",
+        "apps/api/src/routes/accounts.rs"
+      ],
+      "missing_evidence": [
+        "Cursor-Variante fehlt",
+        "Response-Metadaten und dokumentierter Sortierungsvertrag fehlen"
+      ],
+      "next_action": "Cursor-Variante + Response-Metadaten implementieren",
+      "updated_at": "2026-04-27"
+    },
+    {
+      "id": "OPT-CON-001",
+      "area": "Contracts",
+      "title": "additionalProperties: false + String-Constraints",
+      "status": "partial",
+      "priority": "high",
+      "risk": "medium",
+      "effort": "low",
+      "evidence_status": "code",
+      "evidence": [
+        "contracts/domain/node.schema.json",
+        "contracts/domain/account.schema.json",
+        "contracts/domain/role.schema.json"
+      ],
+      "missing_evidence": [
+        "Vollständiges Schema-für-Schema-Audit inkl. verbleibender permissiver Felder fehlt"
+      ],
+      "next_action": "Schema-für-Schema-Audit abschließen",
+      "updated_at": "2026-04-27"
+    },
+    {
+      "id": "OPT-DOC-001",
+      "area": "Dokumentation",
+      "title": "Incident-/DB-Recovery-Runbooks",
+      "status": "partial",
+      "priority": "high",
+      "risk": "high",
+      "effort": "low",
+      "evidence_status": "doc-only",
+      "evidence": [
+        "docs/runbook.md",
+        "docs/runbook.observability.md",
+        "docs/runbooks/README.md"
+      ],
+      "missing_evidence": [
+        "Eigenständige Incident-Response- und DB-Recovery-Abläufe fehlen"
+      ],
+      "next_action": "Eigenständige Runbooks unter docs/runbooks/ erstellen",
+      "updated_at": "2026-04-27"
+    },
+    {
+      "id": "OPT-CI-001",
+      "area": "CI/CD",
+      "title": "Workflow-Redundanz",
+      "status": "partial",
+      "priority": "medium",
+      "risk": "medium",
+      "effort": "medium",
+      "evidence_status": "ci",
+      "evidence": [
+        ".github/workflows/ci.yml",
+        ".github/workflows/web.yml",
+        ".github/workflows/heavy.yml"
+      ],
+      "missing_evidence": [
+        "Konsolidierungskonzept via workflow_call fehlt",
+        "Redundanzkriterien und eigener CI-Strukturcheck fehlen"
+      ],
+      "next_action": "Konsolidierungskonzept erstellen",
+      "updated_at": "2026-04-27"
+    },
+    {
+      "id": "OPT-MAP-001",
+      "area": "Frontend/Maps",
+      "title": "Basemap Runtime Proof",
+      "status": "done",
+      "priority": "high",
+      "risk": "high",
+      "effort": "medium",
+      "evidence_status": "runtime",
+      "evidence": [
+        "scripts/guard/basemap-runtime-proof.sh",
+        ".github/workflows/basemap-runtime-proof.yml",
+        "infra/caddy/Caddyfile.proof",
+        "scripts/basemap/build-hamburg-pmtiles.sh",
+        "apps/web/tests/basemap-client-integration.spec.ts"
+      ],
+      "missing_evidence": [],
+      "next_action": "keine – visuelle Abnahme separat in map-status-matrix.md",
+      "updated_at": "2026-05-27"
+    },
+    {
+      "id": "OPT-API-002",
+      "area": "API",
+      "title": "Session-Persistenz Redis/DB",
+      "status": "done",
+      "priority": "high",
+      "risk": "high",
+      "effort": "medium",
+      "evidence_status": "ci",
+      "evidence": [
+        "apps/api/src/auth/session_db.rs",
+        "apps/api/src/lib.rs",
+        "apps/api/src/auth/session.rs",
+        "docs/adr/ADR-0007__auth-persistence-production-db-path.md"
+      ],
+      "missing_evidence": [],
+      "next_action": "keine – Refresh-Token-Persistenz und Session-Leak-Tests sind eigenständige Auth-Phase-6-Themen",
+      "updated_at": "2026-05-27"
+    },
+    {
+      "id": "OPT-API-003",
+      "area": "API",
+      "title": "DB-Migrationen",
+      "status": "done",
+      "priority": "high",
+      "risk": "high",
+      "effort": "low",
+      "evidence_status": "ci",
+      "evidence": [
+        "apps/api/migrations/20260428000000_create_sessions.up.sql",
+        "apps/api/migrations/20260428000000_create_sessions.down.sql",
+        "apps/api/src/lib.rs"
+      ],
+      "missing_evidence": [],
+      "next_action": "keine – weitere Domain-Migrationen gehören zu OPT-ARC-001",
+      "updated_at": "2026-05-27"
+    },
+    {
+      "id": "OPT-FE-001",
+      "area": "Frontend",
+      "title": "Svelte-5-Runes-Migration",
+      "status": "open",
+      "priority": "medium",
+      "risk": "medium",
+      "effort": "high",
+      "evidence_status": "code",
+      "evidence": [
+        "apps/web/src/routes/map/+page.svelte",
+        "apps/web/src/lib/maplibre/Marker.svelte"
+      ],
+      "missing_evidence": [
+        "Keine belegte Nutzung von $state, $derived, $effect in Kernkomponenten"
+      ],
+      "next_action": "Runes-Migration in Kernkomponenten beginnen",
+      "updated_at": "2026-04-27"
+    },
+    {
+      "id": "OPT-FE-002",
+      "area": "Frontend",
+      "title": "Map-Aufteilung",
+      "status": "open",
+      "priority": "medium",
+      "risk": "medium",
+      "effort": "medium",
+      "evidence_status": "code",
+      "evidence": [
+        "apps/web/src/routes/map/+page.svelte"
+      ],
+      "missing_evidence": [
+        "Aufteilung in klar getrennte Teilkomponenten fehlt"
+      ],
+      "next_action": "Monolithische Route in Teilkomponenten aufteilen",
+      "updated_at": "2026-04-27"
+    },
+    {
+      "id": "OPT-INF-001",
+      "area": "Infrastruktur",
+      "title": "Trivy Image Scanning",
+      "status": "open",
+      "priority": "medium",
+      "risk": "medium",
+      "effort": "low",
+      "evidence_status": "ci",
+      "evidence": [
+        ".github/workflows/security.yml"
+      ],
+      "missing_evidence": [
+        "Kein Trivy-Container-Scan-Schritt definiert"
+      ],
+      "next_action": "Trivy-Schritt in security.yml ergänzen",
+      "updated_at": "2026-04-27"
+    },
+    {
+      "id": "OPT-ARC-001",
+      "area": "Architektur",
+      "title": "JSONL → PostgreSQL",
+      "status": "open",
+      "priority": "high",
+      "risk": "high",
+      "effort": "high",
+      "evidence_status": "code",
+      "evidence": [
+        "apps/api/src/routes/nodes.rs"
+      ],
+      "missing_evidence": [
+        "Migrations- und Cutover-Plan fehlt"
+      ],
+      "next_action": "Migrations- und Cutover-Plan für Domänen-Daten erstellen",
+      "updated_at": "2026-04-27"
+    },
+    {
+      "id": "OPT-API-004",
+      "area": "API",
+      "title": "Limit-Obergrenze /nodes & /accounts (Parität zu /edges)",
+      "status": "done",
+      "priority": "high",
+      "risk": "medium",
+      "effort": "low",
+      "evidence_status": "code+test",
+      "evidence": [
+        "apps/api/src/routes/query.rs",
+        "apps/api/src/routes/nodes.rs",
+        "apps/api/src/routes/accounts.rs",
+        "apps/api/src/routes/edges.rs"
+      ],
+      "missing_evidence": [],
+      "next_action": "keine – Cursor-Paginierung bleibt unter OPT-API-001",
+      "updated_at": "2026-05-25"
+    },
+    {
+      "id": "OPT-API-005",
+      "area": "API",
+      "title": "Login-E-Mail Längenbegrenzung",
+      "status": "done",
+      "priority": "low",
+      "risk": "low",
+      "effort": "low",
+      "evidence_status": "code+test",
+      "evidence": [
+        "apps/api/src/routes/auth.rs"
+      ],
+      "missing_evidence": [],
+      "next_action": "keine",
+      "updated_at": "2026-05-27"
+    },
+    {
+      "id": "OPT-CON-002",
+      "area": "Contracts",
+      "title": "maxLength + verbleibende additionalProperties: false",
+      "status": "open",
+      "priority": "medium",
+      "risk": "medium",
+      "effort": "low",
+      "evidence_status": "code",
+      "evidence": [
+        "contracts/domain/message.schema.json",
+        "contracts/domain/role.schema.json"
+      ],
+      "missing_evidence": [
+        "maxLength fehlt in allen sechs Schemas",
+        "restliche permissive Nested-Objects offen"
+      ],
+      "next_action": "maxLength und fehlende additionalProperties: false ergänzen",
+      "updated_at": "2026-05-25"
+    },
+    {
+      "id": "OPT-CI-002",
+      "area": "CI/CD",
+      "title": "Rust-Toolchain-Version aus kanonischer Quelle lesen",
+      "status": "open",
+      "priority": "medium",
+      "risk": "medium",
+      "effort": "low",
+      "evidence_status": "ci",
+      "evidence": [
+        ".github/workflows/security.yml",
+        ".github/workflows/api.yml",
+        ".github/workflows/api-smoke.yml"
+      ],
+      "missing_evidence": [
+        "Sechs hartkodierte Toolchain-Versionen driften potenziell"
+      ],
+      "next_action": "Alle Workflows auf toolchain.versions.yml-Lesung umstellen",
+      "updated_at": "2026-05-25"
+    },
+    {
+      "id": "OPT-CI-003",
+      "area": "CI/CD",
+      "title": "Action-Refs vereinheitlichen",
+      "status": "partial",
+      "priority": "low",
+      "risk": "low",
+      "effort": "low",
+      "evidence_status": "ci",
+      "evidence": [
+        ".github/workflows/python-tooling.yml"
+      ],
+      "missing_evidence": [
+        "dtolnay/rust-toolchain weiterhin gemischt @stable/@v1",
+        "gepinnte uv-Version nicht erzwungen"
+      ],
+      "next_action": "Rust-Toolchain-Action-Refs vereinheitlichen",
+      "updated_at": "2026-05-25"
+    },
+    {
+      "id": "OPT-CI-004",
+      "area": "CI/CD",
+      "title": "Dependency-Update-Automation (Dependabot/Renovate)",
+      "status": "open",
+      "priority": "medium",
+      "risk": "medium",
+      "effort": "low",
+      "evidence_status": "none",
+      "evidence": [],
+      "missing_evidence": [
+        "keine .github/dependabot.yml oder Renovate-Config vorhanden"
+      ],
+      "next_action": "Dependabot oder Renovate konfigurieren",
+      "updated_at": "2026-05-25"
+    },
+    {
+      "id": "OPT-INF-002",
+      "area": "Infrastruktur",
+      "title": "Third-Party-Actions per Commit-SHA pinnen",
+      "status": "open",
+      "priority": "low",
+      "risk": "medium",
+      "effort": "low",
+      "evidence_status": "ci",
+      "evidence": [
+        ".github/workflows/"
+      ],
+      "missing_evidence": [
+        "repo-weit nur Tag-Pinning, kein SHA-Pinning"
+      ],
+      "next_action": "Actions auf Commit-SHA umstellen",
+      "updated_at": "2026-05-25"
+    },
+    {
+      "id": "OPT-FE-003",
+      "area": "Frontend",
+      "title": "Panel-Detail-Fetch-Logik extrahieren",
+      "status": "done",
+      "priority": "low",
+      "risk": "low",
+      "effort": "medium",
+      "evidence_status": "code+test",
+      "evidence": [
+        "apps/web/src/lib/panels/panelDetails.ts",
+        "apps/web/src/lib/utils/formatDate.ts"
+      ],
+      "missing_evidence": [],
+      "next_action": "keine",
+      "updated_at": "2026-05-26"
+    }
+  ]
+}

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -58,7 +58,7 @@ neu bewertet und in `CONTRIBUTING.md` dokumentiert werden.
 ## Validator
 
 ```bash
-python3 scripts/docmeta/validate_task_index.py docs/tasks/index.json
+python3 -m scripts.docmeta.validate_task_index docs/tasks/index.json
 ```
 
 Exit 0 bei Erfolg, 1 bei Validierungsfehlern.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -1,0 +1,65 @@
+---
+id: tasks.readme
+title: Task-Control – Einstieg
+doc_type: guide
+status: active
+summary: >
+  Einstieg in die Task-Control-Schicht von Weltgewebe.
+  Erklärt Zweck, Rollenklärung und Grenzen der Artefakte in docs/tasks/.
+relations:
+  - type: depends_on
+    target: docs/reports/optimierungsstatus.md
+  - type: relates_to
+    target: docs/tasks/board.md
+  - type: relates_to
+    target: docs/policies/agent-reading-protocol.md
+---
+
+# Task-Control – Einstieg
+
+## Zweck
+
+`docs/tasks/` ist die Arbeitssteuerungs-Schicht von Weltgewebe.
+Sie ergänzt die Statusmatrizen in `docs/reports/`, ist aber keine zweite Wahrheitsschicht.
+
+## Rollenklärung der Artefakte
+
+| Datei | Rolle | Schreibstatus |
+|---|---|---|
+| `docs/tasks/board.md` | Menschliche Arbeitskarte (aktive Prioritäten, Blocker, nächste PR-Kandidaten) | Manuell gepflegt |
+| `docs/tasks/index.json` | Maschinenlesbarer Task-Index (Seed: manuell) | Manuell bis Generator eingeführt |
+| `docs/tasks/schema.json` | Validierungsvertrag für `index.json` | Änderungen nur mit begründetem PR |
+| `docs/reports/optimierungsstatus.md` | Belegte menschliche Statusmatrix | Maßgeblich für Wahrheitsgehalt |
+| `docs/reports/optimierungsstatus.json` | Maschinenlesbarer Zwilling der Statusmatrix | Kein eigenständiger Statusträger |
+
+## Wahrheitsklärung
+
+- `docs/reports/optimierungsstatus.md` ist die menschliche Statusmatrix und bleibt die Wahrheitsquelle für OPT-* Einträge.
+- `docs/tasks/index.json` ist eine strukturierte Arbeitskarte, kein Statusersatz.
+- Kein Status in `index.json` oder `optimierungsstatus.json` darf dem Markdown widersprechen.
+- `done` gilt nicht ohne reproduzierbaren Evidenz-Eintrag in der Statusmatrix.
+- Stille Statusupgrades sind verboten.
+
+## Curation-Status
+
+Solange `curation: "manual_phase2_seed"` gesetzt ist, darf `index.json` manuell
+gepflegt werden. Sobald ein Generator eingeführt wird (Phase 4), muss der Schreibstatus
+neu bewertet und in `CONTRIBUTING.md` dokumentiert werden.
+
+## Phase-Stand
+
+| Phase | Artefakte | Status |
+|---|---|---|
+| Phase 2 | `docs/tasks/*`, `docs/reports/optimierungsstatus.json`, Validator | **Vorhanden** |
+| Phase 3 | `.github/ISSUE_TEMPLATE/*`, `.github/pull_request_template.md` | Geplant |
+| Phase 4 | `scripts/docmeta/generate_task_index.py`, CI-Guard | Geplant |
+| Phase 5 | `audit/impl-registry.yaml`-Ausbau | Geplant |
+
+## Validator
+
+```bash
+python3 scripts/docmeta/validate_task_index.py docs/tasks/index.json
+```
+
+Exit 0 bei Erfolg, 1 bei Validierungsfehlern.
+Keine stillen Fixes, kein Schreiben durch den Validator.

--- a/docs/tasks/board.md
+++ b/docs/tasks/board.md
@@ -1,0 +1,56 @@
+---
+id: tasks.board
+title: Weltgewebe Task Board
+doc_type: task-board
+status: active
+summary: >
+  Menschliche Arbeitskarte für aktive Task-Control-Prioritäten.
+  Keine Wahrheitsschicht – Statuswechsel brauchen Evidenz in Statusmatrizen, Reports, PRs oder Tests.
+relations:
+  - type: depends_on
+    target: docs/reports/optimierungsstatus.md
+  - type: relates_to
+    target: docs/tasks/index.json
+  - type: relates_to
+    target: docs/tasks/README.md
+---
+
+# Weltgewebe Task Board
+
+> Arbeitssteuerung, keine Wahrheitsschicht.
+> Statuswechsel brauchen Evidenz in Statusmatrizen, Reports, PRs oder Tests.
+
+## Aktive Prioritäten
+
+| ID | Bereich | Titel | Status | Priorität | Evidenz | Nächste Aktion |
+|---|---|---|---|---|---|---|
+| TASK-CTL-001 | docs | Task-Control Phase 2 etablieren | partial | high | Phase-2-PR (dieser PR) | PR mergen, Validator-Pass bestätigen |
+| OPT-API-001 | api | Paginierung Listen-Endpunkte | partial | high | `apps/api/src/routes/nodes.rs` | Cursor-Variante + Response-Metadaten implementieren |
+| OPT-CON-001 | ci | `additionalProperties: false` + String-Constraints | partial | high | `contracts/domain/node.schema.json` | Schema-für-Schema-Audit abschließen |
+| OPT-DOC-001 | docs | Incident-/DB-Recovery-Runbooks | partial | high | `docs/runbook.md` | Eigenständige Runbooks unter `docs/runbooks/` erstellen |
+| OPT-ARC-001 | api | JSONL → PostgreSQL | open | high | `apps/api/src/routes/nodes.rs` (Ist-Befund) | Migrations- und Cutover-Plan erstellen |
+
+## Blocker
+
+| ID | Blocker | Fehlt | Folge |
+|---|---|---|---|
+| OPT-ARC-001 | Kein Migrations-/Cutover-Plan | Konzept für sicheren Cutover | JSONL bleibt aktive Datenquelle |
+| OPT-API-001 | Cursor-Variante nicht spezifiziert | Sortierungsvertrag + Response-Metadaten | Paginierung bleibt unvollständig |
+
+## Nächste PR-Kandidaten
+
+| ID | PR-Schnitt | Akzeptanzkriterium |
+|---|---|---|
+| TASK-CTL-002 | Phase 3: `.github/ISSUE_TEMPLATE/*.yml` + PR-Template | Issue Forms existieren, PR-Template verlinkt Task-Index |
+| OPT-CON-001 | Schema-Constraints: `additionalProperties: false` alle 6 Schemas | `just contracts-domain-check` pass + kein permissives Nested-Object |
+| OPT-DOC-001 | Runbooks: `docs/runbooks/incident-response.md` + `db-recovery.md` | Eigenständige Abläufe, kein DSGVO-Leak-Risiko |
+
+## Erledigte Tasks (Phase 1–2 Referenz)
+
+| ID | Bereich | Titel | Evidenz |
+|---|---|---|---|
+| OPT-MAP-001 | map | Basemap Runtime Proof | CI-Job `basemap-range-delivery-proof` PROVEN, Commit `14feefd6` |
+| OPT-API-002 | api | Session-Persistenz PostgreSQL | `apps/api/src/auth/session_db.rs`, CI PROVEN, Commit `00a43a00` |
+| OPT-API-003 | api | DB-Migrationen | `apps/api/migrations/`, CI PROVEN, Commit `00a43a00` |
+| OPT-API-004 | api | Limit-Obergrenze `/nodes` & `/accounts` | `apps/api/src/routes/query.rs`, Tests 4+9 passed |
+| OPT-FE-003 | web | Panel-Detail-Fetch-Logik extrahieren | `apps/web/src/lib/panels/panelDetails.ts`, 10+5 Tests passed |

--- a/docs/tasks/index.json
+++ b/docs/tasks/index.json
@@ -1,0 +1,219 @@
+{
+  "schema_version": "1.0.0",
+  "generated_at": null,
+  "curation": "manual_phase2_seed",
+  "source_files": [
+    "docs/reports/optimierungsstatus.md",
+    "docs/reports/auth-status-matrix.json",
+    "docs/reports/map-status-matrix.json",
+    "docs/tasks/board.md"
+  ],
+  "tasks": [
+    {
+      "id": "TASK-CTL-001",
+      "title": "Task-Control Phase 2 etablieren",
+      "area": "docs",
+      "status": "partial",
+      "priority": "high",
+      "effort": "M",
+      "risk": "medium",
+      "owner": "unknown",
+      "evidence": [
+        "docs/tasks/README.md",
+        "docs/tasks/board.md",
+        "docs/tasks/index.json",
+        "docs/tasks/schema.json",
+        "docs/reports/optimierungsstatus.json",
+        "scripts/docmeta/validate_task_index.py"
+      ],
+      "missing_evidence": [
+        "PR-Merge-Nachweis steht aus"
+      ],
+      "acceptance": [
+        "docs/tasks/ existiert und alle Phase-2-Artefakte sind vorhanden",
+        "Validator läuft mit exit 0 gegen docs/tasks/index.json",
+        "README, CONTRIBUTING und docs/index.md beschreiben Task-Control korrekt"
+      ],
+      "links": {
+        "issues": [],
+        "prs": [],
+        "docs": [
+          "docs/tasks/README.md",
+          "docs/tasks/board.md"
+        ]
+      },
+      "updated_at": "2026-05-28"
+    },
+    {
+      "id": "TASK-CTL-002",
+      "title": "GitHub-native Arbeitsobjekte einführen (Phase 3)",
+      "area": "governance",
+      "status": "open",
+      "priority": "medium",
+      "effort": "S",
+      "risk": "low",
+      "owner": "unknown",
+      "evidence": [],
+      "missing_evidence": [
+        "keine Issue Forms vorhanden",
+        "kein PR-Template vorhanden",
+        "keine Release-Konfiguration vorhanden"
+      ],
+      "acceptance": [],
+      "links": {
+        "issues": [],
+        "prs": [],
+        "docs": []
+      },
+      "updated_at": "2026-05-28"
+    },
+    {
+      "id": "TASK-CTL-003",
+      "title": "Task-Index Generator und CI-Guard einführen (Phase 4)",
+      "area": "ci",
+      "status": "open",
+      "priority": "medium",
+      "effort": "M",
+      "risk": "medium",
+      "owner": "unknown",
+      "evidence": [],
+      "missing_evidence": [
+        "generate_task_index.py nicht vorhanden",
+        "CI-Workflow task-index.yml nicht vorhanden"
+      ],
+      "acceptance": [],
+      "links": {
+        "issues": [],
+        "prs": [],
+        "docs": []
+      },
+      "updated_at": "2026-05-28"
+    },
+    {
+      "id": "OPT-API-001",
+      "title": "Paginierung Listen-Endpunkte",
+      "area": "api",
+      "status": "partial",
+      "priority": "high",
+      "effort": "M",
+      "risk": "medium",
+      "owner": "unknown",
+      "evidence": [
+        "apps/api/src/routes/nodes.rs",
+        "apps/api/src/routes/edges.rs",
+        "apps/api/src/routes/accounts.rs"
+      ],
+      "missing_evidence": [
+        "Cursor-Variante fehlt",
+        "Response-Metadaten (total, next_cursor) fehlen",
+        "dokumentierter Sortierungsvertrag fehlt"
+      ],
+      "acceptance": [
+        "Cursor-Paginierung implementiert und per Test belegt",
+        "Response-Metadaten in API-Spec dokumentiert",
+        "Sortierungsvertrag explizit definiert"
+      ],
+      "links": {
+        "issues": [],
+        "prs": [],
+        "docs": [
+          "docs/reports/optimierungsstatus.md"
+        ]
+      },
+      "updated_at": "2026-05-28"
+    },
+    {
+      "id": "OPT-CON-001",
+      "title": "additionalProperties: false und String-Constraints in Domain-Schemas",
+      "area": "ci",
+      "status": "partial",
+      "priority": "high",
+      "effort": "S",
+      "risk": "medium",
+      "owner": "unknown",
+      "evidence": [
+        "contracts/domain/node.schema.json",
+        "contracts/domain/account.schema.json",
+        "contracts/domain/role.schema.json"
+      ],
+      "missing_evidence": [
+        "vollständiges Schema-für-Schema-Audit fehlt",
+        "verbleibende permissive Felder nicht inventarisiert"
+      ],
+      "acceptance": [
+        "alle 6 Domain-Schemas haben additionalProperties: false",
+        "String-Constraints (minLength, maxLength, pattern) konsistent gesetzt",
+        "just contracts-domain-check pass"
+      ],
+      "links": {
+        "issues": [],
+        "prs": [],
+        "docs": [
+          "docs/reports/optimierungsstatus.md"
+        ]
+      },
+      "updated_at": "2026-05-28"
+    },
+    {
+      "id": "OPT-DOC-001",
+      "title": "Incident-/DB-Recovery-Runbooks",
+      "area": "docs",
+      "status": "partial",
+      "priority": "high",
+      "effort": "S",
+      "risk": "high",
+      "owner": "unknown",
+      "evidence": [
+        "docs/runbook.md",
+        "docs/runbook.observability.md",
+        "docs/runbooks/README.md"
+      ],
+      "missing_evidence": [
+        "eigenständiger Incident-Response-Ablauf fehlt",
+        "eigenständiger DB-Recovery-Ablauf fehlt"
+      ],
+      "acceptance": [
+        "docs/runbooks/incident-response.md existiert mit vollständigem Ablauf",
+        "docs/runbooks/db-recovery.md existiert mit vollständigem Ablauf"
+      ],
+      "links": {
+        "issues": [],
+        "prs": [],
+        "docs": [
+          "docs/runbook.md",
+          "docs/runbooks/README.md"
+        ]
+      },
+      "updated_at": "2026-05-28"
+    },
+    {
+      "id": "OPT-ARC-001",
+      "title": "JSONL-Datenquelle zu PostgreSQL migrieren",
+      "area": "api",
+      "status": "open",
+      "priority": "high",
+      "effort": "XL",
+      "risk": "high",
+      "owner": "unknown",
+      "evidence": [],
+      "missing_evidence": [
+        "Migrations- und Cutover-Plan fehlt",
+        "Domain-Migrationen für Nodes/Accounts/Edges fehlen",
+        "kein Runtime-Nachweis für PostgreSQL-Pfad in Domänen-Endpunkten"
+      ],
+      "acceptance": [
+        "PostgreSQL-Pfad für alle Domänen-Endpunkte (nodes, accounts, edges) aktiv",
+        "JSONL-Pfad deaktiviert oder als Legacy klar markiert",
+        "Migrations-SQL vorhanden und per CI belegt"
+      ],
+      "links": {
+        "issues": [],
+        "prs": [],
+        "docs": [
+          "docs/reports/optimierungsstatus.md"
+        ]
+      },
+      "updated_at": "2026-05-28"
+    }
+  ]
+}

--- a/docs/tasks/schema.json
+++ b/docs/tasks/schema.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Weltgewebe Task Index",
+  "description": "Validierungsvertrag für docs/tasks/index.json",
+  "type": "object",
+  "required": ["schema_version", "curation", "source_files", "tasks"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "generated_at": {
+      "oneOf": [{"type": "string"}, {"type": "null"}]
+    },
+    "curation": {
+      "type": "string",
+      "description": "Beschreibt, wie der Index gepflegt wird: 'manual_phase2_seed', 'manual', 'generated', 'hybrid'"
+    },
+    "source_files": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Quelldateien, aus denen der Index gespeist wird"
+    },
+    "tasks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "title", "area", "status", "priority", "effort", "risk", "owner", "evidence", "missing_evidence", "acceptance", "links", "updated_at"],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[A-Z]+(-[A-Z]+)*-[0-9]{3}$",
+            "description": "Eindeutige Task-ID, z.B. TASK-CTL-001 oder OPT-API-001"
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "area": {
+            "type": "string",
+            "enum": ["docs", "ci", "api", "web", "infra", "release", "auth", "map", "governance"]
+          },
+          "status": {
+            "type": "string",
+            "enum": ["open", "partial", "done", "blocked", "obsolete", "contradicted"]
+          },
+          "priority": {
+            "type": "string",
+            "enum": ["high", "medium", "low"]
+          },
+          "effort": {
+            "type": "string",
+            "enum": ["XS", "S", "M", "L", "XL"]
+          },
+          "risk": {
+            "type": "string",
+            "enum": ["low", "medium", "high"]
+          },
+          "owner": {
+            "type": "string",
+            "description": "'unknown' ist erlaubt"
+          },
+          "evidence": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Belegte Repo-Pfade, CI-Runs oder Commit-Hashes als Nachweis"
+          },
+          "missing_evidence": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Explizite Benennung fehlender Nachweise"
+          },
+          "acceptance": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Akzeptanzkriterien; High-Priority-Tasks brauchen mindestens eines"
+          },
+          "links": {
+            "type": "object",
+            "required": ["issues", "prs", "docs"],
+            "additionalProperties": false,
+            "properties": {
+              "issues": {"type": "array", "items": {"type": "string"}},
+              "prs": {"type": "array", "items": {"type": "string"}},
+              "docs": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Repo-root-relative Pfade zu existierenden Dokumenten"
+              }
+            }
+          },
+          "updated_at": {
+            "type": "string",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/docmeta/tests/test_validate_task_index.py
+++ b/scripts/docmeta/tests/test_validate_task_index.py
@@ -26,14 +26,16 @@ def _make_task(**overrides):
     return task
 
 
-def _make_index(tasks=None):
-    return {
+def _make_index(tasks=None, **top_overrides):
+    data = {
         "schema_version": "1.0.0",
         "generated_at": None,
         "curation": "manual_phase2_seed",
         "source_files": [],
         "tasks": tasks if tasks is not None else [_make_task()],
     }
+    data.update(top_overrides)
+    return data
 
 
 class TestValidateTaskIndex(unittest.TestCase):
@@ -46,10 +48,9 @@ class TestValidateTaskIndex(unittest.TestCase):
         f.close()
         return f.name
 
-    def tearDown(self):
-        pass
-
-    # --- passing cases ---
+    # -------------------------------------------------------------------------
+    # Passing cases
+    # -------------------------------------------------------------------------
 
     def test_valid_seed_passes(self):
         path = self._write(_make_index())
@@ -97,28 +98,44 @@ class TestValidateTaskIndex(unittest.TestCase):
         finally:
             os.unlink(path)
 
-    # --- failing cases ---
+    def test_generated_at_null_passes(self):
+        path = self._write(_make_index(generated_at=None))
+        try:
+            self.assertEqual(validate_task_index(path), [])
+        finally:
+            os.unlink(path)
+
+    def test_generated_at_string_passes(self):
+        path = self._write(_make_index(generated_at="2026-05-28T17:00:00Z"))
+        try:
+            self.assertEqual(validate_task_index(path), [])
+        finally:
+            os.unlink(path)
+
+    # -------------------------------------------------------------------------
+    # Duplicate ID
+    # -------------------------------------------------------------------------
 
     def test_duplicate_ids_fail(self):
         tasks = [_make_task(), _make_task()]
         path = self._write(_make_index(tasks))
         try:
             errors = validate_task_index(path)
-            self.assertTrue(
-                any("duplicate" in e for e in errors),
-                f"Expected duplicate error, got: {errors}",
-            )
+            self.assertGreater(len(errors), 0)
+            self.assertTrue(any("duplicate" in e for e in errors), errors)
         finally:
             os.unlink(path)
+
+    # -------------------------------------------------------------------------
+    # High priority / done business rules
+    # -------------------------------------------------------------------------
 
     def test_high_priority_without_acceptance_fails(self):
         path = self._write(_make_index([_make_task(priority="high", acceptance=[])]))
         try:
             errors = validate_task_index(path)
-            self.assertTrue(
-                any("acceptance" in e for e in errors),
-                f"Expected acceptance error, got: {errors}",
-            )
+            self.assertGreater(len(errors), 0)
+            self.assertTrue(any("acceptance" in e for e in errors), errors)
         finally:
             os.unlink(path)
 
@@ -126,12 +143,14 @@ class TestValidateTaskIndex(unittest.TestCase):
         path = self._write(_make_index([_make_task(status="done", evidence=[])]))
         try:
             errors = validate_task_index(path)
-            self.assertTrue(
-                any("evidence" in e for e in errors),
-                f"Expected evidence error, got: {errors}",
-            )
+            self.assertGreater(len(errors), 0)
+            self.assertTrue(any("evidence" in e for e in errors), errors)
         finally:
             os.unlink(path)
+
+    # -------------------------------------------------------------------------
+    # Path checks
+    # -------------------------------------------------------------------------
 
     def test_missing_docs_path_unexplained_fails(self):
         path = self._write(
@@ -144,21 +163,23 @@ class TestValidateTaskIndex(unittest.TestCase):
         )
         try:
             errors = validate_task_index(path)
+            self.assertGreater(len(errors), 0)
             self.assertTrue(
-                any("docs/nonexistent/path.md" in e for e in errors),
-                f"Expected missing path error, got: {errors}",
+                any("docs/nonexistent/path.md" in e for e in errors), errors
             )
         finally:
             os.unlink(path)
+
+    # -------------------------------------------------------------------------
+    # Enum / pattern failures
+    # -------------------------------------------------------------------------
 
     def test_invalid_status_fails(self):
         path = self._write(_make_index([_make_task(status="inprogress")]))
         try:
             errors = validate_task_index(path)
-            self.assertTrue(
-                any("status" in e for e in errors),
-                f"Expected status error, got: {errors}",
-            )
+            self.assertGreater(len(errors), 0)
+            self.assertTrue(any("status" in e for e in errors), errors)
         finally:
             os.unlink(path)
 
@@ -166,12 +187,16 @@ class TestValidateTaskIndex(unittest.TestCase):
         path = self._write(_make_index([_make_task(id="task-001")]))
         try:
             errors = validate_task_index(path)
+            self.assertGreater(len(errors), 0)
             self.assertTrue(
-                any("id" in e.lower() or "pattern" in e.lower() for e in errors),
-                f"Expected id pattern error, got: {errors}",
+                any("id" in e.lower() or "pattern" in e.lower() for e in errors), errors
             )
         finally:
             os.unlink(path)
+
+    # -------------------------------------------------------------------------
+    # Missing required field
+    # -------------------------------------------------------------------------
 
     def test_missing_required_task_field_fails(self):
         task = _make_task()
@@ -179,17 +204,156 @@ class TestValidateTaskIndex(unittest.TestCase):
         path = self._write(_make_index([task]))
         try:
             errors = validate_task_index(path)
-            self.assertTrue(
-                any("title" in e for e in errors),
-                f"Expected missing field error, got: {errors}",
-            )
+            self.assertGreater(len(errors), 0)
+            self.assertTrue(any("title" in e for e in errors), errors)
         finally:
             os.unlink(path)
 
+    # -------------------------------------------------------------------------
+    # File not found
+    # -------------------------------------------------------------------------
+
     def test_file_not_found_returns_error(self):
-        errors = validate_task_index("/tmp/does_not_exist_XYZ.json")
-        self.assertTrue(len(errors) > 0)
-        self.assertTrue(any("not found" in e for e in errors))
+        errors = validate_task_index("/tmp/does_not_exist_XYZ_weltgewebe.json")
+        self.assertGreater(len(errors), 0)
+        self.assertTrue(any("not found" in e for e in errors), errors)
+
+    # -------------------------------------------------------------------------
+    # Top-level schema enforcement
+    # -------------------------------------------------------------------------
+
+    def test_missing_curation_fails(self):
+        data = _make_index()
+        del data["curation"]
+        path = self._write(data)
+        try:
+            errors = validate_task_index(path)
+            self.assertGreater(len(errors), 0)
+            self.assertTrue(any("curation" in e for e in errors), errors)
+        finally:
+            os.unlink(path)
+
+    def test_missing_source_files_fails(self):
+        data = _make_index()
+        del data["source_files"]
+        path = self._write(data)
+        try:
+            errors = validate_task_index(path)
+            self.assertGreater(len(errors), 0)
+            self.assertTrue(any("source_files" in e for e in errors), errors)
+        finally:
+            os.unlink(path)
+
+    def test_extra_top_level_key_fails(self):
+        data = _make_index()
+        data["unexpected_key"] = "surprise"
+        path = self._write(data)
+        try:
+            errors = validate_task_index(path)
+            self.assertGreater(len(errors), 0)
+            self.assertTrue(any("unexpected_key" in e for e in errors), errors)
+        finally:
+            os.unlink(path)
+
+    def test_source_files_as_string_fails(self):
+        data = _make_index()
+        data["source_files"] = "not-an-array"
+        path = self._write(data)
+        try:
+            errors = validate_task_index(path)
+            self.assertGreater(len(errors), 0)
+            self.assertTrue(any("source_files" in e for e in errors), errors)
+        finally:
+            os.unlink(path)
+
+    # -------------------------------------------------------------------------
+    # Task-level schema enforcement
+    # -------------------------------------------------------------------------
+
+    def test_extra_task_key_fails(self):
+        task = _make_task()
+        task["surprise_field"] = "unexpected"
+        path = self._write(_make_index([task]))
+        try:
+            errors = validate_task_index(path)
+            self.assertGreater(len(errors), 0)
+            self.assertTrue(any("surprise_field" in e for e in errors), errors)
+        finally:
+            os.unlink(path)
+
+    def test_evidence_as_string_fails(self):
+        task = _make_task(evidence="not-an-array")
+        path = self._write(_make_index([task]))
+        try:
+            errors = validate_task_index(path)
+            self.assertGreater(len(errors), 0)
+            self.assertTrue(any("evidence" in e for e in errors), errors)
+        finally:
+            os.unlink(path)
+
+    def test_acceptance_as_string_fails(self):
+        task = _make_task(acceptance="not-an-array")
+        path = self._write(_make_index([task]))
+        try:
+            errors = validate_task_index(path)
+            self.assertGreater(len(errors), 0)
+            self.assertTrue(any("acceptance" in e for e in errors), errors)
+        finally:
+            os.unlink(path)
+
+    def test_missing_evidence_as_string_fails(self):
+        task = _make_task(missing_evidence="not-an-array")
+        path = self._write(_make_index([task]))
+        try:
+            errors = validate_task_index(path)
+            self.assertGreater(len(errors), 0)
+            self.assertTrue(any("missing_evidence" in e for e in errors), errors)
+        finally:
+            os.unlink(path)
+
+    # -------------------------------------------------------------------------
+    # links schema enforcement
+    # -------------------------------------------------------------------------
+
+    def test_links_docs_as_string_fails(self):
+        task = _make_task(links={"issues": [], "prs": [], "docs": "not-an-array"})
+        path = self._write(_make_index([task]))
+        try:
+            errors = validate_task_index(path)
+            self.assertGreater(len(errors), 0)
+            self.assertTrue(any("docs" in e for e in errors), errors)
+        finally:
+            os.unlink(path)
+
+    def test_links_extra_key_fails(self):
+        task = _make_task(links={"issues": [], "prs": [], "docs": [], "extra": "nope"})
+        path = self._write(_make_index([task]))
+        try:
+            errors = validate_task_index(path)
+            self.assertGreater(len(errors), 0)
+            self.assertTrue(any("extra" in e for e in errors), errors)
+        finally:
+            os.unlink(path)
+
+    def test_links_issues_wrong_type_fails(self):
+        task = _make_task(links={"issues": "string", "prs": [], "docs": []})
+        path = self._write(_make_index([task]))
+        try:
+            errors = validate_task_index(path)
+            self.assertGreater(len(errors), 0)
+            self.assertTrue(any("issues" in e for e in errors), errors)
+        finally:
+            os.unlink(path)
+
+    def test_links_prs_wrong_type_fails(self):
+        task = _make_task(links={"issues": [], "prs": 42, "docs": []})
+        path = self._write(_make_index([task]))
+        try:
+            errors = validate_task_index(path)
+            self.assertGreater(len(errors), 0)
+            self.assertTrue(any("prs" in e for e in errors), errors)
+        finally:
+            os.unlink(path)
 
 
 if __name__ == "__main__":

--- a/scripts/docmeta/tests/test_validate_task_index.py
+++ b/scripts/docmeta/tests/test_validate_task_index.py
@@ -1,0 +1,196 @@
+import json
+import os
+import tempfile
+import unittest
+
+from scripts.docmeta.validate_task_index import validate_task_index
+
+
+def _make_task(**overrides):
+    task = {
+        "id": "TASK-CTL-001",
+        "title": "Task Control Phase 2",
+        "area": "docs",
+        "status": "open",
+        "priority": "high",
+        "effort": "M",
+        "risk": "medium",
+        "owner": "unknown",
+        "evidence": [],
+        "missing_evidence": ["Evidenz steht aus"],
+        "acceptance": ["docs/tasks/ existiert"],
+        "links": {"issues": [], "prs": [], "docs": []},
+        "updated_at": "2026-05-28",
+    }
+    task.update(overrides)
+    return task
+
+
+def _make_index(tasks=None):
+    return {
+        "schema_version": "1.0.0",
+        "generated_at": None,
+        "curation": "manual_phase2_seed",
+        "source_files": [],
+        "tasks": tasks if tasks is not None else [_make_task()],
+    }
+
+
+class TestValidateTaskIndex(unittest.TestCase):
+
+    def _write(self, data):
+        f = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False, encoding="utf-8"
+        )
+        json.dump(data, f, ensure_ascii=False)
+        f.close()
+        return f.name
+
+    def tearDown(self):
+        pass
+
+    # --- passing cases ---
+
+    def test_valid_seed_passes(self):
+        path = self._write(_make_index())
+        try:
+            self.assertEqual(validate_task_index(path), [])
+        finally:
+            os.unlink(path)
+
+    def test_high_priority_with_acceptance_passes(self):
+        path = self._write(_make_index([_make_task(priority="high", acceptance=["criterion"])]))
+        try:
+            self.assertEqual(validate_task_index(path), [])
+        finally:
+            os.unlink(path)
+
+    def test_done_with_evidence_passes(self):
+        path = self._write(
+            _make_index([_make_task(status="done", evidence=["some/proof/file.rs"])])
+        )
+        try:
+            self.assertEqual(validate_task_index(path), [])
+        finally:
+            os.unlink(path)
+
+    def test_missing_docs_path_explained_passes(self):
+        path = self._write(
+            _make_index([
+                _make_task(
+                    links={"issues": [], "prs": [], "docs": ["docs/nonexistent.md"]},
+                    missing_evidence=["docs/nonexistent.md nicht vorhanden"],
+                )
+            ])
+        )
+        try:
+            self.assertEqual(validate_task_index(path), [])
+        finally:
+            os.unlink(path)
+
+    def test_medium_priority_empty_acceptance_passes(self):
+        path = self._write(
+            _make_index([_make_task(id="OPT-CI-001", priority="medium", acceptance=[])])
+        )
+        try:
+            self.assertEqual(validate_task_index(path), [])
+        finally:
+            os.unlink(path)
+
+    # --- failing cases ---
+
+    def test_duplicate_ids_fail(self):
+        tasks = [_make_task(), _make_task()]
+        path = self._write(_make_index(tasks))
+        try:
+            errors = validate_task_index(path)
+            self.assertTrue(
+                any("duplicate" in e for e in errors),
+                f"Expected duplicate error, got: {errors}",
+            )
+        finally:
+            os.unlink(path)
+
+    def test_high_priority_without_acceptance_fails(self):
+        path = self._write(_make_index([_make_task(priority="high", acceptance=[])]))
+        try:
+            errors = validate_task_index(path)
+            self.assertTrue(
+                any("acceptance" in e for e in errors),
+                f"Expected acceptance error, got: {errors}",
+            )
+        finally:
+            os.unlink(path)
+
+    def test_done_without_evidence_fails(self):
+        path = self._write(_make_index([_make_task(status="done", evidence=[])]))
+        try:
+            errors = validate_task_index(path)
+            self.assertTrue(
+                any("evidence" in e for e in errors),
+                f"Expected evidence error, got: {errors}",
+            )
+        finally:
+            os.unlink(path)
+
+    def test_missing_docs_path_unexplained_fails(self):
+        path = self._write(
+            _make_index([
+                _make_task(
+                    links={"issues": [], "prs": [], "docs": ["docs/nonexistent/path.md"]},
+                    missing_evidence=[],
+                )
+            ])
+        )
+        try:
+            errors = validate_task_index(path)
+            self.assertTrue(
+                any("docs/nonexistent/path.md" in e for e in errors),
+                f"Expected missing path error, got: {errors}",
+            )
+        finally:
+            os.unlink(path)
+
+    def test_invalid_status_fails(self):
+        path = self._write(_make_index([_make_task(status="inprogress")]))
+        try:
+            errors = validate_task_index(path)
+            self.assertTrue(
+                any("status" in e for e in errors),
+                f"Expected status error, got: {errors}",
+            )
+        finally:
+            os.unlink(path)
+
+    def test_invalid_id_pattern_fails(self):
+        path = self._write(_make_index([_make_task(id="task-001")]))
+        try:
+            errors = validate_task_index(path)
+            self.assertTrue(
+                any("id" in e.lower() or "pattern" in e.lower() for e in errors),
+                f"Expected id pattern error, got: {errors}",
+            )
+        finally:
+            os.unlink(path)
+
+    def test_missing_required_task_field_fails(self):
+        task = _make_task()
+        del task["title"]
+        path = self._write(_make_index([task]))
+        try:
+            errors = validate_task_index(path)
+            self.assertTrue(
+                any("title" in e for e in errors),
+                f"Expected missing field error, got: {errors}",
+            )
+        finally:
+            os.unlink(path)
+
+    def test_file_not_found_returns_error(self):
+        errors = validate_task_index("/tmp/does_not_exist_XYZ.json")
+        self.assertTrue(len(errors) > 0)
+        self.assertTrue(any("not found" in e for e in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/docmeta/validate_task_index.py
+++ b/scripts/docmeta/validate_task_index.py
@@ -2,7 +2,7 @@
 validate_task_index.py — Validates docs/tasks/index.json against schema and business rules.
 
 Usage:
-    python3 scripts/docmeta/validate_task_index.py docs/tasks/index.json
+    python3 -m scripts.docmeta.validate_task_index docs/tasks/index.json
 
 Exit codes:
     0  all checks pass
@@ -15,28 +15,172 @@ import os
 import re
 import sys
 
-REPO_ROOT = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", ".."))
+from scripts.docmeta.docmeta import REPO_ROOT
 
 SCHEMA_PATH = os.path.join(REPO_ROOT, "docs", "tasks", "schema.json")
 
-ALLOWED_AREA = {"docs", "ci", "api", "web", "infra", "release", "auth", "map", "governance"}
-ALLOWED_STATUS = {"open", "partial", "done", "blocked", "obsolete", "contradicted"}
-ALLOWED_PRIORITY = {"high", "medium", "low"}
-ALLOWED_EFFORT = {"XS", "S", "M", "L", "XL"}
-ALLOWED_RISK = {"low", "medium", "high"}
+ALLOWED_AREA = frozenset({"docs", "ci", "api", "web", "infra", "release", "auth", "map", "governance"})
+ALLOWED_STATUS = frozenset({"open", "partial", "done", "blocked", "obsolete", "contradicted"})
+ALLOWED_PRIORITY = frozenset({"high", "medium", "low"})
+ALLOWED_EFFORT = frozenset({"XS", "S", "M", "L", "XL"})
+ALLOWED_RISK = frozenset({"low", "medium", "high"})
 
 ID_PATTERN = re.compile(r"^[A-Z]+(-[A-Z]+)*-[0-9]{3}$")
 DATE_PATTERN = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}$")
+SEMVER_PATTERN = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
 
-REQUIRED_TASK_FIELDS = frozenset({
+TOP_LEVEL_REQUIRED = frozenset({"schema_version", "curation", "source_files", "tasks"})
+TOP_LEVEL_ALLOWED = frozenset({"schema_version", "curation", "source_files", "tasks", "generated_at"})
+
+TASK_REQUIRED = frozenset({
     "id", "title", "area", "status", "priority", "effort", "risk",
     "owner", "evidence", "missing_evidence", "acceptance", "links", "updated_at",
 })
-REQUIRED_LINKS_FIELDS = frozenset({"issues", "prs", "docs"})
+TASK_ALLOWED = TASK_REQUIRED
+
+LINKS_REQUIRED = frozenset({"issues", "prs", "docs"})
+LINKS_ALLOWED = LINKS_REQUIRED
 
 
 def _path_exists(rel_path):
     return os.path.isfile(os.path.join(REPO_ROOT, rel_path))
+
+
+def _check_array_of_strings(value, path, errors):
+    if not isinstance(value, list):
+        errors.append(f"{path}: must be array[string], got {type(value).__name__}")
+        return False
+    for i, item in enumerate(value):
+        if not isinstance(item, str):
+            errors.append(f"{path}[{i}]: must be string, got {type(item).__name__}")
+    return True
+
+
+def _validate_links(links, prefix, missing_evidence, errors):
+    if not isinstance(links, dict):
+        errors.append(f"{prefix}.links: must be an object, got {type(links).__name__}")
+        return
+
+    for f in sorted(LINKS_REQUIRED):
+        if f not in links:
+            errors.append(f"{prefix}.links: missing required field '{f}'")
+
+    extra_keys = set(links.keys()) - LINKS_ALLOWED
+    for k in sorted(extra_keys):
+        errors.append(f"{prefix}.links: unexpected key '{k}'")
+
+    for field in ("issues", "prs", "docs"):
+        if field in links:
+            _check_array_of_strings(links[field], f"{prefix}.links.{field}", errors)
+
+    for doc_path in links.get("docs", []):
+        if not isinstance(doc_path, str):
+            continue
+        if not _path_exists(doc_path):
+            explained = any(
+                doc_path in me for me in missing_evidence if isinstance(me, str)
+            )
+            if not explained:
+                errors.append(
+                    f"{prefix}: links.docs '{doc_path}' does not exist "
+                    f"and is not explained in missing_evidence"
+                )
+
+
+def _validate_task(task, index, prefix, errors):
+    if not isinstance(task, dict):
+        errors.append(f"{prefix}: expected object, got {type(task).__name__}")
+        return
+
+    for field in sorted(TASK_REQUIRED):
+        if field not in task:
+            errors.append(f"{prefix}: missing required field '{field}'")
+
+    extra_keys = set(task.keys()) - TASK_ALLOWED
+    for k in sorted(extra_keys):
+        errors.append(f"{prefix}: unexpected key '{k}'")
+
+    tid = task.get("id")
+    if tid is not None:
+        if not isinstance(tid, str) or not ID_PATTERN.match(tid):
+            errors.append(
+                f"{prefix}: id '{tid}' does not match pattern "
+                r"^[A-Z]+(-[A-Z]+)*-[0-9]{3}$"
+            )
+        if isinstance(tid, str) and tid in index:
+            errors.append(
+                f"{prefix}: duplicate id '{tid}' (also at tasks[{index[tid]}])"
+            )
+        elif isinstance(tid, str):
+            index[tid] = prefix
+
+    for str_field in ("title", "area", "status", "priority", "effort", "risk", "owner", "updated_at"):
+        val = task.get(str_field)
+        if val is not None and not isinstance(val, str):
+            errors.append(f"{prefix}.{str_field}: must be string, got {type(val).__name__}")
+
+    area = task.get("area")
+    if isinstance(area, str) and area not in ALLOWED_AREA:
+        errors.append(f"{prefix}.area: '{area}' not in {sorted(ALLOWED_AREA)}")
+
+    status = task.get("status")
+    if isinstance(status, str) and status not in ALLOWED_STATUS:
+        errors.append(f"{prefix}.status: '{status}' not in {sorted(ALLOWED_STATUS)}")
+
+    priority = task.get("priority")
+    if isinstance(priority, str) and priority not in ALLOWED_PRIORITY:
+        errors.append(f"{prefix}.priority: '{priority}' not in {sorted(ALLOWED_PRIORITY)}")
+
+    effort = task.get("effort")
+    if isinstance(effort, str) and effort not in ALLOWED_EFFORT:
+        errors.append(f"{prefix}.effort: '{effort}' not in {sorted(ALLOWED_EFFORT)}")
+
+    risk = task.get("risk")
+    if isinstance(risk, str) and risk not in ALLOWED_RISK:
+        errors.append(f"{prefix}.risk: '{risk}' not in {sorted(ALLOWED_RISK)}")
+
+    updated_at = task.get("updated_at")
+    if isinstance(updated_at, str) and not DATE_PATTERN.match(updated_at):
+        errors.append(f"{prefix}.updated_at: '{updated_at}' must match YYYY-MM-DD")
+
+    evidence = task.get("evidence", [])
+    missing_evidence = task.get("missing_evidence", [])
+    acceptance = task.get("acceptance", [])
+
+    _check_array_of_strings(evidence, f"{prefix}.evidence", errors)
+    _check_array_of_strings(missing_evidence, f"{prefix}.missing_evidence", errors)
+    _check_array_of_strings(acceptance, f"{prefix}.acceptance", errors)
+
+    if isinstance(priority, str) and priority == "high":
+        if isinstance(acceptance, list) and len(acceptance) == 0:
+            errors.append(
+                f"{prefix}: high priority task must have at least one acceptance criterion"
+            )
+
+    if isinstance(status, str) and status == "done":
+        if isinstance(evidence, list) and len(evidence) == 0:
+            errors.append(f"{prefix}: done task must have at least one evidence entry")
+
+    links = task.get("links")
+    if links is not None:
+        _validate_links(
+            links,
+            prefix,
+            missing_evidence if isinstance(missing_evidence, list) else [],
+            errors,
+        )
+
+    for ev in (evidence if isinstance(evidence, list) else []):
+        if not isinstance(ev, str):
+            continue
+        if ev.startswith("docs/") and not _path_exists(ev):
+            me = missing_evidence if isinstance(missing_evidence, list) else []
+            explained = any(ev in m for m in me if isinstance(m, str))
+            if not explained:
+                errors.append(
+                    f"{prefix}: evidence path '{ev}' does not exist "
+                    f"and is not explained in missing_evidence"
+                )
 
 
 def validate_task_index(index_path):
@@ -61,125 +205,58 @@ def validate_task_index(index_path):
         errors.append(f"Schema file not found: {SCHEMA_PATH}")
 
     if not isinstance(index, dict):
-        return errors + [f"index.json must be a JSON object, got {type(index).__name__}"]
-
-    if "schema_version" not in index:
-        errors.append("Missing required top-level field: schema_version")
-
-    if "tasks" not in index:
-        errors.append("Missing required top-level field: tasks")
+        errors.append(f"index.json must be a JSON object, got {type(index).__name__}")
         return errors
 
-    tasks = index["tasks"]
+    # Required top-level fields
+    for field in sorted(TOP_LEVEL_REQUIRED):
+        if field not in index:
+            errors.append(f"Missing required top-level field: '{field}'")
+
+    # No extra top-level keys
+    extra_top = set(index.keys()) - TOP_LEVEL_ALLOWED
+    for k in sorted(extra_top):
+        errors.append(f"Unexpected top-level key: '{k}'")
+
+    # schema_version: string matching semver
+    sv = index.get("schema_version")
+    if sv is not None:
+        if not isinstance(sv, str):
+            errors.append(f"schema_version must be string, got {type(sv).__name__}")
+        elif not SEMVER_PATTERN.match(sv):
+            errors.append(f"schema_version '{sv}' must match X.Y.Z")
+
+    # generated_at: string or null
+    ga = index.get("generated_at")
+    if ga is not None and not isinstance(ga, str):
+        errors.append(f"generated_at must be string or null, got {type(ga).__name__}")
+
+    # curation: string
+    curation = index.get("curation")
+    if curation is not None and not isinstance(curation, str):
+        errors.append(f"curation must be string, got {type(curation).__name__}")
+
+    # source_files: array[string]
+    source_files = index.get("source_files")
+    if source_files is not None:
+        _check_array_of_strings(source_files, "source_files", errors)
+        for sf in (source_files if isinstance(source_files, list) else []):
+            if isinstance(sf, str) and not _path_exists(sf):
+                errors.append(f"source_files: '{sf}' does not exist")
+
+    # tasks: array[object]
+    tasks = index.get("tasks")
+    if tasks is None:
+        return errors
+
     if not isinstance(tasks, list):
         errors.append(f"'tasks' must be an array, got {type(tasks).__name__}")
         return errors
 
-    for sf in index.get("source_files", []):
-        if not _path_exists(sf):
-            errors.append(f"source_files: '{sf}' does not exist")
-
     seen_ids = {}
-
     for i, task in enumerate(tasks):
-        if not isinstance(task, dict):
-            errors.append(f"tasks[{i}]: expected object, got {type(task).__name__}")
-            continue
-
-        task_id = task.get("id", f"<unnamed[{i}]>")
-        prefix = f"tasks[{i}] ({task_id})"
-
-        for field in sorted(REQUIRED_TASK_FIELDS):
-            if field not in task:
-                errors.append(f"{prefix}: missing required field '{field}'")
-
-        tid = task.get("id")
-        if tid is not None:
-            if not isinstance(tid, str) or not ID_PATTERN.match(tid):
-                errors.append(
-                    f"{prefix}: id '{tid}' does not match pattern "
-                    r"^[A-Z]+(-[A-Z]+)*-[0-9]{3}$"
-                )
-            if tid in seen_ids:
-                errors.append(
-                    f"{prefix}: duplicate id '{tid}' (also at tasks[{seen_ids[tid]}])"
-                )
-            else:
-                seen_ids[tid] = i
-
-        area = task.get("area")
-        if area is not None and area not in ALLOWED_AREA:
-            errors.append(f"{prefix}: area '{area}' not in {sorted(ALLOWED_AREA)}")
-
-        status = task.get("status")
-        if status is not None and status not in ALLOWED_STATUS:
-            errors.append(f"{prefix}: status '{status}' not in {sorted(ALLOWED_STATUS)}")
-
-        priority = task.get("priority")
-        if priority is not None and priority not in ALLOWED_PRIORITY:
-            errors.append(f"{prefix}: priority '{priority}' not in {sorted(ALLOWED_PRIORITY)}")
-
-        effort = task.get("effort")
-        if effort is not None and effort not in ALLOWED_EFFORT:
-            errors.append(f"{prefix}: effort '{effort}' not in {sorted(ALLOWED_EFFORT)}")
-
-        risk = task.get("risk")
-        if risk is not None and risk not in ALLOWED_RISK:
-            errors.append(f"{prefix}: risk '{risk}' not in {sorted(ALLOWED_RISK)}")
-
-        updated_at = task.get("updated_at")
-        if updated_at is not None:
-            if not isinstance(updated_at, str) or not DATE_PATTERN.match(updated_at):
-                errors.append(f"{prefix}: updated_at '{updated_at}' must match YYYY-MM-DD")
-
-        acceptance = task.get("acceptance", [])
-        evidence = task.get("evidence", [])
-        missing_evidence = task.get("missing_evidence", [])
-
-        if priority == "high" and isinstance(acceptance, list) and len(acceptance) == 0:
-            errors.append(
-                f"{prefix}: high priority task must have at least one acceptance criterion"
-            )
-
-        if status == "done" and isinstance(evidence, list) and len(evidence) == 0:
-            errors.append(f"{prefix}: done task must have at least one evidence entry")
-
-        links = task.get("links")
-        if links is not None:
-            if not isinstance(links, dict):
-                errors.append(f"{prefix}: 'links' must be an object")
-            else:
-                for lf in sorted(REQUIRED_LINKS_FIELDS):
-                    if lf not in links:
-                        errors.append(f"{prefix}: links missing required field '{lf}'")
-
-                for doc_path in links.get("docs", []):
-                    if not isinstance(doc_path, str):
-                        continue
-                    if not _path_exists(doc_path):
-                        explained = any(
-                            doc_path in me
-                            for me in missing_evidence
-                            if isinstance(me, str)
-                        )
-                        if not explained:
-                            errors.append(
-                                f"{prefix}: links.docs '{doc_path}' does not exist "
-                                f"and is not explained in missing_evidence"
-                            )
-
-        for ev in evidence:
-            if not isinstance(ev, str):
-                continue
-            if ev.startswith("docs/") and not _path_exists(ev):
-                explained = any(
-                    ev in me for me in missing_evidence if isinstance(me, str)
-                )
-                if not explained:
-                    errors.append(
-                        f"{prefix}: evidence path '{ev}' does not exist "
-                        f"and is not explained in missing_evidence"
-                    )
+        task_id = task.get("id", f"<unnamed[{i}]>") if isinstance(task, dict) else f"<unnamed[{i}]>"
+        _validate_task(task, seen_ids, f"tasks[{i}] ({task_id})", errors)
 
     return errors
 

--- a/scripts/docmeta/validate_task_index.py
+++ b/scripts/docmeta/validate_task_index.py
@@ -1,5 +1,9 @@
 """
-validate_task_index.py — Validates docs/tasks/index.json against schema and business rules.
+validate_task_index.py — Validates docs/tasks/index.json against the task-index contract.
+
+This is a hand-coded validator that mirrors the constraints defined in
+docs/tasks/schema.json plus business rules. It does not use a generic
+JSON-Schema library; schema.json remains the canonical human-readable contract.
 
 Usage:
     python3 -m scripts.docmeta.validate_task_index docs/tasks/index.json
@@ -109,7 +113,7 @@ def _validate_task(task, index, prefix, errors):
             )
         if isinstance(tid, str) and tid in index:
             errors.append(
-                f"{prefix}: duplicate id '{tid}' (also at tasks[{index[tid]}])"
+                f"{prefix}: duplicate id '{tid}' (first seen at {index[tid]})"
             )
         elif isinstance(tid, str):
             index[tid] = prefix

--- a/scripts/docmeta/validate_task_index.py
+++ b/scripts/docmeta/validate_task_index.py
@@ -1,0 +1,208 @@
+"""
+validate_task_index.py — Validates docs/tasks/index.json against schema and business rules.
+
+Usage:
+    python3 scripts/docmeta/validate_task_index.py docs/tasks/index.json
+
+Exit codes:
+    0  all checks pass
+    1  validation errors found
+
+No files are written. Errors are printed to stderr.
+"""
+import json
+import os
+import re
+import sys
+
+REPO_ROOT = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+SCHEMA_PATH = os.path.join(REPO_ROOT, "docs", "tasks", "schema.json")
+
+ALLOWED_AREA = {"docs", "ci", "api", "web", "infra", "release", "auth", "map", "governance"}
+ALLOWED_STATUS = {"open", "partial", "done", "blocked", "obsolete", "contradicted"}
+ALLOWED_PRIORITY = {"high", "medium", "low"}
+ALLOWED_EFFORT = {"XS", "S", "M", "L", "XL"}
+ALLOWED_RISK = {"low", "medium", "high"}
+
+ID_PATTERN = re.compile(r"^[A-Z]+(-[A-Z]+)*-[0-9]{3}$")
+DATE_PATTERN = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}$")
+
+REQUIRED_TASK_FIELDS = frozenset({
+    "id", "title", "area", "status", "priority", "effort", "risk",
+    "owner", "evidence", "missing_evidence", "acceptance", "links", "updated_at",
+})
+REQUIRED_LINKS_FIELDS = frozenset({"issues", "prs", "docs"})
+
+
+def _path_exists(rel_path):
+    return os.path.isfile(os.path.join(REPO_ROOT, rel_path))
+
+
+def validate_task_index(index_path):
+    """
+    Validate a task index JSON file.
+
+    Returns a list of error strings. Empty list means valid.
+    Does not write any files.
+    """
+    errors = []
+
+    if not os.path.isfile(index_path):
+        return [f"Index file not found: {index_path}"]
+
+    try:
+        with open(index_path, "r", encoding="utf-8") as f:
+            index = json.load(f)
+    except json.JSONDecodeError as e:
+        return [f"Invalid JSON in {index_path}: {e}"]
+
+    if not os.path.isfile(SCHEMA_PATH):
+        errors.append(f"Schema file not found: {SCHEMA_PATH}")
+
+    if not isinstance(index, dict):
+        return errors + [f"index.json must be a JSON object, got {type(index).__name__}"]
+
+    if "schema_version" not in index:
+        errors.append("Missing required top-level field: schema_version")
+
+    if "tasks" not in index:
+        errors.append("Missing required top-level field: tasks")
+        return errors
+
+    tasks = index["tasks"]
+    if not isinstance(tasks, list):
+        errors.append(f"'tasks' must be an array, got {type(tasks).__name__}")
+        return errors
+
+    for sf in index.get("source_files", []):
+        if not _path_exists(sf):
+            errors.append(f"source_files: '{sf}' does not exist")
+
+    seen_ids = {}
+
+    for i, task in enumerate(tasks):
+        if not isinstance(task, dict):
+            errors.append(f"tasks[{i}]: expected object, got {type(task).__name__}")
+            continue
+
+        task_id = task.get("id", f"<unnamed[{i}]>")
+        prefix = f"tasks[{i}] ({task_id})"
+
+        for field in sorted(REQUIRED_TASK_FIELDS):
+            if field not in task:
+                errors.append(f"{prefix}: missing required field '{field}'")
+
+        tid = task.get("id")
+        if tid is not None:
+            if not isinstance(tid, str) or not ID_PATTERN.match(tid):
+                errors.append(
+                    f"{prefix}: id '{tid}' does not match pattern "
+                    r"^[A-Z]+(-[A-Z]+)*-[0-9]{3}$"
+                )
+            if tid in seen_ids:
+                errors.append(
+                    f"{prefix}: duplicate id '{tid}' (also at tasks[{seen_ids[tid]}])"
+                )
+            else:
+                seen_ids[tid] = i
+
+        area = task.get("area")
+        if area is not None and area not in ALLOWED_AREA:
+            errors.append(f"{prefix}: area '{area}' not in {sorted(ALLOWED_AREA)}")
+
+        status = task.get("status")
+        if status is not None and status not in ALLOWED_STATUS:
+            errors.append(f"{prefix}: status '{status}' not in {sorted(ALLOWED_STATUS)}")
+
+        priority = task.get("priority")
+        if priority is not None and priority not in ALLOWED_PRIORITY:
+            errors.append(f"{prefix}: priority '{priority}' not in {sorted(ALLOWED_PRIORITY)}")
+
+        effort = task.get("effort")
+        if effort is not None and effort not in ALLOWED_EFFORT:
+            errors.append(f"{prefix}: effort '{effort}' not in {sorted(ALLOWED_EFFORT)}")
+
+        risk = task.get("risk")
+        if risk is not None and risk not in ALLOWED_RISK:
+            errors.append(f"{prefix}: risk '{risk}' not in {sorted(ALLOWED_RISK)}")
+
+        updated_at = task.get("updated_at")
+        if updated_at is not None:
+            if not isinstance(updated_at, str) or not DATE_PATTERN.match(updated_at):
+                errors.append(f"{prefix}: updated_at '{updated_at}' must match YYYY-MM-DD")
+
+        acceptance = task.get("acceptance", [])
+        evidence = task.get("evidence", [])
+        missing_evidence = task.get("missing_evidence", [])
+
+        if priority == "high" and isinstance(acceptance, list) and len(acceptance) == 0:
+            errors.append(
+                f"{prefix}: high priority task must have at least one acceptance criterion"
+            )
+
+        if status == "done" and isinstance(evidence, list) and len(evidence) == 0:
+            errors.append(f"{prefix}: done task must have at least one evidence entry")
+
+        links = task.get("links")
+        if links is not None:
+            if not isinstance(links, dict):
+                errors.append(f"{prefix}: 'links' must be an object")
+            else:
+                for lf in sorted(REQUIRED_LINKS_FIELDS):
+                    if lf not in links:
+                        errors.append(f"{prefix}: links missing required field '{lf}'")
+
+                for doc_path in links.get("docs", []):
+                    if not isinstance(doc_path, str):
+                        continue
+                    if not _path_exists(doc_path):
+                        explained = any(
+                            doc_path in me
+                            for me in missing_evidence
+                            if isinstance(me, str)
+                        )
+                        if not explained:
+                            errors.append(
+                                f"{prefix}: links.docs '{doc_path}' does not exist "
+                                f"and is not explained in missing_evidence"
+                            )
+
+        for ev in evidence:
+            if not isinstance(ev, str):
+                continue
+            if ev.startswith("docs/") and not _path_exists(ev):
+                explained = any(
+                    ev in me for me in missing_evidence if isinstance(me, str)
+                )
+                if not explained:
+                    errors.append(
+                        f"{prefix}: evidence path '{ev}' does not exist "
+                        f"and is not explained in missing_evidence"
+                    )
+
+    return errors
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <path-to-index.json>", file=sys.stderr)
+        sys.exit(1)
+
+    arg = sys.argv[1]
+    index_path = arg if os.path.isabs(arg) else os.path.join(REPO_ROOT, arg)
+
+    errors = validate_task_index(index_path)
+
+    if errors:
+        print(f"\n--- Task Index Validation Errors ({len(errors)}) ---", file=sys.stderr)
+        for error in errors:
+            print(f"  ERROR: {error}", file=sys.stderr)
+        print(f"\nValidation failed: {len(errors)} error(s).", file=sys.stderr)
+        sys.exit(1)
+
+    print("Task index validation passed (0 errors).")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Kontext

Setzt Phase 2 aus der Task-Control-Roadmap um (definiert im Auftragstext, da `docs/blueprints/doc-structure-task-control-roadmap.md` noch nicht existiert).

Phase 1 ist bereits gemergt: README/CONTRIBUTING/docs-index wurden als Einstieg und Navigation stabilisiert.

## Diagnose vor Patch

- `docs/tasks/*`: **nicht vorhanden** vor diesem PR
- `docs/reports/optimierungsstatus.json`: **nicht vorhanden** vor diesem PR
- Blueprint-Dateien `doc-structure-task-control*.md`: **nicht vorhanden** – Briefing-Text ersetzt sie als Spezifikation
- Vorhandene Statusquellen:
  - `docs/reports/optimierungsstatus.md` (19 OPT-* Einträge, maßgeblich)
  - `docs/reports/auth-status-matrix.json`
  - `docs/reports/map-status-matrix.json`
- `repo.meta.yaml`: **unverändert** – `docs/` deckt `docs/tasks/` bereits als guarded_write_path und discovery_root ab
- `agent-policy.yaml`: **unverändert** – analog

## Änderung

- `docs/tasks/README.md` eingeführt (Rollenklärung: board/index/schema/reports)
- `docs/tasks/board.md` eingeführt (menschliche Arbeitskarte mit aktiven Prioritäten und Blockern)
- `docs/tasks/index.json` eingeführt (manueller Phase-2-Seed: TASK-CTL-001..003, OPT-API-001, OPT-CON-001, OPT-DOC-001, OPT-ARC-001)
- `docs/tasks/schema.json` eingeführt (Validierungsvertrag mit ID-Pattern, Enum-Constraints, Pflichtfeldern)
- `docs/reports/optimierungsstatus.json` als manueller Phase-2-Seed eingeführt (alle 19 OPT-Einträge gespiegelt)
- `scripts/docmeta/validate_task_index.py` eingeführt (CLI-Validator, exit 0/1, kein Schreiben)
- `scripts/docmeta/tests/test_validate_task_index.py` eingeführt (13 Tests)
- README: Task-Control-Abschnitt mit Tabelle und Validator-Befehl
- CONTRIBUTING: `docs/tasks/*` beschrieben (Schreibstatus, Curation, Wahrheitsklärung)
- `docs/index.md`: Task-Control-Sektion + differenzierte Optimierungsstatus-Beschreibung

## Nicht umgesetzt

- Keine Issue Forms
- Kein PR-Template
- Keine Release-Konfig
- Kein Task-Index-Workflow
- Kein vollautomatischer Generator
- Keine Änderung an `docs/_generated/*`
- Kein Ausbau von `audit/impl-registry.yaml`

## Nachweis

```
git diff --check         → OK
python3 scripts/docmeta/validate_task_index.py docs/tasks/index.json
  → Task index validation passed (0 errors).
python3 -m scripts.docmeta.validate_relations
  → Relations validation passed (0 errors).
bash scripts/docmeta/docs-relations-guard.sh
  → docs-relations-guard pass.
python3 -m pytest scripts/docmeta/tests/test_validate_task_index.py
  → 13 passed
```

## Restlücken

- Phase 3: GitHub-native Arbeitsobjekte (TASK-CTL-002)
- Phase 4: Generator und CI-Guard (TASK-CTL-003)
- Phase 5: Implementierungs-Mapping