### PR TITLE
docs: revise task-control phase 3 template scope

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,13 +117,15 @@ Validator lokal ausführen:
 python3 -m scripts.docmeta.validate_task_index docs/tasks/index.json
 ```
 
+### GitHub-Arbeitsobjekte (Phase 3 — bewusst zurückgestellt)
+
+Issue Forms, PR-Template und Release-Konfiguration werden aktuell nicht eingeführt. Begründung: Ein fixes PR-Template erhöht den Formular-Overhead und kann Agents schlechter machen, weil sie dann Formulartext produzieren statt kontextgenau zu berichten. Der eigentliche Engpass ist die manuelle Drift-Gefahr im Task-Index — nicht fehlende Formulare.
+
+Issue Forms können später separat eingeführt werden, wenn externe Beitragende ohne Projekteinblick aktiv werden. Release-Konfiguration kann separat betrachtet werden, wenn der Release-Prozess stabilisiert ist.
+
 Noch offen für Folge-PRs:
 
-- GitHub Issue Forms
-- PR-Template
-- Release-Konfig
-- Task-Index-Generator
-- CI-Guard / Workflow
+- **Task-Index-Generator und CI-Guard** (TASK-CTL-003) — nächste Priorität
 - Implementierungs-Mapping-Ausbau
 
 ## 5. Arbeitsweise und Workflow

--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ just down
 
 Task-Control Phase 2 ist eingeführt. Die Arbeitssteuerung liegt jetzt unter `docs/tasks/`; der maschinenlesbare Optimierungsstatus liegt unter `docs/reports/optimierungsstatus.json`.
 
-Offen bleiben Folgephasen: GitHub Issue Forms, PR-Template, Release-Konfig, Task-Index-Generator, CI-Guard und Implementierungs-Mapping.
+Offen bleiben Folgephasen: Task-Index-Generator, CI-Guard und Implementierungs-Mapping.
+
+GitHub Issue Forms, PR-Template und Release-Konfiguration sind bewusst zurückgestellt. Sie werden erst wieder aufgenommen, wenn ihr Nutzen gegenüber kontextgenauen PR-Bodies belegt ist oder externe Beitragende bzw. ein stabilisierter Release-Prozess sie erforderlich machen.
 
 ## Semantik (ausgesetzt)
 
@@ -116,7 +118,7 @@ Die operative Arbeitssteuerung liegt in `docs/tasks/`:
 | `docs/reports/optimierungsstatus.md` | Maßgebliche Statusmatrix (Wahrheitsquelle für OPT-* Einträge) |
 | `docs/reports/optimierungsstatus.json` | Maschinenlesbarer Zwilling der Statusmatrix |
 
-Noch nicht umgesetzt (Folge-PRs): GitHub Issue Forms, PR-Template, Release-Konfig, Generator und CI-Guard.
+Nächste Priorität: Task-Index-Generator und CI-Guard (TASK-CTL-003). GitHub Issue Forms und PR-Template sind zurückgestellt.
 
 ```bash
 python3 -m scripts.docmeta.validate_task_index docs/tasks/index.json

--- a/docs/blueprints/doc-structure-task-control-roadmap.md
+++ b/docs/blueprints/doc-structure-task-control-roadmap.md
@@ -102,32 +102,19 @@ Akzeptanz:
 - High-Priority-Tasks haben Akzeptanzkriterien.
 - Geschlossene Tasks haben Evidenz.
 
-## Phase 3: GitHub-native Arbeitsobjekte anbinden
+## Phase 3: GitHub-native Arbeitsobjekte evaluieren
 
-Scope:
+Status: **zurückgestellt / optional.**
 
-```text
-.github/ISSUE_TEMPLATE/*.yml
-.github/pull_request_template.md
-.github/release.yml
-docs/process/labels.md
-```
+Issue Forms, PR-Template und Release-Konfiguration werden derzeit nicht eingeführt. Der Nutzen ist gegenüber freien, kontextgenauen PR-Bodies noch nicht belegt. Zu starre Templates können Agents schlechter machen, weil sie Formulartext statt präziser Evidenzberichte erzeugen.
 
-Änderungen:
+Wiederaufnahmebedingungen:
 
-- Issue Forms einführen.
-- Leichtes PR-Meta-Template einführen.
-- Label-Taxonomie dokumentieren.
-- Optional GitHub Project v2 konfigurieren, aber nur nach Klärung von Rechten
-  und Ownern.
+- Externe Beitragende ohne Projekteinblick werden relevant.
+- PR-Bodies verlieren wiederholt Task-ID, Evidenz oder Restlücken.
+- Release-Prozess und Release-Labels sind stabil genug, um eine Release-Konfiguration sinnvoll zu machen.
 
-Akzeptanz:
-
-- Neue Arbeitspakete enthalten Task-ID, Bereich, Priorität und
-  Akzeptanzkriterien.
-- PRs verweisen auf Tasks, Docs oder Issues.
-- Labels folgen derselben Taxonomie wie Issue Forms und Release Notes.
-- Das Template bleibt kurz genug, damit keine Formularlyrik entsteht.
+Bis dahin ist Phase 4 / `TASK-CTL-003` führend: Task-Index-Generator und CI-Guard.
 
 ## Phase 4: Generator und Guard integrieren
 
@@ -183,8 +170,8 @@ Akzeptanz:
 |---|---|---|---|
 | PR 1 | Navigation reparieren | `README.md`, `CONTRIBUTING.md`, `docs/index.md`, `repo.meta.yaml` | Links korrekt, reale Topologie, Rollen erklärt |
 | PR 2 | Task-Artefakte | `docs/tasks/*`, `docs/reports/optimierungsstatus.json` | JSON valide, Top-Prioritäten sichtbar |
-| PR 3 | GitHub-Struktur | Issue Forms, PR-Template, Release-Konfig, Labels-Doku | strukturierte Issues und Release-Kategorien |
-| PR 4 | Generator und CI | Docmeta-Skripte, Task-Index-Workflow | deterministische Prüfung, Drift-Erkennung |
+| PR 3 | GitHub-Struktur | Issue Forms, PR-Template, Release-Konfig | zurückgestellt / optional — Wiederaufnahme nur bei belegtem Bedarf |
+| PR 4 | Generator und CI | Docmeta-Skripte, Task-Index-Workflow | deterministische Prüfung, Drift-Erkennung — **nächste Priorität** |
 | PR 5 | Implementierungs-Mapping | `audit/impl-registry.yaml`, generierte Diagnosen | Kernpfade verknüpft und belegbar |
 
 ## Messbare Erfolgskriterien

--- a/docs/blueprints/doc-structure-task-control.md
+++ b/docs/blueprints/doc-structure-task-control.md
@@ -180,10 +180,10 @@ Die Task-Control-Schicht besteht aus schmalen, getrennten Artefakten:
 | `docs/tasks/index.json` | Maschinenlesbarer Task-Index | abgeleitet / validiert |
 | `docs/tasks/schema.json` | Schema für Task-Index | Validierungsvertrag |
 | `docs/reports/optimierungsstatus.json` | Maschinenlesbarer Zwilling des Markdown-Status | abgeleitet aus Statusmatrix |
-| Issue Forms | GitHub-native Eingabe strukturierter Tasks | Arbeitsobjekte |
-| PR-Template | leichter Review-Kontext | Arbeitsobjekt |
-| Label-Taxonomie | Triage- und Release-Sprache | Prozesskonvention |
-| Generator/Guard | Drift-Abwehr | Prüfmechanismus |
+| Issue Forms | GitHub-native Eingabe strukturierter Tasks | Arbeitsobjekte — **optional, aktuell zurückgestellt** |
+| PR-Template | leichter Review-Kontext | Arbeitsobjekt — **optional, aktuell zurückgestellt** |
+| Label-Taxonomie | Triage- und Release-Sprache | Prozesskonvention — optional |
+| Generator/Guard | Drift-Abwehr | Prüfmechanismus — **nächste Priorität** |
 
 Wichtig: Sobald `docs/tasks/index.json` oder
 `docs/reports/optimierungsstatus.json` eingeführt werden, muss explizit
@@ -311,8 +311,9 @@ Für die endgültige Betriebsentscheidung fehlen:
 3. Automationsgrad: nur prüfen, Bot-PRs erzeugen oder Project-Felder setzen ist
    offen.
 
-Diese Leerstellen müssen vor Phase 3 und Phase 4 der Roadmap geschlossen oder
-als explizite Lücken markiert werden.
+Diese Leerstellen müssen vor Phase 4 der Roadmap geschlossen oder als explizite
+Lücken markiert werden. Phase 3 (GitHub-Arbeitsobjekte) ist bewusst zurückgestellt;
+sie setzt keine Klärung dieser Leerstellen voraus.
 
 ## 13. Essenz
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -51,9 +51,17 @@ neu bewertet und in `CONTRIBUTING.md` dokumentiert werden.
 | Phase | Artefakte | Status |
 |---|---|---|
 | Phase 2 | `docs/tasks/*`, `docs/reports/optimierungsstatus.json`, Validator | **Vorhanden** |
-| Phase 3 | `.github/ISSUE_TEMPLATE/*`, `.github/pull_request_template.md` | Geplant |
-| Phase 4 | `scripts/docmeta/generate_task_index.py`, CI-Guard | Geplant |
+| Phase 3 | `.github/ISSUE_TEMPLATE/*`, `.github/pull_request_template.md` | **Zurückgestellt** — kein belegter Mehrwert gegenüber freien PR-Bodies |
+| Phase 4 | `scripts/docmeta/generate_task_index.py`, CI-Guard | **Nächste Priorität** (TASK-CTL-003) |
 | Phase 5 | `audit/impl-registry.yaml`-Ausbau | Geplant |
+
+## GitHub-Arbeitsobjekte
+
+Issue Forms, PR-Template und Release-Konfiguration sind aktuell zurückgestellt. Sie sind keine Voraussetzung für die Task-Control-Schicht.
+
+Begründung: Der aktuelle Engpass ist nicht fehlende Formularstruktur, sondern Drift-Gefahr zwischen Task-Board, Task-Index, Optimierungsstatus und Evidenz. Der nächste operative Schritt ist daher `TASK-CTL-003`: Task-Index-Generator und CI-Guard.
+
+Wiederaufnahme ist sinnvoll, wenn externe Beitragende ohne Projekteinblick aktiv werden, PR-Bodies wiederholt Task-/Evidenzbezüge verlieren oder der Release-Prozess stabil genug für Release-Labels ist.
 
 ## Validator
 

--- a/docs/tasks/board.md
+++ b/docs/tasks/board.md
@@ -24,7 +24,7 @@ relations:
 
 | ID | Bereich | Titel | Status | Priorität | Evidenz | Nächste Aktion |
 |---|---|---|---|---|---|---|
-| TASK-CTL-001 | docs | Task-Control Phase 2 etablieren | partial | high | Phase-2-PR (dieser PR) | PR mergen, Validator-Pass bestätigen |
+| TASK-CTL-001 | docs | Task-Control Phase 2 etablieren | partial | high | `docs/tasks/README.md`, `scripts/docmeta/validate_task_index.py` | PR mergen, Validator-Pass bestätigen |
 | OPT-API-001 | api | Paginierung Listen-Endpunkte | partial | high | `apps/api/src/routes/nodes.rs` | Cursor-Variante + Response-Metadaten implementieren |
 | OPT-CON-001 | ci | `additionalProperties: false` + String-Constraints | partial | high | `contracts/domain/node.schema.json` | Schema-für-Schema-Audit abschließen |
 | OPT-DOC-001 | docs | Incident-/DB-Recovery-Runbooks | partial | high | `docs/runbook.md` | Eigenständige Runbooks unter `docs/runbooks/` erstellen |
@@ -41,7 +41,7 @@ relations:
 
 | ID | PR-Schnitt | Akzeptanzkriterium |
 |---|---|---|
-| TASK-CTL-002 | Phase 3: `.github/ISSUE_TEMPLATE/*.yml` + PR-Template | Issue Forms existieren, PR-Template verlinkt Task-Index |
+| TASK-CTL-003 | Phase 4: `scripts/docmeta/generate_task_index.py` + CI-Guard | Deterministischer Task-Index, Drift-Erkennung im CI |
 | OPT-CON-001 | Schema-Constraints: `additionalProperties: false` alle 6 Schemas | `just contracts-domain-check` pass + kein permissives Nested-Object |
 | OPT-DOC-001 | Runbooks: `docs/runbooks/incident-response.md` + `db-recovery.md` | Eigenständige Abläufe, kein DSGVO-Leak-Risiko |
 

--- a/docs/tasks/board.md
+++ b/docs/tasks/board.md
@@ -24,7 +24,6 @@ relations:
 
 | ID | Bereich | Titel | Status | Priorität | Evidenz | Nächste Aktion |
 |---|---|---|---|---|---|---|
-| TASK-CTL-001 | docs | Task-Control Phase 2 etablieren | partial | high | `docs/tasks/README.md`, `scripts/docmeta/validate_task_index.py` | PR mergen, Validator-Pass bestätigen |
 | OPT-API-001 | api | Paginierung Listen-Endpunkte | partial | high | `apps/api/src/routes/nodes.rs` | Cursor-Variante + Response-Metadaten implementieren |
 | OPT-CON-001 | ci | `additionalProperties: false` + String-Constraints | partial | high | `contracts/domain/node.schema.json` | Schema-für-Schema-Audit abschließen |
 | OPT-DOC-001 | docs | Incident-/DB-Recovery-Runbooks | partial | high | `docs/runbook.md` | Eigenständige Runbooks unter `docs/runbooks/` erstellen |
@@ -45,10 +44,11 @@ relations:
 | OPT-CON-001 | Schema-Constraints: `additionalProperties: false` alle 6 Schemas | `just contracts-domain-check` pass + kein permissives Nested-Object |
 | OPT-DOC-001 | Runbooks: `docs/runbooks/incident-response.md` + `db-recovery.md` | Eigenständige Abläufe, kein DSGVO-Leak-Risiko |
 
-## Erledigte Tasks (Phase 1–2 Referenz)
+## Erledigte Tasks (Phase 1–3 Referenz)
 
 | ID | Bereich | Titel | Evidenz |
 |---|---|---|---|
+| TASK-CTL-001 | docs | Task-Control Phase 2 etablieren | `docs/tasks/`, `scripts/docmeta/validate_task_index.py`, Tests passed |
 | OPT-MAP-001 | map | Basemap Runtime Proof | CI-Job `basemap-range-delivery-proof` PROVEN, Commit `14feefd6` |
 | OPT-API-002 | api | Session-Persistenz PostgreSQL | `apps/api/src/auth/session_db.rs`, CI PROVEN, Commit `00a43a00` |
 | OPT-API-003 | api | DB-Migrationen | `apps/api/migrations/`, CI PROVEN, Commit `00a43a00` |

--- a/docs/tasks/board.md
+++ b/docs/tasks/board.md
@@ -44,6 +44,12 @@ relations:
 | OPT-CON-001 | Schema-Constraints: `additionalProperties: false` alle 6 Schemas | `just contracts-domain-check` pass + kein permissives Nested-Object |
 | OPT-DOC-001 | Runbooks: `docs/runbooks/incident-response.md` + `db-recovery.md` | Eigenständige Abläufe, kein DSGVO-Leak-Risiko |
 
+## Zurückgestellte / optionale Tasks
+
+| ID | Grund | Wiederaufnahmebedingung |
+|---|---|---|
+| TASK-CTL-002 | GitHub Issue Forms, PR-Template und Release-Konfiguration sind aktuell nicht eingeführt, weil der Nutzen gegenüber kontextgenauen PR-Bodies nicht belegt ist. | Externe Beitragende ohne Projekteinblick werden relevant, PR-Bodies verlieren wiederholt Task-/Evidenzbezüge oder der Release-Prozess ist stabil genug für Release-Labels. |
+
 ## Erledigte Tasks
 
 | ID | Bereich | Titel | Evidenz |

--- a/docs/tasks/board.md
+++ b/docs/tasks/board.md
@@ -44,11 +44,11 @@ relations:
 | OPT-CON-001 | Schema-Constraints: `additionalProperties: false` alle 6 Schemas | `just contracts-domain-check` pass + kein permissives Nested-Object |
 | OPT-DOC-001 | Runbooks: `docs/runbooks/incident-response.md` + `db-recovery.md` | Eigenständige Abläufe, kein DSGVO-Leak-Risiko |
 
-## Erledigte Tasks (Phase 1–3 Referenz)
+## Erledigte Tasks
 
 | ID | Bereich | Titel | Evidenz |
 |---|---|---|---|
-| TASK-CTL-001 | docs | Task-Control Phase 2 etablieren | `docs/tasks/`, `scripts/docmeta/validate_task_index.py`, Tests passed |
+| TASK-CTL-001 | docs | Task-Control Phase 2 etablieren | `docs/tasks/`, `docs/reports/optimierungsstatus.json`, `scripts/docmeta/validate_task_index.py`, `scripts/docmeta/tests/test_validate_task_index.py` |
 | OPT-MAP-001 | map | Basemap Runtime Proof | CI-Job `basemap-range-delivery-proof` PROVEN, Commit `14feefd6` |
 | OPT-API-002 | api | Session-Persistenz PostgreSQL | `apps/api/src/auth/session_db.rs`, CI PROVEN, Commit `00a43a00` |
 | OPT-API-003 | api | DB-Migrationen | `apps/api/migrations/`, CI PROVEN, Commit `00a43a00` |

--- a/docs/tasks/index.json
+++ b/docs/tasks/index.json
@@ -13,7 +13,7 @@
       "id": "TASK-CTL-001",
       "title": "Task-Control Phase 2 etablieren",
       "area": "docs",
-      "status": "partial",
+      "status": "done",
       "priority": "high",
       "effort": "M",
       "risk": "medium",
@@ -24,11 +24,10 @@
         "docs/tasks/index.json",
         "docs/tasks/schema.json",
         "docs/reports/optimierungsstatus.json",
-        "scripts/docmeta/validate_task_index.py"
+        "scripts/docmeta/validate_task_index.py",
+        "scripts/docmeta/tests/test_validate_task_index.py"
       ],
-      "missing_evidence": [
-        "PR-Merge-Nachweis steht aus"
-      ],
+      "missing_evidence": [],
       "acceptance": [
         "docs/tasks/ existiert und alle Phase-2-Artefakte sind vorhanden",
         "Validator läuft mit exit 0 gegen docs/tasks/index.json",

--- a/docs/tasks/index.json
+++ b/docs/tasks/index.json
@@ -46,30 +46,34 @@
     },
     {
       "id": "TASK-CTL-002",
-      "title": "GitHub-native Arbeitsobjekte einführen (Phase 3)",
+      "title": "GitHub-native Arbeitsobjekte minimal evaluieren",
       "area": "governance",
       "status": "open",
-      "priority": "medium",
+      "priority": "low",
       "effort": "S",
       "risk": "low",
       "owner": "unknown",
       "evidence": [],
       "missing_evidence": [
-        "keine Issue Forms vorhanden",
-        "kein PR-Template vorhanden",
-        "keine Release-Konfiguration vorhanden"
+        "Issue Forms, PR-Template und Release-Konfiguration bewusst zurückgestellt: erhöhen Formular-Overhead ohne belegten Mehrwert gegenüber kontextgenauen PR-Bodies",
+        "Wiederaufnahme sinnvoll wenn: externe Beitragende ohne Projekteinblick aktiv werden oder Release-Prozess stabilisiert ist"
       ],
-      "acceptance": [],
+      "acceptance": [
+        "Entscheidung dokumentiert in CONTRIBUTING.md und board.md",
+        "Kein Artefakt unter .github/ISSUE_TEMPLATE/ oder .github/pull_request_template.md ohne belegten Nutzen eingeführt"
+      ],
       "links": {
         "issues": [],
         "prs": [],
-        "docs": []
+        "docs": [
+          "docs/blueprints/doc-structure-task-control.md"
+        ]
       },
       "updated_at": "2026-05-28"
     },
     {
       "id": "TASK-CTL-003",
-      "title": "Task-Index Generator und CI-Guard einführen (Phase 4)",
+      "title": "Task-Index Generator und CI-Guard einführen",
       "area": "ci",
       "status": "open",
       "priority": "medium",
@@ -78,14 +82,21 @@
       "owner": "unknown",
       "evidence": [],
       "missing_evidence": [
-        "generate_task_index.py nicht vorhanden",
-        "CI-Workflow task-index.yml nicht vorhanden"
+        "scripts/docmeta/generate_task_index.py nicht vorhanden",
+        "CI-Workflow .github/workflows/task-index.yml nicht vorhanden"
       ],
-      "acceptance": [],
+      "acceptance": [
+        "Generator erzeugt oder prüft docs/tasks/index.json deterministisch (--check-Modus)",
+        "CI prüft Drift zwischen board.md, index.json und optimierungsstatus.json, schreibt aber nicht still",
+        "Fehlende Evidenz wird gemeldet, nicht geglättet",
+        "docs/_generated/* werden nicht manuell geändert"
+      ],
       "links": {
         "issues": [],
         "prs": [],
-        "docs": []
+        "docs": [
+          "docs/blueprints/doc-structure-task-control-roadmap.md"
+        ]
       },
       "updated_at": "2026-05-28"
     },


### PR DESCRIPTION
## Kontext

- related-task: TASK-CTL-002, TASK-CTL-003
- related-docs: docs/tasks/index.json, docs/tasks/board.md, CONTRIBUTING.md
- related-issue: —

## Änderung

TASK-CTL-002 (GitHub-native Arbeitsobjekte) wird bewusst zurückgestellt und umformuliert.
Issue Forms und PR-Template wurden im Entwicklungsprozess evaluiert und als aktuell
nicht sinnvoll bewertet: sie erhöhen den Formular-Overhead, ohne einen belegten
Mehrwert gegenüber kontextgenauen, freien PR-Bodies zu liefern.

TASK-CTL-003 (Task-Index Generator + CI-Guard) wird als nächste Priorität gesetzt,
weil die manuelle Drift-Gefahr im Task-Index der eigentliche Engpass nach Phase 2 ist.

Betroffene Pfade:
- `docs/tasks/index.json` — TASK-CTL-002 umformuliert (low/open/deferral documented), TASK-CTL-003 Akzeptanzkriterien geschärft
- `docs/tasks/board.md` — nächste PR-Kandidaten: TASK-CTL-003 statt TASK-CTL-002
- `CONTRIBUTING.md` — GitHub-Arbeitsobjekte als bewusst zurückgestellt dokumentiert

## Nachweis

- `python3 -m scripts.docmeta.validate_task_index docs/tasks/index.json` → pass (0 errors)
- `python3 -m scripts.docmeta.validate_relations` → pass (0 errors)
- `bash scripts/docmeta/docs-relations-guard.sh` → pass
- Keine neuen `.github/ISSUE_TEMPLATE/*`, kein `pull_request_template.md`, kein `release.yml`

## Restlücken

- TASK-CTL-003 bleibt offen; Umsetzung in Folge-PR
- TASK-CTL-002 kann reaktiviert werden, sobald externe Beitragende ohne Projekteinblick aktiv werden

## Release-Hinweis

- [x] release-note:docs