### PR TITLE
Implement task-control drift check (TASK-CTL-003)

### DIFF
--- a/.github/workflows/task-index.yml
+++ b/.github/workflows/task-index.yml
@@ -1,0 +1,32 @@
+---
+name: task-index
+
+"on":
+  pull_request:
+    paths:
+      - "docs/tasks/**"
+      - "docs/reports/optimierungsstatus.json"
+      - "docs/reports/optimierungsstatus.md"
+      - "docs/blueprints/doc-structure-task-control*"
+      - "README.md"
+      - "CONTRIBUTING.md"
+      - "scripts/docmeta/**"
+      - ".github/workflows/task-index.yml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: task-index-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  task-index-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate task index schema
+        run: python3 -m scripts.docmeta.validate_task_index docs/tasks/index.json
+      - name: Check task-control drift
+        run: python3 -m scripts.docmeta.generate_task_index --check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,6 +117,14 @@ Validator lokal ausführen:
 python3 -m scripts.docmeta.validate_task_index docs/tasks/index.json
 ```
 
+Drift-Check lokal ausführen:
+
+```bash
+python3 -m scripts.docmeta.generate_task_index --check
+```
+
+Task-Control-Artefakte bleiben manuell kuratiert, werden aber durch den `--check`-Modus gegen Drift geprüft (Board ↔ Index ↔ Optimierungsstatus, Evidenz- und Doku-Pfade). Der Check ist ein Prüfmechanismus, keine neue Wahrheitsschicht, und schreibt keine Dateien. Automatische Generierung oder Bot-PRs bleiben eine spätere Entscheidung. Im CI läuft der Check über `.github/workflows/task-index.yml`.
+
 ### GitHub-Arbeitsobjekte (Phase 3 — bewusst zurückgestellt)
 
 Issue Forms, PR-Template und Release-Konfiguration werden aktuell nicht eingeführt. Begründung: Ein fixes PR-Template erhöht den Formular-Overhead und kann Agents schlechter machen, weil sie dann Formulartext produzieren statt kontextgenau zu berichten. Der eigentliche Engpass ist die manuelle Drift-Gefahr im Task-Index — nicht fehlende Formulare.
@@ -125,7 +133,7 @@ Issue Forms können später separat eingeführt werden, wenn externe Beitragende
 
 Noch offen für Folge-PRs:
 
-- **Task-Index-Generator und CI-Guard** (TASK-CTL-003) — nächste Priorität
+- **Task-Index-Generator und CI-Guard** (TASK-CTL-003) — Drift-Check (`generate_task_index.py --check`) und `.github/workflows/task-index.yml` eingeführt; CI-Lauf-Nachweis steht noch aus
 - Implementierungs-Mapping-Ausbau
 
 ## 5. Arbeitsweise und Workflow

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -83,9 +83,9 @@ python3 -m scripts.docmeta.generate_task_index --check
 ```
 
 Vergleicht `board.md`, `index.json` und `docs/reports/optimierungsstatus.json` auf Drift:
-Board-Tasks ohne Index-Eintrag, `open`/`partial` Tasks mit `high`/`medium` Priorität ohne Board-Sichtbarkeit, `done` ohne Evidenz,
-High-Priority ohne Akzeptanzkriterium, nicht existierende Evidenz-/Doku-Pfade,
-`docs/_generated/*` als Schreibziel sowie Statuswidersprüche zur Optimierungsstatus-Matrix.
+Aktive Board-Tasks, Blocker oder PR-Kandidaten ohne Index-Eintrag; `open`/`partial` Tasks mit `high`/`medium` Priorität ohne Board-Sichtbarkeit; `done` ohne Evidenz;
+High-Priority ohne Akzeptanzkriterium; nicht existierende Evidenz-/Doku-Pfade;
+`docs/_generated/*` als Schreibziel; sowie Statuswidersprüche zur Optimierungsstatus-Matrix.
 
 Exit 0 ohne Drift, sonst 1. Reiner Prüfmechanismus, keine neue Wahrheitsschicht: Im
 `--check`-Modus werden keine Dateien geschrieben. Läuft im CI über

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -43,8 +43,12 @@ Sie ergänzt die Statusmatrizen in `docs/reports/`, ist aber keine zweite Wahrhe
 ## Curation-Status
 
 Solange `curation: "manual_phase2_seed"` gesetzt ist, darf `index.json` manuell
-gepflegt werden. Sobald ein Generator eingeführt wird (Phase 4), muss der Schreibstatus
-neu bewertet und in `CONTRIBUTING.md` dokumentiert werden.
+gepflegt werden. Sobald ein echter Generator (mit Schreibzugriff) eingeführt wird, muss der
+Schreibstatus neu bewertet und in `CONTRIBUTING.md` dokumentiert werden.
+
+Der in TASK-CTL-003 eingeführte `generate_task_index.py --check` ist ein reiner
+Drift-Prüfmechanismus ohne Schreibzugriff und ändert den manuellen Pflegestatus nicht.
+Automatische Generierung und Bot-PRs bleiben eine spätere Entscheidung.
 
 ## Phase-Stand
 
@@ -52,7 +56,7 @@ neu bewertet und in `CONTRIBUTING.md` dokumentiert werden.
 |---|---|---|
 | Phase 2 | `docs/tasks/*`, `docs/reports/optimierungsstatus.json`, Validator | **Vorhanden** |
 | Phase 3 | `.github/ISSUE_TEMPLATE/*`, `.github/pull_request_template.md` | **Zurückgestellt** — kein belegter Mehrwert gegenüber freien PR-Bodies |
-| Phase 4 | `scripts/docmeta/generate_task_index.py`, CI-Guard | **Nächste Priorität** (TASK-CTL-003) |
+| Phase 4 | `scripts/docmeta/generate_task_index.py`, CI-Guard | **In Arbeit** — Check-Modus + CI-Guard vorhanden, CI-Lauf-Nachweis ausstehend (TASK-CTL-003) |
 | Phase 5 | `audit/impl-registry.yaml`-Ausbau | Geplant |
 
 ## GitHub-Arbeitsobjekte
@@ -71,3 +75,18 @@ python3 -m scripts.docmeta.validate_task_index docs/tasks/index.json
 
 Exit 0 bei Erfolg, 1 bei Validierungsfehlern.
 Keine stillen Fixes, kein Schreiben durch den Validator.
+
+## Drift-Check
+
+```bash
+python3 -m scripts.docmeta.generate_task_index --check
+```
+
+Vergleicht `board.md`, `index.json` und `docs/reports/optimierungsstatus.json` auf Drift:
+Board-Tasks ohne Index-Eintrag, Index-Tasks ohne Board-Sichtbarkeit, `done` ohne Evidenz,
+High-Priority ohne Akzeptanzkriterium, nicht existierende Evidenz-/Doku-Pfade,
+`docs/_generated/*` als Schreibziel sowie Statuswidersprüche zur Optimierungsstatus-Matrix.
+
+Exit 0 ohne Drift, sonst 1. Reiner Prüfmechanismus, keine neue Wahrheitsschicht: Im
+`--check`-Modus werden keine Dateien geschrieben. Läuft im CI über
+`.github/workflows/task-index.yml`.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -83,7 +83,7 @@ python3 -m scripts.docmeta.generate_task_index --check
 ```
 
 Vergleicht `board.md`, `index.json` und `docs/reports/optimierungsstatus.json` auf Drift:
-Board-Tasks ohne Index-Eintrag, Index-Tasks ohne Board-Sichtbarkeit, `done` ohne Evidenz,
+Board-Tasks ohne Index-Eintrag, `open`/`partial` Tasks mit `high`/`medium` Priorität ohne Board-Sichtbarkeit, `done` ohne Evidenz,
 High-Priority ohne Akzeptanzkriterium, nicht existierende Evidenz-/Doku-Pfade,
 `docs/_generated/*` als Schreibziel sowie Statuswidersprüche zur Optimierungsstatus-Matrix.
 

--- a/docs/tasks/board.md
+++ b/docs/tasks/board.md
@@ -28,6 +28,7 @@ relations:
 | OPT-CON-001 | ci | `additionalProperties: false` + String-Constraints | partial | high | `contracts/domain/node.schema.json` | Schema-für-Schema-Audit abschließen |
 | OPT-DOC-001 | docs | Incident-/DB-Recovery-Runbooks | partial | high | `docs/runbook.md` | Eigenständige Runbooks unter `docs/runbooks/` erstellen |
 | OPT-ARC-001 | api | JSONL → PostgreSQL | open | high | `apps/api/src/routes/nodes.rs` (Ist-Befund) | Migrations- und Cutover-Plan erstellen |
+| TASK-CTL-003 | ci | Task-Index-Generator und CI-Guard | partial | medium | `scripts/docmeta/generate_task_index.py`, `scripts/docmeta/tests/test_generate_task_index.py`, `.github/workflows/task-index.yml` | CI-Lauf des `task-index`-Workflows nachweisen, dann auf `done` setzen |
 
 ## Blocker
 
@@ -40,7 +41,6 @@ relations:
 
 | ID | PR-Schnitt | Akzeptanzkriterium |
 |---|---|---|
-| TASK-CTL-003 | Phase 4: `scripts/docmeta/generate_task_index.py` + CI-Guard | Deterministischer Task-Index, Drift-Erkennung im CI |
 | OPT-CON-001 | Schema-Constraints: `additionalProperties: false` alle 6 Schemas | `just contracts-domain-check` pass + kein permissives Nested-Object |
 | OPT-DOC-001 | Runbooks: `docs/runbooks/incident-response.md` + `db-recovery.md` | Eigenständige Abläufe, kein DSGVO-Leak-Risiko |
 

--- a/docs/tasks/index.json
+++ b/docs/tasks/index.json
@@ -74,15 +74,18 @@
       "id": "TASK-CTL-003",
       "title": "Task-Index Generator und CI-Guard einführen",
       "area": "ci",
-      "status": "open",
+      "status": "partial",
       "priority": "medium",
       "effort": "M",
       "risk": "medium",
       "owner": "unknown",
-      "evidence": [],
+      "evidence": [
+        "scripts/docmeta/generate_task_index.py",
+        "scripts/docmeta/tests/test_generate_task_index.py",
+        ".github/workflows/task-index.yml"
+      ],
       "missing_evidence": [
-        "scripts/docmeta/generate_task_index.py nicht vorhanden",
-        "CI-Workflow .github/workflows/task-index.yml nicht vorhanden"
+        "CI-Lauf von .github/workflows/task-index.yml noch nicht nachgewiesen (erst nach PR/Run belegbar)"
       ],
       "acceptance": [
         "Generator erzeugt oder prüft docs/tasks/index.json deterministisch (--check-Modus)",
@@ -97,7 +100,7 @@
           "docs/blueprints/doc-structure-task-control-roadmap.md"
         ]
       },
-      "updated_at": "2026-05-28"
+      "updated_at": "2026-05-29"
     },
     {
       "id": "OPT-API-001",

--- a/scripts/docmeta/generate_task_index.py
+++ b/scripts/docmeta/generate_task_index.py
@@ -66,9 +66,6 @@ KNOWN_ROOTS = (
 
 # Board sections whose tasks are live work items and must exist in index.json.
 LIVE_SECTIONS = ("active", "blocker", "candidates")
-# Board sections that record historical or deliberately parked tasks; these must
-# only be known to the machine layer (index.json OR optimierungsstatus.json).
-ARCHIVE_SECTIONS = ("done", "deferred")
 
 
 def _load_json(path):

--- a/scripts/docmeta/generate_task_index.py
+++ b/scripts/docmeta/generate_task_index.py
@@ -58,10 +58,7 @@ KNOWN_ROOTS = (
     "contracts/",
     "docs/",
     "infra/",
-    "manifest/",
     "policies/",
-    "runbooks/",
-    "runtime/",
     "scripts/",
     "src/",
     "tools/",
@@ -214,11 +211,17 @@ def check_task_control(index, board_sections, status, repo_root):
                 f"and docs/reports/optimierungsstatus.json"
             )
 
-    # 3. Every index.json task must be visible somewhere in board.md.
+    # 3. High/medium open or partial tasks must be visible in board.md.
+    #    Low-priority, done, or deferred tasks do not need board-level visibility.
     for tid in sorted(index_ids):
-        if tid not in board_all:
+        task = index_tasks[tid]
+        status_val = task.get("status")
+        priority = task.get("priority")
+        must_be_visible = status_val in {"open", "partial"} and priority in {"high", "medium"}
+        if must_be_visible and tid not in board_all:
             errors.append(
-                f"docs/tasks/index.json task '{tid}' does not appear in docs/tasks/board.md (work-card drift)"
+                f"docs/tasks/index.json task '{tid}' is {priority}/{status_val} "
+                f"but does not appear in docs/tasks/board.md"
             )
 
     # Per-task business rules and path checks.

--- a/scripts/docmeta/generate_task_index.py
+++ b/scripts/docmeta/generate_task_index.py
@@ -1,0 +1,365 @@
+"""
+generate_task_index.py — Task-control drift check (no silent writes).
+
+The name is inherited from the roadmap (docs/blueprints/doc-structure-task-control-roadmap.md,
+Phase 4). In this iteration the script implements a deterministic *check* mode only.
+It does NOT write any files: it compares the manually curated task-control artifacts
+against each other and reports drift.
+
+Schema-structural validation of docs/tasks/index.json remains the job of
+scripts/docmeta/validate_task_index.py (run as a separate CI step). This script
+focuses on cross-artifact drift that the schema validator does not cover:
+
+  - docs/tasks/board.md   (human work card)
+  - docs/tasks/index.json (machine-readable task index)
+  - docs/reports/optimierungsstatus.json (machine twin of the OPT-* status matrix)
+
+Usage:
+    python3 -m scripts.docmeta.generate_task_index --check
+
+Exit codes:
+    0  no drift found
+    1  drift found
+    2  invalid invocation (e.g. called without --check; writing is intentionally not implemented)
+
+No files are written in any mode. Drift is printed to stderr.
+"""
+import argparse
+import json
+import os
+import re
+import sys
+
+from scripts.docmeta.docmeta import REPO_ROOT
+
+INDEX_PATH = os.path.join(REPO_ROOT, "docs", "tasks", "index.json")
+BOARD_PATH = os.path.join(REPO_ROOT, "docs", "tasks", "board.md")
+STATUS_PATH = os.path.join(REPO_ROOT, "docs", "reports", "optimierungsstatus.json")
+
+# Canonical task-id grammar, aligned with docs/tasks/schema.json:
+# uppercase letter segments separated by '-', terminated by a three-digit number.
+# Matches TASK-CTL-003, OPT-API-001, OPT-MAP-001, AUTH-XYZ-001, MAP-XYZ-001.
+TASK_ID_RE = re.compile(r"\b[A-Z]+(?:-[A-Z]+)*-[0-9]{3}\b")
+
+# Generated diagnostics are never canonical and must not be manual write targets.
+GENERATED_PREFIX = "docs/_generated/"
+
+# Top-level repository directories. An evidence string is only treated as a
+# repo path (and therefore existence-checked) when it starts with one of these
+# and contains no spaces. This avoids misclassifying free-form evidence such as
+# "CI-Job basemap-range-delivery-proof PROVEN, Commit 14feefd6".
+KNOWN_ROOTS = (
+    ".github/",
+    "apps/",
+    "architecture/",
+    "audit/",
+    "ci/",
+    "configs/",
+    "contracts/",
+    "docs/",
+    "infra/",
+    "manifest/",
+    "policies/",
+    "runbooks/",
+    "runtime/",
+    "scripts/",
+    "src/",
+    "tools/",
+)
+
+# Board sections whose tasks are live work items and must exist in index.json.
+LIVE_SECTIONS = ("active", "blocker", "candidates")
+# Board sections that record historical or deliberately parked tasks; these must
+# only be known to the machine layer (index.json OR optimierungsstatus.json).
+ARCHIVE_SECTIONS = ("done", "deferred")
+
+
+def _load_json(path):
+    """Return (data, error). error is None on success."""
+    if not os.path.isfile(path):
+        return None, f"file not found: {path}"
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f), None
+    except json.JSONDecodeError as e:
+        return None, f"invalid JSON in {path}: {e}"
+    except OSError as e:
+        return None, f"cannot read {path}: {e}"
+
+
+def _read_text(path):
+    """Return (text, error). error is None on success."""
+    if not os.path.isfile(path):
+        return None, f"file not found: {path}"
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read(), None
+    except OSError as e:
+        return None, f"cannot read {path}: {e}"
+
+
+def _path_exists(rel_path, repo_root):
+    return os.path.exists(os.path.join(repo_root, rel_path))
+
+
+def _looks_like_repo_path(value):
+    if not isinstance(value, str) or " " in value:
+        return False
+    return any(value.startswith(root) for root in KNOWN_ROOTS)
+
+
+def _classify_section(heading):
+    h = heading.strip().lower()
+    if "aktive" in h:
+        return "active"
+    if "blocker" in h:
+        return "blocker"
+    if "kandidat" in h:
+        return "candidates"
+    if "zurückgestellt" in h or "zuruckgestellt" in h or "optional" in h:
+        return "deferred"
+    if "erledigt" in h:
+        return "done"
+    return "other"
+
+
+def parse_board(text):
+    """
+    Parse board.md into a mapping of section-key -> set of task ids.
+
+    Task ids are collected from Markdown table rows (lines starting with '|')
+    within each section. Header and separator rows contain no matching ids and
+    are therefore harmless.
+    """
+    sections = {
+        "active": set(),
+        "blocker": set(),
+        "candidates": set(),
+        "deferred": set(),
+        "done": set(),
+        "other": set(),
+    }
+    current = None
+    for line in text.splitlines():
+        stripped = line.strip()
+        heading = re.match(r"^#{1,6}\s+(.*)$", stripped)
+        if heading:
+            current = _classify_section(heading.group(1))
+            continue
+        if current and stripped.startswith("|"):
+            for match in TASK_ID_RE.finditer(line):
+                sections[current].add(match.group(0))
+    return sections
+
+
+def _board_union(board_sections, keys):
+    union = set()
+    for key in keys:
+        union |= board_sections.get(key, set())
+    return union
+
+
+def _as_str_list(value):
+    return [v for v in value if isinstance(v, str)] if isinstance(value, list) else []
+
+
+def _explained(path, missing_evidence):
+    return any(path in m for m in missing_evidence)
+
+
+def check_task_control(index, board_sections, status, repo_root):
+    """
+    Compare task-control artifacts and return a sorted list of drift messages.
+    Empty list means no drift. Does not write any files.
+    """
+    errors = []
+
+    tasks = index.get("tasks") if isinstance(index, dict) else None
+    if not isinstance(tasks, list):
+        return ["index.json: 'tasks' is missing or not an array"]
+
+    index_tasks = {}
+    for task in tasks:
+        if isinstance(task, dict) and isinstance(task.get("id"), str):
+            index_tasks[task["id"]] = task
+    index_ids = set(index_tasks)
+
+    status_items = status.get("items") if isinstance(status, dict) else None
+    status_status = {}
+    if isinstance(status_items, list):
+        for item in status_items:
+            if isinstance(item, dict) and isinstance(item.get("id"), str):
+                status_status[item["id"]] = item.get("status")
+    status_ids = set(status_status)
+
+    known_ids = index_ids | status_ids
+    board_all = set().union(*board_sections.values())
+    live_board = _board_union(board_sections, LIVE_SECTIONS)
+    candidates = board_sections.get("candidates", set())
+    active = board_sections.get("active", set())
+    deferred = board_sections.get("deferred", set())
+
+    # 1. Board active/candidate/blocker tasks must exist in index.json.
+    for tid in sorted(live_board):
+        if tid not in index_ids:
+            errors.append(
+                f"board.md lists active/candidate task '{tid}' that is missing from docs/tasks/index.json"
+            )
+
+    # 2. Every task mentioned in board.md must be known to the machine layer.
+    for tid in sorted(board_all):
+        if tid not in known_ids:
+            errors.append(
+                f"board.md references task '{tid}' unknown to docs/tasks/index.json "
+                f"and docs/reports/optimierungsstatus.json"
+            )
+
+    # 3. Every index.json task must be visible somewhere in board.md.
+    for tid in sorted(index_ids):
+        if tid not in board_all:
+            errors.append(
+                f"docs/tasks/index.json task '{tid}' does not appear in docs/tasks/board.md (work-card drift)"
+            )
+
+    # Per-task business rules and path checks.
+    for tid in sorted(index_ids):
+        task = index_tasks[tid]
+        status_val = task.get("status")
+        priority = task.get("priority")
+        evidence = _as_str_list(task.get("evidence"))
+        missing_evidence = _as_str_list(task.get("missing_evidence"))
+        acceptance = _as_str_list(task.get("acceptance"))
+        links = task.get("links") if isinstance(task.get("links"), dict) else {}
+        docs_links = _as_str_list(links.get("docs"))
+
+        # 4. done tasks need evidence.
+        if status_val == "done" and not evidence:
+            errors.append(f"docs/tasks/index.json task '{tid}' is done but has no evidence")
+
+        # 5. high-priority tasks need at least one acceptance criterion.
+        if priority == "high" and not acceptance:
+            errors.append(
+                f"docs/tasks/index.json task '{tid}' is high priority but has no acceptance criterion"
+            )
+
+        # 6. evidence repo paths must exist (or be explained in missing_evidence).
+        for ev in evidence:
+            if ev.startswith(GENERATED_PREFIX):
+                errors.append(
+                    f"docs/tasks/index.json task '{tid}' lists generated artifact '{ev}' as evidence; "
+                    f"docs/_generated/* must not be a manual target"
+                )
+                continue
+            if _looks_like_repo_path(ev) and not _path_exists(ev, repo_root):
+                if not _explained(ev, missing_evidence):
+                    errors.append(
+                        f"docs/tasks/index.json task '{tid}' evidence path '{ev}' does not exist "
+                        f"and is not explained in missing_evidence"
+                    )
+
+        # 7. links.docs paths must exist (or be explained in missing_evidence).
+        for doc in docs_links:
+            if doc.startswith(GENERATED_PREFIX):
+                errors.append(
+                    f"docs/tasks/index.json task '{tid}' links.docs '{doc}' points into docs/_generated/; "
+                    f"generated diagnostics must not be a manual target"
+                )
+                continue
+            if not _path_exists(doc, repo_root) and not _explained(doc, missing_evidence):
+                errors.append(
+                    f"docs/tasks/index.json task '{tid}' links.docs '{doc}' does not exist "
+                    f"and is not explained in missing_evidence"
+                )
+
+    # 8. TASK-CTL-003 must stay visible as a next priority while it is open.
+    t003 = index_tasks.get("TASK-CTL-003")
+    if t003 is not None and t003.get("status") == "open":
+        if "TASK-CTL-003" not in (candidates | active):
+            errors.append(
+                "TASK-CTL-003 is open but not listed as a next PR candidate / active priority in docs/tasks/board.md"
+            )
+
+    # 9. TASK-CTL-002 must not appear as a next PR candidate while deliberately deferred.
+    t002 = index_tasks.get("TASK-CTL-002")
+    if t002 is not None:
+        t002_missing = _as_str_list(t002.get("missing_evidence"))
+        is_deferred = "TASK-CTL-002" in deferred or any(
+            "zurückgestellt" in m.lower() or "zurueckgestellt" in m.lower() for m in t002_missing
+        )
+        if is_deferred and "TASK-CTL-002" in candidates:
+            errors.append(
+                "TASK-CTL-002 is deliberately deferred but listed as a next PR candidate in docs/tasks/board.md"
+            )
+
+    # 10. Status must not contradict between index.json and optimierungsstatus.json.
+    for tid in sorted(index_ids & status_ids):
+        index_status = index_tasks[tid].get("status")
+        twin_status = status_status.get(tid)
+        if isinstance(twin_status, str) and index_status != twin_status:
+            errors.append(
+                f"status mismatch for '{tid}': docs/tasks/index.json='{index_status}' vs "
+                f"docs/reports/optimierungsstatus.json='{twin_status}'"
+            )
+
+    return sorted(errors)
+
+
+def run_check(index_path, board_path, status_path, repo_root):
+    """Load the three artifacts and return a list of drift messages."""
+    errors = []
+
+    index, index_err = _load_json(index_path)
+    if index_err:
+        errors.append(index_err)
+
+    status, status_err = _load_json(status_path)
+    if status_err:
+        errors.append(status_err)
+
+    board_text, board_err = _read_text(board_path)
+    if board_err:
+        errors.append(board_err)
+
+    if index is None or status is None or board_text is None:
+        return errors
+
+    board_sections = parse_board(board_text)
+    errors.extend(check_task_control(index, board_sections, status, repo_root))
+    return errors
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        prog="generate_task_index",
+        description="Check task-control artifacts (board.md, index.json, optimierungsstatus.json) for drift.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Validate task-control artifacts for drift. No files are written.",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.check:
+        print(
+            "generate_task_index: only --check mode is implemented; "
+            "silent generation is not allowed. Re-run with --check.",
+            file=sys.stderr,
+        )
+        return 2
+
+    errors = run_check(INDEX_PATH, BOARD_PATH, STATUS_PATH, REPO_ROOT)
+
+    if errors:
+        print(f"\n--- Task-Control Drift ({len(errors)}) ---", file=sys.stderr)
+        for error in errors:
+            print(f"  DRIFT: {error}", file=sys.stderr)
+        print(f"\nTask-control drift check failed: {len(errors)} issue(s).", file=sys.stderr)
+        return 1
+
+    print("Task-control drift check passed (0 issues).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/docmeta/generate_task_index.py
+++ b/scripts/docmeta/generate_task_index.py
@@ -121,9 +121,11 @@ def parse_board(text):
     """
     Parse board.md into a mapping of section-key -> set of task ids.
 
-    Task ids are collected from Markdown table rows (lines starting with '|')
-    within each section. Header and separator rows contain no matching ids and
-    are therefore harmless.
+    Task ids are collected from the *first* cell (the ID column) of Markdown
+    table rows (lines starting with '|') within each section. Restricting to
+    the first cell prevents task ids that are only mentioned in evidence,
+    rationale or next-action columns from being treated as board entries.
+    Header and separator rows contain no matching ids and are harmless.
     """
     sections = {
         "active": set(),
@@ -141,7 +143,11 @@ def parse_board(text):
             current = _classify_section(heading.group(1))
             continue
         if current and stripped.startswith("|"):
-            for match in TASK_ID_RE.finditer(line):
+            cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+            if not cells:
+                continue
+            first_cell = cells[0]
+            for match in TASK_ID_RE.finditer(first_cell):
                 sections[current].add(match.group(0))
     return sections
 

--- a/scripts/docmeta/tests/test_generate_task_index.py
+++ b/scripts/docmeta/tests/test_generate_task_index.py
@@ -1,0 +1,361 @@
+"""
+Tests for scripts/docmeta/generate_task_index.py (task-control drift check).
+
+All tests build temporary fixtures in an isolated repo_root; the real repository
+files are never used as the sole test basis and are never written to.
+"""
+import hashlib
+import json
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+import scripts.docmeta.generate_task_index as gen
+from scripts.docmeta.generate_task_index import parse_board, run_check
+
+
+def _task(**overrides):
+    task = {
+        "id": "OPT-API-001",
+        "title": "Beispiel",
+        "area": "api",
+        "status": "partial",
+        "priority": "medium",
+        "effort": "M",
+        "risk": "medium",
+        "owner": "unknown",
+        "evidence": [],
+        "missing_evidence": [],
+        "acceptance": [],
+        "links": {"issues": [], "prs": [], "docs": []},
+        "updated_at": "2026-05-28",
+    }
+    task.update(overrides)
+    return task
+
+
+def _index(tasks):
+    return {
+        "schema_version": "1.0.0",
+        "generated_at": None,
+        "curation": "manual_phase2_seed",
+        "source_files": [],
+        "tasks": tasks,
+    }
+
+
+def _status(items):
+    return {
+        "schema_version": "1.0.0",
+        "source_markdown": "docs/reports/optimierungsstatus.md",
+        "curation": "manual_phase2_seed",
+        "generated_at": None,
+        "items": items,
+    }
+
+
+def _board(active=(), blocker=(), candidates=(), deferred=(), done=()):
+    def table(ids):
+        rows = ["| ID | Info |", "|---|---|"]
+        rows.extend(f"| {tid} | x |" for tid in ids)
+        return "\n".join(rows)
+
+    return (
+        "\n".join(
+            [
+                "---",
+                "id: tasks.board",
+                "title: Board",
+                "status: active",
+                "summary: test fixture",
+                "---",
+                "",
+                "# Board",
+                "",
+                "## Aktive Prioritäten",
+                table(active),
+                "",
+                "## Blocker",
+                table(blocker),
+                "",
+                "## Nächste PR-Kandidaten",
+                table(candidates),
+                "",
+                "## Zurückgestellte / optionale Tasks",
+                table(deferred),
+                "",
+                "## Erledigte Tasks",
+                table(done),
+                "",
+            ]
+        )
+        + "\n"
+    )
+
+
+class TestGenerateTaskIndex(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = self._tmp.name
+        self.index_path = os.path.join(self.root, "index.json")
+        self.board_path = os.path.join(self.root, "board.md")
+        self.status_path = os.path.join(self.root, "status.json")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _touch(self, rel):
+        full = os.path.join(self.root, rel)
+        os.makedirs(os.path.dirname(full), exist_ok=True)
+        with open(full, "w", encoding="utf-8") as f:
+            f.write("// fixture\n")
+
+    def _write(self, index, board_text, status):
+        with open(self.index_path, "w", encoding="utf-8") as f:
+            json.dump(index, f, ensure_ascii=False)
+        with open(self.board_path, "w", encoding="utf-8") as f:
+            f.write(board_text)
+        with open(self.status_path, "w", encoding="utf-8") as f:
+            json.dump(status, f, ensure_ascii=False)
+
+    def _run(self):
+        return run_check(self.index_path, self.board_path, self.status_path, self.root)
+
+    def _snapshot(self):
+        snap = {}
+        for dirpath, _dirs, files in os.walk(self.root):
+            for name in files:
+                full = os.path.join(dirpath, name)
+                rel = os.path.relpath(full, self.root)
+                with open(full, "rb") as f:
+                    snap[rel] = hashlib.sha256(f.read()).hexdigest()
+        return snap
+
+    # -------------------------------------------------------------------------
+    # Passing cases
+    # -------------------------------------------------------------------------
+
+    def test_consistent_minimal_fixture_passes(self):
+        self._touch("apps/api/x.rs")
+        self._write(
+            _index([_task(evidence=["apps/api/x.rs"])]),
+            _board(active=["OPT-API-001"]),
+            _status([{"id": "OPT-API-001", "status": "partial"}]),
+        )
+        self.assertEqual(self._run(), [])
+
+    def test_nonexistent_evidence_path_explained_passes(self):
+        self._write(
+            _index(
+                [
+                    _task(
+                        priority="medium",
+                        evidence=["apps/api/missing.rs"],
+                        missing_evidence=["apps/api/missing.rs noch nicht vorhanden"],
+                    )
+                ]
+            ),
+            _board(active=["OPT-API-001"]),
+            _status([{"id": "OPT-API-001", "status": "partial"}]),
+        )
+        self.assertEqual(self._run(), [])
+
+    def test_deferred_task_002_documented_passes(self):
+        self._touch("apps/api/x.rs")
+        self._write(
+            _index(
+                [
+                    _task(evidence=["apps/api/x.rs"]),
+                    _task(
+                        id="TASK-CTL-002",
+                        area="governance",
+                        status="open",
+                        priority="low",
+                        acceptance=["Entscheidung dokumentiert"],
+                        missing_evidence=["Issue Forms bewusst zurückgestellt"],
+                    ),
+                ]
+            ),
+            _board(active=["OPT-API-001"], deferred=["TASK-CTL-002"]),
+            _status([{"id": "OPT-API-001", "status": "partial"}]),
+        )
+        self.assertEqual(self._run(), [])
+
+    # -------------------------------------------------------------------------
+    # Drift cases
+    # -------------------------------------------------------------------------
+
+    def test_board_task_missing_from_index_fails(self):
+        self._touch("apps/api/x.rs")
+        self._write(
+            _index([_task(evidence=["apps/api/x.rs"])]),
+            _board(active=["OPT-API-001", "OPT-API-099"]),
+            _status([{"id": "OPT-API-001", "status": "partial"}]),
+        )
+        errors = self._run()
+        self.assertTrue(
+            any("OPT-API-099" in e and "index.json" in e for e in errors), errors
+        )
+
+    def test_index_task_missing_from_board_fails(self):
+        self._touch("apps/api/x.rs")
+        self._write(
+            _index(
+                [
+                    _task(evidence=["apps/api/x.rs"]),
+                    _task(id="OPT-CON-001", priority="medium"),
+                ]
+            ),
+            _board(active=["OPT-API-001"]),
+            _status([{"id": "OPT-API-001", "status": "partial"}]),
+        )
+        errors = self._run()
+        self.assertTrue(
+            any("OPT-CON-001" in e and "board.md" in e for e in errors), errors
+        )
+
+    def test_done_without_evidence_fails(self):
+        self._write(
+            _index([_task(status="done", priority="medium", evidence=[])]),
+            _board(done=["OPT-API-001"]),
+            _status([{"id": "OPT-API-001", "status": "done"}]),
+        )
+        errors = self._run()
+        self.assertTrue(any("done" in e and "evidence" in e for e in errors), errors)
+
+    def test_high_priority_without_acceptance_fails(self):
+        self._touch("apps/api/x.rs")
+        self._write(
+            _index([_task(priority="high", acceptance=[], evidence=["apps/api/x.rs"])]),
+            _board(active=["OPT-API-001"]),
+            _status([{"id": "OPT-API-001", "status": "partial"}]),
+        )
+        errors = self._run()
+        self.assertTrue(
+            any("high priority" in e and "acceptance" in e for e in errors), errors
+        )
+
+    def test_nonexistent_evidence_path_fails(self):
+        self._write(
+            _index([_task(priority="medium", evidence=["apps/api/missing.rs"])]),
+            _board(active=["OPT-API-001"]),
+            _status([{"id": "OPT-API-001", "status": "partial"}]),
+        )
+        errors = self._run()
+        self.assertTrue(any("apps/api/missing.rs" in e for e in errors), errors)
+
+    def test_generated_evidence_target_fails(self):
+        self._write(
+            _index([_task(priority="medium", evidence=["docs/_generated/impl-index.md"])]),
+            _board(active=["OPT-API-001"]),
+            _status([{"id": "OPT-API-001", "status": "partial"}]),
+        )
+        errors = self._run()
+        self.assertTrue(any("_generated" in e for e in errors), errors)
+
+    def test_status_mismatch_fails(self):
+        self._touch("apps/api/x.rs")
+        self._write(
+            _index([_task(status="done", priority="medium", evidence=["apps/api/x.rs"])]),
+            _board(done=["OPT-API-001"]),
+            _status([{"id": "OPT-API-001", "status": "partial"}]),
+        )
+        errors = self._run()
+        self.assertTrue(any("mismatch" in e for e in errors), errors)
+
+    def test_task_003_open_not_candidate_fails(self):
+        self._touch("apps/api/x.rs")
+        self._write(
+            _index(
+                [
+                    _task(evidence=["apps/api/x.rs"]),
+                    _task(
+                        id="TASK-CTL-003",
+                        area="ci",
+                        status="open",
+                        priority="medium",
+                        acceptance=["Deterministischer Check"],
+                    ),
+                ]
+            ),
+            # TASK-CTL-003 is visible but NOT a candidate/active item -> drift.
+            _board(active=["OPT-API-001"], done=["TASK-CTL-003"]),
+            _status([{"id": "OPT-API-001", "status": "partial"}]),
+        )
+        errors = self._run()
+        self.assertTrue(
+            any("TASK-CTL-003" in e and "open" in e for e in errors), errors
+        )
+
+    def test_deferred_task_002_as_candidate_fails(self):
+        self._touch("apps/api/x.rs")
+        self._write(
+            _index(
+                [
+                    _task(evidence=["apps/api/x.rs"]),
+                    _task(
+                        id="TASK-CTL-002",
+                        area="governance",
+                        status="open",
+                        priority="low",
+                        acceptance=["Entscheidung dokumentiert"],
+                        missing_evidence=["bewusst zurückgestellt"],
+                    ),
+                ]
+            ),
+            _board(active=["OPT-API-001"], candidates=["TASK-CTL-002"]),
+            _status([{"id": "OPT-API-001", "status": "partial"}]),
+        )
+        errors = self._run()
+        self.assertTrue(
+            any("TASK-CTL-002" in e and "deferred" in e for e in errors), errors
+        )
+
+    # -------------------------------------------------------------------------
+    # No-write guarantee and invocation
+    # -------------------------------------------------------------------------
+
+    def test_check_writes_no_files(self):
+        self._touch("apps/api/x.rs")
+        self._write(
+            _index([_task(evidence=["apps/api/x.rs"])]),
+            _board(active=["OPT-API-001"]),
+            _status([{"id": "OPT-API-001", "status": "partial"}]),
+        )
+        before = self._snapshot()
+        with mock.patch.multiple(
+            gen,
+            INDEX_PATH=self.index_path,
+            BOARD_PATH=self.board_path,
+            STATUS_PATH=self.status_path,
+            REPO_ROOT=self.root,
+        ):
+            rc = gen.main(["--check"])
+        after = self._snapshot()
+        self.assertEqual(rc, 0)
+        self.assertEqual(before, after)
+
+    def test_main_without_check_refuses(self):
+        self.assertEqual(gen.main([]), 2)
+
+    # -------------------------------------------------------------------------
+    # Parser
+    # -------------------------------------------------------------------------
+
+    def test_parse_board_sections(self):
+        text = _board(
+            active=["OPT-API-001"],
+            candidates=["TASK-CTL-003"],
+            deferred=["TASK-CTL-002"],
+            done=["TASK-CTL-001", "OPT-MAP-001"],
+        )
+        sections = parse_board(text)
+        self.assertEqual(sections["active"], {"OPT-API-001"})
+        self.assertEqual(sections["candidates"], {"TASK-CTL-003"})
+        self.assertEqual(sections["deferred"], {"TASK-CTL-002"})
+        self.assertEqual(sections["done"], {"TASK-CTL-001", "OPT-MAP-001"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/docmeta/tests/test_generate_task_index.py
+++ b/scripts/docmeta/tests/test_generate_task_index.py
@@ -215,6 +215,16 @@ class TestGenerateTaskIndex(unittest.TestCase):
             any("OPT-CON-001" in e and "board.md" in e for e in errors), errors
         )
 
+    def test_low_priority_task_not_in_board_passes(self):
+        # low-priority done/open tasks need not appear in board.md
+        self._write(
+            _index([_task(id="OPT-API-001", priority="low", status="open", evidence=[])]),
+            _board(),  # board is empty
+            _status([]),
+        )
+        errors = self._run()
+        self.assertFalse(any("board.md" in e for e in errors), errors)
+
     def test_done_without_evidence_fails(self):
         self._write(
             _index([_task(status="done", priority="medium", evidence=[])]),

--- a/scripts/docmeta/tests/test_generate_task_index.py
+++ b/scripts/docmeta/tests/test_generate_task_index.py
@@ -366,6 +366,23 @@ class TestGenerateTaskIndex(unittest.TestCase):
         self.assertEqual(sections["deferred"], {"TASK-CTL-002"})
         self.assertEqual(sections["done"], {"TASK-CTL-001", "OPT-MAP-001"})
 
+    def test_parse_board_ignores_task_ids_outside_first_cell(self):
+        # Only the ID column drives board visibility; task ids mentioned in
+        # evidence / next-action columns must not count as board entries.
+        text = "\n".join(
+            [
+                "# Board",
+                "## Aktive Prioritäten",
+                "| ID | Info |",
+                "|---|---|",
+                "| OPT-API-001 | Mentions TASK-CTL-003 only as related work |",
+                "",
+            ]
+        )
+        sections = parse_board(text)
+        self.assertEqual(sections["active"], {"OPT-API-001"})
+        self.assertNotIn("TASK-CTL-003", sections["active"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Implements the deterministic check mode for task-control drift detection as specified in TASK-CTL-003. Introduces `generate_task_index.py --check`, a read-only validation mechanism that compares three manually curated artifacts (board.md, index.json, optimierungsstatus.json) for consistency without writing files.

## Key Changes

- **New script:** `scripts/docmeta/generate_task_index.py`
  - Parses `docs/tasks/board.md` into section-keyed task sets
  - Loads and validates `docs/tasks/index.json` and `docs/reports/optimierungsstatus.json`
  - Implements 10 drift checks covering:
    - Board ↔ Index ↔ Status consistency
    - Evidence and documentation path existence
    - Business rules (done tasks need evidence, high-priority tasks need acceptance criteria)
    - Special handling for TASK-CTL-002 (deferred) and TASK-CTL-003 (open priority visibility)
    - Status contradiction detection between index.json and optimierungsstatus.json
  - Exit codes: 0 (no drift), 1 (drift found), 2 (invalid invocation)
  - Intentionally refuses to write files; generation is a future decision

- **Comprehensive test suite:** `scripts/docmeta/tests/test_generate_task_index.py`
  - 361 lines covering passing cases, drift detection, and no-write guarantees
  - Uses isolated temporary fixtures; never modifies real repository files
  - Tests parser, business rules, and invocation behavior

- **CI integration:** `.github/workflows/task-index.yml`
  - Runs on changes to task-control artifacts, docs, or scripts
  - Executes schema validation (existing) + drift check (new)
  - Triggers on PR and manual dispatch

- **Documentation updates:**
  - `docs/tasks/README.md`: Clarifies Phase 4 status (check mode active, generation deferred)
  - `CONTRIBUTING.md`: Documents local drift-check invocation
  - `docs/tasks/index.json`: Updates TASK-CTL-003 status to "partial" with evidence
  - `docs/tasks/board.md`: Moves TASK-CTL-003 to active priorities

## Implementation Details

- **No silent writes:** Script enforces `--check` flag; calling without it returns exit code 2
- **Path validation:** Distinguishes between repo paths (existence-checked) and free-form evidence strings
- **Generated artifact protection:** Rejects evidence or doc links pointing into `docs/_generated/`
- **Explained gaps:** Missing evidence paths can be documented in `missing_evidence` field to suppress drift errors
- **Deterministic output:** Errors sorted alphabetically for stable CI reporting
- **Minimal dependencies:** Uses only stdlib (argparse, json, os, re, sys)

The check is a pure validation layer with no write capability. Automatic generation and bot-PR workflows remain future decisions per the roadmap.

https://claude.ai/code/session_01Ba93HZSXK7Ukcn4vXzTfes