### PR TITLE
Add Agent Safety Control Layer blueprint and index entry

### DIFF
--- a/docs/blueprints/blueprint-agent-safety-control-layer.md
+++ b/docs/blueprints/blueprint-agent-safety-control-layer.md
@@ -9,13 +9,13 @@ relations:
     target: docs/blueprints/agent-operability-blaupause.md
   - type: relates_to
     target: docs/roadmap.md
-  - type: depends_on
+  - type: relates_to
     target: repo.meta.yaml
-  - type: depends_on
+  - type: relates_to
     target: AGENTS.md
-  - type: depends_on
+  - type: relates_to
     target: agent-policy.yaml
-  - type: depends_on
+  - type: relates_to
     target: docs/policies/agent-reading-protocol.md
   - type: relates_to
     target: docs/tasks/index.json
@@ -248,14 +248,19 @@ Diese Artefakte definieren, woran gearbeitet wird.
 
 ### 5.3 Evidence-Flächen
 
-- `docs/claims/registry.yml`
+Bestehende Evidence-Flächen:
+
 - `audit/impl-registry.yaml`
 - `docs/proofs/**`
-- `artifacts/agent-runs/**`
 - CI-Workflows
 - Runtime-/Deploy-Snapshots
 
-Diese Artefakte definieren, was belegt ist.
+Geplante Evidence-Flächen:
+
+- `docs/claims/registry.yml` — erst nach PR 3 `evidence/minimal-claim-spine`
+- `artifacts/agent-runs/**` — erst nach PR 7 `agent/run-evidence-lite`
+
+Diese Artefakte definieren, was belegt ist. Geplante Evidence-Flächen dürfen bis zu ihrer Implementierung nicht als verfügbare Primärquelle gelesen werden.
 
 ### 5.4 Diagnose und Projektion
 
@@ -271,11 +276,11 @@ Der Ausbau erfolgt nicht als Big Bang. Jede Welle muss eine konkrete Fehlerklass
 
 #### PR 1 — agent/safety-preflight
 
-**Zweck**
+##### Zweck
 
 Gefährliche Agentenfehler sofort blockieren, noch bevor ein vollständiger Agent-Runner existiert.
 
-**Neue oder geänderte Artefakte**
+##### Neue oder geänderte Artefakte
 
 - `docs/security/agent-write-scope-baseline.md`
 - `scripts/agent/check_changed_paths_scope.py`
@@ -289,7 +294,7 @@ Optional:
 
 Bevorzugt wird aber die Integration in bestehende Guard-Strukturen, sofern das ohne Verrenkung möglich ist.
 
-**Regeln**
+##### Regeln
 
 1. `docs/_generated/*` darf nicht direkt editiert werden.
 2. Roadmap-`[x]` braucht Claim- oder Proof-Referenz.
@@ -300,7 +305,7 @@ Bevorzugt wird aber die Integration in bestehende Guard-Strukturen, sofern das o
 7. Delete braucht `delete_allowed: true`.
 8. Agent darf kein `done` setzen.
 
-**Minimaler Agent-Marker**
+##### Minimaler Agent-Marker
 
 Zu Beginn genügt ein YAML-Block im PR-Body oder eine kleine Task-Datei:
 
@@ -316,7 +321,7 @@ validation:
 delete_allowed: false
 ```
 
-**Ratchet**
+##### Ratchet
 
 - Stufe 1: report-only
 - Stufe 2: warn
@@ -326,7 +331,7 @@ delete_allowed: false
   - Status `done` ohne `proof_ref`
   - forbidden paths
 
-**Akzeptanzkriterien**
+##### Akzeptanzkriterien
 
 - Ein Patch mit direktem Edit an `docs/_generated/*` wird erkannt.
 - Ein Roadmap-Haken ohne Claim/Proof wird erkannt.
@@ -334,7 +339,7 @@ delete_allowed: false
 - Ein Pfad außerhalb `allowed_paths` wird erkannt.
 - Alle Checks liefern maschinenlesbare Fehlercodes.
 
-**Fehlercodes**
+##### Fehlercodes
 
 - `GENERATED_DIRECT_EDIT`
 - `ROADMAP_DONE_WITHOUT_CLAIM`
@@ -346,17 +351,17 @@ delete_allowed: false
 
 #### PR 2 — agent/readiness-hard-fail
 
-**Zweck**
+##### Zweck
 
 Agent-Readiness darf keine Reife suggerieren, solange Kernmechaniken fehlen.
 
-**Artefakte**
+##### Artefakte
 
 - `scripts/docmeta/generate_agent_readiness.py`
 - `docs/_generated/agent-readiness.md`
 - `docs/_generated/agent-readiness.json`
 
-**Capability-Matrix**
+##### Capability-Matrix
 
 | Capability | Statusregel |
 |---|---|
@@ -369,7 +374,7 @@ Agent-Readiness darf keine Reife suggerieren, solange Kernmechaniken fehlen.
 | Run Evidence | `open`, solange Run-Artefakte fehlen |
 | Overall | maximal `partial`, solange eine Hard-Capability fehlt |
 
-**Akzeptanzkriterien**
+##### Akzeptanzkriterien
 
 - Gesamtstatus kann nicht `pass` sein, solange Contracts, Handoff-Validator oder Runner fehlen.
 - Report nennt fehlende Artefakte konkret.
@@ -380,11 +385,11 @@ Agent-Readiness darf keine Reife suggerieren, solange Kernmechaniken fehlen.
 
 #### PR 3 — evidence/minimal-claim-spine
 
-**Zweck**
+##### Zweck
 
 Handlungsleitende Claims werden maschinenlesbar und beweispflichtig.
 
-**Artefakte**
+##### Artefakte
 
 - `docs/claims/registry.yml`
 - `docs/claims/schema.json`
@@ -392,7 +397,7 @@ Handlungsleitende Claims werden maschinenlesbar und beweispflichtig.
 - `docs/_generated/claim-evidence.md`
 - `docs/_generated/claim-evidence.json`
 
-**Start-Claim-Typen**
+##### Start-Claim-Typen
 
 ```yaml
 claim_type:
@@ -403,7 +408,7 @@ claim_type:
   - security_guard_enforced
 ```
 
-**Beispiel**
+##### Beispiel
 
 ```yaml
 - id: claim.agent.safety_preflight.enforced
@@ -422,7 +427,7 @@ claim_type:
       - .github/workflows/agent-safety-preflight.yml
 ```
 
-**Statuswerte**
+##### Statuswerte
 
 - `open`
 - `partial`
@@ -430,7 +435,7 @@ claim_type:
 - `stale`
 - `contradicted`
 
-**Akzeptanzkriterien**
+##### Akzeptanzkriterien
 
 - Mindestens zehn handlungsleitende Claims sind modelliert.
 - Roadmap-`[x]` in Agent-/CI-/Generated-/Guard-Bereichen braucht Claim-Eintrag.
@@ -440,11 +445,11 @@ claim_type:
 
 #### PR 4 — evidence/impl-registry-critical
 
-**Zweck**
+##### Zweck
 
 Die vorhandene `audit/impl-registry.yaml` wird für kritische Pfade evidence-fähig gemacht.
 
-**Startumfang**
+##### Startumfang
 
 - `impl.workflow.ci`
 - `impl.contracts`
@@ -453,7 +458,7 @@ Die vorhandene `audit/impl-registry.yaml` wird für kritische Pfade evidence-fä
 - `impl.infra.compose`
 - `impl.agent.safety-preflight`
 
-**Schema-Erweiterung**
+##### Schema-Erweiterung
 
 ```yaml
 id: impl.workflow.ci
@@ -470,14 +475,14 @@ evidence_level: ci
 last_verified: "2026-06-01"
 ```
 
-**Regeln**
+##### Regeln
 
 - Impl-Registry ist Evidence-Quelle, nicht Claim-Wahrheit.
 - Claims dürfen auf Impl-Entries verweisen.
 - Impl-Entries dürfen nicht automatisch Roadmap-Status setzen.
 - `criticality: high` ohne `verified_by` wird zunächst warn, später fail.
 
-**Akzeptanzkriterien**
+##### Akzeptanzkriterien
 
 Alle kritischen Einträge haben:
 
@@ -490,13 +495,13 @@ Alle kritischen Einträge haben:
 
 #### PR 5 — agent/minimal-contracts-and-guard
 
-**Zweck**
+##### Zweck
 
 Agent-Tasks erhalten ein maschinenlesbares Minimalformat, und unklare Tasks werden blockiert.
 
 Contracts ohne Guard sind zu weich. Guard ohne Contracts ist zu schwammig. Diese PR verbindet beides.
 
-**Artefakte**
+##### Artefakte
 
 - `contracts/agent/task.schema.json`
 - `contracts/agent/command.read_context.schema.json`
@@ -513,7 +518,7 @@ Contracts ohne Guard sind zu weich. Guard ohne Contracts ist zu schwammig. Diese
 - `tests/fixtures/agent/invalid-status-done-by-agent.json`
 - `docs/reference/agent-operability-fixture-matrix.md`
 
-**Task-Pflichtfelder**
+##### Task-Pflichtfelder
 
 ```yaml
 task_id:
@@ -527,7 +532,7 @@ validation_commands:
 delete_allowed: false
 ```
 
-**Command-Kette**
+##### Command-Kette
 
 ```text
 read_context
@@ -536,7 +541,7 @@ read_context
 → emit_handoff
 ```
 
-**Non-Ideal-Fehlercodes**
+##### Non-Ideal-Fehlercodes
 
 - `NO_ALLOWED_PATHS`
 - `NO_VALIDATION_COMMAND`
@@ -548,7 +553,7 @@ read_context
 - `STATUS_DONE_BY_AGENT`
 - `CONTRADICTION_FOUND`
 
-**Akzeptanzkriterien**
+##### Akzeptanzkriterien
 
 - Drei reale Weltgewebe-Tasktypen sind valide modelliert.
 - Drei gefährliche Negativfälle scheitern.
@@ -560,16 +565,16 @@ read_context
 
 #### PR 6 — agent/dry-run-runner
 
-**Zweck**
+##### Zweck
 
 Agenten können echte Tasks trocken ausführen, ohne Dateien zu ändern.
 
-**Artefakte**
+##### Artefakte
 
 - `scripts/agent/run_task.py`
 - `.github/workflows/agent-operability-smoke.yml`
 
-**Ablauf**
+##### Ablauf
 
 ```text
 load task
@@ -582,12 +587,12 @@ emit handoff.json
 emit run-result.json
 ```
 
-**Standard**
+##### Standard
 
 - `--dry-run` ist default.
 - `--write` existiert noch nicht.
 
-**Smoke-Test**
+##### Smoke-Test
 
 ```bash
 python scripts/agent/run_task.py --dry-run tests/fixtures/agent/valid-doc-drift-task.json
@@ -595,7 +600,7 @@ python scripts/agent/run_task.py --dry-run tests/fixtures/agent/valid-roadmap-cl
 python scripts/agent/run_task.py --dry-run tests/fixtures/agent/valid-generated-refresh-task.json
 ```
 
-**Akzeptanzkriterien**
+##### Akzeptanzkriterien
 
 - Drei reale Tasktypen laufen deterministisch durch.
 - Keine Dateien werden geändert.
@@ -605,11 +610,11 @@ python scripts/agent/run_task.py --dry-run tests/fixtures/agent/valid-generated-
 
 #### PR 7 — agent/run-evidence-lite
 
-**Zweck**
+##### Zweck
 
 Jeder Dry-Run erzeugt minimale, schema-valide Evidence.
 
-**Artefakte**
+##### Artefakte
 
 ```text
 artifacts/agent-runs/<run-id>/
@@ -619,7 +624,7 @@ artifacts/agent-runs/<run-id>/
   run-result.json
 ```
 
-**Noch nicht enthalten**
+##### Noch nicht enthalten
 
 - `evidence.jsonl`
 - `decision.yml`
@@ -627,7 +632,7 @@ artifacts/agent-runs/<run-id>/
 
 Diese kommen erst nach stabilem Runner.
 
-**Akzeptanzkriterien**
+##### Akzeptanzkriterien
 
 - Jeder Dry-Run erzeugt einen eindeutigen `run_id`.
 - Jeder Dry-Run schreibt schema-valide Run-Artefakte.
@@ -638,21 +643,21 @@ Diese kommen erst nach stabilem Runner.
 
 #### PR 8 — docs/generated-control-minimal
 
-**Zweck**
+##### Zweck
 
 Die gefährlichsten Generated-Artefakte werden zuerst kontrolliert.
 
-**Startumfang**
+##### Startumfang
 
 - `docs/_generated/agent-readiness.md`
 - `docs/_generated/claim-evidence.md`
 - `docs/tasks/index.json`
 
-**Artefakt**
+##### Artefakt
 
 - `.wgx/generated-artifacts.yml`
 
-**Beispiel**
+##### Beispiel
 
 ```yaml
 artifacts:
@@ -668,7 +673,7 @@ artifacts:
     blocking: true
 ```
 
-**Akzeptanzkriterien**
+##### Akzeptanzkriterien
 
 - Agent-Readiness, Claim-Evidence und Task-Index dürfen nicht manuell editiert werden.
 - Alle drei Artefakte sind aus Quellen regenerierbar.
@@ -677,23 +682,23 @@ artifacts:
 
 #### PR 9 — docs/roadmap-ratchet-minimal
 
-**Zweck**
+##### Zweck
 
 Gefährliche Statuslügen werden blockiert.
 
-**Regeln**
+##### Regeln
 
 - Roadmap-`[x]` in Agent-/CI-/Generated-Bereichen braucht verified Claim.
 - Statusmatrix `done` braucht `proof_ref`.
 - Blueprint `active` im Agent-Bereich braucht verified Claim-Gruppe.
 
-**Artefakte**
+##### Artefakte
 
 - `scripts/docmeta/check_roadmap_claims.py`
 - `scripts/docmeta/check_statusmatrix_proofs.py`
 - `scripts/docmeta/check_blueprint_activation.py`
 
-**Akzeptanzkriterien**
+##### Akzeptanzkriterien
 
 - Agent-Operability-Haken kann nicht gesetzt werden, solange Contracts, Guard oder Runner fehlen.
 - `done` ohne `proof_ref` scheitert.
@@ -704,11 +709,11 @@ Gefährliche Statuslügen werden blockiert.
 
 #### PR 10 — agent/write-mode-opt-in
 
-**Zweck**
+##### Zweck
 
 Echte Agent-Writes werden möglich, aber nur streng begrenzt.
 
-**Voraussetzungen**
+##### Voraussetzungen
 
 - Safety Preflight pass
 - Readiness hard fail aktiv
@@ -718,13 +723,13 @@ Echte Agent-Writes werden möglich, aber nur streng begrenzt.
 - Dry-Run Runner pass
 - Run Evidence Lite pass
 
-**Befehl**
+##### Befehl
 
 ```bash
 python scripts/agent/run_task.py --write tasks/WG-TASK-....yml
 ```
 
-**Einschränkungen**
+##### Einschränkungen
 
 - nur `allowed_paths`
 - kein `docs/_generated` direkt
@@ -733,7 +738,7 @@ python scripts/agent/run_task.py --write tasks/WG-TASK-....yml
 - kein infra ohne `task_type=infra_change` und `proof_ref`
 - kein roadmap done ohne `claim.status=verified`
 
-**Akzeptanzkriterien**
+##### Akzeptanzkriterien
 
 - Ein kleiner Doku-Code-Drift-Fix läuft end-to-end.
 - Patch wird erzeugt.
@@ -743,11 +748,11 @@ python scripts/agent/run_task.py --write tasks/WG-TASK-....yml
 
 #### PR 11 — agent/run-evidence-full
 
-**Zweck**
+##### Zweck
 
 Vollständige Agent-Observability.
 
-**Artefakte**
+##### Artefakte
 
 ```text
 artifacts/agent-runs/<run-id>/
@@ -760,12 +765,12 @@ artifacts/agent-runs/<run-id>/
   run-result.json
 ```
 
-**Regel**
+##### Regel
 
 Agent darf:
 
 ```yaml
-decision: pass
+decision: pass_proposed
 ```
 
 Agent darf nicht:
@@ -774,7 +779,7 @@ Agent darf nicht:
 repo-status: done
 ```
 
-**Akzeptanzkriterien**
+##### Akzeptanzkriterien
 
 - Dry-Run und Write-Run erzeugen vollständige, schema-valide Evidence.
 - `decision.yml` verweist auf Claims, Validation und Residual Gaps.
@@ -793,7 +798,7 @@ Ausweitung auf:
 - Docmeta
 - Security
 
-**Akzeptanzkriterium**
+##### Akzeptanzkriterium
 
 Alle zentralen Roadmap-Haken in Kernbereichen haben Claim-Evidence.
 
@@ -808,7 +813,7 @@ Alle `docs/_generated/*` bekommen:
 - `commit_required`
 - `blocking`
 
-**Akzeptanzkriterium**
+##### Akzeptanzkriterium
 
 Alle Generated-Artefakte sind klassifiziert, regenerierbar und gegen direkte Edits geschützt.
 
@@ -830,7 +835,7 @@ Nicht für:
 - kleine Doku-Fixes
 - normale Statusupdates
 
-**Artefakte**
+##### Artefakte
 
 ```text
 experiments/<id>/
@@ -842,7 +847,7 @@ experiments/<id>/
   decision.yml
 ```
 
-**Akzeptanzkriterium**
+##### Akzeptanzkriterium
 
 `adopted` ohne `run_meta.json`, Evidence und Decision ist unmöglich.
 
@@ -865,7 +870,7 @@ no-task-required: true
 reason: typo-only
 ```
 
-**Akzeptanzkriterium**
+##### Akzeptanzkriterium
 
 Kein relevanter PR ohne Task-/Claim-/Evidence-Verbindung.
 
@@ -873,7 +878,7 @@ Kein relevanter PR ohne Task-/Claim-/Evidence-Verbindung.
 
 Owner/Review-Intervalle für langlebige Roadmaps und Blueprints.
 
-**Frontmatter-Erweiterung**
+##### Frontmatter-Erweiterung
 
 ```yaml
 owner: alex
@@ -883,7 +888,7 @@ next_review_due: "2026-07-16"
 staleness_policy: warn
 ```
 
-**Akzeptanzkriterium**
+##### Akzeptanzkriterium
 
 Keine aktive Roadmap oder Policy ohne Owner und Review-Intervall.
 

--- a/docs/blueprints/blueprint-agent-safety-control-layer.md
+++ b/docs/blueprints/blueprint-agent-safety-control-layer.md
@@ -276,11 +276,11 @@ Der Ausbau erfolgt nicht als Big Bang. Jede Welle muss eine konkrete Fehlerklass
 
 #### PR 1 — agent/safety-preflight
 
-##### Zweck
+##### PR 1 — agent/safety-preflight: Zweck
 
 Gefährliche Agentenfehler sofort blockieren, noch bevor ein vollständiger Agent-Runner existiert.
 
-##### Neue oder geänderte Artefakte
+##### PR 1 — agent/safety-preflight: Neue oder geänderte Artefakte
 
 - `docs/security/agent-write-scope-baseline.md`
 - `scripts/agent/check_changed_paths_scope.py`
@@ -294,7 +294,7 @@ Optional:
 
 Bevorzugt wird aber die Integration in bestehende Guard-Strukturen, sofern das ohne Verrenkung möglich ist.
 
-##### Regeln
+##### PR 1 — agent/safety-preflight: Regeln
 
 1. `docs/_generated/*` darf nicht direkt editiert werden.
 2. Roadmap-`[x]` braucht Claim- oder Proof-Referenz.
@@ -305,7 +305,7 @@ Bevorzugt wird aber die Integration in bestehende Guard-Strukturen, sofern das o
 7. Delete braucht `delete_allowed: true`.
 8. Agent darf kein `done` setzen.
 
-##### Minimaler Agent-Marker
+##### PR 1 — agent/safety-preflight: Minimaler Agent-Marker
 
 Zu Beginn genügt ein YAML-Block im PR-Body oder eine kleine Task-Datei:
 
@@ -321,7 +321,7 @@ validation:
 delete_allowed: false
 ```
 
-##### Ratchet
+##### PR 1 — agent/safety-preflight: Ratchet
 
 - Stufe 1: report-only
 - Stufe 2: warn
@@ -331,7 +331,7 @@ delete_allowed: false
   - Status `done` ohne `proof_ref`
   - forbidden paths
 
-##### Akzeptanzkriterien
+##### PR 1 — agent/safety-preflight: Akzeptanzkriterien
 
 - Ein Patch mit direktem Edit an `docs/_generated/*` wird erkannt.
 - Ein Roadmap-Haken ohne Claim/Proof wird erkannt.
@@ -339,7 +339,7 @@ delete_allowed: false
 - Ein Pfad außerhalb `allowed_paths` wird erkannt.
 - Alle Checks liefern maschinenlesbare Fehlercodes.
 
-##### Fehlercodes
+##### PR 1 — agent/safety-preflight: Fehlercodes
 
 - `GENERATED_DIRECT_EDIT`
 - `ROADMAP_DONE_WITHOUT_CLAIM`
@@ -351,17 +351,17 @@ delete_allowed: false
 
 #### PR 2 — agent/readiness-hard-fail
 
-##### Zweck
+##### PR 2 — agent/readiness-hard-fail: Zweck
 
 Agent-Readiness darf keine Reife suggerieren, solange Kernmechaniken fehlen.
 
-##### Artefakte
+##### PR 2 — agent/readiness-hard-fail: Artefakte
 
 - `scripts/docmeta/generate_agent_readiness.py`
 - `docs/_generated/agent-readiness.md`
 - `docs/_generated/agent-readiness.json`
 
-##### Capability-Matrix
+##### PR 2 — agent/readiness-hard-fail: Capability-Matrix
 
 | Capability | Statusregel |
 |---|---|
@@ -374,7 +374,7 @@ Agent-Readiness darf keine Reife suggerieren, solange Kernmechaniken fehlen.
 | Run Evidence | `open`, solange Run-Artefakte fehlen |
 | Overall | maximal `partial`, solange eine Hard-Capability fehlt |
 
-##### Akzeptanzkriterien
+##### PR 2 — agent/readiness-hard-fail: Akzeptanzkriterien
 
 - Gesamtstatus kann nicht `pass` sein, solange Contracts, Handoff-Validator oder Runner fehlen.
 - Report nennt fehlende Artefakte konkret.
@@ -385,11 +385,11 @@ Agent-Readiness darf keine Reife suggerieren, solange Kernmechaniken fehlen.
 
 #### PR 3 — evidence/minimal-claim-spine
 
-##### Zweck
+##### PR 3 — evidence/minimal-claim-spine: Zweck
 
 Handlungsleitende Claims werden maschinenlesbar und beweispflichtig.
 
-##### Artefakte
+##### PR 3 — evidence/minimal-claim-spine: Artefakte
 
 - `docs/claims/registry.yml`
 - `docs/claims/schema.json`
@@ -397,7 +397,7 @@ Handlungsleitende Claims werden maschinenlesbar und beweispflichtig.
 - `docs/_generated/claim-evidence.md`
 - `docs/_generated/claim-evidence.json`
 
-##### Start-Claim-Typen
+##### PR 3 — evidence/minimal-claim-spine: Start-Claim-Typen
 
 ```yaml
 claim_type:
@@ -408,7 +408,7 @@ claim_type:
   - security_guard_enforced
 ```
 
-##### Beispiel
+##### PR 3 — evidence/minimal-claim-spine: Beispiel
 
 ```yaml
 - id: claim.agent.safety_preflight.enforced
@@ -427,7 +427,7 @@ claim_type:
       - .github/workflows/agent-safety-preflight.yml
 ```
 
-##### Statuswerte
+##### PR 3 — evidence/minimal-claim-spine: Statuswerte
 
 - `open`
 - `partial`
@@ -435,7 +435,7 @@ claim_type:
 - `stale`
 - `contradicted`
 
-##### Akzeptanzkriterien
+##### PR 3 — evidence/minimal-claim-spine: Akzeptanzkriterien
 
 - Mindestens zehn handlungsleitende Claims sind modelliert.
 - Roadmap-`[x]` in Agent-/CI-/Generated-/Guard-Bereichen braucht Claim-Eintrag.
@@ -445,11 +445,11 @@ claim_type:
 
 #### PR 4 — evidence/impl-registry-critical
 
-##### Zweck
+##### PR 4 — evidence/impl-registry-critical: Zweck
 
 Die vorhandene `audit/impl-registry.yaml` wird für kritische Pfade evidence-fähig gemacht.
 
-##### Startumfang
+##### PR 4 — evidence/impl-registry-critical: Startumfang
 
 - `impl.workflow.ci`
 - `impl.contracts`
@@ -458,7 +458,7 @@ Die vorhandene `audit/impl-registry.yaml` wird für kritische Pfade evidence-fä
 - `impl.infra.compose`
 - `impl.agent.safety-preflight`
 
-##### Schema-Erweiterung
+##### PR 4 — evidence/impl-registry-critical: Schema-Erweiterung
 
 ```yaml
 id: impl.workflow.ci
@@ -475,14 +475,14 @@ evidence_level: ci
 last_verified: "2026-06-01"
 ```
 
-##### Regeln
+##### PR 4 — evidence/impl-registry-critical: Regeln
 
 - Impl-Registry ist Evidence-Quelle, nicht Claim-Wahrheit.
 - Claims dürfen auf Impl-Entries verweisen.
 - Impl-Entries dürfen nicht automatisch Roadmap-Status setzen.
 - `criticality: high` ohne `verified_by` wird zunächst warn, später fail.
 
-##### Akzeptanzkriterien
+##### PR 4 — evidence/impl-registry-critical: Akzeptanzkriterien
 
 Alle kritischen Einträge haben:
 
@@ -495,13 +495,13 @@ Alle kritischen Einträge haben:
 
 #### PR 5 — agent/minimal-contracts-and-guard
 
-##### Zweck
+##### PR 5 — agent/minimal-contracts-and-guard: Zweck
 
 Agent-Tasks erhalten ein maschinenlesbares Minimalformat, und unklare Tasks werden blockiert.
 
 Contracts ohne Guard sind zu weich. Guard ohne Contracts ist zu schwammig. Diese PR verbindet beides.
 
-##### Artefakte
+##### PR 5 — agent/minimal-contracts-and-guard: Artefakte
 
 - `contracts/agent/task.schema.json`
 - `contracts/agent/command.read_context.schema.json`
@@ -518,7 +518,7 @@ Contracts ohne Guard sind zu weich. Guard ohne Contracts ist zu schwammig. Diese
 - `tests/fixtures/agent/invalid-status-done-by-agent.json`
 - `docs/reference/agent-operability-fixture-matrix.md`
 
-##### Task-Pflichtfelder
+##### PR 5 — agent/minimal-contracts-and-guard: Task-Pflichtfelder
 
 ```yaml
 task_id:
@@ -532,7 +532,7 @@ validation_commands:
 delete_allowed: false
 ```
 
-##### Command-Kette
+##### PR 5 — agent/minimal-contracts-and-guard: Command-Kette
 
 ```text
 read_context
@@ -541,7 +541,7 @@ read_context
 → emit_handoff
 ```
 
-##### Non-Ideal-Fehlercodes
+##### PR 5 — agent/minimal-contracts-and-guard: Non-Ideal-Fehlercodes
 
 - `NO_ALLOWED_PATHS`
 - `NO_VALIDATION_COMMAND`
@@ -553,7 +553,7 @@ read_context
 - `STATUS_DONE_BY_AGENT`
 - `CONTRADICTION_FOUND`
 
-##### Akzeptanzkriterien
+##### PR 5 — agent/minimal-contracts-and-guard: Akzeptanzkriterien
 
 - Drei reale Weltgewebe-Tasktypen sind valide modelliert.
 - Drei gefährliche Negativfälle scheitern.
@@ -565,16 +565,16 @@ read_context
 
 #### PR 6 — agent/dry-run-runner
 
-##### Zweck
+##### PR 6 — agent/dry-run-runner: Zweck
 
 Agenten können echte Tasks trocken ausführen, ohne Dateien zu ändern.
 
-##### Artefakte
+##### PR 6 — agent/dry-run-runner: Artefakte
 
 - `scripts/agent/run_task.py`
 - `.github/workflows/agent-operability-smoke.yml`
 
-##### Ablauf
+##### PR 6 — agent/dry-run-runner: Ablauf
 
 ```text
 load task
@@ -587,12 +587,12 @@ emit handoff.json
 emit run-result.json
 ```
 
-##### Standard
+##### PR 6 — agent/dry-run-runner: Standard
 
 - `--dry-run` ist default.
 - `--write` existiert noch nicht.
 
-##### Smoke-Test
+##### PR 6 — agent/dry-run-runner: Smoke-Test
 
 ```bash
 python scripts/agent/run_task.py --dry-run tests/fixtures/agent/valid-doc-drift-task.json
@@ -600,7 +600,7 @@ python scripts/agent/run_task.py --dry-run tests/fixtures/agent/valid-roadmap-cl
 python scripts/agent/run_task.py --dry-run tests/fixtures/agent/valid-generated-refresh-task.json
 ```
 
-##### Akzeptanzkriterien
+##### PR 6 — agent/dry-run-runner: Akzeptanzkriterien
 
 - Drei reale Tasktypen laufen deterministisch durch.
 - Keine Dateien werden geändert.
@@ -610,11 +610,11 @@ python scripts/agent/run_task.py --dry-run tests/fixtures/agent/valid-generated-
 
 #### PR 7 — agent/run-evidence-lite
 
-##### Zweck
+##### PR 7 — agent/run-evidence-lite: Zweck
 
 Jeder Dry-Run erzeugt minimale, schema-valide Evidence.
 
-##### Artefakte
+##### PR 7 — agent/run-evidence-lite: Artefakte
 
 ```text
 artifacts/agent-runs/<run-id>/
@@ -624,7 +624,7 @@ artifacts/agent-runs/<run-id>/
   run-result.json
 ```
 
-##### Noch nicht enthalten
+##### PR 7 — agent/run-evidence-lite: Noch nicht enthalten
 
 - `evidence.jsonl`
 - `decision.yml`
@@ -632,7 +632,7 @@ artifacts/agent-runs/<run-id>/
 
 Diese kommen erst nach stabilem Runner.
 
-##### Akzeptanzkriterien
+##### PR 7 — agent/run-evidence-lite: Akzeptanzkriterien
 
 - Jeder Dry-Run erzeugt einen eindeutigen `run_id`.
 - Jeder Dry-Run schreibt schema-valide Run-Artefakte.
@@ -643,21 +643,21 @@ Diese kommen erst nach stabilem Runner.
 
 #### PR 8 — docs/generated-control-minimal
 
-##### Zweck
+##### PR 8 — docs/generated-control-minimal: Zweck
 
 Die gefährlichsten Generated-Artefakte werden zuerst kontrolliert.
 
-##### Startumfang
+##### PR 8 — docs/generated-control-minimal: Startumfang
 
 - `docs/_generated/agent-readiness.md`
 - `docs/_generated/claim-evidence.md`
 - `docs/tasks/index.json`
 
-##### Artefakt
+##### PR 8 — docs/generated-control-minimal: Artefakt
 
 - `.wgx/generated-artifacts.yml`
 
-##### Beispiel
+##### PR 8 — docs/generated-control-minimal: Beispiel
 
 ```yaml
 artifacts:
@@ -673,7 +673,7 @@ artifacts:
     blocking: true
 ```
 
-##### Akzeptanzkriterien
+##### PR 8 — docs/generated-control-minimal: Akzeptanzkriterien
 
 - Agent-Readiness, Claim-Evidence und Task-Index dürfen nicht manuell editiert werden.
 - Alle drei Artefakte sind aus Quellen regenerierbar.
@@ -682,23 +682,23 @@ artifacts:
 
 #### PR 9 — docs/roadmap-ratchet-minimal
 
-##### Zweck
+##### PR 9 — docs/roadmap-ratchet-minimal: Zweck
 
 Gefährliche Statuslügen werden blockiert.
 
-##### Regeln
+##### PR 9 — docs/roadmap-ratchet-minimal: Regeln
 
 - Roadmap-`[x]` in Agent-/CI-/Generated-Bereichen braucht verified Claim.
 - Statusmatrix `done` braucht `proof_ref`.
 - Blueprint `active` im Agent-Bereich braucht verified Claim-Gruppe.
 
-##### Artefakte
+##### PR 9 — docs/roadmap-ratchet-minimal: Artefakte
 
 - `scripts/docmeta/check_roadmap_claims.py`
 - `scripts/docmeta/check_statusmatrix_proofs.py`
 - `scripts/docmeta/check_blueprint_activation.py`
 
-##### Akzeptanzkriterien
+##### PR 9 — docs/roadmap-ratchet-minimal: Akzeptanzkriterien
 
 - Agent-Operability-Haken kann nicht gesetzt werden, solange Contracts, Guard oder Runner fehlen.
 - `done` ohne `proof_ref` scheitert.
@@ -709,11 +709,11 @@ Gefährliche Statuslügen werden blockiert.
 
 #### PR 10 — agent/write-mode-opt-in
 
-##### Zweck
+##### PR 10 — agent/write-mode-opt-in: Zweck
 
 Echte Agent-Writes werden möglich, aber nur streng begrenzt.
 
-##### Voraussetzungen
+##### PR 10 — agent/write-mode-opt-in: Voraussetzungen
 
 - Safety Preflight pass
 - Readiness hard fail aktiv
@@ -723,13 +723,13 @@ Echte Agent-Writes werden möglich, aber nur streng begrenzt.
 - Dry-Run Runner pass
 - Run Evidence Lite pass
 
-##### Befehl
+##### PR 10 — agent/write-mode-opt-in: Befehl
 
 ```bash
 python scripts/agent/run_task.py --write tasks/WG-TASK-....yml
 ```
 
-##### Einschränkungen
+##### PR 10 — agent/write-mode-opt-in: Einschränkungen
 
 - nur `allowed_paths`
 - kein `docs/_generated` direkt
@@ -738,7 +738,7 @@ python scripts/agent/run_task.py --write tasks/WG-TASK-....yml
 - kein infra ohne `task_type=infra_change` und `proof_ref`
 - kein roadmap done ohne `claim.status=verified`
 
-##### Akzeptanzkriterien
+##### PR 10 — agent/write-mode-opt-in: Akzeptanzkriterien
 
 - Ein kleiner Doku-Code-Drift-Fix läuft end-to-end.
 - Patch wird erzeugt.
@@ -748,11 +748,11 @@ python scripts/agent/run_task.py --write tasks/WG-TASK-....yml
 
 #### PR 11 — agent/run-evidence-full
 
-##### Zweck
+##### PR 11 — agent/run-evidence-full: Zweck
 
 Vollständige Agent-Observability.
 
-##### Artefakte
+##### PR 11 — agent/run-evidence-full: Artefakte
 
 ```text
 artifacts/agent-runs/<run-id>/
@@ -765,7 +765,7 @@ artifacts/agent-runs/<run-id>/
   run-result.json
 ```
 
-##### Regel
+##### PR 11 — agent/run-evidence-full: Regel
 
 Agent darf:
 
@@ -779,7 +779,7 @@ Agent darf nicht:
 repo-status: done
 ```
 
-##### Akzeptanzkriterien
+##### PR 11 — agent/run-evidence-full: Akzeptanzkriterien
 
 - Dry-Run und Write-Run erzeugen vollständige, schema-valide Evidence.
 - `decision.yml` verweist auf Claims, Validation und Residual Gaps.
@@ -798,7 +798,7 @@ Ausweitung auf:
 - Docmeta
 - Security
 
-##### Akzeptanzkriterium
+##### PR 12 — evidence/claim-spine-expand: Akzeptanzkriterium
 
 Alle zentralen Roadmap-Haken in Kernbereichen haben Claim-Evidence.
 
@@ -813,7 +813,7 @@ Alle `docs/_generated/*` bekommen:
 - `commit_required`
 - `blocking`
 
-##### Akzeptanzkriterium
+##### PR 13 — docs/generated-control-full: Akzeptanzkriterium
 
 Alle Generated-Artefakte sind klassifiziert, regenerierbar und gegen direkte Edits geschützt.
 
@@ -835,7 +835,7 @@ Nicht für:
 - kleine Doku-Fixes
 - normale Statusupdates
 
-##### Artefakte
+##### PR 14 — evidence/execution-proof-selective: Artefakte
 
 ```text
 experiments/<id>/
@@ -847,7 +847,7 @@ experiments/<id>/
   decision.yml
 ```
 
-##### Akzeptanzkriterium
+##### PR 14 — evidence/execution-proof-selective: Akzeptanzkriterium
 
 `adopted` ohne `run_meta.json`, Evidence und Decision ist unmöglich.
 
@@ -870,7 +870,7 @@ no-task-required: true
 reason: typo-only
 ```
 
-##### Akzeptanzkriterium
+##### PR 15 — governance/traceability-light: Akzeptanzkriterium
 
 Kein relevanter PR ohne Task-/Claim-/Evidence-Verbindung.
 
@@ -878,7 +878,7 @@ Kein relevanter PR ohne Task-/Claim-/Evidence-Verbindung.
 
 Owner/Review-Intervalle für langlebige Roadmaps und Blueprints.
 
-##### Frontmatter-Erweiterung
+##### PR 16 — docs/owner-staleness-later: Frontmatter-Erweiterung
 
 ```yaml
 owner: alex
@@ -888,7 +888,7 @@ next_review_due: "2026-07-16"
 staleness_policy: warn
 ```
 
-##### Akzeptanzkriterium
+##### PR 16 — docs/owner-staleness-later: Akzeptanzkriterium
 
 Keine aktive Roadmap oder Policy ohne Owner und Review-Intervall.
 
@@ -982,7 +982,7 @@ Ein Handoff ist die Übergabeakte eines Agenten: Was war die Aufgabe, welche Dat
 
 Ein Non-Ideal Task ist ein Auftrag, der zu unklar, zu breit oder unbelegt ist. Solche Aufgaben werden nicht improvisiert, sondern blockiert.
 
-### Ratchet
+### Ratchet (Begriffsnotiz)
 
 Ein Ratchet ist eine stufenweise Verschärfung: erst nur berichten, dann warnen, dann blockieren, dann fail-closed. Wie eine Ratsche: zurück geht es nicht still.
 

--- a/docs/blueprints/blueprint-agent-safety-control-layer.md
+++ b/docs/blueprints/blueprint-agent-safety-control-layer.md
@@ -1,0 +1,1049 @@
+---
+id: docs.blueprints.agent-safety-control-layer
+title: "Blueprint — Agent Safety Control Layer"
+doc_type: blueprint
+status: draft
+summary: "Vollausbau eines KI-narrensicheren Agent-/Evidence-Kontrollsystems für Weltgewebe: Safety Preflight, Claim Evidence, Agent Contracts, Non-Ideal Guard, Dry-Run Runner, Run Evidence und gated Write Mode."
+relations:
+  - type: relates_to
+    target: docs/blueprints/agent-operability-blaupause.md
+  - type: relates_to
+    target: docs/roadmap.md
+  - type: depends_on
+    target: repo.meta.yaml
+  - type: depends_on
+    target: AGENTS.md
+  - type: depends_on
+    target: agent-policy.yaml
+  - type: depends_on
+    target: docs/policies/agent-reading-protocol.md
+  - type: relates_to
+    target: docs/tasks/index.json
+  - type: relates_to
+    target: audit/impl-registry.yaml
+  - type: relates_to
+    target: docs/reports/agent-readiness-audit.md
+---
+
+# Blueprint — Agent Safety Control Layer
+
+## 0. Dialektische Ausgangslage
+
+### These
+
+Weltgewebe wird nahezu vollständig agentisch entwickelt. Deshalb reicht es nicht, Agents gute Hinweise zu geben. Das Repository muss so gebaut sein, dass Agents auch bei unvollständigem Kontext, zu breitem Auftrag, veralteter Roadmap oder fehlender Evidence nicht still falsch handeln können.
+
+### Antithese
+
+Weltgewebe besitzt bereits starke Kontrollflächen: Docmeta, AGENTS-Policy, Task-Control, Statusmatrizen, Generated Reports, CI-Guards, Deploy-Snapshot und Drift-Guards. Ein weiterer Governance-Layer kann selbst zur Driftquelle werden, wenn er bestehende Strukturen ersetzt statt sie zu härten.
+
+### Synthese
+
+Der Agent Safety Control Layer ist kein paralleles Steuerungssystem. Er erweitert vorhandene Kontrollflächen um fehlende agentische Sicherheitsmechaniken:
+
+- Pfad- und Scope-Sicherheit
+- Claim-Evidence-Pflicht
+- maschinenlesbare Agent-Contracts
+- Non-Ideal-Task-Blockade
+- Handoff-Validierung
+- Dry-Run-Ausführung
+- agentische Run-Evidence
+- gated Write Mode
+- Roadmap-/Blueprint-Ratchet
+
+Kurz: Weltgewebe wird nicht nur agentenfreundlich, sondern agentensicher.
+
+### Quellenbasis
+
+Interne Grundlage sind insbesondere `docs/reports/agent-readiness-audit.md` sowie `docs/blueprints/agent-operability-blaupause.md`. Externe bzw. repoübergreifende Vergleichsmuster aus LensKit und Vibe-Lab dienen als Inspirationsachsen, werden aber nicht als Weltgewebe-Primärnorm behandelt.
+
+Dieses Blueprint ist ein Ziel- und Planungsartefakt. Es ist nicht selbst Evidence dafür, dass die beschriebenen Mechaniken existieren.
+
+## 1. Ziel
+
+Dieses Blueprint definiert den Vollausbau eines Agent-Safety-Control-Layers für Weltgewebe.
+
+Ziel ist, dass jede agentische Änderung folgende Kette erfüllt:
+
+```text
+Task
+→ erlaubte Pfade
+→ Claims
+→ Evidence
+→ Validierung
+→ Handoff
+→ Run-Artefakte
+→ CI/Statusentscheidung
+```
+
+Nicht der Agent entscheidet, ob etwas fertig ist. Der Agent erzeugt Evidence. Fertig wird etwas erst durch maschinenprüfbare Belege, CI, Statusmatrix und Review.
+
+### 1.1 Status dieses Blueprints
+
+Dieses Dokument beschreibt eine Zielarchitektur. Die im Wellenplan genannten Pfade, Skripte, Contracts, Workflows und Artefakte gelten erst dann als existierend oder bindend, wenn sie im Code beziehungsweise in CI implementiert und über Claim-/Evidence-Checks belegt sind.
+
+Insbesondere dürfen Agents aus diesem Blueprint keine Implementierungsverfügbarkeit ableiten.
+
+## 2. Nicht-Ziele
+
+Dieses Blueprint verfolgt ausdrücklich nicht:
+
+- keine zweite Task-Control-Schicht
+- kein Big-Bang-Umbau
+- kein sofortiger Write Mode
+- keine vollständige Claim-Registry im ersten Schritt
+- kein vollständiges RepoLens-Bundle
+- keine Issue-Form-Kathedrale
+- keine Execution-Proofs für Kleinkram
+- kein Agent-pass bei Widerspruch
+- kein Generated-Artefakt als Primärwahrheit
+
+Die Kunst besteht nicht darin, das Repo mit Kontrolltafeln vollzustellen. Die Kunst besteht darin, Agents genau dort zu blockieren, wo falsche Produktivität entsteht.
+
+## 3. Systeminvarianten
+
+### 3.1 Kein done durch Agent
+
+Ein Agent darf keinen finalen Status setzen.
+
+Verboten:
+
+```yaml
+status: done
+roadmap: [x]
+blueprint: active
+```
+
+sofern nicht maschinenlesbare Evidence vorliegt.
+
+Erlaubt:
+
+```yaml
+decision: pass_proposed
+evidence: present
+validation: pass
+residual_gap: none
+```
+
+Finale Status entstehen nur durch:
+
+- CI
+- Claim-Evidence-Check
+- Statusmatrix-Regel
+- Review
+- expliziten Proof
+
+### 3.2 Kein Claim ohne Evidence
+
+Jede handlungsleitende Aussage braucht Evidence.
+
+Beispiele für Claims:
+
+- Feature X ist implementiert.
+- Guard Y erzwingt Z.
+- Blueprint A ist active.
+- Roadmap-Phase B ist done.
+- Generated Report C ist aktuell.
+- Agent Capability D ist verfügbar.
+
+Zulässige Evidence:
+
+- Codepfad
+- Test
+- CI-Workflow
+- Proof-Dokument
+- Runtime-Snapshot
+- Run-Artefakt
+- Decision-Artefakt
+
+### 3.3 Kein Task ohne Scope
+
+Jeder agentische Task braucht:
+
+```yaml
+task_id:
+goal:
+task_type:
+allowed_paths:
+forbidden_paths:
+claims:
+expected_evidence:
+validation_commands:
+delete_allowed: false
+```
+
+Fehlt eine dieser Kerninformationen, wird der Task blockiert.
+
+### 3.4 Kein direkter Edit an Generated-Artefakten
+
+`docs/_generated/*` ist Diagnose, Projektion oder Navigation. Es ist nie Primärwahrheit.
+
+Direkte Änderungen an `docs/_generated/*` sind verboten. Änderungen müssen über Generatoren erfolgen.
+
+### 3.5 Widerspruch blockiert
+
+Bei widersprechenden Quellen gilt:
+
+```text
+stop
+mark_contradiction
+emit_evidence_gap
+no_write
+```
+
+Der Agent darf keine stille Synthese erzeugen. Widerspruch ist ein Zustand, kein Schönheitsfehler.
+
+## 4. Architekturüberblick
+
+```text
+repo.meta.yaml
+AGENTS.md
+agent-policy.yaml
+docs/policies/agent-reading-protocol.md
+        │
+        ▼
+docs/tasks/board.md ──→ docs/tasks/index.json
+        │                    │
+        ▼                    ▼
+docs/claims/registry.yml ←→ audit/impl-registry.yaml
+        │                    │
+        ▼                    ▼
+docs/_generated/claim-evidence.md/json
+docs/_generated/impl-evidence.md/json
+        │
+        ▼
+contracts/agent/*.schema.json
+scripts/agent/check_non_ideal_task.py
+scripts/docmeta/validate_agent_handoff.py
+scripts/agent/run_task.py
+        │
+        ▼
+artifacts/agent-runs/<run-id>/
+        │
+        ▼
+CI Ratchet:
+report-only → warn → blocking → fail-closed
+```
+
+## 5. Rollen der vorhandenen Kontrollflächen
+
+### 5.1 Primärnorm
+
+- `repo.meta.yaml`
+- `AGENTS.md`
+- `agent-policy.yaml`
+- `docs/policies/agent-reading-protocol.md`
+- `contracts/**`
+
+Diese Artefakte definieren, was gilt.
+
+### 5.2 Arbeitssteuerung
+
+- `docs/tasks/board.md`
+- `docs/tasks/index.json`
+- `docs/tasks/schema.json`
+- `.github/workflows/task-index.yml`
+
+Diese Artefakte definieren, woran gearbeitet wird.
+
+### 5.3 Evidence-Flächen
+
+- `docs/claims/registry.yml`
+- `audit/impl-registry.yaml`
+- `docs/proofs/**`
+- `artifacts/agent-runs/**`
+- CI-Workflows
+- Runtime-/Deploy-Snapshots
+
+Diese Artefakte definieren, was belegt ist.
+
+### 5.4 Diagnose und Projektion
+
+- `docs/_generated/**`
+
+Diese Artefakte helfen beim Lesen, Entscheiden und Prüfen. Sie ersetzen keine Primärnorm.
+
+## 6. Umsetzung als Wellenplan
+
+Der Ausbau erfolgt nicht als Big Bang. Jede Welle muss eine konkrete Fehlerklasse blockieren oder sichtbar machen.
+
+### Welle 1 — Sofortige Agent-Sicherheit
+
+#### PR 1 — agent/safety-preflight
+
+**Zweck**
+
+Gefährliche Agentenfehler sofort blockieren, noch bevor ein vollständiger Agent-Runner existiert.
+
+**Neue oder geänderte Artefakte**
+
+- `docs/security/agent-write-scope-baseline.md`
+- `scripts/agent/check_changed_paths_scope.py`
+- `scripts/agent/check_generated_direct_edit.py`
+- `scripts/agent/check_agent_status_claims.py`
+- `scripts/agent/check_agent_preflight.py`
+
+Optional:
+
+- `.github/workflows/agent-safety-preflight.yml`
+
+Bevorzugt wird aber die Integration in bestehende Guard-Strukturen, sofern das ohne Verrenkung möglich ist.
+
+**Regeln**
+
+1. `docs/_generated/*` darf nicht direkt editiert werden.
+2. Roadmap-`[x]` braucht Claim- oder Proof-Referenz.
+3. Statusmatrix `done` braucht `proof_ref`.
+4. Changed paths müssen `allowed_paths` entsprechen.
+5. Workflow-Dateien brauchen `task_type: ci_change`.
+6. Infra-/Deploy-Dateien brauchen `task_type: infra_change` und `proof_ref`.
+7. Delete braucht `delete_allowed: true`.
+8. Agent darf kein `done` setzen.
+
+**Minimaler Agent-Marker**
+
+Zu Beginn genügt ein YAML-Block im PR-Body oder eine kleine Task-Datei:
+
+```yaml
+task_id: WG-TASK-...
+task_type: doc_change
+allowed_paths:
+  - docs/...
+claims:
+  - claim....
+validation:
+  - make ci-validate
+delete_allowed: false
+```
+
+**Ratchet**
+
+- Stufe 1: report-only
+- Stufe 2: warn
+- Stufe 3: blocking für:
+  - direct edit in `docs/_generated`
+  - Roadmap-`[x]` ohne Claim/Proof
+  - Status `done` ohne `proof_ref`
+  - forbidden paths
+
+**Akzeptanzkriterien**
+
+- Ein Patch mit direktem Edit an `docs/_generated/*` wird erkannt.
+- Ein Roadmap-Haken ohne Claim/Proof wird erkannt.
+- Ein Statusmatrix-`done` ohne `proof_ref` wird erkannt.
+- Ein Pfad außerhalb `allowed_paths` wird erkannt.
+- Alle Checks liefern maschinenlesbare Fehlercodes.
+
+**Fehlercodes**
+
+- `GENERATED_DIRECT_EDIT`
+- `ROADMAP_DONE_WITHOUT_CLAIM`
+- `STATUS_DONE_WITHOUT_PROOF`
+- `PATH_OUT_OF_SCOPE`
+- `WORKFLOW_CHANGE_WITHOUT_TASK_TYPE`
+- `INFRA_CHANGE_WITHOUT_PROOF`
+- `DELETE_WITHOUT_PERMISSION`
+
+#### PR 2 — agent/readiness-hard-fail
+
+**Zweck**
+
+Agent-Readiness darf keine Reife suggerieren, solange Kernmechaniken fehlen.
+
+**Artefakte**
+
+- `scripts/docmeta/generate_agent_readiness.py`
+- `docs/_generated/agent-readiness.md`
+- `docs/_generated/agent-readiness.json`
+
+**Capability-Matrix**
+
+| Capability | Statusregel |
+|---|---|
+| Agent Policy | `pass`, wenn `AGENTS.md` und `agent-policy.yaml` vorhanden |
+| Claim Evidence | `open`, solange minimale Claim-Registry fehlt |
+| Command Contracts | `open`, solange `contracts/agent/*.schema.json` fehlt |
+| Handoff Validator | `open`, solange Validator fehlt |
+| Non-Ideal Guard | `open`, solange Guard fehlt |
+| Dry-Run Runner | `open`, solange Runner fehlt |
+| Run Evidence | `open`, solange Run-Artefakte fehlen |
+| Overall | maximal `partial`, solange eine Hard-Capability fehlt |
+
+**Akzeptanzkriterien**
+
+- Gesamtstatus kann nicht `pass` sein, solange Contracts, Handoff-Validator oder Runner fehlen.
+- Report nennt fehlende Artefakte konkret.
+- Report unterscheidet `open`, `partial`, `pass`, `fail`.
+- Report bleibt Diagnose und markiert sich selbst als nicht-kanonisch.
+
+### Welle 2 — Evidence Backbone
+
+#### PR 3 — evidence/minimal-claim-spine
+
+**Zweck**
+
+Handlungsleitende Claims werden maschinenlesbar und beweispflichtig.
+
+**Artefakte**
+
+- `docs/claims/registry.yml`
+- `docs/claims/schema.json`
+- `scripts/docmeta/check_claim_evidence.py`
+- `docs/_generated/claim-evidence.md`
+- `docs/_generated/claim-evidence.json`
+
+**Start-Claim-Typen**
+
+```yaml
+claim_type:
+  - roadmap_done
+  - agent_capability_available
+  - generated_artifact_current
+  - ci_enforces
+  - security_guard_enforced
+```
+
+**Beispiel**
+
+```yaml
+- id: claim.agent.safety_preflight.enforced
+  claim_type: security_guard_enforced
+  source:
+    document: docs/roadmap.md
+    section: agent-operability
+  status: verified
+  required_level: ci
+  evidence:
+    files:
+      - scripts/agent/check_changed_paths_scope.py
+      - scripts/agent/check_generated_direct_edit.py
+      - scripts/agent/check_agent_status_claims.py
+    workflows:
+      - .github/workflows/agent-safety-preflight.yml
+```
+
+**Statuswerte**
+
+- `open`
+- `partial`
+- `verified`
+- `stale`
+- `contradicted`
+
+**Akzeptanzkriterien**
+
+- Mindestens zehn handlungsleitende Claims sind modelliert.
+- Roadmap-`[x]` in Agent-/CI-/Generated-/Guard-Bereichen braucht Claim-Eintrag.
+- Fehlende Evidence wird als `missing` oder `partial` berichtet.
+- Widersprüchliche Evidence erzeugt `contradicted`.
+- Initialer Modus: report-only.
+
+#### PR 4 — evidence/impl-registry-critical
+
+**Zweck**
+
+Die vorhandene `audit/impl-registry.yaml` wird für kritische Pfade evidence-fähig gemacht.
+
+**Startumfang**
+
+- `impl.workflow.ci`
+- `impl.contracts`
+- `impl.service.api`
+- `impl.service.web`
+- `impl.infra.compose`
+- `impl.agent.safety-preflight`
+
+**Schema-Erweiterung**
+
+```yaml
+id: impl.workflow.ci
+path:
+  - .github/workflows/
+criticality: high
+documented_by:
+  - docs/...
+verified_by:
+  - .github/workflows/agent-safety-preflight.yml
+claim_refs:
+  - claim.agent.safety_preflight.enforced
+evidence_level: ci
+last_verified: "2026-06-01"
+```
+
+**Regeln**
+
+- Impl-Registry ist Evidence-Quelle, nicht Claim-Wahrheit.
+- Claims dürfen auf Impl-Entries verweisen.
+- Impl-Entries dürfen nicht automatisch Roadmap-Status setzen.
+- `criticality: high` ohne `verified_by` wird zunächst warn, später fail.
+
+**Akzeptanzkriterien**
+
+Alle kritischen Einträge haben:
+
+- `documented_by`
+- `verified_by`
+- `claim_refs`
+- `evidence_level`
+
+### Welle 3 — Agent-Vertrag
+
+#### PR 5 — agent/minimal-contracts-and-guard
+
+**Zweck**
+
+Agent-Tasks erhalten ein maschinenlesbares Minimalformat, und unklare Tasks werden blockiert.
+
+Contracts ohne Guard sind zu weich. Guard ohne Contracts ist zu schwammig. Diese PR verbindet beides.
+
+**Artefakte**
+
+- `contracts/agent/task.schema.json`
+- `contracts/agent/command.read_context.schema.json`
+- `contracts/agent/command.write_change.schema.json`
+- `contracts/agent/command.validate_change.schema.json`
+- `contracts/agent/handoff.schema.json`
+- `scripts/agent/check_non_ideal_task.py`
+- `scripts/docmeta/validate_agent_handoff.py`
+- `tests/fixtures/agent/valid-doc-drift-task.json`
+- `tests/fixtures/agent/valid-roadmap-claim-task.json`
+- `tests/fixtures/agent/valid-generated-refresh-task.json`
+- `tests/fixtures/agent/invalid-missing-scope.json`
+- `tests/fixtures/agent/invalid-forbidden-path.json`
+- `tests/fixtures/agent/invalid-status-done-by-agent.json`
+- `docs/reference/agent-operability-fixture-matrix.md`
+
+**Task-Pflichtfelder**
+
+```yaml
+task_id:
+goal:
+task_type:
+allowed_paths:
+forbidden_paths:
+claims:
+expected_evidence:
+validation_commands:
+delete_allowed: false
+```
+
+**Command-Kette**
+
+```text
+read_context
+→ write_change
+→ validate_change
+→ emit_handoff
+```
+
+**Non-Ideal-Fehlercodes**
+
+- `NO_ALLOWED_PATHS`
+- `NO_VALIDATION_COMMAND`
+- `NO_EXPECTED_EVIDENCE`
+- `CLAIM_WITHOUT_REGISTRY_ENTRY`
+- `ROADMAP_DONE_WITHOUT_PROOF`
+- `FORBIDDEN_PATH`
+- `SCOPE_TOO_BROAD`
+- `STATUS_DONE_BY_AGENT`
+- `CONTRADICTION_FOUND`
+
+**Akzeptanzkriterien**
+
+- Drei reale Weltgewebe-Tasktypen sind valide modelliert.
+- Drei gefährliche Negativfälle scheitern.
+- Fixture-Matrix dokumentiert Coverage und bekannte Lücken.
+- Ein Task ohne Scope oder Validation kann nicht pass werden.
+- `blocked` gilt als korrektes Sicherheitsergebnis.
+
+### Welle 4 — Ausführung ohne Schreibmacht
+
+#### PR 6 — agent/dry-run-runner
+
+**Zweck**
+
+Agenten können echte Tasks trocken ausführen, ohne Dateien zu ändern.
+
+**Artefakte**
+
+- `scripts/agent/run_task.py`
+- `.github/workflows/agent-operability-smoke.yml`
+
+**Ablauf**
+
+```text
+load task
+validate schema
+run non-ideal guard
+read_context
+prepare patch plan
+validate expected evidence
+emit handoff.json
+emit run-result.json
+```
+
+**Standard**
+
+- `--dry-run` ist default.
+- `--write` existiert noch nicht.
+
+**Smoke-Test**
+
+```bash
+python scripts/agent/run_task.py --dry-run tests/fixtures/agent/valid-doc-drift-task.json
+python scripts/agent/run_task.py --dry-run tests/fixtures/agent/valid-roadmap-claim-task.json
+python scripts/agent/run_task.py --dry-run tests/fixtures/agent/valid-generated-refresh-task.json
+```
+
+**Akzeptanzkriterien**
+
+- Drei reale Tasktypen laufen deterministisch durch.
+- Keine Dateien werden geändert.
+- Handoff wird erzeugt.
+- Run-Result wird erzeugt.
+- Ungültige Tasks werden vor Kontextlesen oder Patchplanung blockiert.
+
+#### PR 7 — agent/run-evidence-lite
+
+**Zweck**
+
+Jeder Dry-Run erzeugt minimale, schema-valide Evidence.
+
+**Artefakte**
+
+```text
+artifacts/agent-runs/<run-id>/
+  task.yml
+  handoff.json
+  validation.json
+  run-result.json
+```
+
+**Noch nicht enthalten**
+
+- `evidence.jsonl`
+- `decision.yml`
+- `changed-files.txt`
+
+Diese kommen erst nach stabilem Runner.
+
+**Akzeptanzkriterien**
+
+- Jeder Dry-Run erzeugt einen eindeutigen `run_id`.
+- Jeder Dry-Run schreibt schema-valide Run-Artefakte.
+- Run-Artefakte enthalten Task-ID, Claims, Validierung und Ergebnis.
+- `blocked` wird als eigenes Ergebnis modelliert.
+
+### Welle 5 — Generated und Roadmap hart machen
+
+#### PR 8 — docs/generated-control-minimal
+
+**Zweck**
+
+Die gefährlichsten Generated-Artefakte werden zuerst kontrolliert.
+
+**Startumfang**
+
+- `docs/_generated/agent-readiness.md`
+- `docs/_generated/claim-evidence.md`
+- `docs/tasks/index.json`
+
+**Artefakt**
+
+- `.wgx/generated-artifacts.yml`
+
+**Beispiel**
+
+```yaml
+artifacts:
+  docs/_generated/agent-readiness.md:
+    role: diagnostic
+    canonicality: derived
+    generator: scripts/docmeta/generate_agent_readiness.py
+    source:
+      - contracts/agent/
+      - scripts/agent/
+      - docs/claims/registry.yml
+    commit_required: true
+    blocking: true
+```
+
+**Akzeptanzkriterien**
+
+- Agent-Readiness, Claim-Evidence und Task-Index dürfen nicht manuell editiert werden.
+- Alle drei Artefakte sind aus Quellen regenerierbar.
+- Quellenänderungen erzeugen erwartete Regeneration.
+- Direkte Edits werden blockiert.
+
+#### PR 9 — docs/roadmap-ratchet-minimal
+
+**Zweck**
+
+Gefährliche Statuslügen werden blockiert.
+
+**Regeln**
+
+- Roadmap-`[x]` in Agent-/CI-/Generated-Bereichen braucht verified Claim.
+- Statusmatrix `done` braucht `proof_ref`.
+- Blueprint `active` im Agent-Bereich braucht verified Claim-Gruppe.
+
+**Artefakte**
+
+- `scripts/docmeta/check_roadmap_claims.py`
+- `scripts/docmeta/check_statusmatrix_proofs.py`
+- `scripts/docmeta/check_blueprint_activation.py`
+
+**Akzeptanzkriterien**
+
+- Agent-Operability-Haken kann nicht gesetzt werden, solange Contracts, Guard oder Runner fehlen.
+- `done` ohne `proof_ref` scheitert.
+- Blueprint `active` ohne verified Claim-Gruppe scheitert.
+- Modus startet warn, wird später blocking.
+
+### Welle 6 — Gated Write Mode
+
+#### PR 10 — agent/write-mode-opt-in
+
+**Zweck**
+
+Echte Agent-Writes werden möglich, aber nur streng begrenzt.
+
+**Voraussetzungen**
+
+- Safety Preflight pass
+- Readiness hard fail aktiv
+- Minimal Claim Spine pass
+- Impl Registry Critical pass
+- Minimal Contracts + Guard pass
+- Dry-Run Runner pass
+- Run Evidence Lite pass
+
+**Befehl**
+
+```bash
+python scripts/agent/run_task.py --write tasks/WG-TASK-....yml
+```
+
+**Einschränkungen**
+
+- nur `allowed_paths`
+- kein `docs/_generated` direkt
+- kein delete ohne `delete_allowed`
+- kein workflow ohne `task_type=ci_change`
+- kein infra ohne `task_type=infra_change` und `proof_ref`
+- kein roadmap done ohne `claim.status=verified`
+
+**Akzeptanzkriterien**
+
+- Ein kleiner Doku-Code-Drift-Fix läuft end-to-end.
+- Patch wird erzeugt.
+- Validation läuft.
+- Run-Artefakt wird erzeugt.
+- Status bleibt partial, bis CI/Claim-Evidence grün ist.
+
+#### PR 11 — agent/run-evidence-full
+
+**Zweck**
+
+Vollständige Agent-Observability.
+
+**Artefakte**
+
+```text
+artifacts/agent-runs/<run-id>/
+  task.yml
+  handoff.json
+  evidence.jsonl
+  decision.yml
+  validation.json
+  changed-files.txt
+  run-result.json
+```
+
+**Regel**
+
+Agent darf:
+
+```yaml
+decision: pass
+```
+
+Agent darf nicht:
+
+```yaml
+repo-status: done
+```
+
+**Akzeptanzkriterien**
+
+- Dry-Run und Write-Run erzeugen vollständige, schema-valide Evidence.
+- `decision.yml` verweist auf Claims, Validation und Residual Gaps.
+- `changed-files.txt` stimmt mit tatsächlichem Diff überein.
+- Evidence kann von Claim-Checks gelesen werden.
+
+### Welle 7 — Skalierung
+
+#### PR 12 — evidence/claim-spine-expand
+
+Ausweitung auf:
+
+- Auth
+- Map/Basemap
+- Deploy/Snapshot
+- Docmeta
+- Security
+
+**Akzeptanzkriterium**
+
+Alle zentralen Roadmap-Haken in Kernbereichen haben Claim-Evidence.
+
+#### PR 13 — docs/generated-control-full
+
+Alle `docs/_generated/*` bekommen:
+
+- `source`
+- `generator`
+- `role`
+- `canonicality`
+- `commit_required`
+- `blocking`
+
+**Akzeptanzkriterium**
+
+Alle Generated-Artefakte sind klassifiziert, regenerierbar und gegen direkte Edits geschützt.
+
+#### PR 14 — evidence/execution-proof-selective
+
+Nur für riskante Klassen:
+
+- Auth
+- Sessions
+- DB/Migration
+- Deploy/Infra
+- Agent write mode
+- Basemap/Tile strategy
+- Security workflows
+
+Nicht für:
+
+- Tippfehler
+- kleine Doku-Fixes
+- normale Statusupdates
+
+**Artefakte**
+
+```text
+experiments/<id>/
+  manifest.yml
+  method.md
+  run_meta.json
+  result.md
+  evidence.jsonl
+  decision.yml
+```
+
+**Akzeptanzkriterium**
+
+`adopted` ohne `run_meta.json`, Evidence und Decision ist unmöglich.
+
+#### PR 15 — governance/traceability-light
+
+Pflichtfelder für relevante Änderungen:
+
+- Task-ID
+- Claim(s)
+- Allowed paths
+- Changed paths
+- Evidence
+- Validation
+- Residual gap
+
+Ausnahme:
+
+```yaml
+no-task-required: true
+reason: typo-only
+```
+
+**Akzeptanzkriterium**
+
+Kein relevanter PR ohne Task-/Claim-/Evidence-Verbindung.
+
+#### PR 16 — docs/owner-staleness-later
+
+Owner/Review-Intervalle für langlebige Roadmaps und Blueprints.
+
+**Frontmatter-Erweiterung**
+
+```yaml
+owner: alex
+review_interval_days: 45
+last_reviewed: "2026-06-01"
+next_review_due: "2026-07-16"
+staleness_policy: warn
+```
+
+**Akzeptanzkriterium**
+
+Keine aktive Roadmap oder Policy ohne Owner und Review-Intervall.
+
+## 7. Ratchet-Strategie
+
+Jeder neue Check durchläuft vier Stufen:
+
+```text
+report-only
+→ warn
+→ blocking
+→ fail-closed
+```
+
+Regeln:
+
+- Neue Checks starten nicht sofort fail-closed.
+- Jeder Warnmodus braucht Ablaufdatum.
+- Blocking beginnt zuerst bei sicherheitskritischen Agent-Fehlern.
+- Fail-closed gilt nur, wenn False Positives niedrig sind.
+
+## 8. Risiko- und Nutzenabschätzung
+
+### Nutzen
+
+| Nutzenklasse | Wirkung |
+|---|---|
+| weniger Scope-Drift | Agents können nur erlaubte Pfade ändern |
+| weniger Roadmap-Drift | `[x]` braucht Evidence |
+| weniger Scheinkohärenz | Widerspruch blockiert |
+| bessere Reviews | Evidence liegt strukturiert vor |
+| sicherere Writes | Write Mode erst nach Gates |
+| bessere Agent-Diagnose | Readiness zeigt echte Lücken |
+| reproduzierbare Agent-Arbeit | Run-Artefakte mit `run_id` |
+
+### Risiken
+
+| Risiko | Gegenmaßnahme |
+|---|---|
+| CI wird zu streng | Ratchet statt Big Bang |
+| neue Artefakte erzeugen Pflegekosten | minimaler Start, Expansion später |
+| Claim-Registry wird Doppelwahrheit | Claims verweisen auf Status, Impl, Proofs |
+| Runner bleibt Spielzeug | drei echte Tasktypen als Pflicht |
+| Generated-Control wird zu breit | Minimalumfang zuerst |
+| Write Mode wird gefährlich | erst nach Safety, Contracts, Guard, Evidence |
+| Agents werden oft blockiert | Blockade ist korrektes Sicherheitsergebnis |
+
+## 9. Prämissencheck
+
+Diese Blaupause gilt unter folgenden Prämissen:
+
+1. Weltgewebe wird überwiegend agentisch entwickelt.
+2. Agentische Fehler sollen durch Repo-Mechanik, nicht durch Hoffnung, verhindert werden.
+3. Bestehende Kontrollflächen bleiben führend.
+4. Neue Artefakte dürfen keine Parallelwahrheit erzeugen.
+5. CI darf stufenweise strenger werden.
+
+Wenn Prämisse 1 fällt, wäre der Plan zu schwer. Wenn Prämisse 1 gilt, ist der Plan angemessen.
+
+## 10. Alternative Sinnachse
+
+Nicht fragen:
+
+> Wie machen wir Agents produktiver?
+
+Sondern:
+
+> Wie machen wir falsche Agentenproduktivität unmöglich?
+
+Das verschiebt die Architektur. Ziel ist nicht maximale Geschwindigkeit, sondern beweisfähige Geschwindigkeit.
+
+## 11. Begriffsnotiz für Anfänger
+
+### Agent
+
+Ein Agent ist hier ein KI-gestützter Arbeiter, der Aufgaben im Repo liest, Änderungen vorbereitet und Validierungen ausführt.
+
+### Claim
+
+Ein Claim ist eine Behauptung, etwa: „Feature X ist implementiert“ oder „Guard Y erzwingt Z“.
+
+### Evidence
+
+Evidence ist der Beleg für einen Claim: Code, Test, CI, Proof oder Runtime-Snapshot.
+
+### Handoff
+
+Ein Handoff ist die Übergabeakte eines Agenten: Was war die Aufgabe, welche Dateien wurden betrachtet, was wurde geändert oder geplant, welche Evidence liegt vor?
+
+### Non-Ideal Task
+
+Ein Non-Ideal Task ist ein Auftrag, der zu unklar, zu breit oder unbelegt ist. Solche Aufgaben werden nicht improvisiert, sondern blockiert.
+
+### Ratchet
+
+Ein Ratchet ist eine stufenweise Verschärfung: erst nur berichten, dann warnen, dann blockieren, dann fail-closed. Wie eine Ratsche: zurück geht es nicht still.
+
+## 12. Metriken
+
+### Frühmetriken
+
+- Anzahl blockierter Generated-Direct-Edits
+- Anzahl Roadmap-`[x]` ohne Claim
+- Anzahl Status-`done` ohne `proof_ref`
+- Anzahl Tasks ohne `allowed_paths`
+- Anzahl Non-Ideal-Task-Blocks
+
+### Reifemetriken
+
+- `claim_evidence_coverage`
+- `critical_impl_registry_coverage`
+- `agent_contract_fixture_coverage`
+- `dry_run_success_rate`
+- `blocked_vs_failed_ratio`
+- `generated_artifact_classification_coverage`
+- `roadmap_claim_verification_rate`
+
+### Zielwerte nach Vollausbau
+
+- `critical_impl_registry_coverage: 100%`
+- `agent_contract_fixture_coverage: 100%` für definierte Tasktypen
+- `generated_artifact_classification_coverage: 100%`
+- `roadmap_claim_verification_rate: > 90%` für zentrale Bereiche
+- `direct_generated_edits: 0`
+- `status_done_without_proof: 0`
+
+## 13. Akzeptanz des Gesamt-Blueprints
+
+Der Blueprint gilt als umgesetzt, wenn:
+
+1. Safety Preflight blockiert konkrete Agentenfehler.
+2. Agent-Readiness kann fehlende Hard-Capabilities nicht als pass anzeigen.
+3. Handlungsleitende Claims sind maschinenlesbar.
+4. Kritische Impl-Registry-Einträge haben Evidence.
+5. Agent-Tasks sind schema-validierbar.
+6. Non-Ideal-Tasks blockieren.
+7. Dry-Run Runner führt echte Tasks deterministisch aus.
+8. Run-Artefakte existieren.
+9. Generated-Artefakte im Startumfang sind geschützt.
+10. Roadmap-/Statuslügen in Agent-/CI-/Generated-Bereichen werden blockiert.
+11. Write Mode ist nur gated möglich.
+
+## 14. Essenz
+
+**Hebel:** Früh konkrete Agentenfehler blockieren, dann Evidence und Contracts aufbauen.
+
+**Entscheidung:** Vollausbau bleibt Ziel, aber nicht als Big Bang. Start mit Safety Preflight, Readiness Hard Fail, Minimal Claim Spine, Minimal Contracts und Non-Ideal Guard.
+
+**Nächste Aktion:** PR 1 `agent/safety-preflight`.
+
+Minimaler erster Scope:
+
+- `docs/_generated` direct edit blockieren
+- Roadmap-`[x]` ohne Claim/Proof blockieren
+- Status `done` ohne `proof_ref` blockieren
+- Changed paths gegen `allowed_paths` prüfen
+- Workflow-/Infra-Änderungen `task_type`-pflichtig machen
+
+Humoröse Randnotiz: Der Agent darf weiter kreativ sein. Nur nicht an den Bremsleitungen.
+
+## 15. Epistemischer Status
+
+Dieses Blueprint ist ein Ziel- und Planungsartefakt. Es beschreibt gewünschte Mechaniken, ersetzt aber keine Evidence. Umsetzung und Status müssen durch Tasks, Claims, CI, Proofs und Run-Artefakte belegt werden.

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,7 @@ Kanonische Navigation. Neue UI-Dokumente bestehenden Kategorien zuordnen.
 ### Agenten & Arbeitssteuerung
 
 – **Agent Operability:** [blueprints/agent-operability-blaupause.md](blueprints/agent-operability-blaupause.md) (Blueprint)
+– **Agent Safety Control Layer:** [blueprints/blueprint-agent-safety-control-layer.md](blueprints/blueprint-agent-safety-control-layer.md) (Blueprint)
 – **Dokumentationsstruktur & Task-Steuerung:** [blueprints/doc-structure-task-control.md](blueprints/doc-structure-task-control.md) (Blueprint)
 – **Task-Control Roadmap:** [blueprints/doc-structure-task-control-roadmap.md](blueprints/doc-structure-task-control-roadmap.md) (Roadmap)
 – **Task-Control Beispiele:** [blueprints/doc-structure-task-control-examples.md](blueprints/doc-structure-task-control-examples.md) (Referenz)


### PR DESCRIPTION
### Motivation

- Introduce a repository-level blueprint to harden agent-driven changes with machine-checkable `Claim`/`Evidence` flows and gated write mechanics. 
- Close known gaps around path/scope safety, handoff/validation, dry-run execution and generated-artifact protection to prevent false-positive agent productivity. 
- Provide a staged rollout plan (safety preflight → claim spine → contracts/guard → dry-run → gated write → scaling) and a ratchet strategy for progressive enforcement.

### Description

- Add a comprehensive draft blueprint at `docs/blueprints/blueprint-agent-safety-control-layer.md` describing goals, invariants, architecture, wave plan (PR1..PR16), error codes and acceptance criteria for features like Safety Preflight, Claim-Evidence registry, Agent Contracts, Non-Ideal Guard, Dry-Run Runner, Run Evidence and Gated Write Mode. 
- Update `docs/index.md` to expose the new blueprint link (`blueprints/blueprint-agent-safety-control-layer.md`) in the Agenten & Arbeitssteuerung section. 
- Define required artifacts, example schemas, scripts and artifact layouts to be implemented in later PRs and specify the `report-only → warn → blocking → fail-closed` ratchet for introducing checks.

### Testing

- No automated tests were run as part of this change. 
- The change is documentation-only (blueprint + index), so verification will rely on subsequent implementation PRs and CI checks described in the blueprint. 
- Future waves specify smoke tests (e.g. `python scripts/agent/run_task.py --dry-run ...`) and schema/fixture tests to be added with the corresponding implementation PRs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d01da9634832cafd57b2a59118bcc)