### PR TITLE
test: add regression test for excludeCredentials in passkey register options

### DIFF
--- a/apps/api/tests/api_auth.rs
+++ b/apps/api/tests/api_auth.rs
@@ -4883,3 +4883,92 @@ async fn magic_link_full_round_trip_request_to_session() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn passkey_register_options_excludes_existing_credentials() -> Result<()> {
+    let state = test_state_with_webauthn()?;
+
+    let credential_id = vec![42_u8; 32];
+    let credential_id_b64 = {
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        use base64::Engine;
+        URL_SAFE_NO_PAD.encode(&credential_id)
+    };
+    let passkey: webauthn_rs::prelude::Passkey = serde_json::from_value(serde_json::json!({
+        "cred": {
+            "cred_id": credential_id_b64,
+            "cred": {
+                "type_": "ES256",
+                "key": {
+                    "EC_EC2": {
+                        "curve": "SECP256R1",
+                        "x": vec![1_u8; 32],
+                        "y": vec![2_u8; 32]
+                    }
+                }
+            },
+            "counter": 0,
+            "transports": null,
+            "user_verified": false,
+            "backup_eligible": false,
+            "backup_state": false,
+            "registration_policy": "preferred",
+            "extensions": {
+                "cred_protect": "NotRequested",
+                "hmac_create_secret": "NotRequested"
+            },
+            "attestation": {
+                "data": "None",
+                "metadata": "None"
+            },
+            "attestation_format": "None"
+        }
+    })).unwrap();
+
+    let expected_cred_id = passkey.cred_id().clone();
+    state.passkeys.insert("u1".to_string(), passkey).unwrap();
+
+    let session = create_session(&state, "u1", Some("dev-passkey")).await;
+    let cookie = format!("{}={}", SESSION_COOKIE_NAME, session.id);
+
+    let challenge_id = request_passkey_registration_challenge(&state, &cookie).await?;
+
+    let grant_id = consume_begin_passkey_registration_step_up(
+        &state,
+        &cookie,
+        &challenge_id,
+        &session.account_id,
+        &session.device_id,
+    )
+    .await?;
+
+    let app = app_with_auth(state.clone());
+    let req = Request::post("/auth/passkeys/register/options")
+        .header("Host", "localhost")
+        .header("Origin", "http://localhost:3000")
+        .header("Content-Type", "application/json")
+        .header("Cookie", cookie)
+        .body(body::Body::from(
+            serde_json::json!({"registration_grant_id": grant_id}).to_string(),
+        ))?;
+    let res = app.oneshot(req).await?;
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let bytes = body::to_bytes(res.into_body(), usize::MAX).await?;
+    let body: serde_json::Value = serde_json::from_slice(&bytes)?;
+
+    assert!(body.get("registration_id").is_some());
+    assert!(body.get("options").is_some());
+
+    let exclude_credentials = body["options"]["publicKey"]["excludeCredentials"].as_array()
+        .context("excludeCredentials must be an array")?;
+    assert_eq!(exclude_credentials.len(), 1, "must exclude exactly one credential");
+
+    let id_b64 = exclude_credentials[0]["id"].as_str().context("id must be string")?;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use base64::Engine;
+    let decoded_id = URL_SAFE_NO_PAD.decode(id_b64)?;
+    assert_eq!(decoded_id, expected_cred_id);
+
+    Ok(())
+}

--- a/apps/api/tests/api_auth.rs
+++ b/apps/api/tests/api_auth.rs
@@ -4884,16 +4884,9 @@ async fn magic_link_full_round_trip_request_to_session() -> Result<()> {
     Ok(())
 }
 
-#[tokio::test]
-async fn passkey_register_options_excludes_existing_credentials() -> Result<()> {
-    let state = test_state_with_webauthn()?;
-
-    let credential_id = vec![42_u8; 32];
-    let credential_id_b64 = {
-        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-        use base64::Engine;
-        URL_SAFE_NO_PAD.encode(&credential_id)
-    };
+fn mock_passkey_with_credential_id(
+    credential_id_b64: &str,
+) -> Result<webauthn_rs::prelude::Passkey> {
     let passkey: webauthn_rs::prelude::Passkey = serde_json::from_value(serde_json::json!({
         "cred": {
             "cred_id": credential_id_b64,
@@ -4923,8 +4916,20 @@ async fn passkey_register_options_excludes_existing_credentials() -> Result<()> 
             },
             "attestation_format": "None"
         }
-    }))
-    .unwrap();
+    }))?;
+    Ok(passkey)
+}
+
+#[tokio::test]
+async fn passkey_register_options_excludes_existing_credentials() -> Result<()> {
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use base64::Engine;
+
+    let state = test_state_with_webauthn()?;
+
+    let credential_id = vec![42_u8; 32];
+    let credential_id_b64 = URL_SAFE_NO_PAD.encode(&credential_id);
+    let passkey = mock_passkey_with_credential_id(&credential_id_b64)?;
 
     let expected_cred_id = passkey.cred_id().clone();
     state.passkeys.insert("u1".to_string(), passkey).unwrap();
@@ -4973,8 +4978,6 @@ async fn passkey_register_options_excludes_existing_credentials() -> Result<()> 
     let id_b64 = exclude_credentials[0]["id"]
         .as_str()
         .context("id must be string")?;
-    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-    use base64::Engine;
     let decoded_id = URL_SAFE_NO_PAD.decode(id_b64)?;
     assert_eq!(decoded_id, expected_cred_id);
 

--- a/apps/api/tests/api_auth.rs
+++ b/apps/api/tests/api_auth.rs
@@ -4932,7 +4932,10 @@ async fn passkey_register_options_excludes_existing_credentials() -> Result<()> 
     let passkey = mock_passkey_with_credential_id(&credential_id_b64)?;
 
     let expected_cred_id = passkey.cred_id().clone();
-    state.passkeys.insert("u1".to_string(), passkey).unwrap();
+    state
+        .passkeys
+        .insert("u1".to_string(), passkey)
+        .context("mock passkey insert should succeed")?;
 
     let session = create_session(&state, "u1", Some("dev-passkey")).await;
     let cookie = format!("{}={}", SESSION_COOKIE_NAME, session.id);

--- a/apps/api/tests/api_auth.rs
+++ b/apps/api/tests/api_auth.rs
@@ -4923,7 +4923,8 @@ async fn passkey_register_options_excludes_existing_credentials() -> Result<()> 
             },
             "attestation_format": "None"
         }
-    })).unwrap();
+    }))
+    .unwrap();
 
     let expected_cred_id = passkey.cred_id().clone();
     state.passkeys.insert("u1".to_string(), passkey).unwrap();
@@ -4960,11 +4961,18 @@ async fn passkey_register_options_excludes_existing_credentials() -> Result<()> 
     assert!(body.get("registration_id").is_some());
     assert!(body.get("options").is_some());
 
-    let exclude_credentials = body["options"]["publicKey"]["excludeCredentials"].as_array()
+    let exclude_credentials = body["options"]["publicKey"]["excludeCredentials"]
+        .as_array()
         .context("excludeCredentials must be an array")?;
-    assert_eq!(exclude_credentials.len(), 1, "must exclude exactly one credential");
+    assert_eq!(
+        exclude_credentials.len(),
+        1,
+        "must exclude exactly one credential"
+    );
 
-    let id_b64 = exclude_credentials[0]["id"].as_str().context("id must be string")?;
+    let id_b64 = exclude_credentials[0]["id"]
+        .as_str()
+        .context("id must be string")?;
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
     use base64::Engine;
     let decoded_id = URL_SAFE_NO_PAD.decode(id_b64)?;

--- a/docs/specs/auth-api.md
+++ b/docs/specs/auth-api.md
@@ -242,7 +242,7 @@ device-gebunden). Ohne Grant liefert der Endpunkt `403 STEP_UP_REQUIRED` mit
 - Die `webauthn_user_id` des Accounts ist bei bereits persistiertem Wert dauerhaft stabil;
   bei Accounts ohne persistierten Wert ist sie lazy-backfill/prozessstabil
   (kein Writeback in dieser Phase). Writeback-Persistenz ist Voraussetzung für `register/verify`.
-- `register/verify`, Auth-Optionen/Verify, Passkey-Speicherung über Neustart, List, Remove und UI sind offen.
+- Auth-Optionen/Verify, Passkey-Speicherung über Neustart, List, Remove und UI sind offen.
 
 ### Registrierung abschließen
 


### PR DESCRIPTION
As part of hardening the Passkey Registration flow, this commit explicitly verifies that existing passkeys are excluded when `POST /auth/passkeys/register/options` generates the WebAuthn creation options.

Changes:
- Verified that `apps/api/src/routes/auth.rs` already fetches `state.passkeys.credential_ids_for_account(&account_id)` and forwards them as `exclude_credentials`.
- Added the integration test `passkey_register_options_excludes_existing_credentials` in `apps/api/tests/api_auth.rs`. It injects a mock passkey into `PasskeyStore`, simulates a step-up challenge + valid magic-link grant flow, and asserts that the resulting JSON response from `POST /auth/passkeys/register/options` contains the existing credential in `options.publicKey.excludeCredentials`.
- Cleaned up stale todo remarks in `docs/specs/auth-api.md` (specifically removing the claim that `register/verify` is open, since it exists).
- Validated test functionality with `cargo test -p weltgewebe-api --test api_auth passkey_register_options_excludes_existing_credentials` and full test suite with `cargo test -p weltgewebe-api`. Both ran successfully.

**Importantly**, no new persistence architecture or `.jsonl` data stores were built.

---
*PR created automatically by Jules for task [14148595351486459454](https://jules.google.com/task/14148595351486459454) started by @alexdermohr*