### PR TITLE
docs(deploy): document domain mail provider migration plan

### DIFF
--- a/docs/adr/ADR-0008__domain-mail-provider-boundaries.md
+++ b/docs/adr/ADR-0008__domain-mail-provider-boundaries.md
@@ -26,43 +26,38 @@ accepted
 ## Kontext
 
 - IONOS liefert aktuell DNS/Mailbox und SMTP.
-
 - Public Login/Magic Link hängt an SMTP.
-
 - Heimserver ist Entwicklung/Heimruntime, nicht langfristige Produktionsplattform.
 
 ## Entscheidung
 
 - INWX für Registrar/DNS.
-
 - mailbox.org für menschliche Mailbox `kontakt@weltgewebe.net`.
-
 - Brevo für technische Magic-Link-Mail `login@weltgewebe.net`.
-
 - App-/Produktionshosting bleibt entkoppelt.
+
+Explizite Rollentrennung:
+
+- `kontakt@weltgewebe.net` = menschliche Kontakt-/Adminadresse bei mailbox.org.
+- `login@weltgewebe.net` = technischer Magic-Link-Absender über Brevo.
 
 ## Nicht-Ziele
 
 - keine Secrets im Repo.
-
 - kein Live-Cutover durch diesen PR.
-
 - keine Terraform-/Provider-Automation.
 
 ## Konsequenzen
 
-- IONOS darf erst nach erfolgreichen Gates gekündigt werden.
-
+- IONOS-Kündigung ist erst nach erfolgreichem mailbox.org-, Brevo-, Runtime- und Magic-Link-Gate erlaubt.
 - `kontakt@` und `login@` dürfen nicht vermischt werden.
-
 - `APP_BASE_URL` muss im öffentlichen Betrieb `https://weltgewebe.net` sein.
+- `home.arpa` ist nur Heim-/Entwicklungsziel.
 
 ## Alternativen
 
-- netcup All-in-one.
-
+- netcup All-in-one: verworfen als Ideallösung wegen enger Kopplung von Domain/Mail/Web/Auth-Mail.
 - Cloudflare + Mailprovider.
-
 - IONOS reduziert behalten.
 
 ## Begründung

--- a/docs/adr/ADR-0008__domain-mail-provider-boundaries.md
+++ b/docs/adr/ADR-0008__domain-mail-provider-boundaries.md
@@ -1,0 +1,70 @@
+---
+id: adr.ADR-0008-domain-mail-provider-boundaries
+title: "ADR-0008 — Domain-, Mail- und SMTP-Providergrenzen"
+doc_type: reference
+status: accepted
+summary: >
+  Kanonisiert die Trennung von Domain/DNS, menschlicher Mailbox und technischer
+  Magic-Link-Mail für Weltgewebe.
+relations:
+  - type: relates_to
+    target: docs/adr/ADR-0006__auth-magic-link-session-passkey.md
+  - type: relates_to
+    target: docs/adr/ADR-0007__auth-persistence-production-db-path.md
+  - type: relates_to
+    target: docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md
+  - type: relates_to
+    target: docs/runbooks/domain-mail-cutover.md
+---
+
+# ADR-0008 — Domain-, Mail- und SMTP-Providergrenzen
+
+## Status
+
+accepted
+
+## Kontext
+
+- IONOS liefert aktuell DNS/Mailbox und SMTP.
+
+- Public Login/Magic Link hängt an SMTP.
+
+- Heimserver ist Entwicklung/Heimruntime, nicht langfristige Produktionsplattform.
+
+## Entscheidung
+
+- INWX für Registrar/DNS.
+
+- mailbox.org für menschliche Mailbox `kontakt@weltgewebe.net`.
+
+- Brevo für technische Magic-Link-Mail `login@weltgewebe.net`.
+
+- App-/Produktionshosting bleibt entkoppelt.
+
+## Nicht-Ziele
+
+- keine Secrets im Repo.
+
+- kein Live-Cutover durch diesen PR.
+
+- keine Terraform-/Provider-Automation.
+
+## Konsequenzen
+
+- IONOS darf erst nach erfolgreichen Gates gekündigt werden.
+
+- `kontakt@` und `login@` dürfen nicht vermischt werden.
+
+- `APP_BASE_URL` muss im öffentlichen Betrieb `https://weltgewebe.net` sein.
+
+## Alternativen
+
+- netcup All-in-one.
+
+- Cloudflare + Mailprovider.
+
+- IONOS reduziert behalten.
+
+## Begründung
+
+- Trennung der Lebenszyklen: Domainbesitz, menschliche Mail, technische Login-Mail, App-Hosting.

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -15,6 +15,8 @@ relations:
     target: docs/deploy/heimserver.integration.md
   - type: relates_to
     target: docs/deploy/security.md
+  - type: relates_to
+    target: docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md
 ---
 # Weltgewebe – Deployment
 
@@ -23,6 +25,7 @@ Es ist normativ. Abweichungen davon gelten als Drift.
 
 **Weitere Dokumente:**
 
+- [Domain-/Mail-Migration](domain-mail-migration-ionos-to-inwx-mailbox-brevo.md) – Plan für den Umzug von IONOS
 - [Deployment-Änderungsprotokoll](./CHANGELOG.md) – Infrastrukturänderungen und deren Auswirkungen
 - [Drift-Taxonomie & Guard-Policy](./DRIFT_POLICY.md) – Klassifizierung und Handling von Drift
 

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -25,7 +25,7 @@ Es ist normativ. Abweichungen davon gelten als Drift.
 
 **Weitere Dokumente:**
 
-- [Domain-/Mail-Migration](domain-mail-migration-ionos-to-inwx-mailbox-brevo.md) – Plan für den Umzug von IONOS
+- [Domain-/Mail-Migration](domain-mail-migration-ionos-to-inwx-mailbox-brevo.md) – Plan für den Umzug von IONOS zu INWX + mailbox.org + Brevo
 - [Deployment-Änderungsprotokoll](./CHANGELOG.md) – Infrastrukturänderungen und deren Auswirkungen
 - [Drift-Taxonomie & Guard-Policy](./DRIFT_POLICY.md) – Klassifizierung und Handling von Drift
 

--- a/docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md
+++ b/docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md
@@ -37,7 +37,7 @@ INWX:
   - weltweberei.org
 
 mailbox.org:
-  - kontakt@weltgewebe.net
+  - <kontakt@weltgewebe.net>
   - admin@weltgewebe.net optional als Alias
   - optional temporäre Weiterleitung an externe Recovery-Mail
 
@@ -53,7 +53,6 @@ Weltgewebe Runtime:
   SMTP_USER=<Brevo SMTP User>
   SMTP_PASS=<Secret Store>
   SMTP_FROM=login@weltgewebe.net
-
 ```
 
 ## 3. Aktueller redigierter Ist-Zustand
@@ -74,15 +73,12 @@ SMTP_FROM=kontakt@weltgewebe.net
 SMTP_PASS=<gesetzt, nicht dokumentieren>
 WEB_UPSTREAM_HOST=weltgewebe.home.arpa
 WEB_UPSTREAM_URL=https://weltgewebe.home.arpa
-
 ```
 
 ## 4. Providerrollen
 
 - INWX: DNS-Verwaltung.
-
 - mailbox.org: Verwaltung menschlicher Kommunikation.
-
 - Brevo: Versand transaktionaler E-Mails (Login/Magic-Link).
 
 ## 5. DNS-Zielbild
@@ -101,7 +97,6 @@ DKIM             <mailbox.org DKIM laut Dashboard>
 login  TXT/CNAME <Brevo Verification/DKIM/SPF laut Dashboard>
 
 _dmarc TXT       "v=DMARC1; p=none; rua=mailto:kontakt@weltgewebe.net"
-
 ```
 
 *Hinweis:* Provider-Dashboard-Werte sind Primärquelle. Keine auswendig geratenen SPF/DKIM-Werte.
@@ -109,9 +104,7 @@ _dmarc TXT       "v=DMARC1; p=none; rua=mailto:kontakt@weltgewebe.net"
 Für `weltweb.net` und `weltweberei.org`:
 
 - Klären, ob Mail benötigt wird.
-
 - Falls keine Mail benötigt wird, defensives SPF/DMARC-Ziel dokumentieren, aber nicht live setzen.
-
 - Dienen als Redirect-/Landing-Domains.
 
 ## 6. Runtime-Zielbild
@@ -120,10 +113,75 @@ Applikation und Mail-Infrastruktur müssen konform zur Zielarchitektur in der Pr
 
 ## 7. Migrationsphasen
 
-1. DNS-Übernahme durch INWX.
-2. Einrichtung mailbox.org und Umstellung der MX-Einträge.
-3. Einrichtung Brevo für Transaktionsmails.
-4. Aktualisierung der Runtime-Umgebungsvariablen.
+### Phase 0 — Bestand sichern
+
+- **Ziel**: Vollständige Dokumentation der aktuellen DNS- und E-Mail-Konfiguration.
+- **Aktionen**: DNS-Zonen-Exporte anlegen, MX-Prioritäten notieren, IONOS aktiv lassen.
+- **Gate**: Vollständige IONOS-Zone gesichert.
+- **Rollback-Hinweis**: Keine Live-Veränderungen, daher kein Rollback nötig.
+
+### Phase 1 — Zielkonten vorbereiten
+
+- **Ziel**: accounts anlegen und bereitstellen.
+- **Aktionen**: Accounts bei INWX, mailbox.org und Brevo einrichten.
+- **Gate**: Konten sind zugreifbar.
+- **Rollback-Hinweis**: Konten können wieder gelöscht werden.
+
+### Phase 2 — DNS-Zielzone entwerfen
+
+- **Ziel**: Blaupause der neuen DNS-Zone.
+- **Aktionen**: INWX-Einträge im Dashboard vorbereiten (aber noch nicht als Nameserver eintragen).
+- **Gate**: Ziel-DNS-Tabelle fertig und geprüft.
+- **Rollback-Hinweis**: Einträge können im Dashboard wieder verworfen werden.
+
+### Phase 3 — mailbox.org vorbereiten und testen
+
+- **Ziel**: `kontakt@weltgewebe.net` ist empfangsbereit.
+- **Aktionen**: Mailbox anlegen und (falls möglich) Test-Routing prüfen.
+- **Gate**: mailbox.org Account ist bereit.
+- **Rollback-Hinweis**: Rückkehr zur IONOS-Mailbox.
+
+### Phase 4 — Brevo vorbereiten und testen
+
+- **Ziel**: `login@weltgewebe.net` ist sendebereit.
+- **Aktionen**: Brevo-Dashboard-Verifikationscodes abrufen, ggf. anlegen.
+- **Gate**: Brevo-Verifikationsdaten liegen vor.
+- **Rollback-Hinweis**: Keine Live-Auswirkung auf bisherigen Versand.
+
+### Phase 5 — INWX/DNS-Cutover
+
+- **Ziel**: INWX übernimmt die aktive DNS-Auflösung.
+- **Aktionen**: Nameserver beim Registrar umstellen, MX auf mailbox.org und TXT auf Brevo.
+- **Gate**: DNS-Propagation abgeschlossen. `dig`-Checks erfolgreich.
+- **Rollback-Hinweis**: Nameserver zurück auf IONOS stellen.
+
+### Phase 6 — Runtime-Cutover auf Brevo
+
+- **Ziel**: Weltgewebe API nutzt Brevo statt IONOS.
+- **Aktionen**: `.env` auf Brevo-SMTP ändern, API-Container neustarten.
+- **Gate**: Runtime-Test zeigt Brevo-Werte ohne Errors.
+- **Rollback-Hinweis**: SMTP-Werte zurück auf IONOS ändern.
+
+### Phase 7 — Magic-Link-Proof
+
+- **Ziel**: Benutzer können sich einloggen.
+- **Aktionen**: Login-Prozess über `https://weltgewebe.net` initiieren, E-Mail-Empfang checken, Magic Link klicken.
+- **Gate**: Erfolgreiche Session-Erstellung.
+- **Rollback-Hinweis**: Siehe Phase 5 & 6.
+
+### Phase 8 — Beobachtungsfenster
+
+- **Ziel**: Stabilität gewährleisten.
+- **Aktionen**: Log-Analyse, Fehler-Monitoring, Bounce-Checks in Brevo.
+- **Gate**: Mindestens 48 Stunden ohne Versand-/Empfangsprobleme.
+- **Rollback-Hinweis**: Falls Fehler auftreten, Rollback zu IONOS prüfen.
+
+### Phase 9 — IONOS kündigen
+
+- **Ziel**: Alten Provider abschalten.
+- **Aktionen**: IONOS-Vertrag kündigen.
+- **Gate**: Phase 8 erfolgreich absolviert.
+- **Rollback-Hinweis**: Nach Kündigung kein Rollback mehr möglich.
 
 ## 8. Test-Gates
 
@@ -143,11 +201,17 @@ Sollte ein Migrationsschritt scheitern, müssen DNS und Einstellungen auf die le
 ## 10. Nicht-Ziele / Verbote
 
 - Keine Speicherung von Provider-Secrets im Repository.
-
 - Keine Live-DNS-Änderungen als Teil von Dokumentations-PRs.
 
 ## 11. Offene Belege
 
-- DNS-Propagation verifizieren.
-
-- Brevo Deliverability prüfen.
+- Vollständige IONOS-DNS-Zone für weltgewebe.net, weltweb.net, weltweberei.org.
+- MX-Prioritäten und TTLs gesichert.
+- mailbox.org Empfang und Versand für <kontakt@weltgewebe.net> getestet.
+- Brevo Sending-Domain/Subdomain verifiziert.
+- Brevo SPF/DKIM/DMARC im Test geprüft.
+- AUTH_LOG_MAGIC_TOKEN lokal als 0 bestätigt.
+- Runtime nach Recreate zeigt Brevo-SMTP-Werte.
+- Weltgewebe Magic-Link wird über Brevo verschickt.
+- Magic-Link zeigt auf <https://weltgewebe.net>.
+- Login erzeugt Session.

--- a/docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md
+++ b/docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md
@@ -122,7 +122,7 @@ Applikation und Mail-Infrastruktur müssen konform zur Zielarchitektur in der Pr
 
 ### Phase 1 — Zielkonten vorbereiten
 
-- **Ziel**: accounts anlegen und bereitstellen.
+- **Ziel**: Zielkonten anlegen und bereitstellen.
 - **Aktionen**: Accounts bei INWX, mailbox.org und Brevo einrichten.
 - **Gate**: Konten sind zugreifbar.
 - **Rollback-Hinweis**: Konten können wieder gelöscht werden.
@@ -151,7 +151,7 @@ Applikation und Mail-Infrastruktur müssen konform zur Zielarchitektur in der Pr
 ### Phase 5 — INWX/DNS-Cutover
 
 - **Ziel**: INWX übernimmt die aktive DNS-Auflösung.
-- **Aktionen**: Nameserver beim Registrar umstellen, MX auf mailbox.org und TXT auf Brevo.
+- **Aktionen**: Nameserver/DNS-Autorität auf INWX umstellen; in der INWX-Zone MX für mailbox.org sowie Brevo-Verifikations-/DKIM-/SPF-Records aktivieren.
 - **Gate**: DNS-Propagation abgeschlossen. `dig`-Checks erfolgreich.
 - **Rollback-Hinweis**: Nameserver zurück auf IONOS stellen.
 

--- a/docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md
+++ b/docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md
@@ -1,0 +1,153 @@
+---
+id: deploy.domain-mail-migration-ionos-inwx-mailbox-brevo
+title: "Domain-/Mail-Migration: IONOS zu INWX + mailbox.org + Brevo"
+doc_type: reference
+status: active
+summary: >
+  Zielarchitektur und Migrationsplan für Domain, DNS, Kontaktmail und
+  technische Magic-Link-Mail.
+relations:
+  - type: relates_to
+    target: docs/deploy/README.md
+  - type: relates_to
+    target: docs/deploy/DRIFT_POLICY.md
+  - type: relates_to
+    target: docs/deployment.md
+  - type: relates_to
+    target: docs/deployment_governance.md
+  - type: relates_to
+    target: docs/runbooks/domain-mail-cutover.md
+  - type: relates_to
+    target: docs/adr/ADR-0008__domain-mail-provider-boundaries.md
+---
+
+# Domain-/Mail-Migration: IONOS zu INWX + mailbox.org + Brevo
+
+## 1. Zweck
+
+Dieser Plan beschreibt die Zielarchitektur und den Migrationspfad für die Trennung von Registrar, menschlicher Mailbox und technischer Magic-Link-Mail.
+
+## 2. Zielarchitektur
+
+```text
+INWX:
+  Registrar und DNS für:
+  - weltgewebe.net
+  - weltweb.net
+  - weltweberei.org
+
+mailbox.org:
+  - kontakt@weltgewebe.net
+  - admin@weltgewebe.net optional als Alias
+  - optional temporäre Weiterleitung an externe Recovery-Mail
+
+Brevo:
+  - login@weltgewebe.net
+  - optional noreply@weltgewebe.net
+  - technische Magic-Link-Mail
+
+Weltgewebe Runtime:
+  APP_BASE_URL=https://weltgewebe.net
+  SMTP_HOST=<Brevo SMTP Host>
+  SMTP_PORT=587
+  SMTP_USER=<Brevo SMTP User>
+  SMTP_PASS=<Secret Store>
+  SMTP_FROM=login@weltgewebe.net
+
+```
+
+## 3. Aktueller redigierter Ist-Zustand
+
+```env
+APP_BASE_URL=https://weltgewebe.home.arpa
+AUTH_PUBLIC_LOGIN=1
+AUTH_AUTO_PROVISION=1
+AUTH_ALLOW_EMAILS=
+AUTH_RL_EMAIL_PER_MIN=2
+AUTH_RL_EMAIL_PER_HOUR=10
+AUTH_RL_IP_PER_MIN=5
+AUTH_RL_IP_PER_HOUR=30
+SMTP_HOST=smtp.ionos.de
+SMTP_PORT=587
+SMTP_USER=kontakt@weltgewebe.net
+SMTP_FROM=kontakt@weltgewebe.net
+SMTP_PASS=<gesetzt, nicht dokumentieren>
+WEB_UPSTREAM_HOST=weltgewebe.home.arpa
+WEB_UPSTREAM_URL=https://weltgewebe.home.arpa
+
+```
+
+## 4. Providerrollen
+
+- INWX: DNS-Verwaltung.
+
+- mailbox.org: Verwaltung menschlicher Kommunikation.
+
+- Brevo: Versand transaktionaler E-Mails (Login/Magic-Link).
+
+## 5. DNS-Zielbild
+
+Für `weltgewebe.net`:
+
+```text
+@      A/CNAME   <aktueller oder späterer Produktionshost>
+api    A/CNAME   <aktueller oder späterer API-/Produktionshost>
+www    A/CNAME   <Landingpage oder Redirect-Ziel>
+
+MX     @         <mailbox.org MX>
+TXT    @         <mailbox.org SPF>
+DKIM             <mailbox.org DKIM laut Dashboard>
+
+login  TXT/CNAME <Brevo Verification/DKIM/SPF laut Dashboard>
+
+_dmarc TXT       "v=DMARC1; p=none; rua=mailto:kontakt@weltgewebe.net"
+
+```
+
+*Hinweis:* Provider-Dashboard-Werte sind Primärquelle. Keine auswendig geratenen SPF/DKIM-Werte.
+
+Für `weltweb.net` und `weltweberei.org`:
+
+- Klären, ob Mail benötigt wird.
+
+- Falls keine Mail benötigt wird, defensives SPF/DMARC-Ziel dokumentieren, aber nicht live setzen.
+
+- Dienen als Redirect-/Landing-Domains.
+
+## 6. Runtime-Zielbild
+
+Applikation und Mail-Infrastruktur müssen konform zur Zielarchitektur in der Produktions-Runtime konfiguriert werden.
+
+## 7. Migrationsphasen
+
+1. DNS-Übernahme durch INWX.
+2. Einrichtung mailbox.org und Umstellung der MX-Einträge.
+3. Einrichtung Brevo für Transaktionsmails.
+4. Aktualisierung der Runtime-Umgebungsvariablen.
+
+## 8. Test-Gates
+
+- IONOS darf erst gekündigt werden, wenn:
+  - INWX-DNS-Zone vollständig gesetzt und geprüft ist
+  - mailbox.org Empfang und Versand für `kontakt@weltgewebe.net` funktionieren
+  - Brevo-Domain/Subdomain verifiziert ist
+  - Brevo-Testmail SPF/DKIM/DMARC besteht oder mindestens nicht fehlschlägt
+  - Weltgewebe Magic-Link-Mail über Brevo funktioniert
+  - live-env nach Recreate Brevo-Werte zeigt
+  - Rollback-Pfad noch offen ist
+
+## 9. Rollback-Prinzip
+
+Sollte ein Migrationsschritt scheitern, müssen DNS und Einstellungen auf die letzten funktionierenden Werte (IONOS) zurückgerollt werden können, solange der IONOS-Account aktiv ist.
+
+## 10. Nicht-Ziele / Verbote
+
+- Keine Speicherung von Provider-Secrets im Repository.
+
+- Keine Live-DNS-Änderungen als Teil von Dokumentations-PRs.
+
+## 11. Offene Belege
+
+- DNS-Propagation verifizieren.
+
+- Brevo Deliverability prüfen.

--- a/docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md
+++ b/docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md
@@ -37,7 +37,7 @@ INWX:
   - weltweberei.org
 
 mailbox.org:
-  - <kontakt@weltgewebe.net>
+  - `kontakt@weltgewebe.net`
   - admin@weltgewebe.net optional als Alias
   - optional temporäre Weiterleitung an externe Recovery-Mail
 
@@ -207,11 +207,11 @@ Sollte ein Migrationsschritt scheitern, müssen DNS und Einstellungen auf die le
 
 - Vollständige IONOS-DNS-Zone für weltgewebe.net, weltweb.net, weltweberei.org.
 - MX-Prioritäten und TTLs gesichert.
-- mailbox.org Empfang und Versand für <kontakt@weltgewebe.net> getestet.
+- mailbox.org Empfang und Versand für `kontakt@weltgewebe.net` getestet.
 - Brevo Sending-Domain/Subdomain verifiziert.
 - Brevo SPF/DKIM/DMARC im Test geprüft.
 - AUTH_LOG_MAGIC_TOKEN lokal als 0 bestätigt.
 - Runtime nach Recreate zeigt Brevo-SMTP-Werte.
 - Weltgewebe Magic-Link wird über Brevo verschickt.
-- Magic-Link zeigt auf <https://weltgewebe.net>.
+- Magic-Link zeigt auf `https://weltgewebe.net`.
 - Login erzeugt Session.

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -17,6 +17,8 @@ relations:
     target: docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md
   - type: relates_to
     target: docs/runbooks/uv-tooling.md
+  - type: relates_to
+    target: docs/runbooks/domain-mail-cutover.md
 ---
 # Runbooks
 
@@ -25,5 +27,6 @@ Anleitungen für wiederkehrende Aufgaben.
 - [Incident Response](incident-response.md)
 - [DB Recovery](db-recovery.md)
 - [UV Tooling – Ist-Stand & Ausbauoptionen](uv-tooling.md)
+- [Domain-/Mail-Cutover](domain-mail-cutover.md)
 - [Codespaces Recovery](codespaces-recovery.md)
 - [Zurück zum Doku-Index](../index.md)

--- a/docs/runbooks/domain-mail-cutover.md
+++ b/docs/runbooks/domain-mail-cutover.md
@@ -98,14 +98,24 @@ AUTH_LOG_MAGIC_TOKEN=0
 
 ### Mail-Gates
 
-- mailbox.org Empfang/Versand
-- Brevo-Testmail
-- Headerprüfung
-- Weltgewebe Magic-Link
-- Session-Proof
+- Mail an `kontakt@weltgewebe.net` kommt bei mailbox.org an.
+- Antwort von `kontakt@weltgewebe.net` kommt extern an.
+- Brevo-Testmail von `login@weltgewebe.net` kommt an.
+- Headerprüfung: SPF pass, DKIM pass, DMARC nicht fail.
+- Weltgewebe Magic-Link kommt an.
+- Magic-Link zeigt auf `https://weltgewebe.net`.
+- Login erzeugt Session.
 
 ## Rollback
 
 - MX zurück auf IONOS, falls IONOS aktiv
 - SMTP zurück auf IONOS, falls Credentials aktiv
 - A/CNAME zurück auf letzte bekannte funktionierende Zone
+
+## Post-Cutover
+
+- 48 Stunden Beobachtungsfenster einhalten.
+- Brevo Bounces/Logs prüfen.
+- mailbox.org Empfang/Versand erneut prüfen.
+- IONOS erst nach erfolgreichen Gates und Beobachtungsfenster kündigen.
+- Nach IONOS-Kündigung ist Rollback über IONOS nicht mehr verfügbar.

--- a/docs/runbooks/domain-mail-cutover.md
+++ b/docs/runbooks/domain-mail-cutover.md
@@ -1,0 +1,116 @@
+---
+id: runbooks.domain-mail-cutover
+title: "Runbook — Domain-, Mail- und SMTP-Cutover"
+doc_type: runbook
+status: active
+summary: >
+  Operatives Runbook für den kontrollierten Cutover von IONOS zu
+  INWX, mailbox.org und Brevo.
+relations:
+  - type: relates_to
+    target: docs/runbooks/README.md
+  - type: relates_to
+    target: docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md
+  - type: relates_to
+    target: docs/adr/ADR-0008__domain-mail-provider-boundaries.md
+---
+
+# Runbook — Domain-, Mail- und SMTP-Cutover
+
+## Voraussetzungen
+
+- Zugriff auf INWX, mailbox.org, Brevo und IONOS Dashboards.
+
+- Zugriff auf die Produktions-Runtime (`.env`).
+
+- Kenntnis der Test-Gates und Rollback-Verfahren.
+
+## Rollen
+
+- Operator (Durchführung)
+
+- Reviewer (Prüfung der Gates)
+
+## Sicherheitsregeln
+
+- Keine Secrets in Logs oder Dokumentation.
+
+- Rollback-Zeitfenster von mindestens 48 Stunden sicherstellen.
+
+## Preflight
+
+1. Alle notwendigen Provider-Accounts sind angelegt und bestätigt.
+2. Ziel-DNS-Records liegen in INWX bereit, aber sind noch nicht aktiv.
+
+## Cutover
+
+1. DNS-Nameserver auf INWX umstellen.
+2. MX-Records für mailbox.org aktivieren.
+3. Brevo DNS-Verifikation durchführen.
+4. Runtime (`.env`) auf Brevo SMTP aktualisieren.
+
+## Test-Gates
+
+### DNS-Gates
+
+```bash
+dig weltgewebe.net A
+dig api.weltgewebe.net A
+dig weltgewebe.net MX
+dig weltgewebe.net TXT
+dig _dmarc.weltgewebe.net TXT
+
+```
+
+### Runtime-Prüfung
+
+```bash
+docker inspect weltgewebe-api-1 \
+  --format "{{range .Config.Env}}{{println .}}{{end}}" \
+| grep -E "^(APP_BASE_URL|AUTH_|SMTP_|WEBAUTHN_|RUST_LOG)=" \
+| sed -E "s/^(SMTP_PASS|.*SECRET|.*PASSWORD|.*PRIVATE_KEY|.*API_KEY|.*TOKEN)=.*/\1=<REDACTED>/"
+
+```
+
+### Erwartung nach Ziel-Cutover
+
+```text
+APP_BASE_URL=https://weltgewebe.net
+SMTP_HOST=<Brevo SMTP Host>
+SMTP_PORT=587
+SMTP_USER=<Brevo SMTP User>
+SMTP_FROM=login@weltgewebe.net
+AUTH_PUBLIC_LOGIN=1
+AUTH_LOG_MAGIC_TOKEN=0
+
+```
+
+### Mail-Gates
+
+- Mail an `kontakt@weltgewebe.net` kommt bei mailbox.org an.
+
+- Antwort von `kontakt@weltgewebe.net` kommt extern an.
+
+- Brevo-Testmail von `login@weltgewebe.net` kommt an.
+
+- Headerprüfung: SPF pass, DKIM pass, DMARC nicht fail.
+
+- Weltgewebe Magic-Link kommt an.
+
+- Magic-Link zeigt auf `https://weltgewebe.net`.
+
+- Login erzeugt Session.
+
+## Rollback
+
+- IONOS-Mail/DNS nicht kündigen, solange Rollback benötigt werden kann.
+
+- Bei Mailausfall: MX temporär zurück auf IONOS, falls IONOS-Mail noch aktiv ist.
+
+- Bei SMTP-Ausfall: Weltgewebe SMTP temporär zurück auf alten Provider, falls Credentials noch gültig sind.
+
+- Bei Web/API-Ausfall: A/CNAME-Records gegen letzte bekannte IONOS-Zone vergleichen.
+
+## Post-Cutover
+
+- IONOS-Kündigung erst nach erfolgreichen Gates.

--- a/docs/runbooks/domain-mail-cutover.md
+++ b/docs/runbooks/domain-mail-cutover.md
@@ -20,36 +20,43 @@ relations:
 ## Voraussetzungen
 
 - Zugriff auf INWX, mailbox.org, Brevo und IONOS Dashboards.
-
 - Zugriff auf die Produktions-Runtime (`.env`).
-
 - Kenntnis der Test-Gates und Rollback-Verfahren.
 
 ## Rollen
 
 - Operator (Durchführung)
-
 - Reviewer (Prüfung der Gates)
 
 ## Sicherheitsregeln
 
 - Keine Secrets in Logs oder Dokumentation.
-
 - Rollback-Zeitfenster von mindestens 48 Stunden sicherstellen.
 
 ## Preflight
 
-1. Alle notwendigen Provider-Accounts sind angelegt und bestätigt.
-2. Ziel-DNS-Records liegen in INWX bereit, aber sind noch nicht aktiv.
+- IONOS-Zone exportiert
+- mailbox.org Account vorbereitet
+- Brevo Account vorbereitet
+- DNS-Zielrecords aus Provider-Dashboards notiert
+- Rollback-Zeitfenster offen
+- IONOS noch aktiv
+
+## Dry Run
+
+- Ziel-DNS als Tabelle prüfen
+- Brevo-DNS-Records noch nicht blind setzen
+- Runtime-Zielwerte vorbereitet, aber nicht aktiv
 
 ## Cutover
 
-1. DNS-Nameserver auf INWX umstellen.
-2. MX-Records für mailbox.org aktivieren.
-3. Brevo DNS-Verifikation durchführen.
-4. Runtime (`.env`) auf Brevo SMTP aktualisieren.
+- DNS/Nameserver nur nach Preflight-Gates ändern
+- mailbox.org MX aktivieren
+- Brevo-DNS-Verifikation aktivieren
+- Runtime auf Brevo-SMTP ändern
+- Dienste kontrolliert neu erzeugen / deployen
 
-## Test-Gates
+## Verification
 
 ### DNS-Gates
 
@@ -59,7 +66,6 @@ dig api.weltgewebe.net A
 dig weltgewebe.net MX
 dig weltgewebe.net TXT
 dig _dmarc.weltgewebe.net TXT
-
 ```
 
 ### Runtime-Prüfung
@@ -67,9 +73,15 @@ dig _dmarc.weltgewebe.net TXT
 ```bash
 docker inspect weltgewebe-api-1 \
   --format "{{range .Config.Env}}{{println .}}{{end}}" \
-| grep -E "^(APP_BASE_URL|AUTH_|SMTP_|WEBAUTHN_|RUST_LOG)=" \
-| sed -E "s/^(SMTP_PASS|.*SECRET|.*PASSWORD|.*PRIVATE_KEY|.*API_KEY|.*TOKEN)=.*/\1=<REDACTED>/"
-
+| awk -F= '
+  $1 ~ /^(APP_BASE_URL|AUTH_|SMTP_|WEBAUTHN_|RUST_LOG|WEB_UPSTREAM_)/ {
+    if ($1 ~ /(PASS|PASSWORD|SECRET|TOKEN|PRIVATE_KEY|API_KEY)/) {
+      print $1"=<REDACTED>"
+    } else {
+      print
+    }
+  }
+'
 ```
 
 ### Erwartung nach Ziel-Cutover
@@ -82,35 +94,18 @@ SMTP_USER=<Brevo SMTP User>
 SMTP_FROM=login@weltgewebe.net
 AUTH_PUBLIC_LOGIN=1
 AUTH_LOG_MAGIC_TOKEN=0
-
 ```
 
 ### Mail-Gates
 
-- Mail an `kontakt@weltgewebe.net` kommt bei mailbox.org an.
-
-- Antwort von `kontakt@weltgewebe.net` kommt extern an.
-
-- Brevo-Testmail von `login@weltgewebe.net` kommt an.
-
-- Headerprüfung: SPF pass, DKIM pass, DMARC nicht fail.
-
-- Weltgewebe Magic-Link kommt an.
-
-- Magic-Link zeigt auf `https://weltgewebe.net`.
-
-- Login erzeugt Session.
+- mailbox.org Empfang/Versand
+- Brevo-Testmail
+- Headerprüfung
+- Weltgewebe Magic-Link
+- Session-Proof
 
 ## Rollback
 
-- IONOS-Mail/DNS nicht kündigen, solange Rollback benötigt werden kann.
-
-- Bei Mailausfall: MX temporär zurück auf IONOS, falls IONOS-Mail noch aktiv ist.
-
-- Bei SMTP-Ausfall: Weltgewebe SMTP temporär zurück auf alten Provider, falls Credentials noch gültig sind.
-
-- Bei Web/API-Ausfall: A/CNAME-Records gegen letzte bekannte IONOS-Zone vergleichen.
-
-## Post-Cutover
-
-- IONOS-Kündigung erst nach erfolgreichen Gates.
+- MX zurück auf IONOS, falls IONOS aktiv
+- SMTP zurück auf IONOS, falls Credentials aktiv
+- A/CNAME zurück auf letzte bekannte funktionierende Zone


### PR DESCRIPTION
Adds the canonical documentation slice for the planned migration from IONOS to INWX + mailbox.org + Brevo.

Scope:
- Adds ADR-0008 for domain/mail/provider boundaries.
- Adds deploy migration plan.
- Adds operational cutover runbook.
- Updates deploy and runbook indexes.

Runtime evidence:
Operator audit showed that the current Weltgewebe API runtime uses:
- public login enabled
- IONOS SMTP via smtp.ionos.de
- contact@weltgewebe.net as current SMTP user/from
- APP_BASE_URL currently set to home.arpa

No secrets are committed.

Non-goals:
- No DNS cutover.
- No provider account changes.
- No runtime `.env` changes.
- No Brevo credential changes.
- No IONOS cancellation.

Validation:
- `python3 scripts/docmeta/validate_schema.py`
- `python3 scripts/docmeta/validate_relations.py`
- `python3 scripts/docmeta/check_links.py`
- Secret grep reviewed

---
*PR created automatically by Jules for task [1168851386999268516](https://jules.google.com/task/1168851386999268516) started by @alexdermohr*