### PR TITLE
Fix magic-link Origin null CSRF block

### DIFF
--- a/apps/api/src/middleware/csrf.rs
+++ b/apps/api/src/middleware/csrf.rs
@@ -24,7 +24,18 @@ pub async fn require_csrf(jar: CookieJar, req: Request<Body>, next: Next) -> Res
     }
 
     // 2. Explicit exemptions
-    if req.uri().path().ends_with("/auth/login") || req.uri().path().ends_with("/auth/logout") {
+    let path = req.uri().path();
+    if is_magic_link_consume_post(method, path) {
+        // Magic-link consume is a one-time login confirmation POST that may be
+        // submitted from an email-opened document with `Origin: null`. It must
+        // remain narrowly exempt from the session-cookie Origin/Referer guard
+        // because the handler is authoritative: it validates the submitted
+        // token, verifies the token-bound nonce cookie, and only then creates a
+        // session. Invalid token/nonce cases must continue to fail there.
+        return next.run(req).await;
+    }
+
+    if path.ends_with("/auth/login") || path.ends_with("/auth/logout") {
         return next.run(req).await;
     }
 
@@ -280,4 +291,9 @@ mod tests {
         // Host has explicit port, Origin has different port -> FAIL
         assert!(!check_ports(Some(8080), Some(9090)));
     }
+}
+
+fn is_magic_link_consume_post(method: &Method, path: &str) -> bool {
+    *method == Method::POST
+        && (path == "/auth/magic-link/consume" || path == "/api/auth/magic-link/consume")
 }

--- a/apps/api/src/middleware/csrf.rs
+++ b/apps/api/src/middleware/csrf.rs
@@ -25,7 +25,7 @@ pub async fn require_csrf(jar: CookieJar, req: Request<Body>, next: Next) -> Res
 
     // 2. Explicit exemptions
     let path = req.uri().path();
-    if is_magic_link_consume_post(method, path) {
+    if is_magic_link_consume_post(req.method(), path) {
         // Magic-link consume is a one-time login confirmation POST that may be
         // submitted from an email-opened document with `Origin: null`. It must
         // remain narrowly exempt from the session-cookie Origin/Referer guard
@@ -217,6 +217,10 @@ fn parse_host_header(input: &str) -> (String, Option<u16>) {
     (input.to_string(), None)
 }
 
+fn is_magic_link_consume_post(method: &Method, path: &str) -> bool {
+    *method == Method::POST
+        && (path == "/auth/magic-link/consume" || path == "/api/auth/magic-link/consume")
+}
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -291,9 +295,4 @@ mod tests {
         // Host has explicit port, Origin has different port -> FAIL
         assert!(!check_ports(Some(8080), Some(9090)));
     }
-}
-
-fn is_magic_link_consume_post(method: &Method, path: &str) -> bool {
-    *method == Method::POST
-        && (path == "/auth/magic-link/consume" || path == "/api/auth/magic-link/consume")
 }

--- a/apps/api/tests/api_auth.rs
+++ b/apps/api/tests/api_auth.rs
@@ -180,6 +180,22 @@ fn app_with_addr(state: ApiState, addr: SocketAddr) -> Router {
         .with_state(state)
 }
 
+fn app_with_security(state: ApiState) -> Router {
+    Router::new()
+        .merge(
+            api_router()
+                .route_layer(axum::middleware::from_fn_with_state(
+                    state.clone(),
+                    weltgewebe_api::middleware::auth::auth_middleware,
+                ))
+                .layer(axum::middleware::from_fn(
+                    weltgewebe_api::middleware::csrf::require_csrf,
+                )),
+        )
+        .layer(MockConnectInfo(SocketAddr::from(([127, 0, 0, 1], 8080))))
+        .with_state(state)
+}
+
 struct DeferEnvRemove(&'static str);
 impl Drop for DeferEnvRemove {
     fn drop(&mut self) {
@@ -1013,6 +1029,142 @@ async fn consume_legacy_alias_returns_404() -> Result<()> {
         .body(body::Body::from("token=any&nonce=any"))?;
     let res_post = app.clone().oneshot(req_post).await?;
     assert_eq!(res_post.status(), StatusCode::NOT_FOUND);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn magic_link_consume_origin_null_succeeds_through_security_middleware() -> Result<()> {
+    let mut state = test_state_with_accounts()?;
+    state.config.auth_public_login = true;
+    state.config.app_base_url = Some("http://localhost".to_string());
+
+    let stale_session = create_session(&state, "u1", Some("stale-device")).await;
+    let token = state.tokens.create("u1@example.com".to_string());
+    let app = app_with_security(state.clone());
+
+    let uri = format!("/auth/magic-link/consume?token={}", token);
+    let req_get = Request::get(&uri)
+        .header("Host", "localhost")
+        .body(body::Body::empty())?;
+    let res_get = app.clone().oneshot(req_get).await?;
+    assert_eq!(res_get.status(), StatusCode::OK);
+
+    let nonce_val = extract_cookie_value(res_get.headers(), NONCE_COOKIE_NAME)
+        .context("GET consume must set nonce cookie")?;
+    let (stored_hash, nonce) = nonce_val.split_once('.').context("invalid nonce format")?;
+    assert_eq!(stored_hash, hash_token(&token));
+
+    let body_str = format!("token={}&nonce={}", token, nonce);
+    let req_post = Request::post("/auth/magic-link/consume")
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .header("Host", "localhost")
+        .header("Origin", "null")
+        .header(
+            "Cookie",
+            format!(
+                "{}={}; {}={}",
+                SESSION_COOKIE_NAME, stale_session.id, NONCE_COOKIE_NAME, nonce_val
+            ),
+        )
+        .body(body::Body::from(body_str))?;
+    let res_post = app.oneshot(req_post).await?;
+
+    assert_eq!(res_post.status(), StatusCode::SEE_OTHER);
+    assert_eq!(res_post.headers().get("location").unwrap(), "/");
+
+    let session_id = extract_cookie_value(res_post.headers(), SESSION_COOKIE_NAME)
+        .context("valid magic-link consume must create a session cookie")?;
+    assert!(
+        get_session(&state, &session_id).await.is_some(),
+        "created session id must exist in the session backend"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn magic_link_consume_origin_null_invalid_token_does_not_create_session() -> Result<()> {
+    let mut state = test_state_with_accounts()?;
+    state.config.auth_public_login = true;
+    state.config.app_base_url = Some("http://localhost".to_string());
+
+    let stale_session = create_session(&state, "u1", Some("stale-device")).await;
+    let invalid_token = "invalid-token-for-origin-null-proof";
+    let nonce = "valid-nonce-for-invalid-token-proof";
+    let nonce_val = format!("{}.{}", hash_token(invalid_token), nonce);
+    let app = app_with_security(state);
+
+    let body_str = format!("token={}&nonce={}", invalid_token, nonce);
+    let req_post = Request::post("/auth/magic-link/consume")
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .header("Host", "localhost")
+        .header("Origin", "null")
+        .header(
+            "Cookie",
+            format!(
+                "{}={}; {}={}",
+                SESSION_COOKIE_NAME, stale_session.id, NONCE_COOKIE_NAME, nonce_val
+            ),
+        )
+        .body(body::Body::from(body_str))?;
+    let res_post = app.oneshot(req_post).await?;
+
+    assert_eq!(res_post.status(), StatusCode::SEE_OTHER);
+    assert_eq!(
+        res_post.headers().get("location").unwrap(),
+        "/login?error=invalid_token"
+    );
+    assert!(
+        extract_cookie_value(res_post.headers(), SESSION_COOKIE_NAME).is_none(),
+        "invalid token must not create a session cookie"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn magic_link_consume_origin_null_invalid_nonce_does_not_create_session() -> Result<()> {
+    let mut state = test_state_with_accounts()?;
+    state.config.auth_public_login = true;
+    state.config.app_base_url = Some("http://localhost".to_string());
+
+    let stale_session = create_session(&state, "u1", Some("stale-device")).await;
+    let token = state.tokens.create("u1@example.com".to_string());
+    let nonce_val = format!("{}.{}", hash_token(&token), "stored-nonce");
+    let app = app_with_security(state.clone());
+
+    let body_str = format!("token={}&nonce={}", token, "submitted-different-nonce");
+    let req_post = Request::post("/auth/magic-link/consume")
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .header("Host", "localhost")
+        .header("Origin", "null")
+        .header(
+            "Cookie",
+            format!(
+                "{}={}; {}={}",
+                SESSION_COOKIE_NAME, stale_session.id, NONCE_COOKIE_NAME, nonce_val
+            ),
+        )
+        .body(body::Body::from(body_str))?;
+    let res_post = app.oneshot(req_post).await?;
+
+    assert_eq!(res_post.status(), StatusCode::SEE_OTHER);
+    assert_eq!(
+        res_post.headers().get("location").unwrap(),
+        "/login?error=invalid_token"
+    );
+    assert!(
+        extract_cookie_value(res_post.headers(), SESSION_COOKIE_NAME).is_none(),
+        "invalid nonce must not create a session cookie"
+    );
+    assert!(
+        state.tokens.peek(&token).is_some(),
+        "invalid nonce must not consume the one-time token"
+    );
 
     Ok(())
 }

--- a/apps/api/tests/auth_security_invariants.rs
+++ b/apps/api/tests/auth_security_invariants.rs
@@ -247,6 +247,24 @@ async fn csrf_blocks_all_mutating_endpoints_without_origin() -> Result<()> {
         assert_csrf_blocked(&app, method.clone(), path, &session_cookie).await;
     }
 
+    let origin_null_refresh = Request::post("/auth/session/refresh")
+        .header("Cookie", &session_cookie)
+        .header("Host", "localhost")
+        .header("Origin", "null")
+        .body(body::Body::empty())?;
+    let origin_null_refresh_res = app.clone().oneshot(origin_null_refresh).await?;
+    assert_eq!(
+        origin_null_refresh_res.status(),
+        StatusCode::FORBIDDEN,
+        "session refresh with Origin:null must remain protected by CSRF middleware"
+    );
+    let origin_null_refresh_body =
+        body::to_bytes(origin_null_refresh_res.into_body(), usize::MAX).await?;
+    assert!(
+        origin_null_refresh_body.is_empty(),
+        "Origin:null session refresh rejection must be the bare CSRF 403"
+    );
+
     // Positive control: the same refresh request *with* a matching Origin passes
     // the CSRF guard, proving the rejections above are specifically CSRF-driven
     // and the middleware does not blanket-block legitimate same-origin traffic.


### PR DESCRIPTION
This PR fixes an issue where valid magic link logins were incorrectly blocked by the CSRF middleware.

Specifically, when a user opened a magic link directly from an email client, the browser often sent the request with an `Origin: null` header for privacy reasons. The previous CSRF implementation strictly required matching Origin/Referer headers for mutating requests and blocked these submissions.

This patch exempts the `/auth/magic-link/consume` POST route from this specific check. The security implications have been thoroughly evaluated and documented: this endpoint inherently relies on a double-submit pattern (a unique one-time token plus a cryptographically bound nonce cookie), so it is secure without the strict `Origin` guard.

Comprehensive tests have been added to verify that:
- Legitimate origin-null magic link consumptions succeed.
- Invalid tokens or nonces still properly fail and do not create sessions.
- Unrelated endpoints (like session refresh) remain fully protected against `Origin: null` CSRF attempts.

---
*PR created automatically by Jules for task [17907914438874024959](https://jules.google.com/task/17907914438874024959) started by @alexdermohr*