### PR TITLE
Stream PostgreSQL edge loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3111,6 +3111,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "dotenvy",
+ "futures-util",
  "governor",
  "ipnet",
  "lettre",

--- a/apps/api/Cargo.toml
+++ b/apps/api/Cargo.toml
@@ -12,6 +12,7 @@ axum = { version = "0.7", features = ["macros"] }
 async-trait = "0.1"
 async-nats = "0.47"
 dotenvy = "0.15"
+futures-util = "0.3"
 prometheus = "0.14.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/apps/api/src/domain_db.rs
+++ b/apps/api/src/domain_db.rs
@@ -5,6 +5,7 @@
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
+use futures_util::TryStreamExt;
 use serde_json::{json, Map, Value};
 use sqlx::PgPool;
 use uuid::Uuid;
@@ -137,20 +138,26 @@ pub async fn load_nodes_from_postgres(pool: &PgPool) -> Result<OrderedCache<Node
 pub async fn load_edges_from_postgres(pool: &PgPool) -> Result<OrderedCache<Edge>> {
     let max_edges = crate::routes::edges::max_edges_cache_limit();
     let fetch_limit = max_edges.saturating_add(1).min(i64::MAX as usize) as i64;
-    let rows: Vec<EdgeRow> = sqlx::query_as(
+    let mut rows = sqlx::query_as::<_, EdgeRow>(
         "SELECT id, source_id, target_id, edge_kind, created_at, payload::text \
          FROM domain_edges ORDER BY id ASC LIMIT $1",
     )
     .bind(fetch_limit)
-    .fetch_all(pool)
-    .await
-    .context("failed to load edges from domain_edges")?;
+    .fetch(pool);
 
-    let truncated = rows.len() > max_edges;
     let mut cache = OrderedCache::new();
-    for (id, source_id, target_id, edge_kind, created_at, payload_text) in
-        rows.into_iter().take(max_edges)
+    let mut seen = 0usize;
+    let mut truncated = false;
+    while let Some((id, source_id, target_id, edge_kind, created_at, payload_text)) = rows
+        .try_next()
+        .await
+        .context("failed to load edges from domain_edges")?
     {
+        if seen >= max_edges {
+            truncated = true;
+            break;
+        }
+
         let payload = parse_payload(&payload_text);
         let edge = Edge {
             id: id.clone(),
@@ -163,6 +170,7 @@ pub async fn load_edges_from_postgres(pool: &PgPool) -> Result<OrderedCache<Edge
             created_at: created_at.map(|t| t.to_rfc3339()),
         };
         cache.insert(id, edge);
+        seen += 1;
     }
     if truncated {
         tracing::warn!(


### PR DESCRIPTION
### Motivation
- Reduce peak memory usage in `load_edges_from_postgres()` by avoiding `fetch_all()` which materializes a temporary `Vec<EdgeRow>` up to `MAX_EDGES_CACHE + 1` rows.
- Keep Phase-D semantics intact: ordering, cap calculation, payload mapping and truncation detection must be preserved while lowering temporary allocations.

### Description
- Replaced `fetch_all()` in `load_edges_from_postgres()` with a streaming consumer using `query_as::<_, EdgeRow>(...).fetch(pool)` and `try_next().await`, inserting rows into `OrderedCache<Edge>` as they arrive.
- Preserved existing semantics: `max_edges_cache_limit()` is still used, `fetch_limit = max_edges + 1` clamp remains, SQL still uses `ORDER BY id ASC LIMIT $1`, the extra row sets `truncated = true` without insertion, and the same payload-to-`Edge` mapping is used.
- Added `futures-util` as a direct dependency to import `TryStreamExt` (no new external package beyond what was present transitively in the lockfile was introduced).
- Files changed: `apps/api/src/domain_db.rs`, `apps/api/Cargo.toml` (and `Cargo.lock` updated).

### Testing
- Ran `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings`, both succeeded with no new lints or formatting issues.
- Ran unit and integration tests with `cargo test --locked -p weltgewebe-api`, which completed successfully (repository test suite passed with existing ignored DB tests left ignored by default).
- Ran task/documentation checks (`python3 -m scripts.docmeta.validate_task_index`, `generate_task_index --check`, `agent_entrypoint_smoke`, `check_planning_registration --mode strict`), all passed.
- Attempted direct PostgreSQL proof with `DATABASE_URL=postgres://welt:gewebe@localhost:5432/weltgewebe cargo test --locked -p weltgewebe-api --test db_domain_read_path -- --include-ignored --test-threads=1`, but it failed due to `PoolTimedOut` because PostgreSQL was not reachable in this environment; the streaming change itself compiled and tests without a live DB succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21349934b0832c8c75378f0f763f0d)