### PR TITLE
docs: ignore temporary yamllint environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ npm-debug.log*
 build/
 dist/
 .tmp/
+# Local lint/tool virtual environments
+.tmp-yamllint/
 target/
 # Re-include the SvelteKit `/build` diagnostics route, which is source code, not a build artifact.
 !apps/web/src/routes/build/


### PR DESCRIPTION
### Motivation
- A recent merge-dump contained local yamllint virtualenv/tool artifacts (a `.tmp-yamllint/` tree with `pyvenv.cfg` and `bin/python*`) which are local noise and must not be included in repo snapshots, merge dumps, or agent indices.

### Description
- Add a focused ignore rule for `.tmp-yamllint/` to `.gitignore`, placing it alongside other local build/temp rules, with no changes to claim/freshness registries, claim-evidence generators, or protected `docs/_generated/**` files.

### Testing
- Confirmed that no `.tmp-yamllint` files are tracked, verified the ignore rule prevents `pyvenv.cfg` and `bin/python` under `.tmp-yamllint/` from being considered, executed `python3 scripts/docmeta/validate_claim_registry.py`, `python3 scripts/docmeta/validate_doc_freshness_registry.py` and `python3 -m scripts.docmeta.generate_claim_evidence_map --check` successfully, and verified the repo diff hygiene shows only the intended `.gitignore` change (Lenskit/dump reproduction was not available locally).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a228ea21fb4832ca6cc7fcf4b6012b4)