### PR TITLE
docs: harden freshness evidence target resolution

### DIFF
--- a/scripts/docmeta/tests/test_validate_doc_freshness_registry.py
+++ b/scripts/docmeta/tests/test_validate_doc_freshness_registry.py
@@ -1,4 +1,5 @@
 import json
+import os
 import shutil
 import tempfile
 import unittest
@@ -545,6 +546,106 @@ entries:
         self.assertEqual(exit_code, 1)
         self.assertTrue(self._has(output, "EVIDENCE_TARGET_MISSING"))
         self.assertFalse(self._has(output, "EVIDENCE_NOT_IN_CLAIM_REGISTRY"))
+
+    def test_symlink_target_outside_repo_fails(self):
+        if not hasattr(os, "symlink"):
+            self.skipTest("os.symlink is not available")
+
+        outside_dir = Path(tempfile.mkdtemp(prefix="freshness-outside-"))
+        self.addCleanup(lambda: shutil.rmtree(outside_dir, ignore_errors=True))
+        outside_file = outside_dir / "outside.md"
+        outside_file.write_text("outside\n", encoding="utf-8")
+
+        link_rel = "docs/outside-link.md"
+        link_path = self.root / link_rel
+        link_path.parent.mkdir(parents=True, exist_ok=True)
+
+        try:
+            os.symlink(outside_file, link_path)
+        except (OSError, NotImplementedError) as exc:
+            self.skipTest(f"symlink creation not supported: {exc}")
+
+        claim_evidence = {
+            1: [{"path": link_rel, "kind": "documentation"}],
+            2: self.claim_evidence[2],
+            3: self.claim_evidence[3],
+        }
+        self._write_claims(evidence=claim_evidence)
+
+        entries = self._entries()
+        entries[0]["evidence"] = [{"kind": "file", "target": link_rel}]
+        self._write_registry(entries)
+
+        output, exit_code = self._run()
+
+        self.assertEqual(exit_code, 1)
+        self.assertTrue(self._has(output, "EVIDENCE_TARGET_TRAVERSAL"))
+        self.assertFalse(self._has(output, "EVIDENCE_NOT_IN_CLAIM_REGISTRY"))
+        self.assertFalse(self._has(output, "EVIDENCE_MISSING_FROM_FRESHNESS_REGISTRY"))
+
+    def test_symlink_loop_target_fails_as_missing(self):
+        if not hasattr(os, "symlink"):
+            self.skipTest("os.symlink is not available")
+
+        link_rel = "docs/self-loop.md"
+        link_path = self.root / link_rel
+        link_path.parent.mkdir(parents=True, exist_ok=True)
+
+        try:
+            os.symlink(link_path, link_path)
+        except (OSError, NotImplementedError) as exc:
+            self.skipTest(f"symlink creation not supported: {exc}")
+
+        claim_evidence = {
+            1: [{"path": link_rel, "kind": "documentation"}],
+            2: self.claim_evidence[2],
+            3: self.claim_evidence[3],
+        }
+        self._write_claims(evidence=claim_evidence)
+
+        entries = self._entries()
+        entries[0]["evidence"] = [{"kind": "file", "target": link_rel}]
+        self._write_registry(entries)
+
+        output, exit_code = self._run()
+
+        self.assertEqual(exit_code, 1)
+        self.assertTrue(self._has(output, "EVIDENCE_TARGET_MISSING"))
+        self.assertFalse(self._has(output, "EVIDENCE_TARGET_TRAVERSAL"))
+        self.assertFalse(self._has(output, "EVIDENCE_NOT_IN_CLAIM_REGISTRY"))
+        self.assertFalse(self._has(output, "EVIDENCE_MISSING_FROM_FRESHNESS_REGISTRY"))
+
+    def test_symlink_target_inside_repo_passes(self):
+        if not hasattr(os, "symlink"):
+            self.skipTest("os.symlink is not available")
+
+        real_rel = "docs/real-evidence.md"
+        link_rel = "docs/internal-link.md"
+        real_path = self.root / real_rel
+        link_path = self.root / link_rel
+
+        real_path.parent.mkdir(parents=True, exist_ok=True)
+        real_path.write_text("inside\n", encoding="utf-8")
+
+        try:
+            os.symlink(real_path, link_path)
+        except (OSError, NotImplementedError) as exc:
+            self.skipTest(f"symlink creation not supported: {exc}")
+
+        claim_evidence = {
+            1: [{"path": link_rel, "kind": "documentation"}],
+            2: self.claim_evidence[2],
+            3: self.claim_evidence[3],
+        }
+        self._write_claims(evidence=claim_evidence)
+
+        entries = self._entries()
+        entries[0]["evidence"] = [{"kind": "file", "target": link_rel}]
+        self._write_registry(entries)
+
+        output, exit_code = self._run()
+
+        self.assertEqual(exit_code, 0, output["findings"])
 
     def test_empty_evidence_list_fails(self):
         self._write_claims()

--- a/scripts/docmeta/validate_doc_freshness_registry.py
+++ b/scripts/docmeta/validate_doc_freshness_registry.py
@@ -85,19 +85,6 @@ def _strip_yaml_scalar(value: str) -> str:
         return value[1:-1]
     return value
 
-
-def _is_relative_to(path: Path, root: Path) -> bool:
-    """Return True if *path* is under *root* (checked via relative_to).
-
-    Exists because Path.is_relative_to() was added in Python 3.9.
-    """
-    try:
-        path.relative_to(root)
-        return True
-    except ValueError:
-        return False
-
-
 def _resolve_repo_target(repo_root: Path, target: str) -> tuple[Path | None, str | None]:
     """Resolve *target* as a repo-relative path and return its real path.
 
@@ -114,7 +101,7 @@ def _resolve_repo_target(repo_root: Path, target: str) -> tuple[Path | None, str
     except (OSError, RuntimeError):
         return None, "resolution_error"
 
-    if not _is_relative_to(resolved_target, repo_root_resolved):
+    if not resolved_target.is_relative_to(repo_root_resolved):
         return None, "traversal"
     return resolved_target, None
 

--- a/scripts/docmeta/validate_doc_freshness_registry.py
+++ b/scripts/docmeta/validate_doc_freshness_registry.py
@@ -85,6 +85,7 @@ def _strip_yaml_scalar(value: str) -> str:
         return value[1:-1]
     return value
 
+
 def _resolve_repo_target(repo_root: Path, target: str) -> tuple[Path | None, str | None]:
     """Resolve *target* as a repo-relative path and return its real path.
 

--- a/scripts/docmeta/validate_doc_freshness_registry.py
+++ b/scripts/docmeta/validate_doc_freshness_registry.py
@@ -86,6 +86,39 @@ def _strip_yaml_scalar(value: str) -> str:
     return value
 
 
+def _is_relative_to(path: Path, root: Path) -> bool:
+    """Return True if *path* is under *root* (checked via relative_to).
+
+    Exists because Path.is_relative_to() was added in Python 3.9.
+    """
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _resolve_repo_target(repo_root: Path, target: str) -> tuple[Path | None, str | None]:
+    """Resolve *target* as a repo-relative path and return its real path.
+
+    Returns ``(None, "traversal")`` if the resolved path lies outside the repo
+    root, for example through a symlink that escapes the repo boundary.
+
+    Returns ``(None, "resolution_error")`` when the path cannot be resolved,
+    for example because of a cyclic symlink. The caller reports that as a
+    structured missing target instead of letting the validator crash.
+    """
+    try:
+        repo_root_resolved = repo_root.resolve()
+        resolved_target = (repo_root_resolved / target).resolve()
+    except (OSError, RuntimeError):
+        return None, "resolution_error"
+
+    if not _is_relative_to(resolved_target, repo_root_resolved):
+        return None, "traversal"
+    return resolved_target, None
+
+
 def _read_folded_block(
     lines: list[str], start: int, base_indent: int
 ) -> tuple[str, int]:
@@ -397,7 +430,26 @@ def _validate_evidence(
         else:
             kind = item.get("kind")
             if isinstance(kind, str) and kind in EVIDENCE_KINDS_CHECK_PATH:
-                if not (repo_root / target).is_file():
+                resolved_target, resolution_error = _resolve_repo_target(repo_root, target)
+                if resolution_error == "traversal":
+                    findings.append(
+                        _finding(
+                            "EVIDENCE_TARGET_TRAVERSAL",
+                            entry_id,
+                            "Evidence target resolves outside repo root",
+                            path=target,
+                        )
+                    )
+                elif resolution_error is not None:
+                    findings.append(
+                        _finding(
+                            "EVIDENCE_TARGET_MISSING",
+                            entry_id,
+                            "Evidence target does not exist, is not a file, or could not be resolved",
+                            path=target,
+                        )
+                    )
+                elif resolved_target is None or not resolved_target.is_file():
                     findings.append(
                         _finding(
                             "EVIDENCE_TARGET_MISSING",


### PR DESCRIPTION
## Why

Evidence target paths in `docs/doc-freshness-registry.yml` were joined with the repo root and checked with `is_file()`. Because `is_file()` follows symlinks, a path like `docs/innocent.md -> /etc/passwd` would be silently accepted, and a cyclic symlink would raise a bare `OSError` that crashes the validator.

## What changes

- New helper `_resolve_repo_target` resolves the evidence path via `resolve()` and bounds-checks it against the resolved repo root before calling `is_file()`.
- Symlink escape (resolved path outside repo) → reuses existing error code `EVIDENCE_TARGET_TRAVERSAL` (consistent with `..` traversal).
- Unresolvable paths (cyclic symlinks, permission errors) → report `EVIDENCE_TARGET_MISSING` instead of crashing.
- Symlinks that stay inside the repo and point to a real file pass the check (no regression).

## Test coverage

- `test_symlink_target_outside_repo_fails` — symlink escape
- `test_symlink_loop_target_fails_as_missing` — cyclic symlink
- `test_symlink_target_inside_repo_passes` — valid inside-repo symlink
- All 51 existing tests remain green.

## Follow-up (not in this PR)

- Include `resolved_target` in the `EVIDENCE_TARGET_TRAVERSAL` message so the operator sees where the symlink points.
- Register the hardening change in `audit/impl-registry.yaml`.
