### PR TITLE
docs: add claim evidence map details

### DIFF
--- a/docs/_generated/claim-evidence-map.md
+++ b/docs/_generated/claim-evidence-map.md
@@ -30,10 +30,10 @@ Evidence:
 
 | Kind | Target |
 | ---- | ------ |
-| file | `scripts/agent/check_agent_preflight.py` |
-| test | `scripts/agent/tests/test_check_agent_preflight.py` |
-| file | `.github/workflows/agent-safety-preflight.yml` |
-| file | `docs/security/agent-write-scope-baseline.md` |
+| `file` | `scripts/agent/check_agent_preflight.py` |
+| `test` | `scripts/agent/tests/test_check_agent_preflight.py` |
+| `file` | `.github/workflows/agent-safety-preflight.yml` |
+| `file` | `docs/security/agent-write-scope-baseline.md` |
 
 Does not prove:
 
@@ -51,9 +51,9 @@ Evidence:
 
 | Kind | Target |
 | ---- | ------ |
-| file | `scripts/docmeta/generate_agent_readiness.py` |
-| test | `scripts/docmeta/tests/test_generate_agent_readiness.py` |
-| file | `docs/_generated/agent-readiness.md` |
+| `file` | `scripts/docmeta/generate_agent_readiness.py` |
+| `test` | `scripts/docmeta/tests/test_generate_agent_readiness.py` |
+| `file` | `docs/_generated/agent-readiness.md` |
 
 Does not prove:
 
@@ -71,10 +71,10 @@ Evidence:
 
 | Kind | Target |
 | ---- | ------ |
-| file | `docs/claims/registry.yml` |
-| file | `docs/claims/README.md` |
-| file | `scripts/docmeta/validate_claim_registry.py` |
-| test | `scripts/docmeta/tests/test_validate_claim_registry.py` |
+| `file` | `docs/claims/registry.yml` |
+| `file` | `docs/claims/README.md` |
+| `file` | `scripts/docmeta/validate_claim_registry.py` |
+| `test` | `scripts/docmeta/tests/test_validate_claim_registry.py` |
 
 Does not prove:
 

--- a/docs/_generated/claim-evidence-map.md
+++ b/docs/_generated/claim-evidence-map.md
@@ -19,6 +19,7 @@ Generated automatically. Do not edit.
 ## Details
 
 ### CLAIM-AGENT-SAFE-001
+
 - Entry: `claim-agent-safe-001`
 - Locator: `claims[id=CLAIM-AGENT-SAFE-001]`
 - Status: `partial`
@@ -35,9 +36,11 @@ Evidence:
 | file | `docs/security/agent-write-scope-baseline.md` |
 
 Does not prove:
+
 - A green verify does not prove the claims are true or complete, only that no declared claim contradicts its declared evidence.
 
 ### CLAIM-AGENT-SAFE-002
+
 - Entry: `claim-agent-safe-002`
 - Locator: `claims[id=CLAIM-AGENT-SAFE-002]`
 - Status: `partial`
@@ -53,9 +56,11 @@ Evidence:
 | file | `docs/_generated/agent-readiness.md` |
 
 Does not prove:
+
 - A green verify does not prove the claims are true or complete, only that no declared claim contradicts its declared evidence.
 
 ### CLAIM-AGENT-SAFE-003
+
 - Entry: `claim-agent-safe-003`
 - Locator: `claims[id=CLAIM-AGENT-SAFE-003]`
 - Status: `partial`
@@ -72,4 +77,5 @@ Evidence:
 | test | `scripts/docmeta/tests/test_validate_claim_registry.py` |
 
 Does not prove:
+
 - A green verify does not prove the claims are true or complete, only that no declared claim contradicts its declared evidence.

--- a/docs/_generated/claim-evidence-map.md
+++ b/docs/_generated/claim-evidence-map.md
@@ -15,3 +15,61 @@ Generated automatically. Do not edit.
 | claim-agent-safe-001 | docs/claims/registry.yml | claims[id=CLAIM-AGENT-SAFE-001] | partial | docs-mechanik | 2026-06-05 | 4 items |
 | claim-agent-safe-002 | docs/claims/registry.yml | claims[id=CLAIM-AGENT-SAFE-002] | partial | docs-mechanik | 2026-06-05 | 3 items |
 | claim-agent-safe-003 | docs/claims/registry.yml | claims[id=CLAIM-AGENT-SAFE-003] | partial | docs-mechanik | 2026-06-05 | 4 items |
+
+## Details
+
+### CLAIM-AGENT-SAFE-001
+- Entry: `claim-agent-safe-001`
+- Locator: `claims[id=CLAIM-AGENT-SAFE-001]`
+- Status: `partial`
+- Owner: `docs-mechanik`
+- Last verified: `2026-06-05`
+
+Evidence:
+
+| Kind | Target |
+| ---- | ------ |
+| file | `scripts/agent/check_agent_preflight.py` |
+| test | `scripts/agent/tests/test_check_agent_preflight.py` |
+| file | `.github/workflows/agent-safety-preflight.yml` |
+| file | `docs/security/agent-write-scope-baseline.md` |
+
+Does not prove:
+- A green verify does not prove the claims are true or complete, only that no declared claim contradicts its declared evidence.
+
+### CLAIM-AGENT-SAFE-002
+- Entry: `claim-agent-safe-002`
+- Locator: `claims[id=CLAIM-AGENT-SAFE-002]`
+- Status: `partial`
+- Owner: `docs-mechanik`
+- Last verified: `2026-06-05`
+
+Evidence:
+
+| Kind | Target |
+| ---- | ------ |
+| file | `scripts/docmeta/generate_agent_readiness.py` |
+| test | `scripts/docmeta/tests/test_generate_agent_readiness.py` |
+| file | `docs/_generated/agent-readiness.md` |
+
+Does not prove:
+- A green verify does not prove the claims are true or complete, only that no declared claim contradicts its declared evidence.
+
+### CLAIM-AGENT-SAFE-003
+- Entry: `claim-agent-safe-003`
+- Locator: `claims[id=CLAIM-AGENT-SAFE-003]`
+- Status: `partial`
+- Owner: `docs-mechanik`
+- Last verified: `2026-06-05`
+
+Evidence:
+
+| Kind | Target |
+| ---- | ------ |
+| file | `docs/claims/registry.yml` |
+| file | `docs/claims/README.md` |
+| file | `scripts/docmeta/validate_claim_registry.py` |
+| test | `scripts/docmeta/tests/test_validate_claim_registry.py` |
+
+Does not prove:
+- A green verify does not prove the claims are true or complete, only that no declared claim contradicts its declared evidence.

--- a/scripts/docmeta/generate_claim_evidence_map.py
+++ b/scripts/docmeta/generate_claim_evidence_map.py
@@ -28,6 +28,14 @@ MARKDOWN_REL = "docs/_generated/claim-evidence-map.md"
 GENERATOR_REL = "scripts/docmeta/generate_claim_evidence_map.py"
 
 
+def _claim_id_from_locator(locator: object) -> str:
+    if isinstance(locator, str):
+        prefix = "claims[id="
+        suffix = "]"
+        if locator.startswith(prefix) and locator.endswith(suffix):
+            return locator[len(prefix):-len(suffix)]
+    return "UNKNOWN"
+
 def _build_entries(data: object) -> list[dict[str, object]]:
     raw_entries = data.get("entries", []) if isinstance(data, dict) else []
     entries: list[dict[str, object]] = []
@@ -40,14 +48,17 @@ def _build_entries(data: object) -> list[dict[str, object]]:
         valid_evidence = []
         for item in evidence:
             if isinstance(item, dict):
-                valid_evidence.append({
-                    "kind": item.get("kind"),
-                    "target": item.get("target")
-                })
+                valid_evidence.append(
+                    {
+                        "kind": item.get("kind"),
+                        "target": item.get("target"),
+                    }
+                )
 
         entries.append(
             {
                 "id": raw.get("id"),
+                "claim_id": _claim_id_from_locator(raw.get("locator")),
                 "doc": raw.get("doc"),
                 "locator": raw.get("locator"),
                 "status": raw.get("status"),
@@ -110,10 +121,10 @@ def render_markdown(data: object) -> str:
             lines.append("| Kind | Target |")
             lines.append("| ---- | ------ |")
 
-            # Sort evidence if possible (keep original if not needed, but deterministic is good)
-            sorted_evidence = entry["evidence"] # We can sort it if needed later
-            for ev in sorted_evidence:
-                lines.append(f"| {ev.get('kind', '')} | `{ev.get('target', '')}` |")
+            for ev in entry.get("evidence", []):
+                kind = "" if ev.get("kind") is None else str(ev.get("kind"))
+                target = "" if ev.get("target") is None else str(ev.get("target"))
+                lines.append(f"| `{kind}` | `{target}` |")
 
             if does_not_prove and isinstance(does_not_prove, list):
                 lines.append("")

--- a/scripts/docmeta/generate_claim_evidence_map.py
+++ b/scripts/docmeta/generate_claim_evidence_map.py
@@ -106,7 +106,7 @@ def render_markdown(data: object) -> str:
         lines.append("## Details")
         lines.append("")
         for entry in entries:
-            claim_id = str(entry["id"]).upper() if entry.get("id") else "UNKNOWN"
+            claim_id = str(entry.get("claim_id") or "UNKNOWN")
             lines.append(f"### {claim_id}")
             lines.append("")
             lines.append(f"- Entry: `{entry['id']}`")

--- a/scripts/docmeta/generate_claim_evidence_map.py
+++ b/scripts/docmeta/generate_claim_evidence_map.py
@@ -36,6 +36,15 @@ def _build_entries(data: object) -> list[dict[str, object]]:
             continue
         evidence = raw.get("evidence") or []
         evidence_count = sum(1 for item in evidence if isinstance(item, dict))
+
+        valid_evidence = []
+        for item in evidence:
+            if isinstance(item, dict):
+                valid_evidence.append({
+                    "kind": item.get("kind"),
+                    "target": item.get("target")
+                })
+
         entries.append(
             {
                 "id": raw.get("id"),
@@ -45,6 +54,7 @@ def _build_entries(data: object) -> list[dict[str, object]]:
                 "owner": raw.get("owner"),
                 "last_verified": raw.get("last_verified"),
                 "evidence_count": evidence_count,
+                "evidence": valid_evidence,
             }
         )
 
@@ -54,6 +64,10 @@ def _build_entries(data: object) -> list[dict[str, object]]:
 
 def render_markdown(data: object) -> str:
     entries = _build_entries(data)
+
+    does_not_prove = []
+    if isinstance(data, dict):
+        does_not_prove = data.get("does_not_prove", [])
     lines: list[str] = []
     lines.append("---")
     lines.append("id: docs.generated.claim-evidence-map")
@@ -75,6 +89,43 @@ def render_markdown(data: object) -> str:
             f"| {entry['status']} | {entry['owner']} | {entry['last_verified']} "
             f"| {entry['evidence_count']} items |"
         )
+    lines.append("")
+
+    if entries:
+        lines.append("## Details")
+        lines.append("")
+        for entry in entries:
+            claim_id = str(entry["id"]).upper() if entry.get("id") else "UNKNOWN"
+            lines.append(f"### {claim_id}")
+            lines.append(f"- Entry: `{entry['id']}`")
+            lines.append(f"- Locator: `{entry['locator']}`")
+            lines.append(f"- Status: `{entry['status']}`")
+            lines.append(f"- Owner: `{entry['owner']}`")
+            lines.append(f"- Last verified: `{entry['last_verified']}`")
+
+            lines.append("")
+            lines.append("Evidence:")
+            lines.append("")
+            lines.append("| Kind | Target |")
+            lines.append("| ---- | ------ |")
+
+            # Sort evidence if possible (keep original if not needed, but deterministic is good)
+            sorted_evidence = entry["evidence"] # We can sort it if needed later
+            for ev in sorted_evidence:
+                lines.append(f"| {ev.get('kind', '')} | `{ev.get('target', '')}` |")
+
+            if does_not_prove and isinstance(does_not_prove, list):
+                lines.append("")
+                lines.append("Does not prove:")
+                for item in does_not_prove:
+                    lines.append(f"- {item}")
+
+            lines.append("")
+
+    # Remove the last empty line to match the previous structure ending
+    if lines and lines[-1] == "":
+        lines.pop()
+
     lines.append("")
     return "\n".join(lines)
 

--- a/scripts/docmeta/generate_claim_evidence_map.py
+++ b/scripts/docmeta/generate_claim_evidence_map.py
@@ -97,6 +97,7 @@ def render_markdown(data: object) -> str:
         for entry in entries:
             claim_id = str(entry["id"]).upper() if entry.get("id") else "UNKNOWN"
             lines.append(f"### {claim_id}")
+            lines.append("")
             lines.append(f"- Entry: `{entry['id']}`")
             lines.append(f"- Locator: `{entry['locator']}`")
             lines.append(f"- Status: `{entry['status']}`")
@@ -117,6 +118,7 @@ def render_markdown(data: object) -> str:
             if does_not_prove and isinstance(does_not_prove, list):
                 lines.append("")
                 lines.append("Does not prove:")
+                lines.append("")
                 for item in does_not_prove:
                     lines.append(f"- {item}")
 

--- a/scripts/docmeta/tests/test_generate_claim_evidence_map.py
+++ b/scripts/docmeta/tests/test_generate_claim_evidence_map.py
@@ -96,6 +96,10 @@ class TestGenerateClaimEvidenceMap(unittest.TestCase):
         payload = {
             "kind": "lenskit.doc_freshness_registry",
             "version": "1.0",
+            "does_not_prove": [
+                "truth",
+                "completeness"
+            ],
             "entries": entries if entries is not None else self._entries(),
         }
         path = self.root / gen.REGISTRY_REL
@@ -174,6 +178,37 @@ class TestGenerateClaimEvidenceMap(unittest.TestCase):
         self.assertNotIn("stale", md)
         self.assertNotIn("unknown", md)
         self.assertIn("2026-06-05", md)
+
+    # --- new detail section -------------------------------------------------
+
+    def test_markdown_shows_details_sections(self):
+        self._write_registry()
+        gen.generate(self.root)
+        md = self._read_md()
+        self.assertIn("## Details", md)
+        self.assertIn("### CLAIM-AGENT-SAFE-001", md)
+        self.assertIn("- Entry: `claim-agent-safe-001`", md)
+        self.assertIn("- Locator: `claims[id=CLAIM-AGENT-SAFE-001]`", md)
+        self.assertIn("- Status: `partial`", md)
+        self.assertIn("- Owner: `docs-mechanik`", md)
+        self.assertIn("- Last verified: `2026-06-05`", md)
+
+    def test_markdown_shows_evidence_table_in_details(self):
+        self._write_registry()
+        gen.generate(self.root)
+        md = self._read_md()
+        self.assertIn("Evidence:", md)
+        self.assertIn("| Kind | Target |", md)
+        self.assertIn("| file | `scripts/agent/impl_001.py` |", md)
+        self.assertIn("| test | `scripts/agent/tests/test_001.py` |", md)
+
+    def test_markdown_shows_does_not_prove(self):
+        self._write_registry()
+        gen.generate(self.root)
+        md = self._read_md()
+        self.assertIn("Does not prove:", md)
+        self.assertIn("- truth", md)
+        self.assertIn("- completeness", md)
 
     # --- --check drift ------------------------------------------------------
 

--- a/scripts/docmeta/tests/test_generate_claim_evidence_map.py
+++ b/scripts/docmeta/tests/test_generate_claim_evidence_map.py
@@ -199,8 +199,8 @@ class TestGenerateClaimEvidenceMap(unittest.TestCase):
         md = self._read_md()
         self.assertIn("Evidence:", md)
         self.assertIn("| Kind | Target |", md)
-        self.assertIn("| file | `scripts/agent/impl_001.py` |", md)
-        self.assertIn("| test | `scripts/agent/tests/test_001.py` |", md)
+        self.assertIn("| `file` | `scripts/agent/impl_001.py` |", md)
+        self.assertIn("| `test` | `scripts/agent/tests/test_001.py` |", md)
 
     def test_markdown_shows_does_not_prove(self):
         self._write_registry()
@@ -260,3 +260,24 @@ class TestGenerateClaimEvidenceMap(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+    def test_markdown_shows_custom_locator_heading(self):
+        entries = self._entries()
+        entries[0]["locator"] = "claims[id=CLAIM-CUSTOM-XYZ]"
+        self._write_registry(entries)
+        gen.generate(self.root)
+        md = self._read_md()
+        self.assertIn("### CLAIM-CUSTOM-XYZ", md)
+
+    def test_markdown_omits_does_not_prove_if_missing(self):
+        payload = {
+            "kind": "lenskit.doc_freshness_registry",
+            "version": "1.0",
+            "entries": self._entries(),
+        }
+        path = self.root / gen.REGISTRY_REL
+        import json
+        path.write_text("---\n" + json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        gen.generate(self.root)
+        md = self._read_md()
+        self.assertNotIn("Does not prove:", md)

--- a/scripts/docmeta/tests/test_generate_claim_evidence_map.py
+++ b/scripts/docmeta/tests/test_generate_claim_evidence_map.py
@@ -257,16 +257,21 @@ class TestGenerateClaimEvidenceMap(unittest.TestCase):
 
         self.assertIn("Freshness registry validation failed", str(ctx.exception))
 
-
-if __name__ == "__main__":
-    unittest.main()
-
     def test_markdown_shows_custom_locator_heading(self):
-        entries = self._entries()
-        entries[0]["locator"] = "claims[id=CLAIM-CUSTOM-XYZ]"
-        self._write_registry(entries)
-        gen.generate(self.root)
-        md = self._read_md()
+        # We test the render_markdown directly to avoid validator errors
+        # on custom locator formats.
+        data = {
+            "entries": [
+                {
+                    "id": "claim-custom-xyz",
+                    "locator": "claims[id=CLAIM-CUSTOM-XYZ]",
+                    "status": "partial",
+                    "owner": "docs",
+                    "last_verified": "2026-01-01",
+                }
+            ]
+        }
+        md = gen.render_markdown(data)
         self.assertIn("### CLAIM-CUSTOM-XYZ", md)
 
     def test_markdown_omits_does_not_prove_if_missing(self):
@@ -281,3 +286,6 @@ if __name__ == "__main__":
         gen.generate(self.root)
         md = self._read_md()
         self.assertNotIn("Does not prove:", md)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds deterministic per-claim detail sections to the generated claim evidence map. Keeps the existing overview table, does not change claim scope, registries, validator semantics, evidence kinds, or JSON artifacts.

---
*PR created automatically by Jules for task [14525753647805922407](https://jules.google.com/task/14525753647805922407) started by @alexdermohr*