### PR TITLE
docs: close DOCMETA-WARN-MODE-001 — warn-mode stderr semantics for docmeta guards

### DIFF
--- a/architecture/blueprint.docmeta-engine.md
+++ b/architecture/blueprint.docmeta-engine.md
@@ -121,7 +121,7 @@ Ziel: Policy (in `manifest/review-policy.yaml`) ist verständlich und wirkt wie 
 
 Mode-Semantik anwenden in `check_links.py` und `review_impact.py`:
 
-- [ ] `warn` Mode: Niemals `exit 1` wegen fehlenden IDs oder broken Links, nur `stderr` Warnungen.
+- [x] `warn` Mode: Niemals `exit 1` wegen fehlenden IDs oder broken Links, nur `stderr` Warnungen.
 - [x] `strict` / `fail-closed` Mode: `exit 1` bei "echten Fehlern" (missing id, cycles, broken doc-links).
 
 ### 4.2 Fehler vs. Unknowns definieren

--- a/docs/tasks/board.md
+++ b/docs/tasks/board.md
@@ -62,6 +62,7 @@ relations:
 | ID | Bereich | Titel | Evidenz |
 |---|---|---|---|
 | TASK-CTL-001 | docs | Task-Control Phase 2 etablieren | `docs/tasks/`, `docs/reports/optimierungsstatus.json`, `scripts/docmeta/validate_task_index.py`, `scripts/docmeta/tests/test_validate_task_index.py` |
+| DOCMETA-WARN-MODE-001 | docs | Warn-Mode stderr semantics für Docmeta-Guards schließen | `scripts/docmeta/review_impact.py`, `scripts/docmeta/check_links.py`, `scripts/docmeta/tests/test_review_impact.py`, `scripts/docmeta/tests/test_check_links.py`, `architecture/blueprint.docmeta-engine.md` |
 | OPT-DOC-001 | docs | Incident-/DB-Recovery-Runbooks | `docs/runbooks/incident-response.md`, `docs/runbooks/db-recovery.md`; Navigation in `docs/runbooks/README.md` + `docs/index.md`; Drill-Querverweis in `docs/runbook.md` §2; Doku-Hygiene-Guards grün |
 | OPT-MAP-001 | map | Basemap Runtime Proof | CI-Job `basemap-range-delivery-proof` PROVEN, Commit `14feefd6` |
 | OPT-API-002 | api | Session-Persistenz PostgreSQL | `apps/api/src/auth/session_db.rs`, CI PROVEN, Commit `00a43a00` |

--- a/docs/tasks/index.json
+++ b/docs/tasks/index.json
@@ -397,6 +397,38 @@
       "updated_at": "2026-06-09"
     },
     {
+      "id": "DOCMETA-WARN-MODE-001",
+      "title": "Warn-Mode stderr semantics für Docmeta-Guards schließen",
+      "area": "docs",
+      "status": "done",
+      "priority": "medium",
+      "effort": "S",
+      "risk": "medium",
+      "owner": "docs-mechanik",
+      "evidence": [
+        "scripts/docmeta/review_impact.py",
+        "scripts/docmeta/check_links.py",
+        "scripts/docmeta/tests/test_review_impact.py",
+        "scripts/docmeta/tests/test_check_links.py",
+        "architecture/blueprint.docmeta-engine.md"
+      ],
+      "missing_evidence": [],
+      "acceptance": [
+        "warn-Mode meldet fehlende Doc-IDs auf stderr und endet mit Exit-Code 0",
+        "warn-Mode meldet broken doc:<id>-Links auf stderr und endet mit Exit-Code 0",
+        "strict / fail-closed blockieren weiterhin bei missing IDs und broken doc links",
+        "Blueprint-Checkbox ist nur gesetzt, weil Code und Tests beide Oberflächen abdecken"
+      ],
+      "links": {
+        "issues": [],
+        "prs": [],
+        "docs": [
+          "architecture/blueprint.docmeta-engine.md"
+        ]
+      },
+      "updated_at": "2026-06-09"
+    },
+    {
       "id": "OPT-API-001",
       "title": "Paginierung Listen-Endpunkte",
       "area": "api",

--- a/scripts/docmeta/review_impact.py
+++ b/scripts/docmeta/review_impact.py
@@ -80,6 +80,7 @@ def main():
 
             frontmatter = parse_frontmatter(file_path)
             if not frontmatter:
+                missing_ids.append(rel_file_path)
                 continue
 
             doc_id = frontmatter.get('id')

--- a/scripts/docmeta/review_impact.py
+++ b/scripts/docmeta/review_impact.py
@@ -125,7 +125,7 @@ def main():
 
         return cycles
 
-    missing_ids = sorted(list(set(missing_ids)))
+    missing_ids = sorted(set(missing_ids))
 
     if missing_ids and mode == 'warn':
         print(

--- a/scripts/docmeta/review_impact.py
+++ b/scripts/docmeta/review_impact.py
@@ -126,6 +126,14 @@ def main():
 
     missing_ids = sorted(list(set(missing_ids)))
 
+    if missing_ids and mode == 'warn':
+        print(
+            f"Warning: {len(missing_ids)} document(s) missing 'id' in frontmatter:",
+            file=sys.stderr,
+        )
+        for mid in missing_ids:
+            print(f"- {mid}", file=sys.stderr)
+
     if missing_ids and mode in ['strict', 'fail-closed']:
         print(f"Error: {len(missing_ids)} document(s) missing 'id' in frontmatter:", file=sys.stderr)
         for mid in missing_ids:

--- a/scripts/docmeta/tests/test_check_links.py
+++ b/scripts/docmeta/tests/test_check_links.py
@@ -82,6 +82,29 @@ class TestCheckLinks(unittest.TestCase):
         self.assertIn("Broken link", err)
         self.assertIn("does not exist", err)
 
+    def test_doc_link_unknown_id_fail_closed(self):
+        """Broken doc links remain blocking in fail-closed mode."""
+        exit_code, out, err = self.run_check_links(
+            "This is a [link](doc:unknown.id)",
+            index_content={"docs": []},
+            mode='fail-closed',
+        )
+        self.assertEqual(exit_code, 1)
+        self.assertIn("Broken link", err)
+        self.assertIn("does not exist", err)
+
+    def test_broken_doc_link_warn_mode_emits_stderr_and_exits_zero(self):
+        """Broken doc links warn on stderr without failing in warn mode."""
+        exit_code, out, err = self.run_check_links(
+            "This is a [link](doc:does-not-exist)",
+            index_content={"docs": []},
+            mode='warn',
+        )
+        self.assertEqual(exit_code, 0)
+        self.assertIn("Warnings", err)
+        self.assertIn("does-not-exist", err)
+        self.assertNotIn("Warnings", out)
+
     def test_doc_link_known_id(self):
         """3. doc:known.id bei vorhandenem index -> pass"""
         index = {"docs": [{"id": "known.id"}]}

--- a/scripts/docmeta/tests/test_review_impact.py
+++ b/scripts/docmeta/tests/test_review_impact.py
@@ -202,6 +202,10 @@ class TestReviewImpact(unittest.TestCase):
         self.assertNotIn("warning", captured_out.getvalue().lower())
         self.assertIn("completed successfully", captured_out.getvalue())
 
+        data = self._load_impact_json()
+        self.assertIn("missing_ids", data)
+        self.assertIn("docs/no_frontmatter.md", data["missing_ids"])
+
     @patch('scripts.docmeta.review_impact.parse_review_policy')
     @patch('scripts.docmeta.review_impact.parse_repo_index')
     def test_missing_id_warn_mode_empty_frontmatter_emits_stderr_and_exits_zero(
@@ -231,6 +235,10 @@ class TestReviewImpact(unittest.TestCase):
         self.assertIn("warning", captured_err.getvalue().lower())
         self.assertIn("docs/empty_frontmatter.md", captured_err.getvalue())
         self.assertNotIn("warning", captured_out.getvalue().lower())
+
+        data = self._load_impact_json()
+        self.assertIn("missing_ids", data)
+        self.assertIn("docs/empty_frontmatter.md", data["missing_ids"])
 
     @patch('scripts.docmeta.review_impact.parse_review_policy')
     @patch('scripts.docmeta.review_impact.parse_repo_index')

--- a/scripts/docmeta/tests/test_review_impact.py
+++ b/scripts/docmeta/tests/test_review_impact.py
@@ -173,6 +173,99 @@ class TestReviewImpact(unittest.TestCase):
 
     @patch('scripts.docmeta.review_impact.parse_review_policy')
     @patch('scripts.docmeta.review_impact.parse_repo_index')
+    def test_missing_id_warn_mode_no_frontmatter_emits_stderr_and_exits_zero(
+        self, mock_parse_repo_index, mock_parse_review_policy
+    ):
+        """Warn mode reports canonical documents without frontmatter."""
+        mock_parse_review_policy.return_value = {
+            "mode": "warn", "strict_manifest": False,
+            "warn_days": 90, "fail_days": 180,
+        }
+        mock_parse_repo_index.return_value = {
+            "zones": {
+                "norm": {
+                    "path": "docs/",
+                    "canonical_docs": ["no_frontmatter.md"],
+                }
+            }
+        }
+        self._write_doc("docs/no_frontmatter.md", "Body without frontmatter\n")
+
+        captured_out = io.StringIO()
+        captured_err = io.StringIO()
+        with redirect_stdout(captured_out), redirect_stderr(captured_err):
+            with patch('scripts.docmeta.review_impact.REPO_ROOT', self.temp_dir):
+                main()
+
+        self.assertIn("warning", captured_err.getvalue().lower())
+        self.assertIn("docs/no_frontmatter.md", captured_err.getvalue())
+        self.assertNotIn("warning", captured_out.getvalue().lower())
+        self.assertIn("completed successfully", captured_out.getvalue())
+
+    @patch('scripts.docmeta.review_impact.parse_review_policy')
+    @patch('scripts.docmeta.review_impact.parse_repo_index')
+    def test_missing_id_warn_mode_empty_frontmatter_emits_stderr_and_exits_zero(
+        self, mock_parse_repo_index, mock_parse_review_policy
+    ):
+        """Warn mode reports canonical documents with empty frontmatter."""
+        mock_parse_review_policy.return_value = {
+            "mode": "warn", "strict_manifest": False,
+            "warn_days": 90, "fail_days": 180,
+        }
+        mock_parse_repo_index.return_value = {
+            "zones": {
+                "norm": {
+                    "path": "docs/",
+                    "canonical_docs": ["empty_frontmatter.md"],
+                }
+            }
+        }
+        self._write_doc("docs/empty_frontmatter.md", "---\n---\nBody\n")
+
+        captured_out = io.StringIO()
+        captured_err = io.StringIO()
+        with redirect_stdout(captured_out), redirect_stderr(captured_err):
+            with patch('scripts.docmeta.review_impact.REPO_ROOT', self.temp_dir):
+                main()
+
+        self.assertIn("warning", captured_err.getvalue().lower())
+        self.assertIn("docs/empty_frontmatter.md", captured_err.getvalue())
+        self.assertNotIn("warning", captured_out.getvalue().lower())
+
+    @patch('scripts.docmeta.review_impact.parse_review_policy')
+    @patch('scripts.docmeta.review_impact.parse_repo_index')
+    def test_missing_id_empty_frontmatter_strict_mode_exits(
+        self, mock_parse_repo_index, mock_parse_review_policy
+    ):
+        """Empty frontmatter remains blocking in strict mode."""
+        mock_parse_review_policy.return_value = {
+            "mode": "strict", "strict_manifest": False,
+            "warn_days": 90, "fail_days": 180,
+        }
+        mock_parse_repo_index.return_value = {
+            "zones": {
+                "norm": {
+                    "path": "docs/",
+                    "canonical_docs": ["empty_frontmatter.md"],
+                }
+            }
+        }
+        self._write_doc("docs/empty_frontmatter.md", "---\n---\nBody\n")
+
+        captured_out = io.StringIO()
+        captured_err = io.StringIO()
+        with self.assertRaises(SystemExit) as ctx:
+            with redirect_stdout(captured_out), redirect_stderr(captured_err):
+                with patch('scripts.docmeta.review_impact.REPO_ROOT', self.temp_dir):
+                    main()
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("error", captured_err.getvalue().lower())
+        self.assertIn("missing", captured_err.getvalue().lower())
+        self.assertIn("docs/empty_frontmatter.md", captured_err.getvalue())
+
+    @patch('scripts.docmeta.review_impact.parse_review_policy')
+    @patch('scripts.docmeta.review_impact.parse_repo_index')
     def test_missing_id_strict_mode_exits(self, mock_parse_repo_index, mock_parse_review_policy):
         """Documents missing 'id' in strict mode should cause exit."""
         mock_parse_review_policy.return_value = {

--- a/scripts/docmeta/tests/test_review_impact.py
+++ b/scripts/docmeta/tests/test_review_impact.py
@@ -142,6 +142,37 @@ class TestReviewImpact(unittest.TestCase):
 
     @patch('scripts.docmeta.review_impact.parse_review_policy')
     @patch('scripts.docmeta.review_impact.parse_repo_index')
+    def test_missing_id_warn_mode_emits_stderr_and_exits_zero(
+        self, mock_parse_repo_index, mock_parse_review_policy
+    ):
+        """Warn mode reports missing IDs on stderr without failing."""
+        mock_parse_review_policy.return_value = {
+            "mode": "warn", "strict_manifest": False,
+            "warn_days": 90, "fail_days": 180,
+        }
+        mock_parse_repo_index.return_value = {
+            "zones": {
+                "norm": {
+                    "path": "docs/",
+                    "canonical_docs": ["no_id.md"],
+                }
+            }
+        }
+        self._write_doc("docs/no_id.md", "---\ntitle: No ID\n---\n")
+
+        captured_out = io.StringIO()
+        captured_err = io.StringIO()
+        with redirect_stdout(captured_out), redirect_stderr(captured_err):
+            with patch('scripts.docmeta.review_impact.REPO_ROOT', self.temp_dir):
+                main()
+
+        self.assertIn("warning", captured_err.getvalue().lower())
+        self.assertIn("docs/no_id.md", captured_err.getvalue())
+        self.assertNotIn("warning", captured_out.getvalue().lower())
+        self.assertIn("completed successfully", captured_out.getvalue())
+
+    @patch('scripts.docmeta.review_impact.parse_review_policy')
+    @patch('scripts.docmeta.review_impact.parse_repo_index')
     def test_missing_id_strict_mode_exits(self, mock_parse_repo_index, mock_parse_review_policy):
         """Documents missing 'id' in strict mode should cause exit."""
         mock_parse_review_policy.return_value = {
@@ -158,6 +189,36 @@ class TestReviewImpact(unittest.TestCase):
         }
         mock_parse_repo_index.return_value = repo_index
 
+        self._write_doc("docs/no_id.md", "---\ntitle: No ID\n---\n")
+
+        captured_out = io.StringIO()
+        captured_err = io.StringIO()
+        with self.assertRaises(SystemExit) as ctx:
+            with redirect_stdout(captured_out), redirect_stderr(captured_err):
+                with patch('scripts.docmeta.review_impact.REPO_ROOT', self.temp_dir):
+                    main()
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("missing", captured_err.getvalue().lower())
+
+    @patch('scripts.docmeta.review_impact.parse_review_policy')
+    @patch('scripts.docmeta.review_impact.parse_repo_index')
+    def test_missing_id_fail_closed_mode_exits(
+        self, mock_parse_repo_index, mock_parse_review_policy
+    ):
+        """Documents missing IDs remain blocking in fail-closed mode."""
+        mock_parse_review_policy.return_value = {
+            "mode": "fail-closed", "strict_manifest": False,
+            "warn_days": 90, "fail_days": 180,
+        }
+        mock_parse_repo_index.return_value = {
+            "zones": {
+                "norm": {
+                    "path": "docs/",
+                    "canonical_docs": ["no_id.md"],
+                }
+            }
+        }
         self._write_doc("docs/no_id.md", "---\ntitle: No ID\n---\n")
 
         captured_out = io.StringIO()


### PR DESCRIPTION
### Motivation

- Schließe das offene Blueprint-Bit `warn` Mode: Warnmeldungen müssen sichtbar nach `stderr`, dürfen jedoch im `warn`-Mode nicht mit `exit 1` die Ausführung blockieren.  
- Erhalte bestehendes Verhalten für `strict` / `fail-closed`: diese Modi müssen weiterhin bei echten Fehlern mit Exit-Code `1` blockieren.  

### Description

- `scripts/docmeta/review_impact.py`: Füge dedizierte `warn`-Mode-Ausgabe hinzu, die bei nicht-leeren `missing_ids` eine Warnung auf `stderr` druckt, aber nicht `sys.exit(1)` aufruft; `strict`/`fail-closed` bleiben unverändert blockierend. (`scripts/docmeta/review_impact.py`)  
- Tests ergänzt: `scripts/docmeta/tests/test_review_impact.py` enthält jetzt `test_missing_id_warn_mode_emits_stderr_and_exits_zero` sowie Regressionstests für `strict`/`fail-closed`.  
- Tests ergänzt: `scripts/docmeta/tests/test_check_links.py` enthält `test_broken_doc_link_warn_mode_emits_stderr_and_exits_zero` und ein `fail-closed`-Regressionsszenario; `scripts/docmeta/check_links.py` selbst war bereits korrekt und blieb unverändert.  
- Dokumentation / task-control: Setze die Blueprint-Checkbox in `architecture/blueprint.docmeta-engine.md` auf `[x]` und registriere `DOCMETA-WARN-MODE-001` in `docs/tasks/board.md` und `docs/tasks/index.json` mit Evidenz- und Akzeptanzkriterien.  

### Testing

- Bytecode / syntax checks: `python3 -m py_compile` für die relevanten Module bestanden.  
- Fokus-Unit-Tests: `python3 -m unittest scripts.docmeta.tests.test_review_impact` (12 tests) — OK; `python3 -m unittest scripts.docmeta.tests.test_check_links` (10 tests) — OK.  
- Vollständige Docmeta-Test-Suite: `python3 -m unittest discover scripts/docmeta/tests/` (432 tests) — OK.  
- Laufende Guard-/Tool-Checks: `python3 -m scripts.docmeta.review_impact`, `python3 -m scripts.docmeta.check_links`, `python3 -m scripts.docmeta.validate_schema`, `python3 -m scripts.docmeta.validate_relations`, `python3 -m scripts.docmeta.check_repo_index_consistency`, `python3 -m scripts.docmeta.check_doc_review_age` und `python3 -m scripts.docmeta.generate_claim_evidence_map --check` liefen erfolgreich.  
- Task/CI validations: `python3 -m scripts.docmeta.validate_task_index docs/tasks/index.json` und `python3 -m scripts.docmeta.generate_task_index --check` liefen erfolgreich.  

All automated checks listed above passed in this environment; new tests assert that `warn`-Mode emits human warnings to `stderr` while exiting with code `0`, and that `strict`/`fail-closed` continue to fail with `exit 1` for the same conditions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2867a853fc832ca8bf1603bc9c9ff8)