### PR TITLE
docs: add start-here navigation and system-map drift guard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down logs ps smoke docs-guard validate ci-validate validate-tests validate-core validate-guards validate-shell-tests generate diagnose prepare-commit
+.PHONY: up down logs ps smoke docs-guard validate ci-validate validate-tests validate-core validate-guards validate-shell-tests generate diagnose prepare-commit generate-system-map check-system-map-drift
 
 validate-tests:
 	python3 -m unittest discover scripts/docmeta/tests/
@@ -17,7 +17,13 @@ validate-core:
 	python3 -m scripts.docmeta.generate_audit_gaps
 	python3 -m scripts.docmeta.check_links
 
-validate-guards:
+generate-system-map:
+	python3 -m scripts.docmeta.generate_system_map
+
+check-system-map-drift: generate-system-map
+	git diff --exit-code HEAD -- docs/_generated/system-map.md
+
+validate-guards: check-system-map-drift
 	bash scripts/docmeta/repo-structure-guard.sh
 	bash scripts/docmeta/docs-relations-guard.sh
 	bash scripts/docmeta/generated-files-guard.sh

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ Mobile-first Webprojekt mit SvelteKit (Web), Rust/Axum (API), Postgres + Outbox,
 - Code-Re-Entry erfolgt über die **Gates A–D**; siehe [`docs/process/fahrplan.md`](docs/process/fahrplan.md).
 - Wahrheit und Konfliktauflösung folgen strikt [`repo.meta.yaml`](repo.meta.yaml) und dem [Agent Reading Protocol](docs/policies/agent-reading-protocol.md). `docs/index.md` ist Navigation, keine Wahrheitsschicht. `docs/_generated/*` ist Diagnose, nicht Ursprung.
 
+## Start Here
+
+- **Constitution / Repo Truth Model:** [`repo.meta.yaml`](repo.meta.yaml)
+- **System Map:** [`docs/_generated/system-map.md`](docs/_generated/system-map.md)
+- **Runtime:** [`runtime/README.md`](runtime/README.md)
+- **Operations:** [`runbooks/README.md`](runbooks/README.md)
+- **Architecture Overview:** [`architecture/overview.md`](architecture/overview.md)
+
 ## Schnellzugriff
 
 - [Dokumentationsindex](docs/index.md)

--- a/architecture/blueprint.docmeta-engine.md
+++ b/architecture/blueprint.docmeta-engine.md
@@ -136,8 +136,8 @@ Ziel: Contributor versteht das System in 5 Minuten.
 
 ### 5.1 "Start Here" Links
 
-- [ ] `README.md` oben mit 5 expliziten Links versehen (Constitution, System Map, Runtime, Operations, Architecture Overview).
-- [ ] `docs/_generated/system-map.md` bleibt diff-guarded via `Makefile`.
+- [x] `README.md` oben mit 5 expliziten Links versehen (Constitution, System Map, Runtime, Operations, Architecture Overview).
+- [x] `docs/_generated/system-map.md` bleibt diff-guarded via `Makefile`.
 
 ## Definition of Done (DoD)
 

--- a/docs/_generated/system-map.md
+++ b/docs/_generated/system-map.md
@@ -13,24 +13,24 @@ Source: scripts/docmeta/generate_system_map.py
 
 ## Zone: norm
 
-|id|path|role|organ|status|last_reviewed|depends_on|verifies_with|freshness_status|missing_scripts|
-|---|---|---|---|---|---|---|---|---|---|
-|blueprint.docmeta-engine|architecture/blueprint.docmeta-engine.md|norm|governance|canonical|2026-03-03|||pass||
-|docmeta.schema|architecture/docmeta.schema.md|norm|docmeta|canonical|2026-03-02||scripts/docmeta/check_doc_review_age.py, scripts/docmeta/check_repo_index_consistency.py, scripts/docmeta/generate_system_map.py, scripts/docmeta/validate_relations.py|pass||
-|overview|architecture/overview.md|norm|governance|canonical|2026-02-28|||pass||
-|security|architecture/security.md|norm|governance|canonical|2026-02-28|||pass||
+|id|path|role|organ|status|last_reviewed|depends_on|verifies_with|missing_scripts|
+|---|---|---|---|---|---|---|---|---|
+|blueprint.docmeta-engine|architecture/blueprint.docmeta-engine.md|norm|governance|canonical|2026-06-09||||
+|docmeta.schema|architecture/docmeta.schema.md|norm|docmeta|canonical|2026-06-09||scripts/docmeta/check_doc_review_age.py, scripts/docmeta/check_repo_index_consistency.py, scripts/docmeta/generate_system_map.py, scripts/docmeta/validate_relations.py||
+|overview|architecture/overview.md|norm|governance|canonical|2026-06-09||||
+|security|architecture/security.md|norm|governance|canonical|2026-06-09||||
 
 ## Zone: reality
 
-|id|path|role|organ|status|last_reviewed|depends_on|verifies_with|freshness_status|missing_scripts|
-|---|---|---|---|---|---|---|---|---|---|
-|runtime.readme|runtime/README.md|reality|runtime|canonical|2026-02-28|||pass||
+|id|path|role|organ|status|last_reviewed|depends_on|verifies_with|missing_scripts|
+|---|---|---|---|---|---|---|---|---|
+|runtime.readme|runtime/README.md|reality|runtime|canonical|2026-06-09||||
 
 ## Zone: runbooks
 
-|id|path|role|organ|status|last_reviewed|depends_on|verifies_with|freshness_status|missing_scripts|
-|---|---|---|---|---|---|---|---|---|---|
-|runbooks.readme|runbooks/README.md|runbooks|ops|canonical|2026-02-28|||pass||
+|id|path|role|organ|status|last_reviewed|depends_on|verifies_with|missing_scripts|
+|---|---|---|---|---|---|---|---|---|
+|runbooks.readme|runbooks/README.md|runbooks|ops|canonical|2026-06-09||||
 
 ## Automated Checks
 

--- a/docs/tasks/board.md
+++ b/docs/tasks/board.md
@@ -62,6 +62,7 @@ relations:
 | ID | Bereich | Titel | Evidenz |
 |---|---|---|---|
 | TASK-CTL-001 | docs | Task-Control Phase 2 etablieren | `docs/tasks/`, `docs/reports/optimierungsstatus.json`, `scripts/docmeta/validate_task_index.py`, `scripts/docmeta/tests/test_validate_task_index.py` |
+| DOCMETA-START-HERE-001 | docs | Start-Here Navigation und System-Map Drift Guard | `README.md`, `architecture/blueprint.docmeta-engine.md`, `scripts/docmeta/generate_system_map.py`, `Makefile` |
 | DOCMETA-WARN-MODE-001 | docs | Warn-Mode stderr semantics für Docmeta-Guards schließen | `scripts/docmeta/review_impact.py`, `scripts/docmeta/check_links.py`, `scripts/docmeta/tests/test_review_impact.py`, `scripts/docmeta/tests/test_check_links.py`, `architecture/blueprint.docmeta-engine.md` |
 | OPT-DOC-001 | docs | Incident-/DB-Recovery-Runbooks | `docs/runbooks/incident-response.md`, `docs/runbooks/db-recovery.md`; Navigation in `docs/runbooks/README.md` + `docs/index.md`; Drill-Querverweis in `docs/runbook.md` §2; Doku-Hygiene-Guards grün |
 | OPT-MAP-001 | map | Basemap Runtime Proof | CI-Job `basemap-range-delivery-proof` PROVEN, Commit `14feefd6` |

--- a/docs/tasks/index.json
+++ b/docs/tasks/index.json
@@ -636,6 +636,41 @@
       "updated_at": "2026-06-04"
     },
     {
+      "id": "DOCMETA-START-HERE-001",
+      "title": "Start-Here Navigation und System-Map Drift Guard",
+      "area": "docs",
+      "status": "done",
+      "priority": "medium",
+      "effort": "S",
+      "risk": "medium",
+      "owner": "docs-mechanik",
+      "evidence": [
+        "README.md",
+        "architecture/blueprint.docmeta-engine.md",
+        "scripts/docmeta/generate_system_map.py",
+        "Makefile",
+        "docs/tasks/board.md",
+        "docs/tasks/index.json"
+      ],
+      "missing_evidence": [],
+      "acceptance": [
+        "README.md enthält oben einen Start-Here-Block mit expliziten Links zu Constitution, System Map, Runtime, Operations und Architecture Overview",
+        "Alle Start-Here-Zielpfade existieren im Repo",
+        "docs/_generated/system-map.md wird über Makefile blockierend drift-geprüft",
+        "System-Map-Generator läuft deterministisch genug für einen diff-guard",
+        "Docmeta-Blueprint Phase 5.1 ist nur nach Code-/Guard-Beleg abgehakt"
+      ],
+      "links": {
+        "issues": [],
+        "prs": [],
+        "docs": [
+          "README.md",
+          "architecture/blueprint.docmeta-engine.md"
+        ]
+      },
+      "updated_at": "2026-06-10"
+    },
+    {
       "id": "OPT-CI-005",
       "title": "GitHub Actions Node-24 Runtime Readiness",
       "area": "ci",

--- a/scripts/docmeta/generate_system_map.py
+++ b/scripts/docmeta/generate_system_map.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import datetime
 
 from scripts.docmeta.docmeta import REPO_ROOT, parse_repo_index, parse_frontmatter, parse_review_policy, normalize_list_field, extract_depends_on
 
@@ -8,8 +7,6 @@ def main():
     try:
         policy = parse_review_policy()
         strict_mode = policy.get('strict_manifest', False)
-        warn_days = policy.get('warn_days', 90)
-        fail_days = policy.get('fail_days', 180)
         repo_index = parse_repo_index(strict_manifest=strict_mode)
     except ValueError as e:
         print(f"Error parsing manifest/policy: {e}", file=sys.stderr)
@@ -54,24 +51,6 @@ def main():
                 role = frontmatter.get('role', '')
                 last_reviewed_str = frontmatter.get('last_reviewed', '')
 
-                # Freshness status
-                freshness_status = "unknown"
-                if last_reviewed_str:
-                    try:
-                        last_reviewed_date = datetime.datetime.strptime(last_reviewed_str, "%Y-%m-%d").date()
-                        today = datetime.date.today()
-                        delta = today - last_reviewed_date
-                        if delta.days > fail_days:
-                            freshness_status = "fail"
-                        elif delta.days > warn_days:
-                            freshness_status = "warn"
-                        else:
-                            freshness_status = "pass"
-                    except ValueError:
-                        freshness_status = "invalid"
-                else:
-                    freshness_status = "missing"
-
                 depends_on_list = extract_depends_on(frontmatter)
                 depends_on_str = ', '.join(depends_on_list)
 
@@ -100,13 +79,12 @@ def main():
                 last_reviewed_str = "_Missing_"
                 depends_on_str = "_Missing_"
                 verifies_with_str = "_Missing_"
-                freshness_status = "_Missing_"
                 missing_scripts_str = "_Missing_"
                 file_link = rel_file_path
 
-            rows.append([doc_id, file_link, role, organ, status, last_reviewed_str, depends_on_str, verifies_with_str, freshness_status, missing_scripts_str])
+            rows.append([doc_id, file_link, role, organ, status, last_reviewed_str, depends_on_str, verifies_with_str, missing_scripts_str])
 
-        headers = ["id", "path", "role", "organ", "status", "last_reviewed", "depends_on", "verifies_with", "freshness_status", "missing_scripts"]
+        headers = ["id", "path", "role", "organ", "status", "last_reviewed", "depends_on", "verifies_with", "missing_scripts"]
 
         header_row = "|" + "|".join(headers) + "|"
         output.append(header_row)

--- a/scripts/docmeta/tests/test_generate_system_map.py
+++ b/scripts/docmeta/tests/test_generate_system_map.py
@@ -1,0 +1,43 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import scripts.docmeta.generate_system_map as gen_mod
+
+
+class TestGenerateSystemMap(unittest.TestCase):
+    def _render_system_map(self) -> str:
+        with tempfile.NamedTemporaryFile(suffix='.md', delete=False) as f:
+            tmp = f.name
+        try:
+            real_join = os.path.join
+
+            def patched_join(*args):
+                if len(args) >= 2 and args[-1] == 'system-map.md':
+                    return tmp
+                return real_join(*args)
+
+            with patch('scripts.docmeta.generate_system_map.os.path.join', side_effect=patched_join):
+                gen_mod.main()
+            return Path(tmp).read_text(encoding='utf-8')
+        finally:
+            os.unlink(tmp)
+
+    def test_no_freshness_status_in_output(self):
+        self.assertNotIn('freshness_status', self._render_system_map())
+
+    def test_last_reviewed_present_in_output(self):
+        self.assertIn('last_reviewed', self._render_system_map())
+
+    def test_column_structure_without_freshness(self):
+        content = self._render_system_map()
+        expected_header = '|id|path|role|organ|status|last_reviewed|depends_on|verifies_with|missing_scripts|'
+        expected_sep = '|---|---|---|---|---|---|---|---|---|'
+        self.assertIn(expected_header, content)
+        self.assertIn(expected_sep, content)
+        self.assertEqual(expected_header.count('|'), expected_sep.count('|'))
+
+    def test_generator_deterministic(self):
+        self.assertEqual(self._render_system_map(), self._render_system_map())


### PR DESCRIPTION
## Summary

Implements \`DOCMETA-START-HERE-001\`.

- Adds an explicit Start Here block to \`README.md\`.
- Links to Constitution / repo truth, System Map, Runtime, Operations, and Architecture Overview.
- Adds a Makefile-backed blocking drift guard for \`docs/_generated/system-map.md\`.
- Marks Docmeta Blueprint Phase 5.1 complete after guard proof.
- Registers the task in Task-Control without using \`docs/_generated/*\` as manual task evidence.

## Codex P1 follow-up

The blocking system-map drift guard no longer depends on date-derived freshness output.

- Removed date-derived \`freshness_status\` column from \`docs/_generated/system-map.md\` and its generator.
- \`check-system-map-drift\` compares against \`HEAD\` (\`git diff --exit-code HEAD\`).
- \`generate-system-map\` is now a separate named Makefile target; \`check-system-map-drift\` depends on it.
- \`docs/_generated/system-map.md\` remains a generated output and README target, not manual Task-Control evidence.
- Cleaned up \`test_generate_system_map.py\`: unused imports removed, dead helper removed, os.path.join patching centralized in \`_render_system_map()\` helper, explicit header/separator column-count coverage added.

## Checks

- [x] py_compile generate_system_map
- [x] py_compile test_generate_system_map
- [x] focused generate_system_map test (4 tests)
- [x] full docmeta unittest discovery (439 tests pass)
- [x] validate_task_index
- [x] generate_task_index --check
- [x] make check-system-map-drift (pass)
- [x] make docs-guard (validate-guards chain green; validate-shell-tests fails on pre-existing test_weltgewebe_up_git_branch.sh, reproducible on main)
- [x] git diff --exit-code HEAD: pass
- [x] no freshness_status in system-map output
- [x] no date.today in generator
- [x] no docs/_generated/* in task evidence/links
- [x] hidden unicode
- [x] git diff --check
- [x] diff scope check
- [x] blocked files check

🤖 Generated with [Claude Code](https://claude.com/claude-code)