### PR TITLE
Enforce CI-evidence freshness and full SHA validation for OPT-ARC-001 proof matrix

### DIFF
--- a/.github/workflows/docs-guard.yml
+++ b/.github/workflows/docs-guard.yml
@@ -39,6 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/opt-arc-001-db-proof-matrix.yml
+++ b/.github/workflows/opt-arc-001-db-proof-matrix.yml
@@ -16,6 +16,11 @@ name: OPT-ARC-001 DB proof matrix guard
       - "docs/reports/domain-node-write-path-proof.md"
       - ".github/workflows/api.yml"
       - ".github/workflows/opt-arc-001-db-proof-matrix.yml"
+      - "apps/api/tests/db_domain_schema_migrations.rs"
+      - "apps/api/tests/db_domain_backfill.rs"
+      - "apps/api/tests/db_domain_read_path.rs"
+      - "apps/api/tests/db_domain_account_write_path.rs"
+      - "apps/api/tests/db_domain_node_write_path.rs"
       - "scripts/docmeta/validate_opt_arc_001_db_proof_matrix.py"
       - "scripts/docmeta/tests/test_validate_opt_arc_001_db_proof_matrix.py"
   workflow_dispatch: {}
@@ -32,6 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version-file: ".python-version"

--- a/scripts/docmeta/tests/test_validate_opt_arc_001_db_proof_matrix.py
+++ b/scripts/docmeta/tests/test_validate_opt_arc_001_db_proof_matrix.py
@@ -608,6 +608,9 @@ class ValidateOptArc001DbProofMatrixTests(unittest.TestCase):
         self._write_json(guard.MATRIX_PATH, _ci_proven_matrix())
         with (
             unittest.mock.patch.object(guard, "_git_commit_exists", return_value=True),
+            unittest.mock.patch.object(
+                guard, "_git_commit_is_ancestor_of_head", return_value=True
+            ),
             unittest.mock.patch.object(guard, "_git_changed_paths_since", return_value=[]),
         ):
             self.assert_no_errors()
@@ -620,6 +623,9 @@ class ValidateOptArc001DbProofMatrixTests(unittest.TestCase):
         self._write_json(guard.MATRIX_PATH, matrix)
         with (
             unittest.mock.patch.object(guard, "_git_commit_exists", return_value=True),
+            unittest.mock.patch.object(
+                guard, "_git_commit_is_ancestor_of_head", return_value=True
+            ),
             unittest.mock.patch.object(guard, "_git_changed_paths_since", return_value=[]),
         ):
             self.assert_no_errors()
@@ -631,6 +637,9 @@ class ValidateOptArc001DbProofMatrixTests(unittest.TestCase):
         self._write_json(guard.MATRIX_PATH, matrix)
         with (
             unittest.mock.patch.object(guard, "_git_commit_exists", return_value=True),
+            unittest.mock.patch.object(
+                guard, "_git_commit_is_ancestor_of_head", return_value=True
+            ),
             unittest.mock.patch.object(
                 guard,
                 "_git_changed_paths_since",
@@ -649,6 +658,9 @@ class ValidateOptArc001DbProofMatrixTests(unittest.TestCase):
         self._write_json(guard.MATRIX_PATH, matrix)
         with (
             unittest.mock.patch.object(guard, "_git_commit_exists", return_value=True),
+            unittest.mock.patch.object(
+                guard, "_git_commit_is_ancestor_of_head", return_value=True
+            ),
             unittest.mock.patch.object(
                 guard,
                 "_git_changed_paths_since",
@@ -669,6 +681,9 @@ class ValidateOptArc001DbProofMatrixTests(unittest.TestCase):
 
         with (
             unittest.mock.patch.object(guard, "_git_commit_exists") as exists,
+            unittest.mock.patch.object(
+                guard, "_git_commit_is_ancestor_of_head"
+            ) as ancestor,
             unittest.mock.patch.object(guard, "_git_changed_paths_since") as changed,
         ):
             errors = guard.validate(self.root)
@@ -678,6 +693,7 @@ class ValidateOptArc001DbProofMatrixTests(unittest.TestCase):
         )
         self.assertTrue(any(expected in error for error in errors), errors)
         exists.assert_not_called()
+        ancestor.assert_not_called()
         changed.assert_not_called()
 
     def test_ci_proven_commit_head_ref_rejected_before_git_lookup(self):
@@ -694,6 +710,72 @@ class ValidateOptArc001DbProofMatrixTests(unittest.TestCase):
             "B10076EE743202D3EF07AF42A464267C82F4A5C0"
         )
 
+    def test_ci_proven_evidence_commit_not_ancestor_fails(self):
+        matrix = _valid_matrix()
+        proof = matrix["proofs"][0]
+        proof["state"] = "ci_proven"
+        proof["ci_evidence"] = _evidence_for(proof["id"])
+        self._write_json(guard.MATRIX_PATH, matrix)
+
+        with (
+            unittest.mock.patch.object(guard, "_git_commit_exists", return_value=True),
+            unittest.mock.patch.object(
+                guard, "_git_commit_is_ancestor_of_head", return_value=False
+            ),
+            unittest.mock.patch.object(guard, "_git_changed_paths_since") as changed,
+        ):
+            errors = guard.validate(self.root)
+
+        self.assertTrue(any("is not an ancestor of HEAD" in error for error in errors), errors)
+        changed.assert_not_called()
+
+    def test_ci_proven_evidence_ancestor_git_error_fails(self):
+        matrix = _valid_matrix()
+        proof = matrix["proofs"][0]
+        proof["state"] = "ci_proven"
+        proof["ci_evidence"] = _evidence_for(proof["id"])
+        self._write_json(guard.MATRIX_PATH, matrix)
+
+        with (
+            unittest.mock.patch.object(guard, "_git_commit_exists", return_value=True),
+            unittest.mock.patch.object(
+                guard,
+                "_git_commit_is_ancestor_of_head",
+                side_effect=guard.GitFreshnessError("merge-base failed"),
+            ),
+            unittest.mock.patch.object(guard, "_git_changed_paths_since") as changed,
+        ):
+            errors = guard.validate(self.root)
+
+        self.assertTrue(any("merge-base failed" in error for error in errors), errors)
+        changed.assert_not_called()
+
+    def test_git_commit_is_ancestor_of_head_return_codes(self):
+        with unittest.mock.patch.object(guard, "_run_git") as run_git:
+            run_git.return_value = unittest.mock.Mock(returncode=0, stderr="", stdout="")
+            self.assertTrue(
+                guard._git_commit_is_ancestor_of_head(self.root, "a" * 40)
+            )
+            run_git.assert_called_once_with(
+                self.root, ["merge-base", "--is-ancestor", "a" * 40, "HEAD"]
+            )
+
+            run_git.reset_mock()
+            run_git.return_value = unittest.mock.Mock(returncode=1, stderr="", stdout="")
+            self.assertFalse(
+                guard._git_commit_is_ancestor_of_head(self.root, "a" * 40)
+            )
+
+    def test_git_commit_is_ancestor_of_head_unexpected_error_fails(self):
+        result = unittest.mock.Mock(
+            returncode=128,
+            stderr="fatal: invalid object",
+            stdout="",
+        )
+        with unittest.mock.patch.object(guard, "_run_git", return_value=result):
+            with self.assertRaisesRegex(guard.GitFreshnessError, "fatal: invalid object"):
+                guard._git_commit_is_ancestor_of_head(self.root, "a" * 40)
+
     def test_ci_proven_missing_evidence_commit_fails(self):
         matrix = _valid_matrix()
         matrix["proofs"][0]["state"] = "ci_proven"
@@ -701,11 +783,15 @@ class ValidateOptArc001DbProofMatrixTests(unittest.TestCase):
         self._write_json(guard.MATRIX_PATH, matrix)
         with (
             unittest.mock.patch.object(guard, "_git_commit_exists", return_value=False),
+            unittest.mock.patch.object(
+                guard, "_git_commit_is_ancestor_of_head"
+            ) as ancestor,
             unittest.mock.patch.object(guard, "_git_changed_paths_since") as changed,
         ):
             errors = guard.validate(self.root)
         self.assertTrue(any("ci_evidence commit" in error for error in errors), errors)
         self.assertTrue(any("not found" in error for error in errors), errors)
+        ancestor.assert_not_called()
         changed.assert_not_called()
 
     def test_prepared_does_not_check_evidence_freshness(self):
@@ -715,11 +801,16 @@ class ValidateOptArc001DbProofMatrixTests(unittest.TestCase):
             side_effect=AssertionError("prepared proof must not check Git freshness"),
         ) as commit_exists, unittest.mock.patch.object(
             guard,
+            "_git_commit_is_ancestor_of_head",
+            side_effect=AssertionError("prepared proof must not check Git ancestry"),
+        ) as ancestor, unittest.mock.patch.object(
+            guard,
             "_git_changed_paths_since",
             side_effect=AssertionError("prepared proof must not diff Git paths"),
         ) as changed:
             self.assert_no_errors()
         commit_exists.assert_not_called()
+        ancestor.assert_not_called()
         changed.assert_not_called()
 
     def test_ci_proven_freshness_diff_is_limited_to_proof_harness_paths(self):
@@ -730,6 +821,9 @@ class ValidateOptArc001DbProofMatrixTests(unittest.TestCase):
         self._write_json(guard.MATRIX_PATH, matrix)
         with (
             unittest.mock.patch.object(guard, "_git_commit_exists", return_value=True),
+            unittest.mock.patch.object(
+                guard, "_git_commit_is_ancestor_of_head", return_value=True
+            ),
             unittest.mock.patch.object(
                 guard,
                 "_git_changed_paths_since",

--- a/scripts/docmeta/tests/test_validate_opt_arc_001_db_proof_matrix.py
+++ b/scripts/docmeta/tests/test_validate_opt_arc_001_db_proof_matrix.py
@@ -598,15 +598,19 @@ class ValidateOptArc001DbProofMatrixTests(unittest.TestCase):
         matrix["proofs"][0]["ci_evidence"] = {
             "run_url": "https://github.com/heimgewebe/weltgewebe/actions/runs/1",
             "run_id": 1,
-            "commit": "deadbeef",
+            "commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             "job": NODE_WRITE_PROOF_ID,
         }
         self._write_json(guard.MATRIX_PATH, matrix)
         self.assert_error_containing("state 'prepared' requires ci_evidence")
 
-    def test_all_proofs_ci_proven_with_valid_evidence_validates(self):
+    def test_all_proofs_ci_proven_with_valid_fresh_evidence_validates(self):
         self._write_json(guard.MATRIX_PATH, _ci_proven_matrix())
-        self.assert_no_errors()
+        with (
+            unittest.mock.patch.object(guard, "_git_commit_exists", return_value=True),
+            unittest.mock.patch.object(guard, "_git_changed_paths_since", return_value=[]),
+        ):
+            self.assert_no_errors()
 
     def test_ci_proven_mixed_with_prepared_validates(self):
         # A partial harvest (one proof ci_proven, the rest still prepared) is valid.
@@ -614,7 +618,130 @@ class ValidateOptArc001DbProofMatrixTests(unittest.TestCase):
         matrix["proofs"][0]["state"] = "ci_proven"
         matrix["proofs"][0]["ci_evidence"] = _evidence_for(matrix["proofs"][0]["id"])
         self._write_json(guard.MATRIX_PATH, matrix)
-        self.assert_no_errors()
+        with (
+            unittest.mock.patch.object(guard, "_git_commit_exists", return_value=True),
+            unittest.mock.patch.object(guard, "_git_changed_paths_since", return_value=[]),
+        ):
+            self.assert_no_errors()
+
+    def test_ci_proven_stale_api_workflow_fails(self):
+        matrix = _valid_matrix()
+        matrix["proofs"][0]["state"] = "ci_proven"
+        matrix["proofs"][0]["ci_evidence"] = _evidence_for(matrix["proofs"][0]["id"])
+        self._write_json(guard.MATRIX_PATH, matrix)
+        with (
+            unittest.mock.patch.object(guard, "_git_commit_exists", return_value=True),
+            unittest.mock.patch.object(
+                guard,
+                "_git_changed_paths_since",
+                return_value=[guard.WORKFLOW_PATH],
+            ),
+        ):
+            errors = guard.validate(self.root)
+        self.assertTrue(any("ci_evidence is stale" in error for error in errors), errors)
+        self.assertTrue(any(guard.WORKFLOW_PATH in error for error in errors), errors)
+
+    def test_ci_proven_stale_proof_test_file_fails(self):
+        matrix = _valid_matrix()
+        proof = next(item for item in matrix["proofs"] if item["id"] == NODE_WRITE_PROOF_ID)
+        proof["state"] = "ci_proven"
+        proof["ci_evidence"] = _evidence_for(NODE_WRITE_PROOF_ID)
+        self._write_json(guard.MATRIX_PATH, matrix)
+        with (
+            unittest.mock.patch.object(guard, "_git_commit_exists", return_value=True),
+            unittest.mock.patch.object(
+                guard,
+                "_git_changed_paths_since",
+                return_value=[NODE_WRITE_TEST],
+            ),
+        ):
+            errors = guard.validate(self.root)
+        self.assertTrue(any("ci_evidence is stale" in error for error in errors), errors)
+        self.assertTrue(any("db_domain_node_write_path.rs" in error for error in errors), errors)
+
+    def _assert_invalid_ci_evidence_commit_rejected_before_git_lookup(self, commit):
+        matrix = _valid_matrix()
+        proof = matrix["proofs"][0]
+        proof["state"] = "ci_proven"
+        proof["ci_evidence"] = _evidence_for(proof["id"])
+        proof["ci_evidence"]["commit"] = commit
+        self._write_json(guard.MATRIX_PATH, matrix)
+
+        with (
+            unittest.mock.patch.object(guard, "_git_commit_exists") as exists,
+            unittest.mock.patch.object(guard, "_git_changed_paths_since") as changed,
+        ):
+            errors = guard.validate(self.root)
+
+        expected = (
+            "ci_evidence.commit must be a full 40-character lowercase hex Git SHA"
+        )
+        self.assertTrue(any(expected in error for error in errors), errors)
+        exists.assert_not_called()
+        changed.assert_not_called()
+
+    def test_ci_proven_commit_head_ref_rejected_before_git_lookup(self):
+        self._assert_invalid_ci_evidence_commit_rejected_before_git_lookup("HEAD")
+
+    def test_ci_proven_commit_main_ref_rejected_before_git_lookup(self):
+        self._assert_invalid_ci_evidence_commit_rejected_before_git_lookup("main")
+
+    def test_ci_proven_short_sha_rejected_before_git_lookup(self):
+        self._assert_invalid_ci_evidence_commit_rejected_before_git_lookup("b10076e")
+
+    def test_ci_proven_uppercase_sha_rejected_before_git_lookup(self):
+        self._assert_invalid_ci_evidence_commit_rejected_before_git_lookup(
+            "B10076EE743202D3EF07AF42A464267C82F4A5C0"
+        )
+
+    def test_ci_proven_missing_evidence_commit_fails(self):
+        matrix = _valid_matrix()
+        matrix["proofs"][0]["state"] = "ci_proven"
+        matrix["proofs"][0]["ci_evidence"] = _evidence_for(matrix["proofs"][0]["id"])
+        self._write_json(guard.MATRIX_PATH, matrix)
+        with (
+            unittest.mock.patch.object(guard, "_git_commit_exists", return_value=False),
+            unittest.mock.patch.object(guard, "_git_changed_paths_since") as changed,
+        ):
+            errors = guard.validate(self.root)
+        self.assertTrue(any("ci_evidence commit" in error for error in errors), errors)
+        self.assertTrue(any("not found" in error for error in errors), errors)
+        changed.assert_not_called()
+
+    def test_prepared_does_not_check_evidence_freshness(self):
+        with unittest.mock.patch.object(
+            guard,
+            "_git_commit_exists",
+            side_effect=AssertionError("prepared proof must not check Git freshness"),
+        ) as commit_exists, unittest.mock.patch.object(
+            guard,
+            "_git_changed_paths_since",
+            side_effect=AssertionError("prepared proof must not diff Git paths"),
+        ) as changed:
+            self.assert_no_errors()
+        commit_exists.assert_not_called()
+        changed.assert_not_called()
+
+    def test_ci_proven_freshness_diff_is_limited_to_proof_harness_paths(self):
+        matrix = _valid_matrix()
+        proof = matrix["proofs"][0]
+        proof["state"] = "ci_proven"
+        proof["ci_evidence"] = _evidence_for(proof["id"])
+        self._write_json(guard.MATRIX_PATH, matrix)
+        with (
+            unittest.mock.patch.object(guard, "_git_commit_exists", return_value=True),
+            unittest.mock.patch.object(
+                guard,
+                "_git_changed_paths_since",
+                return_value=[],
+            ) as changed,
+        ):
+            self.assert_no_errors()
+        changed.assert_called_once_with(
+            self.root,
+            proof["ci_evidence"]["commit"],
+            (guard.WORKFLOW_PATH, guard.EXPECTED_PROOFS[proof["id"]]["test"]),
+        )
 
     def test_unknown_state_fails(self):
         matrix = _valid_matrix()
@@ -655,7 +782,7 @@ class ValidateOptArc001DbProofMatrixTests(unittest.TestCase):
         obj = {
             "run_url": "https://github.com/heimgewebe/weltgewebe/actions/runs/1",
             "run_id": 1,
-            "commit": "deadbeef",
+            "commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             "job": NODE_WRITE_PROOF_ID,
         }
         obj.update(overrides)

--- a/scripts/docmeta/validate_opt_arc_001_db_proof_matrix.py
+++ b/scripts/docmeta/validate_opt_arc_001_db_proof_matrix.py
@@ -1,9 +1,10 @@
 """
 validate_opt_arc_001_db_proof_matrix.py — Blocking truth guard for OPT-ARC-001.
 
-OPT-ARC-001 (JSONL → PostgreSQL) has five prepared DB proof jobs in
-.github/workflows/api.yml but no PR-CI evidence yet. This validator pins that
-truth machine-readably and blocks drift toward false completion claims:
+OPT-ARC-001 (JSONL → PostgreSQL) has five DB proof jobs in
+.github/workflows/api.yml with PR-CI evidence. This validator pins that truth
+machine-readably and blocks stale evidence or drift toward false completion
+claims:
 
   - docs/reports/opt-arc-001-db-proof-matrix.json must describe exactly the
     five expected proofs, no cutover, JSONL as default domain read and write
@@ -12,9 +13,11 @@ truth machine-readably and blocks drift toward false completion claims:
     state="ci_proven" with a concrete ci_evidence object (run_url, run_id,
     commit, job). For a ci_proven proof the evidence job must equal the proof
     id, and run_url must be a github.com/heimgewebe/weltgewebe Actions run URL
-    whose trailing run id matches run_id. ci_proven of these five proofs only
-    records that the prepared DB jobs ran green in real PR-CI; it is NOT a
-    cutover — overall_status stays "partial" and JSONL stays read/write truth.
+    whose trailing run id matches run_id. The API workflow and the proof's test
+    file must also be unchanged since the evidence commit. ci_proven of these
+    five proofs only records that the prepared DB jobs ran green in real PR-CI
+    with a fresh proof harness; it is NOT a cutover — overall_status stays
+    "partial" and JSONL stays read/write truth.
   - Each proof job must contain a real run command that invokes the expected cargo test with --include-ignored and --test-threads=1.
   - Task-control and status artifacts (docs/tasks/board.md,
     docs/tasks/index.json, docs/reports/optimierungsstatus.md,
@@ -44,6 +47,7 @@ import json
 import os
 import re
 import shlex
+import subprocess
 import sys
 
 from scripts.docmeta.docmeta import REPO_ROOT
@@ -85,9 +89,8 @@ REQUIRED_NON_GOALS = (
 )
 
 # A proof may only carry state="ci_proven" together with a ci_evidence object
-# whose fields have exactly these types. The current matrix maps prepared
-# proofs only, so "ci_proven" is rejected outright (see _validate_proof).
-# bool is an int subclass; exact type equality prevents it from passing as run_id.
+# whose fields have exactly these types. bool is an int subclass; exact type
+# equality prevents it from passing as run_id.
 CI_EVIDENCE_FIELD_TYPES = {
     "run_url": str,
     "run_id": int,
@@ -95,6 +98,7 @@ CI_EVIDENCE_FIELD_TYPES = {
     "job": str,
 }
 CI_EVIDENCE_REQUIRED_KEYS = tuple(CI_EVIDENCE_FIELD_TYPES)
+CI_EVIDENCE_COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
 
 # A ci_proven proof's run_url must be a real GitHub Actions run URL for this
 # repository; the trailing path segment of the URL must equal run_id.
@@ -540,8 +544,50 @@ def _command_has_required_cargo_test_invocation(command, test_name):
 
 
 # ---------------------------------------------------------------------------
-# CI evidence object checks (ci_proven rule)
+# CI evidence object and proof-harness freshness checks (ci_proven rule)
 # ---------------------------------------------------------------------------
+
+class GitFreshnessError(RuntimeError):
+    """Raised when Git cannot complete a proof-harness freshness check."""
+
+
+def _ci_evidence_freshness_paths(proof_id):
+    """Return the narrowly scoped proof-harness paths for one proof."""
+    spec = EXPECTED_PROOFS[proof_id]
+    return (WORKFLOW_PATH, spec["test"])
+
+
+def _run_git(repo_root, args):
+    """Run a deterministic Git command without invoking a shell."""
+    try:
+        return subprocess.run(
+            ["git", "-C", os.fspath(repo_root), *args],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise GitFreshnessError(str(exc)) from exc
+
+
+def _git_commit_exists(repo_root, commit):
+    """Return whether commit resolves locally to a Git commit object."""
+    result = _run_git(repo_root, ["cat-file", "-e", f"{commit}^{{commit}}"])
+    return result.returncode == 0
+
+
+def _git_changed_paths_since(repo_root, commit, paths):
+    """Return proof-harness paths changed between commit and HEAD."""
+    result = _run_git(
+        repo_root,
+        ["diff", "--name-only", f"{commit}..HEAD", "--", *paths],
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "unknown Git error"
+        raise GitFreshnessError(detail)
+    return [line for line in result.stdout.splitlines() if line]
+
 
 def _check_ci_evidence_object(value):
     """Return True when value is a complete, strictly typed ci_evidence object.
@@ -565,28 +611,23 @@ def _check_ci_evidence_object(value):
 
 
 def _validate_ci_evidence(proof_id, ci_evidence, errors):
-    """Append errors for an invalid ci_evidence object on a ci_proven proof.
-
-    Beyond the strict type/non-empty checks in `_check_ci_evidence_object`,
-    a ci_proven proof must satisfy:
-      - ci_evidence.job equals the proof id (the evidence belongs to this proof),
-      - run_url is a github.com/heimgewebe/weltgewebe Actions run URL,
-      - the run id embedded in run_url matches run_id (URL and id are consistent).
-    """
+    """Append structural evidence errors and return whether evidence is valid."""
     if not _check_ci_evidence_object(ci_evidence):
         errors.append(
             f"{MATRIX_PATH}: proof '{proof_id}': state 'ci_proven' requires a ci_evidence "
             f"object with {', '.join(CI_EVIDENCE_REQUIRED_KEYS)} "
             f"(run_url/commit/job non-empty strings, run_id a real int)"
         )
-        return
+        return False
 
+    valid = True
     job = ci_evidence["job"]
     if job != proof_id:
         errors.append(
             f"{MATRIX_PATH}: proof '{proof_id}': ci_evidence.job must equal the proof id, "
             f"got '{job}'"
         )
+        valid = False
 
     run_url = ci_evidence["run_url"]
     run_id = ci_evidence["run_id"]
@@ -595,6 +636,7 @@ def _validate_ci_evidence(proof_id, ci_evidence, errors):
             f"{MATRIX_PATH}: proof '{proof_id}': ci_evidence.run_url must start with "
             f"'{GITHUB_ACTIONS_RUN_URL_PREFIX}', got '{run_url}'"
         )
+        valid = False
     else:
         url_run_id = run_url[len(GITHUB_ACTIONS_RUN_URL_PREFIX):].split("/")[0].split("?")[0]
         if url_run_id != str(run_id):
@@ -602,6 +644,41 @@ def _validate_ci_evidence(proof_id, ci_evidence, errors):
                 f"{MATRIX_PATH}: proof '{proof_id}': ci_evidence.run_id ({run_id}) "
                 f"must match the run id in run_url ('{url_run_id}')"
             )
+            valid = False
+    return valid
+
+
+def _validate_ci_evidence_freshness(proof_id, repo_root, ci_evidence, errors):
+    """Require a ci_proven proof's narrow harness to be unchanged since evidence."""
+    commit = ci_evidence["commit"].strip()
+    if not CI_EVIDENCE_COMMIT_RE.fullmatch(commit):
+        errors.append(
+            f"{MATRIX_PATH}: proof '{proof_id}': ci_evidence.commit must be a full "
+            f"40-character lowercase hex Git SHA, got '{commit}'"
+        )
+        return
+
+    try:
+        if not _git_commit_exists(repo_root, commit):
+            errors.append(
+                f"{MATRIX_PATH}: proof '{proof_id}': ci_evidence commit '{commit}' "
+                "was not found in the local Git history"
+            )
+            return
+        paths = _ci_evidence_freshness_paths(proof_id)
+        changed_paths = _git_changed_paths_since(repo_root, commit, paths)
+    except GitFreshnessError as exc:
+        errors.append(
+            f"{MATRIX_PATH}: proof '{proof_id}': unable to check ci_evidence commit "
+            f"'{commit}' freshness: {exc}"
+        )
+        return
+
+    if changed_paths:
+        errors.append(
+            f"{MATRIX_PATH}: proof '{proof_id}': ci_evidence is stale; changed proof "
+            f"harness paths since commit {commit}: {', '.join(changed_paths)}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -643,7 +720,8 @@ def _validate_proof(proof, repo_root, errors):
                 f"to be null (no PR-CI evidence recorded for a prepared proof)"
             )
     else:  # state == "ci_proven"
-        _validate_ci_evidence(proof_id, ci_evidence, errors)
+        if _validate_ci_evidence(proof_id, ci_evidence, errors):
+            _validate_ci_evidence_freshness(proof_id, repo_root, ci_evidence, errors)
 
     workflow = proof.get("workflow")
     if workflow != WORKFLOW_PATH:

--- a/scripts/docmeta/validate_opt_arc_001_db_proof_matrix.py
+++ b/scripts/docmeta/validate_opt_arc_001_db_proof_matrix.py
@@ -577,6 +577,17 @@ def _git_commit_exists(repo_root, commit):
     return result.returncode == 0
 
 
+def _git_commit_is_ancestor_of_head(repo_root, commit):
+    """Return whether commit belongs to the current HEAD history."""
+    result = _run_git(repo_root, ["merge-base", "--is-ancestor", commit, "HEAD"])
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+    detail = result.stderr.strip() or result.stdout.strip() or "unknown Git error"
+    raise GitFreshnessError(detail)
+
+
 def _git_changed_paths_since(repo_root, commit, paths):
     """Return proof-harness paths changed between commit and HEAD."""
     result = _run_git(
@@ -663,6 +674,12 @@ def _validate_ci_evidence_freshness(proof_id, repo_root, ci_evidence, errors):
             errors.append(
                 f"{MATRIX_PATH}: proof '{proof_id}': ci_evidence commit '{commit}' "
                 "was not found in the local Git history"
+            )
+            return
+        if not _git_commit_is_ancestor_of_head(repo_root, commit):
+            errors.append(
+                f"{MATRIX_PATH}: proof '{proof_id}': ci_evidence commit '{commit}' "
+                "is not an ancestor of HEAD"
             )
             return
         paths = _ci_evidence_freshness_paths(proof_id)


### PR DESCRIPTION
### Motivation

- Prevent stale PR-CI evidence from being treated as proof of correctness by ensuring the API workflow and the proof's test harness are unchanged since the recorded run.  
- Require canonical, full 40-character lowercase Git SHAs in `ci_evidence.commit` to avoid ambiguous refs (e.g. `HEAD`, branch names, short/uppercase SHAs).  
- Make the repository guard react to changes in the proof test files by including those paths in the workflow trigger so the validator runs on relevant PRs.

### Description

- Add narrow proof-harness freshness checks that verify the API workflow and the proof's test file were not changed since the recorded `ci_evidence.commit` by running Git commands from Python (`_git_commit_exists`, `_git_changed_paths_since`) and surfacing failures as `GitFreshnessError`.  
- Require `ci_evidence.commit` to match `^[0-9a-f]{40}$` and skip Git lookups for structurally invalid commit values.  
- Change `_validate_ci_evidence` to return validity and call the freshness check only for structurally valid evidence; add `_ci_evidence_freshness_paths` to scope the diff to `(WORKFLOW_PATH, test_path)`.  
- Add a safe `_run_git` wrapper using `subprocess.run` with deterministic args, timeout and error handling.  
- Update unit tests in `scripts/docmeta/tests/test_validate_opt_arc_001_db_proof_matrix.py` to cover freshness, invalid commit formats, staleness detection, and to assert that prepared proofs do not invoke Git checks; update fixture commit strings to full 40-char SHAs.  
- Update the GitHub Actions workflow `/.github/workflows/opt-arc-001-db-proof-matrix.yml` to include the proof test files in `paths` and to use `fetch-depth: 0` when checking out so Git history is available to freshness checks.

### Testing

- Ran the validator: `python3 -m scripts.docmeta.validate_opt_arc_001_db_proof_matrix` as part of the job and it completed (no runtime exceptions reported).  
- Ran the unit test suite: `python3 -m unittest scripts.docmeta.tests.test_validate_opt_arc_001_db_proof_matrix` and all new and existing tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a9b7701f8832cb3e5da3919ce9687)