### PR TITLE
Add coverage for domain payload key extraction semantics

### DIFF
--- a/apps/api/src/domain_db.rs
+++ b/apps/api/src/domain_db.rs
@@ -815,6 +815,27 @@ mod write_path_tests {
     }
 
     #[test]
+    fn payload_from_keys_preserves_selected_non_null_fields() {
+        let source = serde_json::json!({
+            "summary": "hello",
+            "tags": ["a", "b"],
+            "private_note": "secret",
+            "empty": null
+        });
+
+        let payload = payload_from_keys(&["summary", "tags", "empty", "missing"], &source);
+        let parsed: serde_json::Value = serde_json::from_str(&payload).unwrap();
+
+        assert_eq!(
+            parsed,
+            serde_json::json!({
+                "summary": "hello",
+                "tags": ["a", "b"]
+            })
+        );
+    }
+
+    #[test]
     fn ron_flag_forces_ron_mode() {
         let record = json!({
             "id": "writepath-unit-ron",

--- a/apps/api/src/domain_db.rs
+++ b/apps/api/src/domain_db.rs
@@ -836,6 +836,18 @@ mod write_path_tests {
     }
 
     #[test]
+    fn payload_from_keys_returns_empty_object_for_missing_or_null_fields() {
+        let source = serde_json::json!({
+            "summary": null,
+            "private_note": "secret"
+        });
+
+        let payload = payload_from_keys(&["summary", "tags"], &source);
+
+        assert_eq!(payload, "{}");
+    }
+
+    #[test]
     fn ron_flag_forces_ron_mode() {
         let record = json!({
             "id": "writepath-unit-ron",


### PR DESCRIPTION
Add focused coverage for payload_from_keys to lock down selected-key extraction, null omission, missing-key omission, and JSON payload preservation. No performance change is included because the investigated lookup loop is not a justified optimization target without stronger profiling evidence.

---
*PR created automatically by Jules for task [12129731058276923898](https://jules.google.com/task/12129731058276923898) started by @alexdermohr*