### PR TITLE
docs(api): clarify postgres edge insert semantics

### DIFF
--- a/apps/api/src/domain_db.rs
+++ b/apps/api/src/domain_db.rs
@@ -818,8 +818,12 @@ pub enum EdgeWriteError {
 
 /// Insert exactly one edge row into `domain_edges` (Phase E-C).
 ///
-/// A primary-key collision surfaces as [`EdgeWriteError::DuplicateId`].
-/// A limit condition surfaces as [`EdgeWriteError::CacheLimitReached`].
+/// The PostgreSQL create path is serialized in a transaction:
+/// table-level lock, duplicate precheck, cache-limit count check, then final
+/// INSERT. Duplicate ids are checked before the cache-limit condition so the
+/// client receives the more precise 409 cause. A unique violation can still
+/// surface as a defensive fallback.
+///
 /// This function performs no in-memory mutation and writes no JSONL.
 pub async fn insert_domain_edge(
     pool: &PgPool,

--- a/apps/api/src/routes/edges.rs
+++ b/apps/api/src/routes/edges.rs
@@ -419,10 +419,11 @@ fn edge_create_error_message(err: &edge_create::EdgeCreateValidationError) -> St
 /// JSONL (default): persistence safety checks (file-level duplicate id,
 /// cache-limit materializability) followed by a durable JSONL append (fsync).
 /// PostgreSQL (opt-in via `WELTGEWEBE_DOMAIN_EDGE_WRITE_SOURCE=postgres`,
-/// requires the PostgreSQL read source): a plain INSERT into `domain_edges`;
-/// a duplicate id surfaces as 409 via the unique violation. No dual-write:
-/// JSONL mode never touches PostgreSQL, PostgreSQL mode never appends JSONL
-/// and never falls back to JSONL.
+/// requires the PostgreSQL read source): PostgreSQL mode uses `insert_domain_edge`: a serialized transaction with a
+/// table-level lock, duplicate precheck, cache-limit count check, and final
+/// INSERT. Duplicate ids still map to 409; a unique violation remains a
+/// defensive fallback. No dual-write: JSONL mode never touches PostgreSQL,
+/// PostgreSQL mode never appends JSONL and never falls back to JSONL.
 pub async fn create_edge(
     State(state): State<ApiState>,
     Json(payload): Json<Value>,
@@ -517,9 +518,10 @@ pub async fn create_edge(
             }
         }
         DomainEdgeWriteSource::Postgres => {
-            // No JSONL inspection and no JSONL append in this mode: the plain
-            // INSERT's primary key makes a duplicate id surface as 409, and a
-            // restart reloads edges from domain_edges.
+            // No JSONL inspection and no JSONL append in this mode. `insert_domain_edge`
+            // serializes the DB write with a table-level lock, duplicate precheck,
+            // cache-limit count check, and final INSERT; unique violation remains only a
+            // defensive fallback.
             //
             // The cache-level duplicate check stays for parity with the JSONL
             // arm: tests may seed the cache directly.

--- a/apps/api/tests/db_domain_edge_write_path.rs
+++ b/apps/api/tests/db_domain_edge_write_path.rs
@@ -2,7 +2,7 @@
 //!
 //! Proves that, when `domain_read_source=postgres` and
 //! `domain_edge_write_source=postgres`, `POST /edges` inserts exactly one row
-//! into `domain_edges` (transactional lock + insert, duplicate id -> 409), updates the
+//! into `domain_edges` (plain INSERT, duplicate id -> 409), updates the
 //! in-memory edge cache only after the successful insert, never touches JSONL,
 //! and that `load_edges_from_postgres` reconstructs the stored edge including
 //! `source_type`, `target_type`, `note` and `created_at`.
@@ -454,11 +454,9 @@ async fn postgres_edge_create_omits_note_key_when_absent() -> Result<()> {
     Ok(())
 }
 
-/// C. Duplicate id from the database surfaces as 409. The conflicting row is
-/// inserted after the cache was loaded, so the route cache check cannot see it;
-/// the PostgreSQL write helper must reject it via its transactional duplicate
-/// precheck under the DB lock. The unique constraint remains a defensive
-/// fallback.
+/// C. Duplicate id from the database surfaces as 409 (plain INSERT, no
+/// ON CONFLICT): the second create leaves exactly one row and no extra cache
+/// entry.
 #[tokio::test]
 #[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
 #[serial]
@@ -485,7 +483,7 @@ async fn postgres_edge_create_duplicate_id_returns_409() -> Result<()> {
 
     // Insert the conflicting row AFTER the cache was loaded, so the route's
     // cache-level duplicate check cannot see it and the 409 must come from the
-    // transactional DB duplicate precheck.
+    // database unique violation.
     sqlx::query(
         "INSERT INTO domain_edges (id, source_id, target_id, edge_kind, created_at, payload) \
          VALUES ($1, $2, $3, 'reference', NOW(), '{}'::jsonb)",

--- a/apps/api/tests/db_domain_edge_write_path.rs
+++ b/apps/api/tests/db_domain_edge_write_path.rs
@@ -2,7 +2,7 @@
 //!
 //! Proves that, when `domain_read_source=postgres` and
 //! `domain_edge_write_source=postgres`, `POST /edges` inserts exactly one row
-//! into `domain_edges` (plain INSERT, duplicate id -> 409), updates the
+//! into `domain_edges` (transactional lock + insert, duplicate id -> 409), updates the
 //! in-memory edge cache only after the successful insert, never touches JSONL,
 //! and that `load_edges_from_postgres` reconstructs the stored edge including
 //! `source_type`, `target_type`, `note` and `created_at`.
@@ -454,9 +454,11 @@ async fn postgres_edge_create_omits_note_key_when_absent() -> Result<()> {
     Ok(())
 }
 
-/// C. Duplicate id from the database surfaces as 409 (plain INSERT, no
-/// ON CONFLICT): the second create leaves exactly one row and no extra cache
-/// entry.
+/// C. Duplicate id from the database surfaces as 409. The conflicting row is
+/// inserted after the cache was loaded, so the route cache check cannot see it;
+/// the PostgreSQL write helper must reject it via its transactional duplicate
+/// precheck under the DB lock. The unique constraint remains a defensive
+/// fallback.
 #[tokio::test]
 #[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
 #[serial]
@@ -483,7 +485,7 @@ async fn postgres_edge_create_duplicate_id_returns_409() -> Result<()> {
 
     // Insert the conflicting row AFTER the cache was loaded, so the route's
     // cache-level duplicate check cannot see it and the 409 must come from the
-    // database unique violation.
+    // transactional DB duplicate precheck.
     sqlx::query(
         "INSERT INTO domain_edges (id, source_id, target_id, edge_kind, created_at, payload) \
          VALUES ($1, $2, $3, 'reference', NOW(), '{}'::jsonb)",

--- a/docs/reports/domain-edge-write-path-proof.md
+++ b/docs/reports/domain-edge-write-path-proof.md
@@ -65,8 +65,11 @@ Downgrade auf JSONL.
 - JSONL-Modus: bestehender Pfad unverändert (Persist-Lock,
   `inspect_edge_persistence_for_create`, Boundary-/Limit-/Suffix-Safety,
   `append_edge_line` mit fsync).
-- PostgreSQL-Modus: kein JSONL-Append, keine JSONL-Inspection; plain `INSERT`
-  in `domain_edges`; fehlender Pool → 500, kein JSONL-Fallback.
+- PostgreSQL-Modus: kein JSONL-Append, keine JSONL-Inspection;
+  `insert_domain_edge` nutzt eine serialisierte Transaktion mit
+  `LOCK TABLE domain_edges IN EXCLUSIVE MODE`, Duplicate-Precheck,
+  `COUNT(*) >= MAX_EDGES_CACHE`-Prüfung und finalem Insert. Fehlender Pool → 500,
+  kein JSONL-Fallback.
 - Routing/Auth unverändert: `POST /edges` bleibt `require_write`;
   `GET /edges` und `GET /edges/{id}` bleiben lesbar wie bisher.
 
@@ -92,14 +95,17 @@ DB-Insert); ein fehlgeschriebener Edge landet nie als Phantom im Cache.
 JSONL und PostgreSQL verwenden denselben finalen Edge-Wert für Cache und
 Response; `GET /edges/{id}` liefert den Edge im selben Prozess.
 
-### Duplicate-/Fehler-Mapping
+### Duplicate-/Limit-/Fehler-Mapping
 
-- Duplicate-ID im PostgreSQL-Modus: plain `INSERT` ohne `ON CONFLICT`;
-  Unique-Violation (SQLSTATE 23505 via `is_unique_violation`) → 409
-  „edge id already exists“. Der Phase-C-Backfill-Upsert bleibt ein separater
-  Nicht-Runtime-Pfad.
+- Duplicate-ID im PostgreSQL-Modus: transaktionaler Duplicate-Precheck unter
+  DB-Lock; Duplicate gewinnt vor Cache-Limit und wird als 409
+  „edge id already exists“ gemappt. Eine Unique-Violation bleibt defensiver
+  Fallback.
+- Cache-Limit im PostgreSQL-Modus: `COUNT(*) >= MAX_EDGES_CACHE` innerhalb
+  derselben serialisierten Transaktion; bei erreichtem Limit 409
+  „edge cache limit reached“, kein Insert, kein Cache-Eintrag, kein JSONL.
 - Andere DB-Fehler → 500 „failed to persist edge“.
-- JSONL-Fehlersemantik unverändert (Limit 409, Append-Fehler 500).
+- JSONL-Fehlersemantik unverändert.
 
 ### JSONL-Regressionsschutz
 
@@ -144,4 +150,8 @@ Datei → 409, Cache-after-persist und kein Phantom-Cache bei Persistenzfehler.
 
 - FK-/Orphan-Semantik bleibt offen (Migrationskommentar in `20260531000002_create_domain_edges.up.sql`).
 - JSONL bleibt Default-Lesequelle und Write-Truth bis zum Cutover.
-- Im JSONL-Modus scannt ein erfolgreicher Create die JSONL-Datei weiterhin O(N) (Duplicate-/Limit-Inspection); der PostgreSQL-Modus ersetzt das durch den Unique-Index.
+- Im JSONL-Modus scannt ein erfolgreicher Create die JSONL-Datei weiterhin O(N)
+  (Duplicate-/Limit-Inspection). Der PostgreSQL-Modus vermeidet die
+  JSONL-Datei-Inspection, nutzt aktuell aber einen table-level Lock plus
+  `COUNT(*)` zur Cache-Limit-Sicherung; diese Serialisierung ist
+  korrektheitsorientiert und für Cutover/Skalierung später erneut zu bewerten.


### PR DESCRIPTION
## Summary

Aligns comments and the Edge Write Path proof report with the current PostgreSQL edge-create implementation.

The current path is no longer just a plain insert. It uses a serialized transaction with table-level lock, duplicate precheck, cache-limit count check, and final insert. Unique violation remains only a defensive fallback.

## Scope

- Documentation/comment-only correction.
- No runtime logic changes.
- No SQL changes.
- No proof-matrix or CI-evidence changes.
- No cutover claim.

## Checks

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --locked -p weltgewebe-api`
- [x] `cargo test --locked -p weltgewebe-api --test api_edges`
- [x] `cargo test --locked -p weltgewebe-api --test db_domain_edge_write_path -- --list`
- [x] `npx markdownlint-cli2 "docs/reports/domain-edge-write-path-proof.md"`
- [x] `git diff --check`
