### PR TITLE
docs(api): align edge write proof with serialized postgres path

### DIFF
--- a/apps/api/tests/db_domain_edge_write_path.rs
+++ b/apps/api/tests/db_domain_edge_write_path.rs
@@ -2,8 +2,7 @@
 //!
 //! Proves that, when `domain_read_source=postgres` and
 //! `domain_edge_write_source=postgres`, `POST /edges` inserts exactly one row
-//! into `domain_edges` (serialized via LOCK TABLE, SELECT EXISTS duplicate precheck,
-//! COUNT limit check, and final INSERT), updates the
+//! into `domain_edges` (plain INSERT, duplicate id -> 409), updates the
 //! in-memory edge cache only after the successful insert, never touches JSONL,
 //! and that `load_edges_from_postgres` reconstructs the stored edge including
 //! `source_type`, `target_type`, `note` and `created_at`.
@@ -455,8 +454,8 @@ async fn postgres_edge_create_omits_note_key_when_absent() -> Result<()> {
     Ok(())
 }
 
-/// C. Duplicate id from the database surfaces as 409 (duplicate id checked via SELECT EXISTS
-/// before the final INSERT): the second create leaves exactly one row and no extra cache
+/// C. Duplicate id from the database surfaces as 409 (plain INSERT, no
+/// ON CONFLICT): the second create leaves exactly one row and no extra cache
 /// entry.
 #[tokio::test]
 #[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
@@ -484,7 +483,7 @@ async fn postgres_edge_create_duplicate_id_returns_409() -> Result<()> {
 
     // Insert the conflicting row AFTER the cache was loaded, so the route's
     // cache-level duplicate check cannot see it and the 409 must come from the
-    // SELECT EXISTS duplicate precheck in the database transaction.
+    // database unique violation.
     sqlx::query(
         "INSERT INTO domain_edges (id, source_id, target_id, edge_kind, created_at, payload) \
          VALUES ($1, $2, $3, 'reference', NOW(), '{}'::jsonb)",

--- a/apps/api/tests/db_domain_edge_write_path.rs
+++ b/apps/api/tests/db_domain_edge_write_path.rs
@@ -2,7 +2,8 @@
 //!
 //! Proves that, when `domain_read_source=postgres` and
 //! `domain_edge_write_source=postgres`, `POST /edges` inserts exactly one row
-//! into `domain_edges` (plain INSERT, duplicate id -> 409), updates the
+//! into `domain_edges` (serialized via LOCK TABLE, SELECT EXISTS duplicate precheck,
+//! COUNT limit check, and final INSERT), updates the
 //! in-memory edge cache only after the successful insert, never touches JSONL,
 //! and that `load_edges_from_postgres` reconstructs the stored edge including
 //! `source_type`, `target_type`, `note` and `created_at`.
@@ -454,8 +455,8 @@ async fn postgres_edge_create_omits_note_key_when_absent() -> Result<()> {
     Ok(())
 }
 
-/// C. Duplicate id from the database surfaces as 409 (plain INSERT, no
-/// ON CONFLICT): the second create leaves exactly one row and no extra cache
+/// C. Duplicate id from the database surfaces as 409 (duplicate id checked via SELECT EXISTS
+/// before the final INSERT): the second create leaves exactly one row and no extra cache
 /// entry.
 #[tokio::test]
 #[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
@@ -483,7 +484,7 @@ async fn postgres_edge_create_duplicate_id_returns_409() -> Result<()> {
 
     // Insert the conflicting row AFTER the cache was loaded, so the route's
     // cache-level duplicate check cannot see it and the 409 must come from the
-    // database unique violation.
+    // SELECT EXISTS duplicate precheck in the database transaction.
     sqlx::query(
         "INSERT INTO domain_edges (id, source_id, target_id, edge_kind, created_at, payload) \
          VALUES ($1, $2, $3, 'reference', NOW(), '{}'::jsonb)",

--- a/docs/reports/domain-edge-create-semantics-preflight.md
+++ b/docs/reports/domain-edge-create-semantics-preflight.md
@@ -232,9 +232,11 @@ sein. Daraus folgt exakt:
 - **Read-after-Write-Symmetrie:** `load_edges_from_postgres` (`domain_db.rs:138-187`)
   rekonstruiert exakt diese Felder — keine Anpassung der Read-Logik nötig.
 - **DB-Fehler-Mapping:** Serialisierter Pfad via `LOCK TABLE domain_edges IN
-  EXCLUSIVE MODE`, Duplicate-Precheck (`SELECT EXISTS`) → 409, Limit-Check
-  (`COUNT(*) >= MAX_EDGES_CACHE`) → 409, finaler `INSERT`. Unique-Violation
-  ist nur ein defensiver Fallback; sonstige `sqlx::Error` → 500. **Keine FKs,
+  EXCLUSIVE MODE`; `SELECT EXISTS` erkennt Duplikate vor dem Limit-Check und
+  mappt sie auf 409. Die DB-Eindeutigkeit bleibt durch den Primary Key auf
+  `domain_edges.id` garantiert. Danach folgen Limit-Check
+  (`COUNT(*) >= MAX_EDGES_CACHE`) und finaler `INSERT`. Unique-Violation ist
+  nur ein defensiver Fallback; sonstige `sqlx::Error` → 500. **Keine FKs,
   kein Orphan-Audit.**
 
 ### Config Matrix
@@ -262,16 +264,19 @@ Cache wird **nur nach** erfolgreicher durabler Schreibung aktualisiert (JSONL:
 nach `fsync`; Postgres: nach `INSERT` ohne Fehler). Bei Persistenzfehler **kein**
 Cache-Insert (kein Phantom-Edge). Der `edges_persist`-Mutex serialisiert
 Dup-Check und Schreibung, damit nebenläufige Creates die `id`-Prüfung nicht
-unterlaufen. Im Postgres-Modus ist die `id`-Eindeutigkeit primär durch den
-`SELECT EXISTS`-Precheck innerhalb der Transaktion sichergestellt, die
-PK-Unique-Violation (409) ist nur ein defensiver Fallback.
+unterlaufen. Im Postgres-Modus dient der `SELECT EXISTS`-Precheck der
+Fehlerordnung: Duplikate werden vor dem Limit-Check erkannt und als 409 gemappt.
+Die `LOCK TABLE domain_edges IN EXCLUSIVE MODE`-Sperre serialisiert die
+Precheck/Insert-Sequenz; die Datenbank-Eindeutigkeit bleibt durch den Primary
+Key auf `domain_edges.id` garantiert. Die PK-Unique-Violation (409) ist nur ein
+defensiver Fallback.
 
 ### Duplicate-/Fehler-Mapping
 
 | Fall | Code |
 |---|---|
 | `id` existiert bereits (Cache, JSONL-Modus) | 409 `edge id already exists` |
-| `id` existiert bereits (Duplicate-Precheck, Postgres-Modus) | 409 `edge id already exists` |
+| `id` existiert bereits (Postgres: Duplicate-Precheck unter Tabellenlock; PK-Fallback) | 409 `edge id already exists` |
 | ungültige Eingabe (fehlendes `source_id`/`target_id`, ungültiges `edge_kind`) | 400 |
 | JSONL-`fsync`-/Append-Fehler | 500 `failed to persist edge` |
 | sonstiger DB-Fehler | 500 |

--- a/docs/reports/domain-edge-create-semantics-preflight.md
+++ b/docs/reports/domain-edge-create-semantics-preflight.md
@@ -231,8 +231,7 @@ sein. Daraus folgt exakt:
   `required` führt.
 - **Read-after-Write-Symmetrie:** `load_edges_from_postgres` (`domain_db.rs:138-187`)
   rekonstruiert exakt diese Felder — keine Anpassung der Read-Logik nötig.
-- **DB-Fehler-Mapping:** reiner `INSERT` (kein `ON CONFLICT`); Unique-Violation
-  auf `id` → 409; sonstige `sqlx::Error` → 500. **Keine FKs, kein Orphan-Audit.**
+- **DB-Fehler-Mapping:** Serialisierter Pfad via `LOCK TABLE domain_edges IN EXCLUSIVE MODE`, Duplicate-Precheck (`SELECT EXISTS`) → 409, Limit-Check (`COUNT(*) >= MAX_EDGES_CACHE`) → 409, finaler `INSERT`. Unique-Violation ist nur ein defensiver Fallback; sonstige `sqlx::Error` → 500. **Keine FKs, kein Orphan-Audit.**
 
 ### Config Matrix
 
@@ -259,15 +258,14 @@ Cache wird **nur nach** erfolgreicher durabler Schreibung aktualisiert (JSONL:
 nach `fsync`; Postgres: nach `INSERT` ohne Fehler). Bei Persistenzfehler **kein**
 Cache-Insert (kein Phantom-Edge). Der `edges_persist`-Mutex serialisiert
 Dup-Check und Schreibung, damit nebenläufige Creates die `id`-Prüfung nicht
-unterlaufen. Im Postgres-Modus bleibt die `id`-Eindeutigkeit zusätzlich durch die
-PK-Unique-Violation (409) abgesichert.
+unterlaufen. Im Postgres-Modus ist die `id`-Eindeutigkeit primär durch den `SELECT EXISTS`-Precheck innerhalb der Transaktion sichergestellt, die PK-Unique-Violation (409) ist nur ein defensiver Fallback.
 
 ### Duplicate-/Fehler-Mapping
 
 | Fall | Code |
 |---|---|
 | `id` existiert bereits (Cache, JSONL-Modus) | 409 `edge id already exists` |
-| `id` existiert bereits (PK-Violation, Postgres-Modus) | 409 `edge id already exists` |
+| `id` existiert bereits (Duplicate-Precheck, Postgres-Modus) | 409 `edge id already exists` |
 | ungültige Eingabe (fehlendes `source_id`/`target_id`, ungültiges `edge_kind`) | 400 |
 | JSONL-`fsync`-/Append-Fehler | 500 `failed to persist edge` |
 | sonstiger DB-Fehler | 500 |

--- a/docs/reports/domain-edge-create-semantics-preflight.md
+++ b/docs/reports/domain-edge-create-semantics-preflight.md
@@ -231,7 +231,11 @@ sein. Daraus folgt exakt:
   `required` führt.
 - **Read-after-Write-Symmetrie:** `load_edges_from_postgres` (`domain_db.rs:138-187`)
   rekonstruiert exakt diese Felder — keine Anpassung der Read-Logik nötig.
-- **DB-Fehler-Mapping:** Serialisierter Pfad via `LOCK TABLE domain_edges IN EXCLUSIVE MODE`, Duplicate-Precheck (`SELECT EXISTS`) → 409, Limit-Check (`COUNT(*) >= MAX_EDGES_CACHE`) → 409, finaler `INSERT`. Unique-Violation ist nur ein defensiver Fallback; sonstige `sqlx::Error` → 500. **Keine FKs, kein Orphan-Audit.**
+- **DB-Fehler-Mapping:** Serialisierter Pfad via `LOCK TABLE domain_edges IN
+  EXCLUSIVE MODE`, Duplicate-Precheck (`SELECT EXISTS`) → 409, Limit-Check
+  (`COUNT(*) >= MAX_EDGES_CACHE`) → 409, finaler `INSERT`. Unique-Violation
+  ist nur ein defensiver Fallback; sonstige `sqlx::Error` → 500. **Keine FKs,
+  kein Orphan-Audit.**
 
 ### Config Matrix
 
@@ -258,7 +262,9 @@ Cache wird **nur nach** erfolgreicher durabler Schreibung aktualisiert (JSONL:
 nach `fsync`; Postgres: nach `INSERT` ohne Fehler). Bei Persistenzfehler **kein**
 Cache-Insert (kein Phantom-Edge). Der `edges_persist`-Mutex serialisiert
 Dup-Check und Schreibung, damit nebenläufige Creates die `id`-Prüfung nicht
-unterlaufen. Im Postgres-Modus ist die `id`-Eindeutigkeit primär durch den `SELECT EXISTS`-Precheck innerhalb der Transaktion sichergestellt, die PK-Unique-Violation (409) ist nur ein defensiver Fallback.
+unterlaufen. Im Postgres-Modus ist die `id`-Eindeutigkeit primär durch den
+`SELECT EXISTS`-Precheck innerhalb der Transaktion sichergestellt, die
+PK-Unique-Violation (409) ist nur ein defensiver Fallback.
 
 ### Duplicate-/Fehler-Mapping
 

--- a/docs/reports/domain-edge-write-path-proof.md
+++ b/docs/reports/domain-edge-write-path-proof.md
@@ -67,7 +67,7 @@ Downgrade auf JSONL.
   `append_edge_line` mit fsync).
 - PostgreSQL-Modus: kein JSONL-Append, keine JSONL-Inspection;
   `insert_domain_edge` nutzt eine serialisierte Transaktion mit
-  `LOCK TABLE domain_edges IN EXCLUSIVE MODE`, Duplicate-Precheck,
+  `LOCK TABLE domain_edges IN EXCLUSIVE MODE`, Duplicate-Precheck via `SELECT EXISTS`,
   `COUNT(*) >= MAX_EDGES_CACHE`-Prüfung und finalem Insert. Fehlender Pool → 500,
   kein JSONL-Fallback.
 - Routing/Auth unverändert: `POST /edges` bleibt `require_write`;


### PR DESCRIPTION
Update the edge write proof and stale comments to describe the actual PostgreSQL edge-create mechanism after PR #1188: transactional table lock, duplicate precheck via SELECT EXISTS, cache-limit COUNT check, and final INSERT.

This removes outdated "plain INSERT" and unique-index-primary wording. Unique violations remain documented only as a defensive fallback. No production logic is changed.