### PR TITLE
fix(api): persist webauthn user id on postgres account create

### DIFF
--- a/apps/api/src/routes/accounts.rs
+++ b/apps/api/src/routes/accounts.rs
@@ -429,8 +429,8 @@ async fn append_account_line(record: &Value) -> std::io::Result<()> {
 /// must be bootstrapped via `scripts/dev/bootstrap-first-account.sh`; all
 /// subsequent Admins can be created through this endpoint by an existing Admin.
 ///
-/// Persists by appending to the JSONL store (durable across restart) and
-/// inserts into the in-memory store (immediate visibility for GET /accounts).
+/// Persists to the configured account-create write source and inserts into the
+/// in-memory store (immediate visibility for GET /accounts).
 pub async fn create_account(
     State(state): State<ApiState>,
     Extension(ctx): Extension<AuthContext>,
@@ -530,6 +530,7 @@ pub async fn create_account(
         .map(str::trim)
         .filter(|s| !s.is_empty())
         .map(str::to_string);
+    let webauthn_user_id = Uuid::new_v4();
 
     // --- Build canonical JSONL record (matches contract after key projection;
     // role/email are operational fields read by the API) ---
@@ -550,6 +551,10 @@ pub async fn create_account(
     if let Some(e) = &email {
         record.insert("email".into(), json!(e));
     }
+    record.insert(
+        "webauthn_user_id".into(),
+        Value::String(webauthn_user_id.to_string()),
+    );
     let record = Value::Object(record);
 
     let public = map_json_to_public_account(&record).ok_or_else(|| {
@@ -626,7 +631,7 @@ pub async fn create_account(
             public: public.clone(),
             role,
             email,
-            webauthn_user_id: Uuid::new_v4(),
+            webauthn_user_id,
         });
     }
 

--- a/apps/api/tests/db_domain_account_write_path.rs
+++ b/apps/api/tests/db_domain_account_write_path.rs
@@ -3,10 +3,11 @@
 //! Proves that, when `domain_read_source=postgres` and
 //! `domain_account_write_source=postgres`, `POST /accounts` writes one row into
 //! `domain_accounts`, updates the in-memory `AccountStore`, never appends JSONL,
-//! and that the Phase D loader reconstructs the same public projection.
+//! and that the Phase D loader reconstructs the same public projection and
+//! stable WebAuthn user identity.
 //!
 //! Phase scope: account-create only. Node writes, edge writes, step-up email
-//! persistence and WebAuthn user-id writeback persistence are NOT implemented.
+//! persistence and WebAuthn credential writeback are NOT implemented.
 //!
 //! Run with:
 //!   DATABASE_URL=postgres://welt:gewebe@localhost:5432/weltgewebe \
@@ -16,7 +17,7 @@
 //! Notes:
 //! - Tests are ignored by default to keep offline paths green.
 //! - DATABASE_URL must point to direct PostgreSQL (not PgBouncer at :6432).
-//! - Fixture rows use the `writepath-%` id prefix and are cleaned before/after.
+//! - Fixture rows use a recognizable UUID namespace and are cleaned before/after.
 
 use anyhow::{Context, Result};
 use axum::{
@@ -79,9 +80,9 @@ async fn run_migrations(pool: &PgPool) {
 // validates them), so fixtures use a recognizable UUID namespace that the
 // cleanup matches with LIKE. Operator ids are in-memory only (never written to
 // the database) and need not be UUIDs.
-const SUCCESS_ID: &str = "aaaaaaaa-aaaa-4aaa-8aaa-000000000001";
 const RADIUS_ID: &str = "aaaaaaaa-aaaa-4aaa-8aaa-000000000002";
 const DUP_ID: &str = "aaaaaaaa-aaaa-4aaa-8aaa-000000000003";
+const WEBAUTHN_STABLE_ID: &str = "aaaaaaaa-aaaa-4aaa-8aaa-000000000004";
 
 async fn clean(pool: &PgPool) {
     pool.execute("DELETE FROM domain_accounts WHERE id LIKE 'aaaaaaaa-aaaa-4aaa-8aaa-%'")
@@ -208,11 +209,12 @@ fn post_accounts(cookie: &str, json_body: &str) -> Request<body::Body> {
 }
 
 /// Core success proof: account create writes domain_accounts, updates the cache,
-/// does not append JSONL, and reloads with the same public projection.
+/// does not append JSONL, and reloads with the same public projection and
+/// WebAuthn user identity.
 #[tokio::test]
 #[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
 #[serial]
-async fn postgres_account_create_writes_domain_accounts_and_updates_cache() -> Result<()> {
+async fn account_create_persists_stable_webauthn_user_id_across_reload() -> Result<()> {
     let pool = connect_pool().await;
     run_migrations(&pool).await;
     clean(&pool).await;
@@ -224,7 +226,7 @@ async fn postgres_account_create_writes_domain_accounts_and_updates_cache() -> R
 
     let (app, cookie, state) = postgres_write_app(pool.clone(), "writepath-admin-1").await?;
 
-    let id = SUCCESS_ID;
+    let id = WEBAUTHN_STABLE_ID;
     let body = format!(
         r#"{{"id":"{id}","title":"Write Path","location":{{"lat":53.55,"lon":9.99}},"radius_m":0,"summary":"Hello","tags":["a","b"],"role":"weber"}}"#
     );
@@ -267,6 +269,15 @@ async fn postgres_account_create_writes_domain_accounts_and_updates_cache() -> R
     assert!((lat.unwrap() - 53.55).abs() < 1e-9);
     assert!((lon.unwrap() - 9.99).abs() < 1e-9);
 
+    let db_webauthn_user_id: Option<String> =
+        sqlx::query_scalar("SELECT webauthn_user_id::text FROM domain_accounts WHERE id = $1")
+            .bind(id)
+            .fetch_one(&pool)
+            .await?;
+    let db_webauthn_user_id =
+        db_webauthn_user_id.expect("new account must persist webauthn_user_id");
+    let db_uuid = uuid::Uuid::parse_str(&db_webauthn_user_id)?;
+
     // JSONB payloads: public carries summary+tags; private mirrors backfill mode.
     let (public_text, private_text): (String, String) = sqlx::query_as(
         "SELECT public_payload::text, private_payload::text FROM domain_accounts WHERE id = $1",
@@ -305,6 +316,7 @@ async fn postgres_account_create_writes_domain_accounts_and_updates_cache() -> R
         assert_eq!(internal.public.title, "Write Path");
         assert_eq!(internal.public.mode, AccountMode::Verortet);
         assert_eq!(internal.role, Role::Weber);
+        assert_eq!(internal.webauthn_user_id, db_uuid);
     }
 
     // Loader reload reconstructs the same public projection.
@@ -316,6 +328,7 @@ async fn postgres_account_create_writes_domain_accounts_and_updates_cache() -> R
     assert_eq!(internal.public.mode, AccountMode::Verortet);
     assert_eq!(internal.public.radius_m, 0);
     assert_eq!(internal.public.summary.as_deref(), Some("Hello"));
+    assert_eq!(internal.webauthn_user_id, db_uuid);
     let pos = internal
         .public
         .public_pos

--- a/docs/reports/domain-account-write-path-proof.md
+++ b/docs/reports/domain-account-write-path-proof.md
@@ -10,7 +10,7 @@ summary: >
   Proof-Bericht für OPT-ARC-001 Phase E-A: optionaler PostgreSQL-Schreibpfad
   ausschließlich für die Account-Erzeugung (`POST /accounts`) hinter explizitem
   Write-Gate. JSONL bleibt Default; kein Dual-Write; Knoten-, Kanten-, Step-up-
-  E-Mail- und WebAuthn-Writeback-Persistenz bleiben unverändert.
+  E-Mail- und WebAuthn-Credential-Persistenz bleiben unverändert.
 relations:
   - type: relates_to
     target: docs/blueprints/domain-data-postgres-cutover.md
@@ -55,8 +55,9 @@ Geltende Grenzen:
   blockiert).
 - Kein Edge-Write-Path.
 - Keine Step-up-E-Mail-Persistenz nach PostgreSQL.
-- Kein WebAuthn-User-ID-Writeback nach PostgreSQL (Account-Create persistiert
-  `webauthn_user_id` als NULL, identisch zum bisherigen JSONL-Verhalten).
+- Kein WebAuthn-Credential-Writeback nach PostgreSQL.
+- Kein Backfill und kein `NOT NULL` für bestehende Accounts mit
+  `webauthn_user_id IS NULL`.
 - Keine Entfernung von JSONL.
 - Kein Startup-Backfill.
 - Kein Produktions-Cutover. OPT-ARC-001 bleibt `partial`.
@@ -116,11 +117,17 @@ Geltende Grenzen:
 
 `id`, `kind` (aus `type`, hier `garnrolle`), `title`, `mode` (`verortet`),
 `radius_m`, `disabled` (`false`), `location_lat`/`location_lon` (private
-Residenz), `role`, `email` (optional), `webauthn_user_id` (NULL — kein
-Writeback), `created_at`/`updated_at` (NULL — wie JSONL-Create + Backfill),
+Residenz), `role`, `email` (optional), `webauthn_user_id` (beim Account-Create
+neu erzeugte UUID), `created_at`/`updated_at` (NULL — wie JSONL-Create +
+Backfill),
 `public_payload` (`summary`, `tags`), `private_payload` (spiegelt den
 Backfill: explizites `mode`; bei Legacy-Eingaben zusätzlich `visibility`,
 `suppress_public_pos`, `ron_flag`).
+
+Neue PostgreSQL-Account-Create-Zeilen persistieren damit eine stabile
+`webauthn_user_id`, die der lokale Cache unverändert übernimmt und die
+`load_accounts_from_postgres` nach einem Reload wiederherstellt. Bestehende
+NULL-Werte bleiben über den Legacy-Fallback unterstützt.
 
 `public_pos` ist **keine** gespeicherte Spalte: Sie wird beim Lesen
 deterministisch aus `location_lat`/`location_lon`/`radius_m`/`id` berechnet.
@@ -151,10 +158,10 @@ DATABASE_URL=postgres://welt:gewebe@localhost:5432/weltgewebe \
 
 Testfälle:
 
-- `postgres_account_create_writes_domain_accounts_and_updates_cache`:
+- `account_create_persists_stable_webauthn_user_id_across_reload`:
   Erfolg (201), korrekte Spalten/Payloads, Cache enthält den Account sofort,
-  kein JSONL-Append, `load_accounts_from_postgres` rekonstruiert dieselbe
-  öffentliche Projektion.
+  kein JSONL-Append; DB, Cache und `load_accounts_from_postgres` verwenden
+  dieselbe parsebare `webauthn_user_id`.
 - `postgres_account_create_radius_persists_obfuscated_public_pos`:
   Bei `radius_m>0` speichert die DB die reale Residenz und den Radius, die
   Antwort ist gejittert, der Loader reproduziert exakt denselben Jitter.
@@ -183,7 +190,7 @@ erhält Datenschutz über `visibility=private` und bestehende Loader-Semantik
 | D | Read-Path-Switch (read-only, opt-in) | implementiert; CI-Beleg ausstehend |
 | E-A | Account-Create-Write-Path (diese Slice) | implementiert; CI-Beleg ausstehend |
 | E-B | Node-Patch-Write-Path (`PATCH /nodes`) | implementiert; CI-Beleg ausstehend |
-| E (Rest) | Edge-Writes, Step-up-E-Mail-Persistenz, WebAuthn-User-ID-Writeback | offen |
+| E (Rest) | Step-up-E-Mail-Persistenz, WebAuthn-Credential-Writeback, Passkey-Cutover sowie Backfill/Audit und späteres `NOT NULL` für Legacy-NULL-Werte | offen |
 | F | Runtime-Smoke und CI-Beweis | offen |
 | G | JSONL-Demontage | offen |
 

--- a/docs/reports/opt-arc-001-db-proof-matrix.json
+++ b/docs/reports/opt-arc-001-db-proof-matrix.json
@@ -9,7 +9,9 @@
   "ci_evidence_policy": "github_pr_ci_required",
   "non_goals": [
     "step_up_email_persistence",
-    "webauthn_user_id_writeback",
+    "webauthn_credential_writeback",
+    "legacy_webauthn_user_id_backfill",
+    "webauthn_user_id_not_null",
     "jsonl_removal",
     "production_cutover",
     "dual_write"
@@ -76,9 +78,9 @@
       "test": "apps/api/tests/db_domain_account_write_path.rs",
       "report": "docs/reports/domain-account-write-path-proof.md",
       "ci_evidence": {
-        "run_url": "https://github.com/heimgewebe/weltgewebe/actions/runs/27429628985",
-        "run_id": 27429628985,
-        "commit": "7f5f2fbdcf891a468cbcf874b499f2032d1de077",
+        "run_url": "https://github.com/heimgewebe/weltgewebe/actions/runs/27460623798",
+        "run_id": 27460623798,
+        "commit": "a194525afded9e0cd4250c0d85001e569e78dd05",
         "job": "db-domain-account-write-path-proof"
       },
       "command": "cargo test --locked -p weltgewebe-api --test db_domain_account_write_path -- --include-ignored --test-threads=1"

--- a/scripts/docmeta/validate_opt_arc_001_db_proof_matrix.py
+++ b/scripts/docmeta/validate_opt_arc_001_db_proof_matrix.py
@@ -84,7 +84,9 @@ PROOF_REQUIRED_FIELDS = frozenset({
 # write path for POST /edges); the remaining non-goals stay binding.
 REQUIRED_NON_GOALS = (
     "step_up_email_persistence",
-    "webauthn_user_id_writeback",
+    "webauthn_credential_writeback",
+    "legacy_webauthn_user_id_backfill",
+    "webauthn_user_id_not_null",
     "jsonl_removal",
     "production_cutover",
     "dual_write",


### PR DESCRIPTION
## Summary

Persist a stable `webauthn_user_id` for newly created PostgreSQL-backed accounts.

Before this PR, PostgreSQL account-create rows could store `webauthn_user_id` as `NULL`, while the in-memory cache could receive a fresh generated UUID. After a reload, the PostgreSQL loader could generate another process-local fallback UUID for the same account.

This PR makes the create path generate one UUID and use the same value for the DB row and local cache.

## Behavior

- New PostgreSQL account-create rows persist `domain_accounts.webauthn_user_id`.
- The local cache uses the same UUID as the persisted DB row.
- Reloading accounts from PostgreSQL preserves the same UUID.
- Legacy rows with `NULL` remain supported for now.

## Tests

- Adds/updates PostgreSQL account-write-path proof for create -> DB -> cache -> reload UUID stability.
- Keeps DB proof tests ignored by default and runnable with PostgreSQL via `--include-ignored`.
- `cargo fmt --check --manifest-path apps/api/Cargo.toml`
- `cargo test --locked --manifest-path apps/api/Cargo.toml --test db_domain_account_write_path --no-run`
- `cargo test --locked --manifest-path apps/api/Cargo.toml account -- --nocapture`
- Repository structure, docs-relations, generated-files, and coverage guards
- `python3 -m scripts.docmeta.validate_opt_arc_001_db_proof_matrix`
- `git diff --check`

The DB integration proof compiled but was not run locally because `DATABASE_URL` was not set.

## Non-goals

- No full WebAuthn credential writeback.
- No passkey cutover claim.
- No NOT NULL migration.
- No legacy backfill.
- No email uniqueness change.
- No multi-instance cache coherence change.