### PR TITLE
docs: add account email uniqueness audit

### DIFF
--- a/docs/reports/domain-account-email-uniqueness-audit.md
+++ b/docs/reports/domain-account-email-uniqueness-audit.md
@@ -54,7 +54,7 @@ Vorbereitung eines Unique-Index auf Account-E-Mails in PostgreSQL durch reproduz
 1. **Trim-Verhalten**: API-Create behält die Logik `trim + empty => keine E-Mail` bei.
 2. **Index-Key**: Persistierte nicht-leere E-Mails werden für spätere Eindeutigkeit ASCII-lowercase verglichen.
 3. **Datenbank-Constraint**: Für den späteren DB-Index ist `lower(email)` nur dann ausreichend, wenn gespeicherte Legacy-Werte bereits getrimmt sind. Falls Legacy-Whitespace möglich ist, muss vor E2 entweder die Datenbank bereinigt werden, oder der Index muss als `lower(btrim(email))` mit passender Policy definiert werden.
-4. **Fehlende Werte**: E-Mails, die nach dem Trimmen leer sind, oder als `null` / abwesend in JSONL stehen, werden ignoriert und unterliegen nicht der Eindeutigkeitsprüfung.
+4. **Fehlende Werte**: Für die vorgeschlagene spätere Constraint-Policy werden E-Mails ignoriert, die nach dem Trimmen leer sind. Die Current-Runtime-Gruppierung bleibt davon unberührt und erfasst rohe String-E-Mails inklusive leerer und Whitespace-Werte.
 
 ## Konfliktklassen
 

--- a/docs/reports/domain-account-email-uniqueness-audit.md
+++ b/docs/reports/domain-account-email-uniqueness-audit.md
@@ -1,0 +1,132 @@
+---
+id: reports.domain-account-email-uniqueness-audit
+title: Domain Account E-Mail Uniqueness Audit
+doc_type: report
+status: draft
+lang: de
+canonicality: supporting
+---
+
+# Domain Account E-Mail Uniqueness Audit
+
+## Ziel
+
+Vorbereitung eines Unique-Index auf Account-E-Mails in PostgreSQL durch reproduzierbares Auditieren von vorhandenen JSONL-Daten. Ziel ist es, das aktuelle Runtime-Verhalten zu dokumentieren und Normalisierungsfragen zu klären, bevor ein Constraint Daten-Integrität bricht. Dieser Report führt noch keine DB-Migration und keinen Unique-Index ein.
+
+## Belegter Ist-Zustand
+
+- Der aktuelle `AccountStore` verbietet Duplikate nicht hart, sondern wählt beim Neu-Einlesen deterministisch die kleinste lexikographische Account-ID als Owner aus.
+- Dieses Verhalten wurde durch eine Code-Prüfung in `apps/api/src/auth/accounts.rs` (insbesondere `rebuild_email_index`) belegt.
+- Das Account-Create-Routing (`apps/api/src/routes/accounts.rs`) trimmt E-Mail-Strings und verwirft leere E-Mail-Inputs (`filter(|s| !s.is_empty())`).
+
+## Aktuelle Runtime-Semantik
+
+- Der Index-Schlüssel wird momentan ohne `.trim()` gebildet, lediglich durch ASCII-Lowercase-Konvertierung: `email.to_ascii_lowercase()`.
+- Bei Duplikaten (auch Bulk-Load) gewinnt die lexikographisch kleinste Account-ID.
+- Das ist als Übergangsverhalten akzeptabel, aber nicht als DB-Cutover-Invariante geeignet.
+- API-Create verhält sich jedoch so: `trim` + `empty` => keine E-Mail (wird nicht gespeichert).
+
+## Audit-Schlüssel
+
+- **raw_email**: Der gespeicherte oder gelesene Originalwert aus der JSONL.
+- **current_runtime_key**: Der Schlüssel, der dem aktuellen AccountStore-Verhalten entspricht (ASCII-lowercase ohne zusätzliche Normalisierung oder Trim).
+- **proposed_constraint_key**: Der Schlüssel, der für einen späteren DB-Unique-Index empfohlen wird (getrimmt, nicht-leer, ASCII-lowercase).
+
+## Vorgeschlagene Normalisierungs-Policy
+
+1. **Trim-Verhalten**: API-Create behält die Logik `trim + empty => keine E-Mail` bei.
+2. **Index-Key**: Persistierte nicht-leere E-Mails werden für spätere Eindeutigkeit ASCII-lowercase verglichen.
+3. **Datenbank-Constraint**: Für den späteren DB-Index ist `lower(email)` nur dann ausreichend, wenn gespeicherte Legacy-Werte bereits getrimmt sind. Falls Legacy-Whitespace möglich ist, muss vor E2 entweder die Datenbank bereinigt werden, oder der Index muss als `lower(btrim(email))` mit passender Policy definiert werden.
+4. **Fehlende Werte**: E-Mails, die nach dem Trimmen leer sind, oder als `null` / abwesend in JSONL stehen, werden ignoriert und unterliegen nicht der Eindeutigkeitsprüfung.
+
+## Konfliktklassen
+
+Das Skript `scripts/docmeta/audit_account_email_uniqueness.py` unterscheidet folgende Klassifikationen für E-Mail-Prüfungen:
+
+- `missing_email`
+- `null_email`
+- `empty_after_trim`
+- `valid_email`
+- `duplicate_current_runtime_key`
+- `duplicate_proposed_constraint_key`
+- `trim_changes_value`
+- `case_changes_value`
+- `invalid_json`
+- `missing_id`
+
+## JSONL-Audit
+
+Das Audit-Skript ermöglicht einen deterministischen Report über JSONL-Quellen:
+
+```bash
+python3 -m scripts.docmeta.audit_account_email_uniqueness \
+  --accounts-jsonl <path> \
+  --format json
+```
+
+Das Skript gibt Exit-Code 0 zurück, außer wenn `--fail-on-duplicates` verwendet wird und Duplikate bezüglich des vorgeschlagenen Schlüssels (`proposed_constraint_key`) vorliegen.
+
+(Audit-Harness vorhanden; Produktions-/Runtime-Datenlauf ausstehend.)
+
+## PostgreSQL-Audit-SQL
+
+Aktuelle Runtime-Annäherung:
+
+```sql
+SELECT
+  lower(email) AS email_key,
+  count(*) AS count,
+  array_agg(id ORDER BY id) AS ids
+FROM domain_accounts
+WHERE email IS NOT NULL
+GROUP BY lower(email)
+HAVING count(*) > 1
+ORDER BY email_key;
+```
+
+Trim-orientierte mögliche Constraint-Policy:
+
+```sql
+SELECT
+  lower(btrim(email)) AS email_key,
+  count(*) AS count,
+  array_agg(id ORDER BY id) AS ids
+FROM domain_accounts
+WHERE email IS NOT NULL
+  AND btrim(email) <> ''
+GROUP BY lower(btrim(email))
+HAVING count(*) > 1
+ORDER BY email_key;
+```
+
+Zusätzliche Datenqualitäts-Prüfungen:
+
+```sql
+SELECT
+  count(*) FILTER (WHERE email IS NULL) AS null_email_count,
+  count(*) FILTER (WHERE email IS NOT NULL AND btrim(email) = '') AS empty_email_count,
+  count(*) FILTER (WHERE email IS NOT NULL AND email <> btrim(email)) AS whitespace_changed_count
+FROM domain_accounts;
+```
+
+## Ergebnis dieses PRs
+
+- Ein reproduzierbares Audit-Paket ist vorhanden.
+- Das aktuelle E-Mail-Runtime-Verhalten ist dokumentiert und auf Grundlage von Code-Prüfung belegt.
+- Konfliktklassen und eine Normalisierungs-Policy wurden definiert.
+- PostgreSQL-Queries für das DB-Audit sind vorbereitet.
+
+## Nicht-Ziele
+
+- Keine DB-Migration.
+- Kein Unique-Index eingeführt.
+- Kein Runtime-Code angefasst (`apps/api/src/**`, `apps/api/migrations/**`, `contracts/**`, `configs/**` sind unberührt).
+- Kein API-Error-Mapping verändert.
+- Kein Step-up-E-Mail-Fix.
+- Kein WebAuthn-Credential-Writeback.
+- Kein PostgreSQL-Cutover-Claim.
+- Keine JSONL-Demontage.
+
+## Nächster PR
+
+PR E2 (falls das Audit keine Blockaden ergibt): Umsetzung des Unique-Constraints in PostgreSQL basierend auf den Entscheidungen dieser Normalisierungs-Policy.

--- a/docs/reports/domain-account-email-uniqueness-audit.md
+++ b/docs/reports/domain-account-email-uniqueness-audit.md
@@ -14,7 +14,10 @@ relations:
     target: apps/api/src/routes/accounts.rs
   - type: relates_to
     target: scripts/docmeta/audit_account_email_uniqueness.py
-summary: Audit report on account e-mail uniqueness, duplicates, and runtime behavior to prepare for a DB unique constraint.
+summary: >
+  Audit- und Policy-Report zur Vorbereitung einer späteren PostgreSQL-
+  E-Mail-Eindeutigkeitsregel für Domain-Accounts ohne Runtime-Code,
+  Migration oder Unique-Index in diesem PR.
 ---
 
 # Domain Account E-Mail Uniqueness Audit
@@ -62,7 +65,9 @@ Das Skript `scripts/docmeta/audit_account_email_uniqueness.py` unterscheidet fol
 - `trim_changes_value`
 - `case_changes_value`
 - `invalid_json`
+- `non_object_json`
 - `missing_id`
+- `non_string_email`
 
 ## JSONL-Audit
 
@@ -86,6 +91,11 @@ Das Skript gibt Exit-Code 0 zurück, außer wenn `--fail-on-duplicates` verwende
 ## PostgreSQL-Audit-SQL
 
 Aktuelle Runtime-Annäherung:
+
+> [!NOTE]
+> PostgreSQL lower(...) ist für Nicht-ASCII-Zeichen nicht identisch mit der
+> aktuellen Rust-Semantik to_ascii_lowercase(). Die SQL-Queries sind daher
+> Audit-Annäherungen, keine finale Constraint-Definition.
 
 ```sql
 SELECT
@@ -131,7 +141,8 @@ FROM domain_accounts;
 
 - Ein reproduzierbares Audit-Paket ist vorhanden.
 - Das aktuelle E-Mail-Runtime-Verhalten ist dokumentiert und auf Grundlage von Code-Prüfung belegt.
-- Konfliktklassen und eine Normalisierungs-Policy wurden definiert.
+- Konfliktklassen sind definiert.
+- Die Normalisierungs-Policy ist als Entscheidungsvorlage dokumentiert und vor PR E2 final zu bestätigen.
 - PostgreSQL-Queries für das DB-Audit sind vorbereitet.
 
 ## Nicht-Ziele
@@ -147,4 +158,7 @@ FROM domain_accounts;
 
 ## Nächster PR
 
-PR E2 (falls das Audit keine Blockaden ergibt): Umsetzung des Unique-Constraints in PostgreSQL basierend auf den Entscheidungen dieser Normalisierungs-Policy.
+PR E2 kann erst nach einem echten Datenlauf gegen relevante JSONL- und/oder
+PostgreSQL-Daten entscheiden, ob der spätere Constraint auf lower(email),
+lower(trim(email)), physisch bereinigten Daten oder einer anderen expliziten
+Policy beruhen soll.

--- a/docs/reports/domain-account-email-uniqueness-audit.md
+++ b/docs/reports/domain-account-email-uniqueness-audit.md
@@ -35,7 +35,11 @@ Vorbereitung eines Unique-Index auf Account-E-Mails in PostgreSQL durch reproduz
 ## Aktuelle Runtime-Semantik
 
 - Der Index-Schlüssel wird momentan ohne `.trim()` gebildet, lediglich durch ASCII-Lowercase-Konvertierung: `email.to_ascii_lowercase()`.
+- Die Runtime lädt nur String-IDs. Account-Records mit ungültigen (z.B. Integer) IDs werden vom Audit als Fehler (`non_string_id`) markiert und in keine Gruppen aufgenommen, da das PostgreSQL-Mapping nicht-leere String-IDs verlangt.
+- Die "Current-Runtime"-Gruppierung erfasst alle rohen E-Mail-Strings, einschließlich leerer (`""`) oder aus Whitespace bestehender (`"   "`) E-Mails.
+- Die "Proposed-Constraint"-Gruppierung ignoriert E-Mails, die nach dem Trimmen leer sind (`empty_after_trim`).
 - Bei Duplikaten (auch Bulk-Load) gewinnt die lexikographisch kleinste Account-ID.
+- Das Audit-Skript implementiert als Grenze einen distinct-ID-Minimalfix: Es meldet nur dann Duplikat-Konflikte, wenn mehr als eine eindeutige Account-ID beteiligt ist.
 - Das ist als Übergangsverhalten akzeptabel, aber nicht als DB-Cutover-Invariante geeignet.
 - API-Create verhält sich jedoch so: `trim` + `empty` => keine E-Mail (wird nicht gespeichert).
 
@@ -67,6 +71,7 @@ Das Skript `scripts/docmeta/audit_account_email_uniqueness.py` unterscheidet fol
 - `invalid_json`
 - `non_object_json`
 - `missing_id`
+- `non_string_id`
 - `non_string_email`
 
 ## JSONL-Audit

--- a/docs/reports/domain-account-email-uniqueness-audit.md
+++ b/docs/reports/domain-account-email-uniqueness-audit.md
@@ -5,6 +5,16 @@ doc_type: report
 status: draft
 lang: de
 canonicality: supporting
+relations:
+  - type: relates_to
+    target: docs/blueprints/domain-data-postgres-cutover.md
+  - type: relates_to
+    target: apps/api/src/auth/accounts.rs
+  - type: relates_to
+    target: apps/api/src/routes/accounts.rs
+  - type: relates_to
+    target: scripts/docmeta/audit_account_email_uniqueness.py
+summary: Audit report on account e-mail uniqueness, duplicates, and runtime behavior to prepare for a DB unique constraint.
 ---
 
 # Domain Account E-Mail Uniqueness Audit
@@ -68,6 +78,11 @@ Das Skript gibt Exit-Code 0 zurück, außer wenn `--fail-on-duplicates` verwende
 
 (Audit-Harness vorhanden; Produktions-/Runtime-Datenlauf ausstehend.)
 
+> [!NOTE]
+> Das Skript streamt JSONL-Rohzeilen und vermeidet eine vollständige Rohdatenliste. Für exakte Duplikaterkennung hält es jedoch Schlüsselzustand im Speicher. Bei sehr großen Produktions-Dumps kann ein späterer Two-Pass- oder SQLite-basierter Audit sinnvoll sein.
+>
+> Produktionsläufe dürfen nicht unredigiert in PRs, Issues oder Reports kopiert werden. Für Produktionsdaten sind nur aggregierte Counts, Hashes oder redigierte Beispiele zulässig.
+
 ## PostgreSQL-Audit-SQL
 
 Aktuelle Runtime-Annäherung:
@@ -85,6 +100,9 @@ ORDER BY email_key;
 ```
 
 Trim-orientierte mögliche Constraint-Policy:
+
+> [!NOTE]
+> Auch `trim(email)` bzw. `btrim(email)` ist nur eine SQL-Annäherung an die API-/Audit-Trim-Semantik in Rust. Vor PR E2 muss geprüft werden, ob Legacy-Daten nur einfache ASCII-Leerzeichen oder weitere Whitespace-Zeichen enthalten.
 
 ```sql
 SELECT

--- a/scripts/docmeta/audit_account_email_uniqueness.py
+++ b/scripts/docmeta/audit_account_email_uniqueness.py
@@ -31,6 +31,7 @@ def main():
         "records_invalid_json": 0,
         "records_non_object_json": 0,
         "records_missing_id": 0,
+        "records_non_string_id": 0,
         "records_non_string_email": 0,
         "records_trim_changes_value": 0,
         "records_case_changes_value": 0,
@@ -110,7 +111,17 @@ def main():
                             add_finding(item_err)
                             continue
                             
-                        id_str = str(id_val)
+                        if not isinstance(id_val, str):
+                            summary["records_non_string_id"] += 1
+                            item_err = {
+                                "source_path": path_str,
+                                "line_number": line_num,
+                                "classifications": ["non_string_id"]
+                            }
+                            add_finding(item_err)
+                            continue
+                            
+                        id_str = id_val
 
                         item = {
                             "source_path": path_str,
@@ -150,6 +161,10 @@ def main():
                             add_classification(item, "empty_after_trim")
                             summary["records_empty_after_trim"] += 1
                             add_finding(item)
+                            
+                            current_runtime_key = normalize_ascii_lower(raw_email)
+                            item["current_runtime_key"] = current_runtime_key
+                            current_groups[current_runtime_key].append(item)
                             continue
                             
                         add_classification(item, "valid_email")
@@ -184,7 +199,7 @@ def main():
 
     # Process current runtime duplicates
     for key, items in sorted(current_groups.items()):
-        if len(items) > 1:
+        if len(set(i["id"] for i in items)) > 1:
             summary["duplicate_current_runtime_key_groups"] += 1
             sorted_items = sorted(items, key=sort_key)
             for i in sorted_items:
@@ -198,7 +213,7 @@ def main():
 
     # Process proposed constraint duplicates
     for key, items in sorted(proposed_groups.items()):
-        if len(items) > 1:
+        if len(set(i["id"] for i in items)) > 1:
             summary["duplicate_proposed_constraint_key_groups"] += 1
             sorted_items = sorted(items, key=sort_key)
             for i in sorted_items:

--- a/scripts/docmeta/audit_account_email_uniqueness.py
+++ b/scripts/docmeta/audit_account_email_uniqueness.py
@@ -41,12 +41,11 @@ def main():
     current_groups = defaultdict(list)
     proposed_groups = defaultdict(list)
 
-    def finding_key(item: dict) -> tuple[str, int, str, str]:
+    def finding_key(item: dict) -> tuple[str, int, str]:
         return (
             item.get("source_path", ""),
             int(item.get("line_number", -1)),
-            str(item.get("id", "")),
-            str(item.get("classifications", [""])[0]) if item.get("classifications") else ""
+            str(item.get("id", ""))
         )
 
     seen_finding_keys = set()
@@ -153,13 +152,17 @@ def main():
                             add_finding(item)
                             continue
                             
+                        add_classification(item, "valid_email")
+                            
                         if raw_email != trimmed_email:
+                            add_classification(item, "trim_changes_value")
                             summary["records_trim_changes_value"] += 1
                             
                         current_runtime_key = normalize_ascii_lower(raw_email)
                         proposed_constraint_key = normalize_ascii_lower(trimmed_email)
                         
                         if current_runtime_key != raw_email:
+                            add_classification(item, "case_changes_value")
                             summary["records_case_changes_value"] += 1
                             
                         item["current_runtime_key"] = current_runtime_key
@@ -167,8 +170,8 @@ def main():
                         
                         current_groups[current_runtime_key].append(item)
                         proposed_groups[proposed_constraint_key].append(item)
-            except Exception as e:
-                print(f"Error reading file {path_str}: {e}", file=sys.stderr)
+            except OSError as exc:
+                print(f"Error reading file {path_str}: {exc}", file=sys.stderr)
                 sys.exit(1)
 
     duplicate_groups_out = {

--- a/scripts/docmeta/audit_account_email_uniqueness.py
+++ b/scripts/docmeta/audit_account_email_uniqueness.py
@@ -1,0 +1,208 @@
+import json
+import argparse
+import sys
+from pathlib import Path
+from collections import defaultdict
+
+ASCII_LOWER_TABLE = str.maketrans(
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    "abcdefghijklmnopqrstuvwxyz",
+)
+
+def normalize_ascii_lower(value: str) -> str:
+    return value.translate(ASCII_LOWER_TABLE)
+
+def main():
+    parser = argparse.ArgumentParser(description="Audit JSONL accounts for email uniqueness.")
+    parser.add_argument("--accounts-jsonl", action="append", required=True, help="Path to accounts JSONL file.")
+    parser.add_argument("--format", choices=["json"], default="json", help="Output format.")
+    parser.add_argument("--fail-on-duplicates", action="store_true", help="Exit non-zero if duplicates are found.")
+    
+    args = parser.parse_args()
+
+    findings = []
+    
+    summary = {
+        "records_total": 0,
+        "records_with_email": 0,
+        "records_missing_email": 0,
+        "records_null_email": 0,
+        "records_empty_after_trim": 0,
+        "records_invalid_json": 0,
+        "records_non_object_json": 0,
+        "records_missing_id": 0,
+        "records_non_string_email": 0,
+        "records_trim_changes_value": 0,
+        "records_case_changes_value": 0,
+        "duplicate_current_runtime_key_groups": 0,
+        "duplicate_proposed_constraint_key_groups": 0
+    }
+
+    current_groups = defaultdict(list)
+    proposed_groups = defaultdict(list)
+
+    if args.accounts_jsonl:
+        for path_str in args.accounts_jsonl:
+            p = Path(path_str)
+            if not p.is_file():
+                print(f"File not found: {path_str}", file=sys.stderr)
+                sys.exit(1)
+            
+            try:
+                with open(p, "r", encoding="utf-8") as f:
+                    for line_num, line in enumerate(f, 1):
+                        line = line.strip()
+                        if not line:
+                            continue
+                            
+                        summary["records_total"] += 1
+                        
+                        try:
+                            data = json.loads(line)
+                        except json.JSONDecodeError:
+                            summary["records_invalid_json"] += 1
+                            findings.append({
+                                "source_path": path_str,
+                                "line_number": line_num,
+                                "classifications": ["invalid_json"]
+                            })
+                            continue
+
+                        if not isinstance(data, dict):
+                            summary["records_non_object_json"] += 1
+                            findings.append({
+                                "source_path": path_str,
+                                "line_number": line_num,
+                                "classifications": ["non_object_json"]
+                            })
+                            continue
+
+                        id_val = data.get("id")
+                        if id_val is None:
+                            summary["records_missing_id"] += 1
+                            findings.append({
+                                "source_path": path_str,
+                                "line_number": line_num,
+                                "classifications": ["missing_id"]
+                            })
+                            continue
+                            
+                        id_str = str(id_val)
+
+                        item = {
+                            "source_path": path_str,
+                            "line_number": line_num,
+                            "id": id_str,
+                            "classifications": []
+                        }
+
+                        if "email" not in data:
+                            item["classifications"].append("missing_email")
+                            summary["records_missing_email"] += 1
+                            findings.append(item)
+                            continue
+                            
+                        raw_email = data["email"]
+                        if raw_email is None:
+                            item["classifications"].append("null_email")
+                            summary["records_null_email"] += 1
+                            item["raw_email"] = None
+                            findings.append(item)
+                            continue
+
+                        if not isinstance(raw_email, str):
+                            item["classifications"].append("non_string_email")
+                            summary["records_non_string_email"] += 1
+                            item["raw_email"] = raw_email
+                            findings.append(item)
+                            continue
+
+                        item["raw_email"] = raw_email
+                        summary["records_with_email"] += 1
+                        
+                        trimmed_email = raw_email.strip()
+                        item["trimmed_email"] = trimmed_email
+                        
+                        if trimmed_email == "":
+                            item["classifications"].append("empty_after_trim")
+                            summary["records_empty_after_trim"] += 1
+                            findings.append(item)
+                            continue
+                            
+                        if raw_email != trimmed_email:
+                            summary["records_trim_changes_value"] += 1
+                            
+                        current_runtime_key = normalize_ascii_lower(raw_email)
+                        proposed_constraint_key = normalize_ascii_lower(trimmed_email)
+                        
+                        if current_runtime_key != raw_email:
+                            summary["records_case_changes_value"] += 1
+                            
+                        item["current_runtime_key"] = current_runtime_key
+                        item["proposed_constraint_key"] = proposed_constraint_key
+                        
+                        current_groups[current_runtime_key].append(item)
+                        proposed_groups[proposed_constraint_key].append(item)
+            except Exception as e:
+                print(f"Error reading file {path_str}: {e}", file=sys.stderr)
+                sys.exit(1)
+
+    duplicate_groups_out = {
+        "current_runtime_key": [],
+        "proposed_constraint_key": []
+    }
+
+    def sort_key(i):
+        return (i["id"], i["source_path"], i["line_number"])
+
+    # Process current runtime duplicates
+    for key, items in sorted(current_groups.items()):
+        if len(items) > 1:
+            summary["duplicate_current_runtime_key_groups"] += 1
+            sorted_items = sorted(items, key=sort_key)
+            for i in sorted_items:
+                i["classifications"].append("duplicate_current_runtime_key")
+                findings.append(i)
+                
+            duplicate_groups_out["current_runtime_key"].append({
+                "key": key,
+                "items": sorted_items
+            })
+
+    # Process proposed constraint duplicates
+    for key, items in sorted(proposed_groups.items()):
+        if len(items) > 1:
+            summary["duplicate_proposed_constraint_key_groups"] += 1
+            sorted_items = sorted(items, key=sort_key)
+            for i in sorted_items:
+                i["classifications"].append("duplicate_proposed_constraint_key")
+                # Add to findings if not already added by current runtime logic
+                if i not in findings:
+                    findings.append(i)
+                    
+            duplicate_groups_out["proposed_constraint_key"].append({
+                "key": key,
+                "items": sorted_items
+            })
+
+    # Sort all findings deterministically
+    findings.sort(key=lambda x: (x.get("id", ""), x["source_path"], x["line_number"]))
+
+    output = {
+        "summary": summary,
+        "policy": {
+            "current_runtime_key": "ascii_lower(raw_email)",
+            "proposed_constraint_key": "ascii_lower(trim(raw_email)) for non-empty emails"
+        },
+        "findings": findings,
+        "duplicate_groups": duplicate_groups_out
+    }
+
+    if args.format == "json":
+        print(json.dumps(output, indent=2, ensure_ascii=False))
+
+    if args.fail_on_duplicates and summary["duplicate_proposed_constraint_key_groups"] > 0:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/docmeta/audit_account_email_uniqueness.py
+++ b/scripts/docmeta/audit_account_email_uniqueness.py
@@ -41,6 +41,27 @@ def main():
     current_groups = defaultdict(list)
     proposed_groups = defaultdict(list)
 
+    def finding_key(item: dict) -> tuple[str, int, str, str]:
+        return (
+            item.get("source_path", ""),
+            int(item.get("line_number", -1)),
+            str(item.get("id", "")),
+            str(item.get("classifications", [""])[0]) if item.get("classifications") else ""
+        )
+
+    seen_finding_keys = set()
+
+    def add_finding(item: dict) -> None:
+        key = finding_key(item)
+        if key not in seen_finding_keys:
+            findings.append(item)
+            seen_finding_keys.add(key)
+
+    def add_classification(item: dict, classification: str) -> None:
+        classes = item.setdefault("classifications", [])
+        if classification not in classes:
+            classes.append(classification)
+
     if args.accounts_jsonl:
         for path_str in args.accounts_jsonl:
             p = Path(path_str)
@@ -61,30 +82,33 @@ def main():
                             data = json.loads(line)
                         except json.JSONDecodeError:
                             summary["records_invalid_json"] += 1
-                            findings.append({
+                            item_err = {
                                 "source_path": path_str,
                                 "line_number": line_num,
                                 "classifications": ["invalid_json"]
-                            })
+                            }
+                            add_finding(item_err)
                             continue
 
                         if not isinstance(data, dict):
                             summary["records_non_object_json"] += 1
-                            findings.append({
+                            item_err = {
                                 "source_path": path_str,
                                 "line_number": line_num,
                                 "classifications": ["non_object_json"]
-                            })
+                            }
+                            add_finding(item_err)
                             continue
 
                         id_val = data.get("id")
                         if id_val is None:
                             summary["records_missing_id"] += 1
-                            findings.append({
+                            item_err = {
                                 "source_path": path_str,
                                 "line_number": line_num,
                                 "classifications": ["missing_id"]
-                            })
+                            }
+                            add_finding(item_err)
                             continue
                             
                         id_str = str(id_val)
@@ -97,24 +121,24 @@ def main():
                         }
 
                         if "email" not in data:
-                            item["classifications"].append("missing_email")
+                            add_classification(item, "missing_email")
                             summary["records_missing_email"] += 1
-                            findings.append(item)
+                            add_finding(item)
                             continue
                             
                         raw_email = data["email"]
                         if raw_email is None:
-                            item["classifications"].append("null_email")
+                            add_classification(item, "null_email")
                             summary["records_null_email"] += 1
                             item["raw_email"] = None
-                            findings.append(item)
+                            add_finding(item)
                             continue
 
                         if not isinstance(raw_email, str):
-                            item["classifications"].append("non_string_email")
+                            add_classification(item, "non_string_email")
                             summary["records_non_string_email"] += 1
                             item["raw_email"] = raw_email
-                            findings.append(item)
+                            add_finding(item)
                             continue
 
                         item["raw_email"] = raw_email
@@ -124,9 +148,9 @@ def main():
                         item["trimmed_email"] = trimmed_email
                         
                         if trimmed_email == "":
-                            item["classifications"].append("empty_after_trim")
+                            add_classification(item, "empty_after_trim")
                             summary["records_empty_after_trim"] += 1
-                            findings.append(item)
+                            add_finding(item)
                             continue
                             
                         if raw_email != trimmed_email:
@@ -161,9 +185,9 @@ def main():
             summary["duplicate_current_runtime_key_groups"] += 1
             sorted_items = sorted(items, key=sort_key)
             for i in sorted_items:
-                i["classifications"].append("duplicate_current_runtime_key")
-                findings.append(i)
-                
+                add_classification(i, "duplicate_current_runtime_key")
+                add_finding(i)
+
             duplicate_groups_out["current_runtime_key"].append({
                 "key": key,
                 "items": sorted_items
@@ -175,11 +199,9 @@ def main():
             summary["duplicate_proposed_constraint_key_groups"] += 1
             sorted_items = sorted(items, key=sort_key)
             for i in sorted_items:
-                i["classifications"].append("duplicate_proposed_constraint_key")
-                # Add to findings if not already added by current runtime logic
-                if i not in findings:
-                    findings.append(i)
-                    
+                add_classification(i, "duplicate_proposed_constraint_key")
+                add_finding(i)
+
             duplicate_groups_out["proposed_constraint_key"].append({
                 "key": key,
                 "items": sorted_items

--- a/scripts/docmeta/tests/test_audit_account_email_uniqueness.py
+++ b/scripts/docmeta/tests/test_audit_account_email_uniqueness.py
@@ -1,0 +1,167 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+def run_script(tmp_path, lines, extra_args=None):
+    jsonl_file = tmp_path / "test.jsonl"
+    with open(jsonl_file, "w", encoding="utf-8") as f:
+        for line in lines:
+            f.write(line + "\n")
+            
+    cmd = [sys.executable, "-m", "scripts.docmeta.audit_account_email_uniqueness", "--accounts-jsonl", str(jsonl_file)]
+    if extra_args:
+        cmd.extend(extra_args)
+        
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    
+    output = None
+    if result.stdout.strip():
+        try:
+            output = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            pass
+            
+    return result.returncode, output, result.stderr
+
+def run_script_no_input():
+    cmd = [sys.executable, "-m", "scripts.docmeta.audit_account_email_uniqueness"]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    return result.returncode, result.stderr
+
+def test_no_input_fails():
+    code, err = run_script_no_input()
+    assert code != 0
+    assert "required" in err.lower() or "too few arguments" in err.lower()
+
+def test_case_only_duplicate(tmp_path):
+    lines = [
+        json.dumps({"id": "1", "email": "ALEX@example.org"}),
+        json.dumps({"id": "2", "email": "alex@example.org"}),
+    ]
+    code, out, err = run_script(tmp_path, lines)
+    assert code == 0
+    assert out["summary"]["duplicate_current_runtime_key_groups"] == 1
+    assert out["summary"]["duplicate_proposed_constraint_key_groups"] == 1
+    
+    group_curr = out["duplicate_groups"]["current_runtime_key"][0]
+    assert group_curr["key"] == "alex@example.org"
+    ids = [i["id"] for i in group_curr["items"]]
+    assert ids == ["1", "2"]
+    
+    group_prop = out["duplicate_groups"]["proposed_constraint_key"][0]
+    assert group_prop["key"] == "alex@example.org"
+
+def test_whitespace_sensitive_duplicate(tmp_path):
+    lines = [
+        json.dumps({"id": "1", "email": " alex@example.org "}),
+        json.dumps({"id": "2", "email": "alex@example.org"}),
+    ]
+    code, out, err = run_script(tmp_path, lines)
+    assert code == 0
+    # current runtime key does not trim, so " alex@example.org " and "alex@example.org" are different!
+    assert out["summary"]["duplicate_current_runtime_key_groups"] == 0
+    # proposed trims, so they are duplicates
+    assert out["summary"]["duplicate_proposed_constraint_key_groups"] == 1
+    assert len(out["duplicate_groups"]["current_runtime_key"]) == 0
+    
+    group = out["duplicate_groups"]["proposed_constraint_key"][0]
+    assert group["key"] == "alex@example.org"
+
+def test_missing_null_empty(tmp_path):
+    lines = [
+        json.dumps({"id": "1"}), # missing
+        json.dumps({"id": "2", "email": None}), # null
+        json.dumps({"id": "3", "email": ""}), # empty
+        json.dumps({"id": "4", "email": "   "}), # empty after trim
+    ]
+    code, out, err = run_script(tmp_path, lines)
+    assert code == 0
+    assert out["summary"]["records_missing_email"] == 1
+    assert out["summary"]["records_null_email"] == 1
+    assert out["summary"]["records_empty_after_trim"] == 2
+
+def test_deterministic_ordering(tmp_path):
+    lines = [
+        json.dumps({"id": "2", "email": "alex@example.org"}),
+        json.dumps({"id": "1", "email": "ALEX@example.org"}),
+    ]
+    code, out, err = run_script(tmp_path, lines)
+    assert code == 0
+    group = out["duplicate_groups"]["proposed_constraint_key"][0]
+    ids = [i["id"] for i in group["items"]]
+    # Even though "2" was first in input, "1" should be first in output because of deterministic sorting
+    assert ids == ["1", "2"]
+
+def test_fail_on_duplicates(tmp_path):
+    lines = [
+        json.dumps({"id": "1", "email": "alex@example.org"}),
+        json.dumps({"id": "2", "email": "alex@example.org"}),
+    ]
+    code, out, err = run_script(tmp_path, lines, ["--fail-on-duplicates"])
+    assert code == 1
+
+def test_fail_on_duplicates_success(tmp_path):
+    lines = [
+        json.dumps({"id": "1", "email": "a@example.org"}),
+        json.dumps({"id": "2", "email": "b@example.org"}),
+    ]
+    code, out, err = run_script(tmp_path, lines, ["--fail-on-duplicates"])
+    assert code == 0
+
+def test_malformed_jsonl(tmp_path):
+    lines = [
+        '{"id": "1", "email": "a@example.org"}',
+        'invalid json',
+        '{"id": "2", "email": "b@example.org"}'
+    ]
+    code, out, err = run_script(tmp_path, lines)
+    assert code == 0
+    assert out["summary"]["records_invalid_json"] == 1
+    invalid_findings = [f for f in out["findings"] if "invalid_json" in f.get("classifications", [])]
+    assert len(invalid_findings) == 1
+
+def test_ascii_only_lower(tmp_path):
+    # 'İ' is I with dot above, 'I' is I. If we use python .lower(), 'İ' becomes 'i\u0307'
+    # we want only A-Z to be lowered
+    lines = [
+        json.dumps({"id": "1", "email": "ALEX-ß-İ-I@example.org"}),
+        json.dumps({"id": "2", "email": "alex-ß-İ-i@example.org"}),
+    ]
+    code, out, err = run_script(tmp_path, lines)
+    assert code == 0
+    assert out["summary"]["duplicate_current_runtime_key_groups"] == 1
+    finding = [f for f in out["findings"] if f["id"] == "1"][0]
+    assert finding["current_runtime_key"] == "alex-ß-İ-i@example.org"
+    assert finding["proposed_constraint_key"] == "alex-ß-İ-i@example.org"
+
+def test_valid_conflict_free_not_in_findings(tmp_path):
+    lines = [
+        json.dumps({"id": "1", "email": "valid@example.org"}),
+        json.dumps({"id": "2", "email": "also-valid@example.org"}),
+    ]
+    code, out, err = run_script(tmp_path, lines)
+    assert code == 0
+    # No findings should exist for valid emails without conflicts
+    assert len(out["findings"]) == 0
+    assert out["summary"]["records_with_email"] == 2
+    
+def test_missing_id_and_non_string_email(tmp_path):
+    lines = [
+        json.dumps({"email": "valid@example.org"}), # missing id
+        json.dumps({"id": "2", "email": {"complex": "object"}}), # non-string
+        json.dumps({"id": "3", "email": 12345}), # non-string
+    ]
+    code, out, err = run_script(tmp_path, lines)
+    assert code == 0
+    assert out["summary"]["records_missing_id"] == 1
+    assert out["summary"]["records_non_string_email"] == 2
+    
+    findings = out["findings"]
+    assert len(findings) == 3
+    
+    missing_id = [f for f in findings if "missing_id" in f["classifications"]][0]
+    assert "missing_id" in missing_id["classifications"]
+    
+    non_strings = [f for f in findings if "non_string_email" in f["classifications"]]
+    assert len(non_strings) == 2

--- a/scripts/docmeta/tests/test_audit_account_email_uniqueness.py
+++ b/scripts/docmeta/tests/test_audit_account_email_uniqueness.py
@@ -220,3 +220,36 @@ def test_unicode_output_is_not_ascii_escaped_with_duplicate(tmp_path):
     assert result.returncode == 0
     assert "ß" in result.stdout
     assert "İ" in result.stdout
+
+def test_empty_whitespace_grouping(tmp_path):
+    lines = [
+        json.dumps({"id": "1", "email": ""}),
+        json.dumps({"id": "2", "email": ""}),
+        json.dumps({"id": "3", "email": "   "}),
+        json.dumps({"id": "4", "email": "   "}),
+    ]
+    code, out, err = run_script(tmp_path, lines)
+    assert code == 0
+    assert out["summary"]["duplicate_current_runtime_key_groups"] == 2
+    assert out["summary"]["duplicate_proposed_constraint_key_groups"] == 0
+
+def test_same_id_no_duplicate(tmp_path):
+    lines = [
+        json.dumps({"id": "1", "email": "a@example.org"}),
+        json.dumps({"id": "1", "email": "a@example.org"}), # same ID
+    ]
+    code, out, err = run_script(tmp_path, lines, ["--fail-on-duplicates"])
+    assert code == 0 # Should not fail because distinct ID count is 1
+    assert out["summary"]["duplicate_current_runtime_key_groups"] == 0
+    assert out["summary"]["duplicate_proposed_constraint_key_groups"] == 0
+
+def test_non_string_id(tmp_path):
+    lines = [
+        json.dumps({"id": 123, "email": "a@example.org"}),
+        json.dumps({"id": 456, "email": "a@example.org"}),
+    ]
+    code, out, err = run_script(tmp_path, lines, ["--fail-on-duplicates"])
+    assert code == 0
+    assert out["summary"]["records_non_string_id"] == 2
+    assert out["summary"]["duplicate_current_runtime_key_groups"] == 0
+    assert out["summary"]["duplicate_proposed_constraint_key_groups"] == 0

--- a/scripts/docmeta/tests/test_audit_account_email_uniqueness.py
+++ b/scripts/docmeta/tests/test_audit_account_email_uniqueness.py
@@ -165,3 +165,69 @@ def test_missing_id_and_non_string_email(tmp_path):
     
     non_strings = [f for f in findings if "non_string_email" in f["classifications"]]
     assert len(non_strings) == 2
+def test_non_object_json(tmp_path):
+    lines = [
+        json.dumps(["not", "an", "object"]),
+        json.dumps({"id": "1", "email": "a@example.org"}),
+    ]
+    code, out, err = run_script(tmp_path, lines)
+    assert code == 0
+    assert out["summary"]["records_non_object_json"] == 1
+
+    findings = [
+        f for f in out["findings"]
+        if "non_object_json" in f.get("classifications", [])
+    ]
+    assert len(findings) == 1
+
+def test_unicode_output_is_not_ascii_escaped(tmp_path):
+    jsonl_file = tmp_path / "test.jsonl"
+    jsonl_file.write_text(
+        json.dumps({"id": "1", "email": "ALEX-ß-İ-I@example.org"}) + "\n",
+        encoding="utf-8",
+    )
+
+    import subprocess
+    import sys
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "scripts.docmeta.audit_account_email_uniqueness",
+            "--accounts-jsonl",
+            str(jsonl_file),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    # In order to trigger stdout with the string, we need a finding or duplicate.
+    # The missing id test logic added "missing_id", but here it's valid so it has NO findings.
+    # We should add a duplicate to ensure it's outputted.
+
+def test_unicode_output_is_not_ascii_escaped_with_duplicate(tmp_path):
+    jsonl_file = tmp_path / "test.jsonl"
+    jsonl_file.write_text(
+        json.dumps({"id": "1", "email": "ALEX-ß-İ-I@example.org"}) + "\n" +
+        json.dumps({"id": "2", "email": "alex-ß-İ-i@example.org"}) + "\n",
+        encoding="utf-8",
+    )
+
+    import subprocess
+    import sys
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "scripts.docmeta.audit_account_email_uniqueness",
+            "--accounts-jsonl",
+            str(jsonl_file),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "ß" in result.stdout
+    assert "İ" in result.stdout

--- a/scripts/docmeta/tests/test_audit_account_email_uniqueness.py
+++ b/scripts/docmeta/tests/test_audit_account_email_uniqueness.py
@@ -51,6 +51,11 @@ def test_case_only_duplicate(tmp_path):
     
     group_prop = out["duplicate_groups"]["proposed_constraint_key"][0]
     assert group_prop["key"] == "alex@example.org"
+    
+    classes_by_id = {item["id"]: item["classifications"] for item in group_curr["items"]}
+    assert "case_changes_value" in classes_by_id["1"]
+    assert "valid_email" in classes_by_id["1"]
+    assert "valid_email" in classes_by_id["2"]
 
 def test_whitespace_sensitive_duplicate(tmp_path):
     lines = [
@@ -67,6 +72,11 @@ def test_whitespace_sensitive_duplicate(tmp_path):
     
     group = out["duplicate_groups"]["proposed_constraint_key"][0]
     assert group["key"] == "alex@example.org"
+
+    classes_by_id = {item["id"]: item["classifications"] for item in group["items"]}
+    assert "trim_changes_value" in classes_by_id["1"]
+    assert "valid_email" in classes_by_id["1"]
+    assert "valid_email" in classes_by_id["2"]
 
 def test_missing_null_empty(tmp_path):
     lines = [
@@ -131,7 +141,9 @@ def test_ascii_only_lower(tmp_path):
     code, out, err = run_script(tmp_path, lines)
     assert code == 0
     assert out["summary"]["duplicate_current_runtime_key_groups"] == 1
-    finding = [f for f in out["findings"] if f["id"] == "1"][0]
+    findings_1 = [f for f in out["findings"] if f["id"] == "1"]
+    assert len(findings_1) == 1
+    finding = findings_1[0]
     assert finding["current_runtime_key"] == "alex-ß-İ-i@example.org"
     assert finding["proposed_constraint_key"] == "alex-ß-İ-i@example.org"
 
@@ -160,8 +172,11 @@ def test_missing_id_and_non_string_email(tmp_path):
     findings = out["findings"]
     assert len(findings) == 3
     
-    missing_id = [f for f in findings if "missing_id" in f["classifications"]][0]
-    assert "missing_id" in missing_id["classifications"]
+    missing_id_findings = [
+        f for f in findings
+        if "missing_id" in f.get("classifications", [])
+    ]
+    assert len(missing_id_findings) == 1
     
     non_strings = [f for f in findings if "non_string_email" in f["classifications"]]
     assert len(non_strings) == 2
@@ -179,32 +194,6 @@ def test_non_object_json(tmp_path):
         if "non_object_json" in f.get("classifications", [])
     ]
     assert len(findings) == 1
-
-def test_unicode_output_is_not_ascii_escaped(tmp_path):
-    jsonl_file = tmp_path / "test.jsonl"
-    jsonl_file.write_text(
-        json.dumps({"id": "1", "email": "ALEX-ß-İ-I@example.org"}) + "\n",
-        encoding="utf-8",
-    )
-
-    import subprocess
-    import sys
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "scripts.docmeta.audit_account_email_uniqueness",
-            "--accounts-jsonl",
-            str(jsonl_file),
-        ],
-        capture_output=True,
-        text=True,
-    )
-
-    assert result.returncode == 0
-    # In order to trigger stdout with the string, we need a finding or duplicate.
-    # The missing id test logic added "missing_id", but here it's valid so it has NO findings.
-    # We should add a duplicate to ensure it's outputted.
 
 def test_unicode_output_is_not_ascii_escaped_with_duplicate(tmp_path):
     jsonl_file = tmp_path / "test.jsonl"

--- a/scripts/docmeta/tests/test_audit_account_email_uniqueness.py
+++ b/scripts/docmeta/tests/test_audit_account_email_uniqueness.py
@@ -180,6 +180,7 @@ def test_missing_id_and_non_string_email(tmp_path):
     
     non_strings = [f for f in findings if "non_string_email" in f["classifications"]]
     assert len(non_strings) == 2
+
 def test_non_object_json(tmp_path):
     lines = [
         json.dumps(["not", "an", "object"]),
@@ -203,8 +204,6 @@ def test_unicode_output_is_not_ascii_escaped_with_duplicate(tmp_path):
         encoding="utf-8",
     )
 
-    import subprocess
-    import sys
     result = subprocess.run(
         [
             sys.executable,
@@ -233,6 +232,14 @@ def test_empty_whitespace_grouping(tmp_path):
     assert out["summary"]["duplicate_current_runtime_key_groups"] == 2
     assert out["summary"]["duplicate_proposed_constraint_key_groups"] == 0
 
+    current_keys = {
+        group["key"]
+        for group in out["duplicate_groups"]["current_runtime_key"]
+    }
+    assert "" in current_keys
+    assert "   " in current_keys
+    assert out["duplicate_groups"]["proposed_constraint_key"] == []
+
 def test_same_id_no_duplicate(tmp_path):
     lines = [
         json.dumps({"id": "1", "email": "a@example.org"}),
@@ -253,3 +260,9 @@ def test_non_string_id(tmp_path):
     assert out["summary"]["records_non_string_id"] == 2
     assert out["summary"]["duplicate_current_runtime_key_groups"] == 0
     assert out["summary"]["duplicate_proposed_constraint_key_groups"] == 0
+    
+    non_string_id_findings = [
+        f for f in out["findings"]
+        if "non_string_id" in f.get("classifications", [])
+    ]
+    assert len(non_string_id_findings) == 2


### PR DESCRIPTION
## Summary

Add and harden a reproducible audit and policy report for account e-mail
uniqueness before introducing any PostgreSQL unique constraint.

## What this does

- Documents the current AccountStore e-mail index behavior.
- Adds a deterministic JSONL e-mail duplicate audit.
- Streams JSONL input line by line instead of retaining raw records.
- Keeps valid conflict-free records out of the findings output.
- Emits separate duplicate groups for current runtime keys and proposed
  constraint keys.
- Distinguishes missing, null, empty, non-string, invalid JSON, missing-ID,
  case-only, and trim-sensitive e-mail cases.
- Documents PostgreSQL SQL as audit approximation, not as identical runtime
  semantics for non-ASCII e-mail values.
- Documents privacy guidance for production audit output.

## Non-goals

- No runtime code changes.
- No API behavior changes.
- No database migration.
- No unique index.
- No Step-up e-mail persistence change.
- No WebAuthn credential writeback.
- No production cutover claim.

## Validation

- `python3 -m pytest scripts/docmeta/tests/test_audit_account_email_uniqueness.py`
- `python3 -m scripts.docmeta.audit_account_email_uniqueness --help`
- audit without input fails
- `python3 -m scripts.docmeta.check_links`
- `python3 -m scripts.docmeta.validate_opt_arc_001_db_proof_matrix`
- `npx markdownlint-cli2 "docs/reports/domain-account-email-uniqueness-audit.md"`
