### PR TITLE
docs: record runtime account email audit result

### DIFF
--- a/docs/reports/domain-account-email-uniqueness-audit.md
+++ b/docs/reports/domain-account-email-uniqueness-audit.md
@@ -226,7 +226,7 @@ Begründung:
 
 ## Runtime-Audit-Lauf 2026-06-13
 
-### Quellen
+### Runtime-Quellen
 
 - PostgreSQL: ausgeführt auf dem Heimserver im Docker-Compose-Projekt `weltgewebe`, Service `db`, Tabelle `public.domain_accounts`.
 - JSONL: keine Runtime-JSONL-Quelle auditiert; repo-lokal wurde nur `.gewebe/in/demo.accounts.jsonl` als `demo_or_fixture` gefunden.
@@ -234,7 +234,7 @@ Begründung:
   - PostgreSQL target: `weltgewebe` Compose-Projekt, Service `db`; konkrete Datenbank-URL nicht dokumentiert.
   - JSONL runtime source: n/a.
 
-### PostgreSQL-Aggregate
+### Runtime-PostgreSQL-Aggregate
 
 | Metrik | Wert |
 | --- | ---: |
@@ -246,17 +246,17 @@ Begründung:
 | empty_email_count | 0 |
 | whitespace_changed_count | 0 |
 
-### Redaktionsregel
+### Runtime-Redaktionsregel
 
 Dieser Runtime-Audit-Abschnitt enthält keine echten E-Mail-Adressen, keine Account-IDs, keine Account-Zeilen und keine Datenbank-URL. Dokumentiert werden nur aggregierte Counts und ein redigiertes Ausführungsziel.
 
-### Policy-Einschätzung
+### Runtime-Policy-Einschätzung
 
 Der aktuelle PostgreSQL-Runtime-Bestand enthält keine Account-Records. Damit liegen im aktuellen DB-Zustand keine vorhandenen E-Mail-Kollisionen vor, die einen späteren Unique-Constraint blockieren würden. Das ist keine Aussage über frühere oder externe Legacy-Datenbestände; es belegt nur den aktuell auditierten Runtime-Zustand auf dem Heimserver.
 
 Für TODO 2 ist damit der Constraint-Design-Schritt freigegeben. Wegen der bereits dokumentierten Trim-Frage bleibt `lower(btrim(email))` gegenüber `lower(email)` der robustere Constraint-Kandidat, sofern die endgültige Policy leere bzw. nach Trim leere E-Mails weiterhin ignoriert.
 
-### Entscheidung für nächsten Schritt
+### Runtime-Entscheidung für nächsten Schritt
 
 Status: `ready_for_constraint_design`
 

--- a/docs/reports/domain-account-email-uniqueness-audit.md
+++ b/docs/reports/domain-account-email-uniqueness-audit.md
@@ -224,6 +224,51 @@ Begründung:
 - `DATABASE_URL` nicht gesetzt; PostgreSQL-Audit nicht durchführbar.
 - Für TODO 2 (Unique-Index) wird ein Datenlauf gegen Deployment-Daten benötigt; der vorliegende Harness ist dafür einsatzbereit.
 
+## Runtime-Audit-Lauf 2026-06-13
+
+### Quellen
+
+- PostgreSQL: ausgeführt auf dem Heimserver im Docker-Compose-Projekt `weltgewebe`, Service `db`, Tabelle `public.domain_accounts`.
+- JSONL: keine Runtime-JSONL-Quelle auditiert; repo-lokal wurde nur `.gewebe/in/demo.accounts.jsonl` als `demo_or_fixture` gefunden.
+- Source-Fingerprint:
+  - PostgreSQL target: `weltgewebe` Compose-Projekt, Service `db`; konkrete Datenbank-URL nicht dokumentiert.
+  - JSONL runtime source: n/a.
+
+### PostgreSQL-Aggregate
+
+| Metrik | Wert |
+| --- | ---: |
+| `domain_accounts` exists | ja |
+| lower(email) duplicate groups | 0 |
+| lower(btrim(email)) duplicate groups | 0 |
+| records_total | 0 |
+| null_email_count | 0 |
+| empty_email_count | 0 |
+| whitespace_changed_count | 0 |
+
+### Redaktionsregel
+
+Dieser Runtime-Audit-Abschnitt enthält keine echten E-Mail-Adressen, keine Account-IDs, keine Account-Zeilen und keine Datenbank-URL. Dokumentiert werden nur aggregierte Counts und ein redigiertes Ausführungsziel.
+
+### Policy-Einschätzung
+
+Der aktuelle PostgreSQL-Runtime-Bestand enthält keine Account-Records. Damit liegen im aktuellen DB-Zustand keine vorhandenen E-Mail-Kollisionen vor, die einen späteren Unique-Constraint blockieren würden. Das ist keine Aussage über frühere oder externe Legacy-Datenbestände; es belegt nur den aktuell auditierten Runtime-Zustand auf dem Heimserver.
+
+Für TODO 2 ist damit der Constraint-Design-Schritt freigegeben. Wegen der bereits dokumentierten Trim-Frage bleibt `lower(btrim(email))` gegenüber `lower(email)` der robustere Constraint-Kandidat, sofern die endgültige Policy leere bzw. nach Trim leere E-Mails weiterhin ignoriert.
+
+### Entscheidung für nächsten Schritt
+
+Status: `ready_for_constraint_design`
+
+Begründung:
+
+- `domain_accounts` ist im PostgreSQL-Runtime-Stack vorhanden.
+- Der aktuelle PostgreSQL-Bestand enthält 0 Account-Records.
+- Es gibt 0 Duplicate-Gruppen für `lower(email)`.
+- Es gibt 0 Duplicate-Gruppen für `lower(btrim(email))`.
+- Es gibt keine gemessenen Whitespace- oder Empty-Email-Legacy-Fälle im aktuellen DB-Bestand.
+- TODO 2 bleibt ein eigener PR: kein Unique-Index, keine Runtime-Änderung und kein API-Konfliktmapping in diesem Report-PR.
+
 ## Nächster PR
 
 PR E2 kann erst nach einem echten Datenlauf gegen relevante JSONL- und/oder


### PR DESCRIPTION
## Summary

Records the redacted runtime/deployment Account E-Mail Uniqueness audit result from the Heimserver `weltgewebe` Docker Compose stack.

## Scope

- Documentation/report only.
- No runtime code.
- No database migration.
- No unique index.
- No API error mapping.
- No raw E-Mail addresses, account IDs, account rows, or database URL.

## Result

- PostgreSQL runtime audit: executed on Heimserver Compose project `weltgewebe`, service `db`, table `public.domain_accounts`.
- JSONL runtime audit: not executed; only `.gewebe/in/demo.accounts.jsonl` was found as `demo_or_fixture`.
- `domain_accounts` exists: yes.
- `records_total`: 0.
- `lower(email)` duplicate groups: 0.
- `lower(btrim(email))` duplicate groups: 0.
- `null_email_count`: 0.
- `empty_email_count`: 0.
- `whitespace_changed_count`: 0.
- decision status: `ready_for_constraint_design`.

## Checks

- [ ] markdownlint changed docs
- [ ] `python3 -m scripts.docmeta.validate_opt_arc_001_db_proof_matrix`
- [ ] `git diff --check`
- [x] PII/raw-data diff check performed conceptually: only aggregate counts and redacted execution target are included.

## Notes

This PR does not implement TODO 2. It only records that the current PostgreSQL runtime state does not contain account e-mail duplicates that would block the next constraint-design PR.