### PR TITLE
docs: add report lifecycle inventory

### DIFF
--- a/.github/workflows/docs-guard.yml
+++ b/.github/workflows/docs-guard.yml
@@ -77,6 +77,9 @@ jobs:
       - name: generate-system-map
         run: python3 -m scripts.docmeta.generate_system_map
 
+      - name: generate-report-lifecycle-inventory
+        run: python3 -m scripts.docmeta.generate_report_lifecycle_inventory
+
       # Policy: generated diagnostics are derived observability outputs; drift is reported, not blocking.
       - name: non-blocking generated drift report
         if: always()
@@ -110,5 +113,6 @@ jobs:
             docs/_generated/backlinks.md
             docs/_generated/orphans.md
             docs/_generated/system-map.md
+            docs/_generated/report-lifecycle-inventory.md
             generated-drift-report.txt
           if-no-files-found: ignore

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ generate:
 	python3 -m scripts.docmeta.generate_claim_evidence_map
 	python3 -m scripts.docmeta.generate_relations_analysis
 	python3 -m scripts.docmeta.generate_relates_to_audit
+	python3 -m scripts.docmeta.generate_report_lifecycle_inventory
 
 diagnose: generate
 

--- a/docs/_generated/backlinks.md
+++ b/docs/_generated/backlinks.md
@@ -10,14 +10,64 @@ summary: Automatisch generierter Graph der Rückverweise.
 
 Generated automatically. Do not edit.
 
+## .github/workflows/api.yml
+
+- [relates_to] docs/reports/domain-account-write-path-proof.md
+- [relates_to] docs/reports/domain-backfill-proof.md
+
 ## AGENTS.md
 
 - [relates_to] docs/blueprints/agent-operability-blaupause.md
+- [relates_to] docs/blueprints/blueprint-agent-safety-control-layer.md
 - [relates_to] docs/policies/agent-reading-protocol.md
+- [relates_to] docs/security/agent-write-scope-baseline.md
 
 ## agent-policy.yaml
 
 - [relates_to] docs/blueprints/agent-operability-blaupause.md
+- [relates_to] docs/blueprints/blueprint-agent-safety-control-layer.md
+- [relates_to] docs/security/agent-write-scope-baseline.md
+
+## apps/api/src/auth/accounts.rs
+
+- [relates_to] docs/reports/domain-account-email-uniqueness-audit.md
+
+## apps/api/src/routes/accounts.rs
+
+- [relates_to] docs/blueprints/domain-data-postgres-cutover.md
+- [relates_to] docs/reports/domain-account-email-uniqueness-audit.md
+
+## apps/api/src/routes/edges.rs
+
+- [relates_to] docs/blueprints/domain-data-postgres-cutover.md
+
+## apps/api/src/routes/nodes.rs
+
+- [relates_to] docs/blueprints/domain-data-postgres-cutover.md
+
+## apps/api/src/state.rs
+
+- [relates_to] docs/blueprints/domain-data-postgres-cutover.md
+
+## apps/api/tests/db_domain_account_write_path.rs
+
+- [relates_to] docs/reports/domain-account-write-path-proof.md
+
+## apps/api/tests/db_domain_backfill.rs
+
+- [relates_to] docs/reports/domain-backfill-proof.md
+
+## audit/impl-registry.yaml
+
+- [relates_to] docs/blueprints/blueprint-agent-safety-control-layer.md
+
+## contracts/agent/task.schema.json
+
+- [relates_to] docs/reference/agent-operability-fixture-matrix.md
+
+## contracts/domain/edge.schema.json
+
+- [relates_to] docs/reports/domain-edge-create-semantics-preflight.md
 
 ## docs/adr/0042-consume-semantah-contracts.md
 
@@ -36,6 +86,7 @@ Generated automatically. Do not edit.
 
 - [relates_to] docs/adr/ADR-0005-auth.md
 - [relates_to] docs/adr/ADR-0007__auth-persistence-production-db-path.md
+- [relates_to] docs/adr/ADR-0008__domain-mail-provider-boundaries.md
 - [relates_to] docs/blueprints/auth-persistence-runtime-proof.md
 - [relates_to] docs/blueprints/auth-roadmap.md
 - [relates_to] docs/blueprints/weltgewebe.auth-and-ui-routing.md
@@ -51,6 +102,7 @@ Generated automatically. Do not edit.
 
 ## docs/adr/ADR-0007__auth-persistence-production-db-path.md
 
+- [relates_to] docs/adr/ADR-0008__domain-mail-provider-boundaries.md
 - [relates_to] docs/blueprints/auth-persistence-runtime-proof.md
 - [relates_to] docs/blueprints/auth-roadmap.md
 - [relates_to] docs/proofs/sqlx-pgbouncer-session-crud-proof.md
@@ -59,6 +111,12 @@ Generated automatically. Do not edit.
 - [relates_to] docs/reports/auth-persistence-runtime-proof.md
 - [relates_to] docs/reports/auth-persistence-runtime-target-reconciliation.md
 - [relates_to] docs/reports/auth-status-matrix.md
+- [relates_to] docs/runbooks/db-recovery.md
+
+## docs/adr/ADR-0008__domain-mail-provider-boundaries.md
+
+- [relates_to] docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md
+- [relates_to] docs/runbooks/domain-mail-cutover.md
 
 ## docs/architekturstruktur.md
 
@@ -70,6 +128,8 @@ Generated automatically. Do not edit.
 
 ## docs/blueprints/agent-operability-blaupause.md
 
+- [relates_to] docs/blueprints/blueprint-agent-safety-control-layer.md
+- [relates_to] docs/blueprints/doc-structure-task-control.md
 - [depends_on] docs/roadmap.md
 
 ## docs/blueprints/auth-persistence-runtime-proof.md
@@ -92,6 +152,37 @@ Generated automatically. Do not edit.
 - [relates_to] docs/reports/passkey-register-verify-prep.md
 - [depends_on] docs/roadmap.md
 - [relates_to] docs/specs/auth-blueprint.md
+
+## docs/blueprints/blueprint-agent-safety-control-layer.md
+
+- [relates_to] docs/claims/README.md
+- [relates_to] docs/security/agent-write-scope-baseline.md
+
+## docs/blueprints/doc-structure-task-control-examples.md
+
+- [relates_to] docs/blueprints/doc-structure-task-control-roadmap.md
+- [relates_to] docs/blueprints/doc-structure-task-control.md
+
+## docs/blueprints/doc-structure-task-control-roadmap.md
+
+- [relates_to] docs/blueprints/doc-structure-task-control-examples.md
+- [relates_to] docs/blueprints/doc-structure-task-control.md
+- [depends_on] docs/roadmap.md
+
+## docs/blueprints/doc-structure-task-control.md
+
+- [depends_on] docs/blueprints/doc-structure-task-control-examples.md
+- [depends_on] docs/blueprints/doc-structure-task-control-roadmap.md
+
+## docs/blueprints/domain-data-postgres-cutover.md
+
+- [relates_to] docs/reports/domain-account-email-uniqueness-audit.md
+- [relates_to] docs/reports/domain-account-write-path-proof.md
+- [relates_to] docs/reports/domain-backfill-proof.md
+- [relates_to] docs/reports/domain-edge-create-semantics-preflight.md
+- [relates_to] docs/reports/domain-edge-write-path-proof.md
+- [relates_to] docs/reports/domain-node-write-path-proof.md
+- [relates_to] docs/reports/domain-read-path-proof.md
 
 ## docs/blueprints/kartenklarheit-phase6.md
 
@@ -151,14 +242,20 @@ Generated automatically. Do not edit.
 - [relates_to] docs/architekturstruktur.md
 - [relates_to] docs/domain/vocabulary.md
 - [relates_to] docs/reports/optimierungsbericht.md
+- [relates_to] docs/runbooks/db-recovery.md
 - [relates_to] docs/specs/contract.md
 - [relates_to] docs/techstack.md
+
+## docs/deploy/DRIFT_POLICY.md
+
+- [relates_to] docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md
 
 ## docs/deploy/README.md
 
 - [relates_to] docs/blueprints/weltgewebe.deploy.plan.md
 - [relates_to] docs/deploy/CHANGELOG.md
 - [relates_to] docs/deploy/DRIFT_POLICY.md
+- [relates_to] docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md
 - [relates_to] docs/deploy/heim-first-phase0.md
 - [relates_to] docs/deploy/heimserver.deployment.md
 - [relates_to] docs/deploy/heimserver.integration.md
@@ -169,6 +266,19 @@ Generated automatically. Do not edit.
 - [relates_to] docs/deployment_governance.md
 - [relates_to] docs/edge/systemd/README.md
 - [relates_to] docs/runbook.md
+
+## docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md
+
+- [relates_to] docs/adr/ADR-0008__domain-mail-provider-boundaries.md
+- [relates_to] docs/deploy/README.md
+- [relates_to] docs/reports/domain-provider-role-finding.md
+- [relates_to] docs/reports/inwx-zone-reconciliation-plan.md
+- [relates_to] docs/runbooks/domain-mail-cutover.md
+
+## docs/deploy/heim-first-phase0.md
+
+- [relates_to] docs/blueprints/weltgewebe.config.diff.md
+- [relates_to] docs/blueprints/weltgewebe.deploy.plan.md
 
 ## docs/deploy/heimserver.deployment.md
 
@@ -186,6 +296,7 @@ Generated automatically. Do not edit.
 
 - [relates_to] docs/deploy/README.md
 - [relates_to] docs/deployment.md
+- [relates_to] docs/runbooks/incident-response.md
 
 ## docs/deployment.md
 
@@ -194,6 +305,7 @@ Generated automatically. Do not edit.
 - [relates_to] docs/blueprints/weltgewebe.deploy.plan.md
 - [relates_to] docs/deploy/DRIFT_POLICY.md
 - [relates_to] docs/deploy/README.md
+- [relates_to] docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md
 - [relates_to] docs/deploy/heimserver.deployment.md
 - [relates_to] docs/deploy/heimserver.integration.md
 - [relates_to] docs/deploy/security.md
@@ -204,6 +316,7 @@ Generated automatically. Do not edit.
 ## docs/deployment_governance.md
 
 - [relates_to] docs/deploy/README.md
+- [relates_to] docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md
 - [relates_to] docs/deployment.md
 
 ## docs/dev/codespaces.md
@@ -250,10 +363,12 @@ Generated automatically. Do not edit.
 ## docs/policies/agent-reading-protocol.md
 
 - [relates_to] docs/blueprints/agent-operability-blaupause.md
+- [relates_to] docs/blueprints/blueprint-agent-safety-control-layer.md
 - [relates_to] docs/policies/architecture-critique.md
 - [relates_to] docs/reports/agent-readiness-audit.md
 - [relates_to] docs/reports/optimierungsbericht.md
 - [relates_to] docs/reports/optimierungsstatus.md
+- [relates_to] docs/tasks/README.md
 
 ## docs/policies/orientierung.md
 
@@ -299,6 +414,7 @@ Generated automatically. Do not edit.
 ## docs/reports/agent-readiness-audit.md
 
 - [relates_to] docs/blueprints/agent-operability-blaupause.md
+- [relates_to] docs/blueprints/blueprint-agent-safety-control-layer.md
 
 ## docs/reports/auth-persistence-next-step.md
 
@@ -332,6 +448,35 @@ Generated automatically. Do not edit.
 - [relates_to] docs/reports/passkey-register-verify-prep.md
 - [depends_on] docs/roadmap.md
 
+## docs/reports/domain-account-write-path-proof.md
+
+- [relates_to] docs/blueprints/domain-data-postgres-cutover.md
+- [relates_to] docs/reports/domain-edge-create-semantics-preflight.md
+- [relates_to] docs/reports/domain-edge-write-path-proof.md
+- [relates_to] docs/reports/domain-node-write-path-proof.md
+- [relates_to] docs/reports/domain-read-path-proof.md
+
+## docs/reports/domain-backfill-proof.md
+
+- [relates_to] docs/reports/domain-read-path-proof.md
+
+## docs/reports/domain-node-write-path-proof.md
+
+- [relates_to] docs/blueprints/domain-data-postgres-cutover.md
+- [relates_to] docs/reports/domain-edge-create-semantics-preflight.md
+- [relates_to] docs/reports/domain-edge-write-path-proof.md
+
+## docs/reports/domain-provider-role-finding.md
+
+- [relates_to] docs/reports/inwx-zone-reconciliation-plan.md
+
+## docs/reports/domain-read-path-proof.md
+
+- [relates_to] docs/reports/domain-account-write-path-proof.md
+- [relates_to] docs/reports/domain-edge-write-path-proof.md
+- [relates_to] docs/reports/domain-node-write-path-proof.md
+- [relates_to] docs/reports/optimierungsstatus.md
+
 ## docs/reports/map-architekturkritik.md
 
 - [relates_to] docs/blueprints/kartenklarheit-phase6.md
@@ -348,17 +493,39 @@ Generated automatically. Do not edit.
 - [relates_to] docs/reports/map-architekturkritik.md
 - [depends_on] docs/roadmap.md
 
+## docs/reports/opt-arc-001-db-proof-matrix.json
+
+- [relates_to] docs/reports/domain-edge-create-semantics-preflight.md
+
 ## docs/reports/optimierungsbericht.md
 
+- [relates_to] docs/blueprints/domain-data-postgres-cutover.md
 - [depends_on] docs/reports/optimierungsstatus.md
 
 ## docs/reports/optimierungsstatus.md
 
+- [relates_to] docs/blueprints/doc-structure-task-control-roadmap.md
+- [relates_to] docs/blueprints/doc-structure-task-control.md
+- [relates_to] docs/blueprints/domain-data-postgres-cutover.md
+- [relates_to] docs/reports/domain-account-write-path-proof.md
+- [relates_to] docs/reports/domain-edge-write-path-proof.md
+- [relates_to] docs/reports/domain-node-write-path-proof.md
+- [relates_to] docs/reports/domain-read-path-proof.md
 - [relates_to] docs/reports/optimierungsbericht.md
 - [depends_on] docs/roadmap.md
+- [relates_to] docs/specs/list-pagination-api.md
+- [depends_on] docs/tasks/README.md
+- [depends_on] docs/tasks/board.md
 
 ## docs/roadmap.md
 
+- [relates_to] docs/blueprints/blueprint-agent-safety-control-layer.md
+- [relates_to] docs/blueprints/kartenklarheit.md
+- [relates_to] docs/blueprints/map-blaupause.md
+- [relates_to] docs/blueprints/ui-blaupause.md
+- [relates_to] docs/blueprints/ui-state-machine.md
+- [relates_to] docs/blueprints/weltgewebe.auth-and-ui-routing.md
+- [relates_to] docs/proofs/basemap-hamburg-artifact-proof.md
 - [relates_to] docs/reports/auth-persistence-runtime-target-reconciliation.md
 
 ## docs/runbook.md
@@ -366,14 +533,20 @@ Generated automatically. Do not edit.
 - [relates_to] docs/deployment.md
 - [relates_to] docs/runbook.observability.md
 - [relates_to] docs/runbooks/README.md
+- [relates_to] docs/runbooks/db-recovery.md
+- [relates_to] docs/runbooks/incident-response.md
 
 ## docs/runbook.observability.md
 
 - [relates_to] docs/runbook.md
+- [relates_to] docs/runbooks/incident-response.md
 
 ## docs/runbooks/README.md
 
 - [relates_to] docs/runbooks/codespaces-recovery.md
+- [relates_to] docs/runbooks/db-recovery.md
+- [relates_to] docs/runbooks/domain-mail-cutover.md
+- [relates_to] docs/runbooks/incident-response.md
 - [relates_to] docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md
 - [relates_to] docs/runbooks/uv-tooling.md
 
@@ -381,6 +554,24 @@ Generated automatically. Do not edit.
 
 - [relates_to] docs/dev/codespaces.md
 - [relates_to] docs/runbooks/README.md
+
+## docs/runbooks/db-recovery.md
+
+- [relates_to] docs/runbooks/README.md
+- [relates_to] docs/runbooks/incident-response.md
+
+## docs/runbooks/domain-mail-cutover.md
+
+- [relates_to] docs/adr/ADR-0008__domain-mail-provider-boundaries.md
+- [relates_to] docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md
+- [relates_to] docs/reports/domain-provider-role-finding.md
+- [relates_to] docs/reports/inwx-zone-reconciliation-plan.md
+- [relates_to] docs/runbooks/README.md
+
+## docs/runbooks/incident-response.md
+
+- [relates_to] docs/runbooks/README.md
+- [relates_to] docs/runbooks/db-recovery.md
 
 ## docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md
 
@@ -416,7 +607,13 @@ Generated automatically. Do not edit.
 
 ## docs/specs/contract.md
 
+- [relates_to] docs/blueprints/domain-data-postgres-cutover.md
 - [relates_to] docs/domain/vocabulary.md
+- [relates_to] docs/specs/list-pagination-api.md
+
+## docs/specs/list-pagination-api.md
+
+- [relates_to] docs/blueprints/domain-data-postgres-cutover.md
 
 ## docs/specs/privacy-api.md
 
@@ -425,6 +622,36 @@ Generated automatically. Do not edit.
 ## docs/specs/privacy-ui.md
 
 - [relates_to] docs/specs/privacy-api.md
+
+## docs/tasks/README.md
+
+- [relates_to] docs/tasks/board.md
+
+## docs/tasks/board.md
+
+- [relates_to] docs/blueprints/domain-data-postgres-cutover.md
+- [relates_to] docs/reports/domain-account-write-path-proof.md
+- [relates_to] docs/reports/domain-edge-create-semantics-preflight.md
+- [relates_to] docs/reports/domain-edge-write-path-proof.md
+- [relates_to] docs/reports/domain-node-write-path-proof.md
+- [relates_to] docs/reports/domain-provider-role-finding.md
+- [relates_to] docs/reports/domain-read-path-proof.md
+- [relates_to] docs/reports/inwx-zone-reconciliation-plan.md
+- [relates_to] docs/security/agent-write-scope-baseline.md
+- [relates_to] docs/tasks/README.md
+
+## docs/tasks/index.json
+
+- [relates_to] docs/blueprints/blueprint-agent-safety-control-layer.md
+- [relates_to] docs/blueprints/doc-structure-task-control-examples.md
+- [relates_to] docs/blueprints/domain-data-postgres-cutover.md
+- [relates_to] docs/claims/README.md
+- [relates_to] docs/reports/domain-backfill-proof.md
+- [relates_to] docs/reports/domain-edge-create-semantics-preflight.md
+- [relates_to] docs/reports/domain-edge-write-path-proof.md
+- [relates_to] docs/reports/domain-node-write-path-proof.md
+- [relates_to] docs/reports/planning-registration-findings.md
+- [relates_to] docs/tasks/board.md
 
 ## docs/techstack.md
 
@@ -464,5 +691,34 @@ Generated automatically. Do not edit.
 
 ## repo.meta.yaml
 
+- [relates_to] docs/blueprints/blueprint-agent-safety-control-layer.md
 - [relates_to] docs/policies/agent-reading-protocol.md
 - [relates_to] docs/policies/architecture-critique.md
+
+## scripts/agent/check_non_ideal_task.py
+
+- [relates_to] docs/reference/agent-operability-fixture-matrix.md
+
+## scripts/agent/tests/test_check_non_ideal_task.py
+
+- [relates_to] docs/reference/agent-operability-fixture-matrix.md
+
+## scripts/basemap/build-hamburg-pmtiles.sh
+
+- [relates_to] docs/proofs/basemap-hamburg-artifact-proof.md
+
+## scripts/docmeta/audit_account_email_uniqueness.py
+
+- [relates_to] docs/reports/domain-account-email-uniqueness-audit.md
+
+## scripts/docmeta/check_planning_registration.py
+
+- [relates_to] docs/reports/planning-registration-findings.md
+
+## scripts/docmeta/validate_claim_registry.py
+
+- [relates_to] docs/claims/README.md
+
+## scripts/guard/basemap-runtime-proof.sh
+
+- [relates_to] docs/proofs/basemap-hamburg-artifact-proof.md

--- a/docs/_generated/doc-index.md
+++ b/docs/_generated/doc-index.md
@@ -21,36 +21,48 @@ Generated automatically. Do not edit.
 | adr.ADR-0005-auth | ADR-0005 — Auth (Cookie-basierte Sessions) | reference | active | docs/adr/ADR-0005-auth.md |
 | adr.ADR-0006-auth-magic-link-session-passkey | ADR-0006 — Auth: Magic Link, Session und optionaler Passkey | reference | active | docs/adr/ADR-0006__auth-magic-link-session-passkey.md |
 | adr.ADR-0007-auth-persistence-production-db-path | ADR-0007 — Auth-Persistenz Produktionspfad: Direkter PostgreSQL-Zugriff statt PgBouncer | reference | accepted | docs/adr/ADR-0007__auth-persistence-production-db-path.md |
+| adr.ADR-0008-domain-mail-provider-boundaries | ADR-0008 — Domain-, Mail- und SMTP-Providergrenzen | reference | accepted | docs/adr/ADR-0008__domain-mail-provider-boundaries.md |
+| blueprint-doc-structure-task-control-examples | Dokumentationsstruktur und Task-Steuerung Beispiele | reference | draft | docs/blueprints/doc-structure-task-control-examples.md |
+| blueprint-doc-structure-task-control-roadmap | Dokumentationsstruktur und Task-Steuerung Roadmap | roadmap | draft | docs/blueprints/doc-structure-task-control-roadmap.md |
+| blueprint-doc-structure-task-control | Weltgewebe Dokumentationsstruktur und Task-Steuerung | blueprint | draft | docs/blueprints/doc-structure-task-control.md |
 | blueprints.auth-persistence-runtime-proof | Auth-Persistenz — Runtime-Proof-Blaupause | blueprint | active | docs/blueprints/auth-persistence-runtime-proof.md |
 | blueprints.auth-roadmap | Auth Roadmap | roadmap | active | docs/blueprints/auth-roadmap.md |
+| blueprints.domain-data-postgres-cutover | Domain Data PostgreSQL Cutover | blueprint | active | docs/blueprints/domain-data-postgres-cutover.md |
 | blueprints.weltgewebe.auth-and-ui-routing | Auth und UI-Routing | reference | active | docs/blueprints/weltgewebe.auth-and-ui-routing.md |
-| blueprints.weltgewebe.config.diff | Config Diff | reference | active | docs/blueprints/weltgewebe.config.diff.md |
-| blueprints.weltgewebe.deploy.plan | Deploy-Plan | reference | active | docs/blueprints/weltgewebe.deploy.plan.md |
+| blueprints.weltgewebe.config.diff | Config Diff | reference | deprecated | docs/blueprints/weltgewebe.config.diff.md |
+| blueprints.weltgewebe.deploy.plan | Deploy-Plan | reference | deprecated | docs/blueprints/weltgewebe.deploy.plan.md |
 | datenmodell | Datenmodell | reference | active | docs/datenmodell.md |
 | deploy.CHANGELOG | Deploy Changelog | reference | active | docs/deploy/CHANGELOG.md |
+| DEPLOY-DNS-001B | Historical INWX Zone Entry Checklist — Predelegation Assumption Superseded | task | done | docs/tasks/DEPLOY-DNS-001B.md |
+| deploy.domain-mail-migration-ionos-inwx-mailbox-brevo | Domain-/Mail-Migration: IONOS zu INWX + mailbox.org + Brevo | reference | active | docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md |
 | deploy.DRIFT_POLICY | Drift Policy | reference | active | docs/deploy/DRIFT_POLICY.md |
-| deploy.README | Deployment-Übersicht | reference | active | docs/deploy/README.md |
 | deploy.heim-first-phase0 | Heim-First Phase 0 | reference | active | docs/deploy/heim-first-phase0.md |
 | deploy.heimserver.deployment | Heimserver Deployment | reference | active | docs/deploy/heimserver.deployment.md |
 | deploy.heimserver.integration | Heimserver Integration | reference | active | docs/deploy/heimserver.integration.md |
+| deployment-contract | Deployment Contract and Preflight Guard | guide | active | docs/deployment.md |
+| deployment_governance | Deployment Governance | reference | active | docs/deployment_governance.md |
+| deploy.README | Deployment-Übersicht | reference | active | docs/deploy/README.md |
 | deploy.security | Deploy Security | architecture | active | docs/deploy/security.md |
 | deploy.vps | VPS-Deployment | reference | active | docs/deploy/vps.md |
 | deploy.weltgewebe.naming | Weltgewebe Naming | reference | active | docs/deploy/weltgewebe.naming.md |
-| deployment-contract | Deployment Contract and Preflight Guard | guide | active | docs/deployment.md |
-| deployment_governance | Deployment Governance | reference | active | docs/deployment_governance.md |
 | dev.codespaces | Codespaces | reference | active | docs/dev/codespaces.md |
 | docs.architecture.overview | Architekturüberblick | architecture | active | docs/architekturstruktur.md |
 | docs.blueprints.agent-operability | Minimaler Agent-Operability-Kern | blueprint | draft | docs/blueprints/agent-operability-blaupause.md |
+| docs.blueprints.agent-safety-control-layer | Blueprint — Agent Safety Control Layer | blueprint | draft | docs/blueprints/blueprint-agent-safety-control-layer.md |
 | docs.blueprints.kartenklarheit | Blaupause zur Optimierung der Karte | blueprint | draft | docs/blueprints/kartenklarheit.md |
 | docs.blueprints.kartenklarheit-phase6 | Kartenklarheit Phase 6: Der Wahrheitsbeweis | blueprint | in progress | docs/blueprints/kartenklarheit-phase6.md |
 | docs.blueprints.kartenklarheit-roadmap | Roadmap - Kartenklarheit | roadmap | active | docs/blueprints/kartenklarheit-roadmap.md |
+| docs.claims.readme | Claim-Registry | reference | active | docs/claims/README.md |
 | docs.index | Weltgewebe - Doku-Index | index | active | docs/index.md |
 | docs.policies.agent-reading-protocol | Agent Reading Protocol | policy | canonical | docs/policies/agent-reading-protocol.md |
 | docs.policies.architecture-critique | Architekturkritik-Skill: weltgewebe.architecture.critique | policy | canonical | docs/policies/architecture-critique.md |
+| docs.proofs.basemap-hamburg-artifact-proof | Basemap Hamburg Artifact Proof (Heimserver) | proof | active | docs/proofs/basemap-hamburg-artifact-proof.md |
+| docs.reference.agent-operability-fixture-matrix | Agent-Betriebsfaehigkeit: Fixture-Matrix | reference | active | docs/reference/agent-operability-fixture-matrix.md |
 | docs.reports.agent-readiness-audit | Agent Readiness Audit | documentation | active | docs/reports/agent-readiness-audit.md |
 | docs.roadmap | Weltgewebe — Master-Umsetzungsroadmap | roadmap | active | docs/roadmap.md |
-| docs.runbook | Runbook | runbook | active | docs/runbook.md |
 | docs.runbook.observability | Observability Runbook | runbook | active | docs/runbook.observability.md |
+| docs.runbook | Runbook | runbook | active | docs/runbook.md |
+| docs.security.agent-write-scope-baseline | Agent Write Scope Baseline | security | active | docs/security/agent-write-scope-baseline.md |
 | docs.techstack | Techstack | architecture | active | docs/techstack.md |
 | docs.vision | Vision | reference | active | docs/vision.md |
 | domain.modules | Modul-IDs | reference | active | docs/domain/modules.md |
@@ -67,9 +79,9 @@ Generated automatically. Do not edit.
 | overview.inhalt | Inhalt (Übersicht) | reference | active | docs/overview/inhalt.md |
 | overview.zusammenstellung | Zusammenstellung (Übersicht) | reference | active | docs/overview/zusammenstellung.md |
 | policies.orientierung | Orientierung | reference | active | docs/policies/orientierung.md |
-| process.README | Prozess-Übersicht | reference | active | docs/process/README.md |
 | process.bash-tooling-guidelines | Bash Tooling Guidelines | reference | active | docs/process/bash-tooling-guidelines.md |
 | process.fahrplan | Fahrplan | reference | active | docs/process/fahrplan.md |
+| process.README | Prozess-Übersicht | reference | active | docs/process/README.md |
 | process.sprache | Sprache | reference | active | docs/process/sprache.md |
 | proofs.sqlx-pgbouncer-session-crud-proof | SQLx → PgBouncer → Postgres — Session-CRUD-Proof | report | active | docs/proofs/sqlx-pgbouncer-session-crud-proof.md |
 | proofs.sqlx-postgres-direct-session-crud-proof | SQLx \u2192 direkter PostgreSQL \u2014 Session-CRUD-Proof | report | active | docs/proofs/sqlx-postgres-direct-session-crud-proof.md |
@@ -82,20 +94,36 @@ Generated automatically. Do not edit.
 | reports.auth-persistence-runtime-target-reconciliation | Auth-Persistenz — Runtime-Zielarchitektur-Abgleich (PgBouncer vs. direkter Postgres) | report | active | docs/reports/auth-persistence-runtime-target-reconciliation.md |
 | reports.auth-status-matrix | Auth Status Matrix | reference | active | docs/reports/auth-status-matrix.md |
 | reports.cost-report | Cost Report | reference | active | docs/reports/cost-report.md |
+| reports.domain-account-email-uniqueness-audit | Domain Account E-Mail Uniqueness Audit | report | draft | docs/reports/domain-account-email-uniqueness-audit.md |
+| reports.domain-account-write-path-proof | Domain Account Write Path Proof | report | active | docs/reports/domain-account-write-path-proof.md |
+| reports.domain-backfill-proof | Domain Backfill Proof | report | active | docs/reports/domain-backfill-proof.md |
+| reports.domain-edge-create-semantics-preflight | Domain Edge Create Semantics Preflight — OPT-ARC-001 Phase E-C | report | active | docs/reports/domain-edge-create-semantics-preflight.md |
+| reports.domain-edge-write-path-proof | Domain Edge Write Path Proof | report | active | docs/reports/domain-edge-write-path-proof.md |
+| reports.domain-node-write-path-proof | Domain Node Write Path Proof | report | active | docs/reports/domain-node-write-path-proof.md |
+| reports.domain-provider-role-finding | Finding: Aktuelle Domain- und Provider-Rollen | report | active | docs/reports/domain-provider-role-finding.md |
+| reports.domain-read-path-proof | Domain Read Path Proof | report | active | docs/reports/domain-read-path-proof.md |
+| reports.inwx-zone-reconciliation-plan | INWX Zone Reconciliation Plan | report | active | docs/reports/inwx-zone-reconciliation-plan.md |
 | reports.optimierungsbericht | Optimierungsbericht Weltgewebe | report | active | docs/reports/optimierungsbericht.md |
 | reports.optimierungsstatus | Optimierungsstatus Weltgewebe | status-matrix | active | docs/reports/optimierungsstatus.md |
 | reports.passkey-register-verify-prep | Passkey Register-Verify – Vorbereitungsbericht | report | active | docs/reports/passkey-register-verify-prep.md |
-| runbooks.README | Runbooks-Übersicht | reference | active | docs/runbooks/README.md |
+| reports.planning-registration-findings | Planning Registration Findings Triage | report | active | docs/reports/planning-registration-findings.md |
 | runbooks.codespaces-recovery | Codespaces Recovery | reference | active | docs/runbooks/codespaces-recovery.md |
+| runbooks.db-recovery | DB Recovery Runbook | reference | active | docs/runbooks/db-recovery.md |
+| runbooks.domain-mail-cutover | Runbook — Domain-, Mail- und SMTP-Cutover | runbook | active | docs/runbooks/domain-mail-cutover.md |
+| runbooks.incident-response | Incident Response Runbook | reference | active | docs/runbooks/incident-response.md |
 | runbooks.ops.runbook.weltgewebe-selfhost-deploy | Selfhost-Deploy Runbook | reference | active | docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md |
+| runbooks.README | Runbooks-Übersicht | reference | active | docs/runbooks/README.md |
 | runbooks.uv-tooling | UV-Tooling | reference | active | docs/runbooks/uv-tooling.md |
 | specs.auth-api | Auth API Spec | reference | active | docs/specs/auth-api.md |
 | specs.auth-blueprint | Auth Blueprint | reference | active | docs/specs/auth-blueprint.md |
 | specs.auth-state-machine | Auth State Machine | reference | active | docs/specs/auth-state-machine.md |
 | specs.auth-ui | Auth UI Spec | reference | active | docs/specs/auth-ui.md |
 | specs.contract | Datenvertrag | reference | active | docs/specs/contract.md |
+| specs.list-pagination-api | List Pagination API Spec | reference | active | docs/specs/list-pagination-api.md |
 | specs.privacy-api | Privacy API | reference | active | docs/specs/privacy-api.md |
 | specs.privacy-ui | Privacy UI | reference | active | docs/specs/privacy-ui.md |
+| tasks.board | Weltgewebe Task Board | task-board | active | docs/tasks/board.md |
+| tasks.readme | Task-Control – Einstieg | guide | active | docs/tasks/README.md |
 | ui-blaupause | Weltgewebe UI-Blaupause | blueprint | canonical | docs/blueprints/ui-blaupause.md |
 | ui-roadmap | Weltgewebe UI Roadmap | blueprint | canonical | docs/blueprints/ui-roadmap.md |
 | ui-state-machine | Weltgewebe UI State Machine | blueprint | canonical | docs/blueprints/ui-state-machine.md |

--- a/docs/_generated/implicit-dependencies.md
+++ b/docs/_generated/implicit-dependencies.md
@@ -15,18 +15,25 @@ Generated automatically. Do not edit.
 | Source | Inferred Dependency | Evidence | Documented |
 | --- | --- | --- | --- |
 | Makefile (validate-tests) | unittest | `python3 -m unittest discover scripts/docmeta/tests/` | *unclear* |
+| Makefile (validate-tests) | unittest | `python3 -m unittest discover scripts/agent/tests/` | *unclear* |
+| Makefile (validate-tests) | scripts.docmeta.generate_claim_evidence_map | `python3 -m scripts.docmeta.generate_claim_evidence_map --check` | *unclear* |
 | Makefile (validate-core) | scripts.docmeta.validate_schema | `python3 -m scripts.docmeta.validate_schema` | *unclear* |
 | Makefile (validate-core) | scripts.docmeta.validate_relations | `python3 -m scripts.docmeta.validate_relations` | *unclear* |
 | Makefile (validate-core) | scripts.docmeta.check_repo_index_consistency | `python3 -m scripts.docmeta.check_repo_index_consistency` | *unclear* |
 | Makefile (validate-core) | scripts.docmeta.check_doc_review_age | `python3 -m scripts.docmeta.check_doc_review_age` | *unclear* |
 | Makefile (validate-core) | scripts.docmeta.review_impact | `python3 -m scripts.docmeta.review_impact` | *unclear* |
+| Makefile (validate-core) | scripts.docmeta.validate_opt_arc_001_db_proof_matrix | `python3 -m scripts.docmeta.validate_opt_arc_001_db_proof_matrix` | *unclear* |
 | Makefile (validate-core) | scripts.docmeta.export_docs_index | `python3 -m scripts.docmeta.export_docs_index` | *unclear* |
 | Makefile (validate-core) | scripts.docmeta.generate_audit_gaps | `python3 -m scripts.docmeta.generate_audit_gaps` | *unclear* |
 | Makefile (validate-core) | scripts.docmeta.check_links | `python3 -m scripts.docmeta.check_links` | *unclear* |
+| Makefile (generate-system-map) | scripts.docmeta.generate_system_map | `python3 -m scripts.docmeta.generate_system_map` | *unclear* |
 | Makefile (validate-guards) | scripts/docmeta/repo-structure-guard.sh | `bash scripts/docmeta/repo-structure-guard.sh` | *unclear* |
 | Makefile (validate-guards) | scripts/docmeta/docs-relations-guard.sh | `bash scripts/docmeta/docs-relations-guard.sh` | *unclear* |
 | Makefile (validate-guards) | scripts/docmeta/generated-files-guard.sh | `bash scripts/docmeta/generated-files-guard.sh` | *unclear* |
 | Makefile (validate-guards) | scripts/docmeta/coverage-guard.sh | `bash scripts/docmeta/coverage-guard.sh` | *unclear* |
+| Makefile (validate-shell-tests) | scripts/tests/test_weltgewebe_up_git_branch.sh | `bash scripts/tests/test_weltgewebe_up_git_branch.sh` | *unclear* |
+| Makefile (validate-shell-tests) | scripts/tests/test_version_guard.sh | `bash scripts/tests/test_version_guard.sh` | *unclear* |
+| Makefile (validate-shell-tests) | scripts/tests/test_basemap_mode_guard.sh | `bash scripts/tests/test_basemap_mode_guard.sh` | *unclear* |
 | Makefile (generate) | scripts/docmeta/generate-doc-index.sh | `bash scripts/docmeta/generate-doc-index.sh` | *unclear* |
 | Makefile (generate) | scripts.docmeta.generate_backlinks | `python3 -m scripts.docmeta.generate_backlinks` | *unclear* |
 | Makefile (generate) | scripts/docmeta/generate-impl-index.sh | `bash scripts/docmeta/generate-impl-index.sh` | *unclear* |
@@ -40,5 +47,7 @@ Generated automatically. Do not edit.
 | Makefile (generate) | scripts.docmeta.generate_change_resonance | `python3 -m scripts.docmeta.generate_change_resonance` | *unclear* |
 | Makefile (generate) | scripts.docmeta.generate_staleness_report | `python3 -m scripts.docmeta.generate_staleness_report` | *unclear* |
 | Makefile (generate) | scripts.docmeta.generate_agent_readiness | `python3 -m scripts.docmeta.generate_agent_readiness` | *unclear* |
+| Makefile (generate) | scripts.docmeta.generate_claim_evidence_map | `python3 -m scripts.docmeta.generate_claim_evidence_map` | *unclear* |
 | Makefile (generate) | scripts.docmeta.generate_relations_analysis | `python3 -m scripts.docmeta.generate_relations_analysis` | *unclear* |
 | Makefile (generate) | scripts.docmeta.generate_relates_to_audit | `python3 -m scripts.docmeta.generate_relates_to_audit` | *unclear* |
+| Makefile (generate) | scripts.docmeta.generate_report_lifecycle_inventory | `python3 -m scripts.docmeta.generate_report_lifecycle_inventory` | *unclear* |

--- a/docs/_generated/orphans.md
+++ b/docs/_generated/orphans.md
@@ -11,3 +11,4 @@ summary: Automatisch generierte Liste verwaister Dokumente.
 Generated automatically. Do not edit.
 
 - docs/reports/cost-report.md
+- docs/tasks/DEPLOY-DNS-001B.md

--- a/docs/_generated/relates-to-audit.md
+++ b/docs/_generated/relates-to-audit.md
@@ -14,11 +14,11 @@ Generated automatically. Do not edit.
 
 | Metrik | Wert |
 | --- | --- |
-| Relationen gesamt | 232 |
-| — depends_on | 13 |
-| — relates_to | 217 |
+| Relationen gesamt | 368 |
+| — depends_on | 18 |
+| — relates_to | 348 |
 | — supersedes | 2 |
-| relates_to Anteil | 94% |
+| relates_to Anteil | 95% |
 
 ### Mögliche supersedes-Lücken
 
@@ -30,74 +30,57 @@ _Keine Lücken erkannt._
 
 > Zusammenhängende Gruppen im relates_to-Graphen.
 
-**Cluster 1** (54 Dokumente):
+**Cluster 1** (134 Dokumente):
 
+- `.github/workflows/api.yml`
 - `AGENTS.md`
 - `agent-policy.yaml`
+- `apps/api/src/auth/accounts.rs`
+- `apps/api/src/routes/accounts.rs`
+- `apps/api/src/routes/edges.rs`
+- `apps/api/src/routes/nodes.rs`
+- `apps/api/src/state.rs`
+- `apps/api/tests/db_domain_account_write_path.rs`
+- `apps/api/tests/db_domain_backfill.rs`
+- `audit/impl-registry.yaml`
+- `contracts/domain/edge.schema.json`
 - `docs/adr/0043-edge-vs-conversation.md`
 - `docs/adr/ADR-0001__clean-slate-docs-monorepo.md`
+- `docs/adr/ADR-0002__reentry-kriterien.md`
 - `docs/adr/ADR-0003__privacy-ungenauigkeitsradius-ron.md`
+- `docs/adr/ADR-0004__fahrplan-verweis.md`
 - `docs/adr/ADR-0005-auth.md`
 - `docs/adr/ADR-0006__auth-magic-link-session-passkey.md`
 - `docs/adr/ADR-0007__auth-persistence-production-db-path.md`
+- `docs/adr/ADR-0008__domain-mail-provider-boundaries.md`
 - `docs/architekturstruktur.md`
 - `docs/blueprints/agent-operability-blaupause.md`
 - `docs/blueprints/auth-persistence-runtime-proof.md`
 - `docs/blueprints/auth-roadmap.md`
+- `docs/blueprints/blueprint-agent-safety-control-layer.md`
+- `docs/blueprints/doc-structure-task-control-examples.md`
+- `docs/blueprints/doc-structure-task-control-roadmap.md`
+- `docs/blueprints/doc-structure-task-control.md`
+- `docs/blueprints/domain-data-postgres-cutover.md`
+- `docs/blueprints/kartenklarheit-phase6.md`
+- `docs/blueprints/kartenklarheit-roadmap.md`
+- `docs/blueprints/kartenklarheit.md`
+- `docs/blueprints/map-blaupause.md`
+- `docs/blueprints/map-roadmap.md`
 - `docs/blueprints/ui-blaupause.md`
 - `docs/blueprints/ui-roadmap.md`
 - `docs/blueprints/ui-state-machine.md`
-- `docs/blueprints/weltgewebe.auth-and-ui-routing.md`
-- `docs/datenmodell.md`
-- `docs/domain/modules.md`
-- `docs/domain/vocabulary.md`
-- `docs/geist-und-plan.md`
-- `docs/inhalt.md`
-- `docs/konzepte/garnrolle-und-verortung.md`
-- `docs/konzepte/garnrolle.md`
-- `docs/overview/inhalt.md`
-- `docs/overview/zusammenstellung.md`
-- `docs/policies/agent-reading-protocol.md`
-- `docs/policies/architecture-critique.md`
-- `docs/policies/orientierung.md`
-- `docs/proofs/sqlx-pgbouncer-session-crud-proof.md`
-- `docs/proofs/sqlx-postgres-direct-session-crud-proof.md`
-- `docs/reference/glossar.md`
-- `docs/reports/agent-readiness-audit.md`
-- `docs/reports/auth-persistence-direct-proof-diagnose-audit.md`
-- `docs/reports/auth-persistence-next-step.md`
-- `docs/reports/auth-persistence-readiness.md`
-- `docs/reports/auth-persistence-runtime-proof.md`
-- `docs/reports/auth-persistence-runtime-target-reconciliation.md`
-- `docs/reports/auth-status-matrix.md`
-- `docs/reports/optimierungsbericht.md`
-- `docs/reports/optimierungsstatus.md`
-- `docs/reports/passkey-register-verify-prep.md`
-- `docs/roadmap.md`
-- `docs/specs/auth-api.md`
-- `docs/specs/auth-blueprint.md`
-- `docs/specs/auth-state-machine.md`
-- `docs/specs/auth-ui.md`
-- `docs/specs/contract.md`
-- `docs/specs/privacy-api.md`
-- `docs/specs/privacy-ui.md`
-- `docs/techstack.md`
-- `docs/vision.md`
-- `docs/weltgewebe-agenten-manifest.md`
-- `docs/zusammenstellung.md`
-- `repo.meta.yaml`
-
-**Cluster 2** (30 Dokumente):
-
-- `docs/adr/ADR-0002__reentry-kriterien.md`
-- `docs/adr/ADR-0004__fahrplan-verweis.md`
 - `docs/blueprints/versionierungs-blaupause.md`
 - `docs/blueprints/versionierungs-statusgrundlage.md`
+- `docs/blueprints/weltgewebe.auth-and-ui-routing.md`
 - `docs/blueprints/weltgewebe.config.diff.md`
 - `docs/blueprints/weltgewebe.deploy.plan.md`
+- `docs/claims/README.md`
+- `docs/datenmodell.md`
 - `docs/deploy/CHANGELOG.md`
 - `docs/deploy/DRIFT_POLICY.md`
 - `docs/deploy/README.md`
+- `docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md`
 - `docs/deploy/heim-first-phase0.md`
 - `docs/deploy/heimserver.deployment.md`
 - `docs/deploy/heimserver.integration.md`
@@ -107,30 +90,91 @@ _Keine Lücken erkannt._
 - `docs/deployment.md`
 - `docs/deployment_governance.md`
 - `docs/dev/codespaces.md`
+- `docs/domain/modules.md`
+- `docs/domain/vocabulary.md`
 - `docs/edge/systemd/README.md`
+- `docs/geist-und-plan.md`
+- `docs/inhalt.md`
+- `docs/konzepte/garnrolle-und-verortung.md`
+- `docs/konzepte/garnrolle.md`
+- `docs/overview/inhalt.md`
+- `docs/overview/zusammenstellung.md`
+- `docs/policies/agent-reading-protocol.md`
+- `docs/policies/architecture-critique.md`
+- `docs/policies/orientierung.md`
 - `docs/process/README.md`
 - `docs/process/bash-tooling-guidelines.md`
 - `docs/process/fahrplan.md`
 - `docs/process/sprache.md`
+- `docs/proofs/basemap-hamburg-artifact-proof.md`
+- `docs/proofs/sqlx-pgbouncer-session-crud-proof.md`
+- `docs/proofs/sqlx-postgres-direct-session-crud-proof.md`
 - `docs/quickstart-gate-c.md`
+- `docs/reference/glossar.md`
+- `docs/reports/agent-readiness-audit.md`
+- `docs/reports/auth-persistence-direct-proof-diagnose-audit.md`
+- `docs/reports/auth-persistence-next-step.md`
+- `docs/reports/auth-persistence-readiness.md`
+- `docs/reports/auth-persistence-runtime-proof.md`
+- `docs/reports/auth-persistence-runtime-target-reconciliation.md`
+- `docs/reports/auth-status-matrix.md`
+- `docs/reports/domain-account-email-uniqueness-audit.md`
+- `docs/reports/domain-account-write-path-proof.md`
+- `docs/reports/domain-backfill-proof.md`
+- `docs/reports/domain-edge-create-semantics-preflight.md`
+- `docs/reports/domain-edge-write-path-proof.md`
+- `docs/reports/domain-node-write-path-proof.md`
+- `docs/reports/domain-provider-role-finding.md`
+- `docs/reports/domain-read-path-proof.md`
+- `docs/reports/inwx-zone-reconciliation-plan.md`
+- `docs/reports/map-architekturkritik.md`
+- `docs/reports/map-status-matrix.md`
+- `docs/reports/opt-arc-001-db-proof-matrix.json`
+- `docs/reports/optimierungsbericht.md`
+- `docs/reports/optimierungsstatus.md`
+- `docs/reports/passkey-register-verify-prep.md`
+- `docs/reports/planning-registration-findings.md`
+- `docs/roadmap.md`
 - `docs/runbook.md`
 - `docs/runbook.observability.md`
 - `docs/runbooks/README.md`
 - `docs/runbooks/codespaces-recovery.md`
+- `docs/runbooks/db-recovery.md`
+- `docs/runbooks/domain-mail-cutover.md`
+- `docs/runbooks/incident-response.md`
 - `docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md`
 - `docs/runbooks/uv-tooling.md`
+- `docs/security/agent-write-scope-baseline.md`
+- `docs/specs/auth-api.md`
+- `docs/specs/auth-blueprint.md`
+- `docs/specs/auth-state-machine.md`
+- `docs/specs/auth-ui.md`
+- `docs/specs/contract.md`
+- `docs/specs/list-pagination-api.md`
+- `docs/specs/privacy-api.md`
+- `docs/specs/privacy-ui.md`
+- `docs/tasks/README.md`
+- `docs/tasks/board.md`
+- `docs/tasks/index.json`
+- `docs/techstack.md`
+- `docs/vision.md`
+- `docs/weltgewebe-agenten-manifest.md`
+- `docs/zusammenstellung.md`
+- `repo.meta.yaml`
+- `scripts/basemap/build-hamburg-pmtiles.sh`
+- `scripts/docmeta/audit_account_email_uniqueness.py`
+- `scripts/docmeta/check_planning_registration.py`
+- `scripts/docmeta/validate_claim_registry.py`
+- `scripts/guard/basemap-runtime-proof.sh`
 
-**Cluster 3** (7 Dokumente):
+**Cluster 2** (4 Dokumente):
 
-- `docs/blueprints/kartenklarheit-phase6.md`
-- `docs/blueprints/kartenklarheit-roadmap.md`
-- `docs/blueprints/kartenklarheit.md`
-- `docs/blueprints/map-blaupause.md`
-- `docs/blueprints/map-roadmap.md`
-- `docs/reports/map-architekturkritik.md`
-- `docs/reports/map-status-matrix.md`
+- `contracts/agent/task.schema.json`
+- `docs/reference/agent-operability-fixture-matrix.md`
+- `scripts/agent/check_non_ideal_task.py`
+- `scripts/agent/tests/test_check_non_ideal_task.py`
 
-**Cluster 4** (3 Dokumente):
+**Cluster 3** (3 Dokumente):
 
 - `docs/adr/0042-consume-semantah-contracts.md`
 - `docs/x-repo/peers-learnings.md`
@@ -140,31 +184,42 @@ _Keine Lücken erkannt._
 
 > Dokumente mit den meisten relates_to-Zielen und ihren konkreten Relationen.
 
-**`docs/blueprints/auth-persistence-runtime-proof.md`**:
+**`docs/blueprints/domain-data-postgres-cutover.md`**:
 
-- relates_to → `docs/adr/ADR-0006__auth-magic-link-session-passkey.md`
-- relates_to → `docs/adr/ADR-0007__auth-persistence-production-db-path.md`
-- relates_to → `docs/blueprints/auth-roadmap.md`
-- relates_to → `docs/reports/auth-persistence-next-step.md`
-- relates_to → `docs/reports/auth-persistence-readiness.md`
-- relates_to → `docs/specs/auth-api.md`
+- relates_to → `apps/api/src/routes/accounts.rs`
+- relates_to → `apps/api/src/routes/edges.rs`
+- relates_to → `apps/api/src/routes/nodes.rs`
+- relates_to → `apps/api/src/state.rs`
+- relates_to → `docs/reports/domain-account-write-path-proof.md`
+- relates_to → `docs/reports/domain-node-write-path-proof.md`
+- relates_to → `docs/reports/optimierungsbericht.md`
+- relates_to → `docs/reports/optimierungsstatus.md`
+- relates_to → `docs/specs/contract.md`
+- relates_to → `docs/specs/list-pagination-api.md`
+- relates_to → `docs/tasks/board.md`
+- relates_to → `docs/tasks/index.json`
 
-**`docs/reports/auth-persistence-runtime-proof.md`**:
+**`docs/blueprints/blueprint-agent-safety-control-layer.md`**:
 
-- relates_to → `docs/adr/ADR-0006__auth-magic-link-session-passkey.md`
-- relates_to → `docs/adr/ADR-0007__auth-persistence-production-db-path.md`
-- relates_to → `docs/blueprints/auth-persistence-runtime-proof.md`
-- relates_to → `docs/blueprints/auth-roadmap.md`
-- relates_to → `docs/proofs/sqlx-postgres-direct-session-crud-proof.md`
-- relates_to → `docs/reports/auth-persistence-next-step.md`
+- relates_to → `AGENTS.md`
+- relates_to → `agent-policy.yaml`
+- relates_to → `audit/impl-registry.yaml`
+- relates_to → `docs/blueprints/agent-operability-blaupause.md`
+- relates_to → `docs/policies/agent-reading-protocol.md`
+- relates_to → `docs/reports/agent-readiness-audit.md`
+- relates_to → `docs/roadmap.md`
+- relates_to → `docs/tasks/index.json`
+- relates_to → `repo.meta.yaml`
 
-**`docs/adr/ADR-0007__auth-persistence-production-db-path.md`**:
+**`docs/reports/domain-edge-create-semantics-preflight.md`**:
 
-- relates_to → `docs/adr/ADR-0006__auth-magic-link-session-passkey.md`
-- relates_to → `docs/blueprints/auth-roadmap.md`
-- relates_to → `docs/proofs/sqlx-pgbouncer-session-crud-proof.md`
-- relates_to → `docs/reports/auth-persistence-runtime-proof.md`
-- relates_to → `docs/reports/auth-persistence-runtime-target-reconciliation.md`
+- relates_to → `contracts/domain/edge.schema.json`
+- relates_to → `docs/blueprints/domain-data-postgres-cutover.md`
+- relates_to → `docs/reports/domain-account-write-path-proof.md`
+- relates_to → `docs/reports/domain-node-write-path-proof.md`
+- relates_to → `docs/reports/opt-arc-001-db-proof-matrix.json`
+- relates_to → `docs/tasks/board.md`
+- relates_to → `docs/tasks/index.json`
 
 ### Hinweise
 

--- a/docs/_generated/relations-analysis.md
+++ b/docs/_generated/relations-analysis.md
@@ -14,25 +14,30 @@ Generated automatically. Do not edit.
 
 | Metrik | Wert |
 | --- | --- |
-| Dokumente gesamt | 93 |
-| Dokumente mit ausgehenden Relationen | 91 |
-| Dokumente als Ziel referenziert | 72 |
-| Relationen gesamt | 232 |
-| — depends_on | 13 |
-| — relates_to | 217 |
+| Dokumente gesamt | 121 |
+| Dokumente mit ausgehenden Relationen | 118 |
+| Dokumente als Ziel referenziert | 92 |
+| Relationen gesamt | 368 |
+| — depends_on | 18 |
+| — relates_to | 348 |
 | — supersedes | 2 |
-| Isolierte Dokumente | 1 |
+| Isolierte Dokumente | 2 |
 | depends_on Zyklen | 0 |
 
 ### Warnungen
 
 > Heuristische Hinweise — keine CI-Fehler. Zyklen deuten auf zirkuläre Abhängigkeiten, hohe Vernetzung auf zentrale Dokumente, die bei Änderungen besondere Aufmerksamkeit erfordern.
 
-- ⚠️ High outbound count (12): `docs/roadmap.md` — possible over-linking
-- ⚠️ High inbound count (14): `docs/adr/ADR-0006__auth-magic-link-session-passkey.md` — central dependency, review carefully
-- ⚠️ High inbound count (13): `docs/deploy/README.md` — central dependency, review carefully
+- ⚠️ High outbound count (13): `docs/roadmap.md` — possible over-linking
+- ⚠️ High outbound count (12): `docs/blueprints/domain-data-postgres-cutover.md` — possible over-linking
+- ⚠️ High outbound count (9): `docs/blueprints/blueprint-agent-safety-control-layer.md` — possible over-linking
+- ⚠️ High inbound count (15): `docs/adr/ADR-0006__auth-magic-link-session-passkey.md` — central dependency, review carefully
+- ⚠️ High inbound count (14): `docs/deploy/README.md` — central dependency, review carefully
+- ⚠️ High inbound count (12): `docs/deployment.md` — central dependency, review carefully
+- ⚠️ High inbound count (12): `docs/reports/optimierungsstatus.md` — central dependency, review carefully
 - ⚠️ High inbound count (11): `docs/blueprints/auth-roadmap.md` — central dependency, review carefully
-- ⚠️ High inbound count (11): `docs/deployment.md` — central dependency, review carefully
+- ⚠️ High inbound count (10): `docs/adr/ADR-0007__auth-persistence-production-db-path.md` — central dependency, review carefully
+- ⚠️ High inbound count (10): `docs/tasks/board.md` — central dependency, review carefully
 
 ### Zyklen (depends_on)
 
@@ -42,18 +47,24 @@ _Keine Zyklen gefunden._
 
 **Ausgehend (outbound):**
 
-- `docs/roadmap.md` — 12 ausgehende Relationen
+- `docs/roadmap.md` — 13 ausgehende Relationen
+- `docs/blueprints/domain-data-postgres-cutover.md` — 12 ausgehende Relationen
+- `docs/blueprints/blueprint-agent-safety-control-layer.md` — 9 ausgehende Relationen
 
 **Eingehend (inbound):**
 
-- `docs/adr/ADR-0006__auth-magic-link-session-passkey.md` — 14 eingehende Relationen
-- `docs/deploy/README.md` — 13 eingehende Relationen
+- `docs/adr/ADR-0006__auth-magic-link-session-passkey.md` — 15 eingehende Relationen
+- `docs/deploy/README.md` — 14 eingehende Relationen
+- `docs/deployment.md` — 12 eingehende Relationen
+- `docs/reports/optimierungsstatus.md` — 12 eingehende Relationen
 - `docs/blueprints/auth-roadmap.md` — 11 eingehende Relationen
-- `docs/deployment.md` — 11 eingehende Relationen
+- `docs/adr/ADR-0007__auth-persistence-production-db-path.md` — 10 eingehende Relationen
+- `docs/tasks/board.md` — 10 eingehende Relationen
 
 ### Isolierte Dokumente
 
 > Dokumente ohne eingehende und ausgehende Relationen (index.md/README.md ausgenommen).
 
 - `docs/reports/cost-report.md`
+- `docs/tasks/DEPLOY-DNS-001B.md`
 

--- a/docs/_generated/report-lifecycle-inventory.md
+++ b/docs/_generated/report-lifecycle-inventory.md
@@ -1,0 +1,126 @@
+---
+id: docs.generated.report-lifecycle-inventory
+title: Report Lifecycle Inventory
+doc_type: generated
+status: active
+canonicality: derived
+summary: Automatisch generiertes Inventar der Report-Lifecycle-Metadaten.
+---
+# Report Lifecycle Inventory
+
+Generated automatically. Do not edit manually.
+This inventory is descriptive only. Missing lifecycle fields are expected at this stage and are not policy violations.
+Reference counts are based on heuristic text matches against selected documentation paths.
+
+## Summary
+
+| Metric | Count |
+| --- | ---: |
+| reports_total | 23 |
+| reports_with_frontmatter | 23 |
+| reports_without_frontmatter | 0 |
+| reports_with_status | 23 |
+| reports_missing_status | 0 |
+| reports_with_lifecycle | 0 |
+| reports_missing_lifecycle | 23 |
+| reports_with_owner_task | 0 |
+| reports_missing_owner_task | 23 |
+| reports_with_review_after | 0 |
+| reports_missing_review_after | 23 |
+| reports_referenced | 21 |
+| reports_unreferenced | 2 |
+
+## Reports
+
+| Path | doc_type | status | lifecycle | owner_task | review_after | superseded_by | refs | missing |
+| --- | --- | --- | --- | --- | --- | --- | ---: | --- |
+| docs/reports/agent-readiness-audit.md | documentation | active |  |  |  |  | 5 | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/auth-persistence-direct-proof-diagnose-audit.md | report | active |  |  |  |  | 3 | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/auth-persistence-next-step.md | report | active |  |  |  |  | 9 | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/auth-persistence-readiness.md | report | active |  |  |  |  | 8 | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/auth-persistence-runtime-proof.md | report | active |  |  |  |  | 6 | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/auth-persistence-runtime-target-reconciliation.md | report | active |  |  |  |  | 3 | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/auth-status-matrix.md | reference | active |  |  |  |  | 7 | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/cost-report.md | reference | active |  |  |  |  | 3 | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/domain-account-email-uniqueness-audit.md | report | draft |  |  |  |  | 0 | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/domain-account-write-path-proof.md | report | active |  |  |  |  | 7 | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/domain-backfill-proof.md | report | active |  |  |  |  | 3 | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/domain-edge-create-semantics-preflight.md | report | active |  |  |  |  | 0 | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/domain-edge-write-path-proof.md | report | active |  |  |  |  | 3 | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/domain-node-write-path-proof.md | report | active |  |  |  |  | 5 | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/domain-provider-role-finding.md | report | active |  |  |  |  | 1 | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/domain-read-path-proof.md | report | active |  |  |  |  | 5 | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/inwx-zone-reconciliation-plan.md | report | active |  |  |  |  | 1 | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/map-architekturkritik.md | report | active |  |  |  |  | 8 | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/map-status-matrix.md | status-matrix | active |  |  |  |  | 10 | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/optimierungsbericht.md | report | active |  |  |  |  | 5 | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/optimierungsstatus.md | status-matrix | active |  |  |  |  | 19 | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/passkey-register-verify-prep.md | report | active |  |  |  |  | 3 | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/planning-registration-findings.md | report | active |  |  |  |  | 1 | lifecycle, owner_task, review_after, superseded_by |
+
+## Missing Lifecycle Fields
+
+| Path | Missing fields |
+| --- | --- |
+| docs/reports/agent-readiness-audit.md | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/auth-persistence-direct-proof-diagnose-audit.md | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/auth-persistence-next-step.md | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/auth-persistence-readiness.md | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/auth-persistence-runtime-proof.md | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/auth-persistence-runtime-target-reconciliation.md | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/auth-status-matrix.md | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/cost-report.md | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/domain-account-email-uniqueness-audit.md | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/domain-account-write-path-proof.md | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/domain-backfill-proof.md | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/domain-edge-create-semantics-preflight.md | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/domain-edge-write-path-proof.md | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/domain-node-write-path-proof.md | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/domain-provider-role-finding.md | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/domain-read-path-proof.md | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/inwx-zone-reconciliation-plan.md | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/map-architekturkritik.md | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/map-status-matrix.md | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/optimierungsbericht.md | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/optimierungsstatus.md | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/passkey-register-verify-prep.md | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/planning-registration-findings.md | lifecycle, owner_task, review_after, superseded_by |
+
+## Referenced Reports
+
+| Path | Referenced by |
+| --- | --- |
+| docs/reports/agent-readiness-audit.md | docs/_generated/backlinks.md, docs/_generated/doc-index.md, docs/_generated/relates-to-audit.md, docs/blueprints/agent-operability-blaupause.md, docs/blueprints/blueprint-agent-safety-control-layer.md |
+| docs/reports/auth-persistence-direct-proof-diagnose-audit.md | docs/_generated/backlinks.md, docs/_generated/doc-index.md, docs/_generated/relates-to-audit.md |
+| docs/reports/auth-persistence-next-step.md | docs/_generated/backlinks.md, docs/_generated/doc-index.md, docs/_generated/relates-to-audit.md, docs/_generated/supersession-map.md, docs/blueprints/auth-persistence-runtime-proof.md, docs/proofs/sqlx-pgbouncer-session-crud-proof.md, docs/reports/auth-persistence-direct-proof-diagnose-audit.md, docs/reports/auth-persistence-runtime-proof.md, docs/reports/passkey-register-verify-prep.md |
+| docs/reports/auth-persistence-readiness.md | docs/_generated/backlinks.md, docs/_generated/doc-index.md, docs/_generated/relates-to-audit.md, docs/_generated/supersession-map.md, docs/blueprints/auth-persistence-runtime-proof.md, docs/reports/auth-persistence-direct-proof-diagnose-audit.md, docs/reports/auth-persistence-next-step.md, docs/reports/optimierungsstatus.md |
+| docs/reports/auth-persistence-runtime-proof.md | docs/_generated/backlinks.md, docs/_generated/doc-index.md, docs/_generated/relates-to-audit.md, docs/proofs/sqlx-pgbouncer-session-crud-proof.md, docs/proofs/sqlx-postgres-direct-session-crud-proof.md, docs/reports/auth-persistence-runtime-target-reconciliation.md |
+| docs/reports/auth-persistence-runtime-target-reconciliation.md | docs/_generated/backlinks.md, docs/_generated/doc-index.md, docs/_generated/relates-to-audit.md |
+| docs/reports/auth-status-matrix.md | docs/_generated/backlinks.md, docs/_generated/doc-index.md, docs/_generated/relates-to-audit.md, docs/blueprints/auth-roadmap.md, docs/reports/optimierungsstatus.md, docs/reports/passkey-register-verify-prep.md, docs/roadmap.md |
+| docs/reports/cost-report.md | docs/_generated/doc-index.md, docs/_generated/orphans.md, docs/_generated/relations-analysis.md |
+| docs/reports/domain-account-write-path-proof.md | docs/blueprints/domain-data-postgres-cutover.md, docs/reports/domain-edge-create-semantics-preflight.md, docs/reports/domain-edge-write-path-proof.md, docs/reports/domain-node-write-path-proof.md, docs/reports/domain-read-path-proof.md, docs/reports/optimierungsstatus.md, docs/tasks/board.md |
+| docs/reports/domain-backfill-proof.md | docs/reports/domain-read-path-proof.md, docs/reports/optimierungsstatus.md, docs/tasks/board.md |
+| docs/reports/domain-edge-write-path-proof.md | docs/reports/domain-edge-create-semantics-preflight.md, docs/reports/optimierungsstatus.md, docs/tasks/board.md |
+| docs/reports/domain-node-write-path-proof.md | docs/blueprints/domain-data-postgres-cutover.md, docs/reports/domain-edge-create-semantics-preflight.md, docs/reports/domain-edge-write-path-proof.md, docs/reports/optimierungsstatus.md, docs/tasks/board.md |
+| docs/reports/domain-provider-role-finding.md | docs/reports/inwx-zone-reconciliation-plan.md |
+| docs/reports/domain-read-path-proof.md | docs/reports/domain-account-write-path-proof.md, docs/reports/domain-edge-write-path-proof.md, docs/reports/domain-node-write-path-proof.md, docs/reports/optimierungsstatus.md, docs/tasks/board.md |
+| docs/reports/inwx-zone-reconciliation-plan.md | docs/tasks/board.md |
+| docs/reports/map-architekturkritik.md | docs/_generated/backlinks.md, docs/_generated/doc-index.md, docs/_generated/impl-index.md, docs/_generated/relates-to-audit.md, docs/blueprints/kartenklarheit-phase6.md, docs/blueprints/kartenklarheit-roadmap.md, docs/blueprints/kartenklarheit.md, docs/reports/map-status-matrix.md |
+| docs/reports/map-status-matrix.md | docs/_generated/backlinks.md, docs/_generated/doc-index.md, docs/_generated/impl-index.md, docs/_generated/relates-to-audit.md, docs/blueprints/kartenklarheit-phase6.md, docs/blueprints/kartenklarheit-roadmap.md, docs/blueprints/kartenklarheit.md, docs/blueprints/map-roadmap.md, docs/reports/map-architekturkritik.md, docs/roadmap.md |
+| docs/reports/optimierungsbericht.md | docs/_generated/backlinks.md, docs/_generated/doc-index.md, docs/_generated/relates-to-audit.md, docs/blueprints/domain-data-postgres-cutover.md, docs/reports/optimierungsstatus.md |
+| docs/reports/optimierungsstatus.md | docs/_generated/backlinks.md, docs/_generated/doc-index.md, docs/_generated/relates-to-audit.md, docs/blueprints/auth-persistence-runtime-proof.md, docs/blueprints/doc-structure-task-control-examples.md, docs/blueprints/doc-structure-task-control-roadmap.md, docs/blueprints/doc-structure-task-control.md, docs/blueprints/domain-data-postgres-cutover.md, docs/reports/auth-persistence-next-step.md, docs/reports/auth-persistence-readiness.md, docs/reports/domain-account-write-path-proof.md, docs/reports/domain-edge-create-semantics-preflight.md, docs/reports/domain-edge-write-path-proof.md, docs/reports/domain-node-write-path-proof.md, docs/reports/domain-read-path-proof.md, docs/reports/optimierungsbericht.md, docs/roadmap.md, docs/tasks/README.md, docs/tasks/board.md |
+| docs/reports/passkey-register-verify-prep.md | docs/_generated/backlinks.md, docs/_generated/doc-index.md, docs/_generated/relates-to-audit.md |
+| docs/reports/planning-registration-findings.md | docs/tasks/board.md |
+
+## Unreferenced Reports
+
+| Path |
+| --- |
+| docs/reports/domain-account-email-uniqueness-audit.md |
+| docs/reports/domain-edge-create-semantics-preflight.md |
+
+## Parse Warnings
+
+| Path | Warning |
+| --- | --- |
+| _None_ | _None_ |

--- a/docs/_generated/report-lifecycle-inventory.md
+++ b/docs/_generated/report-lifecycle-inventory.md
@@ -46,14 +46,14 @@ Primary references are exact path matches in canonical documentation surfaces. D
 
 | Path | doc_type | status | lifecycle | owner_task | review_after | superseded_by | primary refs | derived refs | relations | absent core lifecycle fields | terminal supersession |
 | --- | --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | --- | --- |
-| docs/reports/agent-readiness-audit.md | documentation | active |  |  |  |  | 2 | 3 | 1 | lifecycle, owner_task, review_after |  |
-| docs/reports/auth-persistence-direct-proof-diagnose-audit.md | report | active |  |  |  |  | 0 | 3 | 4 | lifecycle, owner_task, review_after |  |
-| docs/reports/auth-persistence-next-step.md | report | active |  |  |  |  | 5 | 4 | 4 | lifecycle, owner_task, review_after |  |
-| docs/reports/auth-persistence-readiness.md | report | active |  |  |  |  | 4 | 4 | 3 | lifecycle, owner_task, review_after |  |
-| docs/reports/auth-persistence-runtime-proof.md | report | active |  |  |  |  | 3 | 3 | 6 | lifecycle, owner_task, review_after |  |
-| docs/reports/auth-persistence-runtime-target-reconciliation.md | report | active |  |  |  |  | 0 | 3 | 5 | lifecycle, owner_task, review_after |  |
-| docs/reports/auth-status-matrix.md | reference | active |  |  |  |  | 4 | 3 | 3 | lifecycle, owner_task, review_after |  |
-| docs/reports/cost-report.md | reference | active |  |  |  |  | 0 | 3 | 0 | lifecycle, owner_task, review_after |  |
+| docs/reports/agent-readiness-audit.md | documentation | active |  |  |  |  | 2 | 2 | 1 | lifecycle, owner_task, review_after |  |
+| docs/reports/auth-persistence-direct-proof-diagnose-audit.md | report | active |  |  |  |  | 0 | 2 | 4 | lifecycle, owner_task, review_after |  |
+| docs/reports/auth-persistence-next-step.md | report | active |  |  |  |  | 5 | 3 | 4 | lifecycle, owner_task, review_after |  |
+| docs/reports/auth-persistence-readiness.md | report | active |  |  |  |  | 4 | 3 | 3 | lifecycle, owner_task, review_after |  |
+| docs/reports/auth-persistence-runtime-proof.md | report | active |  |  |  |  | 3 | 2 | 6 | lifecycle, owner_task, review_after |  |
+| docs/reports/auth-persistence-runtime-target-reconciliation.md | report | active |  |  |  |  | 0 | 2 | 5 | lifecycle, owner_task, review_after |  |
+| docs/reports/auth-status-matrix.md | reference | active |  |  |  |  | 4 | 2 | 3 | lifecycle, owner_task, review_after |  |
+| docs/reports/cost-report.md | reference | active |  |  |  |  | 0 | 2 | 0 | lifecycle, owner_task, review_after |  |
 | docs/reports/domain-account-email-uniqueness-audit.md | report | draft |  |  |  |  | 0 | 0 | 4 | lifecycle, owner_task, review_after |  |
 | docs/reports/domain-account-write-path-proof.md | report | active |  |  |  |  | 7 | 0 | 6 | lifecycle, owner_task, review_after |  |
 | docs/reports/domain-backfill-proof.md | report | active |  |  |  |  | 3 | 0 | 4 | lifecycle, owner_task, review_after |  |
@@ -63,11 +63,11 @@ Primary references are exact path matches in canonical documentation surfaces. D
 | docs/reports/domain-provider-role-finding.md | report | active |  |  |  |  | 1 | 0 | 3 | lifecycle, owner_task, review_after |  |
 | docs/reports/domain-read-path-proof.md | report | active |  |  |  |  | 5 | 0 | 5 | lifecycle, owner_task, review_after |  |
 | docs/reports/inwx-zone-reconciliation-plan.md | report | active |  |  |  |  | 1 | 0 | 4 | lifecycle, owner_task, review_after |  |
-| docs/reports/map-architekturkritik.md | report | active |  |  |  |  | 4 | 4 | 2 | lifecycle, owner_task, review_after |  |
-| docs/reports/map-status-matrix.md | status-matrix | active |  |  |  |  | 6 | 4 | 2 | lifecycle, owner_task, review_after |  |
-| docs/reports/optimierungsbericht.md | report | active |  |  |  |  | 2 | 3 | 4 | lifecycle, owner_task, review_after |  |
-| docs/reports/optimierungsstatus.md | status-matrix | active |  |  |  |  | 16 | 3 | 4 | lifecycle, owner_task, review_after |  |
-| docs/reports/passkey-register-verify-prep.md | report | active |  |  |  |  | 0 | 3 | 4 | lifecycle, owner_task, review_after |  |
+| docs/reports/map-architekturkritik.md | report | active |  |  |  |  | 4 | 3 | 2 | lifecycle, owner_task, review_after |  |
+| docs/reports/map-status-matrix.md | status-matrix | active |  |  |  |  | 6 | 3 | 2 | lifecycle, owner_task, review_after |  |
+| docs/reports/optimierungsbericht.md | report | active |  |  |  |  | 2 | 2 | 4 | lifecycle, owner_task, review_after |  |
+| docs/reports/optimierungsstatus.md | status-matrix | active |  |  |  |  | 16 | 2 | 4 | lifecycle, owner_task, review_after |  |
+| docs/reports/passkey-register-verify-prep.md | report | active |  |  |  |  | 0 | 2 | 4 | lifecycle, owner_task, review_after |  |
 | docs/reports/planning-registration-findings.md | report | active |  |  |  |  | 1 | 0 | 2 | lifecycle, owner_task, review_after |  |
 
 ## Absent Core Lifecycle Metadata
@@ -237,71 +237,58 @@ Primary references are exact path matches in canonical documentation surfaces. D
 
 - `docs/reports/agent-readiness-audit.md`
   - `docs/_generated/backlinks.md`
-  - `docs/_generated/doc-index.md`
   - `docs/_generated/relates-to-audit.md`
 
 - `docs/reports/auth-persistence-direct-proof-diagnose-audit.md`
   - `docs/_generated/backlinks.md`
-  - `docs/_generated/doc-index.md`
   - `docs/_generated/relates-to-audit.md`
 
 - `docs/reports/auth-persistence-next-step.md`
   - `docs/_generated/backlinks.md`
-  - `docs/_generated/doc-index.md`
   - `docs/_generated/relates-to-audit.md`
   - `docs/_generated/supersession-map.md`
 
 - `docs/reports/auth-persistence-readiness.md`
   - `docs/_generated/backlinks.md`
-  - `docs/_generated/doc-index.md`
   - `docs/_generated/relates-to-audit.md`
   - `docs/_generated/supersession-map.md`
 
 - `docs/reports/auth-persistence-runtime-proof.md`
   - `docs/_generated/backlinks.md`
-  - `docs/_generated/doc-index.md`
   - `docs/_generated/relates-to-audit.md`
 
 - `docs/reports/auth-persistence-runtime-target-reconciliation.md`
   - `docs/_generated/backlinks.md`
-  - `docs/_generated/doc-index.md`
   - `docs/_generated/relates-to-audit.md`
 
 - `docs/reports/auth-status-matrix.md`
   - `docs/_generated/backlinks.md`
-  - `docs/_generated/doc-index.md`
   - `docs/_generated/relates-to-audit.md`
 
 - `docs/reports/cost-report.md`
-  - `docs/_generated/doc-index.md`
   - `docs/_generated/orphans.md`
   - `docs/_generated/relations-analysis.md`
 
 - `docs/reports/map-architekturkritik.md`
   - `docs/_generated/backlinks.md`
-  - `docs/_generated/doc-index.md`
   - `docs/_generated/impl-index.md`
   - `docs/_generated/relates-to-audit.md`
 
 - `docs/reports/map-status-matrix.md`
   - `docs/_generated/backlinks.md`
-  - `docs/_generated/doc-index.md`
   - `docs/_generated/impl-index.md`
   - `docs/_generated/relates-to-audit.md`
 
 - `docs/reports/optimierungsbericht.md`
   - `docs/_generated/backlinks.md`
-  - `docs/_generated/doc-index.md`
   - `docs/_generated/relates-to-audit.md`
 
 - `docs/reports/optimierungsstatus.md`
   - `docs/_generated/backlinks.md`
-  - `docs/_generated/doc-index.md`
   - `docs/_generated/relates-to-audit.md`
 
 - `docs/reports/passkey-register-verify-prep.md`
   - `docs/_generated/backlinks.md`
-  - `docs/_generated/doc-index.md`
   - `docs/_generated/relates-to-audit.md`
 
 ## Primary Unreferenced Reports

--- a/docs/_generated/report-lifecycle-inventory.md
+++ b/docs/_generated/report-lifecycle-inventory.md
@@ -9,118 +9,314 @@ summary: Automatisch generiertes Inventar der Report-Lifecycle-Metadaten.
 # Report Lifecycle Inventory
 
 Generated automatically. Do not edit manually.
-This inventory is descriptive only. Missing lifecycle fields are expected at this stage and are not policy violations.
-Reference counts are based on heuristic text matches against selected documentation paths.
+This inventory is descriptive only. Absent core lifecycle metadata is expected at this stage and is not a policy judgement.
+Primary references are exact path matches in canonical documentation surfaces. Derived generated references are reported separately.
 
 ## Summary
 
 | Metric | Count |
 | --- | ---: |
-| reports_total | 23 |
-| reports_with_frontmatter | 23 |
-| reports_without_frontmatter | 0 |
-| reports_with_status | 23 |
-| reports_missing_status | 0 |
-| reports_with_lifecycle | 0 |
-| reports_missing_lifecycle | 23 |
-| reports_with_owner_task | 0 |
-| reports_missing_owner_task | 23 |
-| reports_with_review_after | 0 |
-| reports_missing_review_after | 23 |
-| reports_referenced | 21 |
-| reports_unreferenced | 2 |
+| files_total | 23 |
+| files_with_frontmatter | 23 |
+| files_without_frontmatter | 0 |
+| files_with_status | 23 |
+| files_missing_status | 0 |
+| files_with_lifecycle | 0 |
+| files_missing_lifecycle | 23 |
+| files_with_owner_task | 0 |
+| files_missing_owner_task | 23 |
+| files_with_review_after | 0 |
+| files_missing_review_after | 23 |
+| files_primary_referenced | 17 |
+| files_primary_unreferenced | 6 |
+| files_with_derived_references | 13 |
+| files_with_relations | 22 |
+| files_with_missing_supersession_target | 0 |
+
+## Doc Type Distribution
+
+| doc_type | Count |
+| --- | ---: |
+| documentation | 1 |
+| reference | 2 |
+| report | 18 |
+| status-matrix | 2 |
 
 ## Reports
 
-| Path | doc_type | status | lifecycle | owner_task | review_after | superseded_by | refs | missing |
-| --- | --- | --- | --- | --- | --- | --- | ---: | --- |
-| docs/reports/agent-readiness-audit.md | documentation | active |  |  |  |  | 5 | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/auth-persistence-direct-proof-diagnose-audit.md | report | active |  |  |  |  | 3 | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/auth-persistence-next-step.md | report | active |  |  |  |  | 9 | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/auth-persistence-readiness.md | report | active |  |  |  |  | 8 | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/auth-persistence-runtime-proof.md | report | active |  |  |  |  | 6 | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/auth-persistence-runtime-target-reconciliation.md | report | active |  |  |  |  | 3 | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/auth-status-matrix.md | reference | active |  |  |  |  | 7 | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/cost-report.md | reference | active |  |  |  |  | 3 | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/domain-account-email-uniqueness-audit.md | report | draft |  |  |  |  | 0 | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/domain-account-write-path-proof.md | report | active |  |  |  |  | 7 | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/domain-backfill-proof.md | report | active |  |  |  |  | 3 | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/domain-edge-create-semantics-preflight.md | report | active |  |  |  |  | 0 | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/domain-edge-write-path-proof.md | report | active |  |  |  |  | 3 | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/domain-node-write-path-proof.md | report | active |  |  |  |  | 5 | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/domain-provider-role-finding.md | report | active |  |  |  |  | 1 | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/domain-read-path-proof.md | report | active |  |  |  |  | 5 | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/inwx-zone-reconciliation-plan.md | report | active |  |  |  |  | 1 | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/map-architekturkritik.md | report | active |  |  |  |  | 8 | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/map-status-matrix.md | status-matrix | active |  |  |  |  | 10 | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/optimierungsbericht.md | report | active |  |  |  |  | 5 | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/optimierungsstatus.md | status-matrix | active |  |  |  |  | 19 | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/passkey-register-verify-prep.md | report | active |  |  |  |  | 3 | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/planning-registration-findings.md | report | active |  |  |  |  | 1 | lifecycle, owner_task, review_after, superseded_by |
+| Path | doc_type | status | lifecycle | owner_task | review_after | superseded_by | primary refs | derived refs | relations | absent core lifecycle fields | terminal supersession |
+| --- | --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | --- | --- |
+| docs/reports/agent-readiness-audit.md | documentation | active |  |  |  |  | 2 | 3 | 1 | lifecycle, owner_task, review_after |  |
+| docs/reports/auth-persistence-direct-proof-diagnose-audit.md | report | active |  |  |  |  | 0 | 3 | 4 | lifecycle, owner_task, review_after |  |
+| docs/reports/auth-persistence-next-step.md | report | active |  |  |  |  | 5 | 4 | 4 | lifecycle, owner_task, review_after |  |
+| docs/reports/auth-persistence-readiness.md | report | active |  |  |  |  | 4 | 4 | 3 | lifecycle, owner_task, review_after |  |
+| docs/reports/auth-persistence-runtime-proof.md | report | active |  |  |  |  | 3 | 3 | 6 | lifecycle, owner_task, review_after |  |
+| docs/reports/auth-persistence-runtime-target-reconciliation.md | report | active |  |  |  |  | 0 | 3 | 5 | lifecycle, owner_task, review_after |  |
+| docs/reports/auth-status-matrix.md | reference | active |  |  |  |  | 4 | 3 | 3 | lifecycle, owner_task, review_after |  |
+| docs/reports/cost-report.md | reference | active |  |  |  |  | 0 | 3 | 0 | lifecycle, owner_task, review_after |  |
+| docs/reports/domain-account-email-uniqueness-audit.md | report | draft |  |  |  |  | 0 | 0 | 4 | lifecycle, owner_task, review_after |  |
+| docs/reports/domain-account-write-path-proof.md | report | active |  |  |  |  | 7 | 0 | 6 | lifecycle, owner_task, review_after |  |
+| docs/reports/domain-backfill-proof.md | report | active |  |  |  |  | 3 | 0 | 4 | lifecycle, owner_task, review_after |  |
+| docs/reports/domain-edge-create-semantics-preflight.md | report | active |  |  |  |  | 0 | 0 | 7 | lifecycle, owner_task, review_after |  |
+| docs/reports/domain-edge-write-path-proof.md | report | active |  |  |  |  | 3 | 0 | 7 | lifecycle, owner_task, review_after |  |
+| docs/reports/domain-node-write-path-proof.md | report | active |  |  |  |  | 5 | 0 | 6 | lifecycle, owner_task, review_after |  |
+| docs/reports/domain-provider-role-finding.md | report | active |  |  |  |  | 1 | 0 | 3 | lifecycle, owner_task, review_after |  |
+| docs/reports/domain-read-path-proof.md | report | active |  |  |  |  | 5 | 0 | 5 | lifecycle, owner_task, review_after |  |
+| docs/reports/inwx-zone-reconciliation-plan.md | report | active |  |  |  |  | 1 | 0 | 4 | lifecycle, owner_task, review_after |  |
+| docs/reports/map-architekturkritik.md | report | active |  |  |  |  | 4 | 4 | 2 | lifecycle, owner_task, review_after |  |
+| docs/reports/map-status-matrix.md | status-matrix | active |  |  |  |  | 6 | 4 | 2 | lifecycle, owner_task, review_after |  |
+| docs/reports/optimierungsbericht.md | report | active |  |  |  |  | 2 | 3 | 4 | lifecycle, owner_task, review_after |  |
+| docs/reports/optimierungsstatus.md | status-matrix | active |  |  |  |  | 16 | 3 | 4 | lifecycle, owner_task, review_after |  |
+| docs/reports/passkey-register-verify-prep.md | report | active |  |  |  |  | 0 | 3 | 4 | lifecycle, owner_task, review_after |  |
+| docs/reports/planning-registration-findings.md | report | active |  |  |  |  | 1 | 0 | 2 | lifecycle, owner_task, review_after |  |
 
-## Missing Lifecycle Fields
+## Absent Core Lifecycle Metadata
 
-| Path | Missing fields |
+| Path | Absent fields |
 | --- | --- |
-| docs/reports/agent-readiness-audit.md | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/auth-persistence-direct-proof-diagnose-audit.md | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/auth-persistence-next-step.md | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/auth-persistence-readiness.md | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/auth-persistence-runtime-proof.md | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/auth-persistence-runtime-target-reconciliation.md | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/auth-status-matrix.md | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/cost-report.md | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/domain-account-email-uniqueness-audit.md | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/domain-account-write-path-proof.md | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/domain-backfill-proof.md | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/domain-edge-create-semantics-preflight.md | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/domain-edge-write-path-proof.md | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/domain-node-write-path-proof.md | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/domain-provider-role-finding.md | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/domain-read-path-proof.md | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/inwx-zone-reconciliation-plan.md | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/map-architekturkritik.md | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/map-status-matrix.md | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/optimierungsbericht.md | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/optimierungsstatus.md | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/passkey-register-verify-prep.md | lifecycle, owner_task, review_after, superseded_by |
-| docs/reports/planning-registration-findings.md | lifecycle, owner_task, review_after, superseded_by |
+| docs/reports/agent-readiness-audit.md | lifecycle, owner_task, review_after |
+| docs/reports/auth-persistence-direct-proof-diagnose-audit.md | lifecycle, owner_task, review_after |
+| docs/reports/auth-persistence-next-step.md | lifecycle, owner_task, review_after |
+| docs/reports/auth-persistence-readiness.md | lifecycle, owner_task, review_after |
+| docs/reports/auth-persistence-runtime-proof.md | lifecycle, owner_task, review_after |
+| docs/reports/auth-persistence-runtime-target-reconciliation.md | lifecycle, owner_task, review_after |
+| docs/reports/auth-status-matrix.md | lifecycle, owner_task, review_after |
+| docs/reports/cost-report.md | lifecycle, owner_task, review_after |
+| docs/reports/domain-account-email-uniqueness-audit.md | lifecycle, owner_task, review_after |
+| docs/reports/domain-account-write-path-proof.md | lifecycle, owner_task, review_after |
+| docs/reports/domain-backfill-proof.md | lifecycle, owner_task, review_after |
+| docs/reports/domain-edge-create-semantics-preflight.md | lifecycle, owner_task, review_after |
+| docs/reports/domain-edge-write-path-proof.md | lifecycle, owner_task, review_after |
+| docs/reports/domain-node-write-path-proof.md | lifecycle, owner_task, review_after |
+| docs/reports/domain-provider-role-finding.md | lifecycle, owner_task, review_after |
+| docs/reports/domain-read-path-proof.md | lifecycle, owner_task, review_after |
+| docs/reports/inwx-zone-reconciliation-plan.md | lifecycle, owner_task, review_after |
+| docs/reports/map-architekturkritik.md | lifecycle, owner_task, review_after |
+| docs/reports/map-status-matrix.md | lifecycle, owner_task, review_after |
+| docs/reports/optimierungsbericht.md | lifecycle, owner_task, review_after |
+| docs/reports/optimierungsstatus.md | lifecycle, owner_task, review_after |
+| docs/reports/passkey-register-verify-prep.md | lifecycle, owner_task, review_after |
+| docs/reports/planning-registration-findings.md | lifecycle, owner_task, review_after |
 
-## Referenced Reports
+## Relations
 
-| Path | Referenced by |
-| --- | --- |
-| docs/reports/agent-readiness-audit.md | docs/_generated/backlinks.md, docs/_generated/doc-index.md, docs/_generated/relates-to-audit.md, docs/blueprints/agent-operability-blaupause.md, docs/blueprints/blueprint-agent-safety-control-layer.md |
-| docs/reports/auth-persistence-direct-proof-diagnose-audit.md | docs/_generated/backlinks.md, docs/_generated/doc-index.md, docs/_generated/relates-to-audit.md |
-| docs/reports/auth-persistence-next-step.md | docs/_generated/backlinks.md, docs/_generated/doc-index.md, docs/_generated/relates-to-audit.md, docs/_generated/supersession-map.md, docs/blueprints/auth-persistence-runtime-proof.md, docs/proofs/sqlx-pgbouncer-session-crud-proof.md, docs/reports/auth-persistence-direct-proof-diagnose-audit.md, docs/reports/auth-persistence-runtime-proof.md, docs/reports/passkey-register-verify-prep.md |
-| docs/reports/auth-persistence-readiness.md | docs/_generated/backlinks.md, docs/_generated/doc-index.md, docs/_generated/relates-to-audit.md, docs/_generated/supersession-map.md, docs/blueprints/auth-persistence-runtime-proof.md, docs/reports/auth-persistence-direct-proof-diagnose-audit.md, docs/reports/auth-persistence-next-step.md, docs/reports/optimierungsstatus.md |
-| docs/reports/auth-persistence-runtime-proof.md | docs/_generated/backlinks.md, docs/_generated/doc-index.md, docs/_generated/relates-to-audit.md, docs/proofs/sqlx-pgbouncer-session-crud-proof.md, docs/proofs/sqlx-postgres-direct-session-crud-proof.md, docs/reports/auth-persistence-runtime-target-reconciliation.md |
-| docs/reports/auth-persistence-runtime-target-reconciliation.md | docs/_generated/backlinks.md, docs/_generated/doc-index.md, docs/_generated/relates-to-audit.md |
-| docs/reports/auth-status-matrix.md | docs/_generated/backlinks.md, docs/_generated/doc-index.md, docs/_generated/relates-to-audit.md, docs/blueprints/auth-roadmap.md, docs/reports/optimierungsstatus.md, docs/reports/passkey-register-verify-prep.md, docs/roadmap.md |
-| docs/reports/cost-report.md | docs/_generated/doc-index.md, docs/_generated/orphans.md, docs/_generated/relations-analysis.md |
-| docs/reports/domain-account-write-path-proof.md | docs/blueprints/domain-data-postgres-cutover.md, docs/reports/domain-edge-create-semantics-preflight.md, docs/reports/domain-edge-write-path-proof.md, docs/reports/domain-node-write-path-proof.md, docs/reports/domain-read-path-proof.md, docs/reports/optimierungsstatus.md, docs/tasks/board.md |
-| docs/reports/domain-backfill-proof.md | docs/reports/domain-read-path-proof.md, docs/reports/optimierungsstatus.md, docs/tasks/board.md |
-| docs/reports/domain-edge-write-path-proof.md | docs/reports/domain-edge-create-semantics-preflight.md, docs/reports/optimierungsstatus.md, docs/tasks/board.md |
-| docs/reports/domain-node-write-path-proof.md | docs/blueprints/domain-data-postgres-cutover.md, docs/reports/domain-edge-create-semantics-preflight.md, docs/reports/domain-edge-write-path-proof.md, docs/reports/optimierungsstatus.md, docs/tasks/board.md |
-| docs/reports/domain-provider-role-finding.md | docs/reports/inwx-zone-reconciliation-plan.md |
-| docs/reports/domain-read-path-proof.md | docs/reports/domain-account-write-path-proof.md, docs/reports/domain-edge-write-path-proof.md, docs/reports/domain-node-write-path-proof.md, docs/reports/optimierungsstatus.md, docs/tasks/board.md |
-| docs/reports/inwx-zone-reconciliation-plan.md | docs/tasks/board.md |
-| docs/reports/map-architekturkritik.md | docs/_generated/backlinks.md, docs/_generated/doc-index.md, docs/_generated/impl-index.md, docs/_generated/relates-to-audit.md, docs/blueprints/kartenklarheit-phase6.md, docs/blueprints/kartenklarheit-roadmap.md, docs/blueprints/kartenklarheit.md, docs/reports/map-status-matrix.md |
-| docs/reports/map-status-matrix.md | docs/_generated/backlinks.md, docs/_generated/doc-index.md, docs/_generated/impl-index.md, docs/_generated/relates-to-audit.md, docs/blueprints/kartenklarheit-phase6.md, docs/blueprints/kartenklarheit-roadmap.md, docs/blueprints/kartenklarheit.md, docs/blueprints/map-roadmap.md, docs/reports/map-architekturkritik.md, docs/roadmap.md |
-| docs/reports/optimierungsbericht.md | docs/_generated/backlinks.md, docs/_generated/doc-index.md, docs/_generated/relates-to-audit.md, docs/blueprints/domain-data-postgres-cutover.md, docs/reports/optimierungsstatus.md |
-| docs/reports/optimierungsstatus.md | docs/_generated/backlinks.md, docs/_generated/doc-index.md, docs/_generated/relates-to-audit.md, docs/blueprints/auth-persistence-runtime-proof.md, docs/blueprints/doc-structure-task-control-examples.md, docs/blueprints/doc-structure-task-control-roadmap.md, docs/blueprints/doc-structure-task-control.md, docs/blueprints/domain-data-postgres-cutover.md, docs/reports/auth-persistence-next-step.md, docs/reports/auth-persistence-readiness.md, docs/reports/domain-account-write-path-proof.md, docs/reports/domain-edge-create-semantics-preflight.md, docs/reports/domain-edge-write-path-proof.md, docs/reports/domain-node-write-path-proof.md, docs/reports/domain-read-path-proof.md, docs/reports/optimierungsbericht.md, docs/roadmap.md, docs/tasks/README.md, docs/tasks/board.md |
-| docs/reports/passkey-register-verify-prep.md | docs/_generated/backlinks.md, docs/_generated/doc-index.md, docs/_generated/relates-to-audit.md |
-| docs/reports/planning-registration-findings.md | docs/tasks/board.md |
+| Path | Count | Types | Targets |
+| --- | ---: | --- | --- |
+| docs/reports/agent-readiness-audit.md | 1 | relates_to | docs/policies/agent-reading-protocol.md |
+| docs/reports/auth-persistence-direct-proof-diagnose-audit.md | 4 | relates_to | docs/adr/ADR-0007__auth-persistence-production-db-path.md, docs/proofs/sqlx-postgres-direct-session-crud-proof.md, docs/reports/auth-persistence-next-step.md, docs/reports/auth-persistence-readiness.md |
+| docs/reports/auth-persistence-next-step.md | 4 | relates_to, supersedes | docs/adr/ADR-0006__auth-magic-link-session-passkey.md, docs/blueprints/auth-roadmap.md, docs/reports/auth-persistence-readiness.md, docs/specs/auth-api.md |
+| docs/reports/auth-persistence-readiness.md | 3 | relates_to | docs/adr/ADR-0006__auth-magic-link-session-passkey.md, docs/blueprints/auth-roadmap.md, docs/specs/auth-api.md |
+| docs/reports/auth-persistence-runtime-proof.md | 6 | relates_to | docs/adr/ADR-0006__auth-magic-link-session-passkey.md, docs/adr/ADR-0007__auth-persistence-production-db-path.md, docs/blueprints/auth-persistence-runtime-proof.md, docs/blueprints/auth-roadmap.md, docs/proofs/sqlx-postgres-direct-session-crud-proof.md, docs/reports/auth-persistence-next-step.md |
+| docs/reports/auth-persistence-runtime-target-reconciliation.md | 5 | relates_to | docs/adr/ADR-0007__auth-persistence-production-db-path.md, docs/blueprints/auth-persistence-runtime-proof.md, docs/proofs/sqlx-pgbouncer-session-crud-proof.md, docs/reports/auth-persistence-runtime-proof.md, docs/roadmap.md |
+| docs/reports/auth-status-matrix.md | 3 | relates_to | docs/adr/ADR-0006__auth-magic-link-session-passkey.md, docs/adr/ADR-0007__auth-persistence-production-db-path.md, docs/blueprints/auth-roadmap.md |
+| docs/reports/domain-account-email-uniqueness-audit.md | 4 | relates_to | apps/api/src/auth/accounts.rs, apps/api/src/routes/accounts.rs, docs/blueprints/domain-data-postgres-cutover.md, scripts/docmeta/audit_account_email_uniqueness.py |
+| docs/reports/domain-account-write-path-proof.md | 6 | relates_to | .github/workflows/api.yml, apps/api/tests/db_domain_account_write_path.rs, docs/blueprints/domain-data-postgres-cutover.md, docs/reports/domain-read-path-proof.md, docs/reports/optimierungsstatus.md, docs/tasks/board.md |
+| docs/reports/domain-backfill-proof.md | 4 | relates_to | .github/workflows/api.yml, apps/api/tests/db_domain_backfill.rs, docs/blueprints/domain-data-postgres-cutover.md, docs/tasks/index.json |
+| docs/reports/domain-edge-create-semantics-preflight.md | 7 | relates_to | contracts/domain/edge.schema.json, docs/blueprints/domain-data-postgres-cutover.md, docs/reports/domain-account-write-path-proof.md, docs/reports/domain-node-write-path-proof.md, docs/reports/opt-arc-001-db-proof-matrix.json, docs/tasks/board.md, docs/tasks/index.json |
+| docs/reports/domain-edge-write-path-proof.md | 7 | relates_to | docs/blueprints/domain-data-postgres-cutover.md, docs/reports/domain-account-write-path-proof.md, docs/reports/domain-node-write-path-proof.md, docs/reports/domain-read-path-proof.md, docs/reports/optimierungsstatus.md, docs/tasks/board.md, docs/tasks/index.json |
+| docs/reports/domain-node-write-path-proof.md | 6 | relates_to | docs/blueprints/domain-data-postgres-cutover.md, docs/reports/domain-account-write-path-proof.md, docs/reports/domain-read-path-proof.md, docs/reports/optimierungsstatus.md, docs/tasks/board.md, docs/tasks/index.json |
+| docs/reports/domain-provider-role-finding.md | 3 | relates_to | docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md, docs/runbooks/domain-mail-cutover.md, docs/tasks/board.md |
+| docs/reports/domain-read-path-proof.md | 5 | relates_to | docs/blueprints/domain-data-postgres-cutover.md, docs/reports/domain-account-write-path-proof.md, docs/reports/domain-backfill-proof.md, docs/reports/optimierungsstatus.md, docs/tasks/board.md |
+| docs/reports/inwx-zone-reconciliation-plan.md | 4 | relates_to | docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md, docs/reports/domain-provider-role-finding.md, docs/runbooks/domain-mail-cutover.md, docs/tasks/board.md |
+| docs/reports/map-architekturkritik.md | 2 | relates_to | docs/blueprints/kartenklarheit-roadmap.md, docs/reports/map-status-matrix.md |
+| docs/reports/map-status-matrix.md | 2 | relates_to | docs/blueprints/kartenklarheit-roadmap.md, docs/reports/map-architekturkritik.md |
+| docs/reports/optimierungsbericht.md | 4 | relates_to | docs/datenmodell.md, docs/policies/agent-reading-protocol.md, docs/reports/optimierungsstatus.md, docs/techstack.md |
+| docs/reports/optimierungsstatus.md | 4 | depends_on, relates_to | docs/policies/agent-reading-protocol.md, docs/reports/auth-persistence-readiness.md, docs/reports/domain-read-path-proof.md, docs/reports/optimierungsbericht.md |
+| docs/reports/passkey-register-verify-prep.md | 4 | relates_to | docs/adr/ADR-0006__auth-magic-link-session-passkey.md, docs/blueprints/auth-roadmap.md, docs/reports/auth-status-matrix.md, docs/specs/auth-api.md |
+| docs/reports/planning-registration-findings.md | 2 | relates_to | docs/tasks/index.json, scripts/docmeta/check_planning_registration.py |
 
-## Unreferenced Reports
+## Primary Referenced Reports
 
-| Path |
-| --- |
-| docs/reports/domain-account-email-uniqueness-audit.md |
-| docs/reports/domain-edge-create-semantics-preflight.md |
+- `docs/reports/agent-readiness-audit.md`
+  - `docs/blueprints/agent-operability-blaupause.md`
+  - `docs/blueprints/blueprint-agent-safety-control-layer.md`
+
+- `docs/reports/auth-persistence-next-step.md`
+  - `docs/blueprints/auth-persistence-runtime-proof.md`
+  - `docs/proofs/sqlx-pgbouncer-session-crud-proof.md`
+  - `docs/reports/auth-persistence-direct-proof-diagnose-audit.md`
+  - `docs/reports/auth-persistence-runtime-proof.md`
+  - `docs/reports/passkey-register-verify-prep.md`
+
+- `docs/reports/auth-persistence-readiness.md`
+  - `docs/blueprints/auth-persistence-runtime-proof.md`
+  - `docs/reports/auth-persistence-direct-proof-diagnose-audit.md`
+  - `docs/reports/auth-persistence-next-step.md`
+  - `docs/reports/optimierungsstatus.md`
+
+- `docs/reports/auth-persistence-runtime-proof.md`
+  - `docs/proofs/sqlx-pgbouncer-session-crud-proof.md`
+  - `docs/proofs/sqlx-postgres-direct-session-crud-proof.md`
+  - `docs/reports/auth-persistence-runtime-target-reconciliation.md`
+
+- `docs/reports/auth-status-matrix.md`
+  - `docs/blueprints/auth-roadmap.md`
+  - `docs/reports/optimierungsstatus.md`
+  - `docs/reports/passkey-register-verify-prep.md`
+  - `docs/roadmap.md`
+
+- `docs/reports/domain-account-write-path-proof.md`
+  - `docs/blueprints/domain-data-postgres-cutover.md`
+  - `docs/reports/domain-edge-create-semantics-preflight.md`
+  - `docs/reports/domain-edge-write-path-proof.md`
+  - `docs/reports/domain-node-write-path-proof.md`
+  - `docs/reports/domain-read-path-proof.md`
+  - `docs/reports/optimierungsstatus.md`
+  - `docs/tasks/board.md`
+
+- `docs/reports/domain-backfill-proof.md`
+  - `docs/reports/domain-read-path-proof.md`
+  - `docs/reports/optimierungsstatus.md`
+  - `docs/tasks/board.md`
+
+- `docs/reports/domain-edge-write-path-proof.md`
+  - `docs/reports/domain-edge-create-semantics-preflight.md`
+  - `docs/reports/optimierungsstatus.md`
+  - `docs/tasks/board.md`
+
+- `docs/reports/domain-node-write-path-proof.md`
+  - `docs/blueprints/domain-data-postgres-cutover.md`
+  - `docs/reports/domain-edge-create-semantics-preflight.md`
+  - `docs/reports/domain-edge-write-path-proof.md`
+  - `docs/reports/optimierungsstatus.md`
+  - `docs/tasks/board.md`
+
+- `docs/reports/domain-provider-role-finding.md`
+  - `docs/reports/inwx-zone-reconciliation-plan.md`
+
+- `docs/reports/domain-read-path-proof.md`
+  - `docs/reports/domain-account-write-path-proof.md`
+  - `docs/reports/domain-edge-write-path-proof.md`
+  - `docs/reports/domain-node-write-path-proof.md`
+  - `docs/reports/optimierungsstatus.md`
+  - `docs/tasks/board.md`
+
+- `docs/reports/inwx-zone-reconciliation-plan.md`
+  - `docs/tasks/board.md`
+
+- `docs/reports/map-architekturkritik.md`
+  - `docs/blueprints/kartenklarheit-phase6.md`
+  - `docs/blueprints/kartenklarheit-roadmap.md`
+  - `docs/blueprints/kartenklarheit.md`
+  - `docs/reports/map-status-matrix.md`
+
+- `docs/reports/map-status-matrix.md`
+  - `docs/blueprints/kartenklarheit-phase6.md`
+  - `docs/blueprints/kartenklarheit-roadmap.md`
+  - `docs/blueprints/kartenklarheit.md`
+  - `docs/blueprints/map-roadmap.md`
+  - `docs/reports/map-architekturkritik.md`
+  - `docs/roadmap.md`
+
+- `docs/reports/optimierungsbericht.md`
+  - `docs/blueprints/domain-data-postgres-cutover.md`
+  - `docs/reports/optimierungsstatus.md`
+
+- `docs/reports/optimierungsstatus.md`
+  - `docs/blueprints/auth-persistence-runtime-proof.md`
+  - `docs/blueprints/doc-structure-task-control-examples.md`
+  - `docs/blueprints/doc-structure-task-control-roadmap.md`
+  - `docs/blueprints/doc-structure-task-control.md`
+  - `docs/blueprints/domain-data-postgres-cutover.md`
+  - `docs/reports/auth-persistence-next-step.md`
+  - `docs/reports/auth-persistence-readiness.md`
+  - `docs/reports/domain-account-write-path-proof.md`
+  - `docs/reports/domain-edge-create-semantics-preflight.md`
+  - `docs/reports/domain-edge-write-path-proof.md`
+  - `docs/reports/domain-node-write-path-proof.md`
+  - `docs/reports/domain-read-path-proof.md`
+  - `docs/reports/optimierungsbericht.md`
+  - `docs/roadmap.md`
+  - `docs/tasks/README.md`
+  - `docs/tasks/board.md`
+
+- `docs/reports/planning-registration-findings.md`
+  - `docs/tasks/board.md`
+
+## Derived Referenced Reports
+
+- `docs/reports/agent-readiness-audit.md`
+  - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
+  - `docs/_generated/relates-to-audit.md`
+
+- `docs/reports/auth-persistence-direct-proof-diagnose-audit.md`
+  - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
+  - `docs/_generated/relates-to-audit.md`
+
+- `docs/reports/auth-persistence-next-step.md`
+  - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
+  - `docs/_generated/relates-to-audit.md`
+  - `docs/_generated/supersession-map.md`
+
+- `docs/reports/auth-persistence-readiness.md`
+  - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
+  - `docs/_generated/relates-to-audit.md`
+  - `docs/_generated/supersession-map.md`
+
+- `docs/reports/auth-persistence-runtime-proof.md`
+  - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
+  - `docs/_generated/relates-to-audit.md`
+
+- `docs/reports/auth-persistence-runtime-target-reconciliation.md`
+  - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
+  - `docs/_generated/relates-to-audit.md`
+
+- `docs/reports/auth-status-matrix.md`
+  - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
+  - `docs/_generated/relates-to-audit.md`
+
+- `docs/reports/cost-report.md`
+  - `docs/_generated/doc-index.md`
+  - `docs/_generated/orphans.md`
+  - `docs/_generated/relations-analysis.md`
+
+- `docs/reports/map-architekturkritik.md`
+  - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
+  - `docs/_generated/impl-index.md`
+  - `docs/_generated/relates-to-audit.md`
+
+- `docs/reports/map-status-matrix.md`
+  - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
+  - `docs/_generated/impl-index.md`
+  - `docs/_generated/relates-to-audit.md`
+
+- `docs/reports/optimierungsbericht.md`
+  - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
+  - `docs/_generated/relates-to-audit.md`
+
+- `docs/reports/optimierungsstatus.md`
+  - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
+  - `docs/_generated/relates-to-audit.md`
+
+- `docs/reports/passkey-register-verify-prep.md`
+  - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
+  - `docs/_generated/relates-to-audit.md`
+
+## Primary Unreferenced Reports
+
+- `docs/reports/auth-persistence-direct-proof-diagnose-audit.md`
+- `docs/reports/auth-persistence-runtime-target-reconciliation.md`
+- `docs/reports/cost-report.md`
+- `docs/reports/domain-account-email-uniqueness-audit.md`
+- `docs/reports/domain-edge-create-semantics-preflight.md`
+- `docs/reports/passkey-register-verify-prep.md`
+
+## Terminal Supersession Diagnostics
+
+None.
 
 ## Parse Warnings
 
-| Path | Warning |
-| --- | --- |
-| _None_ | _None_ |
+None.

--- a/docs/_generated/report-lifecycle-inventory.md
+++ b/docs/_generated/report-lifecycle-inventory.md
@@ -27,9 +27,9 @@ Primary references are exact path matches in canonical documentation surfaces. D
 | files_missing_owner_task | 23 |
 | files_with_review_after | 0 |
 | files_missing_review_after | 23 |
-| files_primary_referenced | 17 |
-| files_primary_unreferenced | 6 |
-| files_with_derived_references | 13 |
+| files_primary_referenced | 18 |
+| files_primary_unreferenced | 5 |
+| files_with_derived_references | 23 |
 | files_with_relations | 22 |
 | files_with_missing_supersession_target | 0 |
 
@@ -46,29 +46,29 @@ Primary references are exact path matches in canonical documentation surfaces. D
 
 | Path | doc_type | status | lifecycle | owner_task | review_after | superseded_by | primary refs | derived refs | relations | absent core lifecycle fields | terminal supersession |
 | --- | --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | --- | --- |
-| docs/reports/agent-readiness-audit.md | documentation | active |  |  |  |  | 2 | 2 | 1 | lifecycle, owner_task, review_after |  |
-| docs/reports/auth-persistence-direct-proof-diagnose-audit.md | report | active |  |  |  |  | 0 | 2 | 4 | lifecycle, owner_task, review_after |  |
-| docs/reports/auth-persistence-next-step.md | report | active |  |  |  |  | 5 | 3 | 4 | lifecycle, owner_task, review_after |  |
-| docs/reports/auth-persistence-readiness.md | report | active |  |  |  |  | 4 | 3 | 3 | lifecycle, owner_task, review_after |  |
-| docs/reports/auth-persistence-runtime-proof.md | report | active |  |  |  |  | 3 | 2 | 6 | lifecycle, owner_task, review_after |  |
-| docs/reports/auth-persistence-runtime-target-reconciliation.md | report | active |  |  |  |  | 0 | 2 | 5 | lifecycle, owner_task, review_after |  |
-| docs/reports/auth-status-matrix.md | reference | active |  |  |  |  | 4 | 2 | 3 | lifecycle, owner_task, review_after |  |
-| docs/reports/cost-report.md | reference | active |  |  |  |  | 0 | 2 | 0 | lifecycle, owner_task, review_after |  |
-| docs/reports/domain-account-email-uniqueness-audit.md | report | draft |  |  |  |  | 0 | 0 | 4 | lifecycle, owner_task, review_after |  |
-| docs/reports/domain-account-write-path-proof.md | report | active |  |  |  |  | 7 | 0 | 6 | lifecycle, owner_task, review_after |  |
-| docs/reports/domain-backfill-proof.md | report | active |  |  |  |  | 3 | 0 | 4 | lifecycle, owner_task, review_after |  |
-| docs/reports/domain-edge-create-semantics-preflight.md | report | active |  |  |  |  | 0 | 0 | 7 | lifecycle, owner_task, review_after |  |
-| docs/reports/domain-edge-write-path-proof.md | report | active |  |  |  |  | 3 | 0 | 7 | lifecycle, owner_task, review_after |  |
-| docs/reports/domain-node-write-path-proof.md | report | active |  |  |  |  | 5 | 0 | 6 | lifecycle, owner_task, review_after |  |
-| docs/reports/domain-provider-role-finding.md | report | active |  |  |  |  | 1 | 0 | 3 | lifecycle, owner_task, review_after |  |
-| docs/reports/domain-read-path-proof.md | report | active |  |  |  |  | 5 | 0 | 5 | lifecycle, owner_task, review_after |  |
-| docs/reports/inwx-zone-reconciliation-plan.md | report | active |  |  |  |  | 1 | 0 | 4 | lifecycle, owner_task, review_after |  |
-| docs/reports/map-architekturkritik.md | report | active |  |  |  |  | 4 | 3 | 2 | lifecycle, owner_task, review_after |  |
-| docs/reports/map-status-matrix.md | status-matrix | active |  |  |  |  | 6 | 3 | 2 | lifecycle, owner_task, review_after |  |
-| docs/reports/optimierungsbericht.md | report | active |  |  |  |  | 2 | 2 | 4 | lifecycle, owner_task, review_after |  |
-| docs/reports/optimierungsstatus.md | status-matrix | active |  |  |  |  | 16 | 2 | 4 | lifecycle, owner_task, review_after |  |
-| docs/reports/passkey-register-verify-prep.md | report | active |  |  |  |  | 0 | 2 | 4 | lifecycle, owner_task, review_after |  |
-| docs/reports/planning-registration-findings.md | report | active |  |  |  |  | 1 | 0 | 2 | lifecycle, owner_task, review_after |  |
+| docs/reports/agent-readiness-audit.md | documentation | active |  |  |  |  | 2 | 3 | 1 | lifecycle, owner_task, review_after |  |
+| docs/reports/auth-persistence-direct-proof-diagnose-audit.md | report | active |  |  |  |  | 0 | 3 | 4 | lifecycle, owner_task, review_after |  |
+| docs/reports/auth-persistence-next-step.md | report | active |  |  |  |  | 5 | 4 | 4 | lifecycle, owner_task, review_after |  |
+| docs/reports/auth-persistence-readiness.md | report | active |  |  |  |  | 4 | 4 | 3 | lifecycle, owner_task, review_after |  |
+| docs/reports/auth-persistence-runtime-proof.md | report | active |  |  |  |  | 4 | 3 | 6 | lifecycle, owner_task, review_after |  |
+| docs/reports/auth-persistence-runtime-target-reconciliation.md | report | active |  |  |  |  | 1 | 3 | 5 | lifecycle, owner_task, review_after |  |
+| docs/reports/auth-status-matrix.md | reference | active |  |  |  |  | 5 | 3 | 3 | lifecycle, owner_task, review_after |  |
+| docs/reports/cost-report.md | reference | active |  |  |  |  | 0 | 3 | 0 | lifecycle, owner_task, review_after |  |
+| docs/reports/domain-account-email-uniqueness-audit.md | report | draft |  |  |  |  | 0 | 3 | 4 | lifecycle, owner_task, review_after |  |
+| docs/reports/domain-account-write-path-proof.md | report | active |  |  |  |  | 7 | 3 | 6 | lifecycle, owner_task, review_after |  |
+| docs/reports/domain-backfill-proof.md | report | active |  |  |  |  | 3 | 3 | 4 | lifecycle, owner_task, review_after |  |
+| docs/reports/domain-edge-create-semantics-preflight.md | report | active |  |  |  |  | 0 | 3 | 7 | lifecycle, owner_task, review_after |  |
+| docs/reports/domain-edge-write-path-proof.md | report | active |  |  |  |  | 3 | 3 | 7 | lifecycle, owner_task, review_after |  |
+| docs/reports/domain-node-write-path-proof.md | report | active |  |  |  |  | 5 | 3 | 6 | lifecycle, owner_task, review_after |  |
+| docs/reports/domain-provider-role-finding.md | report | active |  |  |  |  | 1 | 3 | 3 | lifecycle, owner_task, review_after |  |
+| docs/reports/domain-read-path-proof.md | report | active |  |  |  |  | 5 | 3 | 5 | lifecycle, owner_task, review_after |  |
+| docs/reports/inwx-zone-reconciliation-plan.md | report | active |  |  |  |  | 1 | 3 | 4 | lifecycle, owner_task, review_after |  |
+| docs/reports/map-architekturkritik.md | report | active |  |  |  |  | 4 | 4 | 2 | lifecycle, owner_task, review_after |  |
+| docs/reports/map-status-matrix.md | status-matrix | active |  |  |  |  | 6 | 4 | 2 | lifecycle, owner_task, review_after |  |
+| docs/reports/optimierungsbericht.md | report | active |  |  |  |  | 2 | 3 | 4 | lifecycle, owner_task, review_after |  |
+| docs/reports/optimierungsstatus.md | status-matrix | active |  |  |  |  | 17 | 4 | 4 | lifecycle, owner_task, review_after |  |
+| docs/reports/passkey-register-verify-prep.md | report | active |  |  |  |  | 0 | 3 | 4 | lifecycle, owner_task, review_after |  |
+| docs/reports/planning-registration-findings.md | report | active |  |  |  |  | 1 | 3 | 2 | lifecycle, owner_task, review_after |  |
 
 ## Absent Core Lifecycle Metadata
 
@@ -145,11 +145,16 @@ Primary references are exact path matches in canonical documentation surfaces. D
   - `docs/reports/optimierungsstatus.md`
 
 - `docs/reports/auth-persistence-runtime-proof.md`
+  - `docs/adr/ADR-0007__auth-persistence-production-db-path.md`
   - `docs/proofs/sqlx-pgbouncer-session-crud-proof.md`
   - `docs/proofs/sqlx-postgres-direct-session-crud-proof.md`
   - `docs/reports/auth-persistence-runtime-target-reconciliation.md`
 
+- `docs/reports/auth-persistence-runtime-target-reconciliation.md`
+  - `docs/adr/ADR-0007__auth-persistence-production-db-path.md`
+
 - `docs/reports/auth-status-matrix.md`
+  - `docs/adr/ADR-0006__auth-magic-link-session-passkey.md`
   - `docs/blueprints/auth-roadmap.md`
   - `docs/reports/optimierungsstatus.md`
   - `docs/reports/passkey-register-verify-prep.md`
@@ -227,6 +232,7 @@ Primary references are exact path matches in canonical documentation surfaces. D
   - `docs/reports/domain-read-path-proof.md`
   - `docs/reports/optimierungsbericht.md`
   - `docs/roadmap.md`
+  - `docs/specs/list-pagination-api.md`
   - `docs/tasks/README.md`
   - `docs/tasks/board.md`
 
@@ -237,64 +243,127 @@ Primary references are exact path matches in canonical documentation surfaces. D
 
 - `docs/reports/agent-readiness-audit.md`
   - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
   - `docs/_generated/relates-to-audit.md`
 
 - `docs/reports/auth-persistence-direct-proof-diagnose-audit.md`
   - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
   - `docs/_generated/relates-to-audit.md`
 
 - `docs/reports/auth-persistence-next-step.md`
   - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
   - `docs/_generated/relates-to-audit.md`
   - `docs/_generated/supersession-map.md`
 
 - `docs/reports/auth-persistence-readiness.md`
   - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
   - `docs/_generated/relates-to-audit.md`
   - `docs/_generated/supersession-map.md`
 
 - `docs/reports/auth-persistence-runtime-proof.md`
   - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
   - `docs/_generated/relates-to-audit.md`
 
 - `docs/reports/auth-persistence-runtime-target-reconciliation.md`
   - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
   - `docs/_generated/relates-to-audit.md`
 
 - `docs/reports/auth-status-matrix.md`
   - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
   - `docs/_generated/relates-to-audit.md`
 
 - `docs/reports/cost-report.md`
+  - `docs/_generated/doc-index.md`
   - `docs/_generated/orphans.md`
   - `docs/_generated/relations-analysis.md`
 
+- `docs/reports/domain-account-email-uniqueness-audit.md`
+  - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
+  - `docs/_generated/relates-to-audit.md`
+
+- `docs/reports/domain-account-write-path-proof.md`
+  - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
+  - `docs/_generated/relates-to-audit.md`
+
+- `docs/reports/domain-backfill-proof.md`
+  - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
+  - `docs/_generated/relates-to-audit.md`
+
+- `docs/reports/domain-edge-create-semantics-preflight.md`
+  - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
+  - `docs/_generated/relates-to-audit.md`
+
+- `docs/reports/domain-edge-write-path-proof.md`
+  - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
+  - `docs/_generated/relates-to-audit.md`
+
+- `docs/reports/domain-node-write-path-proof.md`
+  - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
+  - `docs/_generated/relates-to-audit.md`
+
+- `docs/reports/domain-provider-role-finding.md`
+  - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
+  - `docs/_generated/relates-to-audit.md`
+
+- `docs/reports/domain-read-path-proof.md`
+  - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
+  - `docs/_generated/relates-to-audit.md`
+
+- `docs/reports/inwx-zone-reconciliation-plan.md`
+  - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
+  - `docs/_generated/relates-to-audit.md`
+
 - `docs/reports/map-architekturkritik.md`
   - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
   - `docs/_generated/impl-index.md`
   - `docs/_generated/relates-to-audit.md`
 
 - `docs/reports/map-status-matrix.md`
   - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
   - `docs/_generated/impl-index.md`
   - `docs/_generated/relates-to-audit.md`
 
 - `docs/reports/optimierungsbericht.md`
   - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
   - `docs/_generated/relates-to-audit.md`
 
 - `docs/reports/optimierungsstatus.md`
   - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
   - `docs/_generated/relates-to-audit.md`
+  - `docs/_generated/relations-analysis.md`
 
 - `docs/reports/passkey-register-verify-prep.md`
   - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
+  - `docs/_generated/relates-to-audit.md`
+
+- `docs/reports/planning-registration-findings.md`
+  - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
   - `docs/_generated/relates-to-audit.md`
 
 ## Primary Unreferenced Reports
 
 - `docs/reports/auth-persistence-direct-proof-diagnose-audit.md`
-- `docs/reports/auth-persistence-runtime-target-reconciliation.md`
 - `docs/reports/cost-report.md`
 - `docs/reports/domain-account-email-uniqueness-audit.md`
 - `docs/reports/domain-edge-create-semantics-preflight.md`

--- a/scripts/docmeta/generate_report_lifecycle_inventory.py
+++ b/scripts/docmeta/generate_report_lifecycle_inventory.py
@@ -14,11 +14,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 REPORTS_DIR = REPO_ROOT / "docs" / "reports"
 OUTPUT_PATH = REPO_ROOT / "docs" / "_generated" / "report-lifecycle-inventory.md"
 PRIMARY_REFERENCE_SEARCH_PATHS = (
-    REPO_ROOT / "docs" / "tasks",
-    REPO_ROOT / "docs" / "blueprints",
-    REPO_ROOT / "docs" / "reports",
-    REPO_ROOT / "docs" / "proofs",
-    REPO_ROOT / "docs" / "roadmap.md",
+    REPO_ROOT / "docs",
 )
 DERIVED_REFERENCE_SEARCH_PATHS = (
     REPO_ROOT / "docs" / "_generated",
@@ -339,19 +335,34 @@ def _compile_path_reference_pattern(report_rel: str) -> re.Pattern[str]:
     )
 
 
-def _iter_reference_files(search_paths: tuple[Path, ...]) -> list[Path]:
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def _iter_reference_files(
+    search_paths: tuple[Path, ...],
+    exclude_paths: tuple[Path, ...] = (),
+) -> list[Path]:
     files: list[Path] = []
     seen: set[Path] = set()
     for path in search_paths:
         if not path.exists():
             continue
         if path.is_file():
-            if path not in seen:
+            if path not in seen and not any(
+                _is_relative_to(path, excluded_path) for excluded_path in exclude_paths
+            ):
                 files.append(path)
                 seen.add(path)
             continue
         for file_path in sorted(candidate for candidate in path.rglob("*.md") if candidate.is_file()):
-            if file_path not in seen:
+            if file_path not in seen and not any(
+                _is_relative_to(file_path, excluded_path) for excluded_path in exclude_paths
+            ):
                 files.append(file_path)
                 seen.add(file_path)
     return files
@@ -394,7 +405,10 @@ def collect_reports(config: InventoryConfig | None = None) -> list[ReportRecord]
     )
     primary_reference_index = _build_reference_index(
         report_paths=report_paths,
-        search_files=_iter_reference_files(inventory_config.primary_search_paths),
+        search_files=_iter_reference_files(
+            inventory_config.primary_search_paths,
+            exclude_paths=inventory_config.derived_search_paths,
+        ),
         repo_root=inventory_config.repo_root,
     )
     derived_reference_index = _build_reference_index(

--- a/scripts/docmeta/generate_report_lifecycle_inventory.py
+++ b/scripts/docmeta/generate_report_lifecycle_inventory.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import re
 import sys
+from collections import Counter, defaultdict
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -12,15 +13,18 @@ if __package__ in {None, ""}:
 REPO_ROOT = Path(__file__).resolve().parents[2]
 REPORTS_DIR = REPO_ROOT / "docs" / "reports"
 OUTPUT_PATH = REPO_ROOT / "docs" / "_generated" / "report-lifecycle-inventory.md"
-REFERENCE_SEARCH_PATHS = [
+PRIMARY_REFERENCE_SEARCH_PATHS = (
     REPO_ROOT / "docs" / "tasks",
     REPO_ROOT / "docs" / "blueprints",
     REPO_ROOT / "docs" / "reports",
     REPO_ROOT / "docs" / "proofs",
     REPO_ROOT / "docs" / "roadmap.md",
+)
+DERIVED_REFERENCE_SEARCH_PATHS = (
     REPO_ROOT / "docs" / "_generated",
-]
-LIFECYCLE_FIELDS = ("lifecycle", "owner_task", "review_after", "superseded_by")
+)
+CORE_LIFECYCLE_FIELDS = ("lifecycle", "owner_task", "review_after")
+TERMINAL_STATUSES = {"superseded", "archived", "deprecated"}
 
 HEADER = """\
 ---
@@ -34,9 +38,18 @@ summary: Automatisch generiertes Inventar der Report-Lifecycle-Metadaten.
 # Report Lifecycle Inventory
 
 Generated automatically. Do not edit manually.
-This inventory is descriptive only. Missing lifecycle fields are expected at this stage and are not policy violations.
-Reference counts are based on heuristic text matches against selected documentation paths.
+This inventory is descriptive only. Absent core lifecycle metadata is expected at this stage and is not a policy judgement.
+Primary references are exact path matches in canonical documentation surfaces. Derived generated references are reported separately.
 """
+
+
+@dataclass(frozen=True)
+class InventoryConfig:
+    repo_root: Path
+    reports_dir: Path
+    output_path: Path
+    primary_search_paths: tuple[Path, ...]
+    derived_search_paths: tuple[Path, ...]
 
 
 @dataclass(frozen=True)
@@ -60,17 +73,34 @@ class ReportRecord:
     relations_count: int
     relation_types: tuple[str, ...]
     relation_targets: tuple[str, ...]
-    referenced_by_paths: tuple[str, ...]
-    missing_lifecycle_fields: tuple[str, ...]
+    primary_referenced_by_paths: tuple[str, ...]
+    derived_referenced_by_paths: tuple[str, ...]
+    absent_core_lifecycle_fields: tuple[str, ...]
+    missing_supersession_target: bool
     frontmatter_parse_warning: str
 
     @property
+    def referenced_by_paths(self) -> tuple[str, ...]:
+        return self.primary_referenced_by_paths
+
+    @property
     def referenced_by_count(self) -> int:
-        return len(self.referenced_by_paths)
+        # Primary references only; derived/generated references are reported separately.
+        return len(self.primary_referenced_by_paths)
 
 
-def _as_rel(path: Path) -> str:
-    return str(path.relative_to(REPO_ROOT)).replace("\\", "/")
+def default_inventory_config() -> InventoryConfig:
+    return InventoryConfig(
+        repo_root=REPO_ROOT,
+        reports_dir=REPORTS_DIR,
+        output_path=OUTPUT_PATH,
+        primary_search_paths=PRIMARY_REFERENCE_SEARCH_PATHS,
+        derived_search_paths=DERIVED_REFERENCE_SEARCH_PATHS,
+    )
+
+
+def _as_rel(path: Path, repo_root: Path) -> str:
+    return str(path.relative_to(repo_root)).replace("\\", "/")
 
 
 def _read_text(path: Path) -> str:
@@ -193,7 +223,7 @@ def _parse_relations_block(lines: list[str], start_index: int) -> tuple[str, lis
             index += 1
             continue
 
-        if not raw_line[:1] in {" ", "\t"}:
+        if raw_line[:1] not in {" ", "\t"}:
             break
 
         if stripped.startswith("- "):
@@ -247,13 +277,14 @@ def _parse_multiline_scalar_block(lines: list[str], start_index: int) -> tuple[s
 
     while index < len(lines):
         raw_line = lines[index]
-        if raw_line.strip() and not raw_line[:1] in {" ", "\t"}:
+        if raw_line.strip() and raw_line[:1] not in {" ", "\t"}:
             break
-        if raw_line.strip():
+        if raw_line[:1] in {" ", "\t"}:
             values.append(raw_line.strip())
         index += 1
 
-    return " ".join(values).strip(), index
+    joined = " ".join(part for part in values if part)
+    return joined.strip(), index
 
 
 def _parse_generic_block_value(lines: list[str], start_index: int) -> tuple[object, int]:
@@ -266,7 +297,7 @@ def _parse_generic_block_value(lines: list[str], start_index: int) -> tuple[obje
         if not stripped:
             index += 1
             continue
-        if not raw_line[:1] in {" ", "\t"}:
+        if raw_line[:1] not in {" ", "\t"}:
             break
         if stripped.startswith("- "):
             values.append(_strip_quotes(stripped[2:].strip()))
@@ -279,40 +310,10 @@ def _parse_generic_block_value(lines: list[str], start_index: int) -> tuple[obje
     return "", index
 
 
-def collect_reports(reports_dir: Path = REPORTS_DIR) -> list[ReportRecord]:
-    reports = []
-    report_paths = sorted(path for path in reports_dir.glob("*.md") if path.is_file())
-    reference_index = _build_reference_index(report_paths)
-
-    for path in report_paths:
-        content = _read_text(path)
-        has_frontmatter, frontmatter, warning = _parse_frontmatter(content)
-        relations = _extract_relations(frontmatter.get("relations", []))
-        rel_path = _as_rel(path)
-        reports.append(
-            ReportRecord(
-                path=rel_path,
-                has_frontmatter=has_frontmatter,
-                doc_id=_string_value(frontmatter.get("id")),
-                title=_string_value(frontmatter.get("title")),
-                doc_type=_string_value(frontmatter.get("doc_type")),
-                status=_string_value(frontmatter.get("status")),
-                lifecycle=_string_value(frontmatter.get("lifecycle")),
-                owner_task=_string_value(frontmatter.get("owner_task")),
-                review_after=_string_value(frontmatter.get("review_after")),
-                superseded_by=_string_value(frontmatter.get("superseded_by")),
-                relations_count=len(relations),
-                relation_types=tuple(relation.relation_type for relation in relations if relation.relation_type),
-                relation_targets=tuple(relation.target for relation in relations if relation.target),
-                referenced_by_paths=tuple(reference_index.get(rel_path, [])),
-                missing_lifecycle_fields=tuple(
-                    field for field in LIFECYCLE_FIELDS if not _string_value(frontmatter.get(field))
-                ),
-                frontmatter_parse_warning=warning,
-            )
-        )
-
-    return reports
+def _string_value(value: object) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    return ""
 
 
 def _extract_relations(raw_relations: object) -> list[RelationEntry]:
@@ -332,38 +333,17 @@ def _extract_relations(raw_relations: object) -> list[RelationEntry]:
     return relations
 
 
-def _string_value(value: object) -> str:
-    if isinstance(value, str):
-        return value.strip()
-    return ""
+def _contains_exact_path_reference(content: str, report_rel: str) -> bool:
+    pattern = re.compile(
+        rf"(?<![A-Za-z0-9_./-]){re.escape(report_rel)}(?![A-Za-z0-9_./-])"
+    )
+    return pattern.search(content) is not None
 
 
-def _build_reference_index(report_paths: list[Path]) -> dict[str, list[str]]:
-    search_files = _iter_reference_files()
-    reference_index: dict[str, set[str]] = {_as_rel(path): set() for path in report_paths}
-
-    for search_file in search_files:
-        search_rel = _as_rel(search_file)
-        if search_file == OUTPUT_PATH:
-            continue
-        content = _read_text(search_file)
-        for report_path in report_paths:
-            report_rel = _as_rel(report_path)
-            if search_rel == report_rel:
-                continue
-            if report_rel in content:
-                reference_index.setdefault(report_rel, set()).add(search_rel)
-
-    return {
-        report_rel: sorted(paths)
-        for report_rel, paths in sorted(reference_index.items())
-    }
-
-
-def _iter_reference_files() -> list[Path]:
+def _iter_reference_files(search_paths: tuple[Path, ...]) -> list[Path]:
     files: list[Path] = []
     seen: set[Path] = set()
-    for path in REFERENCE_SEARCH_PATHS:
+    for path in search_paths:
         if not path.exists():
             continue
         if path.is_file():
@@ -378,22 +358,118 @@ def _iter_reference_files() -> list[Path]:
     return files
 
 
+def _build_reference_index(
+    report_paths: list[Path],
+    search_files: list[Path],
+    repo_root: Path,
+    skip_file: Path | None = None,
+) -> dict[str, tuple[str, ...]]:
+    reference_index: defaultdict[str, set[str]] = defaultdict(set)
+    report_rels = [_as_rel(path, repo_root) for path in report_paths]
+
+    for search_file in search_files:
+        if skip_file is not None and search_file == skip_file:
+            continue
+        search_rel = _as_rel(search_file, repo_root)
+        content = _read_text(search_file)
+        for report_rel in report_rels:
+            if search_rel == report_rel:
+                continue
+            if _contains_exact_path_reference(content, report_rel):
+                reference_index[report_rel].add(search_rel)
+
+    return {
+        report_rel: tuple(sorted(reference_index.get(report_rel, set())))
+        for report_rel in sorted(report_rels)
+    }
+
+
+def collect_reports(config: InventoryConfig | None = None) -> list[ReportRecord]:
+    inventory_config = config or default_inventory_config()
+    report_paths = sorted(
+        path for path in inventory_config.reports_dir.glob("*.md") if path.is_file()
+    )
+    primary_reference_index = _build_reference_index(
+        report_paths=report_paths,
+        search_files=_iter_reference_files(inventory_config.primary_search_paths),
+        repo_root=inventory_config.repo_root,
+    )
+    derived_reference_index = _build_reference_index(
+        report_paths=report_paths,
+        search_files=_iter_reference_files(inventory_config.derived_search_paths),
+        repo_root=inventory_config.repo_root,
+        skip_file=inventory_config.output_path,
+    )
+
+    records: list[ReportRecord] = []
+    for path in report_paths:
+        content = _read_text(path)
+        has_frontmatter, frontmatter, warning = _parse_frontmatter(content)
+        relations = _extract_relations(frontmatter.get("relations", []))
+        rel_path = _as_rel(path, inventory_config.repo_root)
+        relation_types = tuple(
+            sorted({relation.relation_type for relation in relations if relation.relation_type})
+        )
+        relation_targets = tuple(
+            sorted({relation.target for relation in relations if relation.target})
+        )
+        status = _string_value(frontmatter.get("status"))
+        superseded_by = _string_value(frontmatter.get("superseded_by"))
+        records.append(
+            ReportRecord(
+                path=rel_path,
+                has_frontmatter=has_frontmatter,
+                doc_id=_string_value(frontmatter.get("id")),
+                title=_string_value(frontmatter.get("title")),
+                doc_type=_string_value(frontmatter.get("doc_type")),
+                status=status,
+                lifecycle=_string_value(frontmatter.get("lifecycle")),
+                owner_task=_string_value(frontmatter.get("owner_task")),
+                review_after=_string_value(frontmatter.get("review_after")),
+                superseded_by=superseded_by,
+                relations_count=len(relations),
+                relation_types=relation_types,
+                relation_targets=relation_targets,
+                primary_referenced_by_paths=primary_reference_index.get(rel_path, ()),
+                derived_referenced_by_paths=derived_reference_index.get(rel_path, ()),
+                absent_core_lifecycle_fields=tuple(
+                    field for field in CORE_LIFECYCLE_FIELDS if not _string_value(frontmatter.get(field))
+                ),
+                missing_supersession_target=status in TERMINAL_STATUSES and not superseded_by,
+                frontmatter_parse_warning=warning,
+            )
+        )
+
+    return records
+
+
 def build_summary(records: list[ReportRecord]) -> list[tuple[str, int]]:
     return [
-        ("reports_total", len(records)),
-        ("reports_with_frontmatter", sum(1 for record in records if record.has_frontmatter)),
-        ("reports_without_frontmatter", sum(1 for record in records if not record.has_frontmatter)),
-        ("reports_with_status", sum(1 for record in records if record.status)),
-        ("reports_missing_status", sum(1 for record in records if not record.status)),
-        ("reports_with_lifecycle", sum(1 for record in records if record.lifecycle)),
-        ("reports_missing_lifecycle", sum(1 for record in records if not record.lifecycle)),
-        ("reports_with_owner_task", sum(1 for record in records if record.owner_task)),
-        ("reports_missing_owner_task", sum(1 for record in records if not record.owner_task)),
-        ("reports_with_review_after", sum(1 for record in records if record.review_after)),
-        ("reports_missing_review_after", sum(1 for record in records if not record.review_after)),
-        ("reports_referenced", sum(1 for record in records if record.referenced_by_count > 0)),
-        ("reports_unreferenced", sum(1 for record in records if record.referenced_by_count == 0)),
+        ("files_total", len(records)),
+        ("files_with_frontmatter", sum(1 for record in records if record.has_frontmatter)),
+        ("files_without_frontmatter", sum(1 for record in records if not record.has_frontmatter)),
+        ("files_with_status", sum(1 for record in records if record.status)),
+        ("files_missing_status", sum(1 for record in records if not record.status)),
+        ("files_with_lifecycle", sum(1 for record in records if record.lifecycle)),
+        ("files_missing_lifecycle", sum(1 for record in records if not record.lifecycle)),
+        ("files_with_owner_task", sum(1 for record in records if record.owner_task)),
+        ("files_missing_owner_task", sum(1 for record in records if not record.owner_task)),
+        ("files_with_review_after", sum(1 for record in records if record.review_after)),
+        ("files_missing_review_after", sum(1 for record in records if not record.review_after)),
+        ("files_primary_referenced", sum(1 for record in records if record.referenced_by_count > 0)),
+        ("files_primary_unreferenced", sum(1 for record in records if record.referenced_by_count == 0)),
+        ("files_with_derived_references", sum(1 for record in records if record.derived_referenced_by_paths)),
+        ("files_with_relations", sum(1 for record in records if record.relations_count > 0)),
+        (
+            "files_with_missing_supersession_target",
+            sum(1 for record in records if record.missing_supersession_target),
+        ),
     ]
+
+
+def build_doc_type_distribution(records: list[ReportRecord]) -> list[tuple[str, int]]:
+    counts = Counter(record.doc_type or "<missing>" for record in records)
+    return sorted(counts.items())
 
 
 def render_inventory(records: list[ReportRecord]) -> str:
@@ -404,16 +480,28 @@ def render_inventory(records: list[ReportRecord]) -> str:
     sections.extend(
         [
             "",
+            "## Doc Type Distribution",
+            "",
+            "| doc_type | Count |",
+            "| --- | ---: |",
+        ]
+    )
+    for doc_type, count in build_doc_type_distribution(records):
+        sections.append(f"| {_cell(doc_type)} | {count} |")
+
+    sections.extend(
+        [
+            "",
             "## Reports",
             "",
-            "| Path | doc_type | status | lifecycle | owner_task | review_after | superseded_by | refs | missing |",
-            "| --- | --- | --- | --- | --- | --- | --- | ---: | --- |",
+            "| Path | doc_type | status | lifecycle | owner_task | review_after | superseded_by | primary refs | derived refs | relations | absent core lifecycle fields | terminal supersession |",
+            "| --- | --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | --- | --- |",
         ]
     )
     for record in records:
         sections.append(
             "| {path} | {doc_type} | {status} | {lifecycle} | {owner_task} | {review_after} | "
-            "{superseded_by} | {refs} | {missing} |".format(
+            "{superseded_by} | {primary_refs} | {derived_refs} | {relations} | {absent} | {terminal_supersession} |".format(
                 path=record.path,
                 doc_type=_cell(record.doc_type),
                 status=_cell(record.status),
@@ -421,33 +509,111 @@ def render_inventory(records: list[ReportRecord]) -> str:
                 owner_task=_cell(record.owner_task),
                 review_after=_cell(record.review_after),
                 superseded_by=_cell(record.superseded_by),
-                refs=record.referenced_by_count,
-                missing=_cell(", ".join(record.missing_lifecycle_fields)),
+                primary_refs=record.referenced_by_count,
+                derived_refs=len(record.derived_referenced_by_paths),
+                relations=record.relations_count,
+                absent=_cell(", ".join(record.absent_core_lifecycle_fields)),
+                terminal_supersession="missing target" if record.missing_supersession_target else "",
             )
         )
 
-    sections.extend(["", "## Missing Lifecycle Fields", "", "| Path | Missing fields |", "| --- | --- |"])
-    for record in records:
-        if record.missing_lifecycle_fields:
-            sections.append(f"| {record.path} | {_cell(', '.join(record.missing_lifecycle_fields))} |")
+    sections.extend(
+        [
+            "",
+            "## Absent Core Lifecycle Metadata",
+            "",
+            "| Path | Absent fields |",
+            "| --- | --- |",
+        ]
+    )
+    absent_records = [record for record in records if record.absent_core_lifecycle_fields]
+    if absent_records:
+        for record in absent_records:
+            sections.append(
+                f"| {record.path} | {_cell(', '.join(record.absent_core_lifecycle_fields))} |"
+            )
+    else:
+        sections.append("| _None_ | _None_ |")
 
-    sections.extend(["", "## Referenced Reports", "", "| Path | Referenced by |", "| --- | --- |"])
-    for record in records:
-        if record.referenced_by_paths:
-            sections.append(f"| {record.path} | {_cell(', '.join(record.referenced_by_paths))} |")
+    sections.extend(["", "## Relations", ""])
+    relation_records = [record for record in records if record.relations_count > 0]
+    if relation_records:
+        sections.extend(
+            [
+                "| Path | Count | Types | Targets |",
+                "| --- | ---: | --- | --- |",
+            ]
+        )
+        for record in relation_records:
+            sections.append(
+                "| {path} | {count} | {types} | {targets} |".format(
+                    path=record.path,
+                    count=record.relations_count,
+                    types=_cell(", ".join(record.relation_types)),
+                    targets=_cell(", ".join(record.relation_targets)),
+                )
+            )
+    else:
+        sections.append("_None_")
 
-    sections.extend(["", "## Unreferenced Reports", "", "| Path |", "| --- |"])
-    for record in records:
-        if not record.referenced_by_paths:
-            sections.append(f"| {record.path} |")
+    sections.extend(["", "## Primary Referenced Reports", ""])
+    primary_referenced_records = [record for record in records if record.primary_referenced_by_paths]
+    if primary_referenced_records:
+        for record in primary_referenced_records:
+            sections.append(f"- `{record.path}`")
+            for ref_path in record.primary_referenced_by_paths:
+                sections.append(f"  - `{ref_path}`")
+            sections.append("")
+    else:
+        sections.append("None.")
+        sections.append("")
 
-    sections.extend(["", "## Parse Warnings", "", "| Path | Warning |", "| --- | --- |"])
+    sections.extend(["## Derived Referenced Reports", ""])
+    derived_referenced_records = [record for record in records if record.derived_referenced_by_paths]
+    if derived_referenced_records:
+        for record in derived_referenced_records:
+            sections.append(f"- `{record.path}`")
+            for ref_path in record.derived_referenced_by_paths:
+                sections.append(f"  - `{ref_path}`")
+            sections.append("")
+    else:
+        sections.append("None.")
+        sections.append("")
+
+    sections.extend(["## Primary Unreferenced Reports", ""])
+    primary_unreferenced_records = [record for record in records if not record.primary_referenced_by_paths]
+    if primary_unreferenced_records:
+        for record in primary_unreferenced_records:
+            sections.append(f"- `{record.path}`")
+        sections.append("")
+    else:
+        sections.append("_None_")
+        sections.append("")
+
+    terminal_gap_records = [record for record in records if record.missing_supersession_target]
+    sections.extend(["## Terminal Supersession Diagnostics", ""])
+    if terminal_gap_records:
+        sections.extend(
+            [
+                "| Path | Status | Diagnostic |",
+                "| --- | --- | --- |",
+            ]
+        )
+        for record in terminal_gap_records:
+            sections.append(f"| {record.path} | {_cell(record.status)} | missing superseded_by target |")
+    else:
+        sections.append("None.")
+    sections.append("")
+
+    sections.extend(["## Parse Warnings", ""])
     warning_records = [record for record in records if record.frontmatter_parse_warning]
     if warning_records:
+        sections.extend(["| Path | Warning |", "| --- | --- |"])
         for record in warning_records:
             sections.append(f"| {record.path} | {_cell(record.frontmatter_parse_warning)} |")
     else:
-        sections.append("| _None_ | _None_ |")
+        sections.append("None.")
+        sections.append("")
 
     return "\n".join(sections).rstrip() + "\n"
 
@@ -455,20 +621,21 @@ def render_inventory(records: list[ReportRecord]) -> str:
 def _cell(value: str) -> str:
     if not value:
         return ""
-    return re.sub(r"\s+", " ", value.replace("|", "\\|")).strip()
+    return re.sub(r"\s+", " ", value.replace("|", "&#124;")).strip()
 
 
-def generate(output_path: Path = OUTPUT_PATH, reports_dir: Path = REPORTS_DIR) -> Path:
-    records = collect_reports(reports_dir)
+def generate(config: InventoryConfig | None = None) -> Path:
+    inventory_config = config or default_inventory_config()
+    records = collect_reports(inventory_config)
     content = render_inventory(records)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(content, encoding="utf-8")
-    return output_path
+    inventory_config.output_path.parent.mkdir(parents=True, exist_ok=True)
+    inventory_config.output_path.write_text(content, encoding="utf-8")
+    return inventory_config.output_path
 
 
 def main() -> None:
     output_path = generate()
-    print(f"Generated {_as_rel(output_path)}")
+    print(f"Generated {_as_rel(output_path, default_inventory_config().repo_root)}")
 
 
 if __name__ == "__main__":

--- a/scripts/docmeta/generate_report_lifecycle_inventory.py
+++ b/scripts/docmeta/generate_report_lifecycle_inventory.py
@@ -333,11 +333,10 @@ def _extract_relations(raw_relations: object) -> list[RelationEntry]:
     return relations
 
 
-def _contains_exact_path_reference(content: str, report_rel: str) -> bool:
-    pattern = re.compile(
-        rf"(?<![A-Za-z0-9_./-]){re.escape(report_rel)}(?![A-Za-z0-9_./-])"
+def _compile_path_reference_pattern(report_rel: str) -> re.Pattern[str]:
+    return re.compile(
+        rf"(?<![A-Za-z0-9_./-]){re.escape(report_rel)}(?![A-Za-z0-9_/-]|\.[A-Za-z0-9_])"
     )
-    return pattern.search(content) is not None
 
 
 def _iter_reference_files(search_paths: tuple[Path, ...]) -> list[Path]:
@@ -366,6 +365,10 @@ def _build_reference_index(
 ) -> dict[str, tuple[str, ...]]:
     reference_index: defaultdict[str, set[str]] = defaultdict(set)
     report_rels = [_as_rel(path, repo_root) for path in report_paths]
+    patterns = {
+        report_rel: _compile_path_reference_pattern(report_rel)
+        for report_rel in report_rels
+    }
 
     for search_file in search_files:
         if skip_file is not None and search_file == skip_file:
@@ -375,7 +378,7 @@ def _build_reference_index(
         for report_rel in report_rels:
             if search_rel == report_rel:
                 continue
-            if _contains_exact_path_reference(content, report_rel):
+            if report_rel in content and patterns[report_rel].search(content):
                 reference_index[report_rel].add(search_rel)
 
     return {

--- a/scripts/docmeta/generate_report_lifecycle_inventory.py
+++ b/scripts/docmeta/generate_report_lifecycle_inventory.py
@@ -417,6 +417,7 @@ def collect_reports(config: InventoryConfig | None = None) -> list[ReportRecord]
             sorted({relation.target for relation in relations if relation.target})
         )
         status = _string_value(frontmatter.get("status"))
+        normalized_status = status.lower()
         superseded_by = _string_value(frontmatter.get("superseded_by"))
         records.append(
             ReportRecord(
@@ -438,7 +439,7 @@ def collect_reports(config: InventoryConfig | None = None) -> list[ReportRecord]
                 absent_core_lifecycle_fields=tuple(
                     field for field in CORE_LIFECYCLE_FIELDS if not _string_value(frontmatter.get(field))
                 ),
-                missing_supersession_target=status in TERMINAL_STATUSES and not superseded_by,
+                missing_supersession_target=normalized_status in TERMINAL_STATUSES and not superseded_by,
                 frontmatter_parse_warning=warning,
             )
         )

--- a/scripts/docmeta/generate_report_lifecycle_inventory.py
+++ b/scripts/docmeta/generate_report_lifecycle_inventory.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REPORTS_DIR = REPO_ROOT / "docs" / "reports"
+OUTPUT_PATH = REPO_ROOT / "docs" / "_generated" / "report-lifecycle-inventory.md"
+REFERENCE_SEARCH_PATHS = [
+    REPO_ROOT / "docs" / "tasks",
+    REPO_ROOT / "docs" / "blueprints",
+    REPO_ROOT / "docs" / "reports",
+    REPO_ROOT / "docs" / "proofs",
+    REPO_ROOT / "docs" / "roadmap.md",
+    REPO_ROOT / "docs" / "_generated",
+]
+LIFECYCLE_FIELDS = ("lifecycle", "owner_task", "review_after", "superseded_by")
+
+HEADER = """\
+---
+id: docs.generated.report-lifecycle-inventory
+title: Report Lifecycle Inventory
+doc_type: generated
+status: active
+canonicality: derived
+summary: Automatisch generiertes Inventar der Report-Lifecycle-Metadaten.
+---
+# Report Lifecycle Inventory
+
+Generated automatically. Do not edit manually.
+This inventory is descriptive only. Missing lifecycle fields are expected at this stage and are not policy violations.
+Reference counts are based on heuristic text matches against selected documentation paths.
+"""
+
+
+@dataclass(frozen=True)
+class RelationEntry:
+    relation_type: str
+    target: str
+
+
+@dataclass(frozen=True)
+class ReportRecord:
+    path: str
+    has_frontmatter: bool
+    doc_id: str
+    title: str
+    doc_type: str
+    status: str
+    lifecycle: str
+    owner_task: str
+    review_after: str
+    superseded_by: str
+    relations_count: int
+    relation_types: tuple[str, ...]
+    relation_targets: tuple[str, ...]
+    referenced_by_paths: tuple[str, ...]
+    missing_lifecycle_fields: tuple[str, ...]
+    frontmatter_parse_warning: str
+
+    @property
+    def referenced_by_count(self) -> int:
+        return len(self.referenced_by_paths)
+
+
+def _as_rel(path: Path) -> str:
+    return str(path.relative_to(REPO_ROOT)).replace("\\", "/")
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _split_frontmatter(content: str) -> tuple[bool, list[str], str]:
+    if not content.startswith("---"):
+        return False, [], ""
+
+    lines = content.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return False, [], ""
+
+    closing_index = None
+    for index in range(1, len(lines)):
+        if lines[index].strip() == "---":
+            closing_index = index
+            break
+
+    if closing_index is None:
+        return True, lines[1:], "frontmatter start found without closing delimiter"
+
+    return True, lines[1:closing_index], ""
+
+
+def _strip_quotes(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def _parse_frontmatter(content: str) -> tuple[bool, dict[str, object], str]:
+    has_frontmatter, fm_lines, split_warning = _split_frontmatter(content)
+    if not has_frontmatter:
+        return False, {}, "frontmatter missing"
+
+    data: dict[str, object] = {}
+    relations: list[RelationEntry] = []
+    warning_parts: list[str] = []
+    if split_warning:
+        warning_parts.append(split_warning)
+
+    index = 0
+    while index < len(fm_lines):
+        raw_line = fm_lines[index]
+        stripped = raw_line.strip()
+        index += 1
+
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        if raw_line[:1] in {" ", "\t"}:
+            warning_parts.append(f"unexpected indented line: {stripped}")
+            continue
+
+        if ":" not in raw_line:
+            warning_parts.append(f"unparseable frontmatter line: {stripped}")
+            continue
+
+        key, raw_value = raw_line.split(":", 1)
+        key = key.strip()
+        value = raw_value.strip()
+
+        if key == "relations":
+            if value == "[]":
+                data[key] = []
+                continue
+            if value:
+                warning_parts.append("relations must use block list syntax for this inventory")
+                data[key] = []
+                continue
+
+            relation_warning, parsed_relations, next_index = _parse_relations_block(fm_lines, index)
+            if relation_warning:
+                warning_parts.append(relation_warning)
+            relations = parsed_relations
+            data[key] = [
+                {"type": relation.relation_type, "target": relation.target}
+                for relation in relations
+            ]
+            index = next_index
+            continue
+
+        if value in {">", "|"}:
+            folded_value, next_index = _parse_multiline_scalar_block(fm_lines, index)
+            data[key] = folded_value
+            index = next_index
+            continue
+
+        if value == "":
+            block_value, next_index = _parse_generic_block_value(fm_lines, index)
+            data[key] = block_value
+            index = next_index
+            continue
+
+        data[key] = _strip_quotes(value)
+
+    if relations:
+        data["relations"] = [
+            {"type": relation.relation_type, "target": relation.target}
+            for relation in relations
+        ]
+
+    warning = "; ".join(dict.fromkeys(part for part in warning_parts if part))
+    return True, data, warning
+
+
+def _parse_relations_block(lines: list[str], start_index: int) -> tuple[str, list[RelationEntry], int]:
+    relations: list[RelationEntry] = []
+    warning_parts: list[str] = []
+    index = start_index
+    current: dict[str, str] | None = None
+
+    while index < len(lines):
+        raw_line = lines[index]
+        stripped = raw_line.strip()
+
+        if not stripped or stripped.startswith("#"):
+            index += 1
+            continue
+
+        if not raw_line[:1] in {" ", "\t"}:
+            break
+
+        if stripped.startswith("- "):
+            if current is not None:
+                relations.append(
+                    RelationEntry(
+                        relation_type=current.get("type", ""),
+                        target=current.get("target", ""),
+                    )
+                )
+            current = {}
+            item = stripped[2:].strip()
+            if item:
+                if ":" not in item:
+                    warning_parts.append(f"unparseable relations entry: {item}")
+                else:
+                    sub_key, sub_value = item.split(":", 1)
+                    current[sub_key.strip()] = _strip_quotes(sub_value.strip())
+            index += 1
+            continue
+
+        if current is None:
+            warning_parts.append(f"relation continuation without list item: {stripped}")
+            index += 1
+            continue
+
+        if ":" not in stripped:
+            warning_parts.append(f"unparseable relation line: {stripped}")
+            index += 1
+            continue
+
+        sub_key, sub_value = stripped.split(":", 1)
+        current[sub_key.strip()] = _strip_quotes(sub_value.strip())
+        index += 1
+
+    if current is not None:
+        relations.append(
+            RelationEntry(
+                relation_type=current.get("type", ""),
+                target=current.get("target", ""),
+            )
+        )
+
+    warning = "; ".join(dict.fromkeys(part for part in warning_parts if part))
+    return warning, relations, index
+
+
+def _parse_multiline_scalar_block(lines: list[str], start_index: int) -> tuple[str, int]:
+    values: list[str] = []
+    index = start_index
+
+    while index < len(lines):
+        raw_line = lines[index]
+        if raw_line.strip() and not raw_line[:1] in {" ", "\t"}:
+            break
+        if raw_line.strip():
+            values.append(raw_line.strip())
+        index += 1
+
+    return " ".join(values).strip(), index
+
+
+def _parse_generic_block_value(lines: list[str], start_index: int) -> tuple[object, int]:
+    values: list[str] = []
+    index = start_index
+
+    while index < len(lines):
+        raw_line = lines[index]
+        stripped = raw_line.strip()
+        if not stripped:
+            index += 1
+            continue
+        if not raw_line[:1] in {" ", "\t"}:
+            break
+        if stripped.startswith("- "):
+            values.append(_strip_quotes(stripped[2:].strip()))
+        else:
+            values.append(stripped)
+        index += 1
+
+    if values:
+        return values, index
+    return "", index
+
+
+def collect_reports(reports_dir: Path = REPORTS_DIR) -> list[ReportRecord]:
+    reports = []
+    report_paths = sorted(path for path in reports_dir.glob("*.md") if path.is_file())
+    reference_index = _build_reference_index(report_paths)
+
+    for path in report_paths:
+        content = _read_text(path)
+        has_frontmatter, frontmatter, warning = _parse_frontmatter(content)
+        relations = _extract_relations(frontmatter.get("relations", []))
+        rel_path = _as_rel(path)
+        reports.append(
+            ReportRecord(
+                path=rel_path,
+                has_frontmatter=has_frontmatter,
+                doc_id=_string_value(frontmatter.get("id")),
+                title=_string_value(frontmatter.get("title")),
+                doc_type=_string_value(frontmatter.get("doc_type")),
+                status=_string_value(frontmatter.get("status")),
+                lifecycle=_string_value(frontmatter.get("lifecycle")),
+                owner_task=_string_value(frontmatter.get("owner_task")),
+                review_after=_string_value(frontmatter.get("review_after")),
+                superseded_by=_string_value(frontmatter.get("superseded_by")),
+                relations_count=len(relations),
+                relation_types=tuple(relation.relation_type for relation in relations if relation.relation_type),
+                relation_targets=tuple(relation.target for relation in relations if relation.target),
+                referenced_by_paths=tuple(reference_index.get(rel_path, [])),
+                missing_lifecycle_fields=tuple(
+                    field for field in LIFECYCLE_FIELDS if not _string_value(frontmatter.get(field))
+                ),
+                frontmatter_parse_warning=warning,
+            )
+        )
+
+    return reports
+
+
+def _extract_relations(raw_relations: object) -> list[RelationEntry]:
+    relations: list[RelationEntry] = []
+    if not isinstance(raw_relations, list):
+        return relations
+
+    for entry in raw_relations:
+        if not isinstance(entry, dict):
+            continue
+        relations.append(
+            RelationEntry(
+                relation_type=_string_value(entry.get("type")),
+                target=_string_value(entry.get("target")),
+            )
+        )
+    return relations
+
+
+def _string_value(value: object) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    return ""
+
+
+def _build_reference_index(report_paths: list[Path]) -> dict[str, list[str]]:
+    search_files = _iter_reference_files()
+    reference_index: dict[str, set[str]] = {_as_rel(path): set() for path in report_paths}
+
+    for search_file in search_files:
+        search_rel = _as_rel(search_file)
+        if search_file == OUTPUT_PATH:
+            continue
+        content = _read_text(search_file)
+        for report_path in report_paths:
+            report_rel = _as_rel(report_path)
+            if search_rel == report_rel:
+                continue
+            if report_rel in content:
+                reference_index.setdefault(report_rel, set()).add(search_rel)
+
+    return {
+        report_rel: sorted(paths)
+        for report_rel, paths in sorted(reference_index.items())
+    }
+
+
+def _iter_reference_files() -> list[Path]:
+    files: list[Path] = []
+    seen: set[Path] = set()
+    for path in REFERENCE_SEARCH_PATHS:
+        if not path.exists():
+            continue
+        if path.is_file():
+            if path not in seen:
+                files.append(path)
+                seen.add(path)
+            continue
+        for file_path in sorted(candidate for candidate in path.rglob("*.md") if candidate.is_file()):
+            if file_path not in seen:
+                files.append(file_path)
+                seen.add(file_path)
+    return files
+
+
+def build_summary(records: list[ReportRecord]) -> list[tuple[str, int]]:
+    return [
+        ("reports_total", len(records)),
+        ("reports_with_frontmatter", sum(1 for record in records if record.has_frontmatter)),
+        ("reports_without_frontmatter", sum(1 for record in records if not record.has_frontmatter)),
+        ("reports_with_status", sum(1 for record in records if record.status)),
+        ("reports_missing_status", sum(1 for record in records if not record.status)),
+        ("reports_with_lifecycle", sum(1 for record in records if record.lifecycle)),
+        ("reports_missing_lifecycle", sum(1 for record in records if not record.lifecycle)),
+        ("reports_with_owner_task", sum(1 for record in records if record.owner_task)),
+        ("reports_missing_owner_task", sum(1 for record in records if not record.owner_task)),
+        ("reports_with_review_after", sum(1 for record in records if record.review_after)),
+        ("reports_missing_review_after", sum(1 for record in records if not record.review_after)),
+        ("reports_referenced", sum(1 for record in records if record.referenced_by_count > 0)),
+        ("reports_unreferenced", sum(1 for record in records if record.referenced_by_count == 0)),
+    ]
+
+
+def render_inventory(records: list[ReportRecord]) -> str:
+    sections = [HEADER.rstrip(), "", "## Summary", "", "| Metric | Count |", "| --- | ---: |"]
+    for metric, count in build_summary(records):
+        sections.append(f"| {metric} | {count} |")
+
+    sections.extend(
+        [
+            "",
+            "## Reports",
+            "",
+            "| Path | doc_type | status | lifecycle | owner_task | review_after | superseded_by | refs | missing |",
+            "| --- | --- | --- | --- | --- | --- | --- | ---: | --- |",
+        ]
+    )
+    for record in records:
+        sections.append(
+            "| {path} | {doc_type} | {status} | {lifecycle} | {owner_task} | {review_after} | "
+            "{superseded_by} | {refs} | {missing} |".format(
+                path=record.path,
+                doc_type=_cell(record.doc_type),
+                status=_cell(record.status),
+                lifecycle=_cell(record.lifecycle),
+                owner_task=_cell(record.owner_task),
+                review_after=_cell(record.review_after),
+                superseded_by=_cell(record.superseded_by),
+                refs=record.referenced_by_count,
+                missing=_cell(", ".join(record.missing_lifecycle_fields)),
+            )
+        )
+
+    sections.extend(["", "## Missing Lifecycle Fields", "", "| Path | Missing fields |", "| --- | --- |"])
+    for record in records:
+        if record.missing_lifecycle_fields:
+            sections.append(f"| {record.path} | {_cell(', '.join(record.missing_lifecycle_fields))} |")
+
+    sections.extend(["", "## Referenced Reports", "", "| Path | Referenced by |", "| --- | --- |"])
+    for record in records:
+        if record.referenced_by_paths:
+            sections.append(f"| {record.path} | {_cell(', '.join(record.referenced_by_paths))} |")
+
+    sections.extend(["", "## Unreferenced Reports", "", "| Path |", "| --- |"])
+    for record in records:
+        if not record.referenced_by_paths:
+            sections.append(f"| {record.path} |")
+
+    sections.extend(["", "## Parse Warnings", "", "| Path | Warning |", "| --- | --- |"])
+    warning_records = [record for record in records if record.frontmatter_parse_warning]
+    if warning_records:
+        for record in warning_records:
+            sections.append(f"| {record.path} | {_cell(record.frontmatter_parse_warning)} |")
+    else:
+        sections.append("| _None_ | _None_ |")
+
+    return "\n".join(sections).rstrip() + "\n"
+
+
+def _cell(value: str) -> str:
+    if not value:
+        return ""
+    return re.sub(r"\s+", " ", value.replace("|", "\\|")).strip()
+
+
+def generate(output_path: Path = OUTPUT_PATH, reports_dir: Path = REPORTS_DIR) -> Path:
+    records = collect_reports(reports_dir)
+    content = render_inventory(records)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(content, encoding="utf-8")
+    return output_path
+
+
+def main() -> None:
+    output_path = generate()
+    print(f"Generated {_as_rel(output_path)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/docmeta/generated-files-guard.sh
+++ b/scripts/docmeta/generated-files-guard.sh
@@ -26,6 +26,7 @@ REQUIRED_FILES=(
     "staleness-report.md"
     "agent-readiness.md"
     "claim-evidence-map.md"
+    "report-lifecycle-inventory.md"
 )
 
 for req in "${REQUIRED_FILES[@]}"; do

--- a/scripts/docmeta/tests/test_generate_report_lifecycle_inventory.py
+++ b/scripts/docmeta/tests/test_generate_report_lifecycle_inventory.py
@@ -1,0 +1,161 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+import scripts.docmeta.generate_report_lifecycle_inventory as gen
+
+
+class TestGenerateReportLifecycleInventory(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        (self.root / "docs" / "reports").mkdir(parents=True, exist_ok=True)
+        (self.root / "docs" / "tasks").mkdir(parents=True, exist_ok=True)
+        (self.root / "docs" / "_generated").mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _write(self, rel_path: str, content: str) -> Path:
+        path = self.root / rel_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    def test_collect_reports_parses_complete_frontmatter(self) -> None:
+        report_path = self._write(
+            "docs/reports/alpha.md",
+            """---
+id: docs.reports.alpha
+title: Alpha
+doc_type: report
+status: active
+lifecycle: observed
+owner_task: docs/tasks/alpha.md
+review_after: 2026-12-01
+superseded_by: docs/reports/beta.md
+relations:
+  - type: relates_to
+    target: docs/reports/beta.md
+---
+# Alpha
+""",
+        )
+        self._write("docs/tasks/alpha.md", f"Uses {_rel(report_path, self.root)}\n")
+
+        with temporary_repo_root(self.root):
+            records = gen.collect_reports(self.root / "docs" / "reports")
+
+        self.assertEqual(len(records), 1)
+        record = records[0]
+        self.assertTrue(record.has_frontmatter)
+        self.assertEqual(record.doc_id, "docs.reports.alpha")
+        self.assertEqual(record.title, "Alpha")
+        self.assertEqual(record.lifecycle, "observed")
+        self.assertEqual(record.owner_task, "docs/tasks/alpha.md")
+        self.assertEqual(record.review_after, "2026-12-01")
+        self.assertEqual(record.superseded_by, "docs/reports/beta.md")
+        self.assertEqual(record.relations_count, 1)
+        self.assertEqual(record.relation_types, ("relates_to",))
+        self.assertEqual(record.relation_targets, ("docs/reports/beta.md",))
+        self.assertEqual(record.referenced_by_paths, ("docs/tasks/alpha.md",))
+        self.assertEqual(record.missing_lifecycle_fields, ())
+        self.assertEqual(record.frontmatter_parse_warning, "")
+
+    def test_collect_reports_keeps_report_without_frontmatter(self) -> None:
+        self._write("docs/reports/no-frontmatter.md", "# No frontmatter\n")
+
+        with temporary_repo_root(self.root):
+            records = gen.collect_reports(self.root / "docs" / "reports")
+
+        self.assertEqual(len(records), 1)
+        record = records[0]
+        self.assertFalse(record.has_frontmatter)
+        self.assertEqual(record.frontmatter_parse_warning, "frontmatter missing")
+
+    def test_missing_lifecycle_fields_are_diagnostic_only(self) -> None:
+        self._write(
+            "docs/reports/partial.md",
+            """---
+id: docs.reports.partial
+title: Partial
+doc_type: report
+status: active
+---
+# Partial
+""",
+        )
+
+        with temporary_repo_root(self.root):
+            records = gen.collect_reports(self.root / "docs" / "reports")
+            markdown = gen.render_inventory(records)
+
+        self.assertEqual(records[0].missing_lifecycle_fields, ("lifecycle", "owner_task", "review_after", "superseded_by"))
+        self.assertIn("descriptive only", markdown)
+        self.assertIn("not policy violations", markdown)
+        self.assertNotIn("invalid", markdown.lower())
+        self.assertNotIn("must fix", markdown.lower())
+
+    def test_reference_search_finds_exact_report_paths(self) -> None:
+        report_path = self._write(
+            "docs/reports/bar.md",
+            """---
+id: docs.reports.bar
+title: Bar
+doc_type: report
+status: active
+---
+# Bar
+""",
+        )
+        self._write("docs/tasks/foo.md", f"Reference {_rel(report_path, self.root)}\n")
+
+        with temporary_repo_root(self.root):
+            records = gen.collect_reports(self.root / "docs" / "reports")
+
+        self.assertEqual(records[0].referenced_by_paths, ("docs/tasks/foo.md",))
+
+    def test_inventory_is_sorted_deterministically_by_path(self) -> None:
+        self._write("docs/reports/zeta.md", "# Zeta\n")
+        self._write("docs/reports/alpha.md", "# Alpha\n")
+
+        with temporary_repo_root(self.root):
+            records = gen.collect_reports(self.root / "docs" / "reports")
+
+        self.assertEqual([record.path for record in records], ["docs/reports/alpha.md", "docs/reports/zeta.md"])
+
+
+def _rel(path: Path, root: Path) -> str:
+    return str(path.relative_to(root)).replace("\\", "/")
+
+
+class temporary_repo_root:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.original_repo_root = gen.REPO_ROOT
+        self.original_reports_dir = gen.REPORTS_DIR
+        self.original_output_path = gen.OUTPUT_PATH
+        self.original_reference_search_paths = gen.REFERENCE_SEARCH_PATHS
+
+    def __enter__(self) -> None:
+        gen.REPO_ROOT = self.root
+        gen.REPORTS_DIR = self.root / "docs" / "reports"
+        gen.OUTPUT_PATH = self.root / "docs" / "_generated" / "report-lifecycle-inventory.md"
+        gen.REFERENCE_SEARCH_PATHS = [
+            self.root / "docs" / "tasks",
+            self.root / "docs" / "blueprints",
+            self.root / "docs" / "reports",
+            self.root / "docs" / "proofs",
+            self.root / "docs" / "roadmap.md",
+            self.root / "docs" / "_generated",
+        ]
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        gen.REPO_ROOT = self.original_repo_root
+        gen.REPORTS_DIR = self.original_reports_dir
+        gen.OUTPUT_PATH = self.original_output_path
+        gen.REFERENCE_SEARCH_PATHS = self.original_reference_search_paths
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/docmeta/tests/test_generate_report_lifecycle_inventory.py
+++ b/scripts/docmeta/tests/test_generate_report_lifecycle_inventory.py
@@ -9,18 +9,38 @@ class TestGenerateReportLifecycleInventory(unittest.TestCase):
     def setUp(self) -> None:
         self._tmp = tempfile.TemporaryDirectory()
         self.root = Path(self._tmp.name)
-        (self.root / "docs" / "reports").mkdir(parents=True, exist_ok=True)
-        (self.root / "docs" / "tasks").mkdir(parents=True, exist_ok=True)
-        (self.root / "docs" / "_generated").mkdir(parents=True, exist_ok=True)
+        self._mkdir("docs/reports")
+        self._mkdir("docs/tasks")
+        self._mkdir("docs/blueprints")
+        self._mkdir("docs/proofs")
+        self._mkdir("docs/_generated")
 
     def tearDown(self) -> None:
         self._tmp.cleanup()
+
+    def _mkdir(self, rel_path: str) -> None:
+        (self.root / rel_path).mkdir(parents=True, exist_ok=True)
 
     def _write(self, rel_path: str, content: str) -> Path:
         path = self.root / rel_path
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content, encoding="utf-8")
         return path
+
+    def _config(self) -> gen.InventoryConfig:
+        return gen.InventoryConfig(
+            repo_root=self.root,
+            reports_dir=self.root / "docs" / "reports",
+            output_path=self.root / "docs" / "_generated" / "report-lifecycle-inventory.md",
+            primary_search_paths=(
+                self.root / "docs" / "tasks",
+                self.root / "docs" / "blueprints",
+                self.root / "docs" / "reports",
+                self.root / "docs" / "proofs",
+                self.root / "docs" / "roadmap.md",
+            ),
+            derived_search_paths=(self.root / "docs" / "_generated",),
+        )
 
     def test_collect_reports_parses_complete_frontmatter(self) -> None:
         report_path = self._write(
@@ -43,8 +63,7 @@ relations:
         )
         self._write("docs/tasks/alpha.md", f"Uses {_rel(report_path, self.root)}\n")
 
-        with temporary_repo_root(self.root):
-            records = gen.collect_reports(self.root / "docs" / "reports")
+        records = gen.collect_reports(self._config())
 
         self.assertEqual(len(records), 1)
         record = records[0]
@@ -58,22 +77,23 @@ relations:
         self.assertEqual(record.relations_count, 1)
         self.assertEqual(record.relation_types, ("relates_to",))
         self.assertEqual(record.relation_targets, ("docs/reports/beta.md",))
-        self.assertEqual(record.referenced_by_paths, ("docs/tasks/alpha.md",))
-        self.assertEqual(record.missing_lifecycle_fields, ())
+        self.assertEqual(record.primary_referenced_by_paths, ("docs/tasks/alpha.md",))
+        self.assertEqual(record.derived_referenced_by_paths, ())
+        self.assertEqual(record.absent_core_lifecycle_fields, ())
+        self.assertFalse(record.missing_supersession_target)
         self.assertEqual(record.frontmatter_parse_warning, "")
 
     def test_collect_reports_keeps_report_without_frontmatter(self) -> None:
         self._write("docs/reports/no-frontmatter.md", "# No frontmatter\n")
 
-        with temporary_repo_root(self.root):
-            records = gen.collect_reports(self.root / "docs" / "reports")
+        records = gen.collect_reports(self._config())
 
         self.assertEqual(len(records), 1)
         record = records[0]
         self.assertFalse(record.has_frontmatter)
         self.assertEqual(record.frontmatter_parse_warning, "frontmatter missing")
 
-    def test_missing_lifecycle_fields_are_diagnostic_only(self) -> None:
+    def test_missing_core_lifecycle_metadata_is_diagnostic_only(self) -> None:
         self._write(
             "docs/reports/partial.md",
             """---
@@ -86,17 +106,19 @@ status: active
 """,
         )
 
-        with temporary_repo_root(self.root):
-            records = gen.collect_reports(self.root / "docs" / "reports")
-            markdown = gen.render_inventory(records)
+        records = gen.collect_reports(self._config())
+        markdown = gen.render_inventory(records)
 
-        self.assertEqual(records[0].missing_lifecycle_fields, ("lifecycle", "owner_task", "review_after", "superseded_by"))
+        self.assertEqual(
+            records[0].absent_core_lifecycle_fields,
+            ("lifecycle", "owner_task", "review_after"),
+        )
         self.assertIn("descriptive only", markdown)
-        self.assertIn("not policy violations", markdown)
         self.assertNotIn("invalid", markdown.lower())
         self.assertNotIn("must fix", markdown.lower())
+        self.assertNotIn("violation", markdown.lower())
 
-    def test_reference_search_finds_exact_report_paths(self) -> None:
+    def test_generated_references_do_not_count_as_primary_references(self) -> None:
         report_path = self._write(
             "docs/reports/bar.md",
             """---
@@ -108,53 +130,154 @@ status: active
 # Bar
 """,
         )
-        self._write("docs/tasks/foo.md", f"Reference {_rel(report_path, self.root)}\n")
+        self._write("docs/_generated/doc-index.md", f"Derived {_rel(report_path, self.root)}\n")
 
-        with temporary_repo_root(self.root):
-            records = gen.collect_reports(self.root / "docs" / "reports")
+        records = gen.collect_reports(self._config())
 
-        self.assertEqual(records[0].referenced_by_paths, ("docs/tasks/foo.md",))
+        self.assertEqual(records[0].primary_referenced_by_paths, ())
+        self.assertEqual(records[0].referenced_by_count, 0)
+
+    def test_generated_references_appear_as_derived_references(self) -> None:
+        report_path = self._write(
+            "docs/reports/bar.md",
+            """---
+id: docs.reports.bar
+title: Bar
+doc_type: report
+status: active
+---
+# Bar
+""",
+        )
+        self._write("docs/_generated/doc-index.md", f"Derived {_rel(report_path, self.root)}\n")
+
+        records = gen.collect_reports(self._config())
+
+        self.assertEqual(records[0].derived_referenced_by_paths, ("docs/_generated/doc-index.md",))
+
+    def test_exact_path_matching_ignores_old_suffix(self) -> None:
+        self.assertFalse(
+            gen._contains_exact_path_reference(
+                "docs/reports/foo.md.old",
+                "docs/reports/foo.md",
+            )
+        )
+
+    def test_exact_path_matching_ignores_dash_suffix(self) -> None:
+        self.assertFalse(
+            gen._contains_exact_path_reference(
+                "docs/reports/foo.md-extra",
+                "docs/reports/foo.md",
+            )
+        )
+
+    def test_exact_path_matching_accepts_plain_path(self) -> None:
+        self.assertTrue(
+            gen._contains_exact_path_reference(
+                "docs/reports/foo.md",
+                "docs/reports/foo.md",
+            )
+        )
+
+    def test_exact_path_matching_accepts_anchor_suffix(self) -> None:
+        self.assertTrue(
+            gen._contains_exact_path_reference(
+                "docs/reports/foo.md#section",
+                "docs/reports/foo.md",
+            )
+        )
+
+    def test_superseded_by_not_absent_for_active_reports(self) -> None:
+        self._write(
+            "docs/reports/active.md",
+            """---
+id: docs.reports.active
+title: Active
+doc_type: report
+status: active
+lifecycle: observed
+owner_task: docs/tasks/active.md
+review_after: 2026-12-01
+---
+# Active
+""",
+        )
+
+        record = gen.collect_reports(self._config())[0]
+
+        self.assertEqual(record.absent_core_lifecycle_fields, ())
+        self.assertFalse(record.missing_supersession_target)
+
+    def test_terminal_status_without_superseded_by_is_reported(self) -> None:
+        self._write(
+            "docs/reports/terminal.md",
+            """---
+id: docs.reports.terminal
+title: Terminal
+doc_type: report
+status: superseded
+lifecycle: observed
+owner_task: docs/tasks/terminal.md
+review_after: 2026-12-01
+---
+# Terminal
+""",
+        )
+
+        record = gen.collect_reports(self._config())[0]
+
+        self.assertTrue(record.missing_supersession_target)
+
+    def test_relations_are_rendered_in_markdown_output(self) -> None:
+        self._write(
+            "docs/reports/rel.md",
+            """---
+id: docs.reports.rel
+title: Relation
+doc_type: report
+status: active
+relations:
+  - type: relates_to
+    target: docs/reports/other.md
+---
+# Relation
+""",
+        )
+
+        markdown = gen.render_inventory(gen.collect_reports(self._config()))
+
+        self.assertIn("## Relations", markdown)
+        self.assertIn("relates_to", markdown)
+        self.assertIn("docs/reports/other.md", markdown)
+
+    def test_doc_type_distribution_is_rendered(self) -> None:
+        self._write("docs/reports/a.md", "---\ndoc_type: report\nstatus: active\n---\n")
+        self._write("docs/reports/b.md", "---\ndoc_type: reference\nstatus: active\n---\n")
+
+        markdown = gen.render_inventory(gen.collect_reports(self._config()))
+
+        self.assertIn("## Doc Type Distribution", markdown)
+        self.assertIn("| report | 1 |", markdown)
+        self.assertIn("| reference | 1 |", markdown)
+
+    def test_collect_reports_uses_config_instead_of_global_mutation(self) -> None:
+        self._write("docs/reports/alpha.md", "---\nstatus: active\n---\n")
+
+        records = gen.collect_reports(self._config())
+
+        self.assertEqual([record.path for record in records], ["docs/reports/alpha.md"])
 
     def test_inventory_is_sorted_deterministically_by_path(self) -> None:
         self._write("docs/reports/zeta.md", "# Zeta\n")
         self._write("docs/reports/alpha.md", "# Alpha\n")
 
-        with temporary_repo_root(self.root):
-            records = gen.collect_reports(self.root / "docs" / "reports")
+        records = gen.collect_reports(self._config())
 
         self.assertEqual([record.path for record in records], ["docs/reports/alpha.md", "docs/reports/zeta.md"])
 
 
 def _rel(path: Path, root: Path) -> str:
     return str(path.relative_to(root)).replace("\\", "/")
-
-
-class temporary_repo_root:
-    def __init__(self, root: Path) -> None:
-        self.root = root
-        self.original_repo_root = gen.REPO_ROOT
-        self.original_reports_dir = gen.REPORTS_DIR
-        self.original_output_path = gen.OUTPUT_PATH
-        self.original_reference_search_paths = gen.REFERENCE_SEARCH_PATHS
-
-    def __enter__(self) -> None:
-        gen.REPO_ROOT = self.root
-        gen.REPORTS_DIR = self.root / "docs" / "reports"
-        gen.OUTPUT_PATH = self.root / "docs" / "_generated" / "report-lifecycle-inventory.md"
-        gen.REFERENCE_SEARCH_PATHS = [
-            self.root / "docs" / "tasks",
-            self.root / "docs" / "blueprints",
-            self.root / "docs" / "reports",
-            self.root / "docs" / "proofs",
-            self.root / "docs" / "roadmap.md",
-            self.root / "docs" / "_generated",
-        ]
-
-    def __exit__(self, exc_type, exc, tb) -> None:
-        gen.REPO_ROOT = self.original_repo_root
-        gen.REPORTS_DIR = self.original_reports_dir
-        gen.OUTPUT_PATH = self.original_output_path
-        gen.REFERENCE_SEARCH_PATHS = self.original_reference_search_paths
 
 
 if __name__ == "__main__":

--- a/scripts/docmeta/tests/test_generate_report_lifecycle_inventory.py
+++ b/scripts/docmeta/tests/test_generate_report_lifecycle_inventory.py
@@ -155,37 +155,68 @@ status: active
 
         self.assertEqual(records[0].derived_referenced_by_paths, ("docs/_generated/doc-index.md",))
 
-    def test_exact_path_matching_ignores_old_suffix(self) -> None:
-        self.assertFalse(
-            gen._contains_exact_path_reference(
-                "docs/reports/foo.md.old",
-                "docs/reports/foo.md",
-            )
+    def test_exact_path_matching_accepts_sentence_period(self) -> None:
+        report_path = self._write(
+            "docs/reports/foo.md",
+            """---
+status: active
+---
+# Foo
+""",
         )
+        self._write("docs/tasks/check.md", f"Read {_rel(report_path, self.root)}.\n")
 
-    def test_exact_path_matching_ignores_dash_suffix(self) -> None:
-        self.assertFalse(
-            gen._contains_exact_path_reference(
-                "docs/reports/foo.md-extra",
-                "docs/reports/foo.md",
-            )
-        )
+        records = gen.collect_reports(self._config())
 
-    def test_exact_path_matching_accepts_plain_path(self) -> None:
-        self.assertTrue(
-            gen._contains_exact_path_reference(
-                "docs/reports/foo.md",
-                "docs/reports/foo.md",
-            )
-        )
+        self.assertEqual(records[0].primary_referenced_by_paths, ("docs/tasks/check.md",))
 
-    def test_exact_path_matching_accepts_anchor_suffix(self) -> None:
-        self.assertTrue(
-            gen._contains_exact_path_reference(
-                "docs/reports/foo.md#section",
-                "docs/reports/foo.md",
-            )
-        )
+    def test_exact_path_pattern_accepts_plain_path(self) -> None:
+        pattern = gen._compile_path_reference_pattern("docs/reports/foo.md")
+        self.assertTrue(pattern.search("docs/reports/foo.md"))
+
+    def test_exact_path_pattern_accepts_sentence_period(self) -> None:
+        pattern = gen._compile_path_reference_pattern("docs/reports/foo.md")
+        self.assertTrue(pattern.search("docs/reports/foo.md."))
+
+    def test_exact_path_pattern_accepts_comma_after_path(self) -> None:
+        pattern = gen._compile_path_reference_pattern("docs/reports/foo.md")
+        self.assertTrue(pattern.search("docs/reports/foo.md,"))
+
+    def test_exact_path_pattern_accepts_semicolon_after_path(self) -> None:
+        pattern = gen._compile_path_reference_pattern("docs/reports/foo.md")
+        self.assertTrue(pattern.search("docs/reports/foo.md;"))
+
+    def test_exact_path_pattern_accepts_closing_parenthesis_after_path(self) -> None:
+        pattern = gen._compile_path_reference_pattern("docs/reports/foo.md")
+        self.assertTrue(pattern.search("(docs/reports/foo.md)"))
+
+    def test_exact_path_pattern_accepts_backtick_wrapped_path(self) -> None:
+        pattern = gen._compile_path_reference_pattern("docs/reports/foo.md")
+        self.assertTrue(pattern.search("`docs/reports/foo.md`"))
+
+    def test_exact_path_pattern_accepts_anchor_suffix(self) -> None:
+        pattern = gen._compile_path_reference_pattern("docs/reports/foo.md")
+        self.assertTrue(pattern.search("docs/reports/foo.md#section"))
+
+    def test_exact_path_pattern_rejects_old_suffix(self) -> None:
+        pattern = gen._compile_path_reference_pattern("docs/reports/foo.md")
+        self.assertFalse(pattern.search("docs/reports/foo.md.old"))
+
+    def test_exact_path_pattern_rejects_bak_suffix(self) -> None:
+        pattern = gen._compile_path_reference_pattern("docs/reports/foo.md")
+        self.assertFalse(pattern.search("docs/reports/foo.md.bak"))
+
+    def test_exact_path_pattern_rejects_dash_suffix(self) -> None:
+        pattern = gen._compile_path_reference_pattern("docs/reports/foo.md")
+        self.assertFalse(pattern.search("docs/reports/foo.md-extra"))
+
+    def test_exact_path_pattern_rejects_underscore_suffix(self) -> None:
+        pattern = gen._compile_path_reference_pattern("docs/reports/foo.md")
+        self.assertFalse(pattern.search("docs/reports/foo.md_extra"))
+
+    def test_exact_path_pattern_rejects_slash_suffix(self) -> None:
+        pattern = gen._compile_path_reference_pattern("docs/reports/foo.md")
+        self.assertFalse(pattern.search("docs/reports/foo.md/extra"))
 
     def test_superseded_by_not_absent_for_active_reports(self) -> None:
         self._write(

--- a/scripts/docmeta/tests/test_generate_report_lifecycle_inventory.py
+++ b/scripts/docmeta/tests/test_generate_report_lifecycle_inventory.py
@@ -259,6 +259,26 @@ review_after: 2026-12-01
 
         self.assertTrue(record.missing_supersession_target)
 
+    def test_terminal_status_matching_is_case_insensitive(self) -> None:
+        self._write(
+            "docs/reports/terminal.md",
+            """---
+id: docs.reports.terminal
+title: Terminal
+doc_type: report
+status: Superseded
+lifecycle: observed
+owner_task: docs/tasks/terminal.md
+review_after: 2026-12-01
+---
+# Terminal
+""",
+        )
+
+        record = gen.collect_reports(self._config())[0]
+
+        self.assertTrue(record.missing_supersession_target)
+
     def test_relations_are_rendered_in_markdown_output(self) -> None:
         self._write(
             "docs/reports/rel.md",
@@ -280,6 +300,27 @@ relations:
         self.assertIn("## Relations", markdown)
         self.assertIn("relates_to", markdown)
         self.assertIn("docs/reports/other.md", markdown)
+
+    def test_relation_target_pipe_is_escaped_in_markdown_table(self) -> None:
+        self._write(
+            "docs/reports/rel.md",
+            """---
+id: docs.reports.rel
+title: Relation
+doc_type: report
+status: active
+relations:
+  - type: relates_to
+    target: docs/reports/other|broken.md
+---
+# Relation
+""",
+        )
+
+        markdown = gen.render_inventory(gen.collect_reports(self._config()))
+
+        self.assertIn("docs/reports/other&#124;broken.md", markdown)
+        self.assertNotIn("docs/reports/other|broken.md", markdown)
 
     def test_doc_type_distribution_is_rendered(self) -> None:
         self._write("docs/reports/a.md", "---\ndoc_type: report\nstatus: active\n---\n")

--- a/scripts/docmeta/tests/test_generate_report_lifecycle_inventory.py
+++ b/scripts/docmeta/tests/test_generate_report_lifecycle_inventory.py
@@ -13,6 +13,8 @@ class TestGenerateReportLifecycleInventory(unittest.TestCase):
         self._mkdir("docs/tasks")
         self._mkdir("docs/blueprints")
         self._mkdir("docs/proofs")
+        self._mkdir("docs/adr")
+        self._mkdir("docs/specs")
         self._mkdir("docs/_generated")
 
     def tearDown(self) -> None:
@@ -32,13 +34,7 @@ class TestGenerateReportLifecycleInventory(unittest.TestCase):
             repo_root=self.root,
             reports_dir=self.root / "docs" / "reports",
             output_path=self.root / "docs" / "_generated" / "report-lifecycle-inventory.md",
-            primary_search_paths=(
-                self.root / "docs" / "tasks",
-                self.root / "docs" / "blueprints",
-                self.root / "docs" / "reports",
-                self.root / "docs" / "proofs",
-                self.root / "docs" / "roadmap.md",
-            ),
+            primary_search_paths=(self.root / "docs",),
             derived_search_paths=(self.root / "docs" / "_generated",),
         )
 
@@ -154,6 +150,54 @@ status: active
         records = gen.collect_reports(self._config())
 
         self.assertEqual(records[0].derived_referenced_by_paths, ("docs/_generated/doc-index.md",))
+
+    def test_adr_references_count_as_primary_references(self) -> None:
+        report_path = self._write(
+            "docs/reports/auth-status-matrix.md",
+            """---
+id: docs.reports.auth-status-matrix
+title: Auth Status Matrix
+doc_type: reference
+status: active
+---
+# Auth Status Matrix
+""",
+        )
+        self._write(
+            "docs/adr/ADR-0006__auth-magic-link-session-passkey.md",
+            f"See {_rel(report_path, self.root)}.\n",
+        )
+
+        records = gen.collect_reports(self._config())
+
+        self.assertEqual(
+            records[0].primary_referenced_by_paths,
+            ("docs/adr/ADR-0006__auth-magic-link-session-passkey.md",),
+        )
+
+    def test_specs_references_count_as_primary_references(self) -> None:
+        report_path = self._write(
+            "docs/reports/passkey-register-verify-prep.md",
+            """---
+id: docs.reports.passkey
+title: Passkey Prep
+doc_type: report
+status: active
+---
+# Passkey Prep
+""",
+        )
+        self._write(
+            "docs/specs/auth-api.md",
+            f"See {_rel(report_path, self.root)}.\n",
+        )
+
+        records = gen.collect_reports(self._config())
+
+        self.assertEqual(
+            records[0].primary_referenced_by_paths,
+            ("docs/specs/auth-api.md",),
+        )
 
     def test_exact_path_matching_accepts_sentence_period(self) -> None:
         report_path = self._write(


### PR DESCRIPTION
## Summary
Adds a non-blocking generated inventory for report lifecycle metadata.
This is PR 0 for the report lifecycle mechanism. It only makes the current report surface visible. It does not define policy, classify reports, archive reports, delete reports, or enforce a new guard.

## Scope
- Adds `scripts/docmeta/generate_report_lifecycle_inventory.py`
- Adds `docs/_generated/report-lifecycle-inventory.md`
- No report files changed
- No runtime/API/DB changes
- No new blocking validation

## Checks
- [x] `python3 -m scripts.docmeta.generate_report_lifecycle_inventory`
- [x] `npx markdownlint-cli2 "docs/_generated/report-lifecycle-inventory.md"`
- [x] `python3 -m unittest scripts.docmeta.tests.test_generate_report_lifecycle_inventory`
- [x] `git diff --check`

## Notes
Missing lifecycle fields are expected in this PR. Enforcement comes later.
