### PR TITLE
docs: define report lifecycle policy

### DIFF
--- a/docs/_generated/backlinks.md
+++ b/docs/_generated/backlinks.md
@@ -69,6 +69,10 @@ Generated automatically. Do not edit.
 
 - [relates_to] docs/reports/domain-edge-create-semantics-preflight.md
 
+## docs/_generated/report-lifecycle-inventory.md
+
+- [relates_to] docs/process/report-lifecycle.md
+
 ## docs/adr/0042-consume-semantah-contracts.md
 
 - [relates_to] docs/x-repo/semantAH.md
@@ -378,6 +382,7 @@ Generated automatically. Do not edit.
 
 - [relates_to] docs/process/bash-tooling-guidelines.md
 - [relates_to] docs/process/fahrplan.md
+- [relates_to] docs/process/report-lifecycle.md
 - [relates_to] docs/process/sprache.md
 
 ## docs/process/bash-tooling-guidelines.md
@@ -391,6 +396,10 @@ Generated automatically. Do not edit.
 - [relates_to] docs/process/README.md
 - [relates_to] docs/quickstart-gate-c.md
 - [depends_on] docs/roadmap.md
+
+## docs/process/report-lifecycle.md
+
+- [relates_to] docs/process/README.md
 
 ## docs/process/sprache.md
 

--- a/docs/_generated/doc-index.md
+++ b/docs/_generated/doc-index.md
@@ -12,6 +12,7 @@ Generated automatically. Do not edit.
 
 | id | title | type | status | path |
 | --- | --- | --- | --- | --- |
+| DEPLOY-DNS-001B | Historical INWX Zone Entry Checklist — Predelegation Assumption Superseded | task | done | docs/tasks/DEPLOY-DNS-001B.md |
 | adr.0042-consume-semantah-contracts | ADR-0042 — SemanticAH-Contracts konsumieren | reference | active | docs/adr/0042-consume-semantah-contracts.md |
 | adr.0043-edge-vs-conversation | ADR-0043 — Edge vs. Conversation | reference | active | docs/adr/0043-edge-vs-conversation.md |
 | adr.ADR-0001__clean-slate-docs-monorepo | ADR-0001 — Clean Slate und Docs-Monorepo | reference | active | docs/adr/ADR-0001__clean-slate-docs-monorepo.md |
@@ -22,9 +23,9 @@ Generated automatically. Do not edit.
 | adr.ADR-0006-auth-magic-link-session-passkey | ADR-0006 — Auth: Magic Link, Session und optionaler Passkey | reference | active | docs/adr/ADR-0006__auth-magic-link-session-passkey.md |
 | adr.ADR-0007-auth-persistence-production-db-path | ADR-0007 — Auth-Persistenz Produktionspfad: Direkter PostgreSQL-Zugriff statt PgBouncer | reference | accepted | docs/adr/ADR-0007__auth-persistence-production-db-path.md |
 | adr.ADR-0008-domain-mail-provider-boundaries | ADR-0008 — Domain-, Mail- und SMTP-Providergrenzen | reference | accepted | docs/adr/ADR-0008__domain-mail-provider-boundaries.md |
+| blueprint-doc-structure-task-control | Weltgewebe Dokumentationsstruktur und Task-Steuerung | blueprint | draft | docs/blueprints/doc-structure-task-control.md |
 | blueprint-doc-structure-task-control-examples | Dokumentationsstruktur und Task-Steuerung Beispiele | reference | draft | docs/blueprints/doc-structure-task-control-examples.md |
 | blueprint-doc-structure-task-control-roadmap | Dokumentationsstruktur und Task-Steuerung Roadmap | roadmap | draft | docs/blueprints/doc-structure-task-control-roadmap.md |
-| blueprint-doc-structure-task-control | Weltgewebe Dokumentationsstruktur und Task-Steuerung | blueprint | draft | docs/blueprints/doc-structure-task-control.md |
 | blueprints.auth-persistence-runtime-proof | Auth-Persistenz — Runtime-Proof-Blaupause | blueprint | active | docs/blueprints/auth-persistence-runtime-proof.md |
 | blueprints.auth-roadmap | Auth Roadmap | roadmap | active | docs/blueprints/auth-roadmap.md |
 | blueprints.domain-data-postgres-cutover | Domain Data PostgreSQL Cutover | blueprint | active | docs/blueprints/domain-data-postgres-cutover.md |
@@ -33,18 +34,17 @@ Generated automatically. Do not edit.
 | blueprints.weltgewebe.deploy.plan | Deploy-Plan | reference | deprecated | docs/blueprints/weltgewebe.deploy.plan.md |
 | datenmodell | Datenmodell | reference | active | docs/datenmodell.md |
 | deploy.CHANGELOG | Deploy Changelog | reference | active | docs/deploy/CHANGELOG.md |
-| DEPLOY-DNS-001B | Historical INWX Zone Entry Checklist — Predelegation Assumption Superseded | task | done | docs/tasks/DEPLOY-DNS-001B.md |
-| deploy.domain-mail-migration-ionos-inwx-mailbox-brevo | Domain-/Mail-Migration: IONOS zu INWX + mailbox.org + Brevo | reference | active | docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md |
 | deploy.DRIFT_POLICY | Drift Policy | reference | active | docs/deploy/DRIFT_POLICY.md |
+| deploy.README | Deployment-Übersicht | reference | active | docs/deploy/README.md |
+| deploy.domain-mail-migration-ionos-inwx-mailbox-brevo | Domain-/Mail-Migration: IONOS zu INWX + mailbox.org + Brevo | reference | active | docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md |
 | deploy.heim-first-phase0 | Heim-First Phase 0 | reference | active | docs/deploy/heim-first-phase0.md |
 | deploy.heimserver.deployment | Heimserver Deployment | reference | active | docs/deploy/heimserver.deployment.md |
 | deploy.heimserver.integration | Heimserver Integration | reference | active | docs/deploy/heimserver.integration.md |
-| deployment-contract | Deployment Contract and Preflight Guard | guide | active | docs/deployment.md |
-| deployment_governance | Deployment Governance | reference | active | docs/deployment_governance.md |
-| deploy.README | Deployment-Übersicht | reference | active | docs/deploy/README.md |
 | deploy.security | Deploy Security | architecture | active | docs/deploy/security.md |
 | deploy.vps | VPS-Deployment | reference | active | docs/deploy/vps.md |
 | deploy.weltgewebe.naming | Weltgewebe Naming | reference | active | docs/deploy/weltgewebe.naming.md |
+| deployment-contract | Deployment Contract and Preflight Guard | guide | active | docs/deployment.md |
+| deployment_governance | Deployment Governance | reference | active | docs/deployment_governance.md |
 | dev.codespaces | Codespaces | reference | active | docs/dev/codespaces.md |
 | docs.architecture.overview | Architekturüberblick | architecture | active | docs/architekturstruktur.md |
 | docs.blueprints.agent-operability | Minimaler Agent-Operability-Kern | blueprint | draft | docs/blueprints/agent-operability-blaupause.md |
@@ -60,8 +60,8 @@ Generated automatically. Do not edit.
 | docs.reference.agent-operability-fixture-matrix | Agent-Betriebsfaehigkeit: Fixture-Matrix | reference | active | docs/reference/agent-operability-fixture-matrix.md |
 | docs.reports.agent-readiness-audit | Agent Readiness Audit | documentation | active | docs/reports/agent-readiness-audit.md |
 | docs.roadmap | Weltgewebe — Master-Umsetzungsroadmap | roadmap | active | docs/roadmap.md |
-| docs.runbook.observability | Observability Runbook | runbook | active | docs/runbook.observability.md |
 | docs.runbook | Runbook | runbook | active | docs/runbook.md |
+| docs.runbook.observability | Observability Runbook | runbook | active | docs/runbook.observability.md |
 | docs.security.agent-write-scope-baseline | Agent Write Scope Baseline | security | active | docs/security/agent-write-scope-baseline.md |
 | docs.techstack | Techstack | architecture | active | docs/techstack.md |
 | docs.vision | Vision | reference | active | docs/vision.md |
@@ -79,9 +79,9 @@ Generated automatically. Do not edit.
 | overview.inhalt | Inhalt (Übersicht) | reference | active | docs/overview/inhalt.md |
 | overview.zusammenstellung | Zusammenstellung (Übersicht) | reference | active | docs/overview/zusammenstellung.md |
 | policies.orientierung | Orientierung | reference | active | docs/policies/orientierung.md |
+| process.README | Prozess-Übersicht | reference | active | docs/process/README.md |
 | process.bash-tooling-guidelines | Bash Tooling Guidelines | reference | active | docs/process/bash-tooling-guidelines.md |
 | process.fahrplan | Fahrplan | reference | active | docs/process/fahrplan.md |
-| process.README | Prozess-Übersicht | reference | active | docs/process/README.md |
 | process.report-lifecycle | Report Lifecycle Policy | policy | draft | docs/process/report-lifecycle.md |
 | process.sprache | Sprache | reference | active | docs/process/sprache.md |
 | proofs.sqlx-pgbouncer-session-crud-proof | SQLx → PgBouncer → Postgres — Session-CRUD-Proof | report | active | docs/proofs/sqlx-pgbouncer-session-crud-proof.md |
@@ -108,12 +108,12 @@ Generated automatically. Do not edit.
 | reports.optimierungsstatus | Optimierungsstatus Weltgewebe | status-matrix | active | docs/reports/optimierungsstatus.md |
 | reports.passkey-register-verify-prep | Passkey Register-Verify – Vorbereitungsbericht | report | active | docs/reports/passkey-register-verify-prep.md |
 | reports.planning-registration-findings | Planning Registration Findings Triage | report | active | docs/reports/planning-registration-findings.md |
+| runbooks.README | Runbooks-Übersicht | reference | active | docs/runbooks/README.md |
 | runbooks.codespaces-recovery | Codespaces Recovery | reference | active | docs/runbooks/codespaces-recovery.md |
 | runbooks.db-recovery | DB Recovery Runbook | reference | active | docs/runbooks/db-recovery.md |
 | runbooks.domain-mail-cutover | Runbook — Domain-, Mail- und SMTP-Cutover | runbook | active | docs/runbooks/domain-mail-cutover.md |
 | runbooks.incident-response | Incident Response Runbook | reference | active | docs/runbooks/incident-response.md |
 | runbooks.ops.runbook.weltgewebe-selfhost-deploy | Selfhost-Deploy Runbook | reference | active | docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md |
-| runbooks.README | Runbooks-Übersicht | reference | active | docs/runbooks/README.md |
 | runbooks.uv-tooling | UV-Tooling | reference | active | docs/runbooks/uv-tooling.md |
 | specs.auth-api | Auth API Spec | reference | active | docs/specs/auth-api.md |
 | specs.auth-blueprint | Auth Blueprint | reference | active | docs/specs/auth-blueprint.md |

--- a/docs/_generated/doc-index.md
+++ b/docs/_generated/doc-index.md
@@ -12,7 +12,6 @@ Generated automatically. Do not edit.
 
 | id | title | type | status | path |
 | --- | --- | --- | --- | --- |
-| DEPLOY-DNS-001B | Historical INWX Zone Entry Checklist — Predelegation Assumption Superseded | task | done | docs/tasks/DEPLOY-DNS-001B.md |
 | adr.0042-consume-semantah-contracts | ADR-0042 — SemanticAH-Contracts konsumieren | reference | active | docs/adr/0042-consume-semantah-contracts.md |
 | adr.0043-edge-vs-conversation | ADR-0043 — Edge vs. Conversation | reference | active | docs/adr/0043-edge-vs-conversation.md |
 | adr.ADR-0001__clean-slate-docs-monorepo | ADR-0001 — Clean Slate und Docs-Monorepo | reference | active | docs/adr/ADR-0001__clean-slate-docs-monorepo.md |
@@ -23,9 +22,9 @@ Generated automatically. Do not edit.
 | adr.ADR-0006-auth-magic-link-session-passkey | ADR-0006 — Auth: Magic Link, Session und optionaler Passkey | reference | active | docs/adr/ADR-0006__auth-magic-link-session-passkey.md |
 | adr.ADR-0007-auth-persistence-production-db-path | ADR-0007 — Auth-Persistenz Produktionspfad: Direkter PostgreSQL-Zugriff statt PgBouncer | reference | accepted | docs/adr/ADR-0007__auth-persistence-production-db-path.md |
 | adr.ADR-0008-domain-mail-provider-boundaries | ADR-0008 — Domain-, Mail- und SMTP-Providergrenzen | reference | accepted | docs/adr/ADR-0008__domain-mail-provider-boundaries.md |
-| blueprint-doc-structure-task-control | Weltgewebe Dokumentationsstruktur und Task-Steuerung | blueprint | draft | docs/blueprints/doc-structure-task-control.md |
 | blueprint-doc-structure-task-control-examples | Dokumentationsstruktur und Task-Steuerung Beispiele | reference | draft | docs/blueprints/doc-structure-task-control-examples.md |
 | blueprint-doc-structure-task-control-roadmap | Dokumentationsstruktur und Task-Steuerung Roadmap | roadmap | draft | docs/blueprints/doc-structure-task-control-roadmap.md |
+| blueprint-doc-structure-task-control | Weltgewebe Dokumentationsstruktur und Task-Steuerung | blueprint | draft | docs/blueprints/doc-structure-task-control.md |
 | blueprints.auth-persistence-runtime-proof | Auth-Persistenz — Runtime-Proof-Blaupause | blueprint | active | docs/blueprints/auth-persistence-runtime-proof.md |
 | blueprints.auth-roadmap | Auth Roadmap | roadmap | active | docs/blueprints/auth-roadmap.md |
 | blueprints.domain-data-postgres-cutover | Domain Data PostgreSQL Cutover | blueprint | active | docs/blueprints/domain-data-postgres-cutover.md |
@@ -34,17 +33,18 @@ Generated automatically. Do not edit.
 | blueprints.weltgewebe.deploy.plan | Deploy-Plan | reference | deprecated | docs/blueprints/weltgewebe.deploy.plan.md |
 | datenmodell | Datenmodell | reference | active | docs/datenmodell.md |
 | deploy.CHANGELOG | Deploy Changelog | reference | active | docs/deploy/CHANGELOG.md |
-| deploy.DRIFT_POLICY | Drift Policy | reference | active | docs/deploy/DRIFT_POLICY.md |
-| deploy.README | Deployment-Übersicht | reference | active | docs/deploy/README.md |
+| DEPLOY-DNS-001B | Historical INWX Zone Entry Checklist — Predelegation Assumption Superseded | task | done | docs/tasks/DEPLOY-DNS-001B.md |
 | deploy.domain-mail-migration-ionos-inwx-mailbox-brevo | Domain-/Mail-Migration: IONOS zu INWX + mailbox.org + Brevo | reference | active | docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md |
+| deploy.DRIFT_POLICY | Drift Policy | reference | active | docs/deploy/DRIFT_POLICY.md |
 | deploy.heim-first-phase0 | Heim-First Phase 0 | reference | active | docs/deploy/heim-first-phase0.md |
 | deploy.heimserver.deployment | Heimserver Deployment | reference | active | docs/deploy/heimserver.deployment.md |
 | deploy.heimserver.integration | Heimserver Integration | reference | active | docs/deploy/heimserver.integration.md |
+| deployment-contract | Deployment Contract and Preflight Guard | guide | active | docs/deployment.md |
+| deployment_governance | Deployment Governance | reference | active | docs/deployment_governance.md |
+| deploy.README | Deployment-Übersicht | reference | active | docs/deploy/README.md |
 | deploy.security | Deploy Security | architecture | active | docs/deploy/security.md |
 | deploy.vps | VPS-Deployment | reference | active | docs/deploy/vps.md |
 | deploy.weltgewebe.naming | Weltgewebe Naming | reference | active | docs/deploy/weltgewebe.naming.md |
-| deployment-contract | Deployment Contract and Preflight Guard | guide | active | docs/deployment.md |
-| deployment_governance | Deployment Governance | reference | active | docs/deployment_governance.md |
 | dev.codespaces | Codespaces | reference | active | docs/dev/codespaces.md |
 | docs.architecture.overview | Architekturüberblick | architecture | active | docs/architekturstruktur.md |
 | docs.blueprints.agent-operability | Minimaler Agent-Operability-Kern | blueprint | draft | docs/blueprints/agent-operability-blaupause.md |
@@ -60,8 +60,8 @@ Generated automatically. Do not edit.
 | docs.reference.agent-operability-fixture-matrix | Agent-Betriebsfaehigkeit: Fixture-Matrix | reference | active | docs/reference/agent-operability-fixture-matrix.md |
 | docs.reports.agent-readiness-audit | Agent Readiness Audit | documentation | active | docs/reports/agent-readiness-audit.md |
 | docs.roadmap | Weltgewebe — Master-Umsetzungsroadmap | roadmap | active | docs/roadmap.md |
-| docs.runbook | Runbook | runbook | active | docs/runbook.md |
 | docs.runbook.observability | Observability Runbook | runbook | active | docs/runbook.observability.md |
+| docs.runbook | Runbook | runbook | active | docs/runbook.md |
 | docs.security.agent-write-scope-baseline | Agent Write Scope Baseline | security | active | docs/security/agent-write-scope-baseline.md |
 | docs.techstack | Techstack | architecture | active | docs/techstack.md |
 | docs.vision | Vision | reference | active | docs/vision.md |
@@ -79,9 +79,9 @@ Generated automatically. Do not edit.
 | overview.inhalt | Inhalt (Übersicht) | reference | active | docs/overview/inhalt.md |
 | overview.zusammenstellung | Zusammenstellung (Übersicht) | reference | active | docs/overview/zusammenstellung.md |
 | policies.orientierung | Orientierung | reference | active | docs/policies/orientierung.md |
-| process.README | Prozess-Übersicht | reference | active | docs/process/README.md |
 | process.bash-tooling-guidelines | Bash Tooling Guidelines | reference | active | docs/process/bash-tooling-guidelines.md |
 | process.fahrplan | Fahrplan | reference | active | docs/process/fahrplan.md |
+| process.README | Prozess-Übersicht | reference | active | docs/process/README.md |
 | process.report-lifecycle | Report Lifecycle Policy | policy | draft | docs/process/report-lifecycle.md |
 | process.sprache | Sprache | reference | active | docs/process/sprache.md |
 | proofs.sqlx-pgbouncer-session-crud-proof | SQLx → PgBouncer → Postgres — Session-CRUD-Proof | report | active | docs/proofs/sqlx-pgbouncer-session-crud-proof.md |
@@ -108,12 +108,12 @@ Generated automatically. Do not edit.
 | reports.optimierungsstatus | Optimierungsstatus Weltgewebe | status-matrix | active | docs/reports/optimierungsstatus.md |
 | reports.passkey-register-verify-prep | Passkey Register-Verify – Vorbereitungsbericht | report | active | docs/reports/passkey-register-verify-prep.md |
 | reports.planning-registration-findings | Planning Registration Findings Triage | report | active | docs/reports/planning-registration-findings.md |
-| runbooks.README | Runbooks-Übersicht | reference | active | docs/runbooks/README.md |
 | runbooks.codespaces-recovery | Codespaces Recovery | reference | active | docs/runbooks/codespaces-recovery.md |
 | runbooks.db-recovery | DB Recovery Runbook | reference | active | docs/runbooks/db-recovery.md |
 | runbooks.domain-mail-cutover | Runbook — Domain-, Mail- und SMTP-Cutover | runbook | active | docs/runbooks/domain-mail-cutover.md |
 | runbooks.incident-response | Incident Response Runbook | reference | active | docs/runbooks/incident-response.md |
 | runbooks.ops.runbook.weltgewebe-selfhost-deploy | Selfhost-Deploy Runbook | reference | active | docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md |
+| runbooks.README | Runbooks-Übersicht | reference | active | docs/runbooks/README.md |
 | runbooks.uv-tooling | UV-Tooling | reference | active | docs/runbooks/uv-tooling.md |
 | specs.auth-api | Auth API Spec | reference | active | docs/specs/auth-api.md |
 | specs.auth-blueprint | Auth Blueprint | reference | active | docs/specs/auth-blueprint.md |

--- a/docs/_generated/doc-index.md
+++ b/docs/_generated/doc-index.md
@@ -12,6 +12,7 @@ Generated automatically. Do not edit.
 
 | id | title | type | status | path |
 | --- | --- | --- | --- | --- |
+| DEPLOY-DNS-001B | Historical INWX Zone Entry Checklist — Predelegation Assumption Superseded | task | done | docs/tasks/DEPLOY-DNS-001B.md |
 | adr.0042-consume-semantah-contracts | ADR-0042 — SemanticAH-Contracts konsumieren | reference | active | docs/adr/0042-consume-semantah-contracts.md |
 | adr.0043-edge-vs-conversation | ADR-0043 — Edge vs. Conversation | reference | active | docs/adr/0043-edge-vs-conversation.md |
 | adr.ADR-0001__clean-slate-docs-monorepo | ADR-0001 — Clean Slate und Docs-Monorepo | reference | active | docs/adr/ADR-0001__clean-slate-docs-monorepo.md |
@@ -22,9 +23,9 @@ Generated automatically. Do not edit.
 | adr.ADR-0006-auth-magic-link-session-passkey | ADR-0006 — Auth: Magic Link, Session und optionaler Passkey | reference | active | docs/adr/ADR-0006__auth-magic-link-session-passkey.md |
 | adr.ADR-0007-auth-persistence-production-db-path | ADR-0007 — Auth-Persistenz Produktionspfad: Direkter PostgreSQL-Zugriff statt PgBouncer | reference | accepted | docs/adr/ADR-0007__auth-persistence-production-db-path.md |
 | adr.ADR-0008-domain-mail-provider-boundaries | ADR-0008 — Domain-, Mail- und SMTP-Providergrenzen | reference | accepted | docs/adr/ADR-0008__domain-mail-provider-boundaries.md |
+| blueprint-doc-structure-task-control | Weltgewebe Dokumentationsstruktur und Task-Steuerung | blueprint | draft | docs/blueprints/doc-structure-task-control.md |
 | blueprint-doc-structure-task-control-examples | Dokumentationsstruktur und Task-Steuerung Beispiele | reference | draft | docs/blueprints/doc-structure-task-control-examples.md |
 | blueprint-doc-structure-task-control-roadmap | Dokumentationsstruktur und Task-Steuerung Roadmap | roadmap | draft | docs/blueprints/doc-structure-task-control-roadmap.md |
-| blueprint-doc-structure-task-control | Weltgewebe Dokumentationsstruktur und Task-Steuerung | blueprint | draft | docs/blueprints/doc-structure-task-control.md |
 | blueprints.auth-persistence-runtime-proof | Auth-Persistenz — Runtime-Proof-Blaupause | blueprint | active | docs/blueprints/auth-persistence-runtime-proof.md |
 | blueprints.auth-roadmap | Auth Roadmap | roadmap | active | docs/blueprints/auth-roadmap.md |
 | blueprints.domain-data-postgres-cutover | Domain Data PostgreSQL Cutover | blueprint | active | docs/blueprints/domain-data-postgres-cutover.md |
@@ -33,18 +34,17 @@ Generated automatically. Do not edit.
 | blueprints.weltgewebe.deploy.plan | Deploy-Plan | reference | deprecated | docs/blueprints/weltgewebe.deploy.plan.md |
 | datenmodell | Datenmodell | reference | active | docs/datenmodell.md |
 | deploy.CHANGELOG | Deploy Changelog | reference | active | docs/deploy/CHANGELOG.md |
-| DEPLOY-DNS-001B | Historical INWX Zone Entry Checklist — Predelegation Assumption Superseded | task | done | docs/tasks/DEPLOY-DNS-001B.md |
-| deploy.domain-mail-migration-ionos-inwx-mailbox-brevo | Domain-/Mail-Migration: IONOS zu INWX + mailbox.org + Brevo | reference | active | docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md |
 | deploy.DRIFT_POLICY | Drift Policy | reference | active | docs/deploy/DRIFT_POLICY.md |
+| deploy.README | Deployment-Übersicht | reference | active | docs/deploy/README.md |
+| deploy.domain-mail-migration-ionos-inwx-mailbox-brevo | Domain-/Mail-Migration: IONOS zu INWX + mailbox.org + Brevo | reference | active | docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md |
 | deploy.heim-first-phase0 | Heim-First Phase 0 | reference | active | docs/deploy/heim-first-phase0.md |
 | deploy.heimserver.deployment | Heimserver Deployment | reference | active | docs/deploy/heimserver.deployment.md |
 | deploy.heimserver.integration | Heimserver Integration | reference | active | docs/deploy/heimserver.integration.md |
-| deployment-contract | Deployment Contract and Preflight Guard | guide | active | docs/deployment.md |
-| deployment_governance | Deployment Governance | reference | active | docs/deployment_governance.md |
-| deploy.README | Deployment-Übersicht | reference | active | docs/deploy/README.md |
 | deploy.security | Deploy Security | architecture | active | docs/deploy/security.md |
 | deploy.vps | VPS-Deployment | reference | active | docs/deploy/vps.md |
 | deploy.weltgewebe.naming | Weltgewebe Naming | reference | active | docs/deploy/weltgewebe.naming.md |
+| deployment-contract | Deployment Contract and Preflight Guard | guide | active | docs/deployment.md |
+| deployment_governance | Deployment Governance | reference | active | docs/deployment_governance.md |
 | dev.codespaces | Codespaces | reference | active | docs/dev/codespaces.md |
 | docs.architecture.overview | Architekturüberblick | architecture | active | docs/architekturstruktur.md |
 | docs.blueprints.agent-operability | Minimaler Agent-Operability-Kern | blueprint | draft | docs/blueprints/agent-operability-blaupause.md |
@@ -60,8 +60,8 @@ Generated automatically. Do not edit.
 | docs.reference.agent-operability-fixture-matrix | Agent-Betriebsfaehigkeit: Fixture-Matrix | reference | active | docs/reference/agent-operability-fixture-matrix.md |
 | docs.reports.agent-readiness-audit | Agent Readiness Audit | documentation | active | docs/reports/agent-readiness-audit.md |
 | docs.roadmap | Weltgewebe — Master-Umsetzungsroadmap | roadmap | active | docs/roadmap.md |
-| docs.runbook.observability | Observability Runbook | runbook | active | docs/runbook.observability.md |
 | docs.runbook | Runbook | runbook | active | docs/runbook.md |
+| docs.runbook.observability | Observability Runbook | runbook | active | docs/runbook.observability.md |
 | docs.security.agent-write-scope-baseline | Agent Write Scope Baseline | security | active | docs/security/agent-write-scope-baseline.md |
 | docs.techstack | Techstack | architecture | active | docs/techstack.md |
 | docs.vision | Vision | reference | active | docs/vision.md |
@@ -79,9 +79,10 @@ Generated automatically. Do not edit.
 | overview.inhalt | Inhalt (Übersicht) | reference | active | docs/overview/inhalt.md |
 | overview.zusammenstellung | Zusammenstellung (Übersicht) | reference | active | docs/overview/zusammenstellung.md |
 | policies.orientierung | Orientierung | reference | active | docs/policies/orientierung.md |
+| process.README | Prozess-Übersicht | reference | active | docs/process/README.md |
 | process.bash-tooling-guidelines | Bash Tooling Guidelines | reference | active | docs/process/bash-tooling-guidelines.md |
 | process.fahrplan | Fahrplan | reference | active | docs/process/fahrplan.md |
-| process.README | Prozess-Übersicht | reference | active | docs/process/README.md |
+| process.report-lifecycle | Report Lifecycle Policy | policy | draft | docs/process/report-lifecycle.md |
 | process.sprache | Sprache | reference | active | docs/process/sprache.md |
 | proofs.sqlx-pgbouncer-session-crud-proof | SQLx → PgBouncer → Postgres — Session-CRUD-Proof | report | active | docs/proofs/sqlx-pgbouncer-session-crud-proof.md |
 | proofs.sqlx-postgres-direct-session-crud-proof | SQLx \u2192 direkter PostgreSQL \u2014 Session-CRUD-Proof | report | active | docs/proofs/sqlx-postgres-direct-session-crud-proof.md |
@@ -107,12 +108,12 @@ Generated automatically. Do not edit.
 | reports.optimierungsstatus | Optimierungsstatus Weltgewebe | status-matrix | active | docs/reports/optimierungsstatus.md |
 | reports.passkey-register-verify-prep | Passkey Register-Verify – Vorbereitungsbericht | report | active | docs/reports/passkey-register-verify-prep.md |
 | reports.planning-registration-findings | Planning Registration Findings Triage | report | active | docs/reports/planning-registration-findings.md |
+| runbooks.README | Runbooks-Übersicht | reference | active | docs/runbooks/README.md |
 | runbooks.codespaces-recovery | Codespaces Recovery | reference | active | docs/runbooks/codespaces-recovery.md |
 | runbooks.db-recovery | DB Recovery Runbook | reference | active | docs/runbooks/db-recovery.md |
 | runbooks.domain-mail-cutover | Runbook — Domain-, Mail- und SMTP-Cutover | runbook | active | docs/runbooks/domain-mail-cutover.md |
 | runbooks.incident-response | Incident Response Runbook | reference | active | docs/runbooks/incident-response.md |
 | runbooks.ops.runbook.weltgewebe-selfhost-deploy | Selfhost-Deploy Runbook | reference | active | docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md |
-| runbooks.README | Runbooks-Übersicht | reference | active | docs/runbooks/README.md |
 | runbooks.uv-tooling | UV-Tooling | reference | active | docs/runbooks/uv-tooling.md |
 | specs.auth-api | Auth API Spec | reference | active | docs/specs/auth-api.md |
 | specs.auth-blueprint | Auth Blueprint | reference | active | docs/specs/auth-blueprint.md |

--- a/docs/_generated/relates-to-audit.md
+++ b/docs/_generated/relates-to-audit.md
@@ -14,9 +14,9 @@ Generated automatically. Do not edit.
 
 | Metrik | Wert |
 | --- | --- |
-| Relationen gesamt | 368 |
+| Relationen gesamt | 371 |
 | — depends_on | 18 |
-| — relates_to | 348 |
+| — relates_to | 351 |
 | — supersedes | 2 |
 | relates_to Anteil | 95% |
 
@@ -30,7 +30,7 @@ _Keine Lücken erkannt._
 
 > Zusammenhängende Gruppen im relates_to-Graphen.
 
-**Cluster 1** (134 Dokumente):
+**Cluster 1** (136 Dokumente):
 
 - `.github/workflows/api.yml`
 - `AGENTS.md`
@@ -44,6 +44,7 @@ _Keine Lücken erkannt._
 - `apps/api/tests/db_domain_backfill.rs`
 - `audit/impl-registry.yaml`
 - `contracts/domain/edge.schema.json`
+- `docs/_generated/report-lifecycle-inventory.md`
 - `docs/adr/0043-edge-vs-conversation.md`
 - `docs/adr/ADR-0001__clean-slate-docs-monorepo.md`
 - `docs/adr/ADR-0002__reentry-kriterien.md`
@@ -105,6 +106,7 @@ _Keine Lücken erkannt._
 - `docs/process/README.md`
 - `docs/process/bash-tooling-guidelines.md`
 - `docs/process/fahrplan.md`
+- `docs/process/report-lifecycle.md`
 - `docs/process/sprache.md`
 - `docs/proofs/basemap-hamburg-artifact-proof.md`
 - `docs/proofs/sqlx-pgbouncer-session-crud-proof.md`

--- a/docs/_generated/relations-analysis.md
+++ b/docs/_generated/relations-analysis.md
@@ -14,12 +14,12 @@ Generated automatically. Do not edit.
 
 | Metrik | Wert |
 | --- | --- |
-| Dokumente gesamt | 121 |
-| Dokumente mit ausgehenden Relationen | 118 |
-| Dokumente als Ziel referenziert | 92 |
-| Relationen gesamt | 368 |
+| Dokumente gesamt | 122 |
+| Dokumente mit ausgehenden Relationen | 119 |
+| Dokumente als Ziel referenziert | 93 |
+| Relationen gesamt | 371 |
 | — depends_on | 18 |
-| — relates_to | 348 |
+| — relates_to | 351 |
 | — supersedes | 2 |
 | Isolierte Dokumente | 2 |
 | depends_on Zyklen | 0 |

--- a/docs/process/README.md
+++ b/docs/process/README.md
@@ -22,7 +22,7 @@ relations:
 
 - [Fahrplan](fahrplan.md) – zeitlicher Ablauf und Meilensteine (**kanonisch**)
 - [Sprache](sprache.md) – Leitfaden zur Projektsprache
-- [Report Lifecycle Policy](report-lifecycle.md) – Regeln für Status, Review, Ablösung, Archivierung und Löschung von Reports
+- [Report Lifecycle Policy](report-lifecycle.md) – Regeln für Status, Review, Ablösung, Archivierung und Löschung von Reports.
 - [Bash Tooling Guidelines](bash-tooling-guidelines.md) – Best Practices für zukünftige Shell-Skripte
 
 [Zurück zum Doku-Index](../index.md)

--- a/docs/process/README.md
+++ b/docs/process/README.md
@@ -6,6 +6,8 @@ status: active
 summary: Übersicht über Abläufe, Konventionen und den Fahrplan des Projekts.
 relations:
   - type: relates_to
+    target: docs/process/report-lifecycle.md
+  - type: relates_to
     target: docs/process/fahrplan.md
   - type: relates_to
     target: docs/process/sprache.md
@@ -20,6 +22,7 @@ relations:
 
 - [Fahrplan](fahrplan.md) – zeitlicher Ablauf und Meilensteine (**kanonisch**)
 - [Sprache](sprache.md) – Leitfaden zur Projektsprache
+- [Report Lifecycle Policy](report-lifecycle.md) – Regeln für Status, Review, Ablösung, Archivierung und Löschung von Reports.
 - [Bash Tooling Guidelines](bash-tooling-guidelines.md) – Best Practices für zukünftige Shell-Skripte
 
 [Zurück zum Doku-Index](../index.md)

--- a/docs/process/README.md
+++ b/docs/process/README.md
@@ -22,7 +22,7 @@ relations:
 
 - [Fahrplan](fahrplan.md) – zeitlicher Ablauf und Meilensteine (**kanonisch**)
 - [Sprache](sprache.md) – Leitfaden zur Projektsprache
-- [Report Lifecycle Policy](report-lifecycle.md) – Regeln für Status, Review, Ablösung, Archivierung und Löschung von Reports.
+- [Report Lifecycle Policy](report-lifecycle.md) – Regeln für Status, Review, Ablösung, Archivierung und Löschung von Reports
 - [Bash Tooling Guidelines](bash-tooling-guidelines.md) – Best Practices für zukünftige Shell-Skripte
 
 [Zurück zum Doku-Index](../index.md)

--- a/docs/process/report-lifecycle.md
+++ b/docs/process/report-lifecycle.md
@@ -31,6 +31,10 @@ Jeder Report soll später beantworten können:
 
 Wichtig: Diese Policy ist eine Regelgrundlage, keine rückwirkende Bereinigung.
 
+Diese Policy ist der kanonische Ort für Report-Lifecycle-Regeln. Ihr Status
+bleibt `draft`, bis Pilot-Annotation und Warnmodus die Begriffe praktisch
+bestätigt haben.
+
 ## Geltungsbereich
 
 Gilt für:
@@ -71,10 +75,10 @@ Diese Policy beschreibt zunächst Reports. Andere Dokumenttypen können Reports 
 ## Report-Klassen
 
 - **audit**: Prüft einen Bestand, Datenzustand oder Prozesszustand. Risiko: veraltet schnell, wenn Daten oder Prozess wechseln.
-- **proof**: Belegt eine technische oder organisatorische Eigenschaft. Risiko: verliert Gültigkeit bei Code-, CI- oder Infrastrukturänderungen.
+- **proof**: Belegt eine technische oder organisatorische Eigenschaft. Risiko: verliert Gültigkeit bei Code-, CI- oder Infrastrukturänderungen. Die Klasse `proof` kann für Reports unter `docs/reports/*.md` genutzt werden, die einen Proof-Charakter haben. Dateien unter `docs/proofs/**` bleiben in dieser Phase vom Geltungsbereich ausgenommen und können später eine eigene Lifecycle-Regel bekommen.
 - **status**: Verdichtet aktuellen Stand eines Vorhabens. Risiko: wird leicht mit dauerhafter Wahrheit verwechselt.
 - **decision-prep**: Bereitet eine Entscheidung vor, ersetzt sie aber nicht. Risiko: bleibt nach Entscheidung weiter sichtbar, obwohl die Entscheidung schon gefallen ist.
-- **generated**: Wird automatisch erzeugt und soll nicht manuell editiert werden. Risiko: Drift zwischen Generator und committed Artefakt.
+- **generated**: Wird automatisch erzeugt und soll nicht manuell editiert werden. Diese Klasse gilt nur für Artefakte, die ausdrücklich als Report geführt werden. Nicht jedes Artefakt unter `docs/_generated/**` wird dadurch zu einem Report. Risiko: Drift zwischen Generator und committed Artefakt.
 - **planning**: Beschreibt geplante Arbeit, offene Schritte oder Ordnungsvorhaben. Risiko: Planungsstand wird mit Umsetzung verwechselt.
 - **legacy**: Historisch nützlich, aber nicht mehr aktuell handlungsleitend. Risiko: unmarkierte Legacy-Dokumente erzeugen Scheinkohärenz.
 
@@ -95,9 +99,24 @@ Wichtig:
 ## Lifecycle-Felder
 
 - **lifecycle**: Report-Klasse oder Lifecycle-Rolle.
+- `lifecycle` ersetzt `doc_type` nicht. `doc_type` beschreibt die Dokumentart
+  im Repo, zum Beispiel `report` oder `policy`. `lifecycle` beschreibt die
+  Rolle eines Reports innerhalb seines Lebenszyklus, zum Beispiel `audit`,
+  `proof` oder `status`.
 - **owner_task**: Task, Vorhaben, Kontrollpunkt oder Prozess, der die Verantwortung für den Report trägt. In Phase 1 noch als menschlich lesbarer Wert (noch kein Enum erzwingen).
-- **review_after**: Datum, ab dem erneute Prüfung fällig wird. Für spätere Validatoren soll ein ISO-Datum YYYY-MM-DD bevorzugt werden.
+- **review_after**: ISO-Datum im Format `YYYY-MM-DD`, ab dem erneute Prüfung
+  fällig wird.
 - **superseded_by**: Pfad zum ablösenden Artefakt. Kann ein anderer Report, ein Blueprint, ein Proof oder ein anderes kanonisches Dokument sein.
+
+```yaml
+doc_type: report
+lifecycle: audit
+```
+
+Die Lifecycle-Felder werden in exakt dieser snake_case-Schreibweise geführt:
+`lifecycle`, `owner_task`, `review_after`, `superseded_by`. Spätere Validatoren
+sollen abweichende Schreibweisen wie `ownerTask` oder `reviewAfter` nicht als
+gleichwertig behandeln.
 
 ## Pflichtfelder nach Status
 
@@ -105,10 +124,10 @@ Wichtig:
 | --- | --- | --- | --- | --- | --- |
 | draft | empfohlen | empfohlen | optional | nein | Noch nicht handlungsleitend, aber spätere Zuordnung soll vorbereitet werden. |
 | active | erforderlich | erforderlich | erforderlich | nein | Aktive Reports brauchen Zweck, Verantwortung und Review-Zeitpunkt. |
-| deferred | erforderlich | erforderlich | erforderlich | optional | Zurückgestellte Reports brauchen einen Wiedervorlagepunkt. |
+| deferred | erforderlich | erforderlich | erforderlich | nein | Zurückgestellte Reports warten auf Prüfung oder Reaktivierung; abgelöste Reports sind `superseded`. |
 | superseded | erforderlich | erforderlich | optional | erforderlich | Ablösung muss explizit nachvollziehbar sein. |
-| archived | erforderlich | empfohlen | nein | empfohlen | Historisch erhalten, nicht mehr handlungsleitend. |
-| deprecated | empfohlen | empfohlen | empfohlen | empfohlen | Veraltet, aber endgültiger Umgang noch offen. |
+| archived | erforderlich | erforderlich | nein | empfohlen | Historisch erhalten, nicht mehr handlungsleitend; bei Legacy-Dokumenten ist `owner_task: historical` zulässig. |
+| deprecated | empfohlen | erforderlich | empfohlen | empfohlen | Veraltet, aber endgültiger Umgang noch offen; Verantwortlichkeit soll erhalten bleiben. |
 
 Diese Tabelle ist in Phase 1 eine Policy-Zieldefinition. Sie ist noch kein aktiver CI-Guard. Technische Durchsetzung folgt erst in späteren Phasen.
 
@@ -135,11 +154,19 @@ Regeln:
 - Derived references zeigen aber, dass ein Report noch in generierten Übersichten erscheint.
 - Vor physischer Archivierung oder Löschung muss ein Referenzcheck laufen.
 
+Ob eine Primary Reference Archivierung oder Löschung blockiert, hängt vom
+Status und Zweck des referenzierenden Dokuments ab. Eine historische oder
+bereits archivierte Quelle blockiert nicht automatisch.
+
 ## Archivierungsregeln
 
 Standard: `status: archived`
 
 Status-only Archivierung ist der Standard der ersten Ausbaustufen. Die Datei bleibt zunächst am Ort. Dadurch brechen keine Links.
+
+Bei Archivierung soll ein vorhandenes `owner_task` erhalten bleiben. Für
+historische Legacy-Dokumente ohne rekonstruierbaren Task ist
+`owner_task: historical` zulässig.
 
 Physische Archivierung ist später optional:
 
@@ -175,7 +202,7 @@ Eine Löschung darf nie nebenbei in einem Feature-PR passieren.
 1. **Inventory vorhanden**: Reportbestand sichtbar machen.
 2. **Policy definieren**: diese Datei.
 3. **Pilot**: genau einen Report annotieren.
-4. **Validator**: report/warn/strict implementieren, aber noch nicht hart aktivieren.
+4. **Validator**: `report`, `warn` und `strict` implementieren. `report` ist lokal nutzbar, `warn` kann nicht-blockierend in CI laufen, `strict` bleibt vorhanden, aber noch nicht aktiv.
 5. **Backfill**: kleine Slices statt Massen-PR.
 6. **Changed-only strict**: neue oder geänderte Reports müssen Felder tragen.
 7. **Global strict**: erst nach abgeschlossenem Backfill.
@@ -215,7 +242,7 @@ owner_task: historical
 ## Offene Entscheidungen
 
 - Welche Werte für `owner_task` genau zulässig werden.
-- Ob `review_after` zwingend ISO-Datum YYYY-MM-DD wird.
+- Ob für `review_after` später zusätzliche Regeln wie maximale Review-Intervalle gelten.
 - Ob `lifecycle` später ein Enum wird.
 - Wann `deprecated` statt `superseded` verwendet wird.
 - Ob physische Archivierung überhaupt nötig ist.

--- a/docs/process/report-lifecycle.md
+++ b/docs/process/report-lifecycle.md
@@ -245,7 +245,8 @@ Direktes Löschen aus draft oder active ist nicht erlaubt.
 Löschen nur, wenn alle Bedingungen erfüllt sind:
 
 - Report ist `archived` oder `superseded`.
-- `superseded_by` existiert oder bewusste Verwerfungsbegründung ist dokumentiert.
+- `superseded_by` existiert oder ein später definiertes maschinenlesbares
+  Ausnahmefeld dokumentiert bewusst, warum kein Ersatzartefakt existiert.
 - Keine aktive Primary Reference existiert.
 - Kein Audit-, Compliance- oder historischer Rekonstruktionswert besteht.
 - Generierte Artefakte bleiben reproduzierbar.
@@ -272,6 +273,10 @@ Eine Löschung darf nie nebenbei in einem Feature-PR passieren.
 Changed-only strict kommt vor global strict, damit Altlasten nicht jeden Feature-PR blockieren.
 
 ## Beispiele
+
+Die folgenden Beispiele zeigen das Zielmodell nach abgeschlossenem
+Contract-Alignment. Sie sind in dieser Phase noch keine allgemein gültigen
+DocMeta-Frontmatter-Vorgaben.
 
 ### Active audit
 

--- a/docs/process/report-lifecycle.md
+++ b/docs/process/report-lifecycle.md
@@ -23,83 +23,68 @@ Jeder Report soll später beantworten können:
 
 - Wozu existiert er?
 - Welcher Task oder welches Vorhaben gehört dazu?
-
 - Ist er aktiv?
 - Wann muss er überprüft werden?
-
 - Wodurch wurde er abgelöst?
 - Darf er archiviert werden?
-
 - Darf er gelöscht werden?
 
-Wichtig:
-Diese Policy ist eine Regelgrundlage, keine rückwirkende Bereinigung.
+Wichtig: Diese Policy ist eine Regelgrundlage, keine rückwirkende Bereinigung.
 
 ## Geltungsbereich
 
 Gilt für:
-docs/reports/*.md
+
+- `docs/reports/*.md`
 
 Noch nicht verbindlich für:
-docs/proofs/**
-docs/adr/**
-docs/specs/**
-docs/blueprints/**
-docs/tasks/**
+
+- `docs/proofs/**`
+- `docs/adr/**`
+- `docs/specs/**`
+- `docs/blueprints/**`
+- `docs/tasks/**`
 
 Diese Policy beschreibt zunächst Reports. Andere Dokumenttypen können Reports referenzieren und dadurch deren Archivierung oder Löschung blockieren, werden aber selbst nicht durch diese Policy klassifiziert.
 
 ## Nicht-Ziele
 
 - Diese Policy klassifiziert noch keine bestehenden Reports.
-
 - Diese Policy archiviert keine Reports.
 - Diese Policy löscht keine Reports.
-
 - Diese Policy aktiviert keinen Validator.
 - Diese Policy verschärft keine CI.
-
 - Diese Policy verändert keine Task-Wahrheit.
 - Diese Policy ersetzt keine fachliche Review-Entscheidung.
 
 ## Begriffe
 
 - **Report**: Ein Markdown-Dokument unter `docs/reports/*.md`, das einen Befund, Audit, Proof, Status oder eine entscheidungsvorbereitende Auswertung beschreibt.
-
 - **Lifecycle**: Die Rolle eines Reports im Lebenszyklus: warum er existiert, wie lange er handlungsleitend ist und wann er geprüft oder abgelöst wird.
 - **Status**: Der aktuelle Zustand eines Reports, zum Beispiel `draft`, `active`, `superseded` oder `archived`.
-
 - **Supersession**: Eine explizite Ablösung durch ein anderes Artefakt. Supersession bedeutet nicht automatisch Löschung.
 - **Archivierung**: Ein Report bleibt erhalten, ist aber nicht mehr handlungsleitend.
-
 - **Löschung**: Physisches Entfernen eines Reports aus dem Repo. Löschung ist der letzte Schritt und nur nach separater Prüfung erlaubt.
 - **Primary Reference**: Eine handgeschriebene Referenz aus fachlich relevanten Dokumenten, zum Beispiel Tasks, Blueprints, ADRs, Specs, Proofs, Reports oder Roadmap.
-
 - **Derived Reference**: Eine generierte Referenz aus `docs/_generated/**`. Sie zeigt Sichtbarkeit oder Indexierung, beweist aber nicht automatisch fachliche Aktualität.
 
 ## Report-Klassen
 
 - **audit**: Prüft einen Bestand, Datenzustand oder Prozesszustand. Risiko: veraltet schnell, wenn Daten oder Prozess wechseln.
-
 - **proof**: Belegt eine technische oder organisatorische Eigenschaft. Risiko: verliert Gültigkeit bei Code-, CI- oder Infrastrukturänderungen.
 - **status**: Verdichtet aktuellen Stand eines Vorhabens. Risiko: wird leicht mit dauerhafter Wahrheit verwechselt.
-
 - **decision-prep**: Bereitet eine Entscheidung vor, ersetzt sie aber nicht. Risiko: bleibt nach Entscheidung weiter sichtbar, obwohl die Entscheidung schon gefallen ist.
 - **generated**: Wird automatisch erzeugt und soll nicht manuell editiert werden. Risiko: Drift zwischen Generator und committed Artefakt.
-
 - **planning**: Beschreibt geplante Arbeit, offene Schritte oder Ordnungsvorhaben. Risiko: Planungsstand wird mit Umsetzung verwechselt.
 - **legacy**: Historisch nützlich, aber nicht mehr aktuell handlungsleitend. Risiko: unmarkierte Legacy-Dokumente erzeugen Scheinkohärenz.
 
 ## Status-Semantik
 
 - **draft**: In Arbeit oder vorbereitend. Noch nicht maßgeblich.
-
 - **active**: Aktuell handlungsleitend oder als gültiger Bezugspunkt verwendbar.
 - **deferred**: Bewusst zurückgestellt. Nicht verworfen, aber derzeit nicht handlungsleitend.
-
 - **superseded**: Durch ein anderes Artefakt ersetzt. Das ablösende Artefakt soll über `superseded_by` angegeben werden.
 - **archived**: Historisch erhalten, aber nicht mehr handlungsleitend.
-
 - **deprecated**: Veraltet oder nicht mehr empfohlen, aber Ersatz, Archivierung oder Löschung sind noch nicht abschließend geklärt.
 
 Wichtig:
@@ -110,10 +95,8 @@ Wichtig:
 ## Lifecycle-Felder
 
 - **lifecycle**: Report-Klasse oder Lifecycle-Rolle.
-
 - **owner_task**: Task, Vorhaben, Kontrollpunkt oder Prozess, der die Verantwortung für den Report trägt. In Phase 1 noch als menschlich lesbarer Wert (noch kein Enum erzwingen).
 - **review_after**: Datum, ab dem erneute Prüfung fällig wird. Für spätere Validatoren soll ein ISO-Datum YYYY-MM-DD bevorzugt werden.
-
 - **superseded_by**: Pfad zum ablösenden Artefakt. Kann ein anderer Report, ein Blueprint, ein Proof oder ein anderes kanonisches Dokument sein.
 
 ## Pflichtfelder nach Status
@@ -135,13 +118,10 @@ Primary references kommen aus handgeschriebenen Artefakten, zum Beispiel:
 
 - `docs/tasks/**`
 - `docs/blueprints/**`
-
 - `docs/reports/**`
 - `docs/adr/**`
-
 - `docs/specs/**`
 - `docs/proofs/**`
-
 - `docs/roadmap.md`
 
 Derived references kommen aus:
@@ -152,7 +132,6 @@ Regeln:
 
 - Primary references können Archivierung und Löschung blockieren.
 - Derived references allein blockieren keine Archivierung.
-
 - Derived references zeigen aber, dass ein Report noch in generierten Übersichten erscheint.
 - Vor physischer Archivierung oder Löschung muss ein Referenzcheck laufen.
 
@@ -163,16 +142,15 @@ Standard: `status: archived`
 Status-only Archivierung ist der Standard der ersten Ausbaustufen. Die Datei bleibt zunächst am Ort. Dadurch brechen keine Links.
 
 Physische Archivierung ist später optional:
-`docs/reports/archive/YYYY/<report>.md`
+
+- `docs/reports/archive/YYYY/<report>.md`
 
 Nur erlaubt, wenn:
 
 - keine aktiven Primary References brechen
 - `superseded_by` geprüft ist oder bewusste historische Begründung existiert
-
 - relevante Tasks, Proofs und Blueprints angepasst sind
 - generated docs reproduziert wurden
-
 - eigener PR erstellt wird
 
 Wichtig: Noch keine Archivierung in diesem PR.
@@ -185,10 +163,8 @@ Löschen nur, wenn alle Bedingungen erfüllt sind:
 
 - Report ist `archived` oder `superseded`.
 - `superseded_by` existiert oder bewusste Verwerfungsbegründung ist dokumentiert.
-
 - Keine aktive Primary Reference existiert.
 - Kein Audit-, Compliance- oder historischer Rekonstruktionswert besteht.
-
 - Generierte Artefakte bleiben reproduzierbar.
 - Löschung erfolgt in eigenem PR mit klarer Begründung.
 
@@ -239,12 +215,9 @@ owner_task: historical
 ## Offene Entscheidungen
 
 - Welche Werte für `owner_task` genau zulässig werden.
-
 - Ob `review_after` zwingend ISO-Datum YYYY-MM-DD wird.
 - Ob `lifecycle` später ein Enum wird.
-
 - Wann `deprecated` statt `superseded` verwendet wird.
 - Ob physische Archivierung überhaupt nötig ist.
-
 - Ob `docs/proofs/**` später eigene Lifecycle-Policy bekommt.
 - Ob generated Reports eigene Review-Logik brauchen.

--- a/docs/process/report-lifecycle.md
+++ b/docs/process/report-lifecycle.md
@@ -1,0 +1,250 @@
+---
+id: process.report-lifecycle
+title: Report Lifecycle Policy
+doc_type: policy
+status: draft
+canonicality: canonical
+summary: >
+  Policy für Lebenszyklus, Status, Pflichtfelder, Archivierung und Löschung
+  von Reports.
+relations:
+  - type: relates_to
+    target: docs/process/README.md
+  - type: relates_to
+    target: docs/_generated/report-lifecycle-inventory.md
+---
+
+# Report Lifecycle Policy
+
+## Zweck
+
+Reports sollen nicht dauerhaft als scheinbar aktuelle Wahrheit im Repo liegen.
+Jeder Report soll später beantworten können:
+
+- Wozu existiert er?
+- Welcher Task oder welches Vorhaben gehört dazu?
+
+- Ist er aktiv?
+- Wann muss er überprüft werden?
+
+- Wodurch wurde er abgelöst?
+- Darf er archiviert werden?
+
+- Darf er gelöscht werden?
+
+Wichtig:
+Diese Policy ist eine Regelgrundlage, keine rückwirkende Bereinigung.
+
+## Geltungsbereich
+
+Gilt für:
+docs/reports/*.md
+
+Noch nicht verbindlich für:
+docs/proofs/**
+docs/adr/**
+docs/specs/**
+docs/blueprints/**
+docs/tasks/**
+
+Diese Policy beschreibt zunächst Reports. Andere Dokumenttypen können Reports referenzieren und dadurch deren Archivierung oder Löschung blockieren, werden aber selbst nicht durch diese Policy klassifiziert.
+
+## Nicht-Ziele
+
+- Diese Policy klassifiziert noch keine bestehenden Reports.
+
+- Diese Policy archiviert keine Reports.
+- Diese Policy löscht keine Reports.
+
+- Diese Policy aktiviert keinen Validator.
+- Diese Policy verschärft keine CI.
+
+- Diese Policy verändert keine Task-Wahrheit.
+- Diese Policy ersetzt keine fachliche Review-Entscheidung.
+
+## Begriffe
+
+- **Report**: Ein Markdown-Dokument unter `docs/reports/*.md`, das einen Befund, Audit, Proof, Status oder eine entscheidungsvorbereitende Auswertung beschreibt.
+
+- **Lifecycle**: Die Rolle eines Reports im Lebenszyklus: warum er existiert, wie lange er handlungsleitend ist und wann er geprüft oder abgelöst wird.
+- **Status**: Der aktuelle Zustand eines Reports, zum Beispiel `draft`, `active`, `superseded` oder `archived`.
+
+- **Supersession**: Eine explizite Ablösung durch ein anderes Artefakt. Supersession bedeutet nicht automatisch Löschung.
+- **Archivierung**: Ein Report bleibt erhalten, ist aber nicht mehr handlungsleitend.
+
+- **Löschung**: Physisches Entfernen eines Reports aus dem Repo. Löschung ist der letzte Schritt und nur nach separater Prüfung erlaubt.
+- **Primary Reference**: Eine handgeschriebene Referenz aus fachlich relevanten Dokumenten, zum Beispiel Tasks, Blueprints, ADRs, Specs, Proofs, Reports oder Roadmap.
+
+- **Derived Reference**: Eine generierte Referenz aus `docs/_generated/**`. Sie zeigt Sichtbarkeit oder Indexierung, beweist aber nicht automatisch fachliche Aktualität.
+
+## Report-Klassen
+
+- **audit**: Prüft einen Bestand, Datenzustand oder Prozesszustand. Risiko: veraltet schnell, wenn Daten oder Prozess wechseln.
+
+- **proof**: Belegt eine technische oder organisatorische Eigenschaft. Risiko: verliert Gültigkeit bei Code-, CI- oder Infrastrukturänderungen.
+- **status**: Verdichtet aktuellen Stand eines Vorhabens. Risiko: wird leicht mit dauerhafter Wahrheit verwechselt.
+
+- **decision-prep**: Bereitet eine Entscheidung vor, ersetzt sie aber nicht. Risiko: bleibt nach Entscheidung weiter sichtbar, obwohl die Entscheidung schon gefallen ist.
+- **generated**: Wird automatisch erzeugt und soll nicht manuell editiert werden. Risiko: Drift zwischen Generator und committed Artefakt.
+
+- **planning**: Beschreibt geplante Arbeit, offene Schritte oder Ordnungsvorhaben. Risiko: Planungsstand wird mit Umsetzung verwechselt.
+- **legacy**: Historisch nützlich, aber nicht mehr aktuell handlungsleitend. Risiko: unmarkierte Legacy-Dokumente erzeugen Scheinkohärenz.
+
+## Status-Semantik
+
+- **draft**: In Arbeit oder vorbereitend. Noch nicht maßgeblich.
+
+- **active**: Aktuell handlungsleitend oder als gültiger Bezugspunkt verwendbar.
+- **deferred**: Bewusst zurückgestellt. Nicht verworfen, aber derzeit nicht handlungsleitend.
+
+- **superseded**: Durch ein anderes Artefakt ersetzt. Das ablösende Artefakt soll über `superseded_by` angegeben werden.
+- **archived**: Historisch erhalten, aber nicht mehr handlungsleitend.
+
+- **deprecated**: Veraltet oder nicht mehr empfohlen, aber Ersatz, Archivierung oder Löschung sind noch nicht abschließend geklärt.
+
+Wichtig:
+`deprecated` ist kein Papierkorb.
+`archived` ist keine Löschung.
+`superseded` braucht eine nachvollziehbare Ablösung.
+
+## Lifecycle-Felder
+
+- **lifecycle**: Report-Klasse oder Lifecycle-Rolle.
+
+- **owner_task**: Task, Vorhaben, Kontrollpunkt oder Prozess, der die Verantwortung für den Report trägt. In Phase 1 noch als menschlich lesbarer Wert (noch kein Enum erzwingen).
+- **review_after**: Datum, ab dem erneute Prüfung fällig wird. Für spätere Validatoren soll ein ISO-Datum YYYY-MM-DD bevorzugt werden.
+
+- **superseded_by**: Pfad zum ablösenden Artefakt. Kann ein anderer Report, ein Blueprint, ein Proof oder ein anderes kanonisches Dokument sein.
+
+## Pflichtfelder nach Status
+
+| status | lifecycle | owner_task | review_after | superseded_by | Bemerkung |
+| --- | --- | --- | --- | --- | --- |
+| draft | empfohlen | empfohlen | optional | nein | Noch nicht handlungsleitend, aber spätere Zuordnung soll vorbereitet werden. |
+| active | erforderlich | erforderlich | erforderlich | nein | Aktive Reports brauchen Zweck, Verantwortung und Review-Zeitpunkt. |
+| deferred | erforderlich | erforderlich | erforderlich | optional | Zurückgestellte Reports brauchen einen Wiedervorlagepunkt. |
+| superseded | erforderlich | erforderlich | optional | erforderlich | Ablösung muss explizit nachvollziehbar sein. |
+| archived | erforderlich | empfohlen | nein | empfohlen | Historisch erhalten, nicht mehr handlungsleitend. |
+| deprecated | empfohlen | empfohlen | empfohlen | empfohlen | Veraltet, aber endgültiger Umgang noch offen. |
+
+Diese Tabelle ist in Phase 1 eine Policy-Zieldefinition. Sie ist noch kein aktiver CI-Guard. Technische Durchsetzung folgt erst in späteren Phasen.
+
+## Referenzklassen
+
+Primary references kommen aus handgeschriebenen Artefakten, zum Beispiel:
+
+- `docs/tasks/**`
+- `docs/blueprints/**`
+
+- `docs/reports/**`
+- `docs/adr/**`
+
+- `docs/specs/**`
+- `docs/proofs/**`
+
+- `docs/roadmap.md`
+
+Derived references kommen aus:
+
+- `docs/_generated/**`
+
+Regeln:
+
+- Primary references können Archivierung und Löschung blockieren.
+- Derived references allein blockieren keine Archivierung.
+
+- Derived references zeigen aber, dass ein Report noch in generierten Übersichten erscheint.
+- Vor physischer Archivierung oder Löschung muss ein Referenzcheck laufen.
+
+## Archivierungsregeln
+
+Standard: `status: archived`
+
+Status-only Archivierung ist der Standard der ersten Ausbaustufen. Die Datei bleibt zunächst am Ort. Dadurch brechen keine Links.
+
+Physische Archivierung ist später optional:
+`docs/reports/archive/YYYY/<report>.md`
+
+Nur erlaubt, wenn:
+
+- keine aktiven Primary References brechen
+- `superseded_by` geprüft ist oder bewusste historische Begründung existiert
+
+- relevante Tasks, Proofs und Blueprints angepasst sind
+- generated docs reproduziert wurden
+
+- eigener PR erstellt wird
+
+Wichtig: Noch keine Archivierung in diesem PR.
+
+## Löschregeln
+
+Direktes Löschen aus draft oder active ist nicht erlaubt.
+
+Löschen nur, wenn alle Bedingungen erfüllt sind:
+
+- Report ist `archived` oder `superseded`.
+- `superseded_by` existiert oder bewusste Verwerfungsbegründung ist dokumentiert.
+
+- Keine aktive Primary Reference existiert.
+- Kein Audit-, Compliance- oder historischer Rekonstruktionswert besteht.
+
+- Generierte Artefakte bleiben reproduzierbar.
+- Löschung erfolgt in eigenem PR mit klarer Begründung.
+
+Eine Löschung darf nie nebenbei in einem Feature-PR passieren.
+
+## Rollout-Modell
+
+1. **Inventory vorhanden**: Reportbestand sichtbar machen.
+2. **Policy definieren**: diese Datei.
+3. **Pilot**: genau einen Report annotieren.
+4. **Validator**: report/warn/strict implementieren, aber noch nicht hart aktivieren.
+5. **Backfill**: kleine Slices statt Massen-PR.
+6. **Changed-only strict**: neue oder geänderte Reports müssen Felder tragen.
+7. **Global strict**: erst nach abgeschlossenem Backfill.
+8. **Archivierung**: zunächst status-only.
+9. **Löschung**: nur separat und nach Referenzcheck.
+
+Changed-only strict kommt vor global strict, damit Altlasten nicht jeden Feature-PR blockieren.
+
+## Beispiele
+
+### Active audit
+
+```yaml
+status: active
+lifecycle: audit
+owner_task: OPT-ARC-001
+review_after: 2026-07-13
+```
+
+### Superseded proof
+
+```yaml
+status: superseded
+lifecycle: proof
+owner_task: OPT-ARC-001
+superseded_by: docs/reports/new-proof.md
+```
+
+### Archived legacy report
+
+```yaml
+status: archived
+lifecycle: legacy
+owner_task: historical
+```
+
+## Offene Entscheidungen
+
+- Welche Werte für `owner_task` genau zulässig werden.
+
+- Ob `review_after` zwingend ISO-Datum YYYY-MM-DD wird.
+- Ob `lifecycle` später ein Enum wird.
+
+- Wann `deprecated` statt `superseded` verwendet wird.
+- Ob physische Archivierung überhaupt nötig ist.
+
+- Ob `docs/proofs/**` später eigene Lifecycle-Policy bekommt.
+- Ob generated Reports eigene Review-Logik brauchen.

--- a/docs/process/report-lifecycle.md
+++ b/docs/process/report-lifecycle.md
@@ -31,10 +31,6 @@ Jeder Report soll später beantworten können:
 
 Wichtig: Diese Policy ist eine Regelgrundlage, keine rückwirkende Bereinigung.
 
-Diese Policy ist der kanonische Ort für Report-Lifecycle-Regeln. Ihr Status
-bleibt `draft`, bis Pilot-Annotation und Warnmodus die Begriffe praktisch
-bestätigt haben.
-
 ## Geltungsbereich
 
 Gilt für:
@@ -75,10 +71,10 @@ Diese Policy beschreibt zunächst Reports. Andere Dokumenttypen können Reports 
 ## Report-Klassen
 
 - **audit**: Prüft einen Bestand, Datenzustand oder Prozesszustand. Risiko: veraltet schnell, wenn Daten oder Prozess wechseln.
-- **proof**: Belegt eine technische oder organisatorische Eigenschaft. Risiko: verliert Gültigkeit bei Code-, CI- oder Infrastrukturänderungen. Die Klasse `proof` kann für Reports unter `docs/reports/*.md` genutzt werden, die einen Proof-Charakter haben. Dateien unter `docs/proofs/**` bleiben in dieser Phase vom Geltungsbereich ausgenommen und können später eine eigene Lifecycle-Regel bekommen.
+- **proof**: Belegt eine technische oder organisatorische Eigenschaft. Risiko: verliert Gültigkeit bei Code-, CI- oder Infrastrukturänderungen.
 - **status**: Verdichtet aktuellen Stand eines Vorhabens. Risiko: wird leicht mit dauerhafter Wahrheit verwechselt.
 - **decision-prep**: Bereitet eine Entscheidung vor, ersetzt sie aber nicht. Risiko: bleibt nach Entscheidung weiter sichtbar, obwohl die Entscheidung schon gefallen ist.
-- **generated**: Wird automatisch erzeugt und soll nicht manuell editiert werden. Diese Klasse gilt nur für Artefakte, die ausdrücklich als Report geführt werden. Nicht jedes Artefakt unter `docs/_generated/**` wird dadurch zu einem Report. Risiko: Drift zwischen Generator und committed Artefakt.
+- **generated**: Wird automatisch erzeugt und soll nicht manuell editiert werden. Risiko: Drift zwischen Generator und committed Artefakt.
 - **planning**: Beschreibt geplante Arbeit, offene Schritte oder Ordnungsvorhaben. Risiko: Planungsstand wird mit Umsetzung verwechselt.
 - **legacy**: Historisch nützlich, aber nicht mehr aktuell handlungsleitend. Risiko: unmarkierte Legacy-Dokumente erzeugen Scheinkohärenz.
 
@@ -99,24 +95,9 @@ Wichtig:
 ## Lifecycle-Felder
 
 - **lifecycle**: Report-Klasse oder Lifecycle-Rolle.
-- `lifecycle` ersetzt `doc_type` nicht. `doc_type` beschreibt die Dokumentart
-  im Repo, zum Beispiel `report` oder `policy`. `lifecycle` beschreibt die
-  Rolle eines Reports innerhalb seines Lebenszyklus, zum Beispiel `audit`,
-  `proof` oder `status`.
 - **owner_task**: Task, Vorhaben, Kontrollpunkt oder Prozess, der die Verantwortung für den Report trägt. In Phase 1 noch als menschlich lesbarer Wert (noch kein Enum erzwingen).
-- **review_after**: ISO-Datum im Format `YYYY-MM-DD`, ab dem erneute Prüfung
-  fällig wird.
+- **review_after**: Datum, ab dem erneute Prüfung fällig wird. Für spätere Validatoren soll ein ISO-Datum YYYY-MM-DD bevorzugt werden.
 - **superseded_by**: Pfad zum ablösenden Artefakt. Kann ein anderer Report, ein Blueprint, ein Proof oder ein anderes kanonisches Dokument sein.
-
-```yaml
-doc_type: report
-lifecycle: audit
-```
-
-Die Lifecycle-Felder werden in exakt dieser snake_case-Schreibweise geführt:
-`lifecycle`, `owner_task`, `review_after`, `superseded_by`. Spätere Validatoren
-sollen abweichende Schreibweisen wie `ownerTask` oder `reviewAfter` nicht als
-gleichwertig behandeln.
 
 ## Pflichtfelder nach Status
 
@@ -124,10 +105,10 @@ gleichwertig behandeln.
 | --- | --- | --- | --- | --- | --- |
 | draft | empfohlen | empfohlen | optional | nein | Noch nicht handlungsleitend, aber spätere Zuordnung soll vorbereitet werden. |
 | active | erforderlich | erforderlich | erforderlich | nein | Aktive Reports brauchen Zweck, Verantwortung und Review-Zeitpunkt. |
-| deferred | erforderlich | erforderlich | erforderlich | nein | Zurückgestellte Reports warten auf Prüfung oder Reaktivierung; abgelöste Reports sind `superseded`. |
+| deferred | erforderlich | erforderlich | erforderlich | optional | Zurückgestellte Reports brauchen einen Wiedervorlagepunkt. |
 | superseded | erforderlich | erforderlich | optional | erforderlich | Ablösung muss explizit nachvollziehbar sein. |
-| archived | erforderlich | erforderlich | nein | empfohlen | Historisch erhalten, nicht mehr handlungsleitend; bei Legacy-Dokumenten ist `owner_task: historical` zulässig. |
-| deprecated | empfohlen | erforderlich | empfohlen | empfohlen | Veraltet, aber endgültiger Umgang noch offen; Verantwortlichkeit soll erhalten bleiben. |
+| archived | erforderlich | empfohlen | nein | empfohlen | Historisch erhalten, nicht mehr handlungsleitend. |
+| deprecated | empfohlen | empfohlen | empfohlen | empfohlen | Veraltet, aber endgültiger Umgang noch offen. |
 
 Diese Tabelle ist in Phase 1 eine Policy-Zieldefinition. Sie ist noch kein aktiver CI-Guard. Technische Durchsetzung folgt erst in späteren Phasen.
 
@@ -154,19 +135,11 @@ Regeln:
 - Derived references zeigen aber, dass ein Report noch in generierten Übersichten erscheint.
 - Vor physischer Archivierung oder Löschung muss ein Referenzcheck laufen.
 
-Ob eine Primary Reference Archivierung oder Löschung blockiert, hängt vom
-Status und Zweck des referenzierenden Dokuments ab. Eine historische oder
-bereits archivierte Quelle blockiert nicht automatisch.
-
 ## Archivierungsregeln
 
 Standard: `status: archived`
 
 Status-only Archivierung ist der Standard der ersten Ausbaustufen. Die Datei bleibt zunächst am Ort. Dadurch brechen keine Links.
-
-Bei Archivierung soll ein vorhandenes `owner_task` erhalten bleiben. Für
-historische Legacy-Dokumente ohne rekonstruierbaren Task ist
-`owner_task: historical` zulässig.
 
 Physische Archivierung ist später optional:
 
@@ -202,7 +175,7 @@ Eine Löschung darf nie nebenbei in einem Feature-PR passieren.
 1. **Inventory vorhanden**: Reportbestand sichtbar machen.
 2. **Policy definieren**: diese Datei.
 3. **Pilot**: genau einen Report annotieren.
-4. **Validator**: `report`, `warn` und `strict` implementieren. `report` ist lokal nutzbar, `warn` kann nicht-blockierend in CI laufen, `strict` bleibt vorhanden, aber noch nicht aktiv.
+4. **Validator**: report/warn/strict implementieren, aber noch nicht hart aktivieren.
 5. **Backfill**: kleine Slices statt Massen-PR.
 6. **Changed-only strict**: neue oder geänderte Reports müssen Felder tragen.
 7. **Global strict**: erst nach abgeschlossenem Backfill.
@@ -242,7 +215,7 @@ owner_task: historical
 ## Offene Entscheidungen
 
 - Welche Werte für `owner_task` genau zulässig werden.
-- Ob für `review_after` später zusätzliche Regeln wie maximale Review-Intervalle gelten.
+- Ob `review_after` zwingend ISO-Datum YYYY-MM-DD wird.
 - Ob `lifecycle` später ein Enum wird.
 - Wann `deprecated` statt `superseded` verwendet wird.
 - Ob physische Archivierung überhaupt nötig ist.

--- a/docs/process/report-lifecycle.md
+++ b/docs/process/report-lifecycle.md
@@ -3,7 +3,6 @@ id: process.report-lifecycle
 title: Report Lifecycle Policy
 doc_type: policy
 status: draft
-canonicality: canonical
 summary: >
   Policy für Lebenszyklus, Status, Pflichtfelder, Archivierung und Löschung
   von Reports.
@@ -17,6 +16,11 @@ relations:
 # Report Lifecycle Policy
 
 ## Zweck
+
+Diese Datei ist der vorgeschlagene Zielort für Report-Lifecycle-Regeln. Sie
+bleibt `draft`, bis die Policy in einem späteren Schritt in das Truth Model
+und den DocMeta-Contract integriert oder bewusst als nicht-kanonische
+Prozessregel bestätigt wird.
 
 Reports sollen nicht dauerhaft als scheinbar aktuelle Wahrheit im Repo liegen.
 Jeder Report soll später beantworten können:
@@ -57,6 +61,26 @@ Diese Policy beschreibt zunächst Reports. Andere Dokumenttypen können Reports 
 - Diese Policy verändert keine Task-Wahrheit.
 - Diese Policy ersetzt keine fachliche Review-Entscheidung.
 
+## Contract-Alignment-Gate
+
+Diese Policy beschreibt das Zielmodell. Die hier beschriebenen zusätzlichen
+Lifecycle-Felder und Statuswerte sind noch nicht automatisch Teil des
+bestehenden DocMeta-Contracts.
+
+Vor dem ersten Backfill oder einer Pilot-Annotation im Frontmatter muss ein
+separater Contract-Schritt entscheiden:
+
+- ob `contracts/docmeta.schema.json` und `architecture/docmeta.schema.md`
+  erweitert werden,
+- ob Lifecycle-Metadaten in einem eigenen Report-Lifecycle-Schema validiert
+  werden,
+- oder ob die Policy auf das bestehende DocMeta-Vokabular zurückgeschnitten
+  wird.
+
+Bis diese Entscheidung getroffen ist, dürfen neue Statuswerte wie `deferred`,
+`superseded` und `archived` nicht als allgemein contract-gültige
+DocMeta-Statuswerte verstanden werden.
+
 ## Begriffe
 
 - **Report**: Ein Markdown-Dokument unter `docs/reports/*.md`, das einen Befund, Audit, Proof, Status oder eine entscheidungsvorbereitende Auswertung beschreibt.
@@ -72,13 +96,24 @@ Diese Policy beschreibt zunächst Reports. Andere Dokumenttypen können Reports 
 
 - **audit**: Prüft einen Bestand, Datenzustand oder Prozesszustand. Risiko: veraltet schnell, wenn Daten oder Prozess wechseln.
 - **proof**: Belegt eine technische oder organisatorische Eigenschaft. Risiko: verliert Gültigkeit bei Code-, CI- oder Infrastrukturänderungen.
+  Die Klasse `proof` kann für Reports unter `docs/reports/*.md` genutzt werden,
+  die einen Proof-Charakter haben. Dateien unter `docs/proofs/**` bleiben in
+  dieser Phase vom Geltungsbereich ausgenommen und können später eine eigene
+  Lifecycle-Regel bekommen.
 - **status**: Verdichtet aktuellen Stand eines Vorhabens. Risiko: wird leicht mit dauerhafter Wahrheit verwechselt.
 - **decision-prep**: Bereitet eine Entscheidung vor, ersetzt sie aber nicht. Risiko: bleibt nach Entscheidung weiter sichtbar, obwohl die Entscheidung schon gefallen ist.
 - **generated**: Wird automatisch erzeugt und soll nicht manuell editiert werden. Risiko: Drift zwischen Generator und committed Artefakt.
+  Diese Klasse gilt nur für Artefakte, die ausdrücklich als Report geführt
+  werden. Nicht jedes Artefakt unter `docs/_generated/**` wird dadurch zu einem
+  Report.
 - **planning**: Beschreibt geplante Arbeit, offene Schritte oder Ordnungsvorhaben. Risiko: Planungsstand wird mit Umsetzung verwechselt.
 - **legacy**: Historisch nützlich, aber nicht mehr aktuell handlungsleitend. Risiko: unmarkierte Legacy-Dokumente erzeugen Scheinkohärenz.
 
 ## Status-Semantik
+
+Die folgenden Statuswerte bilden das Zielvokabular für den Report-Lifecycle.
+Sie sind erst dann als Frontmatter-Werte verwendbar, wenn das
+Contract-Alignment-Gate abgeschlossen ist.
 
 - **draft**: In Arbeit oder vorbereitend. Noch nicht maßgeblich.
 - **active**: Aktuell handlungsleitend oder als gültiger Bezugspunkt verwendbar.
@@ -98,7 +133,16 @@ Wichtig:
 - **owner_task**: Task, Vorhaben, Kontrollpunkt oder Prozess, der die Verantwortung für den Report trägt. In Phase 1 noch als menschlich lesbarer Wert (noch kein Enum erzwingen).
 - **review_after**: ISO-Datum im Format `YYYY-MM-DD`, ab dem erneute Prüfung
   fällig wird.
-- **superseded_by**: Pfad zum ablösenden Artefakt. Kann ein anderer Report, ein Blueprint, ein Proof oder ein anderes kanonisches Dokument sein.
+- **superseded_by**: Pfad zum ablösenden Artefakt. Dieses Feld darf nicht als
+  alleinige Supersession-Wahrheit verstanden werden. Die bestehende
+  Repo-Mechanik bildet Supersession über `relations` mit `type: supersedes`
+  ab: Das neue Artefakt verweist auf das alte Artefakt. Ein späterer Validator
+  muss `superseded_by` und `relations[type=supersedes]` gegeneinander prüfen
+  oder eine der beiden Formen als kanonisch festlegen.
+
+Auch diese zusätzlichen Lifecycle-Felder sind Zielmodell-Felder. Ob sie direkt
+im DocMeta-Frontmatter, in einem separaten Lifecycle-Schema oder über einen
+späteren Validator geprüft werden, entscheidet das Contract-Alignment-Gate.
 
 `lifecycle` ersetzt `doc_type` nicht. `doc_type` beschreibt die Dokumentart im
 Repo, zum Beispiel `report` oder `policy`. `lifecycle` beschreibt die Rolle
@@ -112,6 +156,18 @@ doc_type: report
 lifecycle: audit
 ```
 
+Beispiel für die spätere Abbildung einer Ablösung:
+
+```yaml
+# Im alten Report, falls das Lifecycle-Feld contract-aktiv wird:
+status: superseded
+superseded_by: docs/reports/new-proof.md
+# Im neuen oder ersetzenden Dokument:
+relations:
+  - type: supersedes
+    target: docs/reports/old-proof.md
+```
+
 Die Lifecycle-Felder werden in exakt dieser snake_case-Schreibweise geführt:
 `lifecycle`, `owner_task`, `review_after`, `superseded_by`. Spätere Validatoren
 sollen abweichende Schreibweisen wie `ownerTask` oder `reviewAfter` nicht als
@@ -123,10 +179,15 @@ gleichwertig behandeln.
 | --- | --- | --- | --- | --- | --- |
 | draft | empfohlen | empfohlen | optional | nein | Noch nicht handlungsleitend, aber spätere Zuordnung soll vorbereitet werden. |
 | active | erforderlich | erforderlich | erforderlich | nein | Aktive Reports brauchen Zweck, Verantwortung und Review-Zeitpunkt. |
-| deferred | erforderlich | erforderlich | erforderlich | optional | Zurückgestellte Reports brauchen einen Wiedervorlagepunkt. |
+| deferred | erforderlich | erforderlich | erforderlich | nein | Zurückgestellte Reports warten auf Prüfung oder Reaktivierung; abgelöste Reports sind `superseded`. |
 | superseded | erforderlich | erforderlich | optional | erforderlich | Ablösung muss explizit nachvollziehbar sein. |
-| archived | erforderlich | empfohlen | nein | empfohlen | Historisch erhalten, nicht mehr handlungsleitend. |
-| deprecated | erforderlich | erforderlich | empfohlen | empfohlen | Veraltet, aber endgültiger Umgang noch offen; Verantwortlichkeit und Report-Klasse sollen erhalten bleiben. |
+| archived | erforderlich | erforderlich | nein | erforderlich* | Historisch erhalten, nicht mehr handlungsleitend; Legacy-Ausnahmen brauchen später ein explizites Ausnahmefeld. |
+| deprecated | erforderlich | erforderlich | empfohlen | erforderlich* | Veraltet, aber endgültiger Umgang noch offen; Ablösung oder Ausnahme muss später maschinenlesbar werden. |
+
+`erforderlich*` bedeutet: Das aktuelle Inventory meldet terminale Status ohne
+`superseded_by` als Lücke. Falls historische Legacy-Dokumente ohne Ersatz
+zulässig werden sollen, braucht das einen späteren Generator-/Validator-Schritt
+mit explizitem Ausnahmefeld statt stiller Leerstelle.
 
 Diese Tabelle ist in Phase 1 eine Policy-Zieldefinition. Sie ist noch kein aktiver CI-Guard. Technische Durchsetzung folgt erst in späteren Phasen.
 
@@ -152,6 +213,10 @@ Regeln:
 - Derived references allein blockieren keine Archivierung.
 - Derived references zeigen aber, dass ein Report noch in generierten Übersichten erscheint.
 - Vor physischer Archivierung oder Löschung muss ein Referenzcheck laufen.
+
+Ob eine Primary Reference Archivierung oder Löschung blockiert, hängt vom
+Status und Zweck des referenzierenden Dokuments ab. Eine historische oder
+bereits archivierte Quelle blockiert nicht automatisch.
 
 ## Archivierungsregeln
 
@@ -192,13 +257,17 @@ Eine Löschung darf nie nebenbei in einem Feature-PR passieren.
 
 1. **Inventory vorhanden**: Reportbestand sichtbar machen.
 2. **Policy definieren**: diese Datei.
-3. **Pilot**: genau einen Report annotieren.
-4. **Validator**: report/warn/strict implementieren, aber noch nicht hart aktivieren.
-5. **Backfill**: kleine Slices statt Massen-PR.
-6. **Changed-only strict**: neue oder geänderte Reports müssen Felder tragen.
-7. **Global strict**: erst nach abgeschlossenem Backfill.
-8. **Archivierung**: zunächst status-only.
-9. **Löschung**: nur separat und nach Referenzcheck.
+3. **Contract Alignment**: entscheiden, ob DocMeta-Contract,
+   Architecture-Doku oder ein separates Lifecycle-Schema erweitert wird.
+4. **Pilot**: genau einen Report annotieren, erst nach Contract Alignment.
+5. **Validator**: `report`, `warn` und `strict` implementieren. `report` ist
+   lokal nutzbar, `warn` kann nicht-blockierend in CI laufen, `strict` bleibt
+   vorhanden, aber noch nicht aktiv.
+6. **Backfill**: kleine Slices statt Massen-PR.
+7. **Changed-only strict**: neue oder geänderte Reports müssen Felder tragen.
+8. **Global strict**: erst nach abgeschlossenem Backfill.
+9. **Archivierung**: zunächst status-only.
+10. **Löschung**: nur separat und nach Referenzcheck.
 
 Changed-only strict kommt vor global strict, damit Altlasten nicht jeden Feature-PR blockieren.
 
@@ -224,16 +293,14 @@ superseded_by: docs/reports/new-proof.md
 
 ### Archived legacy report
 
-```yaml
-status: archived
-lifecycle: legacy
-owner_task: historical
-```
+Archivierte Legacy-Dokumente ohne eindeutiges Ersatzartefakt bleiben eine
+offene Entscheidung und dürfen erst nach einem eigenen Ausnahmefeld oder
+Validator-Verhalten modelliert werden.
 
 ## Offene Entscheidungen
 
 - Welche Werte für `owner_task` genau zulässig werden.
-- Ob `review_after` zwingend ISO-Datum YYYY-MM-DD wird.
+- Ob für `review_after` später zusätzliche Regeln wie maximale Review-Intervalle gelten.
 - Ob `lifecycle` später ein Enum wird.
 - Wann `deprecated` statt `superseded` verwendet wird.
 - Ob physische Archivierung überhaupt nötig ist.

--- a/docs/process/report-lifecycle.md
+++ b/docs/process/report-lifecycle.md
@@ -96,8 +96,26 @@ Wichtig:
 
 - **lifecycle**: Report-Klasse oder Lifecycle-Rolle.
 - **owner_task**: Task, Vorhaben, Kontrollpunkt oder Prozess, der die Verantwortung für den Report trägt. In Phase 1 noch als menschlich lesbarer Wert (noch kein Enum erzwingen).
-- **review_after**: Datum, ab dem erneute Prüfung fällig wird. Für spätere Validatoren soll ein ISO-Datum YYYY-MM-DD bevorzugt werden.
+- **review_after**: ISO-Datum im Format `YYYY-MM-DD`, ab dem erneute Prüfung
+  fällig wird.
 - **superseded_by**: Pfad zum ablösenden Artefakt. Kann ein anderer Report, ein Blueprint, ein Proof oder ein anderes kanonisches Dokument sein.
+
+`lifecycle` ersetzt `doc_type` nicht. `doc_type` beschreibt die Dokumentart im
+Repo, zum Beispiel `report` oder `policy`. `lifecycle` beschreibt die Rolle
+eines Reports innerhalb seines Lebenszyklus, zum Beispiel `audit`, `proof`
+oder `status`.
+
+Beispiel:
+
+```yaml
+doc_type: report
+lifecycle: audit
+```
+
+Die Lifecycle-Felder werden in exakt dieser snake_case-Schreibweise geführt:
+`lifecycle`, `owner_task`, `review_after`, `superseded_by`. Spätere Validatoren
+sollen abweichende Schreibweisen wie `ownerTask` oder `reviewAfter` nicht als
+gleichwertig behandeln.
 
 ## Pflichtfelder nach Status
 
@@ -108,7 +126,7 @@ Wichtig:
 | deferred | erforderlich | erforderlich | erforderlich | optional | Zurückgestellte Reports brauchen einen Wiedervorlagepunkt. |
 | superseded | erforderlich | erforderlich | optional | erforderlich | Ablösung muss explizit nachvollziehbar sein. |
 | archived | erforderlich | empfohlen | nein | empfohlen | Historisch erhalten, nicht mehr handlungsleitend. |
-| deprecated | empfohlen | empfohlen | empfohlen | empfohlen | Veraltet, aber endgültiger Umgang noch offen. |
+| deprecated | erforderlich | erforderlich | empfohlen | empfohlen | Veraltet, aber endgültiger Umgang noch offen; Verantwortlichkeit und Report-Klasse sollen erhalten bleiben. |
 
 Diese Tabelle ist in Phase 1 eine Policy-Zieldefinition. Sie ist noch kein aktiver CI-Guard. Technische Durchsetzung folgt erst in späteren Phasen.
 

--- a/docs/process/report-lifecycle.md
+++ b/docs/process/report-lifecycle.md
@@ -81,6 +81,9 @@ Bis diese Entscheidung getroffen ist, dürfen neue Statuswerte wie `deferred`,
 `superseded` und `archived` nicht als allgemein contract-gültige
 DocMeta-Statuswerte verstanden werden.
 
+Das Report-Lifecycle-Inventory ist Diagnosebasis für diese Policy, aber keine
+kanonische Policy-Quelle.
+
 ## Begriffe
 
 - **Report**: Ein Markdown-Dokument unter `docs/reports/*.md`, das einen Befund, Audit, Proof, Status oder eine entscheidungsvorbereitende Auswertung beschreibt.
@@ -111,9 +114,10 @@ DocMeta-Statuswerte verstanden werden.
 
 ## Status-Semantik
 
-Die folgenden Statuswerte bilden das Zielvokabular für den Report-Lifecycle.
-Sie sind erst dann als Frontmatter-Werte verwendbar, wenn das
-Contract-Alignment-Gate abgeschlossen ist.
+Bestehende DocMeta-Statuswerte wie `draft`, `active` und `deprecated` behalten
+ihre bisherige Contract-Bedeutung. Neue lifecycle-spezifische Werte wie
+`deferred`, `superseded` und `archived` sind erst nach Contract-Alignment als
+Frontmatter-Werte verwendbar.
 
 - **draft**: In Arbeit oder vorbereitend. Noch nicht maßgeblich.
 - **active**: Aktuell handlungsleitend oder als gültiger Bezugspunkt verwendbar.
@@ -158,11 +162,16 @@ lifecycle: audit
 
 Beispiel für die spätere Abbildung einer Ablösung:
 
+Im alten Report, falls das Lifecycle-Feld contract-aktiv wird:
+
 ```yaml
-# Im alten Report, falls das Lifecycle-Feld contract-aktiv wird:
 status: superseded
 superseded_by: docs/reports/new-proof.md
-# Im neuen oder ersetzenden Dokument:
+```
+
+Im neuen oder ersetzenden Dokument:
+
+```yaml
 relations:
   - type: supersedes
     target: docs/reports/old-proof.md


### PR DESCRIPTION
## Summary
Defines the report lifecycle policy for `docs/reports/*.md`.
This is Phase 1 of the report lifecycle mechanism: rules before pilot annotation, validation, backfill, or enforcement.

## Scope
- Adds `docs/process/report-lifecycle.md`
- Links the policy from `docs/process/README.md`
- Defines report classes, status semantics, expected lifecycle metadata, reference classes, archive rules, delete rules, and rollout phases
- Refreshes generated documentation if required by `make generate`
- No existing report is reclassified
- No report is archived
- No report is deleted
- No validator is added
- No generated lifecycle overview is added
- No CI guard is added

## Checks
- [x] `npx markdownlint-cli2 "docs/process/report-lifecycle.md" "docs/process/README.md"`
- [x] `make generate`
- [x] `bash scripts/docmeta/generated-files-guard.sh`
- [x] `git diff --check`

## Notes
This PR intentionally defines policy only. Pilot annotation, validator implementation, changed-only strict mode, backfill, archive mechanics, and deletion rules are separate later phases.

---
*PR created automatically by Jules for task [7256078711114350004](https://jules.google.com/task/7256078711114350004) started by @alexdermohr*