### PR TITLE
docs: record account email uniqueness CI evidence

### DIFF
--- a/docs/reports/domain-account-email-uniqueness-audit.md
+++ b/docs/reports/domain-account-email-uniqueness-audit.md
@@ -360,6 +360,7 @@ CI-Evidence neu belegt:
   - `db-domain-schema-migrations-proof`
   - `db-domain-backfill-proof`
   - `db-domain-account-write-path-proof`
+
 Die Phase-C-Backfill-Importsemantik ist sonst unverändert; es gibt keinen
 Cutover, kein Dual-Write und keine Runtime-Backfill-Änderung.
 

--- a/docs/reports/domain-account-email-uniqueness-audit.md
+++ b/docs/reports/domain-account-email-uniqueness-audit.md
@@ -349,12 +349,19 @@ Zusätzlich wurde erweitert:
   E-Mail-Kollision als `409 CONFLICT` ohne Cache- oder JSONL-Nebenwirkung
   zurückgegeben wird, sowie direkte Insert-Proofs.
 
-Die drei Proofs (`db-domain-schema-migrations-proof`, `db-domain-backfill-proof`,
-`db-domain-account-write-path-proof`) sind in
-`docs/reports/opt-arc-001-db-proof-matrix.json` auf `prepared` zurückgesetzt
-(`ci_evidence: null`), bis die PR-CI sie gegen den neuen Stand neu belegt. Die
-Phase-C-Backfill-Importsemantik ist sonst unverändert; es gibt keinen Cutover,
-kein Dual-Write und keine Runtime-Backfill-Änderung.
+Die drei Proofs (`db-domain-schema-migrations-proof`,
+`db-domain-backfill-proof`, `db-domain-account-write-path-proof`) sind mit
+CI-Evidence neu belegt:
+
+- Run: `https://github.com/heimgewebe/weltgewebe/actions/runs/27487642549`
+- Run-ID: `27487642549`
+- Commit: `cc5446023417e65df1ae907cae9ad4c39612b3a0`
+- Jobs:
+  - `db-domain-schema-migrations-proof`
+  - `db-domain-backfill-proof`
+  - `db-domain-account-write-path-proof`
+Die Phase-C-Backfill-Importsemantik ist sonst unverändert; es gibt keinen
+Cutover, kein Dual-Write und keine Runtime-Backfill-Änderung.
 
 ### Härtung vor Review
 

--- a/docs/reports/opt-arc-001-db-proof-matrix.json
+++ b/docs/reports/opt-arc-001-db-proof-matrix.json
@@ -21,24 +21,34 @@
       "id": "db-domain-schema-migrations-proof",
       "phase": "B",
       "claim": "Domain PostgreSQL schema migrations are executable in CI against PostgreSQL 16.",
-      "state": "prepared",
+      "state": "ci_proven",
       "workflow": ".github/workflows/api.yml",
       "workflow_job": "db-domain-schema-migrations-proof",
       "test": "apps/api/tests/db_domain_schema_migrations.rs",
       "report": null,
-      "ci_evidence": null,
+      "ci_evidence": {
+        "run_url": "https://github.com/heimgewebe/weltgewebe/actions/runs/27487642549",
+        "run_id": 27487642549,
+        "commit": "cc5446023417e65df1ae907cae9ad4c39612b3a0",
+        "job": "db-domain-schema-migrations-proof"
+      },
       "command": "cargo test --locked -p weltgewebe-api --test db_domain_schema_migrations -- --include-ignored --test-threads=1"
     },
     {
       "id": "db-domain-backfill-proof",
       "phase": "C",
       "claim": "JSONL-to-PostgreSQL backfill for nodes, edges and accounts is implemented as an opt-in proof path.",
-      "state": "prepared",
+      "state": "ci_proven",
       "workflow": ".github/workflows/api.yml",
       "workflow_job": "db-domain-backfill-proof",
       "test": "apps/api/tests/db_domain_backfill.rs",
       "report": "docs/reports/domain-backfill-proof.md",
-      "ci_evidence": null,
+      "ci_evidence": {
+        "run_url": "https://github.com/heimgewebe/weltgewebe/actions/runs/27487642549",
+        "run_id": 27487642549,
+        "commit": "cc5446023417e65df1ae907cae9ad4c39612b3a0",
+        "job": "db-domain-backfill-proof"
+      },
       "command": "cargo test --locked -p weltgewebe-api --test db_domain_backfill -- --include-ignored --test-threads=1"
     },
     {
@@ -62,12 +72,17 @@
       "id": "db-domain-account-write-path-proof",
       "phase": "E-A",
       "claim": "Optional PostgreSQL write path for POST /accounts is implemented behind explicit write gate.",
-      "state": "prepared",
+      "state": "ci_proven",
       "workflow": ".github/workflows/api.yml",
       "workflow_job": "db-domain-account-write-path-proof",
       "test": "apps/api/tests/db_domain_account_write_path.rs",
       "report": "docs/reports/domain-account-write-path-proof.md",
-      "ci_evidence": null,
+      "ci_evidence": {
+        "run_url": "https://github.com/heimgewebe/weltgewebe/actions/runs/27487642549",
+        "run_id": 27487642549,
+        "commit": "cc5446023417e65df1ae907cae9ad4c39612b3a0",
+        "job": "db-domain-account-write-path-proof"
+      },
       "command": "cargo test --locked -p weltgewebe-api --test db_domain_account_write_path -- --include-ignored --test-threads=1"
     },
     {


### PR DESCRIPTION
## Summary
Records CI evidence for the account email uniqueness proofs after TODO 2A was merged.
## Scope
- Updates `docs/reports/opt-arc-001-db-proof-matrix.json`
- Updates `docs/reports/domain-account-email-uniqueness-audit.md`
- No runtime code
- No migration changes
- No test changes
- No workflow changes
## Evidence
- Run: `https://github.com/heimgewebe/weltgewebe/actions/runs/27487642549`
- Run-ID: `27487642549`
- Commit: `cc5446023417e65df1ae907cae9ad4c39612b3a0`
Proofs recorded:
- `db-domain-schema-migrations-proof`
- `db-domain-backfill-proof`
- `db-domain-account-write-path-proof`
## Non-goals
- No code changes
- No migration changes
- No test changes
- No Login-Lookup change
- No JSONL cutover
- No Runtime-Smoke
- No Step-up/WebAuthn changes
## Checks
- [x] `python3 -m scripts.docmeta.validate_opt_arc_001_db_proof_matrix`
- [x] `npx markdownlint-cli2 docs/reports/domain-account-email-uniqueness-audit.md`
- [x] `git diff --check`

---
*PR created automatically by Jules for task [8155343870480254409](https://jules.google.com/task/8155343870480254409) started by @alexdermohr*