### PR TITLE
docs: decide report lifecycle contract alignment

### DIFF
--- a/docs/_generated/backlinks.md
+++ b/docs/_generated/backlinks.md
@@ -69,6 +69,10 @@ Generated automatically. Do not edit.
 
 - [relates_to] docs/reports/domain-edge-create-semantics-preflight.md
 
+## docs/_generated/report-lifecycle-inventory.md
+
+- [relates_to] docs/process/report-lifecycle.md
+
 ## docs/adr/0042-consume-semantah-contracts.md
 
 - [relates_to] docs/x-repo/semantAH.md

--- a/docs/_generated/backlinks.md
+++ b/docs/_generated/backlinks.md
@@ -401,6 +401,7 @@ Generated automatically. Do not edit.
 ## docs/process/report-lifecycle-contract-alignment.md
 
 - [relates_to] docs/process/README.md
+- [relates_to] docs/process/report-lifecycle.md
 
 ## docs/process/report-lifecycle.md
 

--- a/docs/_generated/backlinks.md
+++ b/docs/_generated/backlinks.md
@@ -69,10 +69,6 @@ Generated automatically. Do not edit.
 
 - [relates_to] docs/reports/domain-edge-create-semantics-preflight.md
 
-## docs/_generated/report-lifecycle-inventory.md
-
-- [relates_to] docs/process/report-lifecycle.md
-
 ## docs/adr/0042-consume-semantah-contracts.md
 
 - [relates_to] docs/x-repo/semantAH.md
@@ -382,6 +378,7 @@ Generated automatically. Do not edit.
 
 - [relates_to] docs/process/bash-tooling-guidelines.md
 - [relates_to] docs/process/fahrplan.md
+- [relates_to] docs/process/report-lifecycle-contract-alignment.md
 - [relates_to] docs/process/report-lifecycle.md
 - [relates_to] docs/process/sprache.md
 
@@ -397,9 +394,14 @@ Generated automatically. Do not edit.
 - [relates_to] docs/quickstart-gate-c.md
 - [depends_on] docs/roadmap.md
 
+## docs/process/report-lifecycle-contract-alignment.md
+
+- [relates_to] docs/process/README.md
+
 ## docs/process/report-lifecycle.md
 
 - [relates_to] docs/process/README.md
+- [relates_to] docs/process/report-lifecycle-contract-alignment.md
 
 ## docs/process/sprache.md
 

--- a/docs/_generated/doc-index.md
+++ b/docs/_generated/doc-index.md
@@ -83,6 +83,7 @@ Generated automatically. Do not edit.
 | process.bash-tooling-guidelines | Bash Tooling Guidelines | reference | active | docs/process/bash-tooling-guidelines.md |
 | process.fahrplan | Fahrplan | reference | active | docs/process/fahrplan.md |
 | process.report-lifecycle | Report Lifecycle Policy | policy | draft | docs/process/report-lifecycle.md |
+| process.report-lifecycle-contract-alignment | Report Lifecycle Contract Alignment | decision | draft | docs/process/report-lifecycle-contract-alignment.md |
 | process.sprache | Sprache | reference | active | docs/process/sprache.md |
 | proofs.sqlx-pgbouncer-session-crud-proof | SQLx → PgBouncer → Postgres — Session-CRUD-Proof | report | active | docs/proofs/sqlx-pgbouncer-session-crud-proof.md |
 | proofs.sqlx-postgres-direct-session-crud-proof | SQLx \u2192 direkter PostgreSQL \u2014 Session-CRUD-Proof | report | active | docs/proofs/sqlx-postgres-direct-session-crud-proof.md |

--- a/docs/_generated/relates-to-audit.md
+++ b/docs/_generated/relates-to-audit.md
@@ -14,9 +14,9 @@ Generated automatically. Do not edit.
 
 | Metrik | Wert |
 | --- | --- |
-| Relationen gesamt | 371 |
+| Relationen gesamt | 373 |
 | — depends_on | 18 |
-| — relates_to | 351 |
+| — relates_to | 353 |
 | — supersedes | 2 |
 | relates_to Anteil | 95% |
 
@@ -44,7 +44,6 @@ _Keine Lücken erkannt._
 - `apps/api/tests/db_domain_backfill.rs`
 - `audit/impl-registry.yaml`
 - `contracts/domain/edge.schema.json`
-- `docs/_generated/report-lifecycle-inventory.md`
 - `docs/adr/0043-edge-vs-conversation.md`
 - `docs/adr/ADR-0001__clean-slate-docs-monorepo.md`
 - `docs/adr/ADR-0002__reentry-kriterien.md`
@@ -106,6 +105,7 @@ _Keine Lücken erkannt._
 - `docs/process/README.md`
 - `docs/process/bash-tooling-guidelines.md`
 - `docs/process/fahrplan.md`
+- `docs/process/report-lifecycle-contract-alignment.md`
 - `docs/process/report-lifecycle.md`
 - `docs/process/sprache.md`
 - `docs/proofs/basemap-hamburg-artifact-proof.md`

--- a/docs/_generated/relates-to-audit.md
+++ b/docs/_generated/relates-to-audit.md
@@ -14,9 +14,9 @@ Generated automatically. Do not edit.
 
 | Metrik | Wert |
 | --- | --- |
-| Relationen gesamt | 373 |
+| Relationen gesamt | 374 |
 | — depends_on | 18 |
-| — relates_to | 353 |
+| — relates_to | 354 |
 | — supersedes | 2 |
 | relates_to Anteil | 95% |
 
@@ -30,7 +30,7 @@ _Keine Lücken erkannt._
 
 > Zusammenhängende Gruppen im relates_to-Graphen.
 
-**Cluster 1** (136 Dokumente):
+**Cluster 1** (137 Dokumente):
 
 - `.github/workflows/api.yml`
 - `AGENTS.md`
@@ -44,6 +44,7 @@ _Keine Lücken erkannt._
 - `apps/api/tests/db_domain_backfill.rs`
 - `audit/impl-registry.yaml`
 - `contracts/domain/edge.schema.json`
+- `docs/_generated/report-lifecycle-inventory.md`
 - `docs/adr/0043-edge-vs-conversation.md`
 - `docs/adr/ADR-0001__clean-slate-docs-monorepo.md`
 - `docs/adr/ADR-0002__reentry-kriterien.md`

--- a/docs/_generated/relates-to-audit.md
+++ b/docs/_generated/relates-to-audit.md
@@ -14,9 +14,9 @@ Generated automatically. Do not edit.
 
 | Metrik | Wert |
 | --- | --- |
-| Relationen gesamt | 374 |
+| Relationen gesamt | 375 |
 | — depends_on | 18 |
-| — relates_to | 354 |
+| — relates_to | 355 |
 | — supersedes | 2 |
 | relates_to Anteil | 95% |
 

--- a/docs/_generated/relations-analysis.md
+++ b/docs/_generated/relations-analysis.md
@@ -14,12 +14,12 @@ Generated automatically. Do not edit.
 
 | Metrik | Wert |
 | --- | --- |
-| Dokumente gesamt | 122 |
-| Dokumente mit ausgehenden Relationen | 119 |
-| Dokumente als Ziel referenziert | 93 |
-| Relationen gesamt | 371 |
+| Dokumente gesamt | 123 |
+| Dokumente mit ausgehenden Relationen | 120 |
+| Dokumente als Ziel referenziert | 94 |
+| Relationen gesamt | 373 |
 | — depends_on | 18 |
-| — relates_to | 351 |
+| — relates_to | 353 |
 | — supersedes | 2 |
 | Isolierte Dokumente | 2 |
 | depends_on Zyklen | 0 |

--- a/docs/_generated/relations-analysis.md
+++ b/docs/_generated/relations-analysis.md
@@ -17,9 +17,9 @@ Generated automatically. Do not edit.
 | Dokumente gesamt | 123 |
 | Dokumente mit ausgehenden Relationen | 120 |
 | Dokumente als Ziel referenziert | 94 |
-| Relationen gesamt | 373 |
+| Relationen gesamt | 374 |
 | — depends_on | 18 |
-| — relates_to | 353 |
+| — relates_to | 354 |
 | — supersedes | 2 |
 | Isolierte Dokumente | 2 |
 | depends_on Zyklen | 0 |

--- a/docs/_generated/relations-analysis.md
+++ b/docs/_generated/relations-analysis.md
@@ -17,9 +17,9 @@ Generated automatically. Do not edit.
 | Dokumente gesamt | 123 |
 | Dokumente mit ausgehenden Relationen | 120 |
 | Dokumente als Ziel referenziert | 94 |
-| Relationen gesamt | 374 |
+| Relationen gesamt | 375 |
 | — depends_on | 18 |
-| — relates_to | 354 |
+| — relates_to | 355 |
 | — supersedes | 2 |
 | Isolierte Dokumente | 2 |
 | depends_on Zyklen | 0 |

--- a/docs/_generated/report-lifecycle-inventory.md
+++ b/docs/_generated/report-lifecycle-inventory.md
@@ -27,8 +27,8 @@ Primary references are exact path matches in canonical documentation surfaces. D
 | files_missing_owner_task | 23 |
 | files_with_review_after | 0 |
 | files_missing_review_after | 23 |
-| files_primary_referenced | 18 |
-| files_primary_unreferenced | 5 |
+| files_primary_referenced | 19 |
+| files_primary_unreferenced | 4 |
 | files_with_derived_references | 23 |
 | files_with_relations | 22 |
 | files_with_missing_supersession_target | 0 |
@@ -54,7 +54,7 @@ Primary references are exact path matches in canonical documentation surfaces. D
 | docs/reports/auth-persistence-runtime-target-reconciliation.md | report | active |  |  |  |  | 1 | 3 | 5 | lifecycle, owner_task, review_after |  |
 | docs/reports/auth-status-matrix.md | reference | active |  |  |  |  | 5 | 3 | 3 | lifecycle, owner_task, review_after |  |
 | docs/reports/cost-report.md | reference | active |  |  |  |  | 0 | 3 | 0 | lifecycle, owner_task, review_after |  |
-| docs/reports/domain-account-email-uniqueness-audit.md | report | draft |  |  |  |  | 0 | 3 | 4 | lifecycle, owner_task, review_after |  |
+| docs/reports/domain-account-email-uniqueness-audit.md | report | draft |  |  |  |  | 1 | 3 | 4 | lifecycle, owner_task, review_after |  |
 | docs/reports/domain-account-write-path-proof.md | report | active |  |  |  |  | 7 | 3 | 6 | lifecycle, owner_task, review_after |  |
 | docs/reports/domain-backfill-proof.md | report | active |  |  |  |  | 3 | 3 | 4 | lifecycle, owner_task, review_after |  |
 | docs/reports/domain-edge-create-semantics-preflight.md | report | active |  |  |  |  | 0 | 3 | 7 | lifecycle, owner_task, review_after |  |
@@ -159,6 +159,9 @@ Primary references are exact path matches in canonical documentation surfaces. D
   - `docs/reports/optimierungsstatus.md`
   - `docs/reports/passkey-register-verify-prep.md`
   - `docs/roadmap.md`
+
+- `docs/reports/domain-account-email-uniqueness-audit.md`
+  - `docs/reports/domain-backfill-proof.md`
 
 - `docs/reports/domain-account-write-path-proof.md`
   - `docs/blueprints/domain-data-postgres-cutover.md`
@@ -365,7 +368,6 @@ Primary references are exact path matches in canonical documentation surfaces. D
 
 - `docs/reports/auth-persistence-direct-proof-diagnose-audit.md`
 - `docs/reports/cost-report.md`
-- `docs/reports/domain-account-email-uniqueness-audit.md`
 - `docs/reports/domain-edge-create-semantics-preflight.md`
 - `docs/reports/passkey-register-verify-prep.md`
 

--- a/docs/process/README.md
+++ b/docs/process/README.md
@@ -8,12 +8,15 @@ relations:
   - type: relates_to
     target: docs/process/report-lifecycle.md
   - type: relates_to
+    target: docs/process/report-lifecycle-contract-alignment.md
+  - type: relates_to
     target: docs/process/fahrplan.md
   - type: relates_to
     target: docs/process/sprache.md
   - type: relates_to
     target: docs/process/bash-tooling-guidelines.md
 ---
+
 # Prozess
 
 Übersicht über Abläufe und Konventionen.
@@ -23,6 +26,7 @@ relations:
 - [Fahrplan](fahrplan.md) – zeitlicher Ablauf und Meilensteine (**kanonisch**)
 - [Sprache](sprache.md) – Leitfaden zur Projektsprache
 - [Report Lifecycle Policy](report-lifecycle.md) – Regeln für Status, Review, Ablösung, Archivierung und Löschung von Reports
+- [Report Lifecycle Contract Alignment](report-lifecycle-contract-alignment.md) – Abgrenzung von DocMeta-Status, Report-Lifecycle-Zustand und Supersession-Modell
 - [Bash Tooling Guidelines](bash-tooling-guidelines.md) – Best Practices für zukünftige Shell-Skripte
 
 [Zurück zum Doku-Index](../index.md)

--- a/docs/process/report-lifecycle-contract-alignment.md
+++ b/docs/process/report-lifecycle-contract-alignment.md
@@ -130,7 +130,11 @@ bewusst eine andere kanonische Richtung beschlossen wurde.
 
 ## Inventory- und Validator-Abgrenzung
 
-Das bestehende Report-Lifecycle-Inventory bleibt in diesem PR unverändert.
+Das bestehende Report-Lifecycle-Inventory-Tooling bleibt in diesem PR
+unverändert.
+
+Das generierte Inventory-Artefakt darf sich nur ändern, wenn `make generate`
+eine reproduzierbare Aktualisierung des aktuellen Dokumentationsgraphen erzeugt.
 
 Es ist aktuell eine Bestandsaufnahme und liest noch:
 

--- a/docs/process/report-lifecycle-contract-alignment.md
+++ b/docs/process/report-lifecycle-contract-alignment.md
@@ -1,0 +1,207 @@
+---
+id: process.report-lifecycle-contract-alignment
+title: Report Lifecycle Contract Alignment
+doc_type: decision
+status: draft
+summary: >
+  Entscheidungsvorbereitung und Zielentscheidung zur Abgrenzung von DocMeta-
+  Status, Report-Lifecycle-Zustand, Lifecycle-Feldern, Inventory-Tooling und
+  Supersession-Relationen.
+relations:
+  - type: relates_to
+    target: docs/process/report-lifecycle.md
+  - type: relates_to
+    target: docs/process/README.md
+---
+
+# Report Lifecycle Contract Alignment
+
+## Zweck
+
+Dieses Dokument entscheidet die Abgrenzung zwischen bestehendem DocMeta-Modell
+und künftigem Report-Lifecycle-Modell.
+
+Die Report-Lifecycle-Policy beschreibt ein Zielmodell. Vor Pilot, Backfill oder
+Validator muss festgelegt werden, welche Felder bestehende DocMeta-Wahrheit sind
+und welche Felder als report-spezifisches Lifecycle-Modell eingeführt werden.
+
+## Ausgangslage
+
+- `docs/_generated/report-lifecycle-inventory.md` zeigt den Reportbestand und
+  die aktuell fehlenden Lifecycle-Felder.
+- `docs/process/report-lifecycle.md` beschreibt das Zielmodell.
+- Der bestehende DocMeta-Contract kennt bereits allgemeine Dokumentstatuswerte.
+- `deferred`, `superseded` und `archived` sind aktuell keine global gültigen
+  DocMeta-Statuswerte.
+- Die bestehende Supersession-Mechanik nutzt `relations` mit
+  `type: supersedes`.
+- Das aktuelle Inventory-Tooling liest noch `status` für terminale Zustände und
+  kennt `lifecycle_state` noch nicht.
+
+## Nicht-Ziele
+
+- Keine Änderung an `contracts/docmeta.schema.json`.
+- Keine Änderung an `architecture/docmeta.schema.md`.
+- Keine Änderung an `repo.meta.yaml`.
+- Keine Änderung an `scripts/docmeta/**`.
+- Kein Validator.
+- Kein Backfill.
+- Kein Pilot-Report.
+- Keine Report-Frontmatter-Änderung.
+- Keine Archivierung.
+- Keine Löschung.
+
+## Entscheidung
+
+Report-Lifecycle-Metadaten werden zunächst als report-spezifisches Zielmodell
+behandelt.
+
+Der bestehende DocMeta-Status bleibt global und wird nicht mit
+report-spezifischen Lifecycle-Zuständen überladen.
+
+Für Reports wird folgende Zielstruktur vorbereitet:
+
+```yaml
+doc_type: report
+status: active
+lifecycle: audit
+owner_task: OPT-ARC-001
+review_after: 2026-07-13
+lifecycle_state: active
+```
+
+Dabei gilt:
+
+| Feld | Bedeutung |
+| --- | --- |
+| `doc_type` | bestehende Dokumentart |
+| `status` | bestehender globaler DocMeta-Status |
+| `lifecycle` | Report-Klasse oder Lifecycle-Rolle |
+| `owner_task` | verantwortlicher Task, Vorhaben oder Prozess |
+| `review_after` | Review-Datum im Format `YYYY-MM-DD` |
+| `lifecycle_state` | report-spezifischer Lifecycle-Zustand |
+| `superseded_by` | optionaler Zielpfad bei Ablösung, nur konsistent mit Supersession-Relation |
+
+## Status-Abgrenzung
+
+Bestehende DocMeta-Statuswerte behalten ihre bisherige Bedeutung.
+
+Beispiele:
+
+- `draft`
+- `active`
+- `deprecated`
+- `canonical`
+
+Report-spezifische Lifecycle-Zustände werden nicht direkt als globale
+DocMeta-Statuswerte eingeführt.
+
+Zielvokabular für `lifecycle_state`:
+
+- `active`
+- `deferred`
+- `superseded`
+- `archived`
+
+Damit kann ein Report global `status: active` bleiben, während sein
+report-spezifischer Zustand über `lifecycle_state` genauer beschrieben wird.
+
+## Supersession-Abgrenzung
+
+Die bestehende Repo-Mechanik für Ablösungen bleibt:
+
+```yaml
+relations:
+  - type: supersedes
+    target: docs/reports/old-report.md
+```
+
+Richtung:
+
+```text
+neues Artefakt --supersedes--> altes Artefakt
+```
+
+`superseded_by` darf nicht als alleinige Wahrheit eingeführt werden.
+
+Wenn `superseded_by` später genutzt wird, muss ein Validator mindestens prüfen,
+ob die umgekehrte `relations[type=supersedes]`-Relation existiert oder ob
+bewusst eine andere kanonische Richtung beschlossen wurde.
+
+## Inventory- und Validator-Abgrenzung
+
+Das bestehende Report-Lifecycle-Inventory bleibt in diesem PR unverändert.
+
+Es ist aktuell eine Bestandsaufnahme und liest noch:
+
+- `status`
+- `lifecycle`
+- `owner_task`
+- `review_after`
+- `superseded_by`
+
+Das Inventory kennt `lifecycle_state` noch nicht. Diese Abweichung ist in Phase
+1.5 bewusst akzeptiert, weil dieser PR nur die Modellentscheidung trifft.
+
+Ein späterer Tooling-PR muss entscheiden, ob:
+
+- das Inventory zusätzlich `lifecycle_state` ausliest,
+- terminale Zustände von `status` auf `lifecycle_state` umgestellt werden,
+- oder ein separates Report-Lifecycle-Schema diese Prüfung übernimmt.
+
+## Legacy ohne Ersatz
+
+Archivierte oder veraltete Legacy-Reports ohne eindeutiges Ersatzartefakt
+dürfen nicht durch künstliche `superseded_by`-Pfade repariert werden.
+
+Dafür braucht es später eine explizite Regel, zum Beispiel:
+
+- ein eigenes Ausnahmefeld,
+- eine dokumentierte Verwerfungsbegründung,
+- oder ein Validator-Verhalten für historische Reports.
+
+In diesem PR wird keine solche Ausnahme technisch eingeführt.
+
+## Konsequenzen für Phase 2
+
+Der Pilot darf erst nach dieser Entscheidung erfolgen.
+
+Für den ersten Pilot-Report soll nur bestehendes DocMeta-Vokabular im Feld
+`status` verwendet werden. Neue Report-Zustände gehören in `lifecycle_state`,
+nicht in `status`.
+
+Beispiel für den späteren Pilot:
+
+```yaml
+doc_type: report
+status: active
+lifecycle: audit
+owner_task: OPT-ARC-001
+review_after: 2026-07-13
+lifecycle_state: active
+```
+
+## Konsequenzen für Phase 3
+
+Der spätere Validator soll zunächst report-spezifisch arbeiten.
+
+Er soll prüfen:
+
+- Reports unter `docs/reports/*.md`.
+- Existenz und Format von `lifecycle`.
+- Existenz und Format von `owner_task`.
+- ISO-Format von `review_after`.
+- Zulässigkeit von `lifecycle_state`.
+- Konsistenz von `superseded_by` mit `relations[type=supersedes]`.
+- Keine harte globale DocMeta-Status-Erweiterung ohne separaten Contract-PR.
+
+## Offene Folgeentscheidungen
+
+- Wird `lifecycle_state` Teil von `contracts/docmeta.schema.json`?
+- Oder entsteht ein eigenes Report-Lifecycle-Schema?
+- Wird `superseded_by` gespeichert, abgeleitet oder vermieden?
+- Wie wird Legacy ohne Ersatz maschinenlesbar ausgenommen?
+- Wann darf `status: deprecated` mit `lifecycle_state: archived` kombiniert
+  werden?
+- Wann wird das Inventory-Tooling auf `lifecycle_state` ausgerichtet?
+- Ob und wann `repo.meta.yaml` diese Policy als kanonische Quelle registriert.

--- a/docs/process/report-lifecycle.md
+++ b/docs/process/report-lifecycle.md
@@ -68,11 +68,14 @@ Diese Policy beschreibt zunächst Reports. Andere Dokumenttypen können Reports 
 Diese Policy beschreibt weiterhin ein Zielmodell. Die hier beschriebenen
 Lifecycle-Felder sind durch diesen PR noch nicht automatisch Teil des
 bestehenden DocMeta-Contracts, eines Validators oder eines CI-Guards.
+
 Die Entscheidung zur Abgrenzung von `status`, `lifecycle_state`,
 `superseded_by`, Inventory-Tooling und `relations[type=supersedes]` wird in
 `docs/process/report-lifecycle-contract-alignment.md` vorbereitet.
+
 Das Report-Lifecycle-Inventory ist Diagnosebasis für diese Policy, aber keine
 kanonische Policy-Quelle.
+
 Das bestehende Inventory-Tooling kennt `lifecycle_state` noch nicht. Diese
 Policy benennt das Zielmodell; die Ausrichtung von Inventory, Validator und
 späterer Übersicht folgt in separaten Tooling-PRs.
@@ -81,7 +84,8 @@ späterer Übersicht folgt in separaten Tooling-PRs.
 
 - **Report**: Ein Markdown-Dokument unter `docs/reports/*.md`, das einen Befund, Audit, Proof, Status oder eine entscheidungsvorbereitende Auswertung beschreibt.
 - **Lifecycle**: Die Rolle eines Reports im Lebenszyklus: warum er existiert, wie lange er handlungsleitend ist und wann er geprüft oder abgelöst wird.
-- **Status**: Der aktuelle Zustand eines Reports, zum Beispiel `draft`, `active`, `superseded` oder `archived`.
+- **Status**: Der globale DocMeta-Status eines Reports, zum Beispiel `draft`, `active`, `deprecated` oder `canonical`.
+- **Lifecycle-Zustand**: Der report-spezifische Zustand in `lifecycle_state`, zum Beispiel `active`, `superseded` oder `archived`.
 - **Supersession**: Eine explizite Ablösung durch ein anderes Artefakt. Supersession bedeutet nicht automatisch Löschung.
 - **Archivierung**: Ein Report bleibt erhalten, ist aber nicht mehr handlungsleitend.
 - **Löschung**: Physisches Entfernen eines Reports aus dem Repo. Löschung ist der letzte Schritt und nur nach separater Prüfung erlaubt.
@@ -167,10 +171,11 @@ lifecycle: audit
 
 Beispiel für die spätere Abbildung einer Ablösung:
 
-Im alten Report, falls das Lifecycle-Feld contract-aktiv wird:
+Im alten Report, falls die Lifecycle-Felder contract-aktiv werden:
 
 ```yaml
-status: superseded
+status: deprecated
+lifecycle_state: superseded
 superseded_by: docs/reports/new-proof.md
 ```
 
@@ -183,9 +188,9 @@ relations:
 ```
 
 Die Lifecycle-Felder werden in exakt dieser snake_case-Schreibweise geführt:
-`lifecycle`, `owner_task`, `review_after`, `superseded_by`. Spätere Validatoren
-sollen abweichende Schreibweisen wie `ownerTask` oder `reviewAfter` nicht als
-gleichwertig behandeln.
+`lifecycle`, `owner_task`, `review_after`, `lifecycle_state`, `superseded_by`.
+Spätere Validatoren sollen abweichende Schreibweisen wie `ownerTask`,
+`reviewAfter` oder `lifecycleState` nicht als gleichwertig behandeln.
 
 ## Pflichtfelder nach Lifecycle-Zustand
 
@@ -235,9 +240,9 @@ bereits archivierte Quelle blockiert nicht automatisch.
 
 ## Archivierungsregeln
 
-Standard: `status: archived`
+Standard: `status: deprecated` mit `lifecycle_state: archived`
 
-Status-only Archivierung ist der Standard der ersten Ausbaustufen. Die Datei bleibt zunächst am Ort. Dadurch brechen keine Links.
+Lifecycle-State-only Archivierung ist der Standard der ersten Ausbaustufen. Die Datei bleibt zunächst am Ort. Dadurch brechen keine Links.
 
 Physische Archivierung ist später optional:
 
@@ -255,11 +260,12 @@ Wichtig: Noch keine Archivierung in diesem PR.
 
 ## Löschregeln
 
-Direktes Löschen aus draft oder active ist nicht erlaubt.
+Direktes Löschen aus `status: draft`, `status: active` oder
+`lifecycle_state: active` ist nicht erlaubt.
 
 Löschen nur, wenn alle Bedingungen erfüllt sind:
 
-- Report ist `archived` oder `superseded`.
+- Report hat `lifecycle_state: archived` oder `lifecycle_state: superseded`.
 - `superseded_by` existiert oder ein später definiertes maschinenlesbares
   Ausnahmefeld dokumentiert bewusst, warum kein Ersatzartefakt existiert.
 - Keine aktive Primary Reference existiert.
@@ -282,7 +288,7 @@ Eine Löschung darf nie nebenbei in einem Feature-PR passieren.
 6. **Backfill**: kleine Slices statt Massen-PR.
 7. **Changed-only strict**: neue oder geänderte Reports müssen Felder tragen.
 8. **Global strict**: erst nach abgeschlossenem Backfill.
-9. **Archivierung**: zunächst status-only.
+9. **Archivierung**: zunächst Lifecycle-State-only.
 10. **Löschung**: nur separat und nach Referenzcheck.
 
 Changed-only strict kommt vor global strict, damit Altlasten nicht jeden Feature-PR blockieren.

--- a/docs/process/report-lifecycle.md
+++ b/docs/process/report-lifecycle.md
@@ -11,6 +11,8 @@ relations:
     target: docs/process/README.md
   - type: relates_to
     target: docs/_generated/report-lifecycle-inventory.md
+  - type: relates_to
+    target: docs/process/report-lifecycle-contract-alignment.md
 ---
 
 # Report Lifecycle Policy

--- a/docs/process/report-lifecycle.md
+++ b/docs/process/report-lifecycle.md
@@ -3,70 +3,83 @@ id: process.report-lifecycle
 title: Report Lifecycle Policy
 doc_type: policy
 status: draft
-canonicality: kanonisch nach Contract-Alignment
 summary: >
-  Zukünftige Regeln für den Lebenszyklus von Reports. Definiert Status,
-  Review-Fristen, Ablösung und Archivierung.
+  Policy für Lebenszyklus, Status, Pflichtfelder, Archivierung und Löschung
+  von Reports.
 relations:
   - type: relates_to
     target: docs/process/README.md
+  - type: relates_to
+    target: docs/_generated/report-lifecycle-inventory.md
 ---
 
 # Report Lifecycle Policy
 
 ## Zweck
 
-Dieses Dokument definiert den Lebenszyklus von Dokumenten unter `docs/reports/`
-sowie von weiteren Artefakten, die ausdrücklich die `doc_type: report` oder
-`lifecycle`-Rolle tragen.
+Diese Datei ist der vorgeschlagene Zielort für Report-Lifecycle-Regeln. Sie
+bleibt `draft`, bis die Policy in einem späteren Schritt in das Truth Model
+und den DocMeta-Contract integriert oder bewusst als nicht-kanonische
+Prozessregel bestätigt wird.
 
-Es soll sicherstellen, dass Reports nicht lautlos veralten und bei Ablösung oder
-Archivierung ein klarer Pfad erkennbar bleibt.
+Reports sollen nicht dauerhaft als scheinbar aktuelle Wahrheit im Repo liegen.
+Jeder Report soll später beantworten können:
+
+- Wozu existiert er?
+- Welcher Task oder welches Vorhaben gehört dazu?
+- Ist er aktiv?
+- Wann muss er überprüft werden?
+- Wodurch wurde er abgelöst?
+- Darf er archiviert werden?
+- Darf er gelöscht werden?
+
+Wichtig: Diese Policy ist eine Regelgrundlage, keine rückwirkende Bereinigung.
 
 ## Geltungsbereich
 
-Die Policy gilt für:
+Gilt für:
 
-- Alle Dateien in `docs/reports/*.md`.
-- Jede Datei, die `doc_type: report` deklariert, unabhängig vom Verzeichnis.
+- `docs/reports/*.md`
 
-Sie gilt nicht für:
+Noch nicht verbindlich für:
 
-- Architektur-Dokumente (`docs/adr/`, `docs/blueprints/`, `docs/specs/`),
-  sofern sie nicht explizit als Report markiert sind.
-- Aufgaben (`docs/tasks/`).
-- Code-Kommentare.
+- `docs/proofs/**`
+- `docs/adr/**`
+- `docs/specs/**`
+- `docs/blueprints/**`
+- `docs/tasks/**`
+
+Diese Policy beschreibt zunächst Reports. Andere Dokumenttypen können Reports referenzieren und dadurch deren Archivierung oder Löschung blockieren, werden aber selbst nicht durch diese Policy klassifiziert.
+
+## Nicht-Ziele
+
+- Diese Policy klassifiziert noch keine bestehenden Reports.
+- Diese Policy archiviert keine Reports.
+- Diese Policy löscht keine Reports.
+- Diese Policy aktiviert keinen Validator.
+- Diese Policy verschärft keine CI.
+- Diese Policy verändert keine Task-Wahrheit.
+- Diese Policy ersetzt keine fachliche Review-Entscheidung.
 
 ## Contract-Alignment-Gate
-
-Aktuell ist dieses Dokument ein Entwurf (Draft). Es dokumentiert ein
-Zielmodell. Dieses Modell darf erst auf echten Bestand angewendet werden
-(Pilot, Backfill, Validator), wenn geklärt ist, wo die neuen Lifecycle-Felder
-technisch definiert werden.
 
 Die Entscheidung zur Abgrenzung von `status`, `lifecycle_state`,
 `superseded_by`, Inventory-Tooling und `relations[type=supersedes]` wird in
 `docs/process/report-lifecycle-contract-alignment.md` vorbereitet.
 
-Basis für diese Entscheidung ist die Bestandsaufnahme im
-[Report Lifecycle Inventory](../_generated/report-lifecycle-inventory.md).
-Erst nach dieser Entscheidung wird die Policy verbindlich.
-
 Das bestehende Inventory-Tooling kennt `lifecycle_state` noch nicht. Diese
 Policy benennt das Zielmodell; die Ausrichtung von Inventory, Validator und
 späterer Übersicht folgt in separaten Tooling-PRs.
 
-## Vokabular-Gate
+## Begriffe
 
-Für den ersten Wurf (Inventory, Policy, Pilot) ist nur das Folgende erlaubt:
-
-- Keine harten Enums in Frontmatter-Validatoren einbauen, bevor der Pilot nicht abgeschlossen ist.
-- Referenzklassen in Inventory und Validator strikt trennen: Primary Reference
-  vs Derived Reference.
-
-- **Primary Reference**: Ein direkter Frontmatter-Link aus einem anderen
-  handgeschriebenen Dokument, das als kanonisch oder normativ gilt. Zum
-  Beispiel Tasks, Blueprints, ADRs, Specs, Proofs, Reports oder Roadmap.
+- **Report**: Ein Markdown-Dokument unter `docs/reports/*.md`, das einen Befund, Audit, Proof, Status oder eine entscheidungsvorbereitende Auswertung beschreibt.
+- **Lifecycle**: Die Rolle eines Reports im Lebenszyklus: warum er existiert, wie lange er handlungsleitend ist und wann er geprüft oder abgelöst wird.
+- **Status**: Der aktuelle Zustand eines Reports, zum Beispiel `draft`, `active`, `superseded` oder `archived`.
+- **Supersession**: Eine explizite Ablösung durch ein anderes Artefakt. Supersession bedeutet nicht automatisch Löschung.
+- **Archivierung**: Ein Report bleibt erhalten, ist aber nicht mehr handlungsleitend.
+- **Löschung**: Physisches Entfernen eines Reports aus dem Repo. Löschung ist der letzte Schritt und nur nach separater Prüfung erlaubt.
+- **Primary Reference**: Eine handgeschriebene Referenz aus fachlich relevanten Dokumenten, zum Beispiel Tasks, Blueprints, ADRs, Specs, Proofs, Reports oder Roadmap.
 - **Derived Reference**: Eine generierte Referenz aus `docs/_generated/**`. Sie zeigt Sichtbarkeit oder Indexierung, beweist aber nicht automatisch fachliche Aktualität.
 
 ## Report-Klassen
@@ -121,7 +134,7 @@ Wichtig:
 - **superseded_by**: Pfad zum ablösenden Artefakt. Dieses Feld darf nicht als
   alleinige Supersession-Wahrheit verstanden werden. Die bestehende
   Repo-Mechanik bildet Supersession über `relations` mit `type: supersedes`
-  abb: Das neue Artefakt verweist auf das alte Artefakt. Ein späterer Validator
+  ab: Das neue Artefakt verweist auf das alte Artefakt. Ein späterer Validator
   muss `superseded_by` und `relations[type=supersedes]` gegeneinander prüfen
   oder eine der beiden Formen als kanonisch festlegen.
 

--- a/docs/process/report-lifecycle.md
+++ b/docs/process/report-lifecycle.md
@@ -3,96 +3,70 @@ id: process.report-lifecycle
 title: Report Lifecycle Policy
 doc_type: policy
 status: draft
+canonicality: kanonisch nach Contract-Alignment
 summary: >
-  Policy für Lebenszyklus, Status, Pflichtfelder, Archivierung und Löschung
-  von Reports.
+  Zukünftige Regeln für den Lebenszyklus von Reports. Definiert Status,
+  Review-Fristen, Ablösung und Archivierung.
 relations:
   - type: relates_to
     target: docs/process/README.md
-  - type: relates_to
-    target: docs/_generated/report-lifecycle-inventory.md
 ---
 
 # Report Lifecycle Policy
 
 ## Zweck
 
-Diese Datei ist der vorgeschlagene Zielort für Report-Lifecycle-Regeln. Sie
-bleibt `draft`, bis die Policy in einem späteren Schritt in das Truth Model
-und den DocMeta-Contract integriert oder bewusst als nicht-kanonische
-Prozessregel bestätigt wird.
+Dieses Dokument definiert den Lebenszyklus von Dokumenten unter `docs/reports/`
+sowie von weiteren Artefakten, die ausdrücklich die `doc_type: report` oder
+`lifecycle`-Rolle tragen.
 
-Reports sollen nicht dauerhaft als scheinbar aktuelle Wahrheit im Repo liegen.
-Jeder Report soll später beantworten können:
-
-- Wozu existiert er?
-- Welcher Task oder welches Vorhaben gehört dazu?
-- Ist er aktiv?
-- Wann muss er überprüft werden?
-- Wodurch wurde er abgelöst?
-- Darf er archiviert werden?
-- Darf er gelöscht werden?
-
-Wichtig: Diese Policy ist eine Regelgrundlage, keine rückwirkende Bereinigung.
+Es soll sicherstellen, dass Reports nicht lautlos veralten und bei Ablösung oder
+Archivierung ein klarer Pfad erkennbar bleibt.
 
 ## Geltungsbereich
 
-Gilt für:
+Die Policy gilt für:
 
-- `docs/reports/*.md`
+- Alle Dateien in `docs/reports/*.md`.
+- Jede Datei, die `doc_type: report` deklariert, unabhängig vom Verzeichnis.
 
-Noch nicht verbindlich für:
+Sie gilt nicht für:
 
-- `docs/proofs/**`
-- `docs/adr/**`
-- `docs/specs/**`
-- `docs/blueprints/**`
-- `docs/tasks/**`
-
-Diese Policy beschreibt zunächst Reports. Andere Dokumenttypen können Reports referenzieren und dadurch deren Archivierung oder Löschung blockieren, werden aber selbst nicht durch diese Policy klassifiziert.
-
-## Nicht-Ziele
-
-- Diese Policy klassifiziert noch keine bestehenden Reports.
-- Diese Policy archiviert keine Reports.
-- Diese Policy löscht keine Reports.
-- Diese Policy aktiviert keinen Validator.
-- Diese Policy verschärft keine CI.
-- Diese Policy verändert keine Task-Wahrheit.
-- Diese Policy ersetzt keine fachliche Review-Entscheidung.
+- Architektur-Dokumente (`docs/adr/`, `docs/blueprints/`, `docs/specs/`),
+  sofern sie nicht explizit als Report markiert sind.
+- Aufgaben (`docs/tasks/`).
+- Code-Kommentare.
 
 ## Contract-Alignment-Gate
 
-Diese Policy beschreibt das Zielmodell. Die hier beschriebenen zusätzlichen
-Lifecycle-Felder und Statuswerte sind noch nicht automatisch Teil des
-bestehenden DocMeta-Contracts.
+Aktuell ist dieses Dokument ein Entwurf (Draft). Es dokumentiert ein
+Zielmodell. Dieses Modell darf erst auf echten Bestand angewendet werden
+(Pilot, Backfill, Validator), wenn geklärt ist, wo die neuen Lifecycle-Felder
+technisch definiert werden.
 
-Vor dem ersten Backfill oder einer Pilot-Annotation im Frontmatter muss ein
-separater Contract-Schritt entscheiden:
+Die Entscheidung zur Abgrenzung von `status`, `lifecycle_state`,
+`superseded_by`, Inventory-Tooling und `relations[type=supersedes]` wird in
+`docs/process/report-lifecycle-contract-alignment.md` vorbereitet.
 
-- ob `contracts/docmeta.schema.json` und `architecture/docmeta.schema.md`
-  erweitert werden,
-- ob Lifecycle-Metadaten in einem eigenen Report-Lifecycle-Schema validiert
-  werden,
-- oder ob die Policy auf das bestehende DocMeta-Vokabular zurückgeschnitten
-  wird.
+Basis für diese Entscheidung ist die Bestandsaufnahme im
+[Report Lifecycle Inventory](../_generated/report-lifecycle-inventory.md).
+Erst nach dieser Entscheidung wird die Policy verbindlich.
 
-Bis diese Entscheidung getroffen ist, dürfen neue Statuswerte wie `deferred`,
-`superseded` und `archived` nicht als allgemein contract-gültige
-DocMeta-Statuswerte verstanden werden.
+Das bestehende Inventory-Tooling kennt `lifecycle_state` noch nicht. Diese
+Policy benennt das Zielmodell; die Ausrichtung von Inventory, Validator und
+späterer Übersicht folgt in separaten Tooling-PRs.
 
-Das Report-Lifecycle-Inventory ist Diagnosebasis für diese Policy, aber keine
-kanonische Policy-Quelle.
+## Vokabular-Gate
 
-## Begriffe
+Für den ersten Wurf (Inventory, Policy, Pilot) ist nur das Folgende erlaubt:
 
-- **Report**: Ein Markdown-Dokument unter `docs/reports/*.md`, das einen Befund, Audit, Proof, Status oder eine entscheidungsvorbereitende Auswertung beschreibt.
-- **Lifecycle**: Die Rolle eines Reports im Lebenszyklus: warum er existiert, wie lange er handlungsleitend ist und wann er geprüft oder abgelöst wird.
-- **Status**: Der aktuelle Zustand eines Reports, zum Beispiel `draft`, `active`, `superseded` oder `archived`.
-- **Supersession**: Eine explizite Ablösung durch ein anderes Artefakt. Supersession bedeutet nicht automatisch Löschung.
-- **Archivierung**: Ein Report bleibt erhalten, ist aber nicht mehr handlungsleitend.
-- **Löschung**: Physisches Entfernen eines Reports aus dem Repo. Löschung ist der letzte Schritt und nur nach separater Prüfung erlaubt.
-- **Primary Reference**: Eine handgeschriebene Referenz aus fachlich relevanten Dokumenten, zum Beispiel Tasks, Blueprints, ADRs, Specs, Proofs, Reports oder Roadmap.
+- Keine harten Enums in Frontmatter-Validatoren einbauen, bevor der Pilot nicht abgeschlossen ist.
+- Referenzklassen in Inventory und Validator strikt trennen: Primary Reference
+  vs Derived Reference.
+
+- **Primary Reference**: Ein direkter Frontmatter-Link aus einem anderen
+  handgeschriebenen Dokument, das als kanonisch oder normativ gilt. Zum
+  Beispiel Tasks, Blueprints, ADRs, Specs, Proofs, Reports oder Roadmap.
 - **Derived Reference**: Eine generierte Referenz aus `docs/_generated/**`. Sie zeigt Sichtbarkeit oder Indexierung, beweist aber nicht automatisch fachliche Aktualität.
 
 ## Report-Klassen
@@ -114,17 +88,20 @@ kanonische Policy-Quelle.
 
 ## Status-Semantik
 
-Bestehende DocMeta-Statuswerte wie `draft`, `active` und `deprecated` behalten
-ihre bisherige Contract-Bedeutung. Neue lifecycle-spezifische Werte wie
-`deferred`, `superseded` und `archived` sind erst nach Contract-Alignment als
-Frontmatter-Werte verwendbar.
+Die folgenden Werte beschreiben das Zielvokabular für den report-spezifischen
+`lifecycle_state`. Bestehende DocMeta-Statuswerte wie `draft`, `active` und
+`deprecated` behalten ihre bisherige Contract-Bedeutung. Neue
+lifecycle-spezifische Zustände wie `deferred`, `superseded` und `archived`
+werden nicht direkt als globale DocMeta-Statuswerte eingeführt.
 
-- **draft**: In Arbeit oder vorbereitend. Noch nicht maßgeblich.
 - **active**: Aktuell handlungsleitend oder als gültiger Bezugspunkt verwendbar.
 - **deferred**: Bewusst zurückgestellt. Nicht verworfen, aber derzeit nicht handlungsleitend.
-- **superseded**: Durch ein anderes Artefakt ersetzt. Das ablösende Artefakt soll über `superseded_by` angegeben werden.
+- **superseded**: Durch ein anderes Artefakt ersetzt. Das ablösende Artefakt soll über `superseded_by` und/oder `relations[type=supersedes]` nachvollziehbar sein.
 - **archived**: Historisch erhalten, aber nicht mehr handlungsleitend.
-- **deprecated**: Veraltet oder nicht mehr empfohlen, aber Ersatz, Archivierung oder Löschung sind noch nicht abschließend geklärt.
+
+`draft`, `active`, `deprecated` und `canonical` bleiben DocMeta-Statuswerte.
+Wenn ein Report zusätzlich einen Lifecycle-Zustand braucht, wird dieser über
+`lifecycle_state` modelliert.
 
 Wichtig:
 `deprecated` ist kein Papierkorb.
@@ -137,10 +114,14 @@ Wichtig:
 - **owner_task**: Task, Vorhaben, Kontrollpunkt oder Prozess, der die Verantwortung für den Report trägt. In Phase 1 noch als menschlich lesbarer Wert (noch kein Enum erzwingen).
 - **review_after**: ISO-Datum im Format `YYYY-MM-DD`, ab dem erneute Prüfung
   fällig wird.
+- **lifecycle_state**: Report-spezifischer Lifecycle-Zustand, zum Beispiel
+  `active`, `deferred`, `superseded` oder `archived`. Dieses Feld ist Teil des
+  Zielmodells und wird erst nach Contract-Alignment oder eigenem
+  Lifecycle-Schema validatorfähig.
 - **superseded_by**: Pfad zum ablösenden Artefakt. Dieses Feld darf nicht als
   alleinige Supersession-Wahrheit verstanden werden. Die bestehende
   Repo-Mechanik bildet Supersession über `relations` mit `type: supersedes`
-  ab: Das neue Artefakt verweist auf das alte Artefakt. Ein späterer Validator
+  abb: Das neue Artefakt verweist auf das alte Artefakt. Ein späterer Validator
   muss `superseded_by` und `relations[type=supersedes]` gegeneinander prüfen
   oder eine der beiden Formen als kanonisch festlegen.
 
@@ -182,21 +163,22 @@ Die Lifecycle-Felder werden in exakt dieser snake_case-Schreibweise geführt:
 sollen abweichende Schreibweisen wie `ownerTask` oder `reviewAfter` nicht als
 gleichwertig behandeln.
 
-## Pflichtfelder nach Status
+## Pflichtfelder nach Lifecycle-Zustand
 
-| status | lifecycle | owner_task | review_after | superseded_by | Bemerkung |
+| lifecycle_state | lifecycle | owner_task | review_after | superseded_by | Bemerkung |
 | --- | --- | --- | --- | --- | --- |
-| draft | empfohlen | empfohlen | optional | nein | Noch nicht handlungsleitend, aber spätere Zuordnung soll vorbereitet werden. |
 | active | erforderlich | erforderlich | erforderlich | nein | Aktive Reports brauchen Zweck, Verantwortung und Review-Zeitpunkt. |
 | deferred | erforderlich | erforderlich | erforderlich | nein | Zurückgestellte Reports warten auf Prüfung oder Reaktivierung; abgelöste Reports sind `superseded`. |
 | superseded | erforderlich | erforderlich | optional | erforderlich | Ablösung muss explizit nachvollziehbar sein. |
 | archived | erforderlich | erforderlich | nein | erforderlich* | Historisch erhalten, nicht mehr handlungsleitend; Legacy-Ausnahmen brauchen später ein explizites Ausnahmefeld. |
-| deprecated | erforderlich | erforderlich | empfohlen | erforderlich* | Veraltet, aber endgültiger Umgang noch offen; Ablösung oder Ausnahme muss später maschinenlesbar werden. |
+
+`draft` und `deprecated` bleiben DocMeta-Statuswerte. Wenn ein Report zusätzlich
+einen Lifecycle-Zustand braucht, wird dieser über `lifecycle_state` modelliert.
 
 `erforderlich*` bedeutet: Das aktuelle Inventory meldet terminale Status ohne
-`superseded_by` als Lücke. Falls historische Legacy-Dokumente ohne Ersatz
-zulässig werden sollen, braucht das einen späteren Generator-/Validator-Schritt
-mit explizitem Ausnahmefeld statt stiller Leerstelle.
+`superseded_by` als Lücke. Nach der Contract-Alignment-Entscheidung muss ein
+späterer Tooling-PR diese Prüfung auf `lifecycle_state` oder ein separates
+Lifecycle-Schema ausrichten.
 
 Diese Tabelle ist in Phase 1 eine Policy-Zieldefinition. Sie ist noch kein aktiver CI-Guard. Technische Durchsetzung folgt erst in späteren Phasen.
 
@@ -294,14 +276,16 @@ status: active
 lifecycle: audit
 owner_task: OPT-ARC-001
 review_after: 2026-07-13
+lifecycle_state: active
 ```
 
 ### Superseded proof
 
 ```yaml
-status: superseded
+status: active
 lifecycle: proof
 owner_task: OPT-ARC-001
+lifecycle_state: superseded
 superseded_by: docs/reports/new-proof.md
 ```
 
@@ -310,6 +294,8 @@ superseded_by: docs/reports/new-proof.md
 Archivierte Legacy-Dokumente ohne eindeutiges Ersatzartefakt bleiben eine
 offene Entscheidung und dürfen erst nach einem eigenen Ausnahmefeld oder
 Validator-Verhalten modelliert werden.
+
+Diese Beispiele zeigen das Zielmodell nach abgeschlossenem Contract Alignment.
 
 ## Offene Entscheidungen
 

--- a/docs/process/report-lifecycle.md
+++ b/docs/process/report-lifecycle.md
@@ -65,10 +65,14 @@ Diese Policy beschreibt zunächst Reports. Andere Dokumenttypen können Reports 
 
 ## Contract-Alignment-Gate
 
+Diese Policy beschreibt weiterhin ein Zielmodell. Die hier beschriebenen
+Lifecycle-Felder sind durch diesen PR noch nicht automatisch Teil des
+bestehenden DocMeta-Contracts, eines Validators oder eines CI-Guards.
 Die Entscheidung zur Abgrenzung von `status`, `lifecycle_state`,
 `superseded_by`, Inventory-Tooling und `relations[type=supersedes]` wird in
 `docs/process/report-lifecycle-contract-alignment.md` vorbereitet.
-
+Das Report-Lifecycle-Inventory ist Diagnosebasis für diese Policy, aber keine
+kanonische Policy-Quelle.
 Das bestehende Inventory-Tooling kennt `lifecycle_state` noch nicht. Diese
 Policy benennt das Zielmodell; die Ausrichtung von Inventory, Validator und
 späterer Übersicht folgt in separaten Tooling-PRs.
@@ -117,6 +121,11 @@ werden nicht direkt als globale DocMeta-Statuswerte eingeführt.
 `draft`, `active`, `deprecated` und `canonical` bleiben DocMeta-Statuswerte.
 Wenn ein Report zusätzlich einen Lifecycle-Zustand braucht, wird dieser über
 `lifecycle_state` modelliert.
+
+`active` kann sowohl als bestehender DocMeta-Status als auch als
+report-spezifischer `lifecycle_state` vorkommen. Der DocMeta-Status beschreibt
+die allgemeine Dokumentgültigkeit; `lifecycle_state: active` beschreibt, ob der
+Report fachlich noch handlungsleitend ist.
 
 Wichtig:
 `deprecated` ist kein Papierkorb.
@@ -297,7 +306,7 @@ lifecycle_state: active
 ### Superseded proof
 
 ```yaml
-status: active
+status: deprecated
 lifecycle: proof
 owner_task: OPT-ARC-001
 lifecycle_state: superseded


### PR DESCRIPTION
Adds the Report Lifecycle Contract Alignment decision before annotating the first report.
This keeps Phase 1.5 policy-only and clarifies that Report Lifecycle fields are a report-specific target model, not an immediate global DocMeta contract extension.

Decision:
- Keep global DocMeta `status` small and existing.
- Introduce report-specific `lifecycle_state` as target model.
- Keep `lifecycle`, `owner_task`, `review_after`, and `superseded_by` as report-lifecycle target fields.
- Keep `relations[type=supersedes]` as the existing Supersession mechanism.
- Document that the current inventory tooling does not yet read `lifecycle_state`; tooling alignment is a later PR.
- Do not change `repo.meta.yaml`, DocMeta contract, schema docs, scripts, reports, workflows, or runtime code in this PR.

Checks passed:
- `markdownlint`
- `make generate` and `generated-files-guard.sh`
- `git diff --check`
- scope gate confirms no forbidden files changed

---
*PR created automatically by Jules for task [7008034398071139081](https://jules.google.com/task/7008034398071139081) started by @alexdermohr*