### PR TITLE
docs: align report lifecycle inventory with lifecycle state

### DIFF
--- a/docs/_generated/relations-analysis.md
+++ b/docs/_generated/relations-analysis.md
@@ -14,12 +14,12 @@ Generated automatically. Do not edit.
 
 | Metrik | Wert |
 | --- | --- |
-| Dokumente gesamt | 123 |
-| Dokumente mit ausgehenden Relationen | 120 |
-| Dokumente als Ziel referenziert | 94 |
-| Relationen gesamt | 375 |
+| Dokumente gesamt | 124 |
+| Dokumente mit ausgehenden Relationen | 121 |
+| Dokumente als Ziel referenziert | 95 |
+| Relationen gesamt | 381 |
 | — depends_on | 18 |
-| — relates_to | 355 |
+| — relates_to | 361 |
 | — supersedes | 2 |
 | Isolierte Dokumente | 2 |
 | depends_on Zyklen | 0 |

--- a/docs/_generated/report-lifecycle-inventory.md
+++ b/docs/_generated/report-lifecycle-inventory.md
@@ -21,6 +21,8 @@ Primary references are exact path matches in canonical documentation surfaces. D
 | files_without_frontmatter | 0 |
 | files_with_status | 23 |
 | files_missing_status | 0 |
+| files_with_lifecycle_state | 0 |
+| files_missing_lifecycle_state | 23 |
 | files_with_lifecycle | 0 |
 | files_missing_lifecycle | 23 |
 | files_with_owner_task | 0 |
@@ -44,59 +46,59 @@ Primary references are exact path matches in canonical documentation surfaces. D
 
 ## Reports
 
-| Path | doc_type | status | lifecycle | owner_task | review_after | superseded_by | primary refs | derived refs | relations | absent core lifecycle fields | terminal supersession |
-| --- | --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | --- | --- |
-| docs/reports/agent-readiness-audit.md | documentation | active |  |  |  |  | 2 | 3 | 1 | lifecycle, owner_task, review_after |  |
-| docs/reports/auth-persistence-direct-proof-diagnose-audit.md | report | active |  |  |  |  | 0 | 3 | 4 | lifecycle, owner_task, review_after |  |
-| docs/reports/auth-persistence-next-step.md | report | active |  |  |  |  | 5 | 4 | 4 | lifecycle, owner_task, review_after |  |
-| docs/reports/auth-persistence-readiness.md | report | active |  |  |  |  | 4 | 4 | 3 | lifecycle, owner_task, review_after |  |
-| docs/reports/auth-persistence-runtime-proof.md | report | active |  |  |  |  | 4 | 3 | 6 | lifecycle, owner_task, review_after |  |
-| docs/reports/auth-persistence-runtime-target-reconciliation.md | report | active |  |  |  |  | 1 | 3 | 5 | lifecycle, owner_task, review_after |  |
-| docs/reports/auth-status-matrix.md | reference | active |  |  |  |  | 5 | 3 | 3 | lifecycle, owner_task, review_after |  |
-| docs/reports/cost-report.md | reference | active |  |  |  |  | 0 | 3 | 0 | lifecycle, owner_task, review_after |  |
-| docs/reports/domain-account-email-uniqueness-audit.md | report | draft |  |  |  |  | 1 | 3 | 4 | lifecycle, owner_task, review_after |  |
-| docs/reports/domain-account-write-path-proof.md | report | active |  |  |  |  | 7 | 3 | 6 | lifecycle, owner_task, review_after |  |
-| docs/reports/domain-backfill-proof.md | report | active |  |  |  |  | 3 | 3 | 4 | lifecycle, owner_task, review_after |  |
-| docs/reports/domain-edge-create-semantics-preflight.md | report | active |  |  |  |  | 0 | 3 | 7 | lifecycle, owner_task, review_after |  |
-| docs/reports/domain-edge-write-path-proof.md | report | active |  |  |  |  | 3 | 3 | 7 | lifecycle, owner_task, review_after |  |
-| docs/reports/domain-node-write-path-proof.md | report | active |  |  |  |  | 5 | 3 | 6 | lifecycle, owner_task, review_after |  |
-| docs/reports/domain-provider-role-finding.md | report | active |  |  |  |  | 1 | 3 | 3 | lifecycle, owner_task, review_after |  |
-| docs/reports/domain-read-path-proof.md | report | active |  |  |  |  | 5 | 3 | 5 | lifecycle, owner_task, review_after |  |
-| docs/reports/inwx-zone-reconciliation-plan.md | report | active |  |  |  |  | 1 | 3 | 4 | lifecycle, owner_task, review_after |  |
-| docs/reports/map-architekturkritik.md | report | active |  |  |  |  | 4 | 4 | 2 | lifecycle, owner_task, review_after |  |
-| docs/reports/map-status-matrix.md | status-matrix | active |  |  |  |  | 6 | 4 | 2 | lifecycle, owner_task, review_after |  |
-| docs/reports/optimierungsbericht.md | report | active |  |  |  |  | 2 | 3 | 4 | lifecycle, owner_task, review_after |  |
-| docs/reports/optimierungsstatus.md | status-matrix | active |  |  |  |  | 17 | 4 | 4 | lifecycle, owner_task, review_after |  |
-| docs/reports/passkey-register-verify-prep.md | report | active |  |  |  |  | 0 | 3 | 4 | lifecycle, owner_task, review_after |  |
-| docs/reports/planning-registration-findings.md | report | active |  |  |  |  | 1 | 3 | 2 | lifecycle, owner_task, review_after |  |
+| Path | doc_type | status | lifecycle_state | lifecycle | owner_task | review_after | superseded_by | primary refs | derived refs | relations | absent core lifecycle fields | terminal supersession |
+| --- | --- | --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | --- | --- |
+| docs/reports/agent-readiness-audit.md | documentation | active |  |  |  |  |  | 2 | 3 | 1 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/auth-persistence-direct-proof-diagnose-audit.md | report | active |  |  |  |  |  | 0 | 3 | 4 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/auth-persistence-next-step.md | report | active |  |  |  |  |  | 5 | 4 | 4 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/auth-persistence-readiness.md | report | active |  |  |  |  |  | 4 | 4 | 3 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/auth-persistence-runtime-proof.md | report | active |  |  |  |  |  | 4 | 3 | 6 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/auth-persistence-runtime-target-reconciliation.md | report | active |  |  |  |  |  | 1 | 3 | 5 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/auth-status-matrix.md | reference | active |  |  |  |  |  | 5 | 3 | 3 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/cost-report.md | reference | active |  |  |  |  |  | 0 | 3 | 0 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/domain-account-email-uniqueness-audit.md | report | draft |  |  |  |  |  | 1 | 3 | 4 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/domain-account-write-path-proof.md | report | active |  |  |  |  |  | 7 | 3 | 6 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/domain-backfill-proof.md | report | active |  |  |  |  |  | 3 | 3 | 4 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/domain-edge-create-semantics-preflight.md | report | active |  |  |  |  |  | 0 | 3 | 7 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/domain-edge-write-path-proof.md | report | active |  |  |  |  |  | 3 | 3 | 7 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/domain-node-write-path-proof.md | report | active |  |  |  |  |  | 5 | 3 | 6 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/domain-provider-role-finding.md | report | active |  |  |  |  |  | 1 | 3 | 3 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/domain-read-path-proof.md | report | active |  |  |  |  |  | 5 | 3 | 5 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/inwx-zone-reconciliation-plan.md | report | active |  |  |  |  |  | 1 | 3 | 4 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/map-architekturkritik.md | report | active |  |  |  |  |  | 4 | 4 | 2 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/map-status-matrix.md | status-matrix | active |  |  |  |  |  | 7 | 4 | 3 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/optimierungsbericht.md | report | active |  |  |  |  |  | 2 | 3 | 4 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/optimierungsstatus.md | status-matrix | active |  |  |  |  |  | 17 | 4 | 4 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/passkey-register-verify-prep.md | report | active |  |  |  |  |  | 0 | 3 | 4 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/planning-registration-findings.md | report | active |  |  |  |  |  | 1 | 3 | 2 | lifecycle, owner_task, review_after, lifecycle_state |  |
 
 ## Absent Core Lifecycle Metadata
 
 | Path | Absent fields |
 | --- | --- |
-| docs/reports/agent-readiness-audit.md | lifecycle, owner_task, review_after |
-| docs/reports/auth-persistence-direct-proof-diagnose-audit.md | lifecycle, owner_task, review_after |
-| docs/reports/auth-persistence-next-step.md | lifecycle, owner_task, review_after |
-| docs/reports/auth-persistence-readiness.md | lifecycle, owner_task, review_after |
-| docs/reports/auth-persistence-runtime-proof.md | lifecycle, owner_task, review_after |
-| docs/reports/auth-persistence-runtime-target-reconciliation.md | lifecycle, owner_task, review_after |
-| docs/reports/auth-status-matrix.md | lifecycle, owner_task, review_after |
-| docs/reports/cost-report.md | lifecycle, owner_task, review_after |
-| docs/reports/domain-account-email-uniqueness-audit.md | lifecycle, owner_task, review_after |
-| docs/reports/domain-account-write-path-proof.md | lifecycle, owner_task, review_after |
-| docs/reports/domain-backfill-proof.md | lifecycle, owner_task, review_after |
-| docs/reports/domain-edge-create-semantics-preflight.md | lifecycle, owner_task, review_after |
-| docs/reports/domain-edge-write-path-proof.md | lifecycle, owner_task, review_after |
-| docs/reports/domain-node-write-path-proof.md | lifecycle, owner_task, review_after |
-| docs/reports/domain-provider-role-finding.md | lifecycle, owner_task, review_after |
-| docs/reports/domain-read-path-proof.md | lifecycle, owner_task, review_after |
-| docs/reports/inwx-zone-reconciliation-plan.md | lifecycle, owner_task, review_after |
-| docs/reports/map-architekturkritik.md | lifecycle, owner_task, review_after |
-| docs/reports/map-status-matrix.md | lifecycle, owner_task, review_after |
-| docs/reports/optimierungsbericht.md | lifecycle, owner_task, review_after |
-| docs/reports/optimierungsstatus.md | lifecycle, owner_task, review_after |
-| docs/reports/passkey-register-verify-prep.md | lifecycle, owner_task, review_after |
-| docs/reports/planning-registration-findings.md | lifecycle, owner_task, review_after |
+| docs/reports/agent-readiness-audit.md | lifecycle, owner_task, review_after, lifecycle_state |
+| docs/reports/auth-persistence-direct-proof-diagnose-audit.md | lifecycle, owner_task, review_after, lifecycle_state |
+| docs/reports/auth-persistence-next-step.md | lifecycle, owner_task, review_after, lifecycle_state |
+| docs/reports/auth-persistence-readiness.md | lifecycle, owner_task, review_after, lifecycle_state |
+| docs/reports/auth-persistence-runtime-proof.md | lifecycle, owner_task, review_after, lifecycle_state |
+| docs/reports/auth-persistence-runtime-target-reconciliation.md | lifecycle, owner_task, review_after, lifecycle_state |
+| docs/reports/auth-status-matrix.md | lifecycle, owner_task, review_after, lifecycle_state |
+| docs/reports/cost-report.md | lifecycle, owner_task, review_after, lifecycle_state |
+| docs/reports/domain-account-email-uniqueness-audit.md | lifecycle, owner_task, review_after, lifecycle_state |
+| docs/reports/domain-account-write-path-proof.md | lifecycle, owner_task, review_after, lifecycle_state |
+| docs/reports/domain-backfill-proof.md | lifecycle, owner_task, review_after, lifecycle_state |
+| docs/reports/domain-edge-create-semantics-preflight.md | lifecycle, owner_task, review_after, lifecycle_state |
+| docs/reports/domain-edge-write-path-proof.md | lifecycle, owner_task, review_after, lifecycle_state |
+| docs/reports/domain-node-write-path-proof.md | lifecycle, owner_task, review_after, lifecycle_state |
+| docs/reports/domain-provider-role-finding.md | lifecycle, owner_task, review_after, lifecycle_state |
+| docs/reports/domain-read-path-proof.md | lifecycle, owner_task, review_after, lifecycle_state |
+| docs/reports/inwx-zone-reconciliation-plan.md | lifecycle, owner_task, review_after, lifecycle_state |
+| docs/reports/map-architekturkritik.md | lifecycle, owner_task, review_after, lifecycle_state |
+| docs/reports/map-status-matrix.md | lifecycle, owner_task, review_after, lifecycle_state |
+| docs/reports/optimierungsbericht.md | lifecycle, owner_task, review_after, lifecycle_state |
+| docs/reports/optimierungsstatus.md | lifecycle, owner_task, review_after, lifecycle_state |
+| docs/reports/passkey-register-verify-prep.md | lifecycle, owner_task, review_after, lifecycle_state |
+| docs/reports/planning-registration-findings.md | lifecycle, owner_task, review_after, lifecycle_state |
 
 ## Relations
 
@@ -119,7 +121,7 @@ Primary references are exact path matches in canonical documentation surfaces. D
 | docs/reports/domain-read-path-proof.md | 5 | relates_to | docs/blueprints/domain-data-postgres-cutover.md, docs/reports/domain-account-write-path-proof.md, docs/reports/domain-backfill-proof.md, docs/reports/optimierungsstatus.md, docs/tasks/board.md |
 | docs/reports/inwx-zone-reconciliation-plan.md | 4 | relates_to | docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md, docs/reports/domain-provider-role-finding.md, docs/runbooks/domain-mail-cutover.md, docs/tasks/board.md |
 | docs/reports/map-architekturkritik.md | 2 | relates_to | docs/blueprints/kartenklarheit-roadmap.md, docs/reports/map-status-matrix.md |
-| docs/reports/map-status-matrix.md | 2 | relates_to | docs/blueprints/kartenklarheit-roadmap.md, docs/reports/map-architekturkritik.md |
+| docs/reports/map-status-matrix.md | 3 | relates_to | docs/blueprints/kartenklarheit-roadmap.md, docs/blueprints/ui-interaction-doctrine.md, docs/reports/map-architekturkritik.md |
 | docs/reports/optimierungsbericht.md | 4 | relates_to | docs/datenmodell.md, docs/policies/agent-reading-protocol.md, docs/reports/optimierungsstatus.md, docs/techstack.md |
 | docs/reports/optimierungsstatus.md | 4 | depends_on, relates_to | docs/policies/agent-reading-protocol.md, docs/reports/auth-persistence-readiness.md, docs/reports/domain-read-path-proof.md, docs/reports/optimierungsbericht.md |
 | docs/reports/passkey-register-verify-prep.md | 4 | relates_to | docs/adr/ADR-0006__auth-magic-link-session-passkey.md, docs/blueprints/auth-roadmap.md, docs/reports/auth-status-matrix.md, docs/specs/auth-api.md |
@@ -213,6 +215,7 @@ Primary references are exact path matches in canonical documentation surfaces. D
   - `docs/blueprints/kartenklarheit-roadmap.md`
   - `docs/blueprints/kartenklarheit.md`
   - `docs/blueprints/map-roadmap.md`
+  - `docs/blueprints/ui-interaction-doctrine.md`
   - `docs/reports/map-architekturkritik.md`
   - `docs/roadmap.md`
 

--- a/scripts/docmeta/generate_report_lifecycle_inventory.py
+++ b/scripts/docmeta/generate_report_lifecycle_inventory.py
@@ -19,8 +19,13 @@ PRIMARY_REFERENCE_SEARCH_PATHS = (
 DERIVED_REFERENCE_SEARCH_PATHS = (
     REPO_ROOT / "docs" / "_generated",
 )
-CORE_LIFECYCLE_FIELDS = ("lifecycle", "owner_task", "review_after")
-TERMINAL_STATUSES = {"superseded", "archived", "deprecated"}
+CORE_LIFECYCLE_FIELDS = (
+    "lifecycle",
+    "owner_task",
+    "review_after",
+    "lifecycle_state",
+)
+SUPERSESSION_REQUIRED_LIFECYCLE_STATES = {"superseded"}
 
 HEADER = """\
 ---
@@ -62,6 +67,7 @@ class ReportRecord:
     title: str
     doc_type: str
     status: str
+    lifecycle_state: str
     lifecycle: str
     owner_task: str
     review_after: str
@@ -431,7 +437,8 @@ def collect_reports(config: InventoryConfig | None = None) -> list[ReportRecord]
             sorted({relation.target for relation in relations if relation.target})
         )
         status = _string_value(frontmatter.get("status"))
-        normalized_status = status.lower()
+        lifecycle_state = _string_value(frontmatter.get("lifecycle_state"))
+        normalized_lifecycle_state = lifecycle_state.lower()
         superseded_by = _string_value(frontmatter.get("superseded_by"))
         records.append(
             ReportRecord(
@@ -441,6 +448,7 @@ def collect_reports(config: InventoryConfig | None = None) -> list[ReportRecord]
                 title=_string_value(frontmatter.get("title")),
                 doc_type=_string_value(frontmatter.get("doc_type")),
                 status=status,
+                lifecycle_state=lifecycle_state,
                 lifecycle=_string_value(frontmatter.get("lifecycle")),
                 owner_task=_string_value(frontmatter.get("owner_task")),
                 review_after=_string_value(frontmatter.get("review_after")),
@@ -453,7 +461,10 @@ def collect_reports(config: InventoryConfig | None = None) -> list[ReportRecord]
                 absent_core_lifecycle_fields=tuple(
                     field for field in CORE_LIFECYCLE_FIELDS if not _string_value(frontmatter.get(field))
                 ),
-                missing_supersession_target=normalized_status in TERMINAL_STATUSES and not superseded_by,
+                missing_supersession_target=(
+                    normalized_lifecycle_state in SUPERSESSION_REQUIRED_LIFECYCLE_STATES
+                    and not superseded_by
+                ),
                 frontmatter_parse_warning=warning,
             )
         )
@@ -468,6 +479,8 @@ def build_summary(records: list[ReportRecord]) -> list[tuple[str, int]]:
         ("files_without_frontmatter", sum(1 for record in records if not record.has_frontmatter)),
         ("files_with_status", sum(1 for record in records if record.status)),
         ("files_missing_status", sum(1 for record in records if not record.status)),
+        ("files_with_lifecycle_state", sum(1 for record in records if record.lifecycle_state)),
+        ("files_missing_lifecycle_state", sum(1 for record in records if not record.lifecycle_state)),
         ("files_with_lifecycle", sum(1 for record in records if record.lifecycle)),
         ("files_missing_lifecycle", sum(1 for record in records if not record.lifecycle)),
         ("files_with_owner_task", sum(1 for record in records if record.owner_task)),
@@ -512,17 +525,18 @@ def render_inventory(records: list[ReportRecord]) -> str:
             "",
             "## Reports",
             "",
-            "| Path | doc_type | status | lifecycle | owner_task | review_after | superseded_by | primary refs | derived refs | relations | absent core lifecycle fields | terminal supersession |",
-            "| --- | --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | --- | --- |",
+            "| Path | doc_type | status | lifecycle_state | lifecycle | owner_task | review_after | superseded_by | primary refs | derived refs | relations | absent core lifecycle fields | terminal supersession |",
+            "| --- | --- | --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | --- | --- |",
         ]
     )
     for record in records:
         sections.append(
-            "| {path} | {doc_type} | {status} | {lifecycle} | {owner_task} | {review_after} | "
+            "| {path} | {doc_type} | {status} | {lifecycle_state} | {lifecycle} | {owner_task} | {review_after} | "
             "{superseded_by} | {primary_refs} | {derived_refs} | {relations} | {absent} | {terminal_supersession} |".format(
                 path=record.path,
                 doc_type=_cell(record.doc_type),
                 status=_cell(record.status),
+                lifecycle_state=_cell(record.lifecycle_state),
                 lifecycle=_cell(record.lifecycle),
                 owner_task=_cell(record.owner_task),
                 review_after=_cell(record.review_after),
@@ -613,12 +627,12 @@ def render_inventory(records: list[ReportRecord]) -> str:
     if terminal_gap_records:
         sections.extend(
             [
-                "| Path | Status | Diagnostic |",
+                "| Path | lifecycle_state | Diagnostic |",
                 "| --- | --- | --- |",
             ]
         )
         for record in terminal_gap_records:
-            sections.append(f"| {record.path} | {_cell(record.status)} | missing superseded_by target |")
+            sections.append(f"| {record.path} | {_cell(record.lifecycle_state)} | missing superseded_by target |")
     else:
         sections.append("None.")
     sections.append("")

--- a/scripts/docmeta/tests/test_generate_report_lifecycle_inventory.py
+++ b/scripts/docmeta/tests/test_generate_report_lifecycle_inventory.py
@@ -46,6 +46,7 @@ id: docs.reports.alpha
 title: Alpha
 doc_type: report
 status: active
+lifecycle_state: active
 lifecycle: observed
 owner_task: docs/tasks/alpha.md
 review_after: 2026-12-01
@@ -67,6 +68,7 @@ relations:
         self.assertEqual(record.doc_id, "docs.reports.alpha")
         self.assertEqual(record.title, "Alpha")
         self.assertEqual(record.lifecycle, "observed")
+        self.assertEqual(record.lifecycle_state, "active")
         self.assertEqual(record.owner_task, "docs/tasks/alpha.md")
         self.assertEqual(record.review_after, "2026-12-01")
         self.assertEqual(record.superseded_by, "docs/reports/beta.md")
@@ -107,7 +109,7 @@ status: active
 
         self.assertEqual(
             records[0].absent_core_lifecycle_fields,
-            ("lifecycle", "owner_task", "review_after"),
+            ("lifecycle", "owner_task", "review_after", "lifecycle_state"),
         )
         self.assertIn("descriptive only", markdown)
         self.assertNotIn("invalid", markdown.lower())
@@ -270,6 +272,7 @@ id: docs.reports.active
 title: Active
 doc_type: report
 status: active
+lifecycle_state: active
 lifecycle: observed
 owner_task: docs/tasks/active.md
 review_after: 2026-12-01
@@ -283,14 +286,15 @@ review_after: 2026-12-01
         self.assertEqual(record.absent_core_lifecycle_fields, ())
         self.assertFalse(record.missing_supersession_target)
 
-    def test_terminal_status_without_superseded_by_is_reported(self) -> None:
+    def test_terminal_lifecycle_state_without_superseded_by_is_reported(self) -> None:
         self._write(
             "docs/reports/terminal.md",
             """---
 id: docs.reports.terminal
 title: Terminal
 doc_type: report
-status: superseded
+status: deprecated
+lifecycle_state: superseded
 lifecycle: observed
 owner_task: docs/tasks/terminal.md
 review_after: 2026-12-01
@@ -303,14 +307,15 @@ review_after: 2026-12-01
 
         self.assertTrue(record.missing_supersession_target)
 
-    def test_terminal_status_matching_is_case_insensitive(self) -> None:
+    def test_terminal_lifecycle_state_matching_is_case_insensitive(self) -> None:
         self._write(
             "docs/reports/terminal.md",
             """---
 id: docs.reports.terminal
 title: Terminal
 doc_type: report
-status: Superseded
+status: deprecated
+lifecycle_state: Superseded
 lifecycle: observed
 owner_task: docs/tasks/terminal.md
 review_after: 2026-12-01
@@ -322,6 +327,75 @@ review_after: 2026-12-01
         record = gen.collect_reports(self._config())[0]
 
         self.assertTrue(record.missing_supersession_target)
+
+    def test_deprecated_without_lifecycle_state_is_not_terminal(self) -> None:
+        self._write(
+            "docs/reports/legacy.md",
+            """---
+id: docs.reports.legacy
+title: Legacy
+doc_type: report
+status: deprecated
+lifecycle: legacy
+owner_task: OPT-ARC-001
+review_after: 2026-12-01
+---
+# Legacy
+""",
+        )
+
+        record = gen.collect_reports(self._config())[0]
+
+        self.assertFalse(record.missing_supersession_target)
+        self.assertIn("lifecycle_state", record.absent_core_lifecycle_fields)
+
+    def test_archived_lifecycle_state_without_superseded_by_is_not_supersession_gap(self) -> None:
+        self._write(
+            "docs/reports/archived.md",
+            """---
+id: docs.reports.archived
+title: Archived
+doc_type: report
+status: deprecated
+lifecycle: legacy
+owner_task: OPT-ARC-001
+review_after: 2026-12-01
+lifecycle_state: archived
+---
+# Archived
+""",
+        )
+
+        record = gen.collect_reports(self._config())[0]
+
+        self.assertFalse(record.missing_supersession_target)
+        self.assertEqual(record.lifecycle_state, "archived")
+        self.assertNotIn("lifecycle_state", record.absent_core_lifecycle_fields)
+
+
+    def test_terminal_supersession_diagnostics_render_lifecycle_state(self) -> None:
+        self._write(
+            "docs/reports/terminal.md",
+            """---
+id: docs.reports.terminal
+title: Terminal
+doc_type: report
+status: deprecated
+lifecycle_state: superseded
+lifecycle: observed
+owner_task: docs/tasks/terminal.md
+review_after: 2026-12-01
+---
+# Terminal
+""",
+        )
+        markdown = gen.render_inventory(gen.collect_reports(self._config()))
+        self.assertIn("## Terminal Supersession Diagnostics", markdown)
+        self.assertIn("| Path | lifecycle_state | Diagnostic |", markdown)
+        self.assertIn(
+            "| docs/reports/terminal.md | superseded | missing superseded_by target |",
+            markdown,
+        )
 
     def test_relations_are_rendered_in_markdown_output(self) -> None:
         self._write(
@@ -341,6 +415,9 @@ relations:
 
         markdown = gen.render_inventory(gen.collect_reports(self._config()))
 
+        self.assertIn("files_with_lifecycle_state", markdown)
+        self.assertIn("files_missing_lifecycle_state", markdown)
+        self.assertIn("| Path | doc_type | status | lifecycle_state |", markdown)
         self.assertIn("## Relations", markdown)
         self.assertIn("relates_to", markdown)
         self.assertIn("docs/reports/other.md", markdown)


### PR DESCRIPTION
Aligns the generated Report Lifecycle Inventory with the report-specific `lifecycle_state` target model introduced by the Report Lifecycle Contract Alignment.

- Reads `lifecycle_state` from report frontmatter.
- Adds `lifecycle_state` to the generated inventory table.
- Adds summary counts for reports with and missing `lifecycle_state`.
- Uses `lifecycle_state` rather than global DocMeta status for terminal report-lifecycle states.
- Keeps global DocMeta status unchanged.

---
*PR created automatically by Jules for task [7256480407471410888](https://jules.google.com/task/7256480407471410888) started by @alexdermohr*