### PR TITLE
docs: annotate account email audit lifecycle

### DIFF
--- a/docs/_generated/doc-index.md
+++ b/docs/_generated/doc-index.md
@@ -12,6 +12,7 @@ Generated automatically. Do not edit.
 
 | id | title | type | status | path |
 | --- | --- | --- | --- | --- |
+| DEPLOY-DNS-001B | Historical INWX Zone Entry Checklist — Predelegation Assumption Superseded | task | done | docs/tasks/DEPLOY-DNS-001B.md |
 | adr.0042-consume-semantah-contracts | ADR-0042 — SemanticAH-Contracts konsumieren | reference | active | docs/adr/0042-consume-semantah-contracts.md |
 | adr.0043-edge-vs-conversation | ADR-0043 — Edge vs. Conversation | reference | active | docs/adr/0043-edge-vs-conversation.md |
 | adr.ADR-0001__clean-slate-docs-monorepo | ADR-0001 — Clean Slate und Docs-Monorepo | reference | active | docs/adr/ADR-0001__clean-slate-docs-monorepo.md |
@@ -22,9 +23,9 @@ Generated automatically. Do not edit.
 | adr.ADR-0006-auth-magic-link-session-passkey | ADR-0006 — Auth: Magic Link, Session und optionaler Passkey | reference | active | docs/adr/ADR-0006__auth-magic-link-session-passkey.md |
 | adr.ADR-0007-auth-persistence-production-db-path | ADR-0007 — Auth-Persistenz Produktionspfad: Direkter PostgreSQL-Zugriff statt PgBouncer | reference | accepted | docs/adr/ADR-0007__auth-persistence-production-db-path.md |
 | adr.ADR-0008-domain-mail-provider-boundaries | ADR-0008 — Domain-, Mail- und SMTP-Providergrenzen | reference | accepted | docs/adr/ADR-0008__domain-mail-provider-boundaries.md |
+| blueprint-doc-structure-task-control | Weltgewebe Dokumentationsstruktur und Task-Steuerung | blueprint | draft | docs/blueprints/doc-structure-task-control.md |
 | blueprint-doc-structure-task-control-examples | Dokumentationsstruktur und Task-Steuerung Beispiele | reference | draft | docs/blueprints/doc-structure-task-control-examples.md |
 | blueprint-doc-structure-task-control-roadmap | Dokumentationsstruktur und Task-Steuerung Roadmap | roadmap | draft | docs/blueprints/doc-structure-task-control-roadmap.md |
-| blueprint-doc-structure-task-control | Weltgewebe Dokumentationsstruktur und Task-Steuerung | blueprint | draft | docs/blueprints/doc-structure-task-control.md |
 | blueprints.auth-persistence-runtime-proof | Auth-Persistenz — Runtime-Proof-Blaupause | blueprint | active | docs/blueprints/auth-persistence-runtime-proof.md |
 | blueprints.auth-roadmap | Auth Roadmap | roadmap | active | docs/blueprints/auth-roadmap.md |
 | blueprints.domain-data-postgres-cutover | Domain Data PostgreSQL Cutover | blueprint | active | docs/blueprints/domain-data-postgres-cutover.md |
@@ -33,18 +34,17 @@ Generated automatically. Do not edit.
 | blueprints.weltgewebe.deploy.plan | Deploy-Plan | reference | deprecated | docs/blueprints/weltgewebe.deploy.plan.md |
 | datenmodell | Datenmodell | reference | active | docs/datenmodell.md |
 | deploy.CHANGELOG | Deploy Changelog | reference | active | docs/deploy/CHANGELOG.md |
-| DEPLOY-DNS-001B | Historical INWX Zone Entry Checklist — Predelegation Assumption Superseded | task | done | docs/tasks/DEPLOY-DNS-001B.md |
-| deploy.domain-mail-migration-ionos-inwx-mailbox-brevo | Domain-/Mail-Migration: IONOS zu INWX + mailbox.org + Brevo | reference | active | docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md |
 | deploy.DRIFT_POLICY | Drift Policy | reference | active | docs/deploy/DRIFT_POLICY.md |
+| deploy.README | Deployment-Übersicht | reference | active | docs/deploy/README.md |
+| deploy.domain-mail-migration-ionos-inwx-mailbox-brevo | Domain-/Mail-Migration: IONOS zu INWX + mailbox.org + Brevo | reference | active | docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md |
 | deploy.heim-first-phase0 | Heim-First Phase 0 | reference | active | docs/deploy/heim-first-phase0.md |
 | deploy.heimserver.deployment | Heimserver Deployment | reference | active | docs/deploy/heimserver.deployment.md |
 | deploy.heimserver.integration | Heimserver Integration | reference | active | docs/deploy/heimserver.integration.md |
-| deployment-contract | Deployment Contract and Preflight Guard | guide | active | docs/deployment.md |
-| deployment_governance | Deployment Governance | reference | active | docs/deployment_governance.md |
-| deploy.README | Deployment-Übersicht | reference | active | docs/deploy/README.md |
 | deploy.security | Deploy Security | architecture | active | docs/deploy/security.md |
 | deploy.vps | VPS-Deployment | reference | active | docs/deploy/vps.md |
 | deploy.weltgewebe.naming | Weltgewebe Naming | reference | active | docs/deploy/weltgewebe.naming.md |
+| deployment-contract | Deployment Contract and Preflight Guard | guide | active | docs/deployment.md |
+| deployment_governance | Deployment Governance | reference | active | docs/deployment_governance.md |
 | dev.codespaces | Codespaces | reference | active | docs/dev/codespaces.md |
 | docs.architecture.overview | Architekturüberblick | architecture | active | docs/architekturstruktur.md |
 | docs.blueprints.agent-operability | Minimaler Agent-Operability-Kern | blueprint | draft | docs/blueprints/agent-operability-blaupause.md |
@@ -60,8 +60,8 @@ Generated automatically. Do not edit.
 | docs.reference.agent-operability-fixture-matrix | Agent-Betriebsfaehigkeit: Fixture-Matrix | reference | active | docs/reference/agent-operability-fixture-matrix.md |
 | docs.reports.agent-readiness-audit | Agent Readiness Audit | documentation | active | docs/reports/agent-readiness-audit.md |
 | docs.roadmap | Weltgewebe — Master-Umsetzungsroadmap | roadmap | active | docs/roadmap.md |
-| docs.runbook.observability | Observability Runbook | runbook | active | docs/runbook.observability.md |
 | docs.runbook | Runbook | runbook | active | docs/runbook.md |
+| docs.runbook.observability | Observability Runbook | runbook | active | docs/runbook.observability.md |
 | docs.security.agent-write-scope-baseline | Agent Write Scope Baseline | security | active | docs/security/agent-write-scope-baseline.md |
 | docs.techstack | Techstack | architecture | active | docs/techstack.md |
 | docs.vision | Vision | reference | active | docs/vision.md |
@@ -79,11 +79,11 @@ Generated automatically. Do not edit.
 | overview.inhalt | Inhalt (Übersicht) | reference | active | docs/overview/inhalt.md |
 | overview.zusammenstellung | Zusammenstellung (Übersicht) | reference | active | docs/overview/zusammenstellung.md |
 | policies.orientierung | Orientierung | reference | active | docs/policies/orientierung.md |
+| process.README | Prozess-Übersicht | reference | active | docs/process/README.md |
 | process.bash-tooling-guidelines | Bash Tooling Guidelines | reference | active | docs/process/bash-tooling-guidelines.md |
 | process.fahrplan | Fahrplan | reference | active | docs/process/fahrplan.md |
-| process.README | Prozess-Übersicht | reference | active | docs/process/README.md |
-| process.report-lifecycle-contract-alignment | Report Lifecycle Contract Alignment | decision | draft | docs/process/report-lifecycle-contract-alignment.md |
 | process.report-lifecycle | Report Lifecycle Policy | policy | draft | docs/process/report-lifecycle.md |
+| process.report-lifecycle-contract-alignment | Report Lifecycle Contract Alignment | decision | draft | docs/process/report-lifecycle-contract-alignment.md |
 | process.sprache | Sprache | reference | active | docs/process/sprache.md |
 | proofs.sqlx-pgbouncer-session-crud-proof | SQLx → PgBouncer → Postgres — Session-CRUD-Proof | report | active | docs/proofs/sqlx-pgbouncer-session-crud-proof.md |
 | proofs.sqlx-postgres-direct-session-crud-proof | SQLx \u2192 direkter PostgreSQL \u2014 Session-CRUD-Proof | report | active | docs/proofs/sqlx-postgres-direct-session-crud-proof.md |
@@ -109,12 +109,12 @@ Generated automatically. Do not edit.
 | reports.optimierungsstatus | Optimierungsstatus Weltgewebe | status-matrix | active | docs/reports/optimierungsstatus.md |
 | reports.passkey-register-verify-prep | Passkey Register-Verify – Vorbereitungsbericht | report | active | docs/reports/passkey-register-verify-prep.md |
 | reports.planning-registration-findings | Planning Registration Findings Triage | report | active | docs/reports/planning-registration-findings.md |
+| runbooks.README | Runbooks-Übersicht | reference | active | docs/runbooks/README.md |
 | runbooks.codespaces-recovery | Codespaces Recovery | reference | active | docs/runbooks/codespaces-recovery.md |
 | runbooks.db-recovery | DB Recovery Runbook | reference | active | docs/runbooks/db-recovery.md |
 | runbooks.domain-mail-cutover | Runbook — Domain-, Mail- und SMTP-Cutover | runbook | active | docs/runbooks/domain-mail-cutover.md |
 | runbooks.incident-response | Incident Response Runbook | reference | active | docs/runbooks/incident-response.md |
 | runbooks.ops.runbook.weltgewebe-selfhost-deploy | Selfhost-Deploy Runbook | reference | active | docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md |
-| runbooks.README | Runbooks-Übersicht | reference | active | docs/runbooks/README.md |
 | runbooks.uv-tooling | UV-Tooling | reference | active | docs/runbooks/uv-tooling.md |
 | specs.auth-api | Auth API Spec | reference | active | docs/specs/auth-api.md |
 | specs.auth-blueprint | Auth Blueprint | reference | active | docs/specs/auth-blueprint.md |

--- a/docs/_generated/doc-index.md
+++ b/docs/_generated/doc-index.md
@@ -12,7 +12,6 @@ Generated automatically. Do not edit.
 
 | id | title | type | status | path |
 | --- | --- | --- | --- | --- |
-| DEPLOY-DNS-001B | Historical INWX Zone Entry Checklist — Predelegation Assumption Superseded | task | done | docs/tasks/DEPLOY-DNS-001B.md |
 | adr.0042-consume-semantah-contracts | ADR-0042 — SemanticAH-Contracts konsumieren | reference | active | docs/adr/0042-consume-semantah-contracts.md |
 | adr.0043-edge-vs-conversation | ADR-0043 — Edge vs. Conversation | reference | active | docs/adr/0043-edge-vs-conversation.md |
 | adr.ADR-0001__clean-slate-docs-monorepo | ADR-0001 — Clean Slate und Docs-Monorepo | reference | active | docs/adr/ADR-0001__clean-slate-docs-monorepo.md |
@@ -23,9 +22,9 @@ Generated automatically. Do not edit.
 | adr.ADR-0006-auth-magic-link-session-passkey | ADR-0006 — Auth: Magic Link, Session und optionaler Passkey | reference | active | docs/adr/ADR-0006__auth-magic-link-session-passkey.md |
 | adr.ADR-0007-auth-persistence-production-db-path | ADR-0007 — Auth-Persistenz Produktionspfad: Direkter PostgreSQL-Zugriff statt PgBouncer | reference | accepted | docs/adr/ADR-0007__auth-persistence-production-db-path.md |
 | adr.ADR-0008-domain-mail-provider-boundaries | ADR-0008 — Domain-, Mail- und SMTP-Providergrenzen | reference | accepted | docs/adr/ADR-0008__domain-mail-provider-boundaries.md |
-| blueprint-doc-structure-task-control | Weltgewebe Dokumentationsstruktur und Task-Steuerung | blueprint | draft | docs/blueprints/doc-structure-task-control.md |
 | blueprint-doc-structure-task-control-examples | Dokumentationsstruktur und Task-Steuerung Beispiele | reference | draft | docs/blueprints/doc-structure-task-control-examples.md |
 | blueprint-doc-structure-task-control-roadmap | Dokumentationsstruktur und Task-Steuerung Roadmap | roadmap | draft | docs/blueprints/doc-structure-task-control-roadmap.md |
+| blueprint-doc-structure-task-control | Weltgewebe Dokumentationsstruktur und Task-Steuerung | blueprint | draft | docs/blueprints/doc-structure-task-control.md |
 | blueprints.auth-persistence-runtime-proof | Auth-Persistenz — Runtime-Proof-Blaupause | blueprint | active | docs/blueprints/auth-persistence-runtime-proof.md |
 | blueprints.auth-roadmap | Auth Roadmap | roadmap | active | docs/blueprints/auth-roadmap.md |
 | blueprints.domain-data-postgres-cutover | Domain Data PostgreSQL Cutover | blueprint | active | docs/blueprints/domain-data-postgres-cutover.md |
@@ -34,17 +33,18 @@ Generated automatically. Do not edit.
 | blueprints.weltgewebe.deploy.plan | Deploy-Plan | reference | deprecated | docs/blueprints/weltgewebe.deploy.plan.md |
 | datenmodell | Datenmodell | reference | active | docs/datenmodell.md |
 | deploy.CHANGELOG | Deploy Changelog | reference | active | docs/deploy/CHANGELOG.md |
-| deploy.DRIFT_POLICY | Drift Policy | reference | active | docs/deploy/DRIFT_POLICY.md |
-| deploy.README | Deployment-Übersicht | reference | active | docs/deploy/README.md |
+| DEPLOY-DNS-001B | Historical INWX Zone Entry Checklist — Predelegation Assumption Superseded | task | done | docs/tasks/DEPLOY-DNS-001B.md |
 | deploy.domain-mail-migration-ionos-inwx-mailbox-brevo | Domain-/Mail-Migration: IONOS zu INWX + mailbox.org + Brevo | reference | active | docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md |
+| deploy.DRIFT_POLICY | Drift Policy | reference | active | docs/deploy/DRIFT_POLICY.md |
 | deploy.heim-first-phase0 | Heim-First Phase 0 | reference | active | docs/deploy/heim-first-phase0.md |
 | deploy.heimserver.deployment | Heimserver Deployment | reference | active | docs/deploy/heimserver.deployment.md |
 | deploy.heimserver.integration | Heimserver Integration | reference | active | docs/deploy/heimserver.integration.md |
+| deployment-contract | Deployment Contract and Preflight Guard | guide | active | docs/deployment.md |
+| deployment_governance | Deployment Governance | reference | active | docs/deployment_governance.md |
+| deploy.README | Deployment-Übersicht | reference | active | docs/deploy/README.md |
 | deploy.security | Deploy Security | architecture | active | docs/deploy/security.md |
 | deploy.vps | VPS-Deployment | reference | active | docs/deploy/vps.md |
 | deploy.weltgewebe.naming | Weltgewebe Naming | reference | active | docs/deploy/weltgewebe.naming.md |
-| deployment-contract | Deployment Contract and Preflight Guard | guide | active | docs/deployment.md |
-| deployment_governance | Deployment Governance | reference | active | docs/deployment_governance.md |
 | dev.codespaces | Codespaces | reference | active | docs/dev/codespaces.md |
 | docs.architecture.overview | Architekturüberblick | architecture | active | docs/architekturstruktur.md |
 | docs.blueprints.agent-operability | Minimaler Agent-Operability-Kern | blueprint | draft | docs/blueprints/agent-operability-blaupause.md |
@@ -60,8 +60,8 @@ Generated automatically. Do not edit.
 | docs.reference.agent-operability-fixture-matrix | Agent-Betriebsfaehigkeit: Fixture-Matrix | reference | active | docs/reference/agent-operability-fixture-matrix.md |
 | docs.reports.agent-readiness-audit | Agent Readiness Audit | documentation | active | docs/reports/agent-readiness-audit.md |
 | docs.roadmap | Weltgewebe — Master-Umsetzungsroadmap | roadmap | active | docs/roadmap.md |
-| docs.runbook | Runbook | runbook | active | docs/runbook.md |
 | docs.runbook.observability | Observability Runbook | runbook | active | docs/runbook.observability.md |
+| docs.runbook | Runbook | runbook | active | docs/runbook.md |
 | docs.security.agent-write-scope-baseline | Agent Write Scope Baseline | security | active | docs/security/agent-write-scope-baseline.md |
 | docs.techstack | Techstack | architecture | active | docs/techstack.md |
 | docs.vision | Vision | reference | active | docs/vision.md |
@@ -79,11 +79,11 @@ Generated automatically. Do not edit.
 | overview.inhalt | Inhalt (Übersicht) | reference | active | docs/overview/inhalt.md |
 | overview.zusammenstellung | Zusammenstellung (Übersicht) | reference | active | docs/overview/zusammenstellung.md |
 | policies.orientierung | Orientierung | reference | active | docs/policies/orientierung.md |
-| process.README | Prozess-Übersicht | reference | active | docs/process/README.md |
 | process.bash-tooling-guidelines | Bash Tooling Guidelines | reference | active | docs/process/bash-tooling-guidelines.md |
 | process.fahrplan | Fahrplan | reference | active | docs/process/fahrplan.md |
-| process.report-lifecycle | Report Lifecycle Policy | policy | draft | docs/process/report-lifecycle.md |
+| process.README | Prozess-Übersicht | reference | active | docs/process/README.md |
 | process.report-lifecycle-contract-alignment | Report Lifecycle Contract Alignment | decision | draft | docs/process/report-lifecycle-contract-alignment.md |
+| process.report-lifecycle | Report Lifecycle Policy | policy | draft | docs/process/report-lifecycle.md |
 | process.sprache | Sprache | reference | active | docs/process/sprache.md |
 | proofs.sqlx-pgbouncer-session-crud-proof | SQLx → PgBouncer → Postgres — Session-CRUD-Proof | report | active | docs/proofs/sqlx-pgbouncer-session-crud-proof.md |
 | proofs.sqlx-postgres-direct-session-crud-proof | SQLx \u2192 direkter PostgreSQL \u2014 Session-CRUD-Proof | report | active | docs/proofs/sqlx-postgres-direct-session-crud-proof.md |
@@ -96,7 +96,7 @@ Generated automatically. Do not edit.
 | reports.auth-persistence-runtime-target-reconciliation | Auth-Persistenz — Runtime-Zielarchitektur-Abgleich (PgBouncer vs. direkter Postgres) | report | active | docs/reports/auth-persistence-runtime-target-reconciliation.md |
 | reports.auth-status-matrix | Auth Status Matrix | reference | active | docs/reports/auth-status-matrix.md |
 | reports.cost-report | Cost Report | reference | active | docs/reports/cost-report.md |
-| reports.domain-account-email-uniqueness-audit | Domain Account E-Mail Uniqueness Audit | report | draft | docs/reports/domain-account-email-uniqueness-audit.md |
+| reports.domain-account-email-uniqueness-audit | Domain Account E-Mail Uniqueness Audit | report | active | docs/reports/domain-account-email-uniqueness-audit.md |
 | reports.domain-account-write-path-proof | Domain Account Write Path Proof | report | active | docs/reports/domain-account-write-path-proof.md |
 | reports.domain-backfill-proof | Domain Backfill Proof | report | active | docs/reports/domain-backfill-proof.md |
 | reports.domain-edge-create-semantics-preflight | Domain Edge Create Semantics Preflight — OPT-ARC-001 Phase E-C | report | active | docs/reports/domain-edge-create-semantics-preflight.md |
@@ -109,12 +109,12 @@ Generated automatically. Do not edit.
 | reports.optimierungsstatus | Optimierungsstatus Weltgewebe | status-matrix | active | docs/reports/optimierungsstatus.md |
 | reports.passkey-register-verify-prep | Passkey Register-Verify – Vorbereitungsbericht | report | active | docs/reports/passkey-register-verify-prep.md |
 | reports.planning-registration-findings | Planning Registration Findings Triage | report | active | docs/reports/planning-registration-findings.md |
-| runbooks.README | Runbooks-Übersicht | reference | active | docs/runbooks/README.md |
 | runbooks.codespaces-recovery | Codespaces Recovery | reference | active | docs/runbooks/codespaces-recovery.md |
 | runbooks.db-recovery | DB Recovery Runbook | reference | active | docs/runbooks/db-recovery.md |
 | runbooks.domain-mail-cutover | Runbook — Domain-, Mail- und SMTP-Cutover | runbook | active | docs/runbooks/domain-mail-cutover.md |
 | runbooks.incident-response | Incident Response Runbook | reference | active | docs/runbooks/incident-response.md |
 | runbooks.ops.runbook.weltgewebe-selfhost-deploy | Selfhost-Deploy Runbook | reference | active | docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md |
+| runbooks.README | Runbooks-Übersicht | reference | active | docs/runbooks/README.md |
 | runbooks.uv-tooling | UV-Tooling | reference | active | docs/runbooks/uv-tooling.md |
 | specs.auth-api | Auth API Spec | reference | active | docs/specs/auth-api.md |
 | specs.auth-blueprint | Auth Blueprint | reference | active | docs/specs/auth-blueprint.md |

--- a/docs/_generated/relations-analysis.md
+++ b/docs/_generated/relations-analysis.md
@@ -14,12 +14,12 @@ Generated automatically. Do not edit.
 
 | Metrik | Wert |
 | --- | --- |
-| Dokumente gesamt | 123 |
-| Dokumente mit ausgehenden Relationen | 120 |
-| Dokumente als Ziel referenziert | 94 |
-| Relationen gesamt | 375 |
+| Dokumente gesamt | 124 |
+| Dokumente mit ausgehenden Relationen | 121 |
+| Dokumente als Ziel referenziert | 95 |
+| Relationen gesamt | 381 |
 | — depends_on | 18 |
-| — relates_to | 355 |
+| — relates_to | 361 |
 | — supersedes | 2 |
 | Isolierte Dokumente | 2 |
 | depends_on Zyklen | 0 |

--- a/docs/_generated/report-lifecycle-inventory.md
+++ b/docs/_generated/report-lifecycle-inventory.md
@@ -21,14 +21,14 @@ Primary references are exact path matches in canonical documentation surfaces. D
 | files_without_frontmatter | 0 |
 | files_with_status | 23 |
 | files_missing_status | 0 |
-| files_with_lifecycle_state | 0 |
-| files_missing_lifecycle_state | 23 |
-| files_with_lifecycle | 0 |
-| files_missing_lifecycle | 23 |
-| files_with_owner_task | 0 |
-| files_missing_owner_task | 23 |
-| files_with_review_after | 0 |
-| files_missing_review_after | 23 |
+| files_with_lifecycle_state | 1 |
+| files_missing_lifecycle_state | 22 |
+| files_with_lifecycle | 1 |
+| files_missing_lifecycle | 22 |
+| files_with_owner_task | 1 |
+| files_missing_owner_task | 22 |
+| files_with_review_after | 1 |
+| files_missing_review_after | 22 |
 | files_primary_referenced | 19 |
 | files_primary_unreferenced | 4 |
 | files_with_derived_references | 23 |
@@ -56,7 +56,7 @@ Primary references are exact path matches in canonical documentation surfaces. D
 | docs/reports/auth-persistence-runtime-target-reconciliation.md | report | active |  |  |  |  |  | 1 | 3 | 5 | lifecycle, owner_task, review_after, lifecycle_state |  |
 | docs/reports/auth-status-matrix.md | reference | active |  |  |  |  |  | 5 | 3 | 3 | lifecycle, owner_task, review_after, lifecycle_state |  |
 | docs/reports/cost-report.md | reference | active |  |  |  |  |  | 0 | 3 | 0 | lifecycle, owner_task, review_after, lifecycle_state |  |
-| docs/reports/domain-account-email-uniqueness-audit.md | report | draft |  |  |  |  |  | 1 | 3 | 4 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/domain-account-email-uniqueness-audit.md | report | active | active | audit | OPT-ARC-001 | 2026-07-13 |  | 1 | 3 | 4 |  |  |
 | docs/reports/domain-account-write-path-proof.md | report | active |  |  |  |  |  | 7 | 3 | 6 | lifecycle, owner_task, review_after, lifecycle_state |  |
 | docs/reports/domain-backfill-proof.md | report | active |  |  |  |  |  | 3 | 3 | 4 | lifecycle, owner_task, review_after, lifecycle_state |  |
 | docs/reports/domain-edge-create-semantics-preflight.md | report | active |  |  |  |  |  | 0 | 3 | 7 | lifecycle, owner_task, review_after, lifecycle_state |  |
@@ -66,7 +66,7 @@ Primary references are exact path matches in canonical documentation surfaces. D
 | docs/reports/domain-read-path-proof.md | report | active |  |  |  |  |  | 5 | 3 | 5 | lifecycle, owner_task, review_after, lifecycle_state |  |
 | docs/reports/inwx-zone-reconciliation-plan.md | report | active |  |  |  |  |  | 1 | 3 | 4 | lifecycle, owner_task, review_after, lifecycle_state |  |
 | docs/reports/map-architekturkritik.md | report | active |  |  |  |  |  | 4 | 4 | 2 | lifecycle, owner_task, review_after, lifecycle_state |  |
-| docs/reports/map-status-matrix.md | status-matrix | active |  |  |  |  |  | 6 | 4 | 2 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/map-status-matrix.md | status-matrix | active |  |  |  |  |  | 7 | 4 | 3 | lifecycle, owner_task, review_after, lifecycle_state |  |
 | docs/reports/optimierungsbericht.md | report | active |  |  |  |  |  | 2 | 3 | 4 | lifecycle, owner_task, review_after, lifecycle_state |  |
 | docs/reports/optimierungsstatus.md | status-matrix | active |  |  |  |  |  | 17 | 4 | 4 | lifecycle, owner_task, review_after, lifecycle_state |  |
 | docs/reports/passkey-register-verify-prep.md | report | active |  |  |  |  |  | 0 | 3 | 4 | lifecycle, owner_task, review_after, lifecycle_state |  |
@@ -84,7 +84,6 @@ Primary references are exact path matches in canonical documentation surfaces. D
 | docs/reports/auth-persistence-runtime-target-reconciliation.md | lifecycle, owner_task, review_after, lifecycle_state |
 | docs/reports/auth-status-matrix.md | lifecycle, owner_task, review_after, lifecycle_state |
 | docs/reports/cost-report.md | lifecycle, owner_task, review_after, lifecycle_state |
-| docs/reports/domain-account-email-uniqueness-audit.md | lifecycle, owner_task, review_after, lifecycle_state |
 | docs/reports/domain-account-write-path-proof.md | lifecycle, owner_task, review_after, lifecycle_state |
 | docs/reports/domain-backfill-proof.md | lifecycle, owner_task, review_after, lifecycle_state |
 | docs/reports/domain-edge-create-semantics-preflight.md | lifecycle, owner_task, review_after, lifecycle_state |
@@ -121,7 +120,7 @@ Primary references are exact path matches in canonical documentation surfaces. D
 | docs/reports/domain-read-path-proof.md | 5 | relates_to | docs/blueprints/domain-data-postgres-cutover.md, docs/reports/domain-account-write-path-proof.md, docs/reports/domain-backfill-proof.md, docs/reports/optimierungsstatus.md, docs/tasks/board.md |
 | docs/reports/inwx-zone-reconciliation-plan.md | 4 | relates_to | docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md, docs/reports/domain-provider-role-finding.md, docs/runbooks/domain-mail-cutover.md, docs/tasks/board.md |
 | docs/reports/map-architekturkritik.md | 2 | relates_to | docs/blueprints/kartenklarheit-roadmap.md, docs/reports/map-status-matrix.md |
-| docs/reports/map-status-matrix.md | 2 | relates_to | docs/blueprints/kartenklarheit-roadmap.md, docs/reports/map-architekturkritik.md |
+| docs/reports/map-status-matrix.md | 3 | relates_to | docs/blueprints/kartenklarheit-roadmap.md, docs/blueprints/ui-interaction-doctrine.md, docs/reports/map-architekturkritik.md |
 | docs/reports/optimierungsbericht.md | 4 | relates_to | docs/datenmodell.md, docs/policies/agent-reading-protocol.md, docs/reports/optimierungsstatus.md, docs/techstack.md |
 | docs/reports/optimierungsstatus.md | 4 | depends_on, relates_to | docs/policies/agent-reading-protocol.md, docs/reports/auth-persistence-readiness.md, docs/reports/domain-read-path-proof.md, docs/reports/optimierungsbericht.md |
 | docs/reports/passkey-register-verify-prep.md | 4 | relates_to | docs/adr/ADR-0006__auth-magic-link-session-passkey.md, docs/blueprints/auth-roadmap.md, docs/reports/auth-status-matrix.md, docs/specs/auth-api.md |
@@ -215,6 +214,7 @@ Primary references are exact path matches in canonical documentation surfaces. D
   - `docs/blueprints/kartenklarheit-roadmap.md`
   - `docs/blueprints/kartenklarheit.md`
   - `docs/blueprints/map-roadmap.md`
+  - `docs/blueprints/ui-interaction-doctrine.md`
   - `docs/reports/map-architekturkritik.md`
   - `docs/roadmap.md`
 

--- a/docs/reports/domain-account-email-uniqueness-audit.md
+++ b/docs/reports/domain-account-email-uniqueness-audit.md
@@ -2,7 +2,11 @@
 id: reports.domain-account-email-uniqueness-audit
 title: Domain Account E-Mail Uniqueness Audit
 doc_type: report
-status: draft
+status: active
+lifecycle_state: active
+lifecycle: audit
+owner_task: OPT-ARC-001
+review_after: 2026-07-13
 lang: de
 canonicality: supporting
 relations:
@@ -25,6 +29,13 @@ summary: >
 ## Ziel
 
 Vorbereitung eines Unique-Index auf Account-E-Mails in PostgreSQL durch reproduzierbares Auditieren von vorhandenen JSONL-Daten. Ziel ist es, das aktuelle Runtime-Verhalten zu dokumentieren und Normalisierungsfragen zu klären, bevor ein Constraint Daten-Integrität bricht. Dieser Report führt noch keine DB-Migration und keinen Unique-Index ein.
+
+## Lifecycle
+
+- Zweck: Auditiert die Eindeutigkeit und Nutzbarkeit von Account-E-Mail-Adressen im Domain-Modell.
+- Bereitet vor: OPT-ARC-001 und spätere Validator-/Backfill-Entscheidungen zur Account-E-Mail-Konsistenz.
+- Gültig bis: 2026-07-13 oder bis ein neuerer Audit-/Proof-Report diesen Report ausdrücklich ablöst.
+- Wird abgelöst durch: Noch offen.
 
 ## Belegter Ist-Zustand
 

--- a/scripts/docmeta/generate-doc-index.sh
+++ b/scripts/docmeta/generate-doc-index.sh
@@ -43,7 +43,7 @@ find docs -type f -name "*.md" ! -path "docs/_generated/*" -print0 | while IFS= 
 done
 
 # Sort entries deterministically and append to output
-sort "$TEMP_ENTRIES" >> "$OUT_FILE"
+LC_ALL=C sort "$TEMP_ENTRIES" >> "$OUT_FILE"
 rm -f "$TEMP_ENTRIES"
 
 echo "Generated $OUT_FILE"


### PR DESCRIPTION
## Summary

Annotates `docs/reports/domain-account-email-uniqueness-audit.md` as the first
Report Lifecycle pilot.

## What changed

- Sets report lifecycle frontmatter for the account email uniqueness audit.
- Adds `lifecycle_state: active`, `lifecycle: audit`, `owner_task`, and
  `review_after`.
- Adds a short human-readable Lifecycle section.
- Regenerates the report lifecycle inventory.
- Makes generated doc-index sorting locale-stable by forcing `LC_ALL=C` for the
  generator sort step.

## Non-goals

- No validator.
- No strict CI enforcement.
- No schema or contract change.
- No report backfill.
- No report archival.
- No supersession change.
- No deletion or path move.
- No broad generator refactor.

## Checks

- [x] `make generate`
- [x] `LC_ALL=C.UTF-8 make generate`
- [x] `LC_ALL=C make generate`
- [x] locale-stability check confirmed both generated diffs are identical
- [x] `bash scripts/docmeta/generated-files-guard.sh`
- [x] `npx markdownlint-cli2 docs/reports/domain-account-email-uniqueness-audit.md docs/_generated/report-lifecycle-inventory.md docs/_generated/doc-index.md docs/_generated/relations-analysis.md`
- [x] `PYTHONPATH=$(pwd) python3 -m unittest scripts/docmeta/tests/test_generate_report_lifecycle_inventory.py`
- [x] `python3 -m pytest scripts/docmeta/tests/test_generate_report_lifecycle_inventory.py` or documented unavailable
- [x] `git diff --check`
- [x] second `make generate` produced no additional drift
- [x] scope gate confirmed no forbidden files changed

## Expected inventory effect

- `files_with_lifecycle_state` increases by one.
- `files_missing_lifecycle_state` decreases by one.
- The pilot report no longer lists `lifecycle_state` as an absent core lifecycle field.
- No Supersession Target Diagnostic is created for the pilot report.

## Codex review response

Addressed the generated doc-index reproducibility issue by fixing the generator
sort locale directly:

```bash
LC_ALL=C sort "$TEMP_ENTRIES" >> "$OUT_FILE"
```

This prevents environment-dependent ordering under locales such as `C.UTF-8`.

## Follow-ups

* Add a report lifecycle validator in report/warn/strict modes.
* Define allowed `lifecycle_state` values.
* Continue lifecycle backfill in small slices after the pilot is reviewed.
