### PR TITLE
docs: add report lifecycle validator report mode

### DIFF
--- a/scripts/docmeta/tests/test_validate_report_lifecycle.py
+++ b/scripts/docmeta/tests/test_validate_report_lifecycle.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import io
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from scripts.docmeta.validate_report_lifecycle import main, run, _validate_report, Finding
+
+
+def write_report(root: Path, name: str, frontmatter: str, body: str = "Body\n") -> Path:
+    path = root / "docs" / "reports" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"---\n{frontmatter.strip()}\n---\n\n{body}", encoding="utf-8")
+    return path
+
+
+class TestValidateReportLifecycle(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp_root = Path(self._tmp.name)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def run_main(self, args: list[str]) -> tuple[int, str, str]:
+        stdout_capture = io.StringIO()
+        stderr_capture = io.StringIO()
+        with patch("sys.stdout", stdout_capture), patch("sys.stderr", stderr_capture):
+            exit_code = main(args)
+        return exit_code, stdout_capture.getvalue(), stderr_capture.getvalue()
+
+    def test_report_mode_exits_zero_even_with_findings(self) -> None:
+        # Fixture
+        write_report(
+            self.tmp_root,
+            "example.md",
+            """
+id: reports.example
+title: Example
+doc_type: report
+status: active
+            """
+        )
+
+        exit_code, stdout, stderr = self.run_main(["--mode", "report", "--root", str(self.tmp_root)])
+        self.assertEqual(exit_code, 0)
+        self.assertIn("missing_lifecycle", stdout)
+        self.assertIn("missing_review_after", stdout)
+        self.assertEqual(stderr, "")
+
+    def test_active_report_missing_lifecycle_and_review_after(self) -> None:
+        # Fixture
+        fm = {
+            "id": "reports.example",
+            "title": "Example",
+            "doc_type": "report",
+            "status": "active"
+        }
+        path = self.tmp_root / "docs" / "reports" / "example.md"
+        findings = _validate_report(path, fm, self.tmp_root)
+        codes = [f.code for f in findings]
+        self.assertIn("missing_lifecycle", codes)
+        self.assertIn("missing_review_after", codes)
+
+    def test_lifecycle_state_active_missing_owner_task(self) -> None:
+        # Fixture
+        fm = {
+            "id": "reports.example",
+            "title": "Example",
+            "doc_type": "report",
+            "status": "active",
+            "lifecycle_state": "active",
+            "lifecycle": "audit",
+            "review_after": "2026-07-13"
+        }
+        path = self.tmp_root / "docs" / "reports" / "example.md"
+        findings = _validate_report(path, fm, self.tmp_root)
+        codes = [f.code for f in findings]
+        self.assertEqual(codes, ["missing_owner_task"])
+
+    def test_superseded_needs_superseded_by(self) -> None:
+        # Fixture
+        fm = {
+            "id": "reports.example",
+            "title": "Example",
+            "doc_type": "report",
+            "status": "deprecated",
+            "lifecycle_state": "superseded"
+        }
+        path = self.tmp_root / "docs" / "reports" / "example.md"
+        findings = _validate_report(path, fm, self.tmp_root)
+        codes = [f.code for f in findings]
+        self.assertIn("missing_superseded_by", codes)
+
+    def test_archived_does_not_need_superseded_by(self) -> None:
+        # Fixture
+        fm = {
+            "id": "reports.example",
+            "title": "Example",
+            "doc_type": "report",
+            "status": "deprecated",
+            "lifecycle_state": "archived"
+        }
+        path = self.tmp_root / "docs" / "reports" / "example.md"
+        findings = _validate_report(path, fm, self.tmp_root)
+        codes = [f.code for f in findings]
+        self.assertNotIn("missing_superseded_by", codes)
+
+    def test_deprecated_without_lifecycle_state_is_not_supersession(self) -> None:
+        # Fixture
+        fm = {
+            "id": "reports.example",
+            "title": "Example",
+            "doc_type": "report",
+            "status": "deprecated"
+        }
+        path = self.tmp_root / "docs" / "reports" / "example.md"
+        findings = _validate_report(path, fm, self.tmp_root)
+        codes = [f.code for f in findings]
+        self.assertNotIn("missing_superseded_by", codes)
+
+    def test_case_insensitive_lifecycle_state(self) -> None:
+        # Fixture
+        fm = {
+            "id": "reports.example",
+            "title": "Example",
+            "doc_type": "report",
+            "status": "deprecated",
+            "lifecycle_state": "Superseded"
+        }
+        path = self.tmp_root / "docs" / "reports" / "example.md"
+        findings = _validate_report(path, fm, self.tmp_root)
+        codes = [f.code for f in findings]
+        self.assertIn("missing_superseded_by", codes)
+
+    def test_non_report_doc_type_in_docs_reports_does_not_trigger_required_lifecycle_findings(self) -> None:
+        # Fixture
+        fm = {
+            "id": "reports.reference",
+            "title": "Reference",
+            "doc_type": "reference",
+            "status": "active"
+        }
+        path = self.tmp_root / "docs" / "reports" / "example.md"
+        findings = _validate_report(path, fm, self.tmp_root)
+        self.assertEqual(findings, [])
+
+    def test_pilot_shaped_report_passes_active_lifecycle_checks(self) -> None:
+        # Fixture
+        fm = {
+            "id": "reports.domain-account-email-uniqueness-audit",
+            "title": "Domain Account E-Mail Uniqueness Audit",
+            "doc_type": "report",
+            "status": "active",
+            "lifecycle_state": "active",
+            "lifecycle": "audit",
+            "owner_task": "OPT-ARC-001",
+            "review_after": "2026-07-13"
+        }
+        path = self.tmp_root / "docs" / "reports" / "domain-account-email-uniqueness-audit.md"
+        findings = _validate_report(path, fm, self.tmp_root)
+        self.assertEqual(findings, [])
+
+    def test_render_output_is_stable(self) -> None:
+        write_report(
+            self.tmp_root,
+            "example.md",
+            """
+id: reports.example
+title: Example
+doc_type: report
+status: active
+            """
+        )
+
+        rendered, exit_code = run(self.tmp_root, "report")
+        self.assertEqual(exit_code, 0)
+        self.assertIn("# Report Lifecycle Validation", rendered)
+        self.assertIn("Mode: report", rendered)
+        self.assertIn("| reports_checked |", rendered)
+        self.assertIn("| findings_total |", rendered)
+        self.assertIn("| Path | Severity | Code | Field | Message |", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/docmeta/tests/test_validate_report_lifecycle.py
+++ b/scripts/docmeta/tests/test_validate_report_lifecycle.py
@@ -287,6 +287,64 @@ review_after: 2026-07-13
         self.assertEqual(exit_code, 0)
         self.assertIn("missing_owner_task", rendered)
 
+    def test_report_without_lifecycle_state_yields_finding(self) -> None:
+        fm = {
+            "id": "reports.example",
+            "title": "Example",
+            "doc_type": "report",
+            "status": "active",
+        }
+        path = self.tmp_root / "docs" / "reports" / "example.md"
+        findings = _validate_report(path, fm, self.tmp_root)
+        codes = [f.code for f in findings]
+        self.assertIn("missing_lifecycle_state", codes)
+
+    def test_deferred_lifecycle_state_missing_owner_task_and_review_after(self) -> None:
+        fm = {
+            "id": "reports.example",
+            "title": "Example",
+            "doc_type": "report",
+            "status": "active",
+            "lifecycle_state": "deferred",
+            "lifecycle": "audit",
+        }
+        path = self.tmp_root / "docs" / "reports" / "example.md"
+        findings = _validate_report(path, fm, self.tmp_root)
+        codes = [f.code for f in findings]
+        self.assertIn("missing_owner_task", codes)
+        self.assertIn("missing_review_after", codes)
+
+    def test_superseded_lifecycle_state_with_only_superseded_by(self) -> None:
+        fm = {
+            "id": "reports.example",
+            "title": "Example",
+            "doc_type": "report",
+            "status": "deprecated",
+            "lifecycle_state": "superseded",
+            "superseded_by": "reports.new_one",
+        }
+        path = self.tmp_root / "docs" / "reports" / "example.md"
+        findings = _validate_report(path, fm, self.tmp_root)
+        codes = [f.code for f in findings]
+        self.assertIn("missing_lifecycle", codes)
+        self.assertIn("missing_owner_task", codes)
+        self.assertNotIn("missing_superseded_by", codes)
+
+    def test_archived_lifecycle_state_missing_owner_task(self) -> None:
+        fm = {
+            "id": "reports.example",
+            "title": "Example",
+            "doc_type": "report",
+            "status": "deprecated",
+            "lifecycle_state": "archived",
+            "lifecycle": "audit",
+        }
+        path = self.tmp_root / "docs" / "reports" / "example.md"
+        findings = _validate_report(path, fm, self.tmp_root)
+        codes = [f.code for f in findings]
+        self.assertIn("missing_owner_task", codes)
+        self.assertNotIn("missing_superseded_by", codes)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/docmeta/tests/test_validate_report_lifecycle.py
+++ b/scripts/docmeta/tests/test_validate_report_lifecycle.py
@@ -185,6 +185,7 @@ status: active
         self.assertIn("| reports_checked |", rendered)
         self.assertIn("| reports_ignored_non_report |", rendered)
         self.assertIn("| findings_total |", rendered)
+        self.assertIn("| missing_lifecycle_state |", rendered)
         self.assertIn("| Path | Severity | Code | Field | Message |", rendered)
 
     def test_validate_report_with_datetime_date_review_after(self) -> None:
@@ -344,6 +345,21 @@ review_after: 2026-07-13
         codes = [f.code for f in findings]
         self.assertIn("missing_owner_task", codes)
         self.assertNotIn("missing_superseded_by", codes)
+
+    def test_deferred_lifecycle_state_missing_lifecycle(self) -> None:
+        fm = {
+            "id": "reports.example",
+            "title": "Example",
+            "doc_type": "report",
+            "status": "active",
+            "lifecycle_state": "deferred",
+            "owner_task": "OPT-ARC-001",
+            "review_after": "2026-07-13",
+        }
+        path = self.tmp_root / "docs" / "reports" / "example.md"
+        findings = _validate_report(path, fm, self.tmp_root)
+        codes = [f.code for f in findings]
+        self.assertIn("missing_lifecycle", codes)
 
 
 if __name__ == "__main__":

--- a/scripts/docmeta/tests/test_validate_report_lifecycle.py
+++ b/scripts/docmeta/tests/test_validate_report_lifecycle.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import datetime
 import io
 from pathlib import Path
 import tempfile
 import unittest
 from unittest.mock import patch
 
-from scripts.docmeta.validate_report_lifecycle import main, run, _validate_report, Finding
+from scripts.docmeta.validate_report_lifecycle import main, run, _validate_report
 
 
 def write_report(root: Path, name: str, frontmatter: str, body: str = "Body\n") -> Path:
@@ -180,9 +181,111 @@ status: active
         self.assertEqual(exit_code, 0)
         self.assertIn("# Report Lifecycle Validation", rendered)
         self.assertIn("Mode: report", rendered)
+        self.assertIn("| files_scanned |", rendered)
         self.assertIn("| reports_checked |", rendered)
+        self.assertIn("| reports_ignored_non_report |", rendered)
         self.assertIn("| findings_total |", rendered)
         self.assertIn("| Path | Severity | Code | Field | Message |", rendered)
+
+    def test_validate_report_with_datetime_date_review_after(self) -> None:
+        fm = {
+            "id": "reports.example",
+            "title": "Example",
+            "doc_type": "report",
+            "status": "active",
+            "review_after": datetime.date(2026, 7, 13),
+            "lifecycle": "audit"
+        }
+        path = self.tmp_root / "docs" / "reports" / "example.md"
+        findings = _validate_report(path, fm, self.tmp_root)
+        codes = [f.code for f in findings]
+        self.assertNotIn("missing_review_after", codes)
+
+    def test_run_with_unquoted_date_in_frontmatter(self) -> None:
+        write_report(
+            self.tmp_root,
+            "example.md",
+            """
+id: reports.example
+title: Example
+doc_type: report
+status: active
+lifecycle: audit
+review_after: 2026-07-13
+            """
+        )
+        rendered, exit_code = run(self.tmp_root, "report")
+        self.assertEqual(exit_code, 0)
+        self.assertIn("| missing_review_after | 0 |", rendered)
+
+    def test_run_scans_and_checks_precise_metrics(self) -> None:
+        # Fixture 1: a report
+        write_report(
+            self.tmp_root,
+            "example_report.md",
+            """
+id: reports.example_report
+title: Example Report
+doc_type: report
+status: active
+lifecycle: audit
+review_after: 2026-07-13
+            """
+        )
+        # Fixture 2: a reference (non-report)
+        write_report(
+            self.tmp_root,
+            "example_ref.md",
+            """
+id: reports.example_ref
+title: Example Reference
+doc_type: reference
+status: active
+            """
+        )
+
+        rendered, exit_code = run(self.tmp_root, "report")
+        self.assertEqual(exit_code, 0)
+        self.assertIn("| files_scanned | 2 |", rendered)
+        self.assertIn("| reports_checked | 1 |", rendered)
+        self.assertIn("| reports_ignored_non_report | 1 |", rendered)
+
+    def test_blank_frontmatter_values_are_missing(self) -> None:
+        write_report(
+            self.tmp_root,
+            "example.md",
+            """
+id: reports.example
+title: Example
+doc_type: report
+status: active
+lifecycle:
+review_after:
+            """
+        )
+        rendered, exit_code = run(self.tmp_root, "report")
+        self.assertEqual(exit_code, 0)
+        self.assertIn("missing_lifecycle", rendered)
+        self.assertIn("missing_review_after", rendered)
+
+    def test_blank_owner_task_is_missing_for_lifecycle_state_active(self) -> None:
+        write_report(
+            self.tmp_root,
+            "example.md",
+            """
+id: reports.example
+title: Example
+doc_type: report
+status: active
+lifecycle_state: active
+lifecycle: audit
+owner_task:
+review_after: 2026-07-13
+            """
+        )
+        rendered, exit_code = run(self.tmp_root, "report")
+        self.assertEqual(exit_code, 0)
+        self.assertIn("missing_owner_task", rendered)
 
 
 if __name__ == "__main__":

--- a/scripts/docmeta/validate_report_lifecycle.py
+++ b/scripts/docmeta/validate_report_lifecycle.py
@@ -12,7 +12,6 @@ if __package__ in {None, ""}:
 from scripts.docmeta.docmeta import parse_frontmatter
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-REPORTS_DIR = REPO_ROOT / "docs" / "reports"
 
 
 @dataclass(frozen=True)
@@ -25,9 +24,13 @@ class Finding:
 
 
 def _string_value(value: object) -> str:
+    if value is None:
+        return ""
     if isinstance(value, str):
         return value.strip()
-    return ""
+    if isinstance(value, (list, tuple, set, dict)):
+        return ""
+    return str(value).strip()
 
 
 def _load_frontmatter(path: Path) -> dict[str, object]:
@@ -103,9 +106,16 @@ def _validate_report(path: Path, frontmatter: dict[str, object], root: Path) -> 
     return findings
 
 
-def _build_summary(findings: list[Finding], report_count: int) -> dict[str, int]:
+def _build_summary(
+    findings: list[Finding],
+    files_scanned: int,
+    reports_checked: int,
+    reports_ignored_non_report: int
+) -> dict[str, int]:
     summary = {
-        "reports_checked": report_count,
+        "files_scanned": files_scanned,
+        "reports_checked": reports_checked,
+        "reports_ignored_non_report": reports_ignored_non_report,
         "findings_total": len(findings),
         "missing_status": 0,
         "missing_lifecycle": 0,
@@ -129,7 +139,9 @@ def _render_report(findings: list[Finding], summary: dict[str, int], mode: str) 
         "",
         "| Metric | Value |",
         "| --- | ---: |",
+        f"| files_scanned | {summary['files_scanned']} |",
         f"| reports_checked | {summary['reports_checked']} |",
+        f"| reports_ignored_non_report | {summary['reports_ignored_non_report']} |",
         f"| findings_total | {summary['findings_total']} |",
         f"| missing_status | {summary['missing_status']} |",
         f"| missing_lifecycle | {summary['missing_lifecycle']} |",
@@ -154,14 +166,27 @@ def _render_report(findings: list[Finding], summary: dict[str, int], mode: str) 
 def run(root: Path, mode: str) -> tuple[str, int]:
     paths = _iter_report_paths(root)
     all_findings = []
+    reports_checked = 0
+    reports_ignored_non_report = 0
+
     for p in paths:
         fm = _load_frontmatter(p)
+        doc_type = _string_value(fm.get("doc_type")).strip().lower()
+        if doc_type == "report":
+            reports_checked += 1
+        else:
+            reports_ignored_non_report += 1
         findings = _validate_report(p, fm, root)
         all_findings.extend(findings)
 
     all_findings.sort(key=lambda f: (f.path, f.code))
 
-    summary = _build_summary(all_findings, len(paths))
+    summary = _build_summary(
+        all_findings,
+        files_scanned=len(paths),
+        reports_checked=reports_checked,
+        reports_ignored_non_report=reports_ignored_non_report,
+    )
     report_str = _render_report(all_findings, summary, mode)
     return report_str, 0
 

--- a/scripts/docmeta/validate_report_lifecycle.py
+++ b/scripts/docmeta/validate_report_lifecycle.py
@@ -78,6 +78,10 @@ def _validate_report(path: Path, frontmatter: dict[str, object], root: Path) -> 
             ))
             added_codes.add(code)
 
+    # Rule: doc_type: report needs lifecycle_state
+    if not lifecycle_state:
+        add_finding("missing_lifecycle_state", "lifecycle_state", "report documents should define lifecycle_state")
+
     # Regel 1 — doc_type: report braucht status
     if not status:
         add_finding("missing_status", "status", "report documents should define status")
@@ -90,7 +94,7 @@ def _validate_report(path: Path, frontmatter: dict[str, object], root: Path) -> 
     if status in {"active", "draft"} and not review_after:
         add_finding("missing_review_after", "review_after", "active/draft reports should define review_after")
 
-    # Regel 4 — lifecycle_state: active braucht Kernfelder
+    # Regel 4 — Pflichtfeldlogik für bekannte lifecycle_state-Werte
     if lifecycle_state == "active":
         if not lifecycle:
             add_finding("missing_lifecycle", "lifecycle", "active reports should define lifecycle")
@@ -98,10 +102,25 @@ def _validate_report(path: Path, frontmatter: dict[str, object], root: Path) -> 
             add_finding("missing_owner_task", "owner_task", "active reports should define owner_task")
         if not review_after:
             add_finding("missing_review_after", "review_after", "active/draft reports should define review_after")
-
-    # Regel 5 — lifecycle_state: superseded braucht superseded_by
-    if lifecycle_state == "superseded" and not superseded_by:
-        add_finding("missing_superseded_by", "superseded_by", "superseded reports should define superseded_by")
+    elif lifecycle_state == "deferred":
+        if not lifecycle:
+            add_finding("missing_lifecycle", "lifecycle", "deferred reports should define lifecycle")
+        if not owner_task:
+            add_finding("missing_owner_task", "owner_task", "deferred reports should define owner_task")
+        if not review_after:
+            add_finding("missing_review_after", "review_after", "deferred reports should define review_after")
+    elif lifecycle_state == "superseded":
+        if not lifecycle:
+            add_finding("missing_lifecycle", "lifecycle", "superseded reports should define lifecycle")
+        if not owner_task:
+            add_finding("missing_owner_task", "owner_task", "superseded reports should define owner_task")
+        if not superseded_by:
+            add_finding("missing_superseded_by", "superseded_by", "superseded reports should define superseded_by")
+    elif lifecycle_state == "archived":
+        if not lifecycle:
+            add_finding("missing_lifecycle", "lifecycle", "archived reports should define lifecycle")
+        if not owner_task:
+            add_finding("missing_owner_task", "owner_task", "archived reports should define owner_task")
 
     return findings
 
@@ -122,6 +141,7 @@ def _build_summary(
         "missing_owner_task": 0,
         "missing_review_after": 0,
         "missing_superseded_by": 0,
+        "missing_lifecycle_state": 0,
     }
     for f in findings:
         if f.code in summary:
@@ -148,6 +168,7 @@ def _render_report(findings: list[Finding], summary: dict[str, int], mode: str) 
         f"| missing_owner_task | {summary['missing_owner_task']} |",
         f"| missing_review_after | {summary['missing_review_after']} |",
         f"| missing_superseded_by | {summary['missing_superseded_by']} |",
+        f"| missing_lifecycle_state | {summary['missing_lifecycle_state']} |",
         "",
         "## Findings",
         "",

--- a/scripts/docmeta/validate_report_lifecycle.py
+++ b/scripts/docmeta/validate_report_lifecycle.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scripts.docmeta.docmeta import parse_frontmatter
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REPORTS_DIR = REPO_ROOT / "docs" / "reports"
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: str
+    code: str
+    severity: str
+    message: str
+    field: str | None = None
+
+
+def _string_value(value: object) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    return ""
+
+
+def _load_frontmatter(path: Path) -> dict[str, object]:
+    fm = parse_frontmatter(str(path))
+    if fm is None:
+        return {}
+    return fm
+
+
+def _iter_report_paths(root: Path) -> list[Path]:
+    reports_dir = root / "docs" / "reports"
+    if not reports_dir.exists():
+        return []
+    return sorted([p for p in reports_dir.glob("*.md") if p.is_file()])
+
+
+def _validate_report(path: Path, frontmatter: dict[str, object], root: Path) -> list[Finding]:
+    try:
+        rel_path = path.relative_to(root).as_posix()
+    except ValueError:
+        rel_path = str(path)
+
+    doc_type = _string_value(frontmatter.get("doc_type")).strip().lower()
+    if doc_type != "report":
+        return []
+
+    status = _string_value(frontmatter.get("status")).strip().lower()
+    lifecycle_state = _string_value(frontmatter.get("lifecycle_state")).strip().lower()
+    lifecycle = _string_value(frontmatter.get("lifecycle")).strip()
+    owner_task = _string_value(frontmatter.get("owner_task")).strip()
+    review_after = _string_value(frontmatter.get("review_after")).strip()
+    superseded_by = _string_value(frontmatter.get("superseded_by")).strip()
+
+    findings: list[Finding] = []
+    added_codes = set()
+
+    def add_finding(code: str, field: str, message: str):
+        if code not in added_codes:
+            findings.append(Finding(
+                path=rel_path,
+                code=code,
+                severity="warn",
+                field=field,
+                message=message
+            ))
+            added_codes.add(code)
+
+    # Regel 1 — doc_type: report braucht status
+    if not status:
+        add_finding("missing_status", "status", "report documents should define status")
+
+    # Regel 2 — status: active braucht lifecycle
+    if status == "active" and not lifecycle:
+        add_finding("missing_lifecycle", "lifecycle", "active reports should define lifecycle")
+
+    # Regel 3 — status: active oder status: draft braucht review_after
+    if status in {"active", "draft"} and not review_after:
+        add_finding("missing_review_after", "review_after", "active/draft reports should define review_after")
+
+    # Regel 4 — lifecycle_state: active braucht Kernfelder
+    if lifecycle_state == "active":
+        if not lifecycle:
+            add_finding("missing_lifecycle", "lifecycle", "active reports should define lifecycle")
+        if not owner_task:
+            add_finding("missing_owner_task", "owner_task", "active reports should define owner_task")
+        if not review_after:
+            add_finding("missing_review_after", "review_after", "active/draft reports should define review_after")
+
+    # Regel 5 — lifecycle_state: superseded braucht superseded_by
+    if lifecycle_state == "superseded" and not superseded_by:
+        add_finding("missing_superseded_by", "superseded_by", "superseded reports should define superseded_by")
+
+    return findings
+
+
+def _build_summary(findings: list[Finding], report_count: int) -> dict[str, int]:
+    summary = {
+        "reports_checked": report_count,
+        "findings_total": len(findings),
+        "missing_status": 0,
+        "missing_lifecycle": 0,
+        "missing_owner_task": 0,
+        "missing_review_after": 0,
+        "missing_superseded_by": 0,
+    }
+    for f in findings:
+        if f.code in summary:
+            summary[f.code] += 1
+    return summary
+
+
+def _render_report(findings: list[Finding], summary: dict[str, int], mode: str) -> str:
+    lines = [
+        "# Report Lifecycle Validation",
+        "",
+        f"Mode: {mode}",
+        "",
+        "## Summary",
+        "",
+        "| Metric | Value |",
+        "| --- | ---: |",
+        f"| reports_checked | {summary['reports_checked']} |",
+        f"| findings_total | {summary['findings_total']} |",
+        f"| missing_status | {summary['missing_status']} |",
+        f"| missing_lifecycle | {summary['missing_lifecycle']} |",
+        f"| missing_owner_task | {summary['missing_owner_task']} |",
+        f"| missing_review_after | {summary['missing_review_after']} |",
+        f"| missing_superseded_by | {summary['missing_superseded_by']} |",
+        "",
+        "## Findings",
+        "",
+    ]
+    if findings:
+        lines.append("| Path | Severity | Code | Field | Message |")
+        lines.append("| --- | --- | --- | --- | --- |")
+        for f in findings:
+            field_str = f.field if f.field else ""
+            lines.append(f"| {f.path} | {f.severity} | {f.code} | {field_str} | {f.message} |")
+    else:
+        lines.append("No findings.")
+    return "\n".join(lines) + "\n"
+
+
+def run(root: Path, mode: str) -> tuple[str, int]:
+    paths = _iter_report_paths(root)
+    all_findings = []
+    for p in paths:
+        fm = _load_frontmatter(p)
+        findings = _validate_report(p, fm, root)
+        all_findings.extend(findings)
+
+    all_findings.sort(key=lambda f: (f.path, f.code))
+
+    summary = _build_summary(all_findings, len(paths))
+    report_str = _render_report(all_findings, summary, mode)
+    return report_str, 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate report lifecycle metadata.")
+    parser.add_argument(
+        "--mode",
+        choices=["report"],
+        default="report",
+        help="Validation mode"
+    )
+    parser.add_argument(
+        "--root",
+        type=str,
+        default=None,
+        help="Alternative repository root path"
+    )
+    args = parser.parse_args(argv)
+
+    root_path = Path(args.root) if args.root else REPO_ROOT
+
+    try:
+        report_str, exit_code = run(root_path, args.mode)
+        sys.stdout.write(report_str)
+        return exit_code
+    except Exception as e:
+        sys.stderr.write(f"Error: {e}\n")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds an initial report-only lifecycle validator for `docs/reports/*.md`.

## What changed

- Adds `scripts/docmeta/validate_report_lifecycle.py`.
- Adds unit tests for report lifecycle validation rules.
- Provides `--mode report`, which emits findings and summary output without
  failing on lifecycle gaps.
- Applies required lifecycle metadata checks only to `doc_type: report`.
- Keeps supersession checks based on `lifecycle_state: superseded`.
- Handles non-string scalar frontmatter values as present values in report lifecycle validation.
- Adds summary metrics `files_scanned`, `reports_checked`, and `reports_ignored_non_report` to ensure precise diagnostic counting.
- Hardens scalar value check to treat non-scalar types (list, tuple, set, dict) parsed from empty YAML fields as empty values.
- Adds `missing_lifecycle_state` diagnostic.
- Applies report-only required-field diagnostics across recognized `lifecycle_state` values (active, deferred, superseded, archived).

## Non-goals
- No CI enforcement.
- No `validate-core` integration.
- No strict mode.
- No warn mode.
- No changed-only mode.
- No report backfill.
- No schema or contract change.
- No generated artifact changes.
- No report content changes.
- No allowed-values enforcement.
- No archived-reference validation.
- No owner_task target resolution.
- No review_after date validation.
- Keeps archived `superseded_by`, unknown `lifecycle_state`, strict mode, and CI enforcement out of scope.

## Checks

- [x] `python3 -m scripts.docmeta.validate_report_lifecycle --mode report`
- [x] `PYTHONPATH=$(pwd) python3 -m unittest scripts/docmeta/tests/test_validate_report_lifecycle.py`
- [x] `python3 -m pytest scripts/docmeta/tests/test_validate_report_lifecycle.py` or documented unavailable
- [x] `PYTHONPATH=$(pwd) python3 -m unittest scripts/docmeta/tests/test_generate_report_lifecycle_inventory.py`
- [x] `git diff --check`
- [x] scope gate confirmed no reports/generated/workflows/schema/runtime files changed

## Expected behavior

- The real repo run may emit findings for existing incomplete reports.
- `--mode report` exits 0 even when findings exist.
- Supersession findings are based on `lifecycle_state: superseded`, not global DocMeta `status`.
- `lifecycle_state: archived` does not require `superseded_by`.

## Follow-ups

- Add warn/strict modes after report-only output has been reviewed.
- Add changed-only strict enforcement after lifecycle backfill slices.
- Add a generated lifecycle overview once validator semantics are stable.
- Define allowed `lifecycle_state` values in a separate scope.
