### PR TITLE
feat(auth): add passkey login backend

### DIFF
--- a/apps/api/src/auth/accounts.rs
+++ b/apps/api/src/auth/accounts.rs
@@ -29,6 +29,15 @@ impl AccountStore {
         self.map.get(id)
     }
 
+    /// Returns `true` iff an account with `account_id` exists and is not disabled.
+    ///
+    /// Used by auth flows that must fail-closed when an account is missing or has
+    /// been disabled (e.g. revalidating a passkey login right before a session is
+    /// created, in case the account was disabled mid-ceremony).
+    pub fn is_account_active(&self, account_id: &str) -> bool {
+        self.get(account_id).is_some_and(|acc| !acc.public.disabled)
+    }
+
     fn recompute_email_index_for_key(&mut self, key: &str) {
         let mut candidates = Vec::new();
         for (id, acc) in self.map.iter() {
@@ -183,6 +192,29 @@ mod tests {
         // Test case-insensitive ASCII normalization lookup
         assert!(store.get_by_email("test@example.com").is_some());
         assert!(store.get_by_email("TEST@EXAMPLE.COM").is_some());
+    }
+
+    #[test]
+    fn is_account_active_reflects_existence_and_disabled_flag() {
+        let mut store = AccountStore::new();
+        store.insert(dummy_account("active", Some("active@example.com")));
+
+        let mut disabled = dummy_account("disabled", Some("disabled@example.com"));
+        disabled.public.disabled = true;
+        store.insert(disabled);
+
+        assert!(
+            store.is_account_active("active"),
+            "active account is active"
+        );
+        assert!(
+            !store.is_account_active("disabled"),
+            "disabled account is not active"
+        );
+        assert!(
+            !store.is_account_active("missing"),
+            "missing account is not active"
+        );
     }
 
     #[test]

--- a/apps/api/src/auth/passkeys.rs
+++ b/apps/api/src/auth/passkeys.rs
@@ -37,6 +37,10 @@ const REGISTRATION_TTL_SECS: i64 = 300;
 /// TTL for passkey registration grants (5 minutes — matches step-up token and registration TTL).
 const REGISTRATION_GRANT_TTL_SECS: i64 = 300;
 
+/// TTL for in-progress passkey authentications / login ceremonies (5 minutes —
+/// matches the registration TTL convention).
+const AUTHENTICATION_TTL_SECS: i64 = 300;
+
 /// Error returned when inserting a passkey into [`PasskeyStore`].
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum PasskeyStoreInsertError {
@@ -301,6 +305,100 @@ pub fn start_passkey_registration(
         input.user_display_name,
         exclude_credentials,
     )
+}
+
+// ── Authentication (login) options & state store ──────────────────────────
+
+/// Begin a passkey authentication (login) ceremony.
+///
+/// `allow_credentials` MUST contain the passkeys the ceremony is allowed to
+/// satisfy — i.e. the registered passkeys of the account identified by the
+/// `auth/options` request. webauthn-rs pins `UserVerificationPolicy::Required`
+/// for this ceremony. The returned [`PasskeyAuthentication`] state MUST be stored
+/// server-side (single-use) until the client completes the ceremony via
+/// `auth/verify`; it pairs with the `RequestChallengeResponse` and is required to
+/// verify the assertion.
+pub fn start_passkey_authentication(
+    webauthn: &Webauthn,
+    allow_credentials: &[Passkey],
+) -> Result<(RequestChallengeResponse, PasskeyAuthentication), WebauthnError> {
+    webauthn.start_passkey_authentication(allow_credentials)
+}
+
+/// An in-progress passkey authentication, kept until the client calls
+/// `auth/verify`.
+struct PendingAuthentication {
+    account_id: String,
+    state: PasskeyAuthentication,
+    created_at: DateTime<Utc>,
+}
+
+/// In-memory store for in-progress passkey authentications (login ceremonies).
+///
+/// Keyed by a random opaque ID returned to the client so it can correlate the
+/// `auth/options` response with the subsequent `auth/verify` request.
+///
+/// This store is deliberately **separate** from [`PasskeyRegistrationStore`]:
+/// registration state (`PasskeyRegistration`) and authentication state
+/// (`PasskeyAuthentication`) are distinct WebAuthn ceremonies and must never be
+/// interchangeable. Like the registration store it is in-memory, TTL-bounded
+/// (5 minutes) and single-use.
+#[derive(Clone, Default)]
+pub struct PasskeyAuthenticationStore {
+    store: Arc<TokioRwLock<HashMap<String, PendingAuthentication>>>,
+}
+
+impl PasskeyAuthenticationStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Store a new in-progress authentication bound to `account_id`. Returns the
+    /// opaque authentication ID that must be sent back by the client.
+    pub async fn insert(&self, account_id: String, state: PasskeyAuthentication) -> String {
+        let id = Uuid::new_v4().to_string();
+        let pending = PendingAuthentication {
+            account_id,
+            state,
+            created_at: Utc::now(),
+        };
+        let mut store = self.store.write().await;
+        // Opportunistic cleanup of expired entries.
+        let cutoff = Utc::now() - chrono::Duration::seconds(AUTHENTICATION_TTL_SECS);
+        store.retain(|_, v| v.created_at > cutoff);
+        store.insert(id.clone(), pending);
+        id
+    }
+
+    /// Consume a pending authentication by ID (single-use). Returns the bound
+    /// `account_id` together with the WebAuthn authentication state, or `None` if
+    /// the entry does not exist, has already been consumed, or has expired.
+    ///
+    /// Unlike registration consume there is no account binding to check here: the
+    /// caller of `auth/verify` is unauthenticated and presents only the opaque
+    /// authentication ID. Possession of the ID alone grants nothing — a valid
+    /// assertion over the stored challenge is still required by the caller before
+    /// any session is created.
+    pub async fn consume(
+        &self,
+        authentication_id: &str,
+    ) -> Option<(String, PasskeyAuthentication)> {
+        let mut store = self.store.write().await;
+        let cutoff = Utc::now() - chrono::Duration::seconds(AUTHENTICATION_TTL_SECS);
+        let is_expired = match store.get(authentication_id) {
+            None => return None,
+            Some(entry) => entry.created_at <= cutoff,
+        };
+        if is_expired {
+            // Clean up the stale entry and reject.
+            store.remove(authentication_id);
+            return None;
+        }
+        // Valid: single-use consume.
+        store
+            .remove(authentication_id)
+            .map(|pending| (pending.account_id, pending.state))
+    }
 }
 
 // ── Registration Grant Store ──────────────────────────────────────────────
@@ -619,6 +717,41 @@ webauthn_rp_id: example.com\n";
         assert!(
             correct.is_some(),
             "correct account must still consume after a wrong-account attempt"
+        );
+    }
+
+    #[tokio::test]
+    async fn authentication_store_insert_and_consume_is_single_use() {
+        let store = PasskeyAuthenticationStore::new();
+        let webauthn = test_webauthn();
+        // Proves a passkey is accepted by the authentication-ceremony start.
+        let (_, state) = webauthn
+            .start_passkey_authentication(&[test_passkey(1)])
+            .expect("start_passkey_authentication should accept a credential");
+
+        let id = store.insert("acct-1".to_string(), state).await;
+
+        let consumed = store.consume(&id).await;
+        assert!(consumed.is_some(), "consume should succeed once");
+        assert_eq!(
+            consumed.unwrap().0,
+            "acct-1",
+            "consume must return the bound account_id"
+        );
+
+        let again = store.consume(&id).await;
+        assert!(
+            again.is_none(),
+            "consume must fail on second attempt (single-use)"
+        );
+    }
+
+    #[tokio::test]
+    async fn authentication_store_unknown_id_returns_none() {
+        let store = PasskeyAuthenticationStore::new();
+        assert!(
+            store.consume("no-such-authentication-id").await.is_none(),
+            "unknown authentication id must fail-closed"
         );
     }
 

--- a/apps/api/src/auth/passkeys.rs
+++ b/apps/api/src/auth/passkeys.rs
@@ -62,6 +62,8 @@ pub enum PasskeyStoreInsertError {
 pub enum PasskeyStoreUpdateError {
     #[error("credential not found for account")]
     NotFound,
+    #[error("credential update failed")]
+    UpdateFailed,
 }
 
 /// Stored passkey together with its owning account.
@@ -195,6 +197,8 @@ impl PasskeyStore {
     ///
     /// Returns `true` if the stored credential changed, `false` if it matched
     /// but nothing changed (e.g. a synced passkey reporting a constant counter).
+    ///
+    /// Mutates the stored credential under the store's internal write lock.
     pub fn update_credential(
         &self,
         account_id: &str,
@@ -222,7 +226,15 @@ impl PasskeyStore {
             })
             .ok_or(PasskeyStoreUpdateError::NotFound)?;
 
-        Ok(passkey.update_credential(auth_result).unwrap_or(false))
+        // webauthn-rs' `Passkey::update_credential` returns `Some(changed)` and
+        // only yields `None` on a credential-id mismatch. We located the
+        // credential by `auth_result.cred_id()`, so `None` is unreachable here;
+        // surface it as a hard failure rather than silently smoothing it to
+        // "no change".
+        match passkey.update_credential(auth_result) {
+            Some(changed) => Ok(changed),
+            None => Err(PasskeyStoreUpdateError::UpdateFailed),
+        }
     }
 }
 
@@ -500,21 +512,14 @@ impl PasskeyAuthenticationStore {
         &self,
         authentication_id: &str,
     ) -> Option<(String, PasskeyAuthentication)> {
-        let mut store = self.store.write().await;
+        // Remove-first: a single lookup that is single-use regardless of outcome.
+        // An expired entry is removed and rejected just the same.
+        let pending = self.store.write().await.remove(authentication_id)?;
         let cutoff = Utc::now() - chrono::Duration::seconds(AUTHENTICATION_TTL_SECS);
-        let is_expired = match store.get(authentication_id) {
-            None => return None,
-            Some(entry) => entry.created_at <= cutoff,
-        };
-        if is_expired {
-            // Clean up the stale entry and reject.
-            store.remove(authentication_id);
+        if pending.created_at <= cutoff {
             return None;
         }
-        // Valid: single-use consume.
-        store
-            .remove(authentication_id)
-            .map(|pending| (pending.account_id, pending.state))
+        Some((pending.account_id, pending.state))
     }
 }
 

--- a/apps/api/src/auth/passkeys.rs
+++ b/apps/api/src/auth/passkeys.rs
@@ -41,11 +41,27 @@ const REGISTRATION_GRANT_TTL_SECS: i64 = 300;
 /// matches the registration TTL convention).
 const AUTHENTICATION_TTL_SECS: i64 = 300;
 
+/// Hard upper bound on concurrently in-flight passkey authentications.
+///
+/// `auth/options` is unauthenticated and pre-session, so without a ceiling a
+/// caller could grow the in-memory store without limit (the per-request rate
+/// limiter is the primary bound; this is defence-in-depth). At ~5 min TTL this
+/// caps steady-state memory while staying far above any legitimate concurrency.
+const AUTHENTICATION_STORE_MAX_ENTRIES: usize = 10_000;
+
 /// Error returned when inserting a passkey into [`PasskeyStore`].
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum PasskeyStoreInsertError {
     #[error("passkey credential already exists")]
     DuplicateCredentialId,
+}
+
+/// Error returned when updating a stored passkey via
+/// [`PasskeyStore::update_credential`].
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum PasskeyStoreUpdateError {
+    #[error("credential not found for account")]
+    NotFound,
 }
 
 /// Stored passkey together with its owning account.
@@ -166,6 +182,47 @@ impl PasskeyStore {
             store.credential_index.remove(credential_id);
         }
         changed
+    }
+
+    /// Applies a WebAuthn [`AuthenticationResult`] to the stored credential it
+    /// refers to (signature counter, backup flags) per webauthn-rs semantics.
+    ///
+    /// `update_credential` mutates the credential in place and never changes the
+    /// credential ID, so the `credential_index` stays consistent and needs no
+    /// reindexing. The credential must belong to `account_id`
+    /// (defence-in-depth); a missing credential or a cross-account mismatch
+    /// fail-closes with [`PasskeyStoreUpdateError::NotFound`].
+    ///
+    /// Returns `true` if the stored credential changed, `false` if it matched
+    /// but nothing changed (e.g. a synced passkey reporting a constant counter).
+    pub fn update_credential(
+        &self,
+        account_id: &str,
+        auth_result: &AuthenticationResult,
+    ) -> Result<bool, PasskeyStoreUpdateError> {
+        let mut store = self.store.write_recover();
+        let credential_id = auth_result.cred_id();
+
+        // Verify ownership first; the immutable borrow ends before the mutable one.
+        let owned_by_account = store
+            .credential_index
+            .get(credential_id)
+            .is_some_and(|owner| owner == account_id);
+        if !owned_by_account {
+            return Err(PasskeyStoreUpdateError::NotFound);
+        }
+
+        let passkey = store
+            .account_passkeys
+            .get_mut(account_id)
+            .and_then(|passkeys| {
+                passkeys
+                    .iter_mut()
+                    .find(|candidate| candidate.cred_id() == credential_id)
+            })
+            .ok_or(PasskeyStoreUpdateError::NotFound)?;
+
+        Ok(passkey.update_credential(auth_result).unwrap_or(false))
     }
 }
 
@@ -325,6 +382,13 @@ pub fn start_passkey_authentication(
     webauthn.start_passkey_authentication(allow_credentials)
 }
 
+/// Error returned when inserting into [`PasskeyAuthenticationStore`].
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum PasskeyAuthenticationStoreInsertError {
+    #[error("passkey authentication store is at capacity")]
+    Full,
+}
+
 /// An in-progress passkey authentication, kept until the client calls
 /// `auth/verify`.
 struct PendingAuthentication {
@@ -342,10 +406,22 @@ struct PendingAuthentication {
 /// registration state (`PasskeyRegistration`) and authentication state
 /// (`PasskeyAuthentication`) are distinct WebAuthn ceremonies and must never be
 /// interchangeable. Like the registration store it is in-memory, TTL-bounded
-/// (5 minutes) and single-use.
-#[derive(Clone, Default)]
+/// (5 minutes) and single-use; additionally it is capacity-bounded
+/// ([`AUTHENTICATION_STORE_MAX_ENTRIES`]) as defence-in-depth against unbounded
+/// growth from the unauthenticated `auth/options` endpoint.
+#[derive(Clone)]
 pub struct PasskeyAuthenticationStore {
     store: Arc<TokioRwLock<HashMap<String, PendingAuthentication>>>,
+    max_entries: usize,
+}
+
+impl Default for PasskeyAuthenticationStore {
+    fn default() -> Self {
+        Self {
+            store: Arc::new(TokioRwLock::new(HashMap::new())),
+            max_entries: AUTHENTICATION_STORE_MAX_ENTRIES,
+        }
+    }
 }
 
 impl PasskeyAuthenticationStore {
@@ -353,9 +429,44 @@ impl PasskeyAuthenticationStore {
         Self::default()
     }
 
+    /// Test-only constructor with a custom capacity, so the capacity behaviour
+    /// can be exercised without inserting tens of thousands of entries.
+    #[cfg(test)]
+    fn with_capacity_for_test(max_entries: usize) -> Self {
+        Self {
+            store: Arc::new(TokioRwLock::new(HashMap::new())),
+            max_entries,
+        }
+    }
+
+    /// Test-only: directly insert an already-expired entry (bypassing the cap),
+    /// so the expired-entry pruning path can be exercised deterministically.
+    #[cfg(test)]
+    async fn insert_expired_for_test(&self, account_id: String, state: PasskeyAuthentication) {
+        let pending = PendingAuthentication {
+            account_id,
+            state,
+            created_at: Utc::now() - chrono::Duration::seconds(AUTHENTICATION_TTL_SECS + 1),
+        };
+        self.store
+            .write()
+            .await
+            .insert(Uuid::new_v4().to_string(), pending);
+    }
+
     /// Store a new in-progress authentication bound to `account_id`. Returns the
-    /// opaque authentication ID that must be sent back by the client.
-    pub async fn insert(&self, account_id: String, state: PasskeyAuthentication) -> String {
+    /// opaque authentication ID that must be sent back by the client, or
+    /// [`PasskeyAuthenticationStoreInsertError::Full`] if the store is at
+    /// capacity even after pruning expired entries.
+    ///
+    /// Pruning the expired entries (an `O(N)` `retain`) only runs when the store
+    /// is at capacity, so the steady-state insert stays `O(1)` and does not pay
+    /// for a full scan under the write lock on every call.
+    pub async fn insert(
+        &self,
+        account_id: String,
+        state: PasskeyAuthentication,
+    ) -> Result<String, PasskeyAuthenticationStoreInsertError> {
         let id = Uuid::new_v4().to_string();
         let pending = PendingAuthentication {
             account_id,
@@ -363,11 +474,17 @@ impl PasskeyAuthenticationStore {
             created_at: Utc::now(),
         };
         let mut store = self.store.write().await;
-        // Opportunistic cleanup of expired entries.
-        let cutoff = Utc::now() - chrono::Duration::seconds(AUTHENTICATION_TTL_SECS);
-        store.retain(|_, v| v.created_at > cutoff);
+        if store.len() >= self.max_entries {
+            // Only now pay for the expired-entry sweep; if it does not free a
+            // slot, reject rather than grow without bound.
+            let cutoff = Utc::now() - chrono::Duration::seconds(AUTHENTICATION_TTL_SECS);
+            store.retain(|_, v| v.created_at > cutoff);
+            if store.len() >= self.max_entries {
+                return Err(PasskeyAuthenticationStoreInsertError::Full);
+            }
+        }
         store.insert(id.clone(), pending);
-        id
+        Ok(id)
     }
 
     /// Consume a pending authentication by ID (single-use). Returns the bound
@@ -729,7 +846,10 @@ webauthn_rp_id: example.com\n";
             .start_passkey_authentication(&[test_passkey(1)])
             .expect("start_passkey_authentication should accept a credential");
 
-        let id = store.insert("acct-1".to_string(), state).await;
+        let id = store
+            .insert("acct-1".to_string(), state)
+            .await
+            .expect("insert under capacity should succeed");
 
         let consumed = store.consume(&id).await;
         assert!(consumed.is_some(), "consume should succeed once");
@@ -753,6 +873,104 @@ webauthn_rp_id: example.com\n";
             store.consume("no-such-authentication-id").await.is_none(),
             "unknown authentication id must fail-closed"
         );
+    }
+
+    fn test_authentication_state() -> PasskeyAuthentication {
+        let webauthn = test_webauthn();
+        let (_, state) = webauthn
+            .start_passkey_authentication(&[test_passkey(1)])
+            .expect("start_passkey_authentication should accept a credential");
+        state
+    }
+
+    #[tokio::test]
+    async fn passkey_authentication_store_rejects_insert_when_capacity_reached() {
+        let store = PasskeyAuthenticationStore::with_capacity_for_test(1);
+
+        let first = store
+            .insert("acct-1".to_string(), test_authentication_state())
+            .await;
+        assert!(first.is_ok(), "first insert fits within capacity");
+
+        let second = store
+            .insert("acct-2".to_string(), test_authentication_state())
+            .await;
+        assert_eq!(
+            second,
+            Err(PasskeyAuthenticationStoreInsertError::Full),
+            "insert beyond capacity (no expired entries to prune) must be rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn passkey_authentication_store_allows_insert_after_expired_entries_are_pruned() {
+        let store = PasskeyAuthenticationStore::with_capacity_for_test(1);
+
+        // Pre-fill the single slot with an already-expired entry.
+        store
+            .insert_expired_for_test("stale".to_string(), test_authentication_state())
+            .await;
+
+        // The store is "full" by count, but the expired entry must be pruned so
+        // a fresh insert succeeds.
+        let fresh = store
+            .insert("acct-1".to_string(), test_authentication_state())
+            .await;
+        assert!(
+            fresh.is_ok(),
+            "insert must succeed after the expired entry is pruned"
+        );
+    }
+
+    #[test]
+    fn passkey_store_updates_credential_after_authentication_result() {
+        let store = PasskeyStore::new();
+        let passkey = test_passkey(70);
+        let credential_id = passkey.cred_id().clone();
+        store
+            .insert("acct-a".to_string(), passkey)
+            .expect("insert credential");
+
+        // A genuine `AuthenticationResult` built via serde — no browser needed.
+        let auth_result = test_authentication_result(&credential_id, 7);
+
+        // Wrong account fail-closes and mutates nothing.
+        assert_eq!(
+            store.update_credential("acct-b", &auth_result),
+            Err(PasskeyStoreUpdateError::NotFound),
+            "cross-account update must be rejected"
+        );
+
+        // Correct account: counter advances 0 -> 7, so the credential changed.
+        assert_eq!(
+            store.update_credential("acct-a", &auth_result),
+            Ok(true),
+            "advancing the signature counter must report a change"
+        );
+
+        // Re-applying the same result is a no-op (counter already at 7).
+        assert_eq!(
+            store.update_credential("acct-a", &auth_result),
+            Ok(false),
+            "re-applying an identical result must report no change"
+        );
+    }
+
+    fn test_authentication_result(
+        credential_id: &CredentialID,
+        counter: u32,
+    ) -> AuthenticationResult {
+        let cred_id_value = serde_json::to_value(credential_id).expect("credential id serializes");
+        serde_json::from_value(json!({
+            "cred_id": cred_id_value,
+            "needs_update": true,
+            "user_verified": true,
+            "backup_state": false,
+            "backup_eligible": false,
+            "counter": counter,
+            "extensions": {}
+        }))
+        .expect("authentication result fixture must deserialize")
     }
 
     #[test]

--- a/apps/api/src/lib.rs
+++ b/apps/api/src/lib.rs
@@ -203,6 +203,7 @@ pub async fn run() -> anyhow::Result<()> {
     };
     let passkey_registrations = crate::auth::passkeys::PasskeyRegistrationStore::new();
     let passkey_registration_grants = crate::auth::passkeys::PasskeyRegistrationGrantStore::new();
+    let passkey_authentications = crate::auth::passkeys::PasskeyAuthenticationStore::new();
     let passkeys = crate::auth::passkeys::PasskeyStore::new();
 
     let mailer = match crate::mailer::Mailer::new(&app_config) {
@@ -246,6 +247,7 @@ pub async fn run() -> anyhow::Result<()> {
         webauthn,
         passkey_registrations,
         passkey_registration_grants,
+        passkey_authentications,
         passkeys,
     };
 

--- a/apps/api/src/routes/auth.rs
+++ b/apps/api/src/routes/auth.rs
@@ -18,7 +18,8 @@ use uuid::Uuid;
 use crate::{
     auth::challenges::ChallengeIntent,
     auth::passkeys::{
-        start_passkey_registration, ConsumeGrantResult, PasskeyStoreInsertError, RegistrationInput,
+        start_passkey_authentication, start_passkey_registration, ConsumeGrantResult,
+        PasskeyStoreInsertError, RegistrationInput,
     },
     auth::session::SessionBackendError,
     auth::step_up_tokens::ConsumeMatchResult,
@@ -27,7 +28,7 @@ use crate::{
     routes::accounts::{AccountInternal, AccountPublic},
     state::ApiState,
 };
-use webauthn_rs::prelude::RegisterPublicKeyCredential;
+use webauthn_rs::prelude::{PublicKeyCredential, RegisterPublicKeyCredential};
 
 #[cfg(feature = "integration-testing")]
 const PASSKEY_PROOF_ACCOUNT_ID: &str = "proof-passkey-user";
@@ -2068,6 +2069,276 @@ pub async fn passkey_register_verify(
 
     let body = serde_json::json!({"ok": true});
     (StatusCode::OK, Json(body)).into_response()
+}
+
+// ── Passkey Login (Authentication) ────────────────────────────────────────
+
+#[derive(serde::Deserialize)]
+pub struct PasskeyAuthOptionsPayload {
+    pub email: String,
+}
+
+/// POST /auth/passkeys/auth/options
+///
+/// Starts a passkey authentication (login) ceremony for the account identified
+/// by `email`. The endpoint is **pre-session / unauthenticated** and never sets
+/// a session cookie. On success it returns an opaque `authentication_id` plus the
+/// WebAuthn `RequestChallengeResponse`; the paired authentication state is stored
+/// server-side single-use until `auth/verify`.
+///
+/// **Anti-enumeration:** this flow is account-hint based, so it cannot be made
+/// fully indistinguishable without decoy challenges. For PR 1 the
+/// no-credentials case (unknown identifier *or* an account without passkeys) is
+/// **deliberately fail-closed** with a single uniform `404 NO_PASSKEY_CREDENTIALS`
+/// (no server state, no cookie). The residual signal (has-passkey vs. not) is a
+/// documented, accepted risk to be closed by a later decoy/discoverable
+/// iteration. Malformed input fail-closes with `400`; a missing WebAuthn config
+/// fail-closes with `503`.
+pub async fn passkey_auth_options(
+    State(state): State<ApiState>,
+    headers: HeaderMap,
+    payload: Option<Json<PasskeyAuthOptionsPayload>>,
+) -> impl IntoResponse {
+    let request_id = get_request_id(&headers);
+
+    let webauthn = match state.webauthn.as_ref() {
+        Some(w) => w,
+        None => {
+            tracing::warn!(
+                event = "auth.passkey.auth_options.not_configured",
+                request_id = %request_id,
+                "Passkey auth-options called but WebAuthn is not configured"
+            );
+            let err = serde_json::json!({
+                "error": "PASSKEYS_NOT_CONFIGURED",
+                "message": "Passkey support is not enabled on this server"
+            });
+            return (StatusCode::SERVICE_UNAVAILABLE, Json(err)).into_response();
+        }
+    };
+
+    let email = match payload.as_ref().map(|p| p.email.trim()) {
+        Some(email) if !email.is_empty() && email.len() <= MAX_EMAIL_LEN => email.to_string(),
+        _ => {
+            let err = serde_json::json!({
+                "error": "INVALID_REQUEST",
+                "message": "A valid email is required"
+            });
+            return (StatusCode::BAD_REQUEST, Json(err)).into_response();
+        }
+    };
+
+    // Resolve the account id under the accounts lock, then drop it before
+    // touching the passkey store.
+    let account_id = {
+        let accounts = state.accounts.read().await;
+        accounts.get_by_email(&email).map(|a| a.public.id.clone())
+    };
+
+    // Unknown identifier and an account without passkeys both fail-close
+    // identically: no server state, no cookie.
+    let passkeys = match &account_id {
+        Some(id) => state.passkeys.list_for_account(id),
+        None => Vec::new(),
+    };
+    let (account_id, passkeys) = match account_id {
+        Some(id) if !passkeys.is_empty() => (id, passkeys),
+        _ => {
+            tracing::info!(
+                event = "auth.passkey.auth_options.no_credentials",
+                request_id = %request_id,
+                "Passkey auth-options: no passkey credentials for identifier (fail-closed)"
+            );
+            let err = serde_json::json!({
+                "error": "NO_PASSKEY_CREDENTIALS",
+                "message": "No passkey is available for this account"
+            });
+            return (StatusCode::NOT_FOUND, Json(err)).into_response();
+        }
+    };
+
+    match start_passkey_authentication(webauthn, &passkeys) {
+        Err(e) => {
+            tracing::error!(
+                event = "auth.passkey.auth_options.webauthn_error",
+                request_id = %request_id,
+                account_id = %account_id,
+                error = %e,
+                "WebAuthn start_passkey_authentication failed"
+            );
+            let err = serde_json::json!({"error": "INTERNAL_SERVER_ERROR"});
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(err)).into_response()
+        }
+        Ok((rcr, auth_state)) => {
+            let authentication_id = state
+                .passkey_authentications
+                .insert(account_id.clone(), auth_state)
+                .await;
+
+            tracing::info!(
+                event = "auth.passkey.auth_options.ok",
+                request_id = %request_id,
+                account_id = %account_id,
+                authentication_id = %authentication_id,
+                "Passkey authentication ceremony started"
+            );
+
+            let body = serde_json::json!({
+                "authentication_id": authentication_id,
+                "options": rcr,
+            });
+            (StatusCode::OK, Json(body)).into_response()
+        }
+    }
+}
+
+#[derive(serde::Deserialize)]
+pub struct PasskeyAuthVerifyPayload {
+    pub authentication_id: String,
+    /// Raw WebAuthn assertion. Kept as `Value` and deserialized into
+    /// `PublicKeyCredential` only *after* the single-use state has been consumed,
+    /// so a malformed assertion cannot probe the challenge more than once. The
+    /// real cryptographic check below is unchanged.
+    pub credential: serde_json::Value,
+}
+
+/// POST /auth/passkeys/auth/verify
+///
+/// Completes the passkey login ceremony started by `auth/options`. The handler:
+/// consumes the server-side authentication state **single-use**; performs a real
+/// cryptographic assertion check via `webauthn.finish_passkey_authentication`
+/// (no shortcuts); resolves the asserted credential ID to its owning account via
+/// the global credential index and asserts it matches the ceremony account; and
+/// only then creates a session and sets the session cookie.
+///
+/// **Every** error path fail-closes WITHOUT a cookie. Unknown, reused, expired,
+/// mismatched, or invalid states are all rejected.
+pub async fn passkey_auth_verify(
+    State(state): State<ApiState>,
+    headers: HeaderMap,
+    jar: CookieJar,
+    payload: Option<Json<PasskeyAuthVerifyPayload>>,
+) -> impl IntoResponse {
+    let request_id = get_request_id(&headers);
+
+    let webauthn = match state.webauthn.as_ref() {
+        Some(w) => w,
+        None => {
+            tracing::warn!(
+                event = "auth.passkey.auth_verify.not_configured",
+                request_id = %request_id,
+                "Passkey auth-verify called but WebAuthn is not configured"
+            );
+            let err = serde_json::json!({
+                "error": "PASSKEYS_NOT_CONFIGURED",
+                "message": "Passkey support is not enabled on this server"
+            });
+            return (StatusCode::SERVICE_UNAVAILABLE, Json(err)).into_response();
+        }
+    };
+
+    let payload = match payload {
+        Some(Json(payload)) => payload,
+        None => {
+            let err = serde_json::json!({
+                "error": "INVALID_REQUEST",
+                "message": "A valid authentication_id and credential are required"
+            });
+            return (StatusCode::BAD_REQUEST, Json(err)).into_response();
+        }
+    };
+
+    if payload.authentication_id.trim().is_empty() {
+        let err = serde_json::json!({"error": "INVALID_REQUEST"});
+        return (StatusCode::BAD_REQUEST, Json(err)).into_response();
+    }
+
+    // Single-use consume of the server-side authentication state. Unknown,
+    // reused, and expired ids all fail-close here (consume-first guarantees the
+    // challenge can never be probed twice).
+    let (expected_account_id, auth_state) = match state
+        .passkey_authentications
+        .consume(&payload.authentication_id)
+        .await
+    {
+        Some(value) => value,
+        None => {
+            tracing::warn!(
+                event = "auth.passkey.auth_verify.authentication_invalid",
+                request_id = %request_id,
+                "Passkey auth-verify: authentication_id unknown, already used, or expired"
+            );
+            let err = serde_json::json!({"error": "AUTHENTICATION_INVALID"});
+            return (StatusCode::BAD_REQUEST, Json(err)).into_response();
+        }
+    };
+
+    let credential: PublicKeyCredential = match serde_json::from_value(payload.credential) {
+        Ok(credential) => credential,
+        Err(_) => {
+            tracing::warn!(
+                event = "auth.passkey.auth_verify.credential_malformed",
+                request_id = %request_id,
+                "Passkey auth-verify: assertion payload could not be parsed"
+            );
+            let err = serde_json::json!({"error": "CREDENTIAL_INVALID"});
+            return (StatusCode::BAD_REQUEST, Json(err)).into_response();
+        }
+    };
+
+    // Real WebAuthn assertion verification — no shortcuts.
+    let auth_result = match webauthn.finish_passkey_authentication(&credential, &auth_state) {
+        Ok(result) => result,
+        Err(e) => {
+            tracing::warn!(
+                event = "auth.passkey.auth_verify.webauthn_error",
+                request_id = %request_id,
+                error = %e,
+                "WebAuthn finish_passkey_authentication rejected the assertion"
+            );
+            let err = serde_json::json!({"error": "CREDENTIAL_INVALID"});
+            return (StatusCode::BAD_REQUEST, Json(err)).into_response();
+        }
+    };
+
+    // Resolve the asserted credential to its owning account via the global
+    // credential index, and assert it matches the account the ceremony was
+    // started for (defence-in-depth against a credential/account mismatch).
+    let account_id = match state.passkeys.find_by_credential_id(auth_result.cred_id()) {
+        Some(stored) if stored.account_id == expected_account_id => stored.account_id,
+        _ => {
+            tracing::warn!(
+                event = "auth.passkey.auth_verify.credential_mismatch",
+                request_id = %request_id,
+                "Passkey auth-verify: asserted credential does not resolve to the ceremony account"
+            );
+            let err = serde_json::json!({"error": "CREDENTIAL_MISMATCH"});
+            return (StatusCode::UNAUTHORIZED, Json(err)).into_response();
+        }
+    };
+
+    // Assertion verified — only now is a session created and a cookie set.
+    let session = match state.sessions.create(account_id.clone(), None).await {
+        Ok(session) => session,
+        Err(error) => {
+            return session_backend_json_response_with_jar(
+                "passkey_auth_verify.create",
+                &error,
+                jar,
+            );
+        }
+    };
+
+    tracing::info!(
+        event = "auth.passkey.auth_verify.ok",
+        request_id = %request_id,
+        account_id = %account_id,
+        "Passkey login verified; session established"
+    );
+
+    let cookie = build_session_cookie(session.id, None);
+    let body = serde_json::json!({"ok": true, "account_id": account_id});
+    (StatusCode::OK, jar.add(cookie), Json(body)).into_response()
 }
 
 #[cfg(feature = "integration-testing")]

--- a/apps/api/src/routes/auth.rs
+++ b/apps/api/src/routes/auth.rs
@@ -2162,7 +2162,10 @@ pub async fn passkey_auth_options(
     // Rate-limit BEFORE any expensive or state-creating work (account lookup,
     // WebAuthn ceremony, server-side state insert). This endpoint is pre-session
     // and unauthenticated, so it must be bounded exactly like the magic-link
-    // request path it mirrors.
+    // request path it mirrors. The identifier bucket is the email hash, so it
+    // intentionally shares the per-email budget with the magic-link request path
+    // (a single email is throttled across both login methods); the per-IP bucket
+    // is global. Same SHA-256 hex-prefix convention.
     let email_norm = email.to_ascii_lowercase();
     let client_ip = effective_client_ip(addr, &headers);
     let email_hash = {
@@ -2329,9 +2332,15 @@ pub async fn passkey_auth_verify(
     }
 
     // Rate-limit BEFORE consuming the single-use state or running any WebAuthn
-    // crypto. Keyed by client IP (mandatory) plus a hash of the authentication_id,
-    // so a flood from one peer — or against one ceremony — is bounded, and a
-    // throttled request never consumes the challenge.
+    // crypto, so a throttled request never burns the challenge. Keyed by client
+    // IP (mandatory) plus a route-scoped identifier bucket derived from the
+    // authentication_id (`passkey-verify:<hash>` — a different namespace from the
+    // email the magic-link/options limiter uses). Same SHA-256 hex-prefix
+    // convention as the magic-link/email limiter.
+    //
+    // NOTE: the per-IP bucket is global and shared across the pre-session auth
+    // endpoints, so a full passkey login (options then verify) can legitimately
+    // consume more than one IP rate-limit token.
     let client_ip = effective_client_ip(addr, &headers);
     let auth_id_hash = {
         let mut hasher = Sha256::new();
@@ -2339,7 +2348,8 @@ pub async fn passkey_auth_verify(
         let full = format!("{:x}", hasher.finalize());
         full[..16].to_string()
     };
-    if let Err(e) = state.rate_limiter.check(client_ip, &auth_id_hash) {
+    let verify_rate_key = format!("passkey-verify:{auth_id_hash}");
+    if let Err(e) = state.rate_limiter.check(client_ip, &verify_rate_key) {
         tracing::warn!(
             event = "auth.passkey.auth_verify.rate_limited",
             request_id = %request_id,

--- a/apps/api/src/routes/auth.rs
+++ b/apps/api/src/routes/auth.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::Path as AxumPath,
-    extract::{ConnectInfo, Form, Json, Query, State},
+    extract::{rejection::JsonRejection, ConnectInfo, Form, Json, Query, State},
     http::{HeaderMap, StatusCode},
     response::{Html, IntoResponse, Redirect},
     Extension,
@@ -152,6 +152,28 @@ fn session_backend_json_response_with_jar(
         Json(serde_json::json!({"error": "SESSION_BACKEND_UNAVAILABLE"})),
     )
         .into_response()
+}
+
+/// Maps an axum `JsonRejection` (missing body, wrong content-type, syntactically
+/// invalid JSON, or a type mismatch) to the passkey login endpoints' uniform
+/// `400 INVALID_REQUEST` JSON shape — never a plaintext rejection, never a cookie.
+fn passkey_login_json_rejection(
+    request_id: &str,
+    endpoint: &'static str,
+    rejection: &JsonRejection,
+) -> axum::response::Response {
+    tracing::warn!(
+        event = "auth.passkey.json_rejected",
+        request_id = %request_id,
+        endpoint = endpoint,
+        rejection = %rejection,
+        "Passkey login request body could not be parsed"
+    );
+    let err = serde_json::json!({
+        "error": "INVALID_REQUEST",
+        "message": "A valid JSON request body is required"
+    });
+    (StatusCode::BAD_REQUEST, Json(err)).into_response()
 }
 
 #[derive(Clone)]
@@ -2098,7 +2120,7 @@ pub async fn passkey_auth_options(
     State(state): State<ApiState>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
-    payload: Option<Json<PasskeyAuthOptionsPayload>>,
+    payload: Result<Json<PasskeyAuthOptionsPayload>, JsonRejection>,
 ) -> impl IntoResponse {
     let request_id = get_request_id(&headers);
 
@@ -2118,15 +2140,23 @@ pub async fn passkey_auth_options(
         }
     };
 
-    let email = match payload.as_ref().map(|p| p.email.trim()) {
-        Some(email) if !email.is_empty() && email.len() <= MAX_EMAIL_LEN => email.to_string(),
-        _ => {
+    let Json(payload) = match payload {
+        Ok(payload) => payload,
+        Err(rejection) => {
+            return passkey_login_json_rejection(&request_id, "auth_options", &rejection)
+        }
+    };
+
+    let email = {
+        let trimmed = payload.email.trim();
+        if trimmed.is_empty() || trimmed.len() > MAX_EMAIL_LEN {
             let err = serde_json::json!({
                 "error": "INVALID_REQUEST",
                 "message": "A valid email is required"
             });
             return (StatusCode::BAD_REQUEST, Json(err)).into_response();
         }
+        trimmed.to_string()
     };
 
     // Rate-limit BEFORE any expensive or state-creating work (account lookup,
@@ -2262,9 +2292,10 @@ pub struct PasskeyAuthVerifyPayload {
 /// rejected.
 pub async fn passkey_auth_verify(
     State(state): State<ApiState>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
     jar: CookieJar,
-    payload: Option<Json<PasskeyAuthVerifyPayload>>,
+    payload: Result<Json<PasskeyAuthVerifyPayload>, JsonRejection>,
 ) -> impl IntoResponse {
     let request_id = get_request_id(&headers);
 
@@ -2284,20 +2315,40 @@ pub async fn passkey_auth_verify(
         }
     };
 
-    let payload = match payload {
-        Some(Json(payload)) => payload,
-        None => {
-            let err = serde_json::json!({
-                "error": "INVALID_REQUEST",
-                "message": "A valid authentication_id and credential are required"
-            });
-            return (StatusCode::BAD_REQUEST, Json(err)).into_response();
+    let Json(payload) = match payload {
+        Ok(payload) => payload,
+        Err(rejection) => {
+            return passkey_login_json_rejection(&request_id, "auth_verify", &rejection)
         }
     };
 
-    if payload.authentication_id.trim().is_empty() {
+    let authentication_id = payload.authentication_id.trim();
+    if authentication_id.is_empty() {
         let err = serde_json::json!({"error": "INVALID_REQUEST"});
         return (StatusCode::BAD_REQUEST, Json(err)).into_response();
+    }
+
+    // Rate-limit BEFORE consuming the single-use state or running any WebAuthn
+    // crypto. Keyed by client IP (mandatory) plus a hash of the authentication_id,
+    // so a flood from one peer — or against one ceremony — is bounded, and a
+    // throttled request never consumes the challenge.
+    let client_ip = effective_client_ip(addr, &headers);
+    let auth_id_hash = {
+        let mut hasher = Sha256::new();
+        hasher.update(authentication_id.as_bytes());
+        let full = format!("{:x}", hasher.finalize());
+        full[..16].to_string()
+    };
+    if let Err(e) = state.rate_limiter.check(client_ip, &auth_id_hash) {
+        tracing::warn!(
+            event = "auth.passkey.auth_verify.rate_limited",
+            request_id = %request_id,
+            client_ip = %client_ip,
+            error = %e,
+            "Passkey auth-verify rate limited"
+        );
+        let err = serde_json::json!({"error": "RATE_LIMITED"});
+        return (StatusCode::TOO_MANY_REQUESTS, Json(err)).into_response();
     }
 
     // Single-use consume of the server-side authentication state. Unknown,
@@ -2305,7 +2356,7 @@ pub async fn passkey_auth_verify(
     // challenge can never be probed twice).
     let (expected_account_id, auth_state) = match state
         .passkey_authentications
-        .consume(&payload.authentication_id)
+        .consume(authentication_id)
         .await
     {
         Some(value) => value,
@@ -2363,6 +2414,19 @@ pub async fn passkey_auth_verify(
             return (StatusCode::UNAUTHORIZED, Json(err)).into_response();
         }
     };
+
+    // Reject before mutating any credential state if the account has been deleted
+    // or disabled since auth/options. (Re-checked again immediately before the
+    // session is minted, below, to also close the update -> session window.)
+    if !state.accounts.read().await.is_account_active(&account_id) {
+        tracing::warn!(
+            event = "auth.passkey.auth_verify.account_inactive_pre_update",
+            request_id = %request_id,
+            "Passkey auth-verify: account missing or disabled before credential update; refusing session"
+        );
+        let err = serde_json::json!({"error": "ACCOUNT_INACTIVE"});
+        return (StatusCode::FORBIDDEN, Json(err)).into_response();
+    }
 
     // Persist the WebAuthn credential state (signature counter, backup flags) per
     // webauthn-rs semantics. `update_credential` never changes the credential ID,

--- a/apps/api/src/routes/auth.rs
+++ b/apps/api/src/routes/auth.rs
@@ -19,7 +19,7 @@ use crate::{
     auth::challenges::ChallengeIntent,
     auth::passkeys::{
         start_passkey_authentication, start_passkey_registration, ConsumeGrantResult,
-        PasskeyStoreInsertError, RegistrationInput,
+        PasskeyAuthenticationStoreInsertError, PasskeyStoreInsertError, RegistrationInput,
     },
     auth::session::SessionBackendError,
     auth::step_up_tokens::ConsumeMatchResult,
@@ -2096,6 +2096,7 @@ pub struct PasskeyAuthOptionsPayload {
 /// fail-closes with `503`.
 pub async fn passkey_auth_options(
     State(state): State<ApiState>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
     payload: Option<Json<PasskeyAuthOptionsPayload>>,
 ) -> impl IntoResponse {
@@ -2128,11 +2129,41 @@ pub async fn passkey_auth_options(
         }
     };
 
+    // Rate-limit BEFORE any expensive or state-creating work (account lookup,
+    // WebAuthn ceremony, server-side state insert). This endpoint is pre-session
+    // and unauthenticated, so it must be bounded exactly like the magic-link
+    // request path it mirrors.
+    let email_norm = email.to_ascii_lowercase();
+    let client_ip = effective_client_ip(addr, &headers);
+    let email_hash = {
+        let mut hasher = Sha256::new();
+        hasher.update(email_norm.as_bytes());
+        let full = format!("{:x}", hasher.finalize());
+        full[..16].to_string()
+    };
+    if let Err(e) = state.rate_limiter.check(client_ip, &email_hash) {
+        tracing::warn!(
+            event = "auth.passkey.auth_options.rate_limited",
+            request_id = %request_id,
+            client_ip = %client_ip,
+            email_hash = %email_hash,
+            error = %e,
+            "Passkey auth-options rate limited"
+        );
+        let err = serde_json::json!({"error": "RATE_LIMITED"});
+        return (StatusCode::TOO_MANY_REQUESTS, Json(err)).into_response();
+    }
+
     // Resolve the account id under the accounts lock, then drop it before
-    // touching the passkey store.
+    // touching the passkey store. A **disabled** account is folded into the same
+    // uniform no-credentials path below — no distinguishable response — matching
+    // how the magic-link request path treats disabled accounts.
     let account_id = {
         let accounts = state.accounts.read().await;
-        accounts.get_by_email(&email).map(|a| a.public.id.clone())
+        accounts
+            .get_by_email(&email_norm)
+            .filter(|account| !account.public.disabled)
+            .map(|account| account.public.id.clone())
     };
 
     // Unknown identifier and an account without passkeys both fail-close
@@ -2170,10 +2201,23 @@ pub async fn passkey_auth_options(
             (StatusCode::INTERNAL_SERVER_ERROR, Json(err)).into_response()
         }
         Ok((rcr, auth_state)) => {
-            let authentication_id = state
+            let authentication_id = match state
                 .passkey_authentications
                 .insert(account_id.clone(), auth_state)
-                .await;
+                .await
+            {
+                Ok(id) => id,
+                Err(PasskeyAuthenticationStoreInsertError::Full) => {
+                    tracing::warn!(
+                        event = "auth.passkey.auth_options.store_full",
+                        request_id = %request_id,
+                        account_id = %account_id,
+                        "Passkey auth-options: authentication state store at capacity"
+                    );
+                    let err = serde_json::json!({"error": "SERVICE_OVERLOADED"});
+                    return (StatusCode::SERVICE_UNAVAILABLE, Json(err)).into_response();
+                }
+            };
 
             tracing::info!(
                 event = "auth.passkey.auth_options.ok",
@@ -2208,11 +2252,14 @@ pub struct PasskeyAuthVerifyPayload {
 /// consumes the server-side authentication state **single-use**; performs a real
 /// cryptographic assertion check via `webauthn.finish_passkey_authentication`
 /// (no shortcuts); resolves the asserted credential ID to its owning account via
-/// the global credential index and asserts it matches the ceremony account; and
-/// only then creates a session and sets the session cookie.
+/// the global credential index and asserts it matches the ceremony account;
+/// writes back the WebAuthn credential state (signature counter / backup flags);
+/// re-validates that the account still exists and is enabled; and only then
+/// creates a session and sets the session cookie.
 ///
 /// **Every** error path fail-closes WITHOUT a cookie. Unknown, reused, expired,
-/// mismatched, or invalid states are all rejected.
+/// mismatched, or invalid states — and accounts disabled mid-ceremony — are all
+/// rejected.
 pub async fn passkey_auth_verify(
     State(state): State<ApiState>,
     headers: HeaderMap,
@@ -2316,6 +2363,35 @@ pub async fn passkey_auth_verify(
             return (StatusCode::UNAUTHORIZED, Json(err)).into_response();
         }
     };
+
+    // Persist the WebAuthn credential state (signature counter, backup flags) per
+    // webauthn-rs semantics. `update_credential` never changes the credential ID,
+    // so the global credential index stays consistent. A failure here means the
+    // credential vanished between resolution and update (e.g. a concurrent
+    // removal) — fail-closed rather than mint a session for a gone credential.
+    if let Err(e) = state.passkeys.update_credential(&account_id, &auth_result) {
+        tracing::warn!(
+            event = "auth.passkey.auth_verify.credential_update_failed",
+            request_id = %request_id,
+            error = %e,
+            "Passkey auth-verify: credential state update failed; refusing session"
+        );
+        let err = serde_json::json!({"error": "CREDENTIAL_MISMATCH"});
+        return (StatusCode::UNAUTHORIZED, Json(err)).into_response();
+    }
+
+    // Re-validate the account immediately before minting a session: it may have
+    // been deleted or disabled between auth/options and auth/verify. Fail-closed
+    // (no session, no cookie) if it is no longer active.
+    if !state.accounts.read().await.is_account_active(&account_id) {
+        tracing::warn!(
+            event = "auth.passkey.auth_verify.account_inactive",
+            request_id = %request_id,
+            "Passkey auth-verify: account missing or disabled at verify; refusing session"
+        );
+        let err = serde_json::json!({"error": "ACCOUNT_INACTIVE"});
+        return (StatusCode::FORBIDDEN, Json(err)).into_response();
+    }
 
     // Assertion verified — only now is a session created and a cookie set.
     let session = match state.sessions.create(account_id.clone(), None).await {

--- a/apps/api/src/routes/domain_write_guard.rs
+++ b/apps/api/src/routes/domain_write_guard.rs
@@ -233,6 +233,7 @@ mod tests {
             webauthn: None,
             passkey_registrations: Default::default(),
             passkey_registration_grants: Default::default(),
+            passkey_authentications: Default::default(),
             passkeys: Default::default(),
         }
     }

--- a/apps/api/src/routes/health.rs
+++ b/apps/api/src/routes/health.rs
@@ -341,6 +341,7 @@ mod tests {
             webauthn: None,
             passkey_registrations: Default::default(),
             passkey_registration_grants: Default::default(),
+            passkey_authentications: Default::default(),
             passkeys: Default::default(),
         })
     }

--- a/apps/api/src/routes/mod.rs
+++ b/apps/api/src/routes/mod.rs
@@ -20,8 +20,9 @@ use self::{
     accounts::{create_account, get_account, list_accounts},
     auth::{
         consume_login_get, consume_login_post, consume_step_up, dev_login, list_dev_accounts,
-        list_devices, logout, logout_all, me, passkey_register_options, passkey_register_verify,
-        remove_device, request_login, request_step_up, session, session_refresh, update_email,
+        list_devices, logout, logout_all, me, passkey_auth_options, passkey_auth_verify,
+        passkey_register_options, passkey_register_verify, remove_device, request_login,
+        request_step_up, session, session_refresh, update_email,
     },
     edges::{create_edge, get_edge, list_edges},
     nodes::{get_node, list_nodes, patch_node},
@@ -74,7 +75,9 @@ pub fn api_router() -> Router<ApiState> {
         .route(
             "/auth/passkeys/register/verify",
             post(passkey_register_verify),
-        );
+        )
+        .route("/auth/passkeys/auth/options", post(passkey_auth_options))
+        .route("/auth/passkeys/auth/verify", post(passkey_auth_verify));
 
     #[cfg(feature = "integration-testing")]
     let router = router.route(

--- a/apps/api/src/state.rs
+++ b/apps/api/src/state.rs
@@ -3,9 +3,10 @@ use tokio::sync::{Mutex, RwLock};
 
 use crate::{
     auth::{
-        challenges::ChallengeStore, passkeys::PasskeyRegistrationGrantStore,
-        passkeys::PasskeyRegistrationStore, passkeys::PasskeyStore, rate_limit::AuthRateLimiter,
-        session::SessionBackend, step_up_tokens::StepUpTokenStore, tokens::TokenStore,
+        challenges::ChallengeStore, passkeys::PasskeyAuthenticationStore,
+        passkeys::PasskeyRegistrationGrantStore, passkeys::PasskeyRegistrationStore,
+        passkeys::PasskeyStore, rate_limit::AuthRateLimiter, session::SessionBackend,
+        step_up_tokens::StepUpTokenStore, tokens::TokenStore,
     },
     config::AppConfig,
     mailer::Mailer,
@@ -84,6 +85,9 @@ pub struct ApiState {
     pub webauthn: Option<Arc<Webauthn>>,
     pub passkey_registrations: PasskeyRegistrationStore,
     pub passkey_registration_grants: PasskeyRegistrationGrantStore,
+    /// In-progress passkey authentication (login) ceremonies — separate from
+    /// `passkey_registrations`; in-memory, TTL-bounded, single-use.
+    pub passkey_authentications: PasskeyAuthenticationStore,
     pub passkeys: PasskeyStore,
 }
 

--- a/apps/api/tests/api_accounts.rs
+++ b/apps/api/tests/api_accounts.rs
@@ -86,6 +86,7 @@ async fn test_state() -> Result<ApiState> {
         webauthn: None,
         passkey_registrations: Default::default(),
         passkey_registration_grants: Default::default(),
+        passkey_authentications: Default::default(),
         passkeys: Default::default(),
     })
 }

--- a/apps/api/tests/api_accounts_create.rs
+++ b/apps/api/tests/api_accounts_create.rs
@@ -93,6 +93,7 @@ async fn test_state() -> Result<ApiState> {
         webauthn: None,
         passkey_registrations: Default::default(),
         passkey_registration_grants: Default::default(),
+        passkey_authentications: Default::default(),
         passkeys: Default::default(),
     })
 }

--- a/apps/api/tests/api_auth.rs
+++ b/apps/api/tests/api_auth.rs
@@ -5534,3 +5534,22 @@ async fn passkey_auth_verify_rejects_malformed_json_with_json_error_without_cook
     assert_eq!(json["error"], "INVALID_REQUEST");
     Ok(())
 }
+
+/// A request with no body / no JSON content-type also yields the uniform JSON
+/// `400 INVALID_REQUEST` (via `JsonRejection`), not a plaintext rejection, and
+/// no cookie.
+#[tokio::test]
+async fn passkey_auth_options_rejects_missing_body_with_json_error_without_cookie() -> Result<()> {
+    let state = test_state_with_webauthn()?;
+    let app = app_with_auth(state);
+
+    let req = Request::post("/auth/passkeys/auth/options").body(body::Body::empty())?;
+    let res = app.oneshot(req).await?;
+
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    assert!(!res.headers().contains_key(axum::http::header::SET_COOKIE));
+    let bytes = body::to_bytes(res.into_body(), usize::MAX).await?;
+    let json: serde_json::Value = serde_json::from_slice(&bytes)?;
+    assert_eq!(json["error"], "INVALID_REQUEST");
+    Ok(())
+}

--- a/apps/api/tests/api_auth.rs
+++ b/apps/api/tests/api_auth.rs
@@ -5456,3 +5456,81 @@ async fn passkey_auth_options_is_rate_limited_without_cookie() -> Result<()> {
     assert!(!res2.headers().contains_key(axum::http::header::SET_COOKIE));
     Ok(())
 }
+
+/// `auth/verify` is rate-limited *before* it consumes the single-use state or
+/// runs any WebAuthn crypto: a throttled verify returns `429`, sets no cookie,
+/// and leaves the authentication state intact.
+#[tokio::test]
+async fn passkey_auth_verify_is_rate_limited_without_consuming_state() -> Result<()> {
+    let mut state = test_state_with_webauthn()?;
+    state.config.auth_rl_ip_per_min = Some(1);
+    state.rate_limiter = Arc::new(AuthRateLimiter::new(&state.config));
+    seed_passkey(&state, "u1", 17)?;
+    let auth_store = state.passkey_authentications.clone();
+    let app = app_with_auth(state);
+
+    // The single per-minute IP token is spent by auth/options, which yields a
+    // real authentication_id.
+    let auth_id = start_auth_ceremony(&app, "u1@example.com").await?;
+
+    // auth/verify is now over the IP budget: throttled, no cookie.
+    let req = Request::post("/auth/passkeys/auth/verify")
+        .header("content-type", "application/json")
+        .body(body::Body::from(format!(
+            r#"{{"authentication_id":"{auth_id}","credential":{{}}}}"#
+        )))?;
+    let res = app.oneshot(req).await?;
+    assert_eq!(res.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert!(!res.headers().contains_key(axum::http::header::SET_COOKIE));
+
+    // Crucially, the rate-limited verify must NOT have consumed the state.
+    assert!(
+        auth_store.consume(&auth_id).await.is_some(),
+        "a rate-limited verify must not consume the single-use authentication state"
+    );
+    Ok(())
+}
+
+/// Syntactically invalid JSON to `auth/options` yields the uniform JSON
+/// `400 INVALID_REQUEST` (not a plaintext axum rejection) and no cookie.
+#[tokio::test]
+async fn passkey_auth_options_rejects_malformed_json_with_json_error_without_cookie() -> Result<()>
+{
+    let state = test_state_with_webauthn()?;
+    let app = app_with_auth(state);
+
+    let req = Request::post("/auth/passkeys/auth/options")
+        .header("content-type", "application/json")
+        .body(body::Body::from("{ this is not valid json"))?;
+    let res = app.oneshot(req).await?;
+
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    assert!(!res.headers().contains_key(axum::http::header::SET_COOKIE));
+    let bytes = body::to_bytes(res.into_body(), usize::MAX).await?;
+    let json: serde_json::Value = serde_json::from_slice(&bytes)?;
+    assert_eq!(
+        json["error"], "INVALID_REQUEST",
+        "malformed JSON must yield a structured JSON error"
+    );
+    Ok(())
+}
+
+/// Syntactically invalid JSON to `auth/verify` yields the uniform JSON
+/// `400 INVALID_REQUEST` and no cookie.
+#[tokio::test]
+async fn passkey_auth_verify_rejects_malformed_json_with_json_error_without_cookie() -> Result<()> {
+    let state = test_state_with_webauthn()?;
+    let app = app_with_auth(state);
+
+    let req = Request::post("/auth/passkeys/auth/verify")
+        .header("content-type", "application/json")
+        .body(body::Body::from("not json at all"))?;
+    let res = app.oneshot(req).await?;
+
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    assert!(!res.headers().contains_key(axum::http::header::SET_COOKIE));
+    let bytes = body::to_bytes(res.into_body(), usize::MAX).await?;
+    let json: serde_json::Value = serde_json::from_slice(&bytes)?;
+    assert_eq!(json["error"], "INVALID_REQUEST");
+    Ok(())
+}

--- a/apps/api/tests/api_auth.rs
+++ b/apps/api/tests/api_auth.rs
@@ -123,6 +123,7 @@ fn test_state() -> Result<ApiState> {
         webauthn: None,
         passkey_registrations: Default::default(),
         passkey_registration_grants: Default::default(),
+        passkey_authentications: Default::default(),
         passkeys: Default::default(),
     })
 }
@@ -5140,5 +5141,240 @@ async fn passkey_register_options_excludes_existing_credentials() -> Result<()> 
     let decoded_id = URL_SAFE_NO_PAD.decode(id_b64)?;
     assert_eq!(decoded_id, expected_cred_id);
 
+    Ok(())
+}
+
+// ── Passkey Login (Authentication) backend — PR 1 ─────────────────────────
+//
+// Backend-only slice: the *positive* (real-assertion) path is intentionally
+// left to the browser / virtual-authenticator proof (PR 2). These tests cover
+// the option ceremony, the fail-closed error paths, single-use state, and the
+// hard cookie invariant: a session cookie is set ONLY on a successful verify.
+
+/// Start a real login ceremony via `auth/options` and return its
+/// `authentication_id`. The account must already own a passkey.
+async fn start_auth_ceremony(app: &Router, email: &str) -> Result<String> {
+    let req = Request::post("/auth/passkeys/auth/options")
+        .header("content-type", "application/json")
+        .body(body::Body::from(format!(r#"{{"email":"{email}"}}"#)))?;
+    let res = app.clone().oneshot(req).await?;
+    assert_eq!(
+        res.status(),
+        StatusCode::OK,
+        "auth/options must succeed to start a ceremony"
+    );
+    let bytes = body::to_bytes(res.into_body(), usize::MAX).await?;
+    let json: serde_json::Value = serde_json::from_slice(&bytes)?;
+    Ok(json["authentication_id"]
+        .as_str()
+        .context("authentication_id must be present")?
+        .to_string())
+}
+
+fn seed_passkey(state: &ApiState, account_id: &str, seed: u8) -> Result<()> {
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use base64::Engine;
+    let cred_id_b64 = URL_SAFE_NO_PAD.encode([seed; 32]);
+    state
+        .passkeys
+        .insert(
+            account_id.to_string(),
+            mock_passkey_with_credential_id(&cred_id_b64)?,
+        )
+        .expect("seed passkey must insert");
+    Ok(())
+}
+
+/// `auth/options` returns options + an authentication_id and never sets a cookie.
+#[tokio::test]
+async fn passkey_auth_options_returns_options_without_cookie() -> Result<()> {
+    let state = test_state_with_webauthn()?;
+    seed_passkey(&state, "u1", 7)?;
+    let app = app_with_auth(state);
+
+    let req = Request::post("/auth/passkeys/auth/options")
+        .header("content-type", "application/json")
+        .body(body::Body::from(r#"{"email":"u1@example.com"}"#))?;
+    let res = app.oneshot(req).await?;
+
+    assert_eq!(res.status(), StatusCode::OK);
+    assert!(
+        !res.headers().contains_key(axum::http::header::SET_COOKIE),
+        "auth/options must never set a session cookie"
+    );
+    let bytes = body::to_bytes(res.into_body(), usize::MAX).await?;
+    let json: serde_json::Value = serde_json::from_slice(&bytes)?;
+    assert!(
+        json.get("authentication_id")
+            .and_then(|v| v.as_str())
+            .is_some_and(|s| !s.is_empty()),
+        "must return a non-empty authentication_id"
+    );
+    assert!(
+        json.get("options").is_some(),
+        "must return WebAuthn options"
+    );
+    Ok(())
+}
+
+/// `auth/options` fail-closes with 503 when WebAuthn is unconfigured (no cookie).
+#[tokio::test]
+async fn passkey_auth_options_requires_webauthn_config() -> Result<()> {
+    let state = test_state_with_accounts()?; // webauthn is None
+    let app = app_with_auth(state);
+
+    let req = Request::post("/auth/passkeys/auth/options")
+        .header("content-type", "application/json")
+        .body(body::Body::from(r#"{"email":"u1@example.com"}"#))?;
+    let res = app.oneshot(req).await?;
+
+    assert_eq!(res.status(), StatusCode::SERVICE_UNAVAILABLE);
+    assert!(!res.headers().contains_key(axum::http::header::SET_COOKIE));
+    let bytes = body::to_bytes(res.into_body(), usize::MAX).await?;
+    let json: serde_json::Value = serde_json::from_slice(&bytes)?;
+    assert_eq!(json["error"], "PASSKEYS_NOT_CONFIGURED");
+    Ok(())
+}
+
+/// `auth/options` fail-closes uniformly for an unknown identifier *and* for a
+/// known account without a passkey — same status, no cookie either way.
+#[tokio::test]
+async fn passkey_auth_options_no_credentials_fails_closed_without_cookie() -> Result<()> {
+    let state = test_state_with_webauthn()?; // u1 exists but has NO passkey seeded
+    let app = app_with_auth(state);
+
+    // Known account, but without a registered passkey.
+    let known_no_passkey = Request::post("/auth/passkeys/auth/options")
+        .header("content-type", "application/json")
+        .body(body::Body::from(r#"{"email":"u1@example.com"}"#))?;
+    let res = app.clone().oneshot(known_no_passkey).await?;
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    assert!(!res.headers().contains_key(axum::http::header::SET_COOKIE));
+
+    // Entirely unknown identifier — indistinguishable response.
+    let unknown = Request::post("/auth/passkeys/auth/options")
+        .header("content-type", "application/json")
+        .body(body::Body::from(r#"{"email":"nobody@example.com"}"#))?;
+    let res2 = app.oneshot(unknown).await?;
+    assert_eq!(res2.status(), StatusCode::NOT_FOUND);
+    assert!(!res2.headers().contains_key(axum::http::header::SET_COOKIE));
+    Ok(())
+}
+
+/// `auth/options` rejects a malformed/empty request without a cookie.
+#[tokio::test]
+async fn passkey_auth_options_rejects_malformed_request_without_cookie() -> Result<()> {
+    let state = test_state_with_webauthn()?;
+    let app = app_with_auth(state);
+
+    let req = Request::post("/auth/passkeys/auth/options")
+        .header("content-type", "application/json")
+        .body(body::Body::from(r#"{"email":""}"#))?;
+    let res = app.oneshot(req).await?;
+
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    assert!(!res.headers().contains_key(axum::http::header::SET_COOKIE));
+    Ok(())
+}
+
+/// `auth/verify` fail-closes with 503 when WebAuthn is unconfigured (no cookie).
+#[tokio::test]
+async fn passkey_auth_verify_requires_webauthn_config() -> Result<()> {
+    let state = test_state_with_accounts()?; // webauthn is None
+    let app = app_with_auth(state);
+
+    let req = Request::post("/auth/passkeys/auth/verify")
+        .header("content-type", "application/json")
+        .body(body::Body::from(
+            r#"{"authentication_id":"x","credential":{}}"#,
+        ))?;
+    let res = app.oneshot(req).await?;
+
+    assert_eq!(res.status(), StatusCode::SERVICE_UNAVAILABLE);
+    assert!(!res.headers().contains_key(axum::http::header::SET_COOKIE));
+    Ok(())
+}
+
+/// `auth/verify` with an unknown authentication_id is rejected without a cookie.
+#[tokio::test]
+async fn passkey_auth_verify_unknown_state_rejected_without_cookie() -> Result<()> {
+    let state = test_state_with_webauthn()?;
+    let app = app_with_auth(state);
+
+    let req = Request::post("/auth/passkeys/auth/verify")
+        .header("content-type", "application/json")
+        .body(body::Body::from(
+            r#"{"authentication_id":"does-not-exist","credential":{}}"#,
+        ))?;
+    let res = app.oneshot(req).await?;
+
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    assert!(!res.headers().contains_key(axum::http::header::SET_COOKIE));
+    let bytes = body::to_bytes(res.into_body(), usize::MAX).await?;
+    let json: serde_json::Value = serde_json::from_slice(&bytes)?;
+    assert_eq!(json["error"], "AUTHENTICATION_INVALID");
+    Ok(())
+}
+
+/// `auth/verify` with a malformed assertion over a real, freshly issued state is
+/// rejected as CREDENTIAL_INVALID without a cookie (and consumes the state).
+#[tokio::test]
+async fn passkey_auth_verify_invalid_assertion_rejected_without_cookie() -> Result<()> {
+    let state = test_state_with_webauthn()?;
+    seed_passkey(&state, "u1", 9)?;
+    let app = app_with_auth(state);
+
+    let auth_id = start_auth_ceremony(&app, "u1@example.com").await?;
+
+    let req = Request::post("/auth/passkeys/auth/verify")
+        .header("content-type", "application/json")
+        .body(body::Body::from(format!(
+            r#"{{"authentication_id":"{auth_id}","credential":{{"not":"a-real-assertion"}}}}"#
+        )))?;
+    let res = app.oneshot(req).await?;
+
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    assert!(!res.headers().contains_key(axum::http::header::SET_COOKIE));
+    let bytes = body::to_bytes(res.into_body(), usize::MAX).await?;
+    let json: serde_json::Value = serde_json::from_slice(&bytes)?;
+    assert_eq!(json["error"], "CREDENTIAL_INVALID");
+    Ok(())
+}
+
+/// `auth/verify` consumes the authentication state single-use: a second attempt
+/// with the same authentication_id is rejected as unknown, without a cookie.
+#[tokio::test]
+async fn passkey_auth_verify_reused_state_rejected_without_cookie() -> Result<()> {
+    let state = test_state_with_webauthn()?;
+    seed_passkey(&state, "u1", 11)?;
+    let app = app_with_auth(state);
+
+    let auth_id = start_auth_ceremony(&app, "u1@example.com").await?;
+
+    // First verify consumes the state (and fails the bogus assertion).
+    let first = Request::post("/auth/passkeys/auth/verify")
+        .header("content-type", "application/json")
+        .body(body::Body::from(format!(
+            r#"{{"authentication_id":"{auth_id}","credential":{{}}}}"#
+        )))?;
+    let res1 = app.clone().oneshot(first).await?;
+    assert_eq!(res1.status(), StatusCode::BAD_REQUEST);
+    assert!(!res1.headers().contains_key(axum::http::header::SET_COOKIE));
+    let b1 = body::to_bytes(res1.into_body(), usize::MAX).await?;
+    let j1: serde_json::Value = serde_json::from_slice(&b1)?;
+    assert_eq!(j1["error"], "CREDENTIAL_INVALID");
+
+    // Second verify with the same id is rejected as unknown (single-use).
+    let second = Request::post("/auth/passkeys/auth/verify")
+        .header("content-type", "application/json")
+        .body(body::Body::from(format!(
+            r#"{{"authentication_id":"{auth_id}","credential":{{}}}}"#
+        )))?;
+    let res2 = app.oneshot(second).await?;
+    assert_eq!(res2.status(), StatusCode::BAD_REQUEST);
+    assert!(!res2.headers().contains_key(axum::http::header::SET_COOKIE));
+    let b2 = body::to_bytes(res2.into_body(), usize::MAX).await?;
+    let j2: serde_json::Value = serde_json::from_slice(&b2)?;
+    assert_eq!(j2["error"], "AUTHENTICATION_INVALID");
     Ok(())
 }

--- a/apps/api/tests/api_auth.rs
+++ b/apps/api/tests/api_auth.rs
@@ -3983,6 +3983,9 @@ fn app_with_auth(state: ApiState) -> Router {
             state.clone(),
             weltgewebe_api::middleware::auth::auth_middleware,
         ))
+        // Provide a peer address so handlers that extract `ConnectInfo`
+        // (e.g. the rate-limited `auth/options`) resolve a client IP.
+        .layer(MockConnectInfo(SocketAddr::from(([127, 0, 0, 1], 8080))))
         .with_state(state)
 }
 
@@ -5376,5 +5379,80 @@ async fn passkey_auth_verify_reused_state_rejected_without_cookie() -> Result<()
     let b2 = body::to_bytes(res2.into_body(), usize::MAX).await?;
     let j2: serde_json::Value = serde_json::from_slice(&b2)?;
     assert_eq!(j2["error"], "AUTHENTICATION_INVALID");
+    Ok(())
+}
+
+fn disabled_account(id: &str, email: &str) -> AccountInternal {
+    AccountInternal {
+        public: AccountPublic {
+            id: id.to_string(),
+            kind: "garnrolle".to_string(),
+            title: "Disabled User".to_string(),
+            summary: None,
+            public_pos: None,
+            mode: weltgewebe_api::routes::accounts::AccountMode::Ron,
+            radius_m: 0,
+            disabled: true,
+            tags: vec![],
+        },
+        role: Role::Gast,
+        email: Some(email.to_string()),
+        webauthn_user_id: uuid::Uuid::new_v4(),
+    }
+}
+
+/// A disabled account that *owns a passkey* must still fail-close at
+/// `auth/options` — folded into the uniform no-credentials 404, no cookie — so
+/// a disabled account can neither start a ceremony nor be distinguished.
+#[tokio::test]
+async fn passkey_auth_options_rejects_disabled_account_without_cookie() -> Result<()> {
+    let state = test_state_with_webauthn()?;
+    seed_passkey(&state, "u1", 13)?;
+    // Disable u1 (insert replaces by id); the passkey in PasskeyStore remains.
+    state
+        .accounts
+        .write()
+        .await
+        .insert(disabled_account("u1", "u1@example.com"));
+    let app = app_with_auth(state);
+
+    let req = Request::post("/auth/passkeys/auth/options")
+        .header("content-type", "application/json")
+        .body(body::Body::from(r#"{"email":"u1@example.com"}"#))?;
+    let res = app.oneshot(req).await?;
+
+    assert_eq!(
+        res.status(),
+        StatusCode::NOT_FOUND,
+        "disabled account must fold into the uniform no-credentials response"
+    );
+    assert!(!res.headers().contains_key(axum::http::header::SET_COOKIE));
+    Ok(())
+}
+
+/// `auth/options` is rate-limited before it creates any WebAuthn state, and the
+/// throttled response carries no cookie.
+#[tokio::test]
+async fn passkey_auth_options_is_rate_limited_without_cookie() -> Result<()> {
+    let mut state = test_state_with_webauthn()?;
+    state.config.auth_rl_ip_per_min = Some(1);
+    state.rate_limiter = Arc::new(AuthRateLimiter::new(&state.config));
+    seed_passkey(&state, "u1", 15)?;
+    let app = app_with_auth(state);
+
+    let req = || {
+        Request::post("/auth/passkeys/auth/options")
+            .header("content-type", "application/json")
+            .body(body::Body::from(r#"{"email":"u1@example.com"}"#))
+    };
+
+    // First request within the per-minute IP budget succeeds.
+    let res1 = app.clone().oneshot(req()?).await?;
+    assert_eq!(res1.status(), StatusCode::OK);
+
+    // Second request from the same IP is throttled — and sets no cookie.
+    let res2 = app.oneshot(req()?).await?;
+    assert_eq!(res2.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert!(!res2.headers().contains_key(axum::http::header::SET_COOKIE));
     Ok(())
 }

--- a/apps/api/tests/api_edges.rs
+++ b/apps/api/tests/api_edges.rs
@@ -92,6 +92,7 @@ async fn test_state() -> Result<ApiState> {
         webauthn: None,
         passkey_registrations: Default::default(),
         passkey_registration_grants: Default::default(),
+        passkey_authentications: Default::default(),
         passkeys: Default::default(),
     })
 }

--- a/apps/api/tests/api_nodes.rs
+++ b/apps/api/tests/api_nodes.rs
@@ -109,6 +109,7 @@ async fn test_state() -> Result<ApiState> {
         webauthn: None,
         passkey_registrations: Default::default(),
         passkey_registration_grants: Default::default(),
+        passkey_authentications: Default::default(),
         passkeys: Default::default(),
     })
 }

--- a/apps/api/tests/auth_handler_test.rs
+++ b/apps/api/tests/auth_handler_test.rs
@@ -109,6 +109,7 @@ mod tests {
             webauthn: None,
             passkey_registrations: Default::default(),
             passkey_registration_grants: Default::default(),
+            passkey_authentications: Default::default(),
             passkeys: Default::default(),
         })
     }

--- a/apps/api/tests/auth_open_registration.rs
+++ b/apps/api/tests/auth_open_registration.rs
@@ -93,6 +93,7 @@ fn test_state_open_reg() -> Result<ApiState> {
         webauthn: None,
         passkey_registrations: Default::default(),
         passkey_registration_grants: Default::default(),
+        passkey_authentications: Default::default(),
         passkeys: Default::default(),
     })
 }

--- a/apps/api/tests/auth_ratelimit.rs
+++ b/apps/api/tests/auth_ratelimit.rs
@@ -51,6 +51,7 @@ fn test_state(config: AppConfig) -> Result<ApiState> {
         webauthn: None,
         passkey_registrations: Default::default(),
         passkey_registration_grants: Default::default(),
+        passkey_authentications: Default::default(),
         passkeys: Default::default(),
     })
 }

--- a/apps/api/tests/auth_ratelimit_proxy_trusted.rs
+++ b/apps/api/tests/auth_ratelimit_proxy_trusted.rs
@@ -52,6 +52,7 @@ fn test_state(config: AppConfig) -> Result<ApiState> {
         webauthn: None,
         passkey_registrations: Default::default(),
         passkey_registration_grants: Default::default(),
+        passkey_authentications: Default::default(),
         passkeys: Default::default(),
     })
 }

--- a/apps/api/tests/auth_ratelimit_proxy_untrusted.rs
+++ b/apps/api/tests/auth_ratelimit_proxy_untrusted.rs
@@ -52,6 +52,7 @@ fn test_state(config: AppConfig) -> Result<ApiState> {
         webauthn: None,
         passkey_registrations: Default::default(),
         passkey_registration_grants: Default::default(),
+        passkey_authentications: Default::default(),
         passkeys: Default::default(),
     })
 }

--- a/apps/api/tests/auth_security_invariants.rs
+++ b/apps/api/tests/auth_security_invariants.rs
@@ -136,6 +136,7 @@ fn build_state() -> Result<ApiState> {
         webauthn: None,
         passkey_registrations: Default::default(),
         passkey_registration_grants: Default::default(),
+        passkey_authentications: Default::default(),
         passkeys: Default::default(),
     })
 }
@@ -396,6 +397,14 @@ const CSRF_EXEMPT_MUTATING_ROUTES: &[(&str, &str)] = &[
     // Magic-link request/consume are pre-session or redirect-driven entry points with their own flow handling.
     ("POST", "/auth/magic-link/request"),
     ("POST", "/auth/magic-link/consume"),
+    // Passkey login (auth/options + auth/verify) are pre-session entry points: the
+    // request carries no session cookie, so `require_csrf` skips them (step 3 of the
+    // middleware) — exactly like magic-link request/consume above. There is no
+    // ambient session authority to abuse, and `auth/verify` is authoritative: it
+    // consumes single-use server-side state and verifies a real WebAuthn assertion
+    // before any session is created. They are therefore exempt, not covered.
+    ("POST", "/auth/passkeys/auth/options"),
+    ("POST", "/auth/passkeys/auth/verify"),
     // Logout intentionally remains exempt so a sign-out action can be executed without the CSRF middleware path.
     ("POST", "/auth/logout"),
 ];
@@ -583,4 +592,31 @@ fn csrf_mutating_route_drift_guard_matches_router_declarations() {
         "CSRF policy lists contain routes that are no longer declared: {}",
         format_route_set(&stale_routes)
     );
+}
+
+/// The passkey login routes are classified as CSRF-exempt (pre-session entry
+/// points skipped by `require_csrf`), not covered. This locks the deliberate
+/// classification so a future drift fix cannot silently move them into the
+/// covered set, which would imply a protection the middleware does not apply.
+#[test]
+fn passkey_login_routes_are_classified_csrf_exempt() {
+    let exempt = route_set(CSRF_EXEMPT_MUTATING_ROUTES);
+    let covered = route_set(CSRF_COVERED_MUTATING_ROUTES);
+
+    for route in [
+        (
+            "POST".to_string(),
+            "/auth/passkeys/auth/options".to_string(),
+        ),
+        ("POST".to_string(), "/auth/passkeys/auth/verify".to_string()),
+    ] {
+        assert!(
+            exempt.contains(&route),
+            "{route:?} must be classified CSRF-exempt (pre-session login entry point)"
+        );
+        assert!(
+            !covered.contains(&route),
+            "{route:?} must not be listed as CSRF-covered: it is pre-session and skipped by require_csrf"
+        );
+    }
 }

--- a/apps/api/tests/db_domain_account_write_path.rs
+++ b/apps/api/tests/db_domain_account_write_path.rs
@@ -179,6 +179,7 @@ async fn postgres_write_app(pool: PgPool, operator_id: &str) -> Result<(Router, 
         webauthn: None,
         passkey_registrations: Default::default(),
         passkey_registration_grants: Default::default(),
+        passkey_authentications: Default::default(),
         passkeys: Default::default(),
     };
 

--- a/apps/api/tests/db_domain_edge_write_path.rs
+++ b/apps/api/tests/db_domain_edge_write_path.rs
@@ -202,6 +202,7 @@ async fn edge_write_app(
         webauthn: None,
         passkey_registrations: Default::default(),
         passkey_registration_grants: Default::default(),
+        passkey_authentications: Default::default(),
         passkeys: Default::default(),
     };
 

--- a/apps/api/tests/db_domain_node_write_path.rs
+++ b/apps/api/tests/db_domain_node_write_path.rs
@@ -194,6 +194,7 @@ async fn postgres_write_app(pool: PgPool, operator_id: &str) -> Result<(Router, 
         webauthn: None,
         passkey_registrations: Default::default(),
         passkey_registration_grants: Default::default(),
+        passkey_authentications: Default::default(),
         passkeys: Default::default(),
     };
 
@@ -420,6 +421,7 @@ async fn postgres_read_jsonl_node_write_is_blocked() -> Result<()> {
         webauthn: None,
         passkey_registrations: Default::default(),
         passkey_registration_grants: Default::default(),
+        passkey_authentications: Default::default(),
         passkeys: Default::default(),
     };
 
@@ -590,6 +592,7 @@ async fn jsonl_default_node_patch_compiles_and_routes_correctly() -> Result<()> 
         webauthn: None,
         passkey_registrations: Default::default(),
         passkey_registration_grants: Default::default(),
+        passkey_authentications: Default::default(),
         passkeys: Default::default(),
     };
 

--- a/docs/reports/opt-arc-001-db-proof-matrix.json
+++ b/docs/reports/opt-arc-001-db-proof-matrix.json
@@ -73,9 +73,9 @@
       "test": "apps/api/tests/db_domain_account_write_path.rs",
       "report": "docs/reports/domain-account-write-path-proof.md",
       "ci_evidence": {
-        "run_url": "https://github.com/heimgewebe/weltgewebe/actions/runs/27487642549",
-        "run_id": 27487642549,
-        "commit": "cc5446023417e65df1ae907cae9ad4c39612b3a0",
+        "run_url": "https://github.com/heimgewebe/weltgewebe/actions/runs/27619224355",
+        "run_id": 27619224355,
+        "commit": "05497c120f18176ea9742c0c579d6e41bd33bf12",
         "job": "db-domain-account-write-path-proof"
       },
       "command": "cargo test --locked -p weltgewebe-api --test db_domain_account_write_path -- --include-ignored --test-threads=1"
@@ -90,9 +90,9 @@
       "test": "apps/api/tests/db_domain_node_write_path.rs",
       "report": "docs/reports/domain-node-write-path-proof.md",
       "ci_evidence": {
-        "run_url": "https://github.com/heimgewebe/weltgewebe/actions/runs/27429628985",
-        "run_id": 27429628985,
-        "commit": "7f5f2fbdcf891a468cbcf874b499f2032d1de077",
+        "run_url": "https://github.com/heimgewebe/weltgewebe/actions/runs/27619224355",
+        "run_id": 27619224355,
+        "commit": "05497c120f18176ea9742c0c579d6e41bd33bf12",
         "job": "db-domain-node-write-path-proof"
       },
       "command": "cargo test --locked -p weltgewebe-api --test db_domain_node_write_path -- --include-ignored --test-threads=1"
@@ -107,9 +107,9 @@
       "test": "apps/api/tests/db_domain_edge_write_path.rs",
       "report": "docs/reports/domain-edge-write-path-proof.md",
       "ci_evidence": {
-        "run_url": "https://github.com/heimgewebe/weltgewebe/actions/runs/27441828545",
-        "run_id": 27441828545,
-        "commit": "75ad1ebbaecbc41353d2fb0b39c2d6a9d90434ff",
+        "run_url": "https://github.com/heimgewebe/weltgewebe/actions/runs/27619224355",
+        "run_id": 27619224355,
+        "commit": "05497c120f18176ea9742c0c579d6e41bd33bf12",
         "job": "db-domain-edge-write-path-proof"
       },
       "command": "cargo test --locked -p weltgewebe-api --test db_domain_edge_write_path -- --include-ignored --test-threads=1"


### PR DESCRIPTION
## Passkey-Login-Backend — eng geschnittener PR 1 von 3

> **Backend-only.** Browser-/Virtual-Authenticator-Proof, CI-Workflow, UI und Auth-Doku-Status sind **bewusst nicht** Teil dieses PRs. **Login ist nicht CI-belegt** — der positive Krypto-Pfad folgt in PR 2.

Implementiert die Backend-Stufe des Passkey-Logins auf Basis des gemergten Register-Verify:

- `POST /auth/passkeys/auth/options` — startet eine WebAuthn-Authentication-Ceremony für den per E-Mail aufgelösten Account, speichert den `PasskeyAuthentication`-State serverseitig (single-use, TTL 5 Min, **kapazitätsbeschränkt**) und liefert `authentication_id` + `RequestChallengeResponse`. **Setzt nie ein Cookie.**
- `POST /auth/passkeys/auth/verify` — konsumiert den State single-use, prüft eine **echte** Assertion via `finish_passkey_authentication`, löst die Credential-ID über den globalen Credential-Index auf den Account auf, schreibt den Credential-State zurück, revalidiert den Account und erzeugt **erst dann** Session + Cookie.

### Designentscheidungen
- **Flow: account-hinweisbasiert (allow-credentials / non-discoverable).** Die Discoverable-API in webauthn-rs 0.5 ist hinter `#[cfg(feature = "conditional-ui")]` gated → bräuchte neue Dependency/Lockfile-Änderung und erzwingt `Mediation::Conditional`. Daher das default-verfügbare `start_/finish_passkey_authentication`-Paar, symmetrisch zu den Register-Wrappern.
- **`PasskeyAuthenticationStore`** — getrennt vom Registration-Store; in-memory, TTL-begrenzt, single-use (consume remove-first), **bounded** (`max_entries`, prune-on-full; Steady-State-Insert O(1)).
- **Fail-closed überall ohne Cookie.**

### Stand nach Härtung + Review-Closure (Commits `4da60b7c`, `05497c12`, `03d501a2`)
- **Disabled accounts:** `auth/options` fail-closed in den uniformen `404`; `auth/verify` revalidiert `is_account_active` **zweimal** — vor Credential-Mutation und unmittelbar vor `sessions.create` (`403 ACCOUNT_INACTIVE`).
- **Rate-Limiting:** `auth/options` **und** `auth/verify` laufen durch den bestehenden `AuthRateLimiter` **vor** Account-Lookup/Ceremony/Consume/Crypto. Ein rate-limitierter `auth/verify` liefert `429`, **konsumiert den State nicht** und setzt kein Cookie. Identifier-Buckets: `auth/verify` ist route-scoped (`passkey-verify:<hash>`); `auth/options` teilt den per-E-Mail-Bucket bewusst mit dem Magic-Link-Request-Pfad. **Der per-IP-Bucket ist global/geteilt** — ein vollständiger Login (options + verify) kann legitim mehr als ein IP-Token verbrauchen.
- **Credential-State-Writeback:** `PasskeyStore::update_credential` schreibt Counter/Backup-Flags zurück (Credential-ID unverändert → Index konsistent); webauthn-rs' `None` → hartes `UpdateFailed` (nicht zu `false` geglättet).
- **JSON-Fehler:** beide Login-Routen nehmen `Result<Json<…>, JsonRejection>` → uniform `400 INVALID_REQUEST` (kein Plaintext-Reject, kein Cookie) für fehlenden/kaputten/falsch-typisierten Body.
- **CSRF:** beide Routen pre-session → `require_csrf` überspringt sie; im Route-Drift-Guard bewusst als CSRF-exempt klassifiziert (+ eigener Lock-Test).

### Bekannte Rest-Risiken (offengelegt, bewusst aufgeschoben)
- **TOCTOU:** Dieser PR verengt die Fenster (doppelte Account-Revalidation), liefert aber **keine** transaktionale Account/Session-Atomizität; ein winziges Restfenster zwischen 2. Check und `sessions.create` bleibt (vollständige Atomizität bräuchte Versionierung/Transaktion — außerhalb Scope).
- **Anti-Enumeration:** account-hinweisbasiert → Rest-Signal „has-passkey vs. nicht"; volle Decoy/Timing-Uniformität bleibt Folgearbeit.
- **In-Memory-Persistenz:** `PasskeyStore`/Auth-State in-memory → bei Neustart verloren.
- **Positiver Browser-Proof:** PR 2 (Virtual Authenticator + Playwright-Config + eigener Workflow). Damit auch der verify-seitige *disabled-mid-ceremony*-Race **end-to-end**.

### CI-Hinweis (`validate` / OPT-ARC-001)
Der unvermeidbare `ApiState`-Feld-Add (`passkey_authentications`) ist der **einzige** Diff an drei DB-Proof-Harness-Dateien (account/node/edge write-path) und hatte deren `ci_evidence` im OPT-ARC-001-Proof-Matrix-Guard gestalet. Die DB-Proof-Jobs liefen auf diesem PR **grün** (Run `27619224355`, Commit `05497c12`); nur diese drei `ci_evidence`-Einträge wurden aufgefrischt. Reines Proof-Matrix-Bookkeeping — `overall_status` bleibt `partial`, **kein** CI-PROVEN-Claim für Passkey-Login.

### Validierungen (lokal grün)
`cargo fmt --check` ✓ · `cargo clippy --all-targets -- -D warnings` ✓ · `--test api_auth` ✓ (100) · `--test auth_security_invariants` ✓ (5) · `--lib` ✓ (247) · OPT-ARC-001-Validator ✓ · `git diff --check` ✓.

### Scope
`apps/api/src/**`, `apps/api/tests/**` und (nur OPT-ARC-001-Bookkeeping) `docs/reports/opt-arc-001-db-proof-matrix.json`. Keine web/, workflows/, migrations/, contracts/, Lockfiles; **keine** Auth-Status-/Roadmap-Docs.

https://claude.ai/code/session_01HCbaGSJi5UdCfPc524D52M

---
_Generated by [Claude Code](https://claude.ai/code/session_01HCbaGSJi5UdCfPc524D52M)_