### PR TITLE
Add 13 new PostgreSQL cutover & repo hygiene tasks to task index

### DIFF
--- a/docs/tasks/board.md
+++ b/docs/tasks/board.md
@@ -20,7 +20,7 @@ relations:
 > Arbeitssteuerung, keine Wahrheitsschicht.
 > Statuswechsel brauchen Evidenz in Statusmatrizen, Reports, PRs oder Tests.
 
-### Einordnung 2026-06-16 — optimierte TODO-Liste (Strang A Cutover / Strang B Hygiene)
+## Einordnung 2026-06-16 — optimierte TODO-Liste (Strang A Cutover / Strang B Hygiene)
 
 Die optimierte TODO-Liste wurde gegen den Repo-Stand abgeglichen und einsortiert:
 

--- a/docs/tasks/board.md
+++ b/docs/tasks/board.md
@@ -20,6 +20,24 @@ relations:
 > Arbeitssteuerung, keine Wahrheitsschicht.
 > Statuswechsel brauchen Evidenz in Statusmatrizen, Reports, PRs oder Tests.
 
+### Einordnung 2026-06-16 — optimierte TODO-Liste (Strang A Cutover / Strang B Hygiene)
+
+Die optimierte TODO-Liste wurde gegen den Repo-Stand abgeglichen und einsortiert:
+
+- **Bereits erledigt & belegt — keine Reaktivierung:** E-Mail-Duplicate-Audit (Listen-TODO 1)
+  ist umgesetzt (`scripts/docmeta/audit_account_email_uniqueness.py`,
+  `docs/reports/domain-account-email-uniqueness-audit.md`, Runtime-Audit 2026-06-13: 0 Duplikate);
+  der normalisierte E-Mail-Unique-Index inkl. `409`-Mapping (Listen-TODO 4) ist umgesetzt und
+  CI-belegt (`apps/api/migrations/20260613000001_*`, CI-Run `27487642549`). Diese entsprechen den
+  repo-internen Schritten „TODO 2 / TODO 2A" als OPT-ARC-001-Sub-Deliverables.
+- **Bleibt unter OPT-ARC-001 (nicht dupliziert):** Listenparitäts-Proof (Listen-TODO 3) ist der
+  vorhandene Read-Path-Proof-Harness (`prepared`, Legacy-Order-Preservation-Blocker);
+  Runtime-Smoke (TODO 11) und JSONL-Demontage (TODO 12) sind OPT-ARC-001-Cutover-Akzeptanz.
+- **Neu als eigene PR-Schnitte:** Edge-Orphan-Audit, Edge-Referenz-Policy, Single-/Multi-Instance,
+  Step-up-E-Mail- und WebAuthn-Persistenz, `webauthn_user_id`-Backfill, Edge-Cache-Design
+  (DB-PROOF-/DOMAIN-PG-/AUTH-PG-IDs).
+- **Strang A (PostgreSQL/Auth-Cutover) und Strang B (Repo-/CI-/Docs-Hygiene) nicht in einen PR mischen.**
+
 ## Aktive Prioritäten
 
 | ID | Bereich | Titel | Status | Priorität | Evidenz | Nächste Aktion |
@@ -39,24 +57,39 @@ relations:
 | TASK-CTL-005 | docs | Bestehende Planning-Registration-Findings triagieren und Ratchet vorbereiten | done | high | `docs/reports/planning-registration-findings.md`, `.github/workflows/task-index.yml`, `scripts/docmeta/check_planning_registration.py` | 8 Findings triagiert (6 via Frontmatter-Relation registriert, 2 als `deprecated` terminal); planning-registration guard läuft blockierend im Strict-Modus |
 | DOCMETA-FRESHNESS-001 | docs | Claim-Evidence/Freshness-Spine registrieren und reviewbar halten | partial | medium | `docs/claims/registry.yml`, `docs/claims/README.md`, `docs/doc-freshness-registry.yml`, `scripts/docmeta/validate_claim_registry.py`, `scripts/docmeta/validate_doc_freshness_registry.py`, `scripts/docmeta/freshness_scope_policy.yml`, `scripts/docmeta/generate_claim_evidence_map.py`, `.github/workflows/claim-registry.yml`, `.github/workflows/docs-guard.yml` | Claim-Evidence/Freshness-Spine ist implementiert und validierbar; Markdown-Details je Claim implementiert (DOC-MECH-FRESHNESS-S2); Scope wird deklarativ via `scripts/docmeta/freshness_scope_policy.yml` entschieden, realer Scope bleibt CLAIM-AGENT-SAFE-* (DOC-MECH-FRESHNESS-S3); Claim-Evidence-Information ist intern als `ClaimInfo` typisiert (DOC-MECH-FRESHNESS-TYPED-CLAIMINFO); Review-Age-Hygiene für kanonische Architektur-/Runtime-/Runbook-Dokumente durchgeführt (DOCMETA-FRESHNESS-REVIEW-AGE-001); bleibt `partial`, da Scope bewusst klein bleibt und alle drei Claims `requires_live_check` tragen (kein Wahrheits-/Suffizienz-/Kausalitäts-/Vollständigkeitsbeweis) |
 | DOCMETA-PROOF-001 | docs | Proof-Matrix-Validator-Schema vormerken | open | medium | `docs/reports/opt-arc-001-db-proof-matrix.json`, `scripts/docmeta/validate_opt_arc_001_db_proof_matrix.py`, `scripts/docmeta/tests/test_validate_opt_arc_001_db_proof_matrix.py`, `.github/workflows/opt-arc-001-db-proof-matrix.yml` | Zweiten echten Proof-Matrix-Anwendungsfall abwarten; danach OPT-ARC-001-Pattern retrospektiv prüfen und nur bei wiederholter Struktur ein generisches Schema/Validator-Pattern ableiten |
+| DB-PROOF-001 | api | Edge-Orphan- und Referenz-Audit | open | high | `apps/api/migrations/20260531000002_create_domain_edges.up.sql` (FK in Migration ausdrücklich deferred); Pendant zu `scripts/docmeta/audit_account_email_uniqueness.py` fehlt für Edges | Read-only Audit-Skript + redigierten Report bauen; valide/Orphan-Counts; Option A (FK auf `domain_nodes(id)`) vs. Option B (Guard/Quarantäne) entscheidungsfähig machen; keine Migration |
+| DOMAIN-PG-002 | infra | Single-Instance-Invariante oder Multi-Instance-Kohärenz entscheiden | open | high | keine dokumentierte Betriebsentscheidung; prozesslokale Caches unadressiert | Single-Instance-Grenze ODER Cross-Instance-Kohärenz entscheiden und im Cutover-Blueprint verankern; kein stiller Cache-Split-Brain |
+| AUTH-PG-001 | auth | Step-up-E-Mail-Persistenz nach PostgreSQL | open | high | `apps/api/src/routes/auth.rs` (PUT /auth/me/email vorhanden); OPT-ARC-001-Non-Goal `step_up_email_persistence` | PostgreSQL-Write-Pfad + Restart-Stabilitäts-Proof; E-Mail-Unique-Regel bleibt gewahrt (409) |
+| AUTH-PG-002 | auth | WebAuthn-Credential-Persistenz / Passkey-Cutover | open | high | `apps/api/src/auth/passkeys.rs` (PasskeyStore In-Memory); OPT-ARC-001-Non-Goal `webauthn_credential_writeback` | PostgreSQL-Persistenzmodell + Restart-Proof (Register→Reload→Login); Public/Private-Trennung; menschliches Review (credentials/) |
+| OPT-CI-004 | ci | Dependency-Update-Automation (Dependabot/Renovate) | open | medium | keine `.github/dependabot.yml`/Renovate-Config (Statusmatrix: `docs/reports/optimierungsstatus.md`) | Dependabot ODER Renovate konfigurieren; PR-Flut begrenzen (Limit/Gruppierung); Ökosysteme bewusst ein-/ausschließen |
+| CI-TOOL-001 | ci | Dev-Setup: Task-Runner-Dedup (Makefile/Justfile) + Node/pnpm engines | open | medium | `Makefile`, `Justfile` (beide direkt `docker compose ... up/down`), `apps/web/package.json` (engines vorhanden), Root-`package.json` (engines fehlt) | Eine Compose-Ebene führt, andere delegiert; engines konsistent ergänzen; kleiner risikoarmer PR |
+| DOCS-CTL-001 | docs | Orphan-Dokumente einordnen (cost-report, DEPLOY-DNS-001B) | open | medium | `docs/reports/cost-report.md`, `docs/tasks/DEPLOY-DNS-001B.md` (beide im Orphan-Generator) | Fachliche Lifecycle-Einordnung statt kosmetischer Verlinkung; alte Deploy-/DNS-Aufgabe nicht reaktivieren |
+| DOCS-CTL-002 | docs | Blueprint-/Planning-Status-Konsistenz | open | medium | `docs/reports/planning-registration-findings.md`; `kartenklarheit.md`/`map-blaupause.md` sind `draft`, in `docs/index.md` aber als aktiv/normativ geführt | Betroffene Blueprints einzeln prüfen; nicht pauschal hochstufen; deprecated nicht reaktivieren; Planning-Guard bleibt grün |
 
 ## Blocker
 
 | ID | Blocker | Fehlt | Folge |
 |---|---|---|---|
 | OPT-ARC-001 | Step-up-E-Mail-Persistenz und WebAuthn-User-ID-Writeback offen; Runtime-Smoke und Cutover ausstehend; JSONL-Demontage ausstehend | Offene Migrationsteile bzw. Cutover-Proof vorbereiten | JSONL bleibt Default-Lesequelle und Write-Truth bis vollständiger Cutover; POST /accounts, PATCH /nodes und POST /edges schreiben optional PostgreSQL; Schema- und Backfill-Proof sind belegt; der geänderte Read-Path-Proof-Harness wartet auf frische PR-CI-Evidence |
+| DOMAIN-PG-001 | Edge-Referenz-Policy (FK oder Guard) hängt am Edge-Orphan-Audit | DB-PROOF-001 nicht abgeschlossen; FK-Entscheidung in der Edge-Schema-Migration ausdrücklich deferred | Kein FK-/Referenz-Cutover vor Audit; Orphans dürfen nicht still verworfen werden |
+| AUTH-PG-003 | `webauthn_user_id`-Backfill und späteres `NOT NULL` hängen an WebAuthn-Persistenz | AUTH-PG-002 fachlich offen; kein NULL-Audit, kein Backfill-Test | Kein `NOT NULL` vor Audit + Backfill; keine stille UUID-Neuerzeugung bei Reload |
 
 ## Nächste PR-Kandidaten
 
 | ID | PR-Schnitt | Akzeptanzkriterium |
 |---|---|---|
 | OPT-CON-001 | Schema-Constraints: `additionalProperties: false` alle 6 Schemas | `just contracts-domain-check` pass + kein permissives Nested-Object |
+| DB-PROOF-001 | Edge-Orphan-/Referenz-Audit (read-only, keine Migration) | Reproduzierbarer redigierter Bericht: valide/Orphan-Counts + Policy-Empfehlung (Option A FK vs. Option B Guard) |
+| CI-TOOL-001 | Dev-Setup: Makefile/Justfile-Dedup + Node/pnpm engines (kleiner Hygiene-PR) | Eine Compose-Ebene führt, andere delegiert; engines konsistent; JSON valide; keine Container-Starts nötig |
 
 ## Zurückgestellte / optionale Tasks
 
 | ID | Grund | Wiederaufnahmebedingung |
 |---|---|---|
 | TASK-CTL-002 | GitHub Issue Forms, PR-Template und Release-Konfiguration sind aktuell nicht eingeführt, weil der Nutzen gegenüber kontextgenauen PR-Bodies nicht belegt ist. | Externe Beitragende ohne Projekteinblick werden relevant, PR-Bodies verlieren wiederholt Task-/Evidenzbezüge oder der Release-Prozess ist stabil genug für Release-Labels. |
+| DOMAIN-PG-003 | Edge-Cache-Limit-Performance: kein Lastproblem und kein Cutover-Blocker nachgewiesen (TODO C1) | Erst Messpunkt/Design mit Trade-offs, dann ggf. Umbau; kein spekulativer Performance-Umbau |
+| OPT-CI-003 | dtolnay/uv-Ref-Vereinheitlichung: niedrige Priorität, nicht cutover-relevant | Jederzeit als kleiner CI-Hygiene-PR möglich |
+| OPT-INF-002 | SHA-Pinning der Third-Party-Actions: erst nach Update-Automation sinnvoll (TODO C3) | Nach OPT-CI-004 (Dependency-Update-Automation/Policy) |
 
 ## Erledigte Tasks
 

--- a/docs/tasks/index.json
+++ b/docs/tasks/index.json
@@ -794,6 +794,409 @@
         ]
       },
       "updated_at": "2026-06-05"
+    },
+    {
+      "id": "DB-PROOF-001",
+      "title": "Edge-Orphan- und Referenz-Audit vor PostgreSQL-FK-Entscheidung",
+      "area": "api",
+      "status": "open",
+      "priority": "high",
+      "effort": "M",
+      "risk": "medium",
+      "owner": "unknown",
+      "evidence": [
+        "apps/api/migrations/20260531000002_create_domain_edges.up.sql"
+      ],
+      "missing_evidence": [
+        "Kein Edge-Orphan-/Referenz-Audit-Skript und kein reproduzierbarer Audit-Report vorhanden (Pendant zu scripts/docmeta/audit_account_email_uniqueness.py fehlt fuer Edges)",
+        "Kein Datenlauf gegen Runtime-/Deployment-Edges, der valide vs. verwaiste source_id/target_id-Referenzen quantifiziert"
+      ],
+      "acceptance": [
+        "Audit zaehlt reproduzierbar valide Edges, Orphans (fehlende source_id/target_id-Nodes) und betroffene Edge-Typen, ohne Orphans still zu verwerfen",
+        "Audit benennt entscheidungsfaehig Option A (strikte Foreign Keys auf domain_nodes(id)) vs. Option B (lose Referenzsemantik mit Guard/Quarantaene)",
+        "Keine FK-Migration und keine Runtime-Aenderung in diesem Task",
+        "Bericht ist redigiert: keine unredigierten Rohdaten/IDs aus Produktionslaeufen"
+      ],
+      "links": {
+        "issues": [],
+        "prs": [],
+        "docs": [
+          "docs/blueprints/domain-data-postgres-cutover.md",
+          "docs/reports/domain-account-email-uniqueness-audit.md"
+        ]
+      },
+      "updated_at": "2026-06-16"
+    },
+    {
+      "id": "DOMAIN-PG-001",
+      "title": "Edge-Referenz-Policy umsetzen (Foreign Keys oder Guard)",
+      "area": "api",
+      "status": "blocked",
+      "priority": "high",
+      "effort": "M",
+      "risk": "high",
+      "owner": "unknown",
+      "evidence": [
+        "apps/api/migrations/20260531000002_create_domain_edges.up.sql"
+      ],
+      "missing_evidence": [
+        "DB-PROOF-001 (Edge-Orphan-/Referenz-Audit) ist noch nicht abgeschlossen; die FK-Entscheidung ist in der Edge-Schema-Migration ausdruecklich deferred",
+        "Keine FK-Migration und kein Referenz-Guard implementiert"
+      ],
+      "acceptance": [
+        "Die in DB-PROOF-001 entschiedene Referenzpolitik ist technisch abgesichert (Option A: FK auf domain_nodes(id) mit kontrolliertem API-Fehler; Option B: Guard/Quarantaene-Report mit sichtbaren Orphans)",
+        "Keine stillen Datenverluste; vorhandene Orphans werden vor FK bereinigt oder bewusst als loses Modell dokumentiert",
+        "Tests fuer valide und ungueltige Referenzen ergaenzt"
+      ],
+      "links": {
+        "issues": [],
+        "prs": [],
+        "docs": [
+          "docs/blueprints/domain-data-postgres-cutover.md"
+        ]
+      },
+      "updated_at": "2026-06-16"
+    },
+    {
+      "id": "DOMAIN-PG-002",
+      "title": "Single-Instance-Invariante oder Multi-Instance-Kohaerenz entscheiden",
+      "area": "infra",
+      "status": "open",
+      "priority": "high",
+      "effort": "M",
+      "risk": "high",
+      "owner": "unknown",
+      "evidence": [],
+      "missing_evidence": [
+        "Keine dokumentierte Betriebsentscheidung Single-Instance vs. Multi-Instance fuer den PostgreSQL-Domain-Pfad; prozesslokale Runtime-Caches bleiben unadressiert",
+        "Kein Guard/Smoke, der Cross-Instance-Kohaerenz oder die Single-Instance-Grenze belegt"
+      ],
+      "acceptance": [
+        "Option A: horizontale Skalierung ist ausdruecklich ausgeschlossen, das Risiko 'Instanz B sieht A-Write erst nach Restart' ist in Deployment-/Runtime-Doku festgehalten",
+        "oder Option B: Cross-Instance-Kohaerenz ist technisch geloest oder klar begrenzt und durch Test/Smoke belegt",
+        "Entscheidung ist im Cutover-Blueprint verankert; kein stiller Cache-Split-Brain"
+      ],
+      "links": {
+        "issues": [],
+        "prs": [],
+        "docs": [
+          "docs/blueprints/domain-data-postgres-cutover.md",
+          "docs/reports/auth-persistence-readiness.md"
+        ]
+      },
+      "updated_at": "2026-06-16"
+    },
+    {
+      "id": "AUTH-PG-001",
+      "title": "Step-up-E-Mail-Persistenz nach PostgreSQL",
+      "area": "auth",
+      "status": "open",
+      "priority": "high",
+      "effort": "M",
+      "risk": "high",
+      "owner": "unknown",
+      "evidence": [
+        "apps/api/src/routes/auth.rs"
+      ],
+      "missing_evidence": [
+        "Step-up-E-Mail-Persistenz ist ein ausdrueckliches Non-Goal von OPT-ARC-001 (docs/reports/opt-arc-001-db-proof-matrix.json: step_up_email_persistence) und noch nicht implementiert",
+        "Kein PostgreSQL-Write-Pfad/Proof, der eine via PUT /auth/me/email geaenderte E-Mail restart-stabil belegt"
+      ],
+      "acceptance": [
+        "Step-up-E-Mail-Aenderung (UpdateEmail-Intent) ist nach PostgreSQL-Cutover restart-stabil und nicht cache-only",
+        "E-Mail-Unique-Regel (domain_accounts_email_normalized_unique) bleibt gewahrt; Konflikt liefert kontrolliert 409",
+        "Fehlersemantik definiert: Konflikt, ungueltige E-Mail, nicht autorisiert, abgelaufenes Step-up"
+      ],
+      "links": {
+        "issues": [],
+        "prs": [],
+        "docs": [
+          "docs/reports/auth-status-matrix.md",
+          "docs/blueprints/domain-data-postgres-cutover.md"
+        ]
+      },
+      "updated_at": "2026-06-16"
+    },
+    {
+      "id": "AUTH-PG-002",
+      "title": "WebAuthn-Credential-Persistenz / Passkey-Cutover nach PostgreSQL",
+      "area": "auth",
+      "status": "open",
+      "priority": "high",
+      "effort": "L",
+      "risk": "high",
+      "owner": "unknown",
+      "evidence": [
+        "apps/api/src/auth/passkeys.rs",
+        "apps/api/src/routes/auth.rs",
+        "apps/api/src/routes/accounts.rs"
+      ],
+      "missing_evidence": [
+        "WebAuthn-Credential-Writeback ist ein ausdrueckliches Non-Goal von OPT-ARC-001 (docs/reports/opt-arc-001-db-proof-matrix.json: webauthn_credential_writeback); PasskeyStore und webauthn_user_id-Writeback sind aktuell In-Memory (auth-status-matrix.md 2.8: persistente Ablage ueber Neustart offen)",
+        "Kein PostgreSQL-Persistenzmodell und keine Migration fuer registrierte Passkey-Credentials",
+        "Kein Restart-Stabilitaets-Proof (Registrierung, Reload, Login)"
+      ],
+      "acceptance": [
+        "Registrierter WebAuthn-Credential-Zustand ist restart-stabil (kein reiner Cache)",
+        "Public/Private-Trennung bleibt gewahrt; keine Credential-Daten leaken in die oeffentliche Account-Projektion",
+        "Ein blosser webauthn_user_id-Fix wird nicht als vollstaendiger WebAuthn-Cutover deklariert (siehe AUTH-PG-003)",
+        "Menschliches Review fuer credentials/ vor Merge"
+      ],
+      "links": {
+        "issues": [],
+        "prs": [],
+        "docs": [
+          "docs/reports/auth-status-matrix.md",
+          "docs/reports/passkey-register-verify-prep.md"
+        ]
+      },
+      "updated_at": "2026-06-16"
+    },
+    {
+      "id": "AUTH-PG-003",
+      "title": "Legacy-Backfill fuer webauthn_user_id und spaeteres NOT NULL",
+      "area": "auth",
+      "status": "blocked",
+      "priority": "medium",
+      "effort": "M",
+      "risk": "medium",
+      "owner": "unknown",
+      "evidence": [
+        "apps/api/src/routes/accounts.rs"
+      ],
+      "missing_evidence": [
+        "legacy_webauthn_user_id_backfill und webauthn_user_id_not_null sind ausdrueckliche Non-Goals von OPT-ARC-001 (docs/reports/opt-arc-001-db-proof-matrix.json)",
+        "WebAuthn-Credential-Persistenz (AUTH-PG-002) ist fachlich noch nicht geklaert; die Backfill-Strategie haengt davon ab",
+        "Kein Audit, wie viele Accounts webauthn_user_id IS NULL haben, und kein Backfill-Test"
+      ],
+      "acceptance": [
+        "Audit der Accounts mit fehlender webauthn_user_id liegt vor; Backfill-Strategie ist dokumentiert und testbar",
+        "Reload erzeugt keine neue Identitaet (keine stille UUID-Neuerzeugung)",
+        "NOT NULL wird erst nach Audit und erfolgreichem Backfill geprueft; Migration ist nachvollziehbar"
+      ],
+      "links": {
+        "issues": [],
+        "prs": [],
+        "docs": [
+          "docs/reports/auth-status-matrix.md",
+          "docs/reports/opt-arc-001-db-proof-matrix.json"
+        ]
+      },
+      "updated_at": "2026-06-16"
+    },
+    {
+      "id": "DOMAIN-PG-003",
+      "title": "Edge-Cache-Limit ohne Tabellenlock und Vollzaehlung designen",
+      "area": "api",
+      "status": "open",
+      "priority": "low",
+      "effort": "M",
+      "risk": "medium",
+      "owner": "unknown",
+      "evidence": [
+        "apps/api/src/routes/edges.rs"
+      ],
+      "missing_evidence": [
+        "Kein gemessener Insert-Pfad und keine dokumentierte Trade-off-Entscheidung zur Abloesung von LOCK TABLE + COUNT(*)",
+        "Bewusst zurueckgestellt (TODO C1): erst Messpunkt/Design, dann Umbau"
+      ],
+      "acceptance": [
+        "Entscheidung mit Trade-offs dokumentiert; Race-Sicherheit bleibt erhalten",
+        "Duplicate-vor-Limit-Semantik bleibt erhalten oder wird bewusst geaendert",
+        "Kein ungemessener/spekulativer Performance-Umbau"
+      ],
+      "links": {
+        "issues": [],
+        "prs": [],
+        "docs": [
+          "docs/blueprints/domain-data-postgres-cutover.md"
+        ]
+      },
+      "updated_at": "2026-06-16"
+    },
+    {
+      "id": "CI-TOOL-001",
+      "title": "Dev-Setup-Hygiene: Task-Runner-Dedup (Makefile/Justfile) und Node/pnpm engines",
+      "area": "ci",
+      "status": "open",
+      "priority": "medium",
+      "effort": "S",
+      "risk": "low",
+      "owner": "unknown",
+      "evidence": [
+        "Makefile",
+        "Justfile",
+        "apps/web/package.json",
+        ".node-version",
+        ".nvmrc"
+      ],
+      "missing_evidence": [
+        "Makefile und Justfile fuehren up/down beide direkt 'docker compose ... --profile dev' aus (Duplikat ohne Delegation)",
+        "Root package.json hat kein engines-Feld (apps/web/package.json hat eines: node ^20.19.0 || ^22.13.0 || >=24)"
+      ],
+      "acceptance": [
+        "Nur eine Ebene enthaelt echte Compose-up/down-Logik; die andere delegiert",
+        "Node-/pnpm-Versionen sind konsistent sichtbar (engines), ohne ein zweites Versionssystem zu erzeugen; JSON bleibt valide",
+        "Keine Container-Starts noetig (Dry-Run/Lint genuegt als Nachweis)"
+      ],
+      "links": {
+        "issues": [],
+        "prs": [],
+        "docs": [
+          "docs/techstack.md"
+        ]
+      },
+      "updated_at": "2026-06-16"
+    },
+    {
+      "id": "DOCS-CTL-001",
+      "title": "Orphan-Dokumente einordnen (cost-report, DEPLOY-DNS-001B)",
+      "area": "docs",
+      "status": "open",
+      "priority": "medium",
+      "effort": "S",
+      "risk": "low",
+      "owner": "unknown",
+      "evidence": [
+        "docs/reports/cost-report.md",
+        "docs/tasks/DEPLOY-DNS-001B.md"
+      ],
+      "missing_evidence": [
+        "docs/reports/cost-report.md und docs/tasks/DEPLOY-DNS-001B.md werden vom Orphan-Generator weiterhin als verwaist gefuehrt; fachliche Lifecycle-Einordnung steht aus"
+      ],
+      "acceptance": [
+        "Beide Dokumente sind fachlich eingeordnet (aktiv/archived/superseded/Ausnahme), nicht nur kosmetisch verlinkt",
+        "Orphan-Report ist leer oder die Ausnahmen sind bewusst dokumentiert",
+        "Die historische Deploy-/DNS-Aufgabe (DEPLOY-DNS-001B) wird nicht als aktuelle Handlungsanweisung reaktiviert"
+      ],
+      "links": {
+        "issues": [],
+        "prs": [],
+        "docs": [
+          "docs/reports/cost-report.md",
+          "docs/tasks/DEPLOY-DNS-001B.md",
+          "docs/index.md"
+        ]
+      },
+      "updated_at": "2026-06-16"
+    },
+    {
+      "id": "DOCS-CTL-002",
+      "title": "Blueprint-/Planning-Status-Konsistenz (draft/active/canonical/deprecated)",
+      "area": "docs",
+      "status": "open",
+      "priority": "medium",
+      "effort": "S",
+      "risk": "low",
+      "owner": "unknown",
+      "evidence": [
+        "docs/reports/planning-registration-findings.md",
+        "scripts/docmeta/planning_registration.yml",
+        "docs/blueprints/kartenklarheit.md",
+        "docs/blueprints/map-blaupause.md"
+      ],
+      "missing_evidence": [
+        "kartenklarheit.md und map-blaupause.md tragen frontmatter-status 'draft', werden in docs/index.md aber als aktive/normative Leitdokumente gefuehrt (Status-Widerspruch)"
+      ],
+      "acceptance": [
+        "Keine unbegruendeten draft-/canonical-Widersprueche; betroffene Blueprints werden einzeln gelesen und nicht pauschal hochgestuft",
+        "Deprecated-Dokumente werden nicht reaktiviert",
+        "Planning-Registration-Check (scripts/docmeta/check_planning_registration.py) bleibt gruen; generierte Reports werden ueber ihren Generator aktualisiert"
+      ],
+      "links": {
+        "issues": [],
+        "prs": [],
+        "docs": [
+          "docs/blueprints/kartenklarheit.md",
+          "docs/blueprints/map-blaupause.md",
+          "docs/reports/planning-registration-findings.md"
+        ]
+      },
+      "updated_at": "2026-06-16"
+    },
+    {
+      "id": "OPT-CI-003",
+      "title": "Action-Refs vereinheitlichen (dtolnay/rust-toolchain + uv-Pin)",
+      "area": "ci",
+      "status": "partial",
+      "priority": "low",
+      "effort": "S",
+      "risk": "low",
+      "owner": "unknown",
+      "evidence": [
+        ".github/workflows/python-tooling.yml"
+      ],
+      "missing_evidence": [
+        "dtolnay/rust-toolchain weiterhin gemischt @stable/@v1",
+        "gepinnte uv-Version nicht erzwungen"
+      ],
+      "acceptance": [
+        "Keine gemischten dtolnay-rust-toolchain-Refs; Rust-Version weiterhin aus zentraler Quelle",
+        "uv-Version ist zentral nachvollziehbar und in CI wirksam, ohne zweite Pinning-Logik"
+      ],
+      "links": {
+        "issues": [],
+        "prs": [],
+        "docs": [
+          "docs/reports/optimierungsstatus.md"
+        ]
+      },
+      "updated_at": "2026-06-16"
+    },
+    {
+      "id": "OPT-CI-004",
+      "title": "Dependency-Update-Automation (Dependabot/Renovate)",
+      "area": "ci",
+      "status": "open",
+      "priority": "medium",
+      "effort": "S",
+      "risk": "medium",
+      "owner": "unknown",
+      "evidence": [],
+      "missing_evidence": [
+        "keine .github/dependabot.yml oder Renovate-Config vorhanden"
+      ],
+      "acceptance": [
+        "Update-Automation existiert (Dependabot oder Renovate); PR-Flut ist begrenzt (Limit/Gruppierung)",
+        "Relevante Oekosysteme (Actions, pnpm/npm, Cargo, Docker, Python/uv) sind bewusst ein- oder ausgeschlossen"
+      ],
+      "links": {
+        "issues": [],
+        "prs": [],
+        "docs": [
+          "docs/reports/optimierungsstatus.md"
+        ]
+      },
+      "updated_at": "2026-06-16"
+    },
+    {
+      "id": "OPT-INF-002",
+      "title": "Third-Party-Actions per Commit-SHA pinnen",
+      "area": "infra",
+      "status": "open",
+      "priority": "low",
+      "effort": "S",
+      "risk": "medium",
+      "owner": "unknown",
+      "evidence": [
+        ".github/workflows/"
+      ],
+      "missing_evidence": [
+        "repo-weit nur Tag-Pinning, kein SHA-Pinning",
+        "Sequenzierung (TODO C3): SHA-Pinning erst nach Dependency-Update-Automation (OPT-CI-004), sonst Update-Weg unklar"
+      ],
+      "acceptance": [
+        "Third-Party-Actions sind per Commit-SHA gepinnt; Ursprungstag als Kommentar; Update-Weg bleibt klar",
+        "Policy dokumentiert; CI gruen"
+      ],
+      "links": {
+        "issues": [],
+        "prs": [],
+        "docs": [
+          "docs/reports/optimierungsstatus.md"
+        ]
+      },
+      "updated_at": "2026-06-16"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds 13 new task definitions to `docs/tasks/index.json` covering two parallel work streams:
- **Strang A (PostgreSQL/Auth Cutover):** Edge-orphan audits, referential integrity policy decisions, step-up email persistence, WebAuthn credential migration, and edge-cache design optimization.
- **Strang B (Repo/CI/Docs Hygiene):** Task-runner deduplication, orphan document lifecycle management, blueprint status consistency, CI action pinning, and dependency automation.

Updates `docs/tasks/board.md` with a 2026-06-16 status entry explaining how the optimized TODO list aligns with existing repo work and clarifies non-duplication with OPT-ARC-001.

## Key Changes

- **New task IDs added (13 total):**
  - `DB-PROOF-001`: Edge-orphan and referential audit (prerequisite for FK decision)
  - `DOMAIN-PG-001`: Edge-referential policy implementation (blocked on DB-PROOF-001)
  - `DOMAIN-PG-002`: Single-instance vs. multi-instance coherence decision
  - `DOMAIN-PG-003`: Edge-cache-limit design without table locks
  - `AUTH-PG-001`: Step-up email persistence after PostgreSQL cutover
  - `AUTH-PG-002`: WebAuthn credential persistence and passkey cutover
  - `AUTH-PG-003`: Legacy webauthn_user_id backfill and NOT NULL constraint
  - `CI-TOOL-001`: Task-runner deduplication (Makefile/Justfile) and Node/pnpm engines
  - `DOCS-CTL-001`: Orphan document lifecycle (cost-report, DEPLOY-DNS-001B)
  - `DOCS-CTL-002`: Blueprint/planning status consistency (draft/active/canonical/deprecated)
  - `OPT-CI-003`: Action-ref unification (dtolnay/rust-toolchain + uv pinning)
  - `OPT-CI-004`: Dependency-update automation (Dependabot/Renovate)
  - `OPT-INF-002`: Third-party action SHA pinning

- **Board status entry (2026-06-16):**
  - Clarifies that email-duplicate audit and normalized email unique index are already complete (not reactivated)
  - Explains how new tasks decompose from the optimized TODO list
  - Emphasizes separation of Strang A (cutover) and Strang B (hygiene) in PR planning

## Implementation Details

- All tasks include `evidence`, `missing_evidence`, `acceptance` criteria, and `links` sections per existing task schema
- Tasks are marked with appropriate `status` (open/blocked/partial), `priority` (high/medium/low), `effort` (S/M/L), and `risk` levels
- Blocked tasks (DOMAIN-PG-001, AUTH-PG-003) explicitly reference their prerequisites
- All tasks updated with `updated_at: "2026-06-16"` timestamp
- Board entry references existing audit reports and migration evidence to avoid duplication with OPT-ARC-001 deliverables

https://claude.ai/code/session_01YWFzG5YjE1S3retaJLhhpq