### PR TITLE
docs: classify opt arc report lifecycles

### DIFF
--- a/docs/_generated/report-lifecycle-inventory.md
+++ b/docs/_generated/report-lifecycle-inventory.md
@@ -16,23 +16,23 @@ Primary references are exact path matches in canonical documentation surfaces. D
 
 | Metric | Count |
 | --- | ---: |
-| files_total | 23 |
-| files_with_frontmatter | 23 |
+| files_total | 25 |
+| files_with_frontmatter | 25 |
 | files_without_frontmatter | 0 |
-| files_with_status | 23 |
+| files_with_status | 25 |
 | files_missing_status | 0 |
-| files_with_lifecycle_state | 1 |
-| files_missing_lifecycle_state | 22 |
-| files_with_lifecycle | 1 |
-| files_missing_lifecycle | 22 |
-| files_with_owner_task | 1 |
-| files_missing_owner_task | 22 |
-| files_with_review_after | 1 |
-| files_missing_review_after | 22 |
-| files_primary_referenced | 19 |
-| files_primary_unreferenced | 4 |
-| files_with_derived_references | 23 |
-| files_with_relations | 22 |
+| files_with_lifecycle_state | 8 |
+| files_missing_lifecycle_state | 17 |
+| files_with_lifecycle | 8 |
+| files_missing_lifecycle | 17 |
+| files_with_owner_task | 8 |
+| files_missing_owner_task | 17 |
+| files_with_review_after | 7 |
+| files_missing_review_after | 18 |
+| files_primary_referenced | 20 |
+| files_primary_unreferenced | 5 |
+| files_with_derived_references | 25 |
+| files_with_relations | 24 |
 | files_with_missing_supersession_target | 0 |
 
 ## Doc Type Distribution
@@ -41,7 +41,7 @@ Primary references are exact path matches in canonical documentation surfaces. D
 | --- | ---: |
 | documentation | 1 |
 | reference | 2 |
-| report | 18 |
+| report | 20 |
 | status-matrix | 2 |
 
 ## Reports
@@ -57,16 +57,18 @@ Primary references are exact path matches in canonical documentation surfaces. D
 | docs/reports/auth-status-matrix.md | reference | active |  |  |  |  |  | 5 | 4 | 3 | lifecycle, owner_task, review_after, lifecycle_state |  |
 | docs/reports/cost-report.md | reference | active |  |  |  |  |  | 0 | 4 | 0 | lifecycle, owner_task, review_after, lifecycle_state |  |
 | docs/reports/domain-account-email-uniqueness-audit.md | report | active | active | audit | OPT-ARC-001 | 2026-07-13 |  | 1 | 4 | 4 |  |  |
-| docs/reports/domain-account-write-path-proof.md | report | active |  |  |  |  |  | 7 | 4 | 6 | lifecycle, owner_task, review_after, lifecycle_state |  |
-| docs/reports/domain-backfill-proof.md | report | active |  |  |  |  |  | 3 | 4 | 4 | lifecycle, owner_task, review_after, lifecycle_state |  |
-| docs/reports/domain-edge-create-semantics-preflight.md | report | active |  |  |  |  |  | 0 | 4 | 7 | lifecycle, owner_task, review_after, lifecycle_state |  |
-| docs/reports/domain-edge-write-path-proof.md | report | active |  |  |  |  |  | 3 | 4 | 7 | lifecycle, owner_task, review_after, lifecycle_state |  |
-| docs/reports/domain-node-write-path-proof.md | report | active |  |  |  |  |  | 5 | 4 | 6 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/domain-account-write-path-proof.md | report | active | active | proof | OPT-ARC-001 | 2026-07-16 |  | 7 | 4 | 6 |  |  |
+| docs/reports/domain-backfill-proof.md | report | active | active | proof | OPT-ARC-001 | 2026-07-16 |  | 3 | 4 | 4 |  |  |
+| docs/reports/domain-edge-create-semantics-preflight.md | report | deprecated | superseded | decision-prep | OPT-ARC-001 |  | docs/reports/domain-edge-write-path-proof.md | 0 | 4 | 7 | review_after |  |
+| docs/reports/domain-edge-reference-audit.md | report | active | active | audit | OPT-ARC-001 | 2026-07-16 |  | 0 | 1 | 6 |  |  |
+| docs/reports/domain-edge-write-path-proof.md | report | active | active | proof | OPT-ARC-001 | 2026-07-16 |  | 3 | 4 | 7 |  |  |
+| docs/reports/domain-node-write-path-proof.md | report | active | active | proof | OPT-ARC-001 | 2026-07-16 |  | 5 | 4 | 6 |  |  |
 | docs/reports/domain-provider-role-finding.md | report | active |  |  |  |  |  | 1 | 4 | 3 | lifecycle, owner_task, review_after, lifecycle_state |  |
-| docs/reports/domain-read-path-proof.md | report | active |  |  |  |  |  | 5 | 4 | 5 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/domain-read-path-proof.md | report | active | active | proof | OPT-ARC-001 | 2026-07-16 |  | 5 | 4 | 5 |  |  |
 | docs/reports/inwx-zone-reconciliation-plan.md | report | active |  |  |  |  |  | 1 | 4 | 4 | lifecycle, owner_task, review_after, lifecycle_state |  |
 | docs/reports/map-architekturkritik.md | report | active |  |  |  |  |  | 4 | 5 | 2 | lifecycle, owner_task, review_after, lifecycle_state |  |
-| docs/reports/map-status-matrix.md | status-matrix | active |  |  |  |  |  | 7 | 5 | 3 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/map-basemap-proof-gap-reconciliation.md | report | active |  |  |  |  |  | 2 | 1 | 6 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/map-status-matrix.md | status-matrix | active |  |  |  |  |  | 8 | 5 | 3 | lifecycle, owner_task, review_after, lifecycle_state |  |
 | docs/reports/optimierungsbericht.md | report | active |  |  |  |  |  | 2 | 4 | 4 | lifecycle, owner_task, review_after, lifecycle_state |  |
 | docs/reports/optimierungsstatus.md | status-matrix | active |  |  |  |  |  | 17 | 5 | 4 | lifecycle, owner_task, review_after, lifecycle_state |  |
 | docs/reports/passkey-register-verify-prep.md | report | active |  |  |  |  |  | 0 | 4 | 4 | lifecycle, owner_task, review_after, lifecycle_state |  |
@@ -84,15 +86,11 @@ Primary references are exact path matches in canonical documentation surfaces. D
 | docs/reports/auth-persistence-runtime-target-reconciliation.md | lifecycle, owner_task, review_after, lifecycle_state |
 | docs/reports/auth-status-matrix.md | lifecycle, owner_task, review_after, lifecycle_state |
 | docs/reports/cost-report.md | lifecycle, owner_task, review_after, lifecycle_state |
-| docs/reports/domain-account-write-path-proof.md | lifecycle, owner_task, review_after, lifecycle_state |
-| docs/reports/domain-backfill-proof.md | lifecycle, owner_task, review_after, lifecycle_state |
-| docs/reports/domain-edge-create-semantics-preflight.md | lifecycle, owner_task, review_after, lifecycle_state |
-| docs/reports/domain-edge-write-path-proof.md | lifecycle, owner_task, review_after, lifecycle_state |
-| docs/reports/domain-node-write-path-proof.md | lifecycle, owner_task, review_after, lifecycle_state |
+| docs/reports/domain-edge-create-semantics-preflight.md | review_after |
 | docs/reports/domain-provider-role-finding.md | lifecycle, owner_task, review_after, lifecycle_state |
-| docs/reports/domain-read-path-proof.md | lifecycle, owner_task, review_after, lifecycle_state |
 | docs/reports/inwx-zone-reconciliation-plan.md | lifecycle, owner_task, review_after, lifecycle_state |
 | docs/reports/map-architekturkritik.md | lifecycle, owner_task, review_after, lifecycle_state |
+| docs/reports/map-basemap-proof-gap-reconciliation.md | lifecycle, owner_task, review_after, lifecycle_state |
 | docs/reports/map-status-matrix.md | lifecycle, owner_task, review_after, lifecycle_state |
 | docs/reports/optimierungsbericht.md | lifecycle, owner_task, review_after, lifecycle_state |
 | docs/reports/optimierungsstatus.md | lifecycle, owner_task, review_after, lifecycle_state |
@@ -114,12 +112,14 @@ Primary references are exact path matches in canonical documentation surfaces. D
 | docs/reports/domain-account-write-path-proof.md | 6 | relates_to | .github/workflows/api.yml, apps/api/tests/db_domain_account_write_path.rs, docs/blueprints/domain-data-postgres-cutover.md, docs/reports/domain-read-path-proof.md, docs/reports/optimierungsstatus.md, docs/tasks/board.md |
 | docs/reports/domain-backfill-proof.md | 4 | relates_to | .github/workflows/api.yml, apps/api/tests/db_domain_backfill.rs, docs/blueprints/domain-data-postgres-cutover.md, docs/tasks/index.json |
 | docs/reports/domain-edge-create-semantics-preflight.md | 7 | relates_to | contracts/domain/edge.schema.json, docs/blueprints/domain-data-postgres-cutover.md, docs/reports/domain-account-write-path-proof.md, docs/reports/domain-node-write-path-proof.md, docs/reports/opt-arc-001-db-proof-matrix.json, docs/tasks/board.md, docs/tasks/index.json |
+| docs/reports/domain-edge-reference-audit.md | 6 | relates_to | apps/api/migrations/20260531000002_create_domain_edges.up.sql, contracts/domain/edge.schema.json, docs/blueprints/domain-data-postgres-cutover.md, docs/reports/opt-arc-001-db-proof-matrix.json, docs/tasks/board.md, scripts/docmeta/audit_domain_edge_references.py |
 | docs/reports/domain-edge-write-path-proof.md | 7 | relates_to | docs/blueprints/domain-data-postgres-cutover.md, docs/reports/domain-account-write-path-proof.md, docs/reports/domain-node-write-path-proof.md, docs/reports/domain-read-path-proof.md, docs/reports/optimierungsstatus.md, docs/tasks/board.md, docs/tasks/index.json |
 | docs/reports/domain-node-write-path-proof.md | 6 | relates_to | docs/blueprints/domain-data-postgres-cutover.md, docs/reports/domain-account-write-path-proof.md, docs/reports/domain-read-path-proof.md, docs/reports/optimierungsstatus.md, docs/tasks/board.md, docs/tasks/index.json |
 | docs/reports/domain-provider-role-finding.md | 3 | relates_to | docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md, docs/runbooks/domain-mail-cutover.md, docs/tasks/board.md |
 | docs/reports/domain-read-path-proof.md | 5 | relates_to | docs/blueprints/domain-data-postgres-cutover.md, docs/reports/domain-account-write-path-proof.md, docs/reports/domain-backfill-proof.md, docs/reports/optimierungsstatus.md, docs/tasks/board.md |
 | docs/reports/inwx-zone-reconciliation-plan.md | 4 | relates_to | docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md, docs/reports/domain-provider-role-finding.md, docs/runbooks/domain-mail-cutover.md, docs/tasks/board.md |
 | docs/reports/map-architekturkritik.md | 2 | relates_to | docs/blueprints/kartenklarheit-roadmap.md, docs/reports/map-status-matrix.md |
+| docs/reports/map-basemap-proof-gap-reconciliation.md | 6 | relates_to | .github/workflows/basemap-runtime-proof.yml, docs/blueprints/kartenklarheit-phase6.md, docs/blueprints/kartenklarheit-roadmap.md, docs/proofs/basemap-hamburg-artifact-proof.md, docs/reports/map-status-matrix.md, scripts/guard/basemap-runtime-proof.sh |
 | docs/reports/map-status-matrix.md | 3 | relates_to | docs/blueprints/kartenklarheit-roadmap.md, docs/blueprints/ui-interaction-doctrine.md, docs/reports/map-architekturkritik.md |
 | docs/reports/optimierungsbericht.md | 4 | relates_to | docs/datenmodell.md, docs/policies/agent-reading-protocol.md, docs/reports/optimierungsstatus.md, docs/techstack.md |
 | docs/reports/optimierungsstatus.md | 4 | depends_on, relates_to | docs/policies/agent-reading-protocol.md, docs/reports/auth-persistence-readiness.md, docs/reports/domain-read-path-proof.md, docs/reports/optimierungsbericht.md |
@@ -209,6 +209,10 @@ Primary references are exact path matches in canonical documentation surfaces. D
   - `docs/blueprints/kartenklarheit.md`
   - `docs/reports/map-status-matrix.md`
 
+- `docs/reports/map-basemap-proof-gap-reconciliation.md`
+  - `docs/blueprints/kartenklarheit-roadmap.md`
+  - `docs/reports/map-status-matrix.md`
+
 - `docs/reports/map-status-matrix.md`
   - `docs/blueprints/kartenklarheit-phase6.md`
   - `docs/blueprints/kartenklarheit-roadmap.md`
@@ -216,6 +220,7 @@ Primary references are exact path matches in canonical documentation surfaces. D
   - `docs/blueprints/map-roadmap.md`
   - `docs/blueprints/ui-interaction-doctrine.md`
   - `docs/reports/map-architekturkritik.md`
+  - `docs/reports/map-basemap-proof-gap-reconciliation.md`
   - `docs/roadmap.md`
 
 - `docs/reports/optimierungsbericht.md`
@@ -320,6 +325,9 @@ Primary references are exact path matches in canonical documentation surfaces. D
   - `docs/_generated/relates-to-audit.md`
   - `docs/_generated/report-lifecycle.md`
 
+- `docs/reports/domain-edge-reference-audit.md`
+  - `docs/_generated/report-lifecycle.md`
+
 - `docs/reports/domain-edge-write-path-proof.md`
   - `docs/_generated/backlinks.md`
   - `docs/_generated/doc-index.md`
@@ -355,6 +363,9 @@ Primary references are exact path matches in canonical documentation surfaces. D
   - `docs/_generated/doc-index.md`
   - `docs/_generated/impl-index.md`
   - `docs/_generated/relates-to-audit.md`
+  - `docs/_generated/report-lifecycle.md`
+
+- `docs/reports/map-basemap-proof-gap-reconciliation.md`
   - `docs/_generated/report-lifecycle.md`
 
 - `docs/reports/map-status-matrix.md`
@@ -394,6 +405,7 @@ Primary references are exact path matches in canonical documentation surfaces. D
 - `docs/reports/auth-persistence-direct-proof-diagnose-audit.md`
 - `docs/reports/cost-report.md`
 - `docs/reports/domain-edge-create-semantics-preflight.md`
+- `docs/reports/domain-edge-reference-audit.md`
 - `docs/reports/passkey-register-verify-prep.md`
 
 ## Supersession Target Diagnostics

--- a/docs/_generated/report-lifecycle.md
+++ b/docs/_generated/report-lifecycle.md
@@ -16,36 +16,42 @@ This overview is descriptive only. It surfaces lifecycle metadata and validator 
 
 | Metric | Count |
 | --- | ---: |
-| files_scanned | 23 |
-| reports_checked | 18 |
+| files_scanned | 25 |
+| reports_checked | 20 |
 | reports_ignored_non_report | 5 |
-| reports_with_lifecycle_state | 1 |
-| reports_missing_lifecycle_state | 17 |
-| findings_total | 51 |
+| reports_with_lifecycle_state | 8 |
+| reports_missing_lifecycle_state | 12 |
+| findings_total | 36 |
 
 ## Lifecycle State Summary
 
 | lifecycle_state | Count |
 | --- | ---: |
-| active | 1 |
+| active | 7 |
 | deferred | 0 |
-| superseded | 0 |
+| superseded | 1 |
 | archived | 0 |
-| missing | 17 |
+| missing | 12 |
 
 ## Finding Summary
 
 | Code | Count |
 | --- | ---: |
-| missing_lifecycle | 17 |
-| missing_lifecycle_state | 17 |
-| missing_review_after | 17 |
+| missing_lifecycle | 12 |
+| missing_lifecycle_state | 12 |
+| missing_review_after | 12 |
 
 ## Active Reports
 
 | Report | status | lifecycle | owner_task | review_after | findings |
 | --- | --- | --- | --- | --- | --- |
 | docs/reports/domain-account-email-uniqueness-audit.md | active | audit | OPT-ARC-001 | 2026-07-13 |  |
+| docs/reports/domain-account-write-path-proof.md | active | proof | OPT-ARC-001 | 2026-07-16 |  |
+| docs/reports/domain-backfill-proof.md | active | proof | OPT-ARC-001 | 2026-07-16 |  |
+| docs/reports/domain-edge-reference-audit.md | active | audit | OPT-ARC-001 | 2026-07-16 |  |
+| docs/reports/domain-edge-write-path-proof.md | active | proof | OPT-ARC-001 | 2026-07-16 |  |
+| docs/reports/domain-node-write-path-proof.md | active | proof | OPT-ARC-001 | 2026-07-16 |  |
+| docs/reports/domain-read-path-proof.md | active | proof | OPT-ARC-001 | 2026-07-16 |  |
 
 ## Deferred Reports
 
@@ -57,7 +63,7 @@ This overview is descriptive only. It surfaces lifecycle metadata and validator 
 
 | Report | status | lifecycle | owner_task | review_after | findings |
 | --- | --- | --- | --- | --- | --- |
-| _None_ | | | | | |
+| docs/reports/domain-edge-create-semantics-preflight.md | deprecated | decision-prep | OPT-ARC-001 |  |  |
 
 ## Archived Reports
 
@@ -74,15 +80,10 @@ This overview is descriptive only. It surfaces lifecycle metadata and validator 
 | docs/reports/auth-persistence-readiness.md | active |  |  |  | missing_lifecycle, missing_lifecycle_state, missing_review_after |
 | docs/reports/auth-persistence-runtime-proof.md | active |  |  |  | missing_lifecycle, missing_lifecycle_state, missing_review_after |
 | docs/reports/auth-persistence-runtime-target-reconciliation.md | active |  |  |  | missing_lifecycle, missing_lifecycle_state, missing_review_after |
-| docs/reports/domain-account-write-path-proof.md | active |  |  |  | missing_lifecycle, missing_lifecycle_state, missing_review_after |
-| docs/reports/domain-backfill-proof.md | active |  |  |  | missing_lifecycle, missing_lifecycle_state, missing_review_after |
-| docs/reports/domain-edge-create-semantics-preflight.md | active |  |  |  | missing_lifecycle, missing_lifecycle_state, missing_review_after |
-| docs/reports/domain-edge-write-path-proof.md | active |  |  |  | missing_lifecycle, missing_lifecycle_state, missing_review_after |
-| docs/reports/domain-node-write-path-proof.md | active |  |  |  | missing_lifecycle, missing_lifecycle_state, missing_review_after |
 | docs/reports/domain-provider-role-finding.md | active |  |  |  | missing_lifecycle, missing_lifecycle_state, missing_review_after |
-| docs/reports/domain-read-path-proof.md | active |  |  |  | missing_lifecycle, missing_lifecycle_state, missing_review_after |
 | docs/reports/inwx-zone-reconciliation-plan.md | active |  |  |  | missing_lifecycle, missing_lifecycle_state, missing_review_after |
 | docs/reports/map-architekturkritik.md | active |  |  |  | missing_lifecycle, missing_lifecycle_state, missing_review_after |
+| docs/reports/map-basemap-proof-gap-reconciliation.md | active |  |  |  | missing_lifecycle, missing_lifecycle_state, missing_review_after |
 | docs/reports/optimierungsbericht.md | active |  |  |  | missing_lifecycle, missing_lifecycle_state, missing_review_after |
 | docs/reports/passkey-register-verify-prep.md | active |  |  |  | missing_lifecycle, missing_lifecycle_state, missing_review_after |
 | docs/reports/planning-registration-findings.md | active |  |  |  | missing_lifecycle, missing_lifecycle_state, missing_review_after |
@@ -96,15 +97,10 @@ This overview is descriptive only. It surfaces lifecycle metadata and validator 
 | docs/reports/auth-persistence-readiness.md |  | active | missing_lifecycle, missing_lifecycle_state, missing_review_after |
 | docs/reports/auth-persistence-runtime-proof.md |  | active | missing_lifecycle, missing_lifecycle_state, missing_review_after |
 | docs/reports/auth-persistence-runtime-target-reconciliation.md |  | active | missing_lifecycle, missing_lifecycle_state, missing_review_after |
-| docs/reports/domain-account-write-path-proof.md |  | active | missing_lifecycle, missing_lifecycle_state, missing_review_after |
-| docs/reports/domain-backfill-proof.md |  | active | missing_lifecycle, missing_lifecycle_state, missing_review_after |
-| docs/reports/domain-edge-create-semantics-preflight.md |  | active | missing_lifecycle, missing_lifecycle_state, missing_review_after |
-| docs/reports/domain-edge-write-path-proof.md |  | active | missing_lifecycle, missing_lifecycle_state, missing_review_after |
-| docs/reports/domain-node-write-path-proof.md |  | active | missing_lifecycle, missing_lifecycle_state, missing_review_after |
 | docs/reports/domain-provider-role-finding.md |  | active | missing_lifecycle, missing_lifecycle_state, missing_review_after |
-| docs/reports/domain-read-path-proof.md |  | active | missing_lifecycle, missing_lifecycle_state, missing_review_after |
 | docs/reports/inwx-zone-reconciliation-plan.md |  | active | missing_lifecycle, missing_lifecycle_state, missing_review_after |
 | docs/reports/map-architekturkritik.md |  | active | missing_lifecycle, missing_lifecycle_state, missing_review_after |
+| docs/reports/map-basemap-proof-gap-reconciliation.md |  | active | missing_lifecycle, missing_lifecycle_state, missing_review_after |
 | docs/reports/optimierungsbericht.md |  | active | missing_lifecycle, missing_lifecycle_state, missing_review_after |
 | docs/reports/passkey-register-verify-prep.md |  | active | missing_lifecycle, missing_lifecycle_state, missing_review_after |
 | docs/reports/planning-registration-findings.md |  | active | missing_lifecycle, missing_lifecycle_state, missing_review_after |

--- a/docs/reports/domain-account-write-path-proof.md
+++ b/docs/reports/domain-account-write-path-proof.md
@@ -3,6 +3,10 @@ id: reports.domain-account-write-path-proof
 title: "Domain Account Write Path Proof"
 doc_type: report
 status: active
+lifecycle_state: active
+lifecycle: proof
+owner_task: OPT-ARC-001
+review_after: 2026-07-16
 canonicality: evidence
 created: 2026-06-04
 lang: de
@@ -61,6 +65,13 @@ Geltende Grenzen:
 - Keine Entfernung von JSONL.
 - Kein Startup-Backfill.
 - Kein Produktions-Cutover. OPT-ARC-001 bleibt `partial`.
+
+## Lifecycle
+
+- Zweck: Belegt den OPT-ARC-001 PostgreSQL-Teilpfad für den Account-Schreibpfad `POST /accounts` im dokumentierten Scope.
+- Bereitet vor: Fortlaufende OPT-ARC-001 Cutover- und Proof-Matrix-Entscheidungen.
+- Gültig bis: Review am 2026-07-16 oder bis ein neuerer Proof diesen Bericht ersetzt.
+- Wird abgelöst durch: Noch offen; mögliche spätere Runtime-/Cutover-Proofs oder aktualisierte Proof-Matrix-Artefakte.
 
 ## Konfiguration
 

--- a/docs/reports/domain-backfill-proof.md
+++ b/docs/reports/domain-backfill-proof.md
@@ -3,6 +3,10 @@ id: reports.domain-backfill-proof
 title: Domain Backfill Proof
 doc_type: report
 status: active
+lifecycle_state: active
+lifecycle: proof
+owner_task: OPT-ARC-001
+review_after: 2026-07-16
 canonicality: evidence
 summary: >
   Proof-Bericht für OPT-ARC-001 Phase C: deterministischer JSONL→PostgreSQL-Backfill
@@ -32,6 +36,13 @@ Phase C only: deterministic JSONL→PostgreSQL import proof for domain data (nod
 - No API endpoint behavior changes.
 - No production data migration on API startup.
 - Does not mark OPT-ARC-001 done.
+
+## Lifecycle
+
+- Zweck: Belegt den OPT-ARC-001 PostgreSQL-Teilpfad für den deterministischen JSONL→PostgreSQL-Backfill im dokumentierten Scope.
+- Bereitet vor: Fortlaufende OPT-ARC-001 Cutover- und Proof-Matrix-Entscheidungen.
+- Gültig bis: Review am 2026-07-16 oder bis ein neuerer Proof diesen Bericht ersetzt.
+- Wird abgelöst durch: Noch offen; mögliche spätere Runtime-/Cutover-Proofs oder aktualisierte Proof-Matrix-Artefakte.
 
 ## Phase Boundary Confirmation
 

--- a/docs/reports/domain-edge-create-semantics-preflight.md
+++ b/docs/reports/domain-edge-create-semantics-preflight.md
@@ -2,7 +2,11 @@
 id: reports.domain-edge-create-semantics-preflight
 title: "Domain Edge Create Semantics Preflight — OPT-ARC-001 Phase E-C"
 doc_type: report
-status: active
+status: deprecated
+lifecycle_state: superseded
+lifecycle: decision-prep
+owner_task: OPT-ARC-001
+superseded_by: docs/reports/domain-edge-write-path-proof.md
 created: 2026-06-11
 lang: de
 summary: >
@@ -55,6 +59,13 @@ Status: diagnostic
   PostgreSQL-Write + Proof-Ripple). Ein einzelner PR wäre zu breit: er vermischt
   Contract-Klärung, Runtime-Logik, ein neues Config-Feld mit ~17 betroffenen
   `AppConfig`-Literalen und einen großen Proof-/Task-Control-Ripple.
+
+## Lifecycle
+
+- Zweck: Dokumentierte die Entscheidungs- und Semantikvorbereitung für OPT-ARC-001 Phase E-C.
+- Bereitet vor: Den späteren Edge-Write-Proof und dessen Proof-/Status-Ripple.
+- Gültig bis: Abgelöst durch den Edge-Write-Path-Proof.
+- Wird abgelöst durch: `docs/reports/domain-edge-write-path-proof.md`.
 
 ## Belege
 

--- a/docs/reports/domain-edge-reference-audit.md
+++ b/docs/reports/domain-edge-reference-audit.md
@@ -3,6 +3,10 @@ id: reports.domain-edge-reference-audit
 title: "Domain Edge Reference Audit — OPT-ARC-001 Teilaufgabe 4"
 doc_type: report
 status: active
+lifecycle_state: active
+lifecycle: audit
+owner_task: OPT-ARC-001
+review_after: 2026-07-16
 created: 2026-06-14
 lang: de
 summary: >
@@ -63,6 +67,13 @@ Nicht geprüft oder nicht geändert:
 - keine Edge-Normalisierung
 - keine Quarantäne-Mutation
 - keine JSONL-Demontage
+
+## Lifecycle
+
+- Zweck: Auditiert Edge-Referenzen gegen vorhandene Nodes und bereitet die FK-Entscheidung vor.
+- Bereitet vor: OPT-ARC-001 Entscheidung zwischen strikten Node-FKs und loser Referenzsemantik.
+- Gültig bis: Review am 2026-07-16 oder bis ein repräsentativer Runtime-Datenlauf den Audit ersetzt.
+- Wird abgelöst durch: Noch offen; erforderlich ist ein Auditlauf gegen repräsentative Runtime-Daten.
 
 ## Blueprint-Anker
 

--- a/docs/reports/domain-edge-write-path-proof.md
+++ b/docs/reports/domain-edge-write-path-proof.md
@@ -3,6 +3,10 @@ id: reports.domain-edge-write-path-proof
 title: "Domain Edge Write Path Proof"
 doc_type: report
 status: active
+lifecycle_state: active
+lifecycle: proof
+owner_task: OPT-ARC-001
+review_after: 2026-07-16
 canonicality: evidence
 created: 2026-06-12
 lang: de
@@ -38,6 +42,13 @@ Edge-Writes waren im PostgreSQL-Cutover offen: `POST /edges` schrieb
 ausschließlich JSONL und wurde unter `WELTGEWEBE_DOMAIN_READ_SOURCE=postgres`
 pauschal mit 409 blockiert. Damit blieb der dritte Domain-Schreibpfad (nach
 Account-Create E-A und Node-Patch E-B) ohne PostgreSQL-Persistenz.
+
+## Lifecycle
+
+- Zweck: Belegt den OPT-ARC-001 PostgreSQL-Teilpfad für den Edge-Schreibpfad `POST /edges` im dokumentierten Scope.
+- Bereitet vor: Fortlaufende OPT-ARC-001 Cutover- und Proof-Matrix-Entscheidungen.
+- Gültig bis: Review am 2026-07-16 oder bis ein neuerer Proof diesen Bericht ersetzt.
+- Wird abgelöst durch: Noch offen; mögliche spätere Runtime-/Cutover-Proofs oder aktualisierte Proof-Matrix-Artefakte.
 
 ## Implementierte Semantik
 

--- a/docs/reports/domain-node-write-path-proof.md
+++ b/docs/reports/domain-node-write-path-proof.md
@@ -3,6 +3,10 @@ id: reports.domain-node-write-path-proof
 title: "Domain Node Write Path Proof"
 doc_type: report
 status: active
+lifecycle_state: active
+lifecycle: proof
+owner_task: OPT-ARC-001
+review_after: 2026-07-16
 canonicality: evidence
 created: 2026-06-05
 lang: de
@@ -42,6 +46,13 @@ OPT-ARC-001 Phase E-B implementiert einen engen PostgreSQL-Write-Path nur für
 - kein JSONL-Abbau
 - kein Produktions-Cutover
 - kein Dual-Write
+
+## Lifecycle
+
+- Zweck: Belegt den OPT-ARC-001 PostgreSQL-Teilpfad für den Node-Schreibpfad `PATCH /nodes` im dokumentierten Scope.
+- Bereitet vor: Fortlaufende OPT-ARC-001 Cutover- und Proof-Matrix-Entscheidungen.
+- Gültig bis: Review am 2026-07-16 oder bis ein neuerer Proof diesen Bericht ersetzt.
+- Wird abgelöst durch: Noch offen; mögliche spätere Runtime-/Cutover-Proofs oder aktualisierte Proof-Matrix-Artefakte.
 
 ## Config-Matrix
 

--- a/docs/reports/domain-read-path-proof.md
+++ b/docs/reports/domain-read-path-proof.md
@@ -3,6 +3,10 @@ id: reports.domain-read-path-proof
 title: "Domain Read Path Proof"
 doc_type: report
 status: active
+lifecycle_state: active
+lifecycle: proof
+owner_task: OPT-ARC-001
+review_after: 2026-07-16
 created: 2026-06-03
 lang: de
 summary: >
@@ -48,6 +52,13 @@ Geltende Grenzen:
 > Account-Write-Source weiterhin `jsonl` ist. Knoten-, Kanten-, Step-up-E-Mail-
 > und WebAuthn-Writeback-Mutationen bleiben blockiert bzw. unverändert. Details:
 > `docs/reports/domain-account-write-path-proof.md`.
+
+## Lifecycle
+
+- Zweck: Belegt den OPT-ARC-001 PostgreSQL-Teilpfad für den optionalen PostgreSQL-Read-Path im dokumentierten Scope.
+- Bereitet vor: Fortlaufende OPT-ARC-001 Cutover- und Proof-Matrix-Entscheidungen.
+- Gültig bis: Review am 2026-07-16 oder bis ein neuerer Proof diesen Bericht ersetzt.
+- Wird abgelöst durch: Noch offen; mögliche spätere Runtime-/Cutover-Proofs oder aktualisierte Proof-Matrix-Artefakte.
 
 ## Implementierte Belege
 


### PR DESCRIPTION
## Summary

Classifies OPT-ARC-001-related reports with report lifecycle metadata.

## What changed

- Adds lifecycle metadata to active OPT-ARC proof reports.
- Marks the Edge Create Semantics Preflight as superseded by the Edge Write Path Proof.
- Adds short `## Lifecycle` blocks without rewriting report content.
- Regenerates report lifecycle overview and inventory.

## Scope

Touched report files:

- `docs/reports/domain-read-path-proof.md`
- `docs/reports/domain-backfill-proof.md`
- `docs/reports/domain-account-write-path-proof.md`
- `docs/reports/domain-node-write-path-proof.md`
- `docs/reports/domain-edge-write-path-proof.md`
- `docs/reports/domain-edge-create-semantics-preflight.md`
- `docs/reports/domain-edge-reference-audit.md`

Generated files:

- `docs/_generated/report-lifecycle.md`
- `docs/_generated/report-lifecycle-inventory.md`

> Note: `docs/_generated/doc-index.md` was intentionally **not** included. Regenerating it surfaced the preflight status flip *plus* unrelated pre-existing drift (new rows for `map-basemap-proof-gap-reconciliation.md` and `domain-edge-reference-audit.md` that predate this PR), so it did not *exclusively* reflect this change. Same reasoning for `backlinks.md` / `relates-to-audit.md` / `relations-analysis.md`: pre-existing drift only — no `relations:` frontmatter was modified in this PR.

## Non-goals

- No report content rewrite.
- No proof-matrix update.
- No optimization-status update.
- No task-board update.
- No CI or workflow change.
- No validator change.
- No strict/warn/changed-only mode.
- No archive move.
- No deletion.
- No runtime or app code change.

## Checks

- [x] `python3 -m scripts.docmeta.validate_report_lifecycle --mode report`
- [x] `python3 -m scripts.docmeta.generate_report_lifecycle`
- [x] `python3 -m scripts.docmeta.generate_report_lifecycle_inventory`
- [x] `python3 -m scripts.docmeta.validate_opt_arc_001_db_proof_matrix`
- [x] `PYTHONPATH=$(pwd) python3 -m unittest scripts.docmeta.tests.test_validate_report_lifecycle`
- [x] `PYTHONPATH=$(pwd) python3 -m unittest scripts.docmeta.tests.test_generate_report_lifecycle`
- [x] `PYTHONPATH=$(pwd) python3 -m unittest scripts.docmeta.tests.test_generate_report_lifecycle_inventory`
- [x] `git diff --check`
- [x] Scope gate confirms no runtime, CI, task, proof-matrix or optimization-status files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVP76Y9fLnEVD9A5E1hxtj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVP76Y9fLnEVD9A5E1hxtj)_