### PR TITLE
scripts: add warn and strict modes to report lifecycle validator

### DIFF
--- a/scripts/docmeta/tests/test_validate_report_lifecycle.py
+++ b/scripts/docmeta/tests/test_validate_report_lifecycle.py
@@ -8,7 +8,27 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-from scripts.docmeta.validate_report_lifecycle import main, run, _validate_report
+from scripts.docmeta.validate_report_lifecycle import (
+    Finding,
+    main,
+    run,
+    _validate_report,
+    _gha_escape_data,
+    _gha_escape_property,
+    _render_github_warnings,
+)
+
+
+VALID_REPORT_FRONTMATTER = """
+id: reports.example
+title: Example
+doc_type: report
+status: active
+lifecycle_state: active
+lifecycle: audit
+owner_task: OPT-ARC-001
+review_after: 2026-07-13
+"""
 
 
 def write_report(root: Path, name: str, frontmatter: str, body: str = "Body\n") -> Path:
@@ -51,6 +71,100 @@ status: active
         self.assertIn("missing_lifecycle", stdout)
         self.assertIn("missing_review_after", stdout)
         self.assertEqual(stderr, "")
+
+    def test_warn_mode_exits_zero_and_emits_github_warnings(self) -> None:
+        # Fixture with at least one lifecycle finding (missing lifecycle_state)
+        write_report(
+            self.tmp_root,
+            "example.md",
+            """
+id: reports.example
+title: Example
+doc_type: report
+status: active
+            """
+        )
+
+        exit_code, stdout, stderr = self.run_main(["--mode", "warn", "--root", str(self.tmp_root)])
+        self.assertEqual(exit_code, 0)
+        self.assertIn("::warning", stdout)
+        self.assertIn("docs/reports/example.md", stdout)
+        self.assertIn("missing_lifecycle_state", stdout)
+        # Markdown report (summary) is still emitted alongside the annotations.
+        self.assertIn("## Summary", stdout)
+        self.assertEqual(stderr, "")
+
+    def test_warn_mode_exits_zero_without_findings(self) -> None:
+        # Fixture: minimal valid report (no findings).
+        write_report(self.tmp_root, "example.md", VALID_REPORT_FRONTMATTER)
+
+        exit_code, stdout, stderr = self.run_main(["--mode", "warn", "--root", str(self.tmp_root)])
+        self.assertEqual(exit_code, 0)
+        self.assertNotIn("::warning", stdout)
+        self.assertIn("| findings_total | 0 |", stdout)
+        self.assertIn("No findings.", stdout)
+        self.assertEqual(stderr, "")
+
+    def test_strict_mode_exits_one_with_findings(self) -> None:
+        # Fixture with at least one lifecycle finding.
+        write_report(
+            self.tmp_root,
+            "example.md",
+            """
+id: reports.example
+title: Example
+doc_type: report
+status: active
+            """
+        )
+
+        exit_code, stdout, stderr = self.run_main(["--mode", "strict", "--root", str(self.tmp_root)])
+        self.assertEqual(exit_code, 1)
+        self.assertIn("## Summary", stdout)
+        self.assertIn("missing_lifecycle_state", stdout)
+        self.assertEqual(stderr, "")
+
+    def test_strict_mode_exits_zero_without_findings(self) -> None:
+        # Fixture: minimal valid report (no findings).
+        write_report(self.tmp_root, "example.md", VALID_REPORT_FRONTMATTER)
+
+        exit_code, stdout, stderr = self.run_main(["--mode", "strict", "--root", str(self.tmp_root)])
+        self.assertEqual(exit_code, 0)
+        self.assertIn("| findings_total | 0 |", stdout)
+        self.assertIn("No findings.", stdout)
+        self.assertEqual(stderr, "")
+
+    def test_github_warning_annotation_escapes_special_characters(self) -> None:
+        # Data escaping: percent first, then CR/LF.
+        self.assertEqual(_gha_escape_data("100%"), "100%25")
+        self.assertEqual(_gha_escape_data("line1\nline2"), "line1%0Aline2")
+        self.assertEqual(_gha_escape_data("a\rb"), "a%0Db")
+        # Property escaping additionally handles ":" and ",".
+        self.assertEqual(_gha_escape_property("a:b"), "a%3Ab")
+        self.assertEqual(_gha_escape_property("a,b"), "a%2Cb")
+        # Percent is escaped first, so no double-escaping of the "%0A"/"%3A" markers.
+        self.assertEqual(_gha_escape_property("%\n:"), "%25%0A%3A")
+
+        # End-to-end: the rendered annotation escapes path (property) and message (data).
+        finding = Finding(
+            path="docs/reports/weird,name.md",
+            code="missing_lifecycle_state",
+            severity="warn",
+            field="lifecycle_state",
+            message="needs 100% coverage: now",
+        )
+        rendered = _render_github_warnings([finding])
+        self.assertIn("::warning ", rendered)
+        self.assertIn("file=docs/reports/weird%2Cname.md", rendered)
+        self.assertIn("title=Report lifecycle finding", rendered)
+        # The message uses data escaping, so ":" stays but "%" becomes "%25".
+        self.assertIn("missing_lifecycle_state: needs 100%25 coverage: now", rendered)
+
+    def test_invalid_mode_is_rejected(self) -> None:
+        # argparse `choices` rejects unknown modes with a non-zero SystemExit.
+        with self.assertRaises(SystemExit) as ctx:
+            self.run_main(["--mode", "nonsense", "--root", str(self.tmp_root)])
+        self.assertNotEqual(ctx.exception.code, 0)
 
     def test_active_report_missing_lifecycle_and_review_after(self) -> None:
         # Fixture

--- a/scripts/docmeta/tests/test_validate_report_lifecycle.py
+++ b/scripts/docmeta/tests/test_validate_report_lifecycle.py
@@ -134,6 +134,12 @@ status: active
         self.assertIn("No findings.", stdout)
         self.assertEqual(stderr, "")
 
+    def test_run_rejects_invalid_mode(self) -> None:
+        # run(root, mode) should reject unsupported modes directly.
+        with self.assertRaises(ValueError) as ctx:
+            run(self.tmp_root, "nonsense")
+        self.assertIn("unsupported report lifecycle mode", str(ctx.exception))
+
     def test_github_warning_annotation_escapes_special_characters(self) -> None:
         # Data escaping: percent first, then CR/LF.
         self.assertEqual(_gha_escape_data("100%"), "100%25")

--- a/scripts/docmeta/validate_report_lifecycle.py
+++ b/scripts/docmeta/validate_report_lifecycle.py
@@ -184,6 +184,33 @@ def _render_report(findings: list[Finding], summary: dict[str, int], mode: str) 
     return "\n".join(lines) + "\n"
 
 
+def _gha_escape_data(value: str) -> str:
+    return (
+        value
+        .replace("%", "%25")
+        .replace("\r", "%0D")
+        .replace("\n", "%0A")
+    )
+
+
+def _gha_escape_property(value: str) -> str:
+    return (
+        _gha_escape_data(value)
+        .replace(":", "%3A")
+        .replace(",", "%2C")
+    )
+
+
+def _render_github_warnings(findings: list[Finding]) -> str:
+    lines: list[str] = []
+    for finding in findings:
+        file_prop = _gha_escape_property(str(finding.path))
+        title_prop = _gha_escape_property("Report lifecycle finding")
+        message = _gha_escape_data(f"{finding.code}: {finding.message}")
+        lines.append(f"::warning file={file_prop},title={title_prop}::{message}")
+    return "\n".join(lines)
+
+
 def run(root: Path, mode: str) -> tuple[str, int]:
     paths = _iter_report_paths(root)
     all_findings = []
@@ -208,15 +235,24 @@ def run(root: Path, mode: str) -> tuple[str, int]:
         reports_checked=reports_checked,
         reports_ignored_non_report=reports_ignored_non_report,
     )
-    report_str = _render_report(all_findings, summary, mode)
-    return report_str, 0
+    output = _render_report(all_findings, summary, mode)
+
+    if mode == "warn":
+        warnings = _render_github_warnings(all_findings)
+        if warnings:
+            output = output + "\n" + warnings + "\n"
+
+    if mode == "strict" and summary["findings_total"] > 0:
+        return output, 1
+
+    return output, 0
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Validate report lifecycle metadata.")
     parser.add_argument(
         "--mode",
-        choices=["report"],
+        choices=["report", "warn", "strict"],
         default="report",
         help="Validation mode"
     )

--- a/scripts/docmeta/validate_report_lifecycle.py
+++ b/scripts/docmeta/validate_report_lifecycle.py
@@ -12,6 +12,7 @@ if __package__ in {None, ""}:
 from scripts.docmeta.docmeta import parse_frontmatter
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+VALID_MODES = ("report", "warn", "strict")
 
 
 @dataclass(frozen=True)
@@ -212,6 +213,8 @@ def _render_github_warnings(findings: list[Finding]) -> str:
 
 
 def run(root: Path, mode: str) -> tuple[str, int]:
+    if mode not in VALID_MODES:
+        raise ValueError(f"unsupported report lifecycle mode: {mode}")
     paths = _iter_report_paths(root)
     all_findings = []
     reports_checked = 0
@@ -252,7 +255,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Validate report lifecycle metadata.")
     parser.add_argument(
         "--mode",
-        choices=["report", "warn", "strict"],
+        choices=VALID_MODES,
         default="report",
         help="Validation mode"
     )


### PR DESCRIPTION
## Summary

Adds `warn` and `strict` modes to `validate_report_lifecycle`.

## What changed

- Keeps `--mode report` as non-blocking Markdown report mode.
- Adds `--mode warn` for non-blocking GitHub warning annotations.
- Adds `--mode strict` for failing when lifecycle findings exist.
- Adds tests for report, warn and strict behavior.
- Adds GitHub annotation escaping for warning output.

## Non-goals

- No CI activation of strict mode.
- No changed-only strict guard.
- No global lifecycle enforcement.
- No report lifecycle backfill.
- No generated doc refresh.
- No report content changes.
- No schema or contract change.

## Checks

- [x] `PYTHONPATH=$(pwd) python3 -m unittest scripts.docmeta.tests.test_validate_report_lifecycle` — 26 tests OK
- [x] `python3 -m scripts.docmeta.validate_report_lifecycle --mode report` — exit 0
- [x] `python3 -m scripts.docmeta.validate_report_lifecycle --mode warn` — exit 0, emits `::warning` annotations
- [x] `python3 -m scripts.docmeta.validate_report_lifecycle --mode strict || true` — exit 1 (known existing findings, expected)
- [x] `python3 -m scripts.docmeta.validate_relations` — passed (0 errors)
- [x] `python3 -m scripts.docmeta.validate_opt_arc_001_db_proof_matrix` — passed
- [x] `git diff --check` — clean
- [x] Scope limited to validator and tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HLxdWkhTvGx6Lijq71gPgx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLxdWkhTvGx6Lijq71gPgx)_