### PR TITLE
docs: backfill auth persistence report lifecycle metadata

### DIFF
--- a/docs/_generated/report-lifecycle-inventory.md
+++ b/docs/_generated/report-lifecycle-inventory.md
@@ -21,16 +21,16 @@ Primary references are exact path matches in canonical documentation surfaces. D
 | files_without_frontmatter | 0 |
 | files_with_status | 25 |
 | files_missing_status | 0 |
-| files_with_lifecycle_state | 8 |
-| files_missing_lifecycle_state | 17 |
-| files_with_lifecycle | 8 |
-| files_missing_lifecycle | 17 |
-| files_with_owner_task | 8 |
-| files_missing_owner_task | 17 |
-| files_with_review_after | 7 |
-| files_missing_review_after | 18 |
-| files_primary_referenced | 21 |
-| files_primary_unreferenced | 4 |
+| files_with_lifecycle_state | 13 |
+| files_missing_lifecycle_state | 12 |
+| files_with_lifecycle | 13 |
+| files_missing_lifecycle | 12 |
+| files_with_owner_task | 13 |
+| files_missing_owner_task | 12 |
+| files_with_review_after | 8 |
+| files_missing_review_after | 17 |
+| files_primary_referenced | 22 |
+| files_primary_unreferenced | 3 |
 | files_with_derived_references | 25 |
 | files_with_relations | 24 |
 | files_with_missing_supersession_target | 0 |
@@ -49,28 +49,28 @@ Primary references are exact path matches in canonical documentation surfaces. D
 | Path | doc_type | status | lifecycle_state | lifecycle | owner_task | review_after | superseded_by | primary refs | derived refs | relations | absent core lifecycle fields | supersession target diagnostic |
 | --- | --- | --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | --- | --- |
 | docs/reports/agent-readiness-audit.md | documentation | active |  |  |  |  |  | 2 | 4 | 1 | lifecycle, owner_task, review_after, lifecycle_state |  |
-| docs/reports/auth-persistence-direct-proof-diagnose-audit.md | report | active |  |  |  |  |  | 0 | 4 | 4 | lifecycle, owner_task, review_after, lifecycle_state |  |
-| docs/reports/auth-persistence-next-step.md | report | active |  |  |  |  |  | 5 | 5 | 4 | lifecycle, owner_task, review_after, lifecycle_state |  |
-| docs/reports/auth-persistence-readiness.md | report | active |  |  |  |  |  | 4 | 5 | 3 | lifecycle, owner_task, review_after, lifecycle_state |  |
-| docs/reports/auth-persistence-runtime-proof.md | report | active |  |  |  |  |  | 4 | 4 | 6 | lifecycle, owner_task, review_after, lifecycle_state |  |
-| docs/reports/auth-persistence-runtime-target-reconciliation.md | report | active |  |  |  |  |  | 1 | 4 | 5 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/auth-persistence-direct-proof-diagnose-audit.md | report | deprecated | superseded | audit | OPT-API-002 |  | docs/reports/optimierungsstatus.md | 0 | 4 | 4 | review_after |  |
+| docs/reports/auth-persistence-next-step.md | report | deprecated | superseded | decision-prep | OPT-API-002 |  | docs/reports/optimierungsstatus.md | 6 | 5 | 4 | review_after |  |
+| docs/reports/auth-persistence-readiness.md | report | deprecated | superseded | decision-prep | OPT-API-002 |  | docs/reports/auth-persistence-next-step.md | 4 | 5 | 3 | review_after |  |
+| docs/reports/auth-persistence-runtime-proof.md | report | deprecated | superseded | proof | OPT-API-002 |  | docs/reports/optimierungsstatus.md | 4 | 4 | 6 | review_after |  |
+| docs/reports/auth-persistence-runtime-target-reconciliation.md | report | active | active | decision-prep | OPT-API-002 | 2026-07-17 |  | 1 | 4 | 5 |  |  |
 | docs/reports/auth-status-matrix.md | reference | active |  |  |  |  |  | 5 | 4 | 3 | lifecycle, owner_task, review_after, lifecycle_state |  |
-| docs/reports/cost-report.md | reference | active |  |  |  |  |  | 0 | 4 | 0 | lifecycle, owner_task, review_after, lifecycle_state |  |
-| docs/reports/domain-account-email-uniqueness-audit.md | report | active | active | audit | OPT-ARC-001 | 2026-07-13 |  | 1 | 4 | 4 |  |  |
+| docs/reports/cost-report.md | reference | active |  |  |  |  |  | 1 | 4 | 0 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/domain-account-email-uniqueness-audit.md | report | active | active | audit | OPT-ARC-001 | 2026-07-13 |  | 2 | 4 | 4 |  |  |
 | docs/reports/domain-account-write-path-proof.md | report | active | active | proof | OPT-ARC-001 | 2026-07-16 |  | 7 | 4 | 6 |  |  |
 | docs/reports/domain-backfill-proof.md | report | active | active | proof | OPT-ARC-001 | 2026-07-16 |  | 3 | 4 | 4 |  |  |
 | docs/reports/domain-edge-create-semantics-preflight.md | report | deprecated | superseded | decision-prep | OPT-ARC-001 |  | docs/reports/domain-edge-write-path-proof.md | 1 | 5 | 7 | review_after |  |
-| docs/reports/domain-edge-reference-audit.md | report | active | active | audit | OPT-ARC-001 | 2026-07-16 |  | 0 | 4 | 6 |  |  |
+| docs/reports/domain-edge-reference-audit.md | report | active | active | audit | OPT-ARC-001 | 2026-07-16 |  | 0 | 3 | 6 |  |  |
 | docs/reports/domain-edge-write-path-proof.md | report | active | active | proof | OPT-ARC-001 | 2026-07-16 |  | 3 | 6 | 8 |  |  |
 | docs/reports/domain-node-write-path-proof.md | report | active | active | proof | OPT-ARC-001 | 2026-07-16 |  | 5 | 4 | 6 |  |  |
 | docs/reports/domain-provider-role-finding.md | report | active |  |  |  |  |  | 1 | 4 | 3 | lifecycle, owner_task, review_after, lifecycle_state |  |
 | docs/reports/domain-read-path-proof.md | report | active | active | proof | OPT-ARC-001 | 2026-07-16 |  | 5 | 4 | 5 |  |  |
 | docs/reports/inwx-zone-reconciliation-plan.md | report | active |  |  |  |  |  | 1 | 4 | 4 | lifecycle, owner_task, review_after, lifecycle_state |  |
 | docs/reports/map-architekturkritik.md | report | active |  |  |  |  |  | 4 | 5 | 2 | lifecycle, owner_task, review_after, lifecycle_state |  |
-| docs/reports/map-basemap-proof-gap-reconciliation.md | report | active |  |  |  |  |  | 2 | 4 | 6 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/map-basemap-proof-gap-reconciliation.md | report | active |  |  |  |  |  | 2 | 3 | 6 | lifecycle, owner_task, review_after, lifecycle_state |  |
 | docs/reports/map-status-matrix.md | status-matrix | active |  |  |  |  |  | 8 | 5 | 3 | lifecycle, owner_task, review_after, lifecycle_state |  |
 | docs/reports/optimierungsbericht.md | report | active |  |  |  |  |  | 2 | 4 | 4 | lifecycle, owner_task, review_after, lifecycle_state |  |
-| docs/reports/optimierungsstatus.md | status-matrix | active |  |  |  |  |  | 17 | 5 | 4 | lifecycle, owner_task, review_after, lifecycle_state |  |
+| docs/reports/optimierungsstatus.md | status-matrix | active |  |  |  |  |  | 19 | 5 | 4 | lifecycle, owner_task, review_after, lifecycle_state |  |
 | docs/reports/passkey-register-verify-prep.md | report | active |  |  |  |  |  | 0 | 4 | 4 | lifecycle, owner_task, review_after, lifecycle_state |  |
 | docs/reports/planning-registration-findings.md | report | active |  |  |  |  |  | 1 | 4 | 2 | lifecycle, owner_task, review_after, lifecycle_state |  |
 
@@ -79,11 +79,10 @@ Primary references are exact path matches in canonical documentation surfaces. D
 | Path | Absent fields |
 | --- | --- |
 | docs/reports/agent-readiness-audit.md | lifecycle, owner_task, review_after, lifecycle_state |
-| docs/reports/auth-persistence-direct-proof-diagnose-audit.md | lifecycle, owner_task, review_after, lifecycle_state |
-| docs/reports/auth-persistence-next-step.md | lifecycle, owner_task, review_after, lifecycle_state |
-| docs/reports/auth-persistence-readiness.md | lifecycle, owner_task, review_after, lifecycle_state |
-| docs/reports/auth-persistence-runtime-proof.md | lifecycle, owner_task, review_after, lifecycle_state |
-| docs/reports/auth-persistence-runtime-target-reconciliation.md | lifecycle, owner_task, review_after, lifecycle_state |
+| docs/reports/auth-persistence-direct-proof-diagnose-audit.md | review_after |
+| docs/reports/auth-persistence-next-step.md | review_after |
+| docs/reports/auth-persistence-readiness.md | review_after |
+| docs/reports/auth-persistence-runtime-proof.md | review_after |
 | docs/reports/auth-status-matrix.md | lifecycle, owner_task, review_after, lifecycle_state |
 | docs/reports/cost-report.md | lifecycle, owner_task, review_after, lifecycle_state |
 | docs/reports/domain-edge-create-semantics-preflight.md | review_after |
@@ -136,6 +135,7 @@ Primary references are exact path matches in canonical documentation surfaces. D
   - `docs/blueprints/auth-persistence-runtime-proof.md`
   - `docs/proofs/sqlx-pgbouncer-session-crud-proof.md`
   - `docs/reports/auth-persistence-direct-proof-diagnose-audit.md`
+  - `docs/reports/auth-persistence-readiness.md`
   - `docs/reports/auth-persistence-runtime-proof.md`
   - `docs/reports/passkey-register-verify-prep.md`
 
@@ -161,8 +161,12 @@ Primary references are exact path matches in canonical documentation surfaces. D
   - `docs/reports/passkey-register-verify-prep.md`
   - `docs/roadmap.md`
 
+- `docs/reports/cost-report.md`
+  - `docs/tasks/board.md`
+
 - `docs/reports/domain-account-email-uniqueness-audit.md`
   - `docs/reports/domain-backfill-proof.md`
+  - `docs/tasks/board.md`
 
 - `docs/reports/domain-account-write-path-proof.md`
   - `docs/blueprints/domain-data-postgres-cutover.md`
@@ -236,8 +240,10 @@ Primary references are exact path matches in canonical documentation surfaces. D
   - `docs/blueprints/doc-structure-task-control-roadmap.md`
   - `docs/blueprints/doc-structure-task-control.md`
   - `docs/blueprints/domain-data-postgres-cutover.md`
+  - `docs/reports/auth-persistence-direct-proof-diagnose-audit.md`
   - `docs/reports/auth-persistence-next-step.md`
   - `docs/reports/auth-persistence-readiness.md`
+  - `docs/reports/auth-persistence-runtime-proof.md`
   - `docs/reports/domain-account-write-path-proof.md`
   - `docs/reports/domain-edge-create-semantics-preflight.md`
   - `docs/reports/domain-edge-write-path-proof.md`
@@ -331,7 +337,6 @@ Primary references are exact path matches in canonical documentation surfaces. D
 
 - `docs/reports/domain-edge-reference-audit.md`
   - `docs/_generated/backlinks.md`
-  - `docs/_generated/doc-index.md`
   - `docs/_generated/relates-to-audit.md`
   - `docs/_generated/report-lifecycle.md`
 
@@ -376,7 +381,6 @@ Primary references are exact path matches in canonical documentation surfaces. D
 
 - `docs/reports/map-basemap-proof-gap-reconciliation.md`
   - `docs/_generated/backlinks.md`
-  - `docs/_generated/doc-index.md`
   - `docs/_generated/relates-to-audit.md`
   - `docs/_generated/report-lifecycle.md`
 
@@ -415,7 +419,6 @@ Primary references are exact path matches in canonical documentation surfaces. D
 ## Primary Unreferenced Reports
 
 - `docs/reports/auth-persistence-direct-proof-diagnose-audit.md`
-- `docs/reports/cost-report.md`
 - `docs/reports/domain-edge-reference-audit.md`
 - `docs/reports/passkey-register-verify-prep.md`
 

--- a/docs/_generated/report-lifecycle-inventory.md
+++ b/docs/_generated/report-lifecycle-inventory.md
@@ -53,7 +53,7 @@ Primary references are exact path matches in canonical documentation surfaces. D
 | docs/reports/auth-persistence-next-step.md | report | deprecated | superseded | decision-prep | OPT-API-002 |  | docs/reports/optimierungsstatus.md | 6 | 5 | 4 | review_after |  |
 | docs/reports/auth-persistence-readiness.md | report | deprecated | superseded | decision-prep | OPT-API-002 |  | docs/reports/auth-persistence-next-step.md | 4 | 5 | 3 | review_after |  |
 | docs/reports/auth-persistence-runtime-proof.md | report | deprecated | superseded | proof | OPT-API-002 |  | docs/reports/optimierungsstatus.md | 4 | 4 | 6 | review_after |  |
-| docs/reports/auth-persistence-runtime-target-reconciliation.md | report | active | active | decision-prep | OPT-API-002 | 2026-07-17 |  | 1 | 4 | 5 |  |  |
+| docs/reports/auth-persistence-runtime-target-reconciliation.md | report | active | active | audit | OPT-API-002 | 2026-07-17 |  | 1 | 4 | 5 |  |  |
 | docs/reports/auth-status-matrix.md | reference | active |  |  |  |  |  | 5 | 4 | 3 | lifecycle, owner_task, review_after, lifecycle_state |  |
 | docs/reports/cost-report.md | reference | active |  |  |  |  |  | 1 | 4 | 0 | lifecycle, owner_task, review_after, lifecycle_state |  |
 | docs/reports/domain-account-email-uniqueness-audit.md | report | active | active | audit | OPT-ARC-001 | 2026-07-13 |  | 2 | 4 | 4 |  |  |

--- a/docs/_generated/report-lifecycle.md
+++ b/docs/_generated/report-lifecycle.md
@@ -45,7 +45,7 @@ This overview is descriptive only. It surfaces lifecycle metadata and validator 
 
 | Report | status | lifecycle | owner_task | review_after | findings |
 | --- | --- | --- | --- | --- | --- |
-| docs/reports/auth-persistence-runtime-target-reconciliation.md | active | decision-prep | OPT-API-002 | 2026-07-17 |  |
+| docs/reports/auth-persistence-runtime-target-reconciliation.md | active | audit | OPT-API-002 | 2026-07-17 |  |
 | docs/reports/domain-account-email-uniqueness-audit.md | active | audit | OPT-ARC-001 | 2026-07-13 |  |
 | docs/reports/domain-account-write-path-proof.md | active | proof | OPT-ARC-001 | 2026-07-16 |  |
 | docs/reports/domain-backfill-proof.md | active | proof | OPT-ARC-001 | 2026-07-16 |  |

--- a/docs/_generated/report-lifecycle.md
+++ b/docs/_generated/report-lifecycle.md
@@ -19,32 +19,33 @@ This overview is descriptive only. It surfaces lifecycle metadata and validator 
 | files_scanned | 25 |
 | reports_checked | 20 |
 | reports_ignored_non_report | 5 |
-| reports_with_lifecycle_state | 8 |
-| reports_missing_lifecycle_state | 12 |
-| findings_total | 36 |
+| reports_with_lifecycle_state | 13 |
+| reports_missing_lifecycle_state | 7 |
+| findings_total | 21 |
 
 ## Lifecycle State Summary
 
 | lifecycle_state | Count |
 | --- | ---: |
-| active | 7 |
+| active | 8 |
 | deferred | 0 |
-| superseded | 1 |
+| superseded | 5 |
 | archived | 0 |
-| missing | 12 |
+| missing | 7 |
 
 ## Finding Summary
 
 | Code | Count |
 | --- | ---: |
-| missing_lifecycle | 12 |
-| missing_lifecycle_state | 12 |
-| missing_review_after | 12 |
+| missing_lifecycle | 7 |
+| missing_lifecycle_state | 7 |
+| missing_review_after | 7 |
 
 ## Active Reports
 
 | Report | status | lifecycle | owner_task | review_after | findings |
 | --- | --- | --- | --- | --- | --- |
+| docs/reports/auth-persistence-runtime-target-reconciliation.md | active | decision-prep | OPT-API-002 | 2026-07-17 |  |
 | docs/reports/domain-account-email-uniqueness-audit.md | active | audit | OPT-ARC-001 | 2026-07-13 |  |
 | docs/reports/domain-account-write-path-proof.md | active | proof | OPT-ARC-001 | 2026-07-16 |  |
 | docs/reports/domain-backfill-proof.md | active | proof | OPT-ARC-001 | 2026-07-16 |  |
@@ -63,6 +64,10 @@ This overview is descriptive only. It surfaces lifecycle metadata and validator 
 
 | Report | status | lifecycle | owner_task | review_after | findings |
 | --- | --- | --- | --- | --- | --- |
+| docs/reports/auth-persistence-direct-proof-diagnose-audit.md | deprecated | audit | OPT-API-002 |  |  |
+| docs/reports/auth-persistence-next-step.md | deprecated | decision-prep | OPT-API-002 |  |  |
+| docs/reports/auth-persistence-readiness.md | deprecated | decision-prep | OPT-API-002 |  |  |
+| docs/reports/auth-persistence-runtime-proof.md | deprecated | proof | OPT-API-002 |  |  |
 | docs/reports/domain-edge-create-semantics-preflight.md | deprecated | decision-prep | OPT-ARC-001 |  |  |
 
 ## Archived Reports
@@ -75,11 +80,6 @@ This overview is descriptive only. It surfaces lifecycle metadata and validator 
 
 | Report | status | lifecycle | owner_task | review_after | findings |
 | --- | --- | --- | --- | --- | --- |
-| docs/reports/auth-persistence-direct-proof-diagnose-audit.md | active |  |  |  | missing_lifecycle, missing_lifecycle_state, missing_review_after |
-| docs/reports/auth-persistence-next-step.md | active |  |  |  | missing_lifecycle, missing_lifecycle_state, missing_review_after |
-| docs/reports/auth-persistence-readiness.md | active |  |  |  | missing_lifecycle, missing_lifecycle_state, missing_review_after |
-| docs/reports/auth-persistence-runtime-proof.md | active |  |  |  | missing_lifecycle, missing_lifecycle_state, missing_review_after |
-| docs/reports/auth-persistence-runtime-target-reconciliation.md | active |  |  |  | missing_lifecycle, missing_lifecycle_state, missing_review_after |
 | docs/reports/domain-provider-role-finding.md | active |  |  |  | missing_lifecycle, missing_lifecycle_state, missing_review_after |
 | docs/reports/inwx-zone-reconciliation-plan.md | active |  |  |  | missing_lifecycle, missing_lifecycle_state, missing_review_after |
 | docs/reports/map-architekturkritik.md | active |  |  |  | missing_lifecycle, missing_lifecycle_state, missing_review_after |
@@ -92,11 +92,6 @@ This overview is descriptive only. It surfaces lifecycle metadata and validator 
 
 | Report | lifecycle_state | status | findings |
 | --- | --- | --- | --- |
-| docs/reports/auth-persistence-direct-proof-diagnose-audit.md |  | active | missing_lifecycle, missing_lifecycle_state, missing_review_after |
-| docs/reports/auth-persistence-next-step.md |  | active | missing_lifecycle, missing_lifecycle_state, missing_review_after |
-| docs/reports/auth-persistence-readiness.md |  | active | missing_lifecycle, missing_lifecycle_state, missing_review_after |
-| docs/reports/auth-persistence-runtime-proof.md |  | active | missing_lifecycle, missing_lifecycle_state, missing_review_after |
-| docs/reports/auth-persistence-runtime-target-reconciliation.md |  | active | missing_lifecycle, missing_lifecycle_state, missing_review_after |
 | docs/reports/domain-provider-role-finding.md |  | active | missing_lifecycle, missing_lifecycle_state, missing_review_after |
 | docs/reports/inwx-zone-reconciliation-plan.md |  | active | missing_lifecycle, missing_lifecycle_state, missing_review_after |
 | docs/reports/map-architekturkritik.md |  | active | missing_lifecycle, missing_lifecycle_state, missing_review_after |

--- a/docs/reports/auth-persistence-direct-proof-diagnose-audit.md
+++ b/docs/reports/auth-persistence-direct-proof-diagnose-audit.md
@@ -2,7 +2,11 @@
 id: reports.auth-persistence-direct-proof-diagnose-audit
 title: "Auth-Persistenz - Diagnose-Audit zum Direct-Postgres-Proof"
 doc_type: report
-status: active
+status: deprecated
+lifecycle_state: superseded
+lifecycle: audit
+owner_task: OPT-API-002
+superseded_by: docs/reports/optimierungsstatus.md
 created: 2026-05-14
 lang: de
 summary: >
@@ -31,6 +35,13 @@ relations:
 Hinweis zur Eingabe: `docs/proofs/auth-postgres-direct-proof.md` ist im Repo nicht vorhanden.
 Bewertet wurde stattdessen das vorhandene Dokument
 `docs/proofs/sqlx-postgres-direct-session-crud-proof.md`.
+
+## Lifecycle
+- **Lifecycle-State:** superseded
+- **Lifecycle:** audit
+- **Owner-Task:** OPT-API-002
+- **Superseded by:** `docs/reports/optimierungsstatus.md`
+- **Bewertung:** Historisches Diagnose-Audit zur korrekten Lesart des Direct-Postgres-Proofs. Die damalige Warnung vor einer Überdeutung bleibt als Kontext nützlich, ist aber durch die spätere implementierte und CI-belegte Session-Persistenz nicht mehr handlungsleitend.
 
 ## Urteil
 

--- a/docs/reports/auth-persistence-direct-proof-diagnose-audit.md
+++ b/docs/reports/auth-persistence-direct-proof-diagnose-audit.md
@@ -37,11 +37,15 @@ Bewertet wurde stattdessen das vorhandene Dokument
 `docs/proofs/sqlx-postgres-direct-session-crud-proof.md`.
 
 ## Lifecycle
+
 - **Lifecycle-State:** superseded
 - **Lifecycle:** audit
 - **Owner-Task:** OPT-API-002
 - **Superseded by:** `docs/reports/optimierungsstatus.md`
-- **Bewertung:** Historisches Diagnose-Audit zur korrekten Lesart des Direct-Postgres-Proofs. Die damalige Warnung vor einer Überdeutung bleibt als Kontext nützlich, ist aber durch die spätere implementierte und CI-belegte Session-Persistenz nicht mehr handlungsleitend.
+- **Bewertung:** Historisches Diagnose-Audit zur korrekten Lesart des
+  Direct-Postgres-Proofs. Die damalige Warnung vor einer Überdeutung bleibt als
+  Kontext nützlich, ist aber durch die spätere implementierte und CI-belegte
+  Session-Persistenz nicht mehr handlungsleitend.
 
 ## Urteil
 

--- a/docs/reports/auth-persistence-next-step.md
+++ b/docs/reports/auth-persistence-next-step.md
@@ -2,7 +2,11 @@
 id: reports.auth-persistence-next-step
 title: "Auth-Persistenz — Nächster Schritt"
 doc_type: report
-status: active
+status: deprecated
+lifecycle_state: superseded
+lifecycle: decision-prep
+owner_task: OPT-API-002
+superseded_by: docs/reports/optimierungsstatus.md
 created: 2026-05-04
 lang: de
 summary: >
@@ -34,6 +38,13 @@ relations:
 > **Zweck:** Diagnose- und Entscheidungsgrundlage. Kein Implementierungs-PR.
 > Ziel: belegter Ist-Zustand nach Migration-Schema-PR, Klärung offener
 > Implementierungsfragen, konkreter Folge-PR-Vorschlag.
+
+## Lifecycle
+- **Lifecycle-State:** superseded
+- **Lifecycle:** decision-prep
+- **Owner-Task:** OPT-API-002
+- **Superseded by:** `docs/reports/optimierungsstatus.md`
+- **Bewertung:** Historische Entscheidungs- und Umsetzungsvorbereitung. Der vorgeschlagene `DbSessionStore`-/PostgreSQL-Pfad ist inzwischen umgesetzt und im Optimierungsstatus belegt. Keine aktuelle Next-Step-Quelle.
 
 ---
 

--- a/docs/reports/auth-persistence-next-step.md
+++ b/docs/reports/auth-persistence-next-step.md
@@ -40,11 +40,14 @@ relations:
 > Implementierungsfragen, konkreter Folge-PR-Vorschlag.
 
 ## Lifecycle
+
 - **Lifecycle-State:** superseded
 - **Lifecycle:** decision-prep
 - **Owner-Task:** OPT-API-002
 - **Superseded by:** `docs/reports/optimierungsstatus.md`
-- **Bewertung:** Historische Entscheidungs- und Umsetzungsvorbereitung. Der vorgeschlagene `DbSessionStore`-/PostgreSQL-Pfad ist inzwischen umgesetzt und im Optimierungsstatus belegt. Keine aktuelle Next-Step-Quelle.
+- **Bewertung:** Historische Entscheidungs- und Umsetzungsvorbereitung. Der
+  vorgeschlagene `DbSessionStore`-/PostgreSQL-Pfad ist inzwischen umgesetzt
+  und im Optimierungsstatus belegt. Keine aktuelle Next-Step-Quelle.
 
 ---
 

--- a/docs/reports/auth-persistence-readiness.md
+++ b/docs/reports/auth-persistence-readiness.md
@@ -31,11 +31,14 @@ relations:
 > Ziel: belegter Ist-Zustand, fehlende Strukturen, Entscheidung, Testplan.
 
 ## Lifecycle
+
 - **Lifecycle-State:** superseded
 - **Lifecycle:** decision-prep
 - **Owner-Task:** OPT-API-002
 - **Superseded by:** `docs/reports/auth-persistence-next-step.md`
-- **Bewertung:** Historische Readiness-Diagnose. Der Bericht wurde durch den konkreteren Next-Step-Report abgelöst und enthält mittlerweile überholte Aussagen zum Fehlen von Migrationen. Keine aktuelle Umsetzungsquelle.
+- **Bewertung:** Historische Readiness-Diagnose. Der Bericht wurde durch den
+  konkreteren Next-Step-Report abgelöst und enthält mittlerweile überholte
+  Aussagen zum Fehlen von Migrationen. Keine aktuelle Umsetzungsquelle.
 
 ---
 

--- a/docs/reports/auth-persistence-readiness.md
+++ b/docs/reports/auth-persistence-readiness.md
@@ -2,7 +2,11 @@
 id: reports.auth-persistence-readiness
 title: "Auth-Persistenzbereitschaft — OPT-API-002"
 doc_type: report
-status: active
+status: deprecated
+lifecycle_state: superseded
+lifecycle: decision-prep
+owner_task: OPT-API-002
+superseded_by: docs/reports/auth-persistence-next-step.md
 created: 2026-04-28
 lang: de
 summary: >
@@ -25,6 +29,13 @@ relations:
 
 > **Zweck:** Diagnosebericht. Kein Patch, kein Umbau.
 > Ziel: belegter Ist-Zustand, fehlende Strukturen, Entscheidung, Testplan.
+
+## Lifecycle
+- **Lifecycle-State:** superseded
+- **Lifecycle:** decision-prep
+- **Owner-Task:** OPT-API-002
+- **Superseded by:** `docs/reports/auth-persistence-next-step.md`
+- **Bewertung:** Historische Readiness-Diagnose. Der Bericht wurde durch den konkreteren Next-Step-Report abgelöst und enthält mittlerweile überholte Aussagen zum Fehlen von Migrationen. Keine aktuelle Umsetzungsquelle.
 
 ---
 

--- a/docs/reports/auth-persistence-runtime-proof.md
+++ b/docs/reports/auth-persistence-runtime-proof.md
@@ -50,11 +50,14 @@ relations:
 > Blueprint: `docs/blueprints/auth-persistence-runtime-proof.md`
 
 ## Lifecycle
+
 - **Lifecycle-State:** superseded
 - **Lifecycle:** proof
 - **Owner-Task:** OPT-API-002
 - **Superseded by:** `docs/reports/optimierungsstatus.md`
-- **Bewertung:** Historischer Partial-Proof für Migration und CRUD-Pfad. Der Bericht bleibt als Belegkette nützlich, wurde aber durch die spätere `DbSessionStore`-Implementierung und den CI-belegten Persistenzpfad überholt.
+- **Bewertung:** Historischer Partial-Proof für Migration und CRUD-Pfad. Der
+  Bericht bleibt als Belegkette nützlich, wurde aber durch die spätere
+  `DbSessionStore`-Implementierung und den CI-belegten Persistenzpfad überholt.
 
 ---
 

--- a/docs/reports/auth-persistence-runtime-proof.md
+++ b/docs/reports/auth-persistence-runtime-proof.md
@@ -2,7 +2,11 @@
 id: reports.auth-persistence-runtime-proof
 title: "Auth-Persistenz — Runtime-Proof"
 doc_type: report
-status: active
+status: deprecated
+lifecycle_state: superseded
+lifecycle: proof
+owner_task: OPT-API-002
+superseded_by: docs/reports/optimierungsstatus.md
 created: 2026-05-12
 lang: de
 summary: >
@@ -44,6 +48,13 @@ relations:
 > direkten PostgreSQL-Zugriff.
 >
 > Blueprint: `docs/blueprints/auth-persistence-runtime-proof.md`
+
+## Lifecycle
+- **Lifecycle-State:** superseded
+- **Lifecycle:** proof
+- **Owner-Task:** OPT-API-002
+- **Superseded by:** `docs/reports/optimierungsstatus.md`
+- **Bewertung:** Historischer Partial-Proof für Migration und CRUD-Pfad. Der Bericht bleibt als Belegkette nützlich, wurde aber durch die spätere `DbSessionStore`-Implementierung und den CI-belegten Persistenzpfad überholt.
 
 ---
 

--- a/docs/reports/auth-persistence-runtime-target-reconciliation.md
+++ b/docs/reports/auth-persistence-runtime-target-reconciliation.md
@@ -3,6 +3,10 @@ id: reports.auth-persistence-runtime-target-reconciliation
 title: "Auth-Persistenz — Runtime-Zielarchitektur-Abgleich (PgBouncer vs. direkter Postgres)"
 doc_type: report
 status: active
+lifecycle_state: active
+lifecycle: decision-prep
+owner_task: OPT-API-002
+review_after: 2026-07-17
 created: 2026-05-13
 lang: de
 summary: >
@@ -39,6 +43,13 @@ relations:
 > **Kein Produktionscode. Kein CI-Job. Keine Session-Persistenz. Keine Compose-Änderung.**
 >
 > Aussagen sind als **PROVEN / NOT_PROVEN / CONFLICT_RESOLVED / DECIDED** markiert.
+
+## Lifecycle
+- **Lifecycle-State:** active
+- **Lifecycle:** decision-prep
+- **Owner-Task:** OPT-API-002
+- **Review after:** 2026-07-17
+- **Bewertung:** Weiterhin aktiver Architekturabgleich zur Produktionsentscheidung direkter PostgreSQL-Pfad vs. PgBouncer-Dev-/Spezialpfad. Keine neue Runtime-Aussage in diesem PR.
 
 ---
 

--- a/docs/reports/auth-persistence-runtime-target-reconciliation.md
+++ b/docs/reports/auth-persistence-runtime-target-reconciliation.md
@@ -4,7 +4,7 @@ title: "Auth-Persistenz — Runtime-Zielarchitektur-Abgleich (PgBouncer vs. dire
 doc_type: report
 status: active
 lifecycle_state: active
-lifecycle: decision-prep
+lifecycle: audit
 owner_task: OPT-API-002
 review_after: 2026-07-17
 created: 2026-05-13
@@ -45,11 +45,14 @@ relations:
 > Aussagen sind als **PROVEN / NOT_PROVEN / CONFLICT_RESOLVED / DECIDED** markiert.
 
 ## Lifecycle
+
 - **Lifecycle-State:** active
-- **Lifecycle:** decision-prep
+- **Lifecycle:** audit
 - **Owner-Task:** OPT-API-002
 - **Review after:** 2026-07-17
-- **Bewertung:** Weiterhin aktiver Architekturabgleich zur Produktionsentscheidung direkter PostgreSQL-Pfad vs. PgBouncer-Dev-/Spezialpfad. Keine neue Runtime-Aussage in diesem PR.
+- **Bewertung:** Weiterhin aktiver Architekturabgleich zur Produktionsentscheidung
+  direkter PostgreSQL-Pfad vs. PgBouncer-Dev-/Spezialpfad. Keine neue
+  Runtime-Aussage in diesem PR.
 
 ---
 


### PR DESCRIPTION
## Summary
Backfills lifecycle metadata for the Auth persistence report cluster.
## What changed
- Marks historical Auth persistence readiness, next-step, direct-proof audit and runtime-proof reports as superseded.
- Keeps the runtime target reconciliation report active as the current architecture reconciliation document.
- Adds short `## Lifecycle` sections to all five target reports.
- Regenerates report lifecycle generated surfaces.
## Non-goals
- No Auth runtime implementation.
- No database migration.
- No validator change.
- No CI strict activation.
- No global report lifecycle backfill.
- No task-board changes.
- No manual generated-file edits.
- No rewrite of historical report findings.
## Checks
- [x] `PYTHONPATH=$(pwd) python3 -m unittest scripts.docmeta.tests.test_validate_report_lifecycle`
- [x] `python3 -m scripts.docmeta.validate_report_lifecycle --mode report`
- [x] `python3 -m scripts.docmeta.validate_report_lifecycle --mode warn`
- [x] `python3 -m scripts.docmeta.validate_report_lifecycle --mode strict || true`
- [x] `python3 -m scripts.docmeta.validate_relations`
- [x] `python3 -m scripts.docmeta.validate_opt_arc_001_db_proof_matrix`
- [x] `./scripts/docmeta/generated-files-guard.sh`
- [x] `git diff --check`
- [x] Scope limited to Auth reports and generated lifecycle surfaces