### PR TITLE
fix(deploy): canonicalize public APP_BASE_URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,13 @@ jobs:
             bash "$t"
           done
 
+      - name: Validate production public base URL contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          REPO_ROOT="$GITHUB_WORKSPACE" \
+            bash scripts/guard/prod-public-base-url-guard.sh
+
       - name: Run core guard orchestrator
         shell: bash
         run: bash scripts/guard/run.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
           set -euo pipefail
           bash -n scripts/guard/domain-single-instance-guard.sh
           bash -n scripts/tests/test_domain_single_instance_guard.sh
+          bash -n scripts/guard/prod-public-base-url-guard.sh
+          bash -n scripts/tests/test_prod_public_base_url_guard.sh
           bash -n scripts/guard/run.sh
 
       - name: Run guard fixture suites
@@ -67,7 +69,8 @@ jobs:
             scripts/tests/test_token_leak_guard.sh \
             scripts/tests/test_compose_volumes_guard.sh \
             scripts/tests/test_metrics_ref_guard.sh \
-            scripts/tests/test_domain_single_instance_guard.sh
+            scripts/tests/test_domain_single_instance_guard.sh \
+            scripts/tests/test_prod_public_base_url_guard.sh
           do
             echo "── $t ──"
             bash "$t"

--- a/.github/workflows/contracts-validate.yml
+++ b/.github/workflows/contracts-validate.yml
@@ -1,191 +1,99 @@
 ---
 name: "contracts-validate"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
-
-concurrency:
-  # Keep PR-specific groups to prevent cross-branch cancellations.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
 
 "on":
   workflow_dispatch:
   push:
     paths:
-      - "json/**"
-      - "proto/**"
-      - "fixtures/**"
-      - ".github/workflows/**"   # ensure pin guard runs when ANY workflow changes
+      - "contracts/**/*.json"
+      - "tests/fixtures/**/*.json"
+      - ".github/workflows/contracts-validate.yml"
+      - "scripts/contracts-domain-check.sh"
   pull_request:
     paths:
-      - "json/**"
-      - "proto/**"
-      - "fixtures/**"
-      - ".github/workflows/**"   # ensure pin guard runs when ANY workflow changes
+      - "contracts/**/*.json"
+      - "tests/fixtures/**/*.json"
+      - ".github/workflows/contracts-validate.yml"
+      - "scripts/contracts-domain-check.sh"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 defaults:
   run:
     shell: bash --noprofile --norc -euo pipefail {0}
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-  FAIL_ON_NO_BASE: true
-  ALLOW_REMOVALS: false
-
 jobs:
-  version-sync-check:
-    name: "Security: enforce static pin for contracts reusable workflow"
+  json-syntax:
+    name: Validate contract and fixture JSON syntax
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
           persist-credentials: false
 
-      - name: Verify 'uses:' pins for heimgewebe/contracts
-        env:
-          REQUIRED_REPO: "heimgewebe/contracts/.github/workflows/contracts-ajv-reusable.yml"
-          REQUIRED_REF: "contracts-v1"
+      - name: Parse tracked contract and fixture JSON
         run: |
-          set -euo pipefail
-          shopt -s extglob
+          python3 - <<'PY'
+          import json
+          import subprocess
+          import sys
+          from pathlib import Path
 
-          files=()
-          while IFS= read -r -d '' f; do files+=("$f"); done < \
-            <(git ls-files -z -- '.github/workflows/*.yml' '.github/workflows/*.yaml' || true)
+          roots = ("contracts/", "tests/fixtures/")
+          tracked = subprocess.run(
+              ["git", "ls-files", "--", *roots],
+              check=True,
+              text=True,
+              capture_output=True,
+          ).stdout.splitlines()
+          paths = [Path(path) for path in tracked if path.endswith(".json")]
 
-          [[ ${#files[@]} -gt 0 ]] || { echo "::notice::No workflow files"; exit 0; }
+          if not paths:
+              print("ERROR: no tracked contract or fixture JSON files found", file=sys.stderr)
+              raise SystemExit(2)
 
-          # shellcheck disable=SC2254
-          extract_pair() {
-            local line="$1"
-            line="${line%%#*}"
-            line="${line##+([[:space:]])}"
-            line="${line%%+([[:space:]])}"
-            if [[ "$line" =~ ^(-[[:space:]]*)?uses:[[:space:]]*'([^']+)' ]]; then
-              echo "${BASHREMATCH[2]}"; return 0
-            fi
-            if [[ "$line" =~ ^(-[[:space:]]*)?uses:[[:space:]]*\"([^\"]+)\" ]]; then
-              echo "${BASHREMATCH[2]}"; return 0
-            fi
-            if [[ "$line" =~ ^(-[[:space:]]*)?uses:[[:space:]]*([^[:space:]#]+) ]]; then
-              echo "${BASHREMATCH[2]}"; return 0
-            fi
-            return 1
-          }
+          failures: list[str] = []
+          for path in paths:
+              try:
+                  json.loads(path.read_text(encoding="utf-8"))
+              except (OSError, json.JSONDecodeError) as exc:
+                  failures.append(f"{path}: {exc}")
 
-          check_pair() {
-            local wf="$1" repo="$2" ref="$3"
-            [[ "$repo" == "$REQUIRED_REPO" ]] || return 0
-            if [[ "$ref" =~ (\$\{|\$\(|\$[A-Za-z_]) ]]; then
-              echo "::error file=$wf::Dynamic ref not allowed: $ref"; return 1
-            fi
-            if [[ "$ref" != "$REQUIRED_REF" ]]; then
-              echo "::error file=$wf::Pin mismatch: expected '$REQUIRED_REF', got '$ref'"; return 1
-            fi
-            return 0
-          }
+          if failures:
+              for failure in failures:
+                  print(f"ERROR: {failure}", file=sys.stderr)
+              raise SystemExit(1)
 
-          mismatches=0
-          for wf in "${files[@]}"; do
-            while IFS= read -r line || [[ -n "$line" ]]; do
-              if pair="$(extract_pair "$line")"; then
-                [[ "$pair" == *"@"* ]] || continue
-                repo="${pair%@*}"; ref="${pair#*@}"
-                if ! check_pair "$wf" "$repo" "$ref"; then mismatches=1; fi
-              fi
-            done < "$wf"
-          done
+          print(f"Validated JSON syntax for {len(paths)} tracked files.")
+          PY
 
-          [[ $mismatches -eq 0 ]] || exit 1
-          echo "::notice::✅ All version pins validated"
-
-  guard:
-    name: "Security: guard deletion policy (json/proto)"
+  domain-contracts:
+    name: Compile domain schemas and validate examples
     runs-on: ubuntu-latest
     timeout-minutes: 8
-    env:
-      GH_DEFAULT_BRANCH: ${{ github.event.repository.default_branch || 'main' }}
-      GH_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-      GH_PUSH_BEFORE: ${{ github.event.before }}
-      PROTECTED_REGEX: '^(json|proto)/'
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           persist-credentials: false
 
-      - name: Enforce guard policy
-        run: |
-          set -euo pipefail
-          is_truthy() { case "${1:-0}" in 1|true|yes|on) return 0 ;; esac; return 1; }
+      - uses: pnpm/action-setup@v4
 
-          if is_truthy "${ALLOW_REMOVALS:-0}"; then
-            echo "::notice::ALLOW_REMOVALS=1 → skipping guard"
-            exit 0
-          fi
+      - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b
+        with:
+          node-version-file: ".node-version"
+          cache: "pnpm"
 
-          base=""
-          base_src=""
+      - name: Install AJV tooling
+        run: pnpm install --global ajv-cli ajv-formats
 
-          if [[ -n "${GH_PR_BASE_SHA:-}" ]] && git rev-parse --verify "${GH_PR_BASE_SHA}^{commit}" &>/dev/null; then
-            if mb="$(git merge-base "$GH_PR_BASE_SHA" HEAD 2>/dev/null)"; then
-              base="$mb"; base_src="merge-base(pr_base,HEAD)"
-            fi
-          fi
-
-          if [[ -z "$base" && -n "${GH_PUSH_BEFORE:-}" && ! "${GH_PUSH_BEFORE}" =~ ^0{40}$ ]] \
-             && git rev-parse --verify "${GH_PUSH_BEFORE}^{commit}" &>/dev/null; then
-            base="$GH_PUSH_BEFORE"; base_src="push_before"
-          fi
-
-          if [[ -z "$base" ]]; then
-            git fetch -q origin "${GH_DEFAULT_BRANCH}" || true
-            if git rev-parse "origin/${GH_DEFAULT_BRANCH}^{commit}" &>/dev/null; then
-              if mb="$(git merge-base "origin/${GH_DEFAULT_BRANCH}" HEAD 2>/dev/null)"; then
-                base="$mb"; base_src="merge-base(origin/${GH_DEFAULT_BRANCH},HEAD)"
-              fi
-            fi
-          fi
-
-          if [[ -z "$base" ]]; then
-            if is_truthy "${FAIL_ON_NO_BASE:-1}"; then
-              echo "::error::Cannot determine merge-base"; exit 1
-            else
-              echo "::notice::No merge-base found - skipping guard"; exit 0
-            fi
-          fi
-
-          echo "::notice::Checking diff from ${base:0:8}...HEAD (source=$base_src)"
-
-          blocked=()
-          while IFS=$'\t' read -r -a fields; do
-            status="${fields[0]}"
-            p1="${fields[1]}"
-            p2="${fields[2]:-}"
-            [[ "$p1" =~ ${PROTECTED_REGEX} ]] || continue
-            case "$status" in
-              D)  blocked+=("DELETE: $p1") ;;
-              R*) blocked+=("RENAME: $p1 → ${p2:-(unknown destination)}") ;;
-            esac
-          done < <(git diff --name-status --diff-filter=DR "${base}...HEAD")
-
-          if (( ${#blocked[@]} )); then
-            echo "::group::❌ Protected file deletions blocked"
-            printf '  • %s\n' "${blocked[@]}" | sort -u
-            echo "::endgroup::"
-            echo "::error::Guard violation"
-            exit 1
-          fi
-
-          echo "::notice::✅ Guard passed"
-
-  validate:
-    name: "Validate fixtures via reusable workflow"
-    needs: [version-sync-check, guard]
-    uses: heimgewebe/contracts/.github/workflows/contracts-ajv-reusable.yml@contracts-v1
-    secrets: inherit
-    with:
-      fixtures_glob: ${{ vars.FIXTURES_GLOB || 'fixtures/**/*.jsonl' }}
+      - name: Validate repository-owned domain contracts
+        run: bash scripts/contracts-domain-check.sh

--- a/.github/workflows/contracts-validate.yml
+++ b/.github/workflows/contracts-validate.yml
@@ -3,6 +3,8 @@ name: "contracts-validate"
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  FAIL_ON_NO_BASE: "true"
+  ALLOW_REMOVALS: "false"
 
 permissions:
   contents: read
@@ -31,6 +33,89 @@ defaults:
     shell: bash --noprofile --norc -euo pipefail {0}
 
 jobs:
+  protected-files:
+    name: Guard contract and fixture deletions
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GH_DEFAULT_BRANCH: ${{ github.event.repository.default_branch || 'main' }}
+      GH_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      GH_PUSH_BEFORE: ${{ github.event.before }}
+      PROTECTED_REGEX: '^(contracts/|tests/fixtures/)'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Enforce deletion and rename policy
+        run: |
+          is_truthy() {
+            case "${1:-0}" in
+              1|true|yes|on) return 0 ;;
+            esac
+            return 1
+          }
+
+          if is_truthy "${ALLOW_REMOVALS:-0}"; then
+            echo "::notice::ALLOW_REMOVALS=1; skipping deletion guard"
+            exit 0
+          fi
+
+          base=""
+          base_source=""
+
+          if [[ -n "${GH_PR_BASE_SHA:-}" ]] \
+            && git rev-parse --verify "${GH_PR_BASE_SHA}^{commit}" >/dev/null 2>&1
+          then
+            base="$(git merge-base "$GH_PR_BASE_SHA" HEAD)"
+            base_source="merge-base(pr-base,HEAD)"
+          fi
+
+          if [[ -z "$base" \
+            && -n "${GH_PUSH_BEFORE:-}" \
+            && ! "${GH_PUSH_BEFORE}" =~ ^0{40}$ \
+            && $(git rev-parse --verify "${GH_PUSH_BEFORE}^{commit}" >/dev/null 2>&1; echo $?) -eq 0 ]]
+          then
+            base="$GH_PUSH_BEFORE"
+            base_source="push-before"
+          fi
+
+          if [[ -z "$base" ]]; then
+            git fetch --quiet origin "$GH_DEFAULT_BRANCH" || true
+            if git rev-parse --verify "origin/${GH_DEFAULT_BRANCH}^{commit}" >/dev/null 2>&1; then
+              base="$(git merge-base "origin/${GH_DEFAULT_BRANCH}" HEAD)"
+              base_source="merge-base(origin/${GH_DEFAULT_BRANCH},HEAD)"
+            fi
+          fi
+
+          if [[ -z "$base" ]]; then
+            if is_truthy "${FAIL_ON_NO_BASE:-1}"; then
+              echo "::error::Cannot determine merge base"
+              exit 2
+            fi
+            echo "::notice::No merge base found; skipping deletion guard"
+            exit 0
+          fi
+
+          echo "::notice::Checking protected paths from ${base:0:8}...HEAD ($base_source)"
+
+          blocked=()
+          while IFS=$'\t' read -r status path_old path_new; do
+            [[ "$path_old" =~ $PROTECTED_REGEX ]] || continue
+            case "$status" in
+              D) blocked+=("DELETE: $path_old") ;;
+              R*) blocked+=("RENAME: $path_old -> ${path_new:-unknown}") ;;
+            esac
+          done < <(git diff --name-status --diff-filter=DR "${base}...HEAD")
+
+          if (( ${#blocked[@]} )); then
+            printf 'ERROR: %s\n' "${blocked[@]}" >&2
+            exit 1
+          fi
+
+          echo "Protected contract and fixture paths are intact."
+
   json-syntax:
     name: Validate contract and fixture JSON syntax
     runs-on: ubuntu-latest

--- a/.github/workflows/contracts-validate.yml
+++ b/.github/workflows/contracts-validate.yml
@@ -74,11 +74,12 @@ jobs:
 
           if [[ -z "$base" \
             && -n "${GH_PUSH_BEFORE:-}" \
-            && ! "${GH_PUSH_BEFORE}" =~ ^0{40}$ \
-            && $(git rev-parse --verify "${GH_PUSH_BEFORE}^{commit}" >/dev/null 2>&1; echo $?) -eq 0 ]]
+            && ! "${GH_PUSH_BEFORE}" =~ ^0{40}$ ]]
           then
-            base="$GH_PUSH_BEFORE"
-            base_source="push-before"
+            if git rev-parse --verify "${GH_PUSH_BEFORE}^{commit}" >/dev/null 2>&1; then
+              base="$GH_PUSH_BEFORE"
+              base_source="push-before"
+            fi
           fi
 
           if [[ -z "$base" ]]; then

--- a/.github/workflows/contracts-validate.yml
+++ b/.github/workflows/contracts-validate.yml
@@ -13,16 +13,20 @@ permissions:
   workflow_dispatch:
   push:
     paths:
-      - "contracts/**/*.json"
-      - "tests/fixtures/**/*.json"
+      - "contracts/**"
+      - "tests/fixtures/**"
       - ".github/workflows/contracts-validate.yml"
       - "scripts/contracts-domain-check.sh"
+      - "package.json"
+      - "pnpm-lock.yaml"
   pull_request:
     paths:
-      - "contracts/**/*.json"
-      - "tests/fixtures/**/*.json"
+      - "contracts/**"
+      - "tests/fixtures/**"
       - ".github/workflows/contracts-validate.yml"
       - "scripts/contracts-domain-check.sh"
+      - "package.json"
+      - "pnpm-lock.yaml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -178,8 +182,8 @@ jobs:
           node-version-file: ".node-version"
           cache: "pnpm"
 
-      - name: Install AJV tooling
-        run: pnpm install --global ajv-cli ajv-formats
+      - name: Install locked repository dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Validate repository-owned domain contracts
         run: bash scripts/contracts-domain-check.sh

--- a/audit/impl-registry.yaml
+++ b/audit/impl-registry.yaml
@@ -184,3 +184,15 @@ implementations:
     verified_by:
       - scripts/tests/test_domain_single_instance_guard.sh
       - .github/workflows/ci.yml
+
+  - id: impl.guard.prod-public-base-url
+    path: scripts/guard/prod-public-base-url-guard.sh
+    impl_type: guard
+    status: active
+    criticality: high
+    evidence_level: ci
+    documented_by:
+      - docs/deploy/public-app-base-url.md
+    verified_by:
+      - scripts/tests/test_prod_public_base_url_guard.sh
+      - .github/workflows/ci.yml

--- a/docs/deploy/public-app-base-url.md
+++ b/docs/deploy/public-app-base-url.md
@@ -14,6 +14,14 @@ relations:
 
 Stand: 2026-06-19
 
+## Abgrenzung zum Migrationsplan
+
+Für den aktuellen Wert von `APP_BASE_URL` und den bereits erbrachten Magic-Link-Proof ersetzt dieses Dokument den historischen Ist-Zustand sowie die entsprechenden offenen Belegpunkte in `docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md`. Die dort noch genannte `.home.arpa`-Konfiguration beschreibt den Zustand vor dem Runtime-Cutover und darf nicht als aktuelle Betriebs- oder Copy-Paste-Quelle verwendet werden.
+
+Vor diesem Repo-Fix war bereits belegt, dass die Live-Runtime `APP_BASE_URL=https://weltgewebe.net` verwendet und ein danach erzeugter Magic Link auf `https://weltgewebe.net` zeigte und erfolgreich eine Session erzeugte. Davon getrennt bleibt nach dem Merge ein kontrollierter Abgleich des Server-Checkouts und eine erneute Prüfung der effektiven Runtime erforderlich.
+
+## Produktionsvertrag
+
 Die produktive `APP_BASE_URL` ist `https://weltgewebe.net`. Sie wird für öffentlich klickbare URLs verwendet, insbesondere für Magic Links.
 
 Die internen Proxy-Ziele bleiben davon getrennt:

--- a/docs/deploy/public-app-base-url.md
+++ b/docs/deploy/public-app-base-url.md
@@ -1,0 +1,39 @@
+---
+id: deploy.public-app-base-url
+title: Public APP_BASE_URL Contract
+doc_type: reference
+status: active
+summary: Produktionsvertrag für öffentliche Magic-Link-URLs und interne Web-Upstreams.
+relations:
+  - type: relates_to
+    target: docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md
+  - type: relates_to
+    target: infra/compose/compose.prod.override.yml
+---
+# Öffentliche APP_BASE_URL im Produktionsbetrieb
+
+Stand: 2026-06-19
+
+Die produktive `APP_BASE_URL` ist `https://weltgewebe.net`. Sie wird für öffentlich klickbare URLs verwendet, insbesondere für Magic Links.
+
+Die internen Proxy-Ziele bleiben davon getrennt:
+
+- `WEB_UPSTREAM_HOST=weltgewebe.home.arpa`
+- `WEB_UPSTREAM_URL=https://weltgewebe.home.arpa`
+
+Diese Trennung ist absichtlich. `APP_BASE_URL` beschreibt die öffentliche Adresse der Anwendung; `WEB_UPSTREAM_*` beschreibt den internen Zielweg hinter Caddy. Ein öffentlicher Upstream-Wert kann eine Proxy-Schleife oder falsches internes Routing erzeugen.
+
+## Durchsetzung
+
+`scripts/guard/prod-public-base-url-guard.sh` rendert `compose.prod.yml` und `compose.prod.override.yml` mit einer synthetischen Env-Datei und prüft:
+
+- öffentliche `APP_BASE_URL` im API-Service;
+- aktivierten öffentlichen Login;
+- deaktiviertes Magic-Token-Logging;
+- interne `WEB_UPSTREAM_*`-Werte im API- und Caddy-Service.
+
+Die zugehörige Fixture-Suite liegt unter `scripts/tests/test_prod_public_base_url_guard.sh`. CI führt sowohl die Fixtures als auch den Guard gegen den echten Repository-Checkout aus.
+
+## Betriebsgrenze
+
+Diese Repo-Änderung führt keinen Live-Deploy, keine DNS-Änderung und keine Mailprovider-Änderung aus. Nach dem Merge bleibt ein kontrollierter Abgleich des Server-Checkouts und der laufenden Runtime erforderlich.

--- a/infra/compose/compose.prod.override.yml
+++ b/infra/compose/compose.prod.override.yml
@@ -9,7 +9,7 @@ services:
       - ${WELTGEWEBE_ENV_FILE:-/opt/weltgewebe/.env}
     environment:
       POLICY_LIMITS_PATH: /app/policies/limits.yaml
-      APP_BASE_URL: https://weltgewebe.home.arpa
+      APP_BASE_URL: https://weltgewebe.net
       AUTH_PUBLIC_LOGIN: '1'
       AUTH_LOG_MAGIC_TOKEN: '0'
       AUTH_AUTO_PROVISION: '1'

--- a/scripts/guard/prod-public-base-url-guard.sh
+++ b/scripts/guard/prod-public-base-url-guard.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+TMP_ENV=$(mktemp)
+trap 'rm -f "$TMP_ENV"' EXIT
+
+cat > "$TMP_ENV" << 'EOF'
+DATABASE_URL=postgres://dummy:dummy@localhost:5432/dummy
+POSTGRES_USER=dummy
+POSTGRES_PASSWORD=dummy
+POSTGRES_DB=dummy
+WEB_UPSTREAM_HOST=weltgewebe.home.arpa
+WEB_UPSTREAM_URL=https://weltgewebe.home.arpa
+EOF
+
+if [ ! -f "$REPO_ROOT/infra/compose/compose.prod.yml" ] || [ ! -f "$REPO_ROOT/infra/compose/compose.prod.override.yml" ]; then
+  echo "Error: Compose files not found" >&2
+  exit 2
+fi
+
+# Compose render explicitly with the expected override
+COMPOSE_OUTPUT=$(
+  WELTGEWEBE_ENV_FILE="$TMP_ENV" \
+  REPO_DIR="$REPO_ROOT" \
+  docker compose \
+    --env-file "$TMP_ENV" \
+    -f "$REPO_ROOT/infra/compose/compose.prod.yml" \
+    -f "$REPO_ROOT/infra/compose/compose.prod.override.yml" \
+    config --format json 2>/dev/null
+) || {
+  echo "Error: docker compose config failed" >&2
+  exit 2
+}
+
+# Use Python to evaluate the JSON configuration
+python3 -c '
+import sys, json
+
+try:
+    config = json.load(sys.stdin)
+except Exception as e:
+    print(f"Error parsing compose config JSON: {e}", file=sys.stderr)
+    sys.exit(1)
+
+api_service = config.get("services", {}).get("api", {})
+env = api_service.get("environment", {})
+
+app_base_url = env.get("APP_BASE_URL")
+auth_public_login = env.get("AUTH_PUBLIC_LOGIN")
+auth_log_magic_token = env.get("AUTH_LOG_MAGIC_TOKEN")
+web_upstream_host = env.get("WEB_UPSTREAM_HOST")
+web_upstream_url = env.get("WEB_UPSTREAM_URL")
+
+errors = []
+
+if app_base_url != "https://weltgewebe.net":
+    errors.append(f"APP_BASE_URL expected https://weltgewebe.net, got {app_base_url}")
+
+if auth_public_login != "1":
+    errors.append(f"AUTH_PUBLIC_LOGIN expected 1, got {auth_public_login}")
+
+if auth_log_magic_token != "0":
+    errors.append(f"AUTH_LOG_MAGIC_TOKEN expected 0, got {auth_log_magic_token}")
+
+if web_upstream_host != "weltgewebe.home.arpa":
+    errors.append(f"WEB_UPSTREAM_HOST expected weltgewebe.home.arpa, got {web_upstream_host}")
+
+if web_upstream_url != "https://weltgewebe.home.arpa":
+    errors.append(f"WEB_UPSTREAM_URL expected https://weltgewebe.home.arpa, got {web_upstream_url}")
+
+if errors:
+    for err in errors:
+        print(err, file=sys.stderr)
+    sys.exit(1)
+
+print("prod-public-base-url guard passed")
+sys.exit(0)
+' <<< "$COMPOSE_OUTPUT"

--- a/scripts/guard/prod-public-base-url-guard.sh
+++ b/scripts/guard/prod-public-base-url-guard.sh
@@ -1,10 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+SCRIPT_DIR="$(
+  cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1
+  pwd
+)"
+REPO_ROOT="${REPO_ROOT:-$(
+  cd -- "${SCRIPT_DIR}/../.." >/dev/null 2>&1
+  pwd
+)}"
 
-TMP_ENV=$(mktemp)
-trap 'rm -f "$TMP_ENV"' EXIT
+TMP_ENV="$(mktemp)"
+TMP_JSON="$(mktemp)"
+TMP_ERR="$(mktemp)"
+
+cleanup() {
+  rm -f "$TMP_ENV" "$TMP_JSON" "$TMP_ERR"
+}
+trap cleanup EXIT
 
 cat > "$TMP_ENV" << 'EOF'
 DATABASE_URL=postgres://dummy:dummy@localhost:5432/dummy
@@ -16,59 +29,70 @@ WEB_UPSTREAM_URL=https://weltgewebe.home.arpa
 EOF
 
 if [ ! -f "$REPO_ROOT/infra/compose/compose.prod.yml" ] || [ ! -f "$REPO_ROOT/infra/compose/compose.prod.override.yml" ]; then
-  echo "Error: Compose files not found" >&2
+  echo "Error: Compose files not found at $REPO_ROOT/infra/compose/" >&2
   exit 2
 fi
 
 # Compose render explicitly with the expected override
-COMPOSE_OUTPUT=$(
-  WELTGEWEBE_ENV_FILE="$TMP_ENV" \
+if ! WELTGEWEBE_ENV_FILE="$TMP_ENV" \
   REPO_DIR="$REPO_ROOT" \
   docker compose \
     --env-file "$TMP_ENV" \
     -f "$REPO_ROOT/infra/compose/compose.prod.yml" \
     -f "$REPO_ROOT/infra/compose/compose.prod.override.yml" \
-    config --format json 2>/dev/null
-) || {
-  echo "Error: docker compose config failed" >&2
+    config --format json >"$TMP_JSON" 2>"$TMP_ERR"
+then
+  echo "ERROR: docker compose config failed" >&2
+  cat "$TMP_ERR" >&2
   exit 2
-}
+fi
 
 # Use Python to evaluate the JSON configuration
 python3 -c '
 import sys, json
 
 try:
-    config = json.load(sys.stdin)
+    with open(sys.argv[1], "r") as f:
+        config = json.load(f)
 except Exception as e:
     print(f"Error parsing compose config JSON: {e}", file=sys.stderr)
-    sys.exit(1)
+    sys.exit(2)
 
-api_service = config.get("services", {}).get("api", {})
-env = api_service.get("environment", {})
-
-app_base_url = env.get("APP_BASE_URL")
-auth_public_login = env.get("AUTH_PUBLIC_LOGIN")
-auth_log_magic_token = env.get("AUTH_LOG_MAGIC_TOKEN")
-web_upstream_host = env.get("WEB_UPSTREAM_HOST")
-web_upstream_url = env.get("WEB_UPSTREAM_URL")
+services = config.get("services", {})
+api_env = services.get("api", {}).get("environment", {})
+caddy_env = services.get("caddy", {}).get("environment", {})
 
 errors = []
 
-if app_base_url != "https://weltgewebe.net":
-    errors.append(f"APP_BASE_URL expected https://weltgewebe.net, got {app_base_url}")
+# Check api_env
+if api_env.get("APP_BASE_URL") != "https://weltgewebe.net":
+    val = api_env.get("APP_BASE_URL")
+    errors.append(f"api.environment.APP_BASE_URL expected https://weltgewebe.net, got {val}")
 
-if auth_public_login != "1":
-    errors.append(f"AUTH_PUBLIC_LOGIN expected 1, got {auth_public_login}")
+if api_env.get("AUTH_PUBLIC_LOGIN") != "1":
+    val = api_env.get("AUTH_PUBLIC_LOGIN")
+    errors.append(f"api.environment.AUTH_PUBLIC_LOGIN expected 1, got {val}")
 
-if auth_log_magic_token != "0":
-    errors.append(f"AUTH_LOG_MAGIC_TOKEN expected 0, got {auth_log_magic_token}")
+if api_env.get("AUTH_LOG_MAGIC_TOKEN") != "0":
+    val = api_env.get("AUTH_LOG_MAGIC_TOKEN")
+    errors.append(f"api.environment.AUTH_LOG_MAGIC_TOKEN expected 0, got {val}")
 
-if web_upstream_host != "weltgewebe.home.arpa":
-    errors.append(f"WEB_UPSTREAM_HOST expected weltgewebe.home.arpa, got {web_upstream_host}")
+if api_env.get("WEB_UPSTREAM_HOST") != "weltgewebe.home.arpa":
+    val = api_env.get("WEB_UPSTREAM_HOST")
+    errors.append(f"api.environment.WEB_UPSTREAM_HOST expected weltgewebe.home.arpa, got {val}")
 
-if web_upstream_url != "https://weltgewebe.home.arpa":
-    errors.append(f"WEB_UPSTREAM_URL expected https://weltgewebe.home.arpa, got {web_upstream_url}")
+if api_env.get("WEB_UPSTREAM_URL") != "https://weltgewebe.home.arpa":
+    val = api_env.get("WEB_UPSTREAM_URL")
+    errors.append(f"api.environment.WEB_UPSTREAM_URL expected https://weltgewebe.home.arpa, got {val}")
+
+# Check caddy_env
+if caddy_env.get("WEB_UPSTREAM_HOST") != "weltgewebe.home.arpa":
+    val = caddy_env.get("WEB_UPSTREAM_HOST")
+    errors.append(f"caddy.environment.WEB_UPSTREAM_HOST expected weltgewebe.home.arpa, got {val}")
+
+if caddy_env.get("WEB_UPSTREAM_URL") != "https://weltgewebe.home.arpa":
+    val = caddy_env.get("WEB_UPSTREAM_URL")
+    errors.append(f"caddy.environment.WEB_UPSTREAM_URL expected https://weltgewebe.home.arpa, got {val}")
 
 if errors:
     for err in errors:
@@ -77,4 +101,4 @@ if errors:
 
 print("prod-public-base-url guard passed")
 sys.exit(0)
-' <<< "$COMPOSE_OUTPUT"
+' "$TMP_JSON"

--- a/scripts/guard/prod-public-base-url-guard.sh
+++ b/scripts/guard/prod-public-base-url-guard.sh
@@ -10,6 +10,26 @@ REPO_ROOT="${REPO_ROOT:-$(
   pwd
 )}"
 
+BASE_FILE="${REPO_ROOT}/infra/compose/compose.prod.yml"
+OVERRIDE_FILE="${REPO_ROOT}/infra/compose/compose.prod.override.yml"
+
+for required_file in "$BASE_FILE" "$OVERRIDE_FILE"; do
+  if [[ ! -f "$required_file" ]]; then
+    echo "ERROR: required Compose file missing: $required_file" >&2
+    exit 2
+  fi
+done
+
+if ! command -v docker >/dev/null 2>&1 || ! docker compose version >/dev/null 2>&1; then
+  echo "ERROR: docker compose is required" >&2
+  exit 2
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "ERROR: python3 is required" >&2
+  exit 2
+fi
+
 TMP_ENV="$(mktemp)"
 TMP_JSON="$(mktemp)"
 TMP_ERR="$(mktemp)"
@@ -19,27 +39,21 @@ cleanup() {
 }
 trap cleanup EXIT
 
-cat > "$TMP_ENV" << 'EOF'
+cat >"$TMP_ENV" <<'EOF_ENV'
 DATABASE_URL=postgres://dummy:dummy@localhost:5432/dummy
 POSTGRES_USER=dummy
 POSTGRES_PASSWORD=dummy
 POSTGRES_DB=dummy
 WEB_UPSTREAM_HOST=weltgewebe.home.arpa
 WEB_UPSTREAM_URL=https://weltgewebe.home.arpa
-EOF
+EOF_ENV
 
-if [ ! -f "$REPO_ROOT/infra/compose/compose.prod.yml" ] || [ ! -f "$REPO_ROOT/infra/compose/compose.prod.override.yml" ]; then
-  echo "Error: Compose files not found at $REPO_ROOT/infra/compose/" >&2
-  exit 2
-fi
-
-# Compose render explicitly with the expected override
 if ! WELTGEWEBE_ENV_FILE="$TMP_ENV" \
   REPO_DIR="$REPO_ROOT" \
   docker compose \
     --env-file "$TMP_ENV" \
-    -f "$REPO_ROOT/infra/compose/compose.prod.yml" \
-    -f "$REPO_ROOT/infra/compose/compose.prod.override.yml" \
+    -f "$BASE_FILE" \
+    -f "$OVERRIDE_FILE" \
     config --format json >"$TMP_JSON" 2>"$TMP_ERR"
 then
   echo "ERROR: docker compose config failed" >&2
@@ -47,58 +61,77 @@ then
   exit 2
 fi
 
-# Use Python to evaluate the JSON configuration
-python3 -c '
-import sys, json
+python3 - "$TMP_JSON" <<'PY'
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def fail_structural(message: str) -> None:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def require_mapping(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        fail_structural(f"{label} must be a mapping")
+    return value
+
 
 try:
-    with open(sys.argv[1], "r") as f:
-        config = json.load(f)
-except Exception as e:
-    print(f"Error parsing compose config JSON: {e}", file=sys.stderr)
-    sys.exit(2)
+    config = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+except (OSError, json.JSONDecodeError) as exc:
+    fail_structural(f"cannot parse Compose JSON: {exc}")
 
-services = config.get("services", {})
-api_env = services.get("api", {}).get("environment", {})
-caddy_env = services.get("caddy", {}).get("environment", {})
+config_map = require_mapping(config, "Compose root")
+services = require_mapping(config_map.get("services"), "services")
+api = require_mapping(services.get("api"), "services.api")
+caddy = require_mapping(services.get("caddy"), "services.caddy")
+api_env = require_mapping(api.get("environment"), "services.api.environment")
+caddy_env = require_mapping(caddy.get("environment"), "services.caddy.environment")
 
-errors = []
+expected = {
+    "services.api.environment.APP_BASE_URL": (
+        api_env.get("APP_BASE_URL"),
+        "https://weltgewebe.net",
+    ),
+    "services.api.environment.AUTH_PUBLIC_LOGIN": (
+        api_env.get("AUTH_PUBLIC_LOGIN"),
+        "1",
+    ),
+    "services.api.environment.AUTH_LOG_MAGIC_TOKEN": (
+        api_env.get("AUTH_LOG_MAGIC_TOKEN"),
+        "0",
+    ),
+    "services.api.environment.WEB_UPSTREAM_HOST": (
+        api_env.get("WEB_UPSTREAM_HOST"),
+        "weltgewebe.home.arpa",
+    ),
+    "services.api.environment.WEB_UPSTREAM_URL": (
+        api_env.get("WEB_UPSTREAM_URL"),
+        "https://weltgewebe.home.arpa",
+    ),
+    "services.caddy.environment.WEB_UPSTREAM_HOST": (
+        caddy_env.get("WEB_UPSTREAM_HOST"),
+        "weltgewebe.home.arpa",
+    ),
+    "services.caddy.environment.WEB_UPSTREAM_URL": (
+        caddy_env.get("WEB_UPSTREAM_URL"),
+        "https://weltgewebe.home.arpa",
+    ),
+}
 
-# Check api_env
-val = api_env.get("APP_BASE_URL")
-if val != "https://weltgewebe.net":
-    errors.append(f"api.environment.APP_BASE_URL expected https://weltgewebe.net, got {val}")
-
-val = api_env.get("AUTH_PUBLIC_LOGIN")
-if val != "1":
-    errors.append(f"api.environment.AUTH_PUBLIC_LOGIN expected 1, got {val}")
-
-val = api_env.get("AUTH_LOG_MAGIC_TOKEN")
-if val != "0":
-    errors.append(f"api.environment.AUTH_LOG_MAGIC_TOKEN expected 0, got {val}")
-
-val = api_env.get("WEB_UPSTREAM_HOST")
-if val != "weltgewebe.home.arpa":
-    errors.append(f"api.environment.WEB_UPSTREAM_HOST expected weltgewebe.home.arpa, got {val}")
-
-val = api_env.get("WEB_UPSTREAM_URL")
-if val != "https://weltgewebe.home.arpa":
-    errors.append(f"api.environment.WEB_UPSTREAM_URL expected https://weltgewebe.home.arpa, got {val}")
-
-# Check caddy_env
-val = caddy_env.get("WEB_UPSTREAM_HOST")
-if val != "weltgewebe.home.arpa":
-    errors.append(f"caddy.environment.WEB_UPSTREAM_HOST expected weltgewebe.home.arpa, got {val}")
-
-val = caddy_env.get("WEB_UPSTREAM_URL")
-if val != "https://weltgewebe.home.arpa":
-    errors.append(f"caddy.environment.WEB_UPSTREAM_URL expected https://weltgewebe.home.arpa, got {val}")
+errors = [
+    f"{label} expected {wanted!r}, got {actual!r}"
+    for label, (actual, wanted) in expected.items()
+    if actual != wanted
+]
 
 if errors:
-    for err in errors:
-        print(err, file=sys.stderr)
-    sys.exit(1)
+    for error in errors:
+        print(f"ERROR: {error}", file=sys.stderr)
+    raise SystemExit(1)
 
 print("prod-public-base-url guard passed")
-sys.exit(0)
-' "$TMP_JSON"
+PY

--- a/scripts/guard/prod-public-base-url-guard.sh
+++ b/scripts/guard/prod-public-base-url-guard.sh
@@ -65,33 +65,33 @@ caddy_env = services.get("caddy", {}).get("environment", {})
 errors = []
 
 # Check api_env
-if api_env.get("APP_BASE_URL") != "https://weltgewebe.net":
-    val = api_env.get("APP_BASE_URL")
+val = api_env.get("APP_BASE_URL")
+if val != "https://weltgewebe.net":
     errors.append(f"api.environment.APP_BASE_URL expected https://weltgewebe.net, got {val}")
 
-if api_env.get("AUTH_PUBLIC_LOGIN") != "1":
-    val = api_env.get("AUTH_PUBLIC_LOGIN")
+val = api_env.get("AUTH_PUBLIC_LOGIN")
+if val != "1":
     errors.append(f"api.environment.AUTH_PUBLIC_LOGIN expected 1, got {val}")
 
-if api_env.get("AUTH_LOG_MAGIC_TOKEN") != "0":
-    val = api_env.get("AUTH_LOG_MAGIC_TOKEN")
+val = api_env.get("AUTH_LOG_MAGIC_TOKEN")
+if val != "0":
     errors.append(f"api.environment.AUTH_LOG_MAGIC_TOKEN expected 0, got {val}")
 
-if api_env.get("WEB_UPSTREAM_HOST") != "weltgewebe.home.arpa":
-    val = api_env.get("WEB_UPSTREAM_HOST")
+val = api_env.get("WEB_UPSTREAM_HOST")
+if val != "weltgewebe.home.arpa":
     errors.append(f"api.environment.WEB_UPSTREAM_HOST expected weltgewebe.home.arpa, got {val}")
 
-if api_env.get("WEB_UPSTREAM_URL") != "https://weltgewebe.home.arpa":
-    val = api_env.get("WEB_UPSTREAM_URL")
+val = api_env.get("WEB_UPSTREAM_URL")
+if val != "https://weltgewebe.home.arpa":
     errors.append(f"api.environment.WEB_UPSTREAM_URL expected https://weltgewebe.home.arpa, got {val}")
 
 # Check caddy_env
-if caddy_env.get("WEB_UPSTREAM_HOST") != "weltgewebe.home.arpa":
-    val = caddy_env.get("WEB_UPSTREAM_HOST")
+val = caddy_env.get("WEB_UPSTREAM_HOST")
+if val != "weltgewebe.home.arpa":
     errors.append(f"caddy.environment.WEB_UPSTREAM_HOST expected weltgewebe.home.arpa, got {val}")
 
-if caddy_env.get("WEB_UPSTREAM_URL") != "https://weltgewebe.home.arpa":
-    val = caddy_env.get("WEB_UPSTREAM_URL")
+val = caddy_env.get("WEB_UPSTREAM_URL")
+if val != "https://weltgewebe.home.arpa":
     errors.append(f"caddy.environment.WEB_UPSTREAM_URL expected https://weltgewebe.home.arpa, got {val}")
 
 if errors:

--- a/scripts/tests/test_prod_public_base_url_guard.sh
+++ b/scripts/tests/test_prod_public_base_url_guard.sh
@@ -5,172 +5,191 @@ SCRIPT_DIR="$(
   cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1
   pwd
 )"
-GUARD_SCRIPT="${SCRIPT_DIR}/../guard/prod-public-base-url-guard.sh"
+REPO_ROOT="$(
+  cd -- "${SCRIPT_DIR}/../.." >/dev/null 2>&1
+  pwd
+)"
+GUARD_SCRIPT="${REPO_ROOT}/scripts/guard/prod-public-base-url-guard.sh"
+BASE_SOURCE="${REPO_ROOT}/infra/compose/compose.prod.yml"
 
-if [ ! -f "$GUARD_SCRIPT" ]; then
-    echo "Guard script not found at $GUARD_SCRIPT" >&2
-    exit 1
-fi
+for required_file in "$GUARD_SCRIPT" "$BASE_SOURCE"; do
+  if [[ ! -f "$required_file" ]]; then
+    echo "ERROR: required test input missing: $required_file" >&2
+    exit 2
+  fi
+done
 
-TEST_TMP=$(mktemp -d)
-trap 'rm -rf "$TEST_TMP"' EXIT
+TEST_TMP="$(mktemp -d)"
+LAST_EXIT=0
+LAST_OUTPUT=""
+
+cleanup() {
+  rm -rf "$TEST_TMP"
+}
+trap cleanup EXIT
 
 mkdir -p "$TEST_TMP/infra/compose"
-cp "${SCRIPT_DIR}/../../infra/compose/compose.prod.yml" "$TEST_TMP/infra/compose/"
-
-run_guard() {
-    local caddy_web_host="$1"
-    local caddy_web_url="$2"
-
-    local tmp_env="$TEST_TMP/test.env"
-    cat > "$tmp_env" <<EOF
-DATABASE_URL=postgres://dummy:dummy@localhost:5432/dummy
-POSTGRES_USER=dummy
-POSTGRES_PASSWORD=dummy
-POSTGRES_DB=dummy
-WEB_UPSTREAM_HOST=$caddy_web_host
-WEB_UPSTREAM_URL=$caddy_web_url
-EOF
-
-    local out
-    local exit_code=0
-    # Provide the env file to the guard through WELTGEWEBE_ENV_FILE but actually we can't easily override the TMP_ENV inside the guard unless we export it or it uses an argument.
-    # Wait, the guard creates its own TMP_ENV. We can't override its TMP_ENV directly.
-    # Instead, the guard's TMP_ENV has hardcoded values!
-    # Ah! The prompt says "Die Fixture muss WEB_UPSTREAM_* dort setzen, wo der reale gerenderte Vertrag sie benötigt ... Caddy-Werte über die synthetische Env beziehungsweise einen gezielten Caddy-Override."
-    # Since the guard script hardcodes its TMP_ENV, the test script can't change the Caddy env via the guard's TMP_ENV easily unless we provide an override file for caddy too!
-
-    # We can inject Caddy values via the override file in the test.
-    out=$(REPO_ROOT="$TEST_TMP" bash "$GUARD_SCRIPT" 2>&1) || exit_code=$?
-
-    echo "$exit_code"
-    echo "$out"
-}
+cp "$BASE_SOURCE" "$TEST_TMP/infra/compose/compose.prod.yml"
 
 write_override() {
-    local app_base="$1"
-    local web_host="$2"
-    local web_url="$3"
-    local caddy_web_host="$4"
-    local caddy_web_url="$5"
-    local auth_login="$6"
-    local auth_token="$7"
+  local app_base="$1"
+  local api_web_host="$2"
+  local api_web_url="$3"
+  local caddy_web_host="$4"
+  local caddy_web_url="$5"
+  local auth_login="$6"
+  local auth_token="$7"
 
-    cat > "$TEST_TMP/infra/compose/compose.prod.override.yml" <<EOF
+  cat >"$TEST_TMP/infra/compose/compose.prod.override.yml" <<EOF_OVERRIDE
 services:
   api:
     environment:
       APP_BASE_URL: $app_base
       AUTH_PUBLIC_LOGIN: '$auth_login'
       AUTH_LOG_MAGIC_TOKEN: '$auth_token'
-      WEB_UPSTREAM_HOST: $web_host
-      WEB_UPSTREAM_URL: $web_url
+      WEB_UPSTREAM_HOST: $api_web_host
+      WEB_UPSTREAM_URL: $api_web_url
   caddy:
     environment:
       WEB_UPSTREAM_HOST: $caddy_web_host
       WEB_UPSTREAM_URL: $caddy_web_url
-EOF
+EOF_OVERRIDE
 }
 
-check_result() {
-    local name="$1"
-    local exit_code="$2"
-    local expected_code="$3"
-    local output="$4"
-    local expected_msg="$5"
-
-    if [ "$exit_code" -ne "$expected_code" ]; then
-        echo "FAIL: $name - Expected exit $expected_code, got $exit_code" >&2
-        echo "Output was: $output" >&2
-        exit 1
-    fi
-    if [ -n "$expected_msg" ] && [[ "$output" != *"$expected_msg"* ]]; then
-        echo "FAIL: $name - Expected message '$expected_msg' not found in output" >&2
-        echo "Output was: $output" >&2
-        exit 1
-    fi
-    echo "PASS: $name"
+run_guard() {
+  LAST_EXIT=0
+  LAST_OUTPUT="$(REPO_ROOT="$TEST_TMP" bash "$GUARD_SCRIPT" 2>&1)" || LAST_EXIT=$?
 }
 
-echo "Running prod-public-base-url-guard tests..."
+assert_result() {
+  local name="$1"
+  local expected_exit="$2"
+  local expected_fragment="$3"
 
-# Helper to run and check
-run_test() {
-    local name="$1"
-    local app_base="$2"
-    local web_host="$3"
-    local web_url="$4"
-    local caddy_host="$5"
-    local caddy_url="$6"
-    local auth_login="${7:-1}"
-    local auth_token="${8:-0}"
-    local expected_code="$9"
-    local expected_msg="${10}"
+  if [[ "$LAST_EXIT" -ne "$expected_exit" ]]; then
+    echo "FAIL: $name: expected exit $expected_exit, got $LAST_EXIT" >&2
+    echo "$LAST_OUTPUT" >&2
+    exit 1
+  fi
 
-    write_override "$app_base" "$web_host" "$web_url" "$caddy_host" "$caddy_url" "$auth_login" "$auth_token"
+  if [[ -n "$expected_fragment" && "$LAST_OUTPUT" != *"$expected_fragment"* ]]; then
+    echo "FAIL: $name: expected output fragment '$expected_fragment'" >&2
+    echo "$LAST_OUTPUT" >&2
+    exit 1
+  fi
 
-    # We pass the Caddy host/url to run_guard, but right now run_guard uses the override file to set Caddy env.
-    local res
-    res=$(run_guard "$caddy_host" "$caddy_url")
-    local exit_code
-    exit_code=$(echo "$res" | head -n1)
-    local output
-    output=$(echo "$res" | tail -n +2)
-
-    check_result "$name" "$exit_code" "$expected_code" "$output" "$expected_msg"
+  echo "PASS: $name"
 }
 
-# 1. Positiv
-run_test "1. Positiv: gültige Konfiguration" \
-    "https://weltgewebe.net" "weltgewebe.home.arpa" "https://weltgewebe.home.arpa" \
-    "weltgewebe.home.arpa" "https://weltgewebe.home.arpa" \
-    "1" "0" \
-    0 ""
+run_case() {
+  local name="$1"
+  local app_base="$2"
+  local api_web_host="$3"
+  local api_web_url="$4"
+  local caddy_web_host="$5"
+  local caddy_web_url="$6"
+  local auth_login="$7"
+  local auth_token="$8"
+  local expected_exit="$9"
+  local expected_fragment="${10}"
 
-# 2. Negativ: interne APP_BASE_URL
-run_test "2. Negativ: interne APP_BASE_URL" \
-    "https://weltgewebe.home.arpa" "weltgewebe.home.arpa" "https://weltgewebe.home.arpa" \
-    "weltgewebe.home.arpa" "https://weltgewebe.home.arpa" \
-    "1" "0" \
-    1 "api.environment.APP_BASE_URL"
+  write_override \
+    "$app_base" \
+    "$api_web_host" \
+    "$api_web_url" \
+    "$caddy_web_host" \
+    "$caddy_web_url" \
+    "$auth_login" \
+    "$auth_token"
+  run_guard
+  assert_result "$name" "$expected_exit" "$expected_fragment"
+}
 
-# 3. Negativ: öffentliche Caddy-WEB_UPSTREAM_URL
-run_test "3. Negativ: öffentliche Caddy-WEB_UPSTREAM_URL" \
-    "https://weltgewebe.net" "weltgewebe.home.arpa" "https://weltgewebe.home.arpa" \
-    "weltgewebe.home.arpa" "https://weltgewebe.net" \
-    "1" "0" \
-    1 "caddy.environment.WEB_UPSTREAM_URL"
+echo "Running prod-public-base-url guard tests..."
 
-# 4. Negativ: öffentlicher Caddy-WEB_UPSTREAM_HOST
-run_test "4. Negativ: öffentlicher Caddy-WEB_UPSTREAM_HOST" \
-    "https://weltgewebe.net" "weltgewebe.home.arpa" "https://weltgewebe.home.arpa" \
-    "weltgewebe.net" "https://weltgewebe.home.arpa" \
-    "1" "0" \
-    1 "caddy.environment.WEB_UPSTREAM_HOST"
+run_case \
+  "valid production contract" \
+  "https://weltgewebe.net" \
+  "weltgewebe.home.arpa" \
+  "https://weltgewebe.home.arpa" \
+  "weltgewebe.home.arpa" \
+  "https://weltgewebe.home.arpa" \
+  "1" "0" \
+  0 "prod-public-base-url guard passed"
 
-# 5. Negativ: AUTH_PUBLIC_LOGIN ungleich 1
-run_test "5. Negativ: AUTH_PUBLIC_LOGIN ungleich 1" \
-    "https://weltgewebe.net" "weltgewebe.home.arpa" "https://weltgewebe.home.arpa" \
-    "weltgewebe.home.arpa" "https://weltgewebe.home.arpa" \
-    "0" "0" \
-    1 "api.environment.AUTH_PUBLIC_LOGIN"
+run_case \
+  "internal APP_BASE_URL is rejected" \
+  "https://weltgewebe.home.arpa" \
+  "weltgewebe.home.arpa" \
+  "https://weltgewebe.home.arpa" \
+  "weltgewebe.home.arpa" \
+  "https://weltgewebe.home.arpa" \
+  "1" "0" \
+  1 "services.api.environment.APP_BASE_URL"
 
-# 6. Negativ: AUTH_LOG_MAGIC_TOKEN ungleich 0
-run_test "6. Negativ: AUTH_LOG_MAGIC_TOKEN ungleich 0" \
-    "https://weltgewebe.net" "weltgewebe.home.arpa" "https://weltgewebe.home.arpa" \
-    "weltgewebe.home.arpa" "https://weltgewebe.home.arpa" \
-    "1" "1" \
-    1 "api.environment.AUTH_LOG_MAGIC_TOKEN"
+run_case \
+  "public API WEB_UPSTREAM_URL is rejected" \
+  "https://weltgewebe.net" \
+  "weltgewebe.home.arpa" \
+  "https://weltgewebe.net" \
+  "weltgewebe.home.arpa" \
+  "https://weltgewebe.home.arpa" \
+  "1" "0" \
+  1 "services.api.environment.WEB_UPSTREAM_URL"
 
-# 7. fehlende Basisdatei
+run_case \
+  "public Caddy WEB_UPSTREAM_HOST is rejected" \
+  "https://weltgewebe.net" \
+  "weltgewebe.home.arpa" \
+  "https://weltgewebe.home.arpa" \
+  "weltgewebe.net" \
+  "https://weltgewebe.home.arpa" \
+  "1" "0" \
+  1 "services.caddy.environment.WEB_UPSTREAM_HOST"
+
+run_case \
+  "public Caddy WEB_UPSTREAM_URL is rejected" \
+  "https://weltgewebe.net" \
+  "weltgewebe.home.arpa" \
+  "https://weltgewebe.home.arpa" \
+  "weltgewebe.home.arpa" \
+  "https://weltgewebe.net" \
+  "1" "0" \
+  1 "services.caddy.environment.WEB_UPSTREAM_URL"
+
+run_case \
+  "disabled public login is rejected" \
+  "https://weltgewebe.net" \
+  "weltgewebe.home.arpa" \
+  "https://weltgewebe.home.arpa" \
+  "weltgewebe.home.arpa" \
+  "https://weltgewebe.home.arpa" \
+  "0" "0" \
+  1 "services.api.environment.AUTH_PUBLIC_LOGIN"
+
+run_case \
+  "magic-token logging is rejected" \
+  "https://weltgewebe.net" \
+  "weltgewebe.home.arpa" \
+  "https://weltgewebe.home.arpa" \
+  "weltgewebe.home.arpa" \
+  "https://weltgewebe.home.arpa" \
+  "1" "1" \
+  1 "services.api.environment.AUTH_LOG_MAGIC_TOKEN"
+
 rm "$TEST_TMP/infra/compose/compose.prod.yml"
-res=$(REPO_ROOT="$TEST_TMP" bash "$GUARD_SCRIPT" 2>&1) || exit_code=$?
-check_result "7. Negativ: fehlende Basisdatei" "$exit_code" 2 "$res" "Error: Compose files not found"
-cp "${SCRIPT_DIR}/../../infra/compose/compose.prod.yml" "$TEST_TMP/infra/compose/"
+run_guard
+assert_result \
+  "missing base Compose file is an execution error" \
+  2 \
+  "required Compose file missing: $TEST_TMP/infra/compose/compose.prod.yml"
+cp "$BASE_SOURCE" "$TEST_TMP/infra/compose/compose.prod.yml"
 
-# 8. fehlende Override-Datei
 rm "$TEST_TMP/infra/compose/compose.prod.override.yml"
-res=$(REPO_ROOT="$TEST_TMP" bash "$GUARD_SCRIPT" 2>&1) || exit_code=$?
-check_result "8. Negativ: fehlende Override-Datei" "$exit_code" 2 "$res" "Error: Compose files not found"
+run_guard
+assert_result \
+  "missing override Compose file is an execution error" \
+  2 \
+  "required Compose file missing: $TEST_TMP/infra/compose/compose.prod.override.yml"
 
-echo "All tests passed."
+echo "All prod-public-base-url guard tests passed."

--- a/scripts/tests/test_prod_public_base_url_guard.sh
+++ b/scripts/tests/test_prod_public_base_url_guard.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-GUARD_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/guard/prod-public-base-url-guard.sh"
+SCRIPT_DIR="$(
+  cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1
+  pwd
+)"
+GUARD_SCRIPT="${SCRIPT_DIR}/../guard/prod-public-base-url-guard.sh"
+
 if [ ! -f "$GUARD_SCRIPT" ]; then
     echo "Guard script not found at $GUARD_SCRIPT" >&2
     exit 1
@@ -10,68 +15,162 @@ fi
 TEST_TMP=$(mktemp -d)
 trap 'rm -rf "$TEST_TMP"' EXIT
 
-# Provide a mock REPO_ROOT structure
 mkdir -p "$TEST_TMP/infra/compose"
-cp "$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/infra/compose/compose.prod.yml" "$TEST_TMP/infra/compose/"
+cp "${SCRIPT_DIR}/../../infra/compose/compose.prod.yml" "$TEST_TMP/infra/compose/"
 
-# Helper to write override and run guard
 run_guard() {
+    local caddy_web_host="$1"
+    local caddy_web_url="$2"
+
+    local tmp_env="$TEST_TMP/test.env"
+    cat > "$tmp_env" <<EOF
+DATABASE_URL=postgres://dummy:dummy@localhost:5432/dummy
+POSTGRES_USER=dummy
+POSTGRES_PASSWORD=dummy
+POSTGRES_DB=dummy
+WEB_UPSTREAM_HOST=$caddy_web_host
+WEB_UPSTREAM_URL=$caddy_web_url
+EOF
+
+    local out
     local exit_code=0
-    REPO_ROOT="$TEST_TMP" "$GUARD_SCRIPT" >/dev/null 2>&1 || exit_code=$?
+    # Provide the env file to the guard through WELTGEWEBE_ENV_FILE but actually we can't easily override the TMP_ENV inside the guard unless we export it or it uses an argument.
+    # Wait, the guard creates its own TMP_ENV. We can't override its TMP_ENV directly.
+    # Instead, the guard's TMP_ENV has hardcoded values!
+    # Ah! The prompt says "Die Fixture muss WEB_UPSTREAM_* dort setzen, wo der reale gerenderte Vertrag sie benötigt ... Caddy-Werte über die synthetische Env beziehungsweise einen gezielten Caddy-Override."
+    # Since the guard script hardcodes its TMP_ENV, the test script can't change the Caddy env via the guard's TMP_ENV easily unless we provide an override file for caddy too!
+
+    # We can inject Caddy values via the override file in the test.
+    out=$(REPO_ROOT="$TEST_TMP" bash "$GUARD_SCRIPT" 2>&1) || exit_code=$?
+
     echo "$exit_code"
+    echo "$out"
 }
 
 write_override() {
     local app_base="$1"
     local web_host="$2"
     local web_url="$3"
+    local caddy_web_host="$4"
+    local caddy_web_url="$5"
+    local auth_login="$6"
+    local auth_token="$7"
+
     cat > "$TEST_TMP/infra/compose/compose.prod.override.yml" <<EOF
 services:
   api:
     environment:
       APP_BASE_URL: $app_base
-      AUTH_PUBLIC_LOGIN: '1'
-      AUTH_LOG_MAGIC_TOKEN: '0'
+      AUTH_PUBLIC_LOGIN: '$auth_login'
+      AUTH_LOG_MAGIC_TOKEN: '$auth_token'
       WEB_UPSTREAM_HOST: $web_host
       WEB_UPSTREAM_URL: $web_url
+  caddy:
+    environment:
+      WEB_UPSTREAM_HOST: $caddy_web_host
+      WEB_UPSTREAM_URL: $caddy_web_url
 EOF
+}
+
+check_result() {
+    local name="$1"
+    local exit_code="$2"
+    local expected_code="$3"
+    local output="$4"
+    local expected_msg="$5"
+
+    if [ "$exit_code" -ne "$expected_code" ]; then
+        echo "FAIL: $name - Expected exit $expected_code, got $exit_code" >&2
+        echo "Output was: $output" >&2
+        exit 1
+    fi
+    if [ -n "$expected_msg" ] && [[ "$output" != *"$expected_msg"* ]]; then
+        echo "FAIL: $name - Expected message '$expected_msg' not found in output" >&2
+        echo "Output was: $output" >&2
+        exit 1
+    fi
+    echo "PASS: $name"
 }
 
 echo "Running prod-public-base-url-guard tests..."
 
-# 1. Positiv: aktueller Repo-Zustand besteht
-write_override "https://weltgewebe.net" "weltgewebe.home.arpa" "https://weltgewebe.home.arpa"
-if [ "$(run_guard)" -ne 0 ]; then
-    echo "FAIL: Expected success for correct configuration" >&2
-    exit 1
-fi
+# Helper to run and check
+run_test() {
+    local name="$1"
+    local app_base="$2"
+    local web_host="$3"
+    local web_url="$4"
+    local caddy_host="$5"
+    local caddy_url="$6"
+    local auth_login="${7:-1}"
+    local auth_token="${8:-0}"
+    local expected_code="$9"
+    local expected_msg="${10}"
 
-# 2. Negativ: interne APP_BASE_URL schlägt fehl
-write_override "https://weltgewebe.home.arpa" "weltgewebe.home.arpa" "https://weltgewebe.home.arpa"
-if [ "$(run_guard)" -ne 1 ]; then
-    echo "FAIL: Expected exit 1 for internal APP_BASE_URL" >&2
-    exit 1
-fi
+    write_override "$app_base" "$web_host" "$web_url" "$caddy_host" "$caddy_url" "$auth_login" "$auth_token"
 
-# 3. Negativ: öffentliche WEB_UPSTREAM_URL schlägt fehl
-write_override "https://weltgewebe.net" "weltgewebe.home.arpa" "https://weltgewebe.net"
-if [ "$(run_guard)" -ne 1 ]; then
-    echo "FAIL: Expected exit 1 for public WEB_UPSTREAM_URL" >&2
-    exit 1
-fi
+    # We pass the Caddy host/url to run_guard, but right now run_guard uses the override file to set Caddy env.
+    local res
+    res=$(run_guard "$caddy_host" "$caddy_url")
+    local exit_code
+    exit_code=$(echo "$res" | head -n1)
+    local output
+    output=$(echo "$res" | tail -n +2)
 
-# 4. Negativ: öffentliche WEB_UPSTREAM_HOST schlägt fehl
-write_override "https://weltgewebe.net" "weltgewebe.net" "https://weltgewebe.home.arpa"
-if [ "$(run_guard)" -ne 1 ]; then
-    echo "FAIL: Expected exit 1 for public WEB_UPSTREAM_HOST" >&2
-    exit 1
-fi
+    check_result "$name" "$exit_code" "$expected_code" "$output" "$expected_msg"
+}
 
-# 5. Negativ: fehlende Compose-Datei schlägt kontrolliert fehl (Exit 2)
+# 1. Positiv
+run_test "1. Positiv: gültige Konfiguration" \
+    "https://weltgewebe.net" "weltgewebe.home.arpa" "https://weltgewebe.home.arpa" \
+    "weltgewebe.home.arpa" "https://weltgewebe.home.arpa" \
+    "1" "0" \
+    0 ""
+
+# 2. Negativ: interne APP_BASE_URL
+run_test "2. Negativ: interne APP_BASE_URL" \
+    "https://weltgewebe.home.arpa" "weltgewebe.home.arpa" "https://weltgewebe.home.arpa" \
+    "weltgewebe.home.arpa" "https://weltgewebe.home.arpa" \
+    "1" "0" \
+    1 "api.environment.APP_BASE_URL"
+
+# 3. Negativ: öffentliche Caddy-WEB_UPSTREAM_URL
+run_test "3. Negativ: öffentliche Caddy-WEB_UPSTREAM_URL" \
+    "https://weltgewebe.net" "weltgewebe.home.arpa" "https://weltgewebe.home.arpa" \
+    "weltgewebe.home.arpa" "https://weltgewebe.net" \
+    "1" "0" \
+    1 "caddy.environment.WEB_UPSTREAM_URL"
+
+# 4. Negativ: öffentlicher Caddy-WEB_UPSTREAM_HOST
+run_test "4. Negativ: öffentlicher Caddy-WEB_UPSTREAM_HOST" \
+    "https://weltgewebe.net" "weltgewebe.home.arpa" "https://weltgewebe.home.arpa" \
+    "weltgewebe.net" "https://weltgewebe.home.arpa" \
+    "1" "0" \
+    1 "caddy.environment.WEB_UPSTREAM_HOST"
+
+# 5. Negativ: AUTH_PUBLIC_LOGIN ungleich 1
+run_test "5. Negativ: AUTH_PUBLIC_LOGIN ungleich 1" \
+    "https://weltgewebe.net" "weltgewebe.home.arpa" "https://weltgewebe.home.arpa" \
+    "weltgewebe.home.arpa" "https://weltgewebe.home.arpa" \
+    "0" "0" \
+    1 "api.environment.AUTH_PUBLIC_LOGIN"
+
+# 6. Negativ: AUTH_LOG_MAGIC_TOKEN ungleich 0
+run_test "6. Negativ: AUTH_LOG_MAGIC_TOKEN ungleich 0" \
+    "https://weltgewebe.net" "weltgewebe.home.arpa" "https://weltgewebe.home.arpa" \
+    "weltgewebe.home.arpa" "https://weltgewebe.home.arpa" \
+    "1" "1" \
+    1 "api.environment.AUTH_LOG_MAGIC_TOKEN"
+
+# 7. fehlende Basisdatei
+rm "$TEST_TMP/infra/compose/compose.prod.yml"
+res=$(REPO_ROOT="$TEST_TMP" bash "$GUARD_SCRIPT" 2>&1) || exit_code=$?
+check_result "7. Negativ: fehlende Basisdatei" "$exit_code" 2 "$res" "Error: Compose files not found"
+cp "${SCRIPT_DIR}/../../infra/compose/compose.prod.yml" "$TEST_TMP/infra/compose/"
+
+# 8. fehlende Override-Datei
 rm "$TEST_TMP/infra/compose/compose.prod.override.yml"
-if [ "$(run_guard)" -ne 2 ]; then
-    echo "FAIL: Expected exit 2 for missing compose file" >&2
-    exit 1
-fi
+res=$(REPO_ROOT="$TEST_TMP" bash "$GUARD_SCRIPT" 2>&1) || exit_code=$?
+check_result "8. Negativ: fehlende Override-Datei" "$exit_code" 2 "$res" "Error: Compose files not found"
 
 echo "All tests passed."

--- a/scripts/tests/test_prod_public_base_url_guard.sh
+++ b/scripts/tests/test_prod_public_base_url_guard.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GUARD_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/guard/prod-public-base-url-guard.sh"
+if [ ! -f "$GUARD_SCRIPT" ]; then
+    echo "Guard script not found at $GUARD_SCRIPT" >&2
+    exit 1
+fi
+
+TEST_TMP=$(mktemp -d)
+trap 'rm -rf "$TEST_TMP"' EXIT
+
+# Provide a mock REPO_ROOT structure
+mkdir -p "$TEST_TMP/infra/compose"
+cp "$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/infra/compose/compose.prod.yml" "$TEST_TMP/infra/compose/"
+
+# Helper to write override and run guard
+run_guard() {
+    local exit_code=0
+    REPO_ROOT="$TEST_TMP" "$GUARD_SCRIPT" >/dev/null 2>&1 || exit_code=$?
+    echo "$exit_code"
+}
+
+write_override() {
+    local app_base="$1"
+    local web_host="$2"
+    local web_url="$3"
+    cat > "$TEST_TMP/infra/compose/compose.prod.override.yml" <<EOF
+services:
+  api:
+    environment:
+      APP_BASE_URL: $app_base
+      AUTH_PUBLIC_LOGIN: '1'
+      AUTH_LOG_MAGIC_TOKEN: '0'
+      WEB_UPSTREAM_HOST: $web_host
+      WEB_UPSTREAM_URL: $web_url
+EOF
+}
+
+echo "Running prod-public-base-url-guard tests..."
+
+# 1. Positiv: aktueller Repo-Zustand besteht
+write_override "https://weltgewebe.net" "weltgewebe.home.arpa" "https://weltgewebe.home.arpa"
+if [ "$(run_guard)" -ne 0 ]; then
+    echo "FAIL: Expected success for correct configuration" >&2
+    exit 1
+fi
+
+# 2. Negativ: interne APP_BASE_URL schlägt fehl
+write_override "https://weltgewebe.home.arpa" "weltgewebe.home.arpa" "https://weltgewebe.home.arpa"
+if [ "$(run_guard)" -ne 1 ]; then
+    echo "FAIL: Expected exit 1 for internal APP_BASE_URL" >&2
+    exit 1
+fi
+
+# 3. Negativ: öffentliche WEB_UPSTREAM_URL schlägt fehl
+write_override "https://weltgewebe.net" "weltgewebe.home.arpa" "https://weltgewebe.net"
+if [ "$(run_guard)" -ne 1 ]; then
+    echo "FAIL: Expected exit 1 for public WEB_UPSTREAM_URL" >&2
+    exit 1
+fi
+
+# 4. Negativ: öffentliche WEB_UPSTREAM_HOST schlägt fehl
+write_override "https://weltgewebe.net" "weltgewebe.net" "https://weltgewebe.home.arpa"
+if [ "$(run_guard)" -ne 1 ]; then
+    echo "FAIL: Expected exit 1 for public WEB_UPSTREAM_HOST" >&2
+    exit 1
+fi
+
+# 5. Negativ: fehlende Compose-Datei schlägt kontrolliert fehl (Exit 2)
+rm "$TEST_TMP/infra/compose/compose.prod.override.yml"
+if [ "$(run_guard)" -ne 2 ]; then
+    echo "FAIL: Expected exit 2 for missing compose file" >&2
+    exit 1
+fi
+
+echo "All tests passed."


### PR DESCRIPTION
## Summary

- canonicalizes the production `APP_BASE_URL` as `https://weltgewebe.net`
- preserves the internal `WEB_UPSTREAM_HOST=weltgewebe.home.arpa` and `WEB_UPSTREAM_URL=https://weltgewebe.home.arpa`
- renders the merged production Compose model and enforces the API/Caddy boundary in a dedicated guard
- covers positive, policy-failure, auth-safety, and missing-file cases
- runs both the fixture suite and the guard against the real checkout in CI
- documents the production URL contract under `docs/deploy/`
- replaces the stale, non-resolvable external contracts workflow with repository-owned JSON, schema, example, and protected-path checks
- aligns contract workflow triggers with the full protected path surface
- installs AJV tooling reproducibly from the repository lockfile
- registers the new production URL guard in `audit/impl-registry.yaml`

## Why

The live runtime was already cut over to the public base URL, but the canonical production override still pointed to `.home.arpa`. A later normal deploy could therefore have reintroduced internal Magic-Link URLs.

`APP_BASE_URL` and `WEB_UPSTREAM_*` intentionally describe different layers:

- `APP_BASE_URL` is the public application origin used for externally clickable links.
- `WEB_UPSTREAM_*` remains the internal Caddy upstream and must not be publicized.

The previous `contracts-validate` workflow referenced `heimgewebe/contracts/...@contracts-v1`. GitHub could not resolve that reusable workflow, so workflow startup failed before any job existed. The workflow now validates the contracts owned by this repository locally and retains deletion/rename protection for contract and fixture paths.

## Operational evidence

Redacted production evidence established before this PR:

- authoritative and public DNS resolution succeeded for apex, `www`, and `api`
- the public web root and both API readiness paths returned HTTP 200
- the API runtime was healthy
- a Brevo Magic-Link message was delivered
- SPF, DKIM, and DMARC passed
- the Magic Link created a valid session

No recipient address, token, message ID, raw mail headers, tracking URL, or provider secret is included in this PR.

## Validation

- `bash -n scripts/guard/prod-public-base-url-guard.sh`
- `bash -n scripts/tests/test_prod_public_base_url_guard.sh`
- fixture suite for valid config, internal `APP_BASE_URL`, public API/Caddy upstreams, auth flags, and missing Compose files
- direct guard execution against the repository checkout in CI
- contract and fixture JSON syntax validation
- protected contract/fixture deletion and rename guard
- lockfile-based dependency installation with `pnpm install --frozen-lockfile`
- AJV compilation of repository-owned domain schemas
- AJV validation of domain examples
- blocking documentation validations via `make ci-validate`
- `shellcheck` on both new shell scripts
- `git diff --check`

Current head `ae9098c4bb6122b205607168a0ecce9ca12dd996`:

Executed successfully:

- Core Guard Tests
- Docs & Shell Hygiene
- contracts-validate: all three jobs
- Docs Guard: blocking validations and generated diagnostics
- Deploy Drift Guard
- infra
- policies
- docs-style
- seo-archive

Explicitly skipped by the current repository workflow logic:

- normal `ci` build/test job, because the PR contains Markdown and the existing classifier treats any Markdown match as docs-only
- Web E2E, because it depends on the skipped `ci` job
- Heavy CI `e2e`; only its gate job ran

These skipped jobs are not represented as executed validation evidence for this PR.

## Task relation

Relates to `DEPLOY-DNS-001`.

The broader migration task remains open until the observation window and later operational closeout are complete.

## Explicit non-goals

- no live deploy
- no DNS change
- no DynDNS implementation
- no Caddy runtime modification
- no mail-provider or tracking change
- no IONOS cancellation
- no migration closeout
- no repair of the repository-wide docs-only CI classifier in this PR

## Post-merge operations

1. archive the operational server backup files outside the Git working tree
2. reconcile the live override with merged `main`
3. restore a clean server checkout
4. deploy through the normal controlled path
5. re-check live environment and public readiness paths
