### PR TITLE
fix(docmeta): align lifecycle overview with validator frontmatter semantics

### DIFF
--- a/scripts/docmeta/generate_report_lifecycle.py
+++ b/scripts/docmeta/generate_report_lifecycle.py
@@ -17,7 +17,10 @@ from scripts.docmeta.generate_report_lifecycle_inventory import (
     _cell,
 )
 from scripts.docmeta.validate_report_lifecycle import _validate_report, _load_frontmatter
-from scripts.docmeta.report_lifecycle_requirements import missing_required_report_fields
+from scripts.docmeta.report_lifecycle_requirements import (
+    missing_required_report_fields,
+    string_value,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -61,17 +64,20 @@ def collect_lifecycle_rows(root: Path, records: list[ReportRecord]) -> list[Life
         findings = _validate_report(full_path, frontmatter, root)
         finding_codes = tuple(sorted(f.code for f in findings))
 
+        # Policy-visible values use the same parsed frontmatter and
+        # normalization as validator findings. ReportRecord remains
+        # the source for path, title, and reference metadata.
         rows.append(
             LifecycleOverviewRow(
                 path=record.path,
                 title=record.title,
-                doc_type=record.doc_type,
-                status=record.status,
-                lifecycle_state=record.lifecycle_state,
-                lifecycle=record.lifecycle,
-                owner_task=record.owner_task,
-                review_after=record.review_after,
-                superseded_by=record.superseded_by,
+                doc_type=string_value(frontmatter.get("doc_type")),
+                status=string_value(frontmatter.get("status")),
+                lifecycle_state=string_value(frontmatter.get("lifecycle_state")),
+                lifecycle=string_value(frontmatter.get("lifecycle")),
+                owner_task=string_value(frontmatter.get("owner_task")),
+                review_after=string_value(frontmatter.get("review_after")),
+                superseded_by=string_value(frontmatter.get("superseded_by")),
                 primary_refs=record.referenced_by_count,
                 derived_refs=len(record.derived_referenced_by_paths),
                 findings=finding_codes,

--- a/scripts/docmeta/tests/test_generate_report_lifecycle.py
+++ b/scripts/docmeta/tests/test_generate_report_lifecycle.py
@@ -1,9 +1,17 @@
 #!/usr/bin/env python3
 import tempfile
+from dataclasses import replace
 from pathlib import Path
 import unittest
 
-from scripts.docmeta.generate_report_lifecycle import generate
+from scripts.docmeta.generate_report_lifecycle import (
+    generate,
+    collect_lifecycle_rows,
+    group_rows,
+    build_summary,
+)
+from scripts.docmeta.generate_report_lifecycle_inventory import collect_reports, InventoryConfig
+from scripts.docmeta.validate_report_lifecycle import _load_frontmatter
 
 class TestGenerateReportLifecycle(unittest.TestCase):
     def setUp(self):
@@ -162,15 +170,282 @@ class TestGenerateReportLifecycle(unittest.TestCase):
     def test_no_real_repo_mutation_when_output_is_temp(self):
         import time
         start_time = time.time()
-        
+
         self._write_report("fake.md", "---\ndoc_type: report\n---")
         generate(self.root, self.output_path)
-        
+
         real_output = Path(__file__).resolve().parents[3] / "docs" / "_generated" / "report-lifecycle.md"
-        
+
         if real_output.exists():
             stat = real_output.stat()
             self.assertTrue(stat.st_mtime < start_time, "Real repo file was modified!")
+
+    def _make_config(self) -> InventoryConfig:
+        return InventoryConfig(
+            repo_root=self.root,
+            reports_dir=self.reports_dir,
+            output_path=self.output_path,
+            primary_search_paths=(self.root / "docs",),
+            derived_search_paths=(self.root / "docs" / "_generated",),
+        )
+
+    def test_policy_fields_source_is_frontmatter(self):
+        """Seven policy-visible fields use parsed frontmatter; title and refs use ReportRecord."""
+        self._write_report(
+            "real.md",
+            "---\n"
+            "title: File Title\n"
+            "doc_type: report\n"
+            "status: deprecated\n"
+            "lifecycle_state: archived\n"
+            "lifecycle: audit\n"
+            "owner_task: TASK-REAL\n"
+            "review_after: 2026-07-01\n"
+            "superseded_by: docs/reports/replacement.md\n"
+            "---\n"
+            "# File Title\n",
+        )
+        config = self._make_config()
+        record = collect_reports(config)[0]
+        conflicting_record = replace(
+            record,
+            title="Record Title",
+            doc_type="reference",
+            status="[draft]",
+            lifecycle_state="[superseded]",
+            lifecycle="[fake]",
+            owner_task="[TASK-FAKE]",
+            review_after="[never]",
+            superseded_by="[nowhere]",
+            primary_referenced_by_paths=("docs/source-a.md",),
+            derived_referenced_by_paths=(
+                "docs/_generated/source-b.md",
+                "docs/_generated/source-c.md",
+            ),
+        )
+
+        row = collect_lifecycle_rows(self.root, [conflicting_record])[0]
+
+        # title and refs remain Record-based
+        self.assertEqual(row.title, "Record Title")
+        self.assertEqual(row.primary_refs, 1)
+        self.assertEqual(row.derived_refs, 2)
+
+        # seven policy fields must come from file frontmatter
+        self.assertEqual(row.doc_type, "report")
+        self.assertEqual(row.status, "deprecated")
+        self.assertEqual(row.lifecycle_state, "archived")
+        self.assertEqual(row.lifecycle, "audit")
+        self.assertEqual(row.owner_task, "TASK-REAL")
+        self.assertEqual(row.review_after, "2026-07-01")
+        self.assertEqual(row.superseded_by, "docs/reports/replacement.md")
+
+    def test_inline_list_values_are_normalized(self):
+        """Inline-list frontmatter values must normalize to empty string, not appear as-is."""
+        CASES = [
+            {
+                "name": "status_empty_list",
+                "field": "status",
+                "inline_value": "[]",
+                "extra_fields": (
+                    "doc_type: report\n"
+                    "lifecycle_state: archived\n"
+                    "lifecycle: audit\n"
+                    "owner_task: TASK-1\n"
+                ),
+                "expect_row_field": "status",
+                "expect_row_value": "",
+                "expect_finding": "missing_status",
+                "expect_group": "archived",
+            },
+            {
+                "name": "status_active_list",
+                "field": "status",
+                "inline_value": "[active]",
+                "extra_fields": (
+                    "doc_type: report\n"
+                    "lifecycle_state: archived\n"
+                    "lifecycle: audit\n"
+                    "owner_task: TASK-1\n"
+                ),
+                "expect_row_field": "status",
+                "expect_row_value": "",
+                "expect_finding": "missing_status",
+                "expect_group": "archived",
+            },
+            {
+                "name": "lifecycle_state_empty_list",
+                "field": "lifecycle_state",
+                "inline_value": "[]",
+                "extra_fields": (
+                    "doc_type: report\n"
+                    "status: deprecated\n"
+                    "lifecycle: audit\n"
+                    "owner_task: TASK-1\n"
+                ),
+                "expect_row_field": "lifecycle_state",
+                "expect_row_value": "",
+                "expect_finding": "missing_lifecycle_state",
+                "expect_group": "unclassified",
+            },
+            {
+                "name": "lifecycle_state_archived_list",
+                "field": "lifecycle_state",
+                "inline_value": "[archived]",
+                "extra_fields": (
+                    "doc_type: report\n"
+                    "status: deprecated\n"
+                    "lifecycle: audit\n"
+                    "owner_task: TASK-1\n"
+                ),
+                "expect_row_field": "lifecycle_state",
+                "expect_row_value": "",
+                "expect_finding": "missing_lifecycle_state",
+                "expect_group": "unclassified",
+            },
+            {
+                "name": "owner_task_list",
+                "field": "owner_task",
+                "inline_value": "[TASK-1]",
+                "extra_fields": (
+                    "doc_type: report\n"
+                    "status: deprecated\n"
+                    "lifecycle_state: archived\n"
+                    "lifecycle: audit\n"
+                ),
+                "expect_row_field": "owner_task",
+                "expect_row_value": "",
+                "expect_finding": "missing_owner_task",
+                "expect_group": "archived",
+            },
+        ]
+
+        for case in CASES:
+            with self.subTest(name=case["name"]):
+                fname = f"{case['name']}.md"
+                content = (
+                    "---\n"
+                    + case["extra_fields"]
+                    + f"{case['field']}: {case['inline_value']}\n"
+                    + "---\n"
+                )
+                self._write_report(fname, content)
+                path = self.reports_dir / fname
+
+                # prove the validator parser returns a list for the inline value
+                fm = _load_frontmatter(path)
+                self.assertIsInstance(
+                    fm.get(case["field"]),
+                    list,
+                    msg=f"{case['field']}: {case['inline_value']!r} must parse as list",
+                )
+
+                config = self._make_config()
+                records = collect_reports(config)
+                record = next(r for r in records if r.path.endswith(fname))
+                row = collect_lifecycle_rows(self.root, [record])[0]
+
+                # policy field must be normalized to empty string
+                actual_value = getattr(row, case["expect_row_field"])
+                self.assertEqual(
+                    actual_value,
+                    case["expect_row_value"],
+                    msg=(
+                        f"{case['name']}: {case['expect_row_field']} expected "
+                        f"{case['expect_row_value']!r}, got {actual_value!r}"
+                    ),
+                )
+
+                # expected finding must be present
+                self.assertIn(
+                    case["expect_finding"],
+                    row.findings,
+                    msg=f"{case['name']}: expected finding {case['expect_finding']!r}",
+                )
+
+                # grouping must match validator interpretation
+                groups = group_rows([row])
+                self.assertIn(
+                    case["expect_group"],
+                    groups,
+                    msg=f"{case['name']}: expected group {case['expect_group']!r}",
+                )
+                self.assertTrue(
+                    any(r.path == row.path for r in groups[case["expect_group"]]),
+                    msg=f"{case['name']}: row not in group {case['expect_group']!r}",
+                )
+
+                # summary counts lifecycle_state empty as missing
+                if case["field"] == "lifecycle_state":
+                    summary = build_summary([row])
+                    self.assertEqual(
+                        summary["reports_missing_lifecycle_state"],
+                        1,
+                        msg=f"{case['name']}: inline list must count as missing lifecycle_state",
+                    )
+                    self.assertEqual(
+                        summary["reports_with_lifecycle_state"],
+                        0,
+                        msg=f"{case['name']}: inline list must not count as present lifecycle_state",
+                    )
+
+                # clean up report for next subTest
+                path.unlink()
+
+    def test_rendering_with_status_inline_list(self):
+        """Rendered markdown must not show [active] as a policy value; finding must appear."""
+        self._write_report(
+            "status_list.md",
+            "---\n"
+            "doc_type: report\n"
+            "status: [active]\n"
+            "lifecycle_state: archived\n"
+            "lifecycle: audit\n"
+            "owner_task: TASK-1\n"
+            "---\n",
+        )
+        generate(self.root, self.output_path)
+        content = self.output_path.read_text(encoding="utf-8")
+
+        # inline list string must not appear as a policy value in any table cell
+        self.assertNotIn("[active]", content)
+
+        # finding must be reported because the value normalizes to empty
+        self.assertIn("missing_status", content)
+
+    def test_rendering_with_lifecycle_state_inline_list(self):
+        """[archived] lifecycle_state must not appear, row goes to unclassified, not archived."""
+        self._write_report(
+            "ls_list.md",
+            "---\n"
+            "doc_type: report\n"
+            "status: deprecated\n"
+            "lifecycle_state: [archived]\n"
+            "lifecycle: audit\n"
+            "owner_task: TASK-1\n"
+            "---\n",
+        )
+        generate(self.root, self.output_path)
+        content = self.output_path.read_text(encoding="utf-8")
+
+        # inline list string must not appear as a policy value
+        self.assertNotIn("[archived]", content)
+
+        # finding must be reported
+        self.assertIn("missing_lifecycle_state", content)
+
+        # row must be in Unclassified, not Archived
+        unclassified_section = content.split("## Unclassified Reports", 1)
+        self.assertEqual(len(unclassified_section), 2, "Unclassified Reports section missing")
+        self.assertIn("docs/reports/ls_list.md", unclassified_section[1].split("## ")[0])
+
+        archived_section = content.split("## Archived Reports", 1)
+        self.assertEqual(len(archived_section), 2, "Archived Reports section missing")
+        self.assertNotIn("docs/reports/ls_list.md", archived_section[1].split("## ")[0])
+
+        # summary: lifecycle_state counts as missing
+        self.assertIn("| reports_missing_lifecycle_state | 1 |", content)
+        self.assertIn("| reports_with_lifecycle_state | 0 |", content)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem
The lifecycle overview combined policy-visible values from the inventory
record with findings derived from validator frontmatter. Inline-list or
otherwise non-scalar values could therefore be displayed as present while the
same overview classified them as missing.

## Change
The following policy-visible overview fields now use the same parsed
frontmatter and `string_value()` normalization as lifecycle validator findings:
- doc_type
- status
- lifecycle_state
- lifecycle
- owner_task
- review_after
- superseded_by

`ReportRecord` remains the source for path, title, and reference metadata.
The raw lifecycle inventory parser and inventory output remain unchanged.

## Target proof
Before the production patch, the new regression tests failed because values
such as `[active]`, `[archived]`, and `[TASK-1]` were rendered from the
inventory record while validator findings treated them as missing.
The lifecycle-state cases were additionally grouped and counted according to
the inventory string rather than the validator-normalized value.
After the patch, the same tests pass.

## Regression coverage
- direct source-ownership test for all seven policy-visible fields
- title and reference counts remain Record-based
- `status: []`
- `status: [active]`
- `lifecycle_state: []`
- `lifecycle_state: [archived]`
- `owner_task: [TASK-1]`
- visible Markdown coverage for status and lifecycle-state list cases

## Validation
- lifecycle overview generator tests
- lifecycle validator parity tests
- lifecycle inventory tests
- complete lifecycle test group
- complete docmeta suite
- validator report output unchanged
- double `make generate`
- no diff under `docs/_generated`
- generated tree hashes unchanged
- `make ci-validate`
- `git diff --check`

## Boundaries
No validator, lifecycle-policy, inventory-parser, schema, workflow,
task-status, finding-order, or global parser-architecture change.
Related: `DOCMETA-REPORT-LIFECYCLE-001`, which remains `partial`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AECVVJbXGK987SvvBQ4WeU)_