### PR TITLE
docs(deploy): define Heimberry DynDNS owner handoff

### DIFF
--- a/docs/_generated/backlinks.md
+++ b/docs/_generated/backlinks.md
@@ -74,8 +74,14 @@ Generated automatically. Do not edit.
 
 - [relates_to] docs/blueprints/blueprint-agent-safety-control-layer.md
 
+## contracts/agent/handoff.schema.json
+
+- [relates_to] docs/reference/agent-handoff-contract.md
+- [relates_to] docs/reference/agent-operability-fixture-matrix.md
+
 ## contracts/agent/task.schema.json
 
+- [relates_to] docs/reference/agent-handoff-contract.md
 - [relates_to] docs/reference/agent-operability-fixture-matrix.md
 
 ## contracts/domain/edge.schema.json
@@ -174,6 +180,7 @@ Generated automatically. Do not edit.
 ## docs/blueprints/blueprint-agent-safety-control-layer.md
 
 - [relates_to] docs/claims/README.md
+- [relates_to] docs/reference/agent-handoff-contract.md
 - [relates_to] docs/security/agent-write-scope-baseline.md
 
 ## docs/blueprints/doc-structure-task-control-examples.md
@@ -652,6 +659,7 @@ Generated automatically. Do not edit.
 
 ## docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md
 
+- [relates_to] docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md
 - [relates_to] docs/runbooks/README.md
 
 ## docs/runbooks/uv-tooling.md
@@ -788,8 +796,21 @@ Generated automatically. Do not edit.
 
 - [relates_to] docs/reference/agent-operability-fixture-matrix.md
 
+## scripts/agent/json_contract.py
+
+- [relates_to] docs/reference/agent-handoff-contract.md
+
 ## scripts/agent/tests/test_check_non_ideal_task.py
 
+- [relates_to] docs/reference/agent-operability-fixture-matrix.md
+
+## scripts/agent/tests/test_validate_handoff.py
+
+- [relates_to] docs/reference/agent-operability-fixture-matrix.md
+
+## scripts/agent/validate_handoff.py
+
+- [relates_to] docs/reference/agent-handoff-contract.md
 - [relates_to] docs/reference/agent-operability-fixture-matrix.md
 
 ## scripts/basemap/build-hamburg-pmtiles.sh
@@ -828,6 +849,10 @@ Generated automatically. Do not edit.
 ## scripts/tests/test_domain_single_instance_guard.sh
 
 - [relates_to] docs/reports/domain-postgres-instance-coherence-decision.md
+
+## tests/fixtures/agent/handoff-valid.json
+
+- [relates_to] docs/reference/agent-handoff-contract.md
 
 ## tools/py/cost/model.csv
 

--- a/docs/_generated/backlinks.md
+++ b/docs/_generated/backlinks.md
@@ -672,6 +672,7 @@ Generated automatically. Do not edit.
 ## docs/runbooks/weltgewebe-ddns-runtime-verification.md
 
 - [relates_to] docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md
+- [relates_to] docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md
 
 ## docs/specs/auth-api.md
 

--- a/docs/_generated/doc-index.md
+++ b/docs/_generated/doc-index.md
@@ -59,6 +59,7 @@ Generated automatically. Do not edit.
 | docs.policies.agent-reading-protocol | Agent Reading Protocol | policy | canonical | docs/policies/agent-reading-protocol.md |
 | docs.policies.architecture-critique | Architekturkritik-Skill: weltgewebe.architecture.critique | policy | canonical | docs/policies/architecture-critique.md |
 | docs.proofs.basemap-hamburg-artifact-proof | Basemap Hamburg Artifact Proof (Heimserver) | proof | active | docs/proofs/basemap-hamburg-artifact-proof.md |
+| docs.reference.agent-handoff-contract | Agent Handoff Contract | reference | active | docs/reference/agent-handoff-contract.md |
 | docs.reference.agent-operability-fixture-matrix | Agent-Betriebsfaehigkeit: Fixture-Matrix | reference | active | docs/reference/agent-operability-fixture-matrix.md |
 | docs.reports.agent-readiness-audit | Agent Readiness Audit | documentation | active | docs/reports/agent-readiness-audit.md |
 | docs.reports.domain-runtime-data-source-reconciliation | Domain Runtime Data Source Reconciliation | report | active | docs/reports/domain-runtime-data-source-reconciliation.md |

--- a/docs/_generated/doc-index.md
+++ b/docs/_generated/doc-index.md
@@ -122,7 +122,7 @@ Generated automatically. Do not edit.
 | runbooks.db-recovery | DB Recovery Runbook | reference | active | docs/runbooks/db-recovery.md |
 | runbooks.domain-mail-cutover | Runbook — Domain-, Mail- und SMTP-Cutover | runbook | deprecated | docs/runbooks/domain-mail-cutover.md |
 | runbooks.incident-response | Incident Response Runbook | reference | active | docs/runbooks/incident-response.md |
-| runbooks.ops.runbook.weltgewebe-selfhost-deploy | Selfhost-Deploy Runbook | reference | active | docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md |
+| runbooks.ops.runbook.weltgewebe-selfhost-deploy | Selfhost-Deploy Runbook | reference | deprecated | docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md |
 | runbooks.uv-tooling | UV-Tooling | reference | active | docs/runbooks/uv-tooling.md |
 | runbooks.weltgewebe-ddns-runtime-verification | Weltgewebe DynDNS Runtime-Verifikation | runbook | active | docs/runbooks/weltgewebe-ddns-runtime-verification.md |
 | specs.auth-api | Auth API Spec | reference | active | docs/specs/auth-api.md |

--- a/docs/_generated/relates-to-audit.md
+++ b/docs/_generated/relates-to-audit.md
@@ -14,9 +14,9 @@ Generated automatically. Do not edit.
 
 | Metrik | Wert |
 | --- | --- |
-| Relationen gesamt | 422 |
+| Relationen gesamt | 432 |
 | — depends_on | 18 |
-| — relates_to | 401 |
+| — relates_to | 411 |
 | — supersedes | 3 |
 | relates_to Anteil | 95% |
 
@@ -30,7 +30,7 @@ _Keine Lücken erkannt._
 
 > Zusammenhängende Gruppen im relates_to-Graphen.
 
-**Cluster 1** (153 Dokumente):
+**Cluster 1** (163 Dokumente):
 
 - `.github/workflows/api.yml`
 - `.github/workflows/basemap-runtime-proof.yml`
@@ -45,6 +45,8 @@ _Keine Lücken erkannt._
 - `apps/api/tests/db_domain_account_write_path.rs`
 - `apps/api/tests/db_domain_backfill.rs`
 - `audit/impl-registry.yaml`
+- `contracts/agent/handoff.schema.json`
+- `contracts/agent/task.schema.json`
 - `contracts/domain/edge.schema.json`
 - `docs/_generated/report-lifecycle-inventory.md`
 - `docs/adr/0043-edge-vs-conversation.md`
@@ -118,6 +120,8 @@ _Keine Lücken erkannt._
 - `docs/proofs/sqlx-pgbouncer-session-crud-proof.md`
 - `docs/proofs/sqlx-postgres-direct-session-crud-proof.md`
 - `docs/quickstart-gate-c.md`
+- `docs/reference/agent-handoff-contract.md`
+- `docs/reference/agent-operability-fixture-matrix.md`
 - `docs/reference/glossar.md`
 - `docs/reports/agent-readiness-audit.md`
 - `docs/reports/auth-persistence-direct-proof-diagnose-audit.md`
@@ -176,6 +180,11 @@ _Keine Lücken erkannt._
 - `docs/zusammenstellung.md`
 - `infra/compose/compose.prod.override.yml`
 - `repo.meta.yaml`
+- `scripts/agent/check_non_ideal_task.py`
+- `scripts/agent/json_contract.py`
+- `scripts/agent/tests/test_check_non_ideal_task.py`
+- `scripts/agent/tests/test_validate_handoff.py`
+- `scripts/agent/validate_handoff.py`
 - `scripts/basemap/build-hamburg-pmtiles.sh`
 - `scripts/docmeta/audit_account_email_uniqueness.py`
 - `scripts/docmeta/audit_domain_edge_references.py`
@@ -185,6 +194,7 @@ _Keine Lücken erkannt._
 - `scripts/guard/basemap-runtime-proof.sh`
 - `scripts/guard/domain-single-instance-guard.sh`
 - `scripts/tests/test_domain_single_instance_guard.sh`
+- `tests/fixtures/agent/handoff-valid.json`
 
 **Cluster 2** (4 Dokumente):
 
@@ -193,14 +203,7 @@ _Keine Lücken erkannt._
 - `tools/py/cost/model.csv`
 - `tools/py/cost/report.py`
 
-**Cluster 3** (4 Dokumente):
-
-- `contracts/agent/task.schema.json`
-- `docs/reference/agent-operability-fixture-matrix.md`
-- `scripts/agent/check_non_ideal_task.py`
-- `scripts/agent/tests/test_check_non_ideal_task.py`
-
-**Cluster 4** (3 Dokumente):
+**Cluster 3** (3 Dokumente):
 
 - `docs/adr/0042-consume-semantah-contracts.md`
 - `docs/x-repo/peers-learnings.md`

--- a/docs/_generated/relates-to-audit.md
+++ b/docs/_generated/relates-to-audit.md
@@ -14,9 +14,9 @@ Generated automatically. Do not edit.
 
 | Metrik | Wert |
 | --- | --- |
-| Relationen gesamt | 436 |
+| Relationen gesamt | 437 |
 | — depends_on | 18 |
-| — relates_to | 415 |
+| — relates_to | 416 |
 | — supersedes | 3 |
 | relates_to Anteil | 95% |
 

--- a/docs/_generated/relations-analysis.md
+++ b/docs/_generated/relations-analysis.md
@@ -17,9 +17,9 @@ Generated automatically. Do not edit.
 | Dokumente gesamt | 133 |
 | Dokumente mit ausgehenden Relationen | 132 |
 | Dokumente als Ziel referenziert | 102 |
-| Relationen gesamt | 436 |
+| Relationen gesamt | 437 |
 | — depends_on | 18 |
-| — relates_to | 415 |
+| — relates_to | 416 |
 | — supersedes | 3 |
 | Isolierte Dokumente | 0 |
 | depends_on Zyklen | 0 |

--- a/docs/_generated/relations-analysis.md
+++ b/docs/_generated/relations-analysis.md
@@ -14,12 +14,12 @@ Generated automatically. Do not edit.
 
 | Metrik | Wert |
 | --- | --- |
-| Dokumente gesamt | 131 |
-| Dokumente mit ausgehenden Relationen | 130 |
+| Dokumente gesamt | 132 |
+| Dokumente mit ausgehenden Relationen | 131 |
 | Dokumente als Ziel referenziert | 101 |
-| Relationen gesamt | 422 |
+| Relationen gesamt | 432 |
 | — depends_on | 18 |
-| — relates_to | 401 |
+| — relates_to | 411 |
 | — supersedes | 3 |
 | Isolierte Dokumente | 0 |
 | depends_on Zyklen | 0 |

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -27,7 +27,7 @@ Es ist normativ. Abweichungen davon gelten als Drift.
 
 **Weitere Dokumente:**
 
-- [Domain-/Mail-Migration](domain-mail-migration-ionos-to-inwx-mailbox-brevo.md) – Plan für den Umzug von IONOS zu INWX + mailbox.org + Brevo
+- [Domain-/Providerarchitektur und DDNS-Handoff](domain-mail-migration-ionos-to-inwx-mailbox-brevo.md) – aktueller Providerstand, Implementierungsbesitz und Runtime-Beweisgrenze
 - [Sekundäre Domain-Webflächen](secondary-domain-web-surfaces.md) – Artefakt- und Handoff-Vertrag für die Weltweberei-Informationsfläche und den späteren Heimserver-Edge (keine öffentliche Einsatzbereitschaft)
 - [Deployment-Änderungsprotokoll](./CHANGELOG.md) – Infrastrukturänderungen und deren Auswirkungen
 - [Drift-Taxonomie & Guard-Policy](./DRIFT_POLICY.md) – Klassifizierung und Handling von Drift

--- a/docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md
+++ b/docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md
@@ -18,7 +18,7 @@ relations:
   - type: relates_to
     target: docs/runbooks/domain-mail-cutover.md
   - type: relates_to
-    target: docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md
+    target: docs/runbooks/weltgewebe-ddns-runtime-verification.md
   - type: relates_to
     target: docs/adr/ADR-0008__domain-mail-provider-boundaries.md
 ---
@@ -68,6 +68,8 @@ Dieses Repository besitzt den öffentlichen Vertrag, nicht die Heimberry-Impleme
 - `scripts/heimberry/install_weltgewebe_ddns.sh` – Installation, read-only Driftprüfung und explizite Aktivierung,
 - `ops/systemd/weltgewebe-ddns.service` und `ops/systemd/weltgewebe-ddns.timer` – Laufzeitsteuerung,
 - `runbooks/weltgewebe-dyndns.md` – Betrieb, Diagnose und Rollback.
+
+Die repository-übergreifende Runtime-Abnahme steht in `docs/runbooks/weltgewebe-ddns-runtime-verification.md`.
 
 Die öffentliche Host-Allowlist ist exakt:
 

--- a/docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md
+++ b/docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md
@@ -18,6 +18,8 @@ relations:
   - type: relates_to
     target: docs/runbooks/domain-mail-cutover.md
   - type: relates_to
+    target: docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md
+  - type: relates_to
     target: docs/adr/ADR-0008__domain-mail-provider-boundaries.md
 ---
 
@@ -57,6 +59,38 @@ Die IONOS-Kündigung wurde nach menschlicher Freigabe durchgeführt. Ein reprodu
 ## 4. DNS- und DDNS-Prinzip
 
 Die Produktions-Runtime erfordert keine statische WAN-IP. Das Routing erfolgt primär über DDNS für `weltgewebe.net`. Die öffentliche URL der Anwendung wird zusätzlich in `docs/deploy/public-app-base-url.md` vertraglich geregelt.
+
+### Implementierungsbesitz
+
+Dieses Repository besitzt den öffentlichen Vertrag, nicht die Heimberry-Implementierung. Der Implementierungsbesitzer ist das Repository `heimgewebe/heimserver`. Dort liegen die kanonischen Pfade:
+
+- `scripts/heimberry/weltgewebe_ddns.py` – fail-closed Reconciliation-Client,
+- `scripts/heimberry/install_weltgewebe_ddns.sh` – Installation, read-only Driftprüfung und explizite Aktivierung,
+- `ops/systemd/weltgewebe-ddns.service` und `ops/systemd/weltgewebe-ddns.timer` – Laufzeitsteuerung,
+- `runbooks/weltgewebe-dyndns.md` – Betrieb, Diagnose und Rollback.
+
+Die öffentliche Host-Allowlist ist exakt:
+
+- `weltgewebe.net`,
+- `www.weltgewebe.net`,
+- `api.weltgewebe.net`.
+
+Weitere öffentliche DynDNS-Hosts, Wildcards oder eine statische WAN-IP benötigen eine neue Architekturentscheidung. Credentials und installierter Runtime-Zustand gehören nicht in dieses Repository.
+
+### Beweisgrenze
+
+Ein grüner Repository-Test im Implementierungsrepo beweist Quellcode, Installervertrag und deterministische Gegenwelten. Er beweist weder, dass Heimberry bereits aktualisiert wurde, noch dass DNS, Edge und Anwendung live den Zielzustand erfüllen.
+
+Ein vollständiger Runtime-Nachweis erfordert separat:
+
+1. installierte Programm- und Unit-Dateien stimmen mit einem exakten gemergten `heimserver`-Commit überein,
+2. Service und Timer besitzen den erwarteten Zustand,
+3. alle drei autoritativen INWX-Nameserver liefern für alle drei erlaubten Hosts den erwarteten einzelnen A-Record,
+4. öffentliches HTTPS antwortet für Apex, `www` und `api`,
+5. der kanonische API-Health-Pfad antwortet erfolgreich,
+6. Heimberry besitzt keinen eingehenden öffentlichen DDNS-Dienst und App-, Admin- oder Datenbankports sind nicht direkt exponiert.
+
+Live-Aktivierung erfolgt erst nach Review und Merge des Implementierungscommits. Ein PR, ein Merge-Dump oder ein erfolgreicher Health-Bericht ersetzt diesen Runtime-Nachweis nicht.
 
 ## 5. Wiederherstellungsgrenze
 

--- a/docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md
+++ b/docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md
@@ -40,19 +40,19 @@ Dieses Runbook besitzt weder den Updater noch Credentials oder eine statische WA
 
 Die damalige Migration beinhaltete:
 
-* DNS-Umstellung
-* Router-Portfreigaben
-* Edge-Gateway-Validierung
-* Mail-DNS-Fix
+- DNS-Umstellung
+- Router-Portfreigaben
+- Edge-Gateway-Validierung
+- Mail-DNS-Fix
 
 Ziel ist ein reproduzierbares Deployment-Runbook.
 
 ## Scope
 
-* DNS-Migration
-* Router-Portforward
-* Caddy-Gateway
-* typische Fehler
+- DNS-Migration
+- Router-Portforward
+- Caddy-Gateway
+- typische Fehler
 
 ## DNS-Migration (Historisch)
 
@@ -96,9 +96,9 @@ _dmarc  TXT    "v=DMARC1; p=quarantine; rua=mailto:postmaster@weltgewebe.net"
 
 Dabei:
 
-* `<public-ip>` bleibt Platzhalter
-* `<selector>` bleibt generisch
-* keine provider-internen Details einbauen
+- `<public-ip>` bleibt Platzhalter
+- `<selector>` bleibt generisch
+- keine provider-internen Details einbauen
 
 ## Router-Konfiguration (kritisch)
 
@@ -157,8 +157,8 @@ Grund:
 
 Der HTTP-Host-Header lautet dann `<public-ip>`, während Caddy-vHosts typischerweise nur auf
 
-* `weltgewebe.net`
-* `api.weltgewebe.net`
+- `weltgewebe.net`
+- `api.weltgewebe.net`
 
 matchen.
 
@@ -219,9 +219,9 @@ curl -I https://weltgewebe.net
 
 Erwartung:
 
-* HTTPS antwortet
-* Zertifikat wird sauber ausgeliefert (kein SSL/TLS-Fehler)
-* Response kommt über Caddy
+- HTTPS antwortet
+- Zertifikat wird sauber ausgeliefert (kein SSL/TLS-Fehler)
+- Response kommt über Caddy
 
 ## Ergebnis
 
@@ -245,15 +245,15 @@ System ist jetzt öffentlich erreichbar.
 
 Ohne diese Dokumentation sind typische Fehlerszenarien schwer zu diagnostizieren:
 
-* DNS korrekt, aber Router blockiert
-* NAT-Loopback-Fehler
-* fehlende MX-Records
-* falsche DNS-Authority
+- DNS korrekt, aber Router blockiert
+- NAT-Loopback-Fehler
+- fehlende MX-Records
+- falsche DNS-Authority
 
 Das Runbook verhindert zukünftige Deployment-Blocker.
 
 ## Optionale weitere Härtung
 
-* DNS Healthcheck CI
-* Deploy-Guard für fehlende A-Records
-* Mail-Delivery Test
+- DNS Healthcheck CI
+- Deploy-Guard für fehlende A-Records
+- Mail-Delivery Test

--- a/docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md
+++ b/docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md
@@ -23,20 +23,10 @@ zu einem **self-hosted Heimserver-Deployment mit edge-caddy**.
 > **Historische DNS-Phase**
 > Dieses Dokument beschreibt den historischen Schritt von Netlify zu IONOS.
 > Der heutige Zustand von `weltgewebe.net` nutzt INWX und dynamisches DDNS. Die Nebendomains sind DNS-seitig noch offen.
-
-## Aktueller DDNS-Handoff
-
-Die folgenden IONOS-Recordbeispiele sind ausschließlich historisch und dürfen nicht als aktuelle Betriebsanweisung verwendet werden. Der heutige Vertrag steht in `docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md`.
-
-Die Heimberry-Implementierung wird im Repository `heimgewebe/heimserver` verwaltet:
-
-- `scripts/heimberry/weltgewebe_ddns.py`,
-- `scripts/heimberry/install_weltgewebe_ddns.sh`,
-- `ops/systemd/weltgewebe-ddns.service`,
-- `ops/systemd/weltgewebe-ddns.timer`,
-- `runbooks/weltgewebe-dyndns.md`.
-
-Dieses Runbook besitzt weder den Updater noch Credentials oder eine statische WAN-IP. Erlaubt sind ausschließlich `weltgewebe.net`, `www.weltgewebe.net` und `api.weltgewebe.net`. Ein Repository-Pass im Implementierungsrepo ist noch kein Live-Nachweis auf Heimberry.
+>
+> Die aktuelle DDNS-Installation und Runtime-Abnahme steht ausschließlich in
+> `docs/runbooks/weltgewebe-ddns-runtime-verification.md`. Die folgenden
+> IONOS-Beispiele sind keine heutige Betriebsanweisung.
 
 Die damalige Migration beinhaltete:
 
@@ -184,19 +174,10 @@ Hairpin-NAT kann zusätzlich lokale Tests beeinflussen.
 
 ### DNS
 
-Die aktuelle DDNS-Abnahme muss die autoritative Sicht aller drei INWX-Nameserver prüfen:
-
 ```bash
-for ns in ns.inwx.de ns2.inwx.de ns3.inwx.eu; do
-  for host in weltgewebe.net www.weltgewebe.net api.weltgewebe.net; do
-    dig +noall +comments +answer "@$ns" "$host" A
-  done
-done
-
+dig A weltgewebe.net
 dig MX weltgewebe.net
 ```
-
-Erwartet wird pro Host und Nameserver genau derselbe einzelne A-Record. DNS-Protokollfehler wie `SERVFAIL` oder `REFUSED` sind kein leerer Record und dürfen keine Korrekturschreibung auslösen.
 
 ### HTTP
 

--- a/docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md
+++ b/docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md
@@ -2,8 +2,8 @@
 id: runbooks.ops.runbook.weltgewebe-selfhost-deploy
 title: Selfhost-Deploy Runbook
 doc_type: reference
-status: active
-summary: Operatives Runbook für Selfhost-Deployments des Weltgewebe.
+status: deprecated
+summary: Historische Referenz der Netlify-/IONOS-Selfhost-Migration.
 relations:
   - type: relates_to
     target: docs/runbooks/README.md
@@ -11,6 +11,8 @@ relations:
     target: docs/deployment.md
   - type: relates_to
     target: docs/deploy/heimserver.deployment.md
+  - type: relates_to
+    target: docs/runbooks/weltgewebe-ddns-runtime-verification.md
 ---
 # Ops Runbook: Weltgewebe Self-Hosted Deployment
 

--- a/docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md
+++ b/docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md
@@ -24,6 +24,20 @@ zu einem **self-hosted Heimserver-Deployment mit edge-caddy**.
 > Dieses Dokument beschreibt den historischen Schritt von Netlify zu IONOS.
 > Der heutige Zustand von `weltgewebe.net` nutzt INWX und dynamisches DDNS. Die Nebendomains sind DNS-seitig noch offen.
 
+## Aktueller DDNS-Handoff
+
+Die folgenden IONOS-Recordbeispiele sind ausschließlich historisch und dürfen nicht als aktuelle Betriebsanweisung verwendet werden. Der heutige Vertrag steht in `docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md`.
+
+Die Heimberry-Implementierung wird im Repository `heimgewebe/heimserver` verwaltet:
+
+- `scripts/heimberry/weltgewebe_ddns.py`,
+- `scripts/heimberry/install_weltgewebe_ddns.sh`,
+- `ops/systemd/weltgewebe-ddns.service`,
+- `ops/systemd/weltgewebe-ddns.timer`,
+- `runbooks/weltgewebe-dyndns.md`.
+
+Dieses Runbook besitzt weder den Updater noch Credentials oder eine statische WAN-IP. Erlaubt sind ausschließlich `weltgewebe.net`, `www.weltgewebe.net` und `api.weltgewebe.net`. Ein Repository-Pass im Implementierungsrepo ist noch kein Live-Nachweis auf Heimberry.
+
 Die damalige Migration beinhaltete:
 
 * DNS-Umstellung
@@ -170,10 +184,19 @@ Hairpin-NAT kann zusätzlich lokale Tests beeinflussen.
 
 ### DNS
 
+Die aktuelle DDNS-Abnahme muss die autoritative Sicht aller drei INWX-Nameserver prüfen:
+
 ```bash
-dig A weltgewebe.net
+for ns in ns.inwx.de ns2.inwx.de ns3.inwx.eu; do
+  for host in weltgewebe.net www.weltgewebe.net api.weltgewebe.net; do
+    dig +noall +comments +answer "@$ns" "$host" A
+  done
+done
+
 dig MX weltgewebe.net
 ```
+
+Erwartet wird pro Host und Nameserver genau derselbe einzelne A-Record. DNS-Protokollfehler wie `SERVFAIL` oder `REFUSED` sind kein leerer Record und dürfen keine Korrekturschreibung auslösen.
 
 ### HTTP
 

--- a/docs/runbooks/weltgewebe-ddns-runtime-verification.md
+++ b/docs/runbooks/weltgewebe-ddns-runtime-verification.md
@@ -1,0 +1,49 @@
+---
+id: runbooks.weltgewebe-ddns-runtime-verification
+title: Weltgewebe DynDNS Runtime-Verifikation
+doc_type: runbook
+status: active
+summary: Kontrollierte Ende-zu-Ende-Abnahme des Heimberry-DynDNS-Dienstes.
+relations:
+  - type: relates_to
+    target: docs/runbooks/README.md
+  - type: relates_to
+    target: docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md
+  - type: relates_to
+    target: docs/deploy/heimserver.deployment.md
+  - type: relates_to
+    target: docs/runbooks/incident-response.md
+---
+
+# Weltgewebe DynDNS Runtime-Verifikation
+
+## Vertrag
+
+Die Implementierung gehört zu `heimgewebe/heimserver`. Erlaubt sind ausschließlich `weltgewebe.net`, `www.weltgewebe.net` und `api.weltgewebe.net`. Ein Pull Request oder Repository-Test beweist noch keinen installierten Runtime-Zustand. Die Abnahme erfolgt erst nach Review und Merge des zu installierenden Heimserver-Commits.
+
+## Erforderliche Belege
+
+1. Der saubere Heimserver-Checkout steht auf einem exakten Commit von `main`; dessen Hash wird im Abschlussbericht festgehalten.
+2. Updater, Service und Timer stimmen bytegenau mit diesem Checkout überein. Der Standard-Installer wird vor der Aktivierung ausgeführt und anschließend mit `--check` geprüft.
+3. `--activate` beendet den unmittelbaren Service-Lauf erfolgreich, bevor der Timer aktiviert wird. Erwartet werden `Result=success`, `ExecMainStatus=0` sowie ein aktiver und aktivierter Timer.
+4. Jeder der drei autoritativen INWX-Nameserver liefert für jeden der drei erlaubten Hosts genau einen A-Record mit der aktuellen öffentlichen IPv4.
+5. HTTPS antwortet für Apex, `www` und `api` ohne TLS-Fehler.
+6. `https://weltgewebe.net/api/health/live` und `https://api.weltgewebe.net/health/live` antworten erfolgreich.
+7. Heimberry besitzt keinen Listener des DynDNS-Prozesses. Auf dem Heimserver meldet `ops/checks/preflight.sh` keine direkte Exposition der App- oder Datenbankports 8080 und 5432.
+8. Journald enthält keine Credential-Werte.
+
+## Referenzbefehle
+
+Auf Heimberry: `git pull --ff-only origin main`, Commit mit `git rev-parse HEAD` festhalten, Standard-Installer, `--check` und erst danach `--activate` ausführen. Anschließend alle neun Nameserver-/Host-Kombinationen mit `dig +time=3 +tries=1 +noall +comments +answer` prüfen. HTTPS muss für Apex, `www` und `api` antworten; zusätzlich müssen `/api/health/live` am Apex und `/health/live` am API-Host erfolgreich sein.
+
+## Fail-closed Kriterien
+
+`SERVFAIL`, `REFUSED`, fehlende DNS-Statuszeilen, mehrere A-Records, eine abweichende Adresse, ein fehlgeschlagener Healthcheck oder eine direkte Portexposition lassen die Abnahme scheitern. Repository-Health-Berichte und Merge-Dumps ersetzen keinen dieser Runtime-Belege.
+
+## Nachweisformat
+
+Der Abschlussbericht enthält Zeitstempel, Heimserver-Commit, Dateivergleiche, Service- und Timerzustand, neun autoritative DNS-Prüfungen, drei HTTPS-Prüfungen, beide Healthchecks sowie die Expositionsprüfungen auf Heimberry und Heimserver.
+
+## Rollback
+
+Bei einem Fehler wird `weltgewebe-ddns.timer` deaktiviert. Programm und Units werden aus dem letzten freigegebenen Heimserver-Commit wiederhergestellt. Credentials werden weder gelöscht noch in Berichte kopiert. Eine statische WAN-IP in Git ist kein zulässiger Rollback.


### PR DESCRIPTION
## Ziel

Der öffentliche DDNS-Vertrag bleibt in `weltgewebe`, während die ausführbare Heimberry-Implementierung eindeutig dem Repository `heimgewebe/heimserver` zugeordnet wird.

## Änderungen

- Deployment-Übersicht auf den aktuellen Provider-/DDNS-Handoff ausgerichtet
- kanonische Implementierungspfade im Owner-Repo dokumentiert
- Host-Allowlist auf `weltgewebe.net`, `www.weltgewebe.net` und `api.weltgewebe.net` festgelegt
- Repository-Beweis klar vom Live-Runtime-Nachweis getrennt
- Ende-zu-Ende-Abnahmekriterien für installierte Dateien, systemd, autoritative DNS-Sicht, HTTPS, API-Health und Expositionsgrenzen ergänzt
- historisches Selfhost-Runbook ausdrücklich von der heutigen INWX-/DDNS-Betriebsanweisung getrennt
- generierte Relations- und Indexartefakte aktualisiert

## Abhängigkeit

Dieser PR hängt von `heimgewebe/heimserver#39` ab. Er darf erst gemergt werden, wenn die dort dokumentierten Implementierungspfade auf `main` gelandet sind. Er aktiviert nichts auf Heimberry und beweist keinen Live-Zustand.

## Validierung

PASS:

- 745 Docmeta-Tests
- 115 Agent-Tests
- Claim-/Freshness-Registry
- Schema- und Relationsvalidierung
- Repo-Index-Konsistenz
- Linkprüfung
- repo-structure-, docs-relations-, generated-files- und coverage-guard
- `git diff-index --check HEAD`

Bekannte Baseline-Lücke außerhalb dieses Diffs:

Der vollständige `make validate`-Lauf erreicht alle obigen Docs-Gates und scheitert anschließend im unveränderten `scripts/tests/test_weltgewebe_up_git_branch.sh` an dessen temporärem Default-Branch-Fixture. Weder der Test noch `scripts/weltgewebe-up` werden in diesem PR geändert; `git diff origin/main --` für beide Pfade ist leer.

## Nicht behauptet

- keine Live-Aktivierung
- kein installierter Heimberry-Stand
- kein aktueller DNS-/HTTPS-Runtime-Beweis
- keine Credential- oder WAN-IP-Wahrheit im Repository