### PR TITLE
chore(docs): regenerate agent handoff indices

### DIFF
--- a/docs/_generated/backlinks.md
+++ b/docs/_generated/backlinks.md
@@ -74,8 +74,14 @@ Generated automatically. Do not edit.
 
 - [relates_to] docs/blueprints/blueprint-agent-safety-control-layer.md
 
+## contracts/agent/handoff.schema.json
+
+- [relates_to] docs/reference/agent-handoff-contract.md
+- [relates_to] docs/reference/agent-operability-fixture-matrix.md
+
 ## contracts/agent/task.schema.json
 
+- [relates_to] docs/reference/agent-handoff-contract.md
 - [relates_to] docs/reference/agent-operability-fixture-matrix.md
 
 ## contracts/domain/edge.schema.json
@@ -174,6 +180,7 @@ Generated automatically. Do not edit.
 ## docs/blueprints/blueprint-agent-safety-control-layer.md
 
 - [relates_to] docs/claims/README.md
+- [relates_to] docs/reference/agent-handoff-contract.md
 - [relates_to] docs/security/agent-write-scope-baseline.md
 
 ## docs/blueprints/doc-structure-task-control-examples.md
@@ -788,8 +795,21 @@ Generated automatically. Do not edit.
 
 - [relates_to] docs/reference/agent-operability-fixture-matrix.md
 
+## scripts/agent/json_contract.py
+
+- [relates_to] docs/reference/agent-handoff-contract.md
+
 ## scripts/agent/tests/test_check_non_ideal_task.py
 
+- [relates_to] docs/reference/agent-operability-fixture-matrix.md
+
+## scripts/agent/tests/test_validate_handoff.py
+
+- [relates_to] docs/reference/agent-operability-fixture-matrix.md
+
+## scripts/agent/validate_handoff.py
+
+- [relates_to] docs/reference/agent-handoff-contract.md
 - [relates_to] docs/reference/agent-operability-fixture-matrix.md
 
 ## scripts/basemap/build-hamburg-pmtiles.sh
@@ -828,6 +848,10 @@ Generated automatically. Do not edit.
 ## scripts/tests/test_domain_single_instance_guard.sh
 
 - [relates_to] docs/reports/domain-postgres-instance-coherence-decision.md
+
+## tests/fixtures/agent/handoff-valid.json
+
+- [relates_to] docs/reference/agent-handoff-contract.md
 
 ## tools/py/cost/model.csv
 

--- a/docs/_generated/doc-index.md
+++ b/docs/_generated/doc-index.md
@@ -59,6 +59,7 @@ Generated automatically. Do not edit.
 | docs.policies.agent-reading-protocol | Agent Reading Protocol | policy | canonical | docs/policies/agent-reading-protocol.md |
 | docs.policies.architecture-critique | Architekturkritik-Skill: weltgewebe.architecture.critique | policy | canonical | docs/policies/architecture-critique.md |
 | docs.proofs.basemap-hamburg-artifact-proof | Basemap Hamburg Artifact Proof (Heimserver) | proof | active | docs/proofs/basemap-hamburg-artifact-proof.md |
+| docs.reference.agent-handoff-contract | Agent Handoff Contract | reference | active | docs/reference/agent-handoff-contract.md |
 | docs.reference.agent-operability-fixture-matrix | Agent-Betriebsfaehigkeit: Fixture-Matrix | reference | active | docs/reference/agent-operability-fixture-matrix.md |
 | docs.reports.agent-readiness-audit | Agent Readiness Audit | documentation | active | docs/reports/agent-readiness-audit.md |
 | docs.reports.domain-runtime-data-source-reconciliation | Domain Runtime Data Source Reconciliation | report | active | docs/reports/domain-runtime-data-source-reconciliation.md |

--- a/docs/_generated/relates-to-audit.md
+++ b/docs/_generated/relates-to-audit.md
@@ -14,9 +14,9 @@ Generated automatically. Do not edit.
 
 | Metrik | Wert |
 | --- | --- |
-| Relationen gesamt | 422 |
+| Relationen gesamt | 431 |
 | — depends_on | 18 |
-| — relates_to | 401 |
+| — relates_to | 410 |
 | — supersedes | 3 |
 | relates_to Anteil | 95% |
 
@@ -30,7 +30,7 @@ _Keine Lücken erkannt._
 
 > Zusammenhängende Gruppen im relates_to-Graphen.
 
-**Cluster 1** (153 Dokumente):
+**Cluster 1** (163 Dokumente):
 
 - `.github/workflows/api.yml`
 - `.github/workflows/basemap-runtime-proof.yml`
@@ -45,6 +45,8 @@ _Keine Lücken erkannt._
 - `apps/api/tests/db_domain_account_write_path.rs`
 - `apps/api/tests/db_domain_backfill.rs`
 - `audit/impl-registry.yaml`
+- `contracts/agent/handoff.schema.json`
+- `contracts/agent/task.schema.json`
 - `contracts/domain/edge.schema.json`
 - `docs/_generated/report-lifecycle-inventory.md`
 - `docs/adr/0043-edge-vs-conversation.md`
@@ -118,6 +120,8 @@ _Keine Lücken erkannt._
 - `docs/proofs/sqlx-pgbouncer-session-crud-proof.md`
 - `docs/proofs/sqlx-postgres-direct-session-crud-proof.md`
 - `docs/quickstart-gate-c.md`
+- `docs/reference/agent-handoff-contract.md`
+- `docs/reference/agent-operability-fixture-matrix.md`
 - `docs/reference/glossar.md`
 - `docs/reports/agent-readiness-audit.md`
 - `docs/reports/auth-persistence-direct-proof-diagnose-audit.md`
@@ -176,6 +180,11 @@ _Keine Lücken erkannt._
 - `docs/zusammenstellung.md`
 - `infra/compose/compose.prod.override.yml`
 - `repo.meta.yaml`
+- `scripts/agent/check_non_ideal_task.py`
+- `scripts/agent/json_contract.py`
+- `scripts/agent/tests/test_check_non_ideal_task.py`
+- `scripts/agent/tests/test_validate_handoff.py`
+- `scripts/agent/validate_handoff.py`
 - `scripts/basemap/build-hamburg-pmtiles.sh`
 - `scripts/docmeta/audit_account_email_uniqueness.py`
 - `scripts/docmeta/audit_domain_edge_references.py`
@@ -185,6 +194,7 @@ _Keine Lücken erkannt._
 - `scripts/guard/basemap-runtime-proof.sh`
 - `scripts/guard/domain-single-instance-guard.sh`
 - `scripts/tests/test_domain_single_instance_guard.sh`
+- `tests/fixtures/agent/handoff-valid.json`
 
 **Cluster 2** (4 Dokumente):
 
@@ -193,14 +203,7 @@ _Keine Lücken erkannt._
 - `tools/py/cost/model.csv`
 - `tools/py/cost/report.py`
 
-**Cluster 3** (4 Dokumente):
-
-- `contracts/agent/task.schema.json`
-- `docs/reference/agent-operability-fixture-matrix.md`
-- `scripts/agent/check_non_ideal_task.py`
-- `scripts/agent/tests/test_check_non_ideal_task.py`
-
-**Cluster 4** (3 Dokumente):
+**Cluster 3** (3 Dokumente):
 
 - `docs/adr/0042-consume-semantah-contracts.md`
 - `docs/x-repo/peers-learnings.md`

--- a/docs/_generated/relations-analysis.md
+++ b/docs/_generated/relations-analysis.md
@@ -14,12 +14,12 @@ Generated automatically. Do not edit.
 
 | Metrik | Wert |
 | --- | --- |
-| Dokumente gesamt | 131 |
-| Dokumente mit ausgehenden Relationen | 130 |
+| Dokumente gesamt | 132 |
+| Dokumente mit ausgehenden Relationen | 131 |
 | Dokumente als Ziel referenziert | 101 |
-| Relationen gesamt | 422 |
+| Relationen gesamt | 431 |
 | — depends_on | 18 |
-| — relates_to | 401 |
+| — relates_to | 410 |
 | — supersedes | 3 |
 | Isolierte Dokumente | 0 |
 | depends_on Zyklen | 0 |


### PR DESCRIPTION
Regeneriert ausschließlich vier bereits auf main veraltete Beziehungs- und Indexartefakte. Kein Runtime-Code und keine normative Dokumentation ändern sich. make validate-core validate-guards ist grün. Der Baseline-Fix wird aus DynDNS-Handoff-PR #1263 herausgelöst.