### PR TITLE
ci: pin reusable WGX guard workflow

### DIFF
--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -17,4 +17,4 @@ concurrency:
 
 jobs:
   guard:
-    uses: heimgewebe/wgx/.github/workflows/wgx-guard.yml@main
+    uses: heimgewebe/wgx/.github/workflows/wgx-guard.yml@17e349d872e16f927bdd8e0d770d2295f8b6e663


### PR DESCRIPTION
## Ziel

Replace the mutable `@main` reference with the exact merged WGX workflow commit.

## Änderung

- pin `heimgewebe/wgx/.github/workflows/wgx-guard.yml` to `17e349d872e16f927bdd8e0d770d2295f8b6e663`

## Nutzen

Re-runs and future pull requests use reviewed workflow bytes instead of a moving branch reference.

## Validierung

The same workflow implementation already passed both WGX guard jobs and nested observatory validation in PR #1266. This PR re-runs that integration through the immutable reference.