### PR TITLE
fix(ci): restore reusable metrics workflow

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -19,5 +19,3 @@ jobs:
     uses: heimgewebe/metarepo/.github/workflows/wgx-metrics.yml@77b9fc21be6a9eaf2126931ede60232e53e74bcc
     with:
       metarepo_ref: "77b9fc21be6a9eaf2126931ede60232e53e74bcc"
-      post_url: ${{ secrets.HAUSKI_METRICS_URL }}
-    secrets: inherit


### PR DESCRIPTION
## Problem

The metrics workflow fails before creating jobs because a repository secret is passed through a normal reusable-workflow input. GitHub does not allow the secrets expression context in jobs.<job>.with.

## Fix

- remove the invalid secret-backed post_url input
- remove broad secrets inheritance, which the pinned reusable workflow does not consume
- keep the pinned metarepo workflow and schema ref unchanged

## Validation

- yamllint .github/workflows/metrics.yml
- git diff --check
- bash scripts/wgx-metrics-snapshot.sh --json

## Residual gap

The optional hausKI POST remains disabled. Preserving it safely requires the metarepo reusable workflow to declare an explicit workflow_call secret contract and consume the value through secrets, not with. This PR restores snapshot generation and schema validation without inventing an unsafe transport.

## Non-claims

A successful run proves workflow parsing and execution for this branch. It does not prove that the external ingest endpoint is configured or reachable.