### PR TITLE
docs: close TASK-CTL-002 GitHub work object decision

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,6 +133,8 @@ Issue Forms, PR-Template und Release-Konfiguration werden aktuell nicht eingefü
 
 Issue Forms können später separat eingeführt werden, wenn externe Beitragende ohne Projekteinblick aktiv werden. Release-Konfiguration kann separat betrachtet werden, wenn der Release-Prozess stabilisiert ist.
 
+Diese Entscheidung schließt TASK-CTL-002: GitHub-native Arbeitsobjekte bleiben vorerst bewusste Nicht-Implementierung. Neue Dateien unter `.github/ISSUE_TEMPLATE/` oder `.github/pull_request_template.md` brauchen künftig einen belegten Nutzen und einen eigenen PR-Schnitt.
+
 Noch offen für Folge-PRs:
 
 - **Task-Index-Generator und CI-Guard** (TASK-CTL-003) — Drift-Check (`generate_task_index.py --check`) und `.github/workflows/task-index.yml` eingeführt; CI-Lauf-Nachweis steht noch aus

--- a/docs/tasks/board.md
+++ b/docs/tasks/board.md
@@ -86,7 +86,7 @@ Die optimierte TODO-Liste wurde gegen den Repo-Stand abgeglichen und einsortiert
 
 | ID | Grund | Wiederaufnahmebedingung |
 |---|---|---|
-| TASK-CTL-002 | GitHub Issue Forms, PR-Template und Release-Konfiguration sind aktuell nicht eingeführt, weil der Nutzen gegenüber kontextgenauen PR-Bodies nicht belegt ist. | Externe Beitragende ohne Projekteinblick werden relevant, PR-Bodies verlieren wiederholt Task-/Evidenzbezüge oder der Release-Prozess ist stabil genug für Release-Labels. |
+| TASK-CTL-002 | Entscheidung abgeschlossen: GitHub Issue Forms, PR-Template und Release-Konfiguration werden aktuell nicht eingeführt, weil der Nutzen gegenüber kontextgenauen PR-Bodies nicht belegt ist. | Externe Beitragende ohne Projekteinblick werden relevant, PR-Bodies verlieren wiederholt Task-/Evidenzbezüge oder der Release-Prozess ist stabil genug für Release-Labels. |
 | DOMAIN-PG-003 | Edge-Cache-Limit-Performance: kein Lastproblem und kein Cutover-Blocker nachgewiesen (TODO C1) | Erst Messpunkt/Design mit Trade-offs, dann ggf. Umbau; kein spekulativer Performance-Umbau |
 | OPT-CI-003 | dtolnay/uv-Ref-Vereinheitlichung: niedrige Priorität, nicht cutover-relevant | Jederzeit als kleiner CI-Hygiene-PR möglich |
 | OPT-INF-002 | SHA-Pinning der Third-Party-Actions: erst nach Update-Automation sinnvoll (TODO C3) | Nach OPT-CI-004 (Dependency-Update-Automation/Policy) |

--- a/docs/tasks/index.json
+++ b/docs/tasks/index.json
@@ -121,16 +121,17 @@
       "id": "TASK-CTL-002",
       "title": "GitHub-native Arbeitsobjekte minimal evaluieren",
       "area": "governance",
-      "status": "open",
+      "status": "done",
       "priority": "low",
       "effort": "S",
       "risk": "low",
       "owner": "unknown",
-      "evidence": [],
-      "missing_evidence": [
-        "Issue Forms, PR-Template und Release-Konfiguration bewusst zurückgestellt: erhöhen Formular-Overhead ohne belegten Mehrwert gegenüber kontextgenauen PR-Bodies",
-        "Wiederaufnahme sinnvoll wenn: externe Beitragende ohne Projekteinblick aktiv werden oder Release-Prozess stabilisiert ist"
+      "evidence": [
+        "CONTRIBUTING.md",
+        "docs/tasks/board.md",
+        "docs/blueprints/doc-structure-task-control.md"
       ],
+      "missing_evidence": [],
       "acceptance": [
         "Entscheidung dokumentiert in CONTRIBUTING.md und board.md",
         "Kein Artefakt unter .github/ISSUE_TEMPLATE/ oder .github/pull_request_template.md ohne belegten Nutzen eingeführt"
@@ -142,7 +143,7 @@
           "docs/blueprints/doc-structure-task-control.md"
         ]
       },
-      "updated_at": "2026-05-28"
+      "updated_at": "2026-06-29"
     },
     {
       "id": "TASK-CTL-003",


### PR DESCRIPTION
## Summary
- document the current decision not to introduce GitHub Issue Forms, PR templates, or release configuration
- close TASK-CTL-002 with durable evidence in CONTRIBUTING.md, docs/tasks/board.md, and the task-control index
- confirm that no .github/ISSUE_TEMPLATE or pull_request_template artifact is introduced

## Validation
- python3 -m scripts.docmeta.validate_task_index docs/tasks/index.json
- python3 -c "import sys; from scripts.docmeta import generate_task_index as g; sys.argv=['generate_task_index','--check']; raise SystemExit(g.main())"
- python3 -m scripts.docmeta.validate_schema
- python3 -m scripts.docmeta.validate_relations
- no .github/ISSUE_TEMPLATE or pull_request_template artifact exists
- git diff --check

## Notes
This is a governance closure, not a GitHub-template rollout. The decision remains reversible once external contribution volume, repeated PR-body drift, or a stable release process gives templates measurable value.
