### PR TITLE
docs: close DOMAIN-PG-003 design decision

### DIFF
--- a/docs/reports/domain-edge-cache-limit-design.md
+++ b/docs/reports/domain-edge-cache-limit-design.md
@@ -1,0 +1,76 @@
+---
+id: reports.domain-edge-cache-limit-design
+title: "Domain Edge Cache-Limit Design — DOMAIN-PG-003"
+doc_type: report
+status: active
+lifecycle_state: active
+lifecycle: decision-prep
+owner_task: DOMAIN-PG-003
+review_after: 2026-09-29
+created: 2026-06-29
+lang: de
+summary: >
+  Designentscheidung zu DOMAIN-PG-003: Der aktuelle PostgreSQL-Edge-Write-Pfad
+  bleibt vorerst korrektheitsorientiert. Ein Umbau der Limitprüfung wird erst
+  nach Messung und unter Erhalt der Duplicate-vor-Limit-Semantik umgesetzt.
+relations:
+  - type: relates_to
+    target: apps/api/src/domain_db.rs
+  - type: relates_to
+    target: apps/api/src/routes/edges.rs
+  - type: relates_to
+    target: docs/blueprints/domain-data-postgres-cutover.md
+  - type: relates_to
+    target: docs/tasks/board.md
+  - type: relates_to
+    target: docs/tasks/index.json
+---
+
+# Domain Edge Cache-Limit Design — DOMAIN-PG-003
+
+## Entscheidung
+
+DOMAIN-PG-003 wird als Design- und Mess-Gate abgeschlossen. Es gibt in diesem Slice keine Runtime-Aenderung.
+
+Der aktuelle PostgreSQL-Write-Pfad bleibt vorerst bestehen. Er prueft Duplicate-ID vor Cache-Limit und serialisiert die Persistenz so, dass parallele Inserts die sichtbare API-Semantik nicht unterlaufen.
+
+## Beizubehaltende Semantik
+
+Jeder spaetere Umbau muss diese Semantik erhalten oder ausdruecklich aendern:
+
+- Duplicate-ID liefert weiter `409 duplicate edge id`.
+- Duplicate-ID wird vor Cache-Limit entschieden.
+- Cache-Limit liefert weiter `409 edge cache limit reached`.
+- Race-Sicherheit bleibt erhalten.
+- JSONL- und PostgreSQL-Pfade bleiben semantisch nachvollziehbar vergleichbar.
+
+## Bewertete Optionen
+
+| Option | Beschreibung | Vorteil | Risiko | Entscheidung |
+|---|---|---|---|---|
+| A — Status quo | serialisierte Pruefung plus Count und Insert | einfach, korrekt, Race-sicher | skaliert schlecht bei hoher Insert-Last | bleibt bis Messpunkt |
+| B — Counter-Tabelle | eigene Zaehlertabelle mit Row-Lock | O(1)-Limitpruefung | zusaetzliche Konsistenzflaeche | nur nach Messung |
+| C — Deferred Guard | Insert zuerst, periodische Korrektur | hohe Write-Performance | aendert Limit-Semantik | nicht fuer Stage A |
+| D — Advisory Lock + Count | weniger harte Serialisierung | potenziell weniger Sperrwirkung | Semantik schwerer zu beweisen | nur mit Concurrency-Test |
+| E — Limit entfernen | PostgreSQL ohne Cache-Limit | einfachster DB-Pfad | bricht bestehende API-Grenze | nicht ohne Produktentscheidung |
+
+## Mess-Gate vor Umbau
+
+Ein spaeterer Implementierungs-PR muss vor dem Umbau mindestens dokumentieren:
+
+- erwartete Insert-Rate fuer `POST /edges`,
+- gemessene Latenz des aktuellen Pfads bei repraesentativem Datenstand,
+- Verhalten bei parallelen Inserts mit gleicher ID,
+- Verhalten bei parallelen Inserts knapp unter oder ueber dem Limit,
+- gewuenschte Semantik bei Limit-Erreichen.
+
+## Minimaler Testumfang fuer einen spaeteren Umbau
+
+- Duplicate-vor-Limit-Test,
+- paralleler Insert-Test gegen Limitgrenze,
+- eindeutige Zuordnung von DB-Fehlern zu HTTP-409-Varianten,
+- Regressionstest fuer JSONL-/PostgreSQL-Paritaet der sichtbaren API-Semantik.
+
+## Ergebnis
+
+DOMAIN-PG-003 entscheidet nicht, dass der aktuelle Pfad dauerhaft ideal ist. Es entscheidet, dass ein Ersatz ohne Messung und ohne Semantikbeweis nicht eingefuehrt wird. Damit ist der naechste Schritt klar: messen, dann umbauen.

--- a/docs/tasks/board.md
+++ b/docs/tasks/board.md
@@ -87,7 +87,7 @@ Die optimierte TODO-Liste wurde gegen den Repo-Stand abgeglichen und einsortiert
 | ID | Grund | Wiederaufnahmebedingung |
 |---|---|---|
 | TASK-CTL-002 | Entscheidung abgeschlossen: GitHub Issue Forms, PR-Template und Release-Konfiguration werden aktuell nicht eingeführt, weil der Nutzen gegenüber kontextgenauen PR-Bodies nicht belegt ist. | Externe Beitragende ohne Projekteinblick werden relevant, PR-Bodies verlieren wiederholt Task-/Evidenzbezüge oder der Release-Prozess ist stabil genug für Release-Labels. |
-| DOMAIN-PG-003 | api | Edge-Cache-Limit ohne Tabellenlock und Vollzählung designen | done | low | `docs/reports/domain-edge-cache-limit-design.md`, `apps/api/src/domain_db.rs`, `apps/api/src/routes/edges.rs` | Designentscheidung abgeschlossen: kein ungemessener Runtime-Umbau; Duplicate-vor-Limit und Race-Sicherheit bleiben verbindliche Folgesemantik. |
+| DOMAIN-PG-003 | Designentscheidung abgeschlossen: kein ungemessener Runtime-Umbau; Ersatz des aktuellen Pfads erst nach Messung und Concurrency-Tests. | Wiederaufnahme nur als Implementierungs-Slice mit Messdaten und Semantiktests fuer Duplicate-vor-Limit und Race-Sicherheit. |
 | OPT-INF-002 | SHA-Pinning der Third-Party-Actions: erst nach Update-Automation sinnvoll (TODO C3) | Nach OPT-CI-004 (Dependency-Update-Automation/Policy) |
 
 ## Erledigte Tasks

--- a/docs/tasks/board.md
+++ b/docs/tasks/board.md
@@ -87,7 +87,7 @@ Die optimierte TODO-Liste wurde gegen den Repo-Stand abgeglichen und einsortiert
 | ID | Grund | Wiederaufnahmebedingung |
 |---|---|---|
 | TASK-CTL-002 | Entscheidung abgeschlossen: GitHub Issue Forms, PR-Template und Release-Konfiguration werden aktuell nicht eingeführt, weil der Nutzen gegenüber kontextgenauen PR-Bodies nicht belegt ist. | Externe Beitragende ohne Projekteinblick werden relevant, PR-Bodies verlieren wiederholt Task-/Evidenzbezüge oder der Release-Prozess ist stabil genug für Release-Labels. |
-| DOMAIN-PG-003 | Edge-Cache-Limit-Performance: kein Lastproblem und kein Cutover-Blocker nachgewiesen (TODO C1) | Erst Messpunkt/Design mit Trade-offs, dann ggf. Umbau; kein spekulativer Performance-Umbau |
+| DOMAIN-PG-003 | api | Edge-Cache-Limit ohne Tabellenlock und Vollzählung designen | done | low | `docs/reports/domain-edge-cache-limit-design.md`, `apps/api/src/domain_db.rs`, `apps/api/src/routes/edges.rs` | Designentscheidung abgeschlossen: kein ungemessener Runtime-Umbau; Duplicate-vor-Limit und Race-Sicherheit bleiben verbindliche Folgesemantik. |
 | OPT-INF-002 | SHA-Pinning der Third-Party-Actions: erst nach Update-Automation sinnvoll (TODO C3) | Nach OPT-CI-004 (Dependency-Update-Automation/Policy) |
 
 ## Erledigte Tasks

--- a/docs/tasks/index.json
+++ b/docs/tasks/index.json
@@ -1184,18 +1184,18 @@
       "id": "DOMAIN-PG-003",
       "title": "Edge-Cache-Limit ohne Tabellenlock und Vollzaehlung designen",
       "area": "api",
-      "status": "open",
+      "status": "done",
       "priority": "low",
       "effort": "M",
       "risk": "medium",
       "owner": "unknown",
       "evidence": [
-        "apps/api/src/routes/edges.rs"
+        "docs/reports/domain-edge-cache-limit-design.md",
+        "apps/api/src/domain_db.rs",
+        "apps/api/src/routes/edges.rs",
+        "docs/blueprints/domain-data-postgres-cutover.md"
       ],
-      "missing_evidence": [
-        "Kein gemessener Insert-Pfad und keine dokumentierte Trade-off-Entscheidung zur Abloesung von LOCK TABLE + COUNT(*)",
-        "Bewusst zurueckgestellt (TODO C1): erst Messpunkt/Design, dann Umbau"
-      ],
+      "missing_evidence": [],
       "acceptance": [
         "Entscheidung mit Trade-offs dokumentiert; Race-Sicherheit bleibt erhalten",
         "Duplicate-vor-Limit-Semantik bleibt erhalten oder wird bewusst geaendert",
@@ -1208,7 +1208,7 @@
           "docs/blueprints/domain-data-postgres-cutover.md"
         ]
       },
-      "updated_at": "2026-06-16"
+      "updated_at": "2026-06-29"
     },
     {
       "id": "CI-TOOL-001",


### PR DESCRIPTION
## Summary
- add a design decision report for DOMAIN-PG-003
- document trade-offs, required measurement gates, and preserved API semantics
- close the task-control entry without changing runtime code

## Validation
- python3 -m scripts.docmeta.validate_task_index docs/tasks/index.json
- task-index drift check via scripts.docmeta.generate_task_index --check
- python3 -m scripts.docmeta.validate_schema
- python3 -m scripts.docmeta.validate_relations

## Notes
This is a design slice only. A later implementation needs measurement and concurrency tests before changing the current write path.
