### PR TITLE
docs(auth): reconcile passkey PostgreSQL evidence

### DIFF
--- a/docs/tasks/board.md
+++ b/docs/tasks/board.md
@@ -73,7 +73,7 @@ Die optimierte TODO-Liste wurde gegen den Repo-Stand abgeglichen und einsortiert
 |---|---|---|---|
 | OPT-ARC-001 | Step-up-E-Mail-Persistenz und WebAuthn-User-ID-Writeback offen; Runtime-Smoke und Cutover ausstehend; JSONL-Demontage ausstehend | Offene Migrationsteile bzw. Cutover-Proof vorbereiten | JSONL bleibt Default-Lesequelle und Write-Truth bis vollständiger Cutover; POST /accounts, PATCH /nodes und POST /edges schreiben optional PostgreSQL; Schema- und Backfill-Proof sind belegt; der geänderte Read-Path-Proof-Harness wartet auf frische PR-CI-Evidence |
 | DOMAIN-PG-001 | Edge-Referenz-Policy (FK oder Guard) hängt am Edge-Orphan-Audit | DB-PROOF-001 ist nur partial; repräsentativer Runtime-/Deployment-Datenlauf mit auditable_edges_total > 0 und FK-vs-Guard-Policyentscheidung fehlen. | Kein FK-/Referenz-Cutover vor Audit; Orphans dürfen nicht still verworfen werden |
-| AUTH-PG-003 | `webauthn_user_id`-Backfill und späteres `NOT NULL` hängen an WebAuthn-Persistenz | AUTH-PG-002 fachlich offen; kein NULL-Audit, kein Backfill-Test | Kein `NOT NULL` vor Audit + Backfill; keine stille UUID-Neuerzeugung bei Reload |
+| AUTH-PG-003 | `webauthn_user_id`-Backfill und späteres `NOT NULL` hängen an WebAuthn-Persistenz | AUTH-PG-002 Store/Runtime-Facade und Cutover-Plan sind belegt; Produktions-Cutover, Browser-/Authenticator-E2E und Backfill-Strategie fehlen; kein NULL-Audit, kein Backfill-Test | Kein `NOT NULL` vor Audit + Backfill; keine stille UUID-Neuerzeugung bei Reload |
 
 ## Nächste PR-Kandidaten
 

--- a/docs/tasks/index.json
+++ b/docs/tasks/index.json
@@ -1158,7 +1158,11 @@
       ],
       "links": {
         "issues": [],
-        "prs": [],
+        "prs": [
+          "#1295",
+          "#1299",
+          "#1300"
+        ],
         "docs": [
           "docs/reports/auth-status-matrix.md",
           "docs/reports/passkey-register-verify-prep.md",
@@ -1183,7 +1187,7 @@
       ],
       "missing_evidence": [
         "legacy_webauthn_user_id_backfill und webauthn_user_id_not_null sind ausdrueckliche Non-Goals von OPT-ARC-001 (docs/reports/opt-arc-001-db-proof-matrix.json)",
-        "WebAuthn-Credential-Persistenz (AUTH-PG-002) ist fachlich noch nicht geklaert; die Backfill-Strategie haengt davon ab",
+        "AUTH-PG-002 Store/Runtime-Facade und Cutover-Plan sind belegt; Produktions-Cutover, Browser-/Authenticator-E2E und Backfill-Strategie fuer Legacy-Accounts bleiben offen",
         "Kein Audit, wie viele Accounts webauthn_user_id IS NULL haben, und kein Backfill-Test"
       ],
       "acceptance": [
@@ -1199,7 +1203,7 @@
           "docs/reports/opt-arc-001-db-proof-matrix.json"
         ]
       },
-      "updated_at": "2026-06-16"
+      "updated_at": "2026-07-01"
     },
     {
       "id": "DOMAIN-PG-003",


### PR DESCRIPTION
## Summary
- Reconcile AUTH-PG-002 docs after merged passkey PostgreSQL store/runtime work.
- Replace stale 'PR-CI pending' language with PR #1299 / Run 28494688328 / Job 84458418708 evidence.
- Keep AUTH-PG-002 partial and preserve open cutover gaps: production cutover, full Register→Reload→Login E2E, management UI, and AUTH-PG-003 backfill/NOT NULL.

## Validation
- python3 -m json.tool docs/tasks/index.json
- python3 -m scripts.docmeta.check_links
- git diff --check
- python3 -m scripts.docmeta.validate_task_index docs/tasks/index.json
- python3 -m scripts.docmeta.generate_task_index --check

## Notes
- Docs-only reconciliation.
- No runtime code change.
