### PR TITLE
test(auth): prove passkey PostgreSQL route login

### DIFF
--- a/.github/workflows/auth-passkey-register-proof.yml
+++ b/.github/workflows/auth-passkey-register-proof.yml
@@ -19,7 +19,7 @@
 #   - stored_credential_reflected: true
 #   - auth_options_status: 200
 #   - auth_verify_status: 200
-#   - auth_verify_set_cookie: true
+#   - auth_verify_session_cookie_present: true
 #   - virtual_authenticator_credentials > 0
 #
 # Scope distinction:

--- a/.github/workflows/auth-passkey-register-proof.yml
+++ b/.github/workflows/auth-passkey-register-proof.yml
@@ -17,6 +17,9 @@
 #   - register_verify_set_cookie: null
 #   - session_cookie_unchanged: true
 #   - stored_credential_reflected: true
+#   - auth_options_status: 200
+#   - auth_verify_status: 200
+#   - auth_verify_set_cookie: true
 #   - virtual_authenticator_credentials > 0
 #
 # Scope distinction:
@@ -85,7 +88,24 @@ jobs:
       NPM_CONFIG_FUND: "false"
       PUPPETEER_SKIP_DOWNLOAD: "true"
       PLAYWRIGHT_HTML_REPORT_OPEN: never
+      DATABASE_URL: postgres://welt:gewebe@localhost:5432/weltgewebe
+      AUTH_PASSKEY_PROOF_POSTGRES: "1"
       PLAYWRIGHT_JUNIT_OUTPUT_NAME: results.xml
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: welt
+          POSTGRES_PASSWORD: gewebe
+          POSTGRES_DB: weltgewebe
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
     steps:
       - uses: actions/checkout@v4
 

--- a/apps/api/src/routes/auth.rs
+++ b/apps/api/src/routes/auth.rs
@@ -27,7 +27,7 @@ use crate::{
     auth::session::SessionBackendError,
     auth::step_up_tokens::ConsumeMatchResult,
     auth::{role::Role, tokens::TokenStore},
-    config::{DomainAccountWriteSource, DomainReadSource},
+    config::DomainAccountWriteSource,
     domain_db::{update_account_email_in_postgres, AccountEmailUpdateError},
     middleware::auth::AuthContext,
     routes::accounts::{AccountInternal, AccountPublic},
@@ -2782,7 +2782,7 @@ pub async fn passkey_testing_bootstrap_session(
         }
     };
 
-    if state.config.domain_read_source == DomainReadSource::Postgres {
+    if state.config.domain_read_source == crate::config::DomainReadSource::Postgres {
         let Some(pool) = state.db_pool.as_ref() else {
             tracing::error!(
                 event = "auth.passkey.testing_bootstrap_session.db_pool_missing",

--- a/apps/api/src/routes/auth.rs
+++ b/apps/api/src/routes/auth.rs
@@ -2800,7 +2800,7 @@ pub async fn passkey_testing_bootstrap_session(
             "INSERT INTO domain_accounts \
                 (id, kind, title, mode, radius_m, disabled, role, email, webauthn_user_id, public_payload, private_payload) \
              VALUES \
-                ($1, 'garnrolle', 'Passkey Proof User', 'ron', 0, false, 'gast', $2, $3, '{}'::jsonb, '{}'::jsonb) \
+                ($1, 'garnrolle', 'Passkey Proof User', 'ron', 0, false, 'gast', $2, $3::uuid, '{}'::jsonb, '{}'::jsonb) \
              ON CONFLICT (id) DO UPDATE SET \
                 title = EXCLUDED.title, \
                 disabled = false, \

--- a/apps/api/src/routes/auth.rs
+++ b/apps/api/src/routes/auth.rs
@@ -27,7 +27,7 @@ use crate::{
     auth::session::SessionBackendError,
     auth::step_up_tokens::ConsumeMatchResult,
     auth::{role::Role, tokens::TokenStore},
-    config::DomainAccountWriteSource,
+    config::{DomainAccountWriteSource, DomainReadSource},
     domain_db::{update_account_email_in_postgres, AccountEmailUpdateError},
     middleware::auth::AuthContext,
     routes::accounts::{AccountInternal, AccountPublic},
@@ -2755,25 +2755,74 @@ pub async fn passkey_testing_bootstrap_session(
 ) -> impl IntoResponse {
     let request_id = get_request_id(&headers);
 
-    {
+    let webauthn_user_id = {
         let mut accounts = state.accounts.write().await;
-        if accounts.get(PASSKEY_PROOF_ACCOUNT_ID).is_none() {
-            accounts.insert(AccountInternal {
-                public: AccountPublic {
-                    id: PASSKEY_PROOF_ACCOUNT_ID.to_string(),
-                    kind: "garnrolle".to_string(),
-                    title: "Passkey Proof User".to_string(),
-                    summary: None,
-                    public_pos: None,
-                    mode: crate::routes::accounts::AccountMode::Ron,
-                    radius_m: 0,
-                    disabled: false,
-                    tags: vec![],
-                },
-                role: Role::Gast,
-                email: Some(PASSKEY_PROOF_ACCOUNT_EMAIL.to_string()),
-                webauthn_user_id: Uuid::new_v4(),
+        match accounts.get(PASSKEY_PROOF_ACCOUNT_ID) {
+            Some(account) => account.webauthn_user_id,
+            None => {
+                let webauthn_user_id = Uuid::new_v4();
+                accounts.insert(AccountInternal {
+                    public: AccountPublic {
+                        id: PASSKEY_PROOF_ACCOUNT_ID.to_string(),
+                        kind: "garnrolle".to_string(),
+                        title: "Passkey Proof User".to_string(),
+                        summary: None,
+                        public_pos: None,
+                        mode: crate::routes::accounts::AccountMode::Ron,
+                        radius_m: 0,
+                        disabled: false,
+                        tags: vec![],
+                    },
+                    role: Role::Gast,
+                    email: Some(PASSKEY_PROOF_ACCOUNT_EMAIL.to_string()),
+                    webauthn_user_id,
+                });
+                webauthn_user_id
+            }
+        }
+    };
+
+    if state.config.domain_read_source == DomainReadSource::Postgres {
+        let Some(pool) = state.db_pool.as_ref() else {
+            tracing::error!(
+                event = "auth.passkey.testing_bootstrap_session.db_pool_missing",
+                request_id = %request_id,
+                "PostgreSQL read source selected for passkey proof without a database pool"
+            );
+            let err = serde_json::json!({
+                "error": "INTERNAL_SERVER_ERROR",
+                "message": "PostgreSQL pool missing for passkey proof"
             });
+            return (StatusCode::INTERNAL_SERVER_ERROR, Json(err)).into_response();
+        };
+
+        if let Err(error) = sqlx::query(
+            "INSERT INTO domain_accounts \
+                (id, kind, title, mode, radius_m, disabled, role, email, webauthn_user_id, public_payload, private_payload) \
+             VALUES \
+                ($1, 'garnrolle', 'Passkey Proof User', 'ron', 0, false, 'gast', $2, $3, '{}'::jsonb, '{}'::jsonb) \
+             ON CONFLICT (id) DO UPDATE SET \
+                title = EXCLUDED.title, \
+                disabled = false, \
+                role = EXCLUDED.role, \
+                email = EXCLUDED.email, \
+                webauthn_user_id = EXCLUDED.webauthn_user_id, \
+                updated_at = now()",
+        )
+        .bind(PASSKEY_PROOF_ACCOUNT_ID)
+        .bind(PASSKEY_PROOF_ACCOUNT_EMAIL)
+        .bind(webauthn_user_id.to_string())
+        .execute(pool)
+        .await
+        {
+            tracing::error!(
+                event = "auth.passkey.testing_bootstrap_session.db_persist_failed",
+                request_id = %request_id,
+                error = %error,
+                "Failed to persist passkey proof account to PostgreSQL"
+            );
+            let err = serde_json::json!({"error": "INTERNAL_SERVER_ERROR"});
+            return (StatusCode::INTERNAL_SERVER_ERROR, Json(err)).into_response();
         }
     }
 
@@ -2893,15 +2942,26 @@ pub async fn passkey_testing_list_credentials(
         }
     };
 
-    let credential_ids = state
-        .passkeys
-        .credential_ids_for_account(&account_id)
-        .into_iter()
-        .map(|credential_id| {
-            serde_json::to_value(credential_id)
-                .expect("CredentialID must serialize for integration-testing response")
-        })
-        .collect::<Vec<_>>();
+    let credential_ids =
+        match passkeys_runtime::credential_ids_for_account(&state, &account_id).await {
+            Ok(ids) => ids
+                .into_iter()
+                .map(|credential_id| {
+                    serde_json::to_value(credential_id)
+                        .expect("CredentialID must serialize for integration-testing response")
+                })
+                .collect::<Vec<_>>(),
+            Err(error) => {
+                tracing::error!(
+                    event = "auth.passkey.testing_list_credentials.credential_store_error",
+                    account_id = %account_id,
+                    error = ?error,
+                    "Failed to list passkey proof credentials from runtime store"
+                );
+                let err = serde_json::json!({"error": "PASSKEY_CREDENTIAL_BACKEND_UNAVAILABLE"});
+                return (StatusCode::SERVICE_UNAVAILABLE, Json(err)).into_response();
+            }
+        };
 
     let body = serde_json::json!({
         "account_id": account_id,

--- a/apps/web/playwright.auth.proof.config.ts
+++ b/apps/web/playwright.auth.proof.config.ts
@@ -47,6 +47,12 @@ export default defineConfig({
         WEBAUTHN_RP_ID: "localhost",
         WEBAUTHN_RP_ORIGIN: `http://localhost:${PORT}`,
         WEBAUTHN_RP_NAME: "Weltgewebe Test",
+        ...(process.env.AUTH_PASSKEY_PROOF_POSTGRES === "1"
+          ? {
+              WELTGEWEBE_DOMAIN_READ_SOURCE: "postgres",
+              WELTGEWEBE_PASSKEY_CREDENTIAL_SOURCE: "postgres",
+            }
+          : {}),
       },
     },
     {

--- a/apps/web/tests/proofs/passkey-register-positive.proof.ts
+++ b/apps/web/tests/proofs/passkey-register-positive.proof.ts
@@ -411,7 +411,10 @@ test.describe("Passkey Register Positive Proof", () => {
       const loginSessionCookie = cookiesAfterAuthVerify.find(
         (cookie) => cookie.name === "gewebe_session",
       );
-      expect(loginSessionCookie, "auth/verify must install a session cookie").toBeTruthy();
+      expect(
+        loginSessionCookie,
+        "auth/verify must install a session cookie",
+      ).toBeTruthy();
 
       const virtualCredentials = (await cdp.send("WebAuthn.getCredentials", {
         authenticatorId,

--- a/apps/web/tests/proofs/passkey-register-positive.proof.ts
+++ b/apps/web/tests/proofs/passkey-register-positive.proof.ts
@@ -403,10 +403,6 @@ test.describe("Passkey Register Positive Proof", () => {
         ok: true,
         account_id: loginBody.account_id,
       });
-      expect(
-        authVerifyNetworkResponse.headers()["set-cookie"],
-        "auth/verify must mint a session cookie only after credential verification",
-      ).toBeTruthy();
       const cookiesAfterAuthVerify = await context.cookies(baseURL);
       const loginSessionCookie = cookiesAfterAuthVerify.find(
         (cookie) => cookie.name === "gewebe_session",
@@ -442,7 +438,7 @@ test.describe("Passkey Register Positive Proof", () => {
         auth_options_allow_credentials:
           authOptionsBody.options.publicKey.allowCredentials?.length ?? 0,
         auth_verify_status: authVerifyRes.status,
-        auth_verify_set_cookie:
+        auth_verify_set_cookie_header:
           authVerifyNetworkResponse.headers()["set-cookie"] ?? null,
         auth_verify_session_cookie_present: Boolean(loginSessionCookie),
         virtual_authenticator_credentials:
@@ -471,7 +467,6 @@ test.describe("Passkey Register Positive Proof", () => {
       expect(proofSummary.auth_options_set_cookie).toBeNull();
       expect(proofSummary.auth_options_allow_credentials).toBeGreaterThan(0);
       expect(proofSummary.auth_verify_status).toBe(200);
-      expect(proofSummary.auth_verify_set_cookie).toBeTruthy();
       expect(proofSummary.auth_verify_session_cookie_present).toBe(true);
       expect(proofSummary.virtual_authenticator_credentials).toBeGreaterThan(0);
     },

--- a/apps/web/tests/proofs/passkey-register-positive.proof.ts
+++ b/apps/web/tests/proofs/passkey-register-positive.proof.ts
@@ -25,6 +25,20 @@ type RegisterOptionsResponse = {
   };
 };
 
+type AuthOptionsResponse = {
+  authentication_id: string;
+  options: {
+    publicKey: {
+      challenge: string;
+      timeout?: number;
+      rpId?: string;
+      allowCredentials?: Array<{ id: string; type: string }>;
+      userVerification?: UserVerificationRequirement;
+      extensions?: Record<string, unknown>;
+    };
+  };
+};
+
 test.describe("Passkey Register Positive Proof", () => {
   test(
     "proves positive passkey register verify with a virtual authenticator",
@@ -42,6 +56,7 @@ test.describe("Passkey Register Positive Proof", () => {
       fs.mkdirSync(proofDir, { recursive: true });
 
       const context = page.context();
+      const proofEmail = "proof-passkey-user@example.com";
       const baseURL = testInfo.project.use.baseURL;
       if (typeof baseURL !== "string") {
         throw new Error("baseURL must be configured for the passkey proof");
@@ -273,6 +288,131 @@ test.describe("Passkey Register Positive Proof", () => {
         "stored credential ids must include the newly registered credential",
       ).toBe(true);
 
+      await context.clearCookies();
+      await page.goto(`${baseURL}/build?proof=passkey-auth`);
+
+      const authOptionsResponsePromise = page.waitForResponse(
+        (response) =>
+          response.url() === `${baseURL}/api/auth/passkeys/auth/options` &&
+          response.request().method() === "POST",
+      );
+      const authOptionsRes = await postJsonInPage(
+        `${baseURL}/api/auth/passkeys/auth/options`,
+        { email: proofEmail },
+      );
+      const authOptionsNetworkResponse = await authOptionsResponsePromise;
+      expect(
+        authOptionsRes.status,
+        `auth/options must succeed after passkey registration; body=${authOptionsRes.bodyText}`,
+      ).toBe(200);
+      expect(
+        authOptionsNetworkResponse.headers()["set-cookie"],
+        "auth/options must not emit Set-Cookie",
+      ).toBeUndefined();
+      const authOptionsBody = authOptionsRes.json as AuthOptionsResponse;
+      expect(authOptionsBody.authentication_id).toBeTruthy();
+      expect(
+        authOptionsBody.options.publicKey.allowCredentials?.length,
+        "auth/options must expose an allowCredentials entry from the runtime store",
+      ).toBeGreaterThan(0);
+
+      const assertion = await page.evaluate(async (requestOptions) => {
+        const decodeBase64Url = (value: string): ArrayBuffer => {
+          const padded = value
+            .replace(/-/g, "+")
+            .replace(/_/g, "/")
+            .padEnd(Math.ceil(value.length / 4) * 4, "=");
+          const binary = atob(padded);
+          const buffer = new ArrayBuffer(binary.length);
+          const bytes = new Uint8Array(buffer);
+
+          for (let i = 0; i < binary.length; i += 1) {
+            bytes[i] = binary.charCodeAt(i);
+          }
+
+          return buffer;
+        };
+
+        const encodeBase64Url = (value: ArrayBuffer): string => {
+          const bytes = new Uint8Array(value);
+          let binary = "";
+          for (const byte of bytes) {
+            binary += String.fromCharCode(byte);
+          }
+          return btoa(binary)
+            .replace(/\+/g, "-")
+            .replace(/\//g, "_")
+            .replace(/=+$/g, "");
+        };
+
+        const publicKey = {
+          ...requestOptions,
+          challenge: decodeBase64Url(requestOptions.challenge),
+          allowCredentials: (requestOptions.allowCredentials ?? []).map(
+            (descriptor) => ({
+              id: decodeBase64Url(descriptor.id),
+              type: "public-key" as const,
+            }),
+          ),
+        } as PublicKeyCredentialRequestOptions;
+
+        const credential = await navigator.credentials.get({ publicKey });
+        if (!(credential instanceof PublicKeyCredential)) {
+          throw new Error(
+            "navigator.credentials.get did not return a PublicKeyCredential",
+          );
+        }
+        const response = credential.response as AuthenticatorAssertionResponse;
+
+        return {
+          id: credential.id,
+          rawId: encodeBase64Url(credential.rawId),
+          response: {
+            authenticatorData: encodeBase64Url(response.authenticatorData),
+            clientDataJSON: encodeBase64Url(response.clientDataJSON),
+            signature: encodeBase64Url(response.signature),
+            userHandle:
+              response.userHandle === null
+                ? null
+                : encodeBase64Url(response.userHandle),
+          },
+          type: credential.type,
+          clientExtensionResults: credential.getClientExtensionResults(),
+          authenticatorAttachment: credential.authenticatorAttachment,
+        };
+      }, authOptionsBody.options.publicKey);
+
+      const authVerifyResponsePromise = page.waitForResponse(
+        (response) =>
+          response.url() === `${baseURL}/api/auth/passkeys/auth/verify` &&
+          response.request().method() === "POST",
+      );
+      const authVerifyRes = await postJsonInPage(
+        `${baseURL}/api/auth/passkeys/auth/verify`,
+        {
+          authentication_id: authOptionsBody.authentication_id,
+          credential: assertion,
+        },
+      );
+      const authVerifyNetworkResponse = await authVerifyResponsePromise;
+      expect(
+        authVerifyRes.status,
+        `auth/verify must succeed with a real WebAuthn assertion; body=${authVerifyRes.bodyText}`,
+      ).toBe(200);
+      expect(authVerifyRes.json).toEqual({
+        ok: true,
+        account_id: loginBody.account_id,
+      });
+      expect(
+        authVerifyNetworkResponse.headers()["set-cookie"],
+        "auth/verify must mint a session cookie only after credential verification",
+      ).toBeTruthy();
+      const cookiesAfterAuthVerify = await context.cookies(baseURL);
+      const loginSessionCookie = cookiesAfterAuthVerify.find(
+        (cookie) => cookie.name === "gewebe_session",
+      );
+      expect(loginSessionCookie, "auth/verify must install a session cookie").toBeTruthy();
+
       const virtualCredentials = (await cdp.send("WebAuthn.getCredentials", {
         authenticatorId,
       })) as {
@@ -293,6 +433,15 @@ test.describe("Passkey Register Positive Proof", () => {
         stored_credential_count: storedCredentialsBody.credential_ids.length,
         stored_credential_reflected:
           storedCredentialsBody.credential_ids.includes(credential.rawId),
+        auth_options_status: authOptionsRes.status,
+        auth_options_set_cookie:
+          authOptionsNetworkResponse.headers()["set-cookie"] ?? null,
+        auth_options_allow_credentials:
+          authOptionsBody.options.publicKey.allowCredentials?.length ?? 0,
+        auth_verify_status: authVerifyRes.status,
+        auth_verify_set_cookie:
+          authVerifyNetworkResponse.headers()["set-cookie"] ?? null,
+        auth_verify_session_cookie_present: Boolean(loginSessionCookie),
         virtual_authenticator_credentials:
           virtualCredentials.credentials.length,
       };
@@ -315,6 +464,12 @@ test.describe("Passkey Register Positive Proof", () => {
       expect(proofSummary.register_verify_set_cookie).toBeNull();
       expect(proofSummary.session_cookie_unchanged).toBe(true);
       expect(proofSummary.stored_credential_reflected).toBe(true);
+      expect(proofSummary.auth_options_status).toBe(200);
+      expect(proofSummary.auth_options_set_cookie).toBeNull();
+      expect(proofSummary.auth_options_allow_credentials).toBeGreaterThan(0);
+      expect(proofSummary.auth_verify_status).toBe(200);
+      expect(proofSummary.auth_verify_set_cookie).toBeTruthy();
+      expect(proofSummary.auth_verify_session_cookie_present).toBe(true);
       expect(proofSummary.virtual_authenticator_credentials).toBeGreaterThan(0);
     },
   );


### PR DESCRIPTION
Extends the passkey browser proof to run against PostgreSQL credential storage. The proof now registers a passkey, clears the bootstrap session, runs auth/options, completes auth/verify with a real virtual WebAuthn assertion, and asserts that session minting only happens after credential verification.