### PR TITLE
test(auth): audit webauthn user id backfill readiness

### DIFF
--- a/apps/api/src/domain_db.rs
+++ b/apps/api/src/domain_db.rs
@@ -203,7 +203,7 @@ pub struct AuthUserIdBackfillAudit {
     pub credential_accounts_missing_auth_user_id: i64,
     pub credential_accounts_without_domain_account: i64,
     pub credential_accounts_with_multiple_auth_user_ids: i64,
-    pub credential_account_auth_user_id_mismatches: i64,
+    pub credential_accounts_with_account_credential_uuid_mismatch: i64,
 }
 
 impl AuthUserIdBackfillAudit {
@@ -218,7 +218,7 @@ impl AuthUserIdBackfillAudit {
         self.credential_accounts_missing_auth_user_id > 0
             || self.credential_accounts_without_domain_account > 0
             || self.credential_accounts_with_multiple_auth_user_ids > 0
-            || self.credential_account_auth_user_id_mismatches > 0
+            || self.credential_accounts_with_account_credential_uuid_mismatch > 0
     }
 }
 
@@ -287,7 +287,7 @@ pub async fn audit_auth_user_id_backfill_readiness(
          ) multi_webauthn_user_id_accounts",
     )
     .await?;
-    let credential_account_auth_user_id_mismatches = count_scalar(
+    let credential_accounts_with_account_credential_uuid_mismatch = count_scalar(
         pool,
         "SELECT COUNT(*) FROM (\
              SELECT p.account_id \
@@ -308,7 +308,7 @@ pub async fn audit_auth_user_id_backfill_readiness(
         credential_accounts_missing_auth_user_id,
         credential_accounts_without_domain_account,
         credential_accounts_with_multiple_auth_user_ids,
-        credential_account_auth_user_id_mismatches,
+        credential_accounts_with_account_credential_uuid_mismatch,
     })
 }
 

--- a/apps/api/src/domain_db.rs
+++ b/apps/api/src/domain_db.rs
@@ -187,6 +187,131 @@ pub async fn load_edges_from_postgres(pool: &PgPool) -> Result<OrderedCache<Edge
     Ok(cache)
 }
 
+/// Read-only readiness counters for a future `domain_accounts.webauthn_user_id`
+/// backfill (AUTH-PG-003).
+///
+/// This is deliberately an audit surface, not a migration primitive: it reads
+/// `domain_accounts` and `passkey_credentials`, classifies unsafe states, and
+/// performs no writes. A later backfill/NOT NULL decision must use these counts
+/// as evidence instead of assuming that missing UUIDs can be regenerated safely.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct AuthUserIdBackfillAudit {
+    pub accounts_total: i64,
+    pub accounts_missing_auth_user_id: i64,
+    pub credential_rows_total: i64,
+    pub credential_account_ids_distinct: i64,
+    pub credential_accounts_missing_auth_user_id: i64,
+    pub credential_accounts_without_domain_account: i64,
+    pub credential_accounts_with_multiple_auth_user_ids: i64,
+    pub credential_account_auth_user_id_mismatches: i64,
+}
+
+impl AuthUserIdBackfillAudit {
+    /// `true` when a later backfill would have any account rows to touch.
+    pub fn has_backfill_scope(&self) -> bool {
+        self.accounts_missing_auth_user_id > 0
+    }
+
+    /// `true` when current credential/account data is not safe for cutover or
+    /// a mechanical NOT NULL migration without human review.
+    pub fn has_cutover_blockers(&self) -> bool {
+        self.credential_accounts_missing_auth_user_id > 0
+            || self.credential_accounts_without_domain_account > 0
+            || self.credential_accounts_with_multiple_auth_user_ids > 0
+            || self.credential_account_auth_user_id_mismatches > 0
+    }
+}
+
+async fn count_scalar(pool: &PgPool, sql: &str) -> Result<i64> {
+    sqlx::query_scalar::<_, i64>(sql)
+        .fetch_one(pool)
+        .await
+        .with_context(|| format!("failed to run AUTH-PG-003 audit query: {sql}"))
+}
+
+/// Audit `webauthn_user_id` backfill readiness without mutating the database.
+///
+/// The counters intentionally separate three cases that would otherwise be
+/// easy to flatten incorrectly:
+/// - accounts missing `webauthn_user_id` but carrying no credential yet
+///   (backfill scope, not automatically a cutover blocker),
+/// - credential-bearing accounts whose domain-account row has NULL
+///   `webauthn_user_id` (identity repair required before cutover),
+/// - credential rows that cannot be reconciled to exactly one account UUID
+///   (orphan, multi-UUID, or mismatch blockers).
+pub async fn audit_auth_user_id_backfill_readiness(
+    pool: &PgPool,
+) -> Result<AuthUserIdBackfillAudit> {
+    let accounts_total = count_scalar(pool, "SELECT COUNT(*) FROM domain_accounts").await?;
+    let accounts_missing_auth_user_id = count_scalar(
+        pool,
+        "SELECT COUNT(*) FROM domain_accounts WHERE webauthn_user_id IS NULL",
+    )
+    .await?;
+    let credential_rows_total =
+        count_scalar(pool, "SELECT COUNT(*) FROM passkey_credentials").await?;
+    let credential_account_ids_distinct = count_scalar(
+        pool,
+        "SELECT COUNT(DISTINCT account_id) FROM passkey_credentials",
+    )
+    .await?;
+    let credential_accounts_missing_auth_user_id = count_scalar(
+        pool,
+        "SELECT COUNT(*) FROM (\
+             SELECT p.account_id \
+             FROM passkey_credentials p \
+             JOIN domain_accounts a ON a.id = p.account_id \
+             WHERE a.webauthn_user_id IS NULL \
+             GROUP BY p.account_id\
+         ) credential_accounts_with_null_domain_uuid",
+    )
+    .await?;
+    let credential_accounts_without_domain_account = count_scalar(
+        pool,
+        "SELECT COUNT(*) FROM (\
+             SELECT p.account_id \
+             FROM passkey_credentials p \
+             LEFT JOIN domain_accounts a ON a.id = p.account_id \
+             WHERE a.id IS NULL \
+             GROUP BY p.account_id\
+         ) orphan_credential_accounts",
+    )
+    .await?;
+    let credential_accounts_with_multiple_auth_user_ids = count_scalar(
+        pool,
+        "SELECT COUNT(*) FROM (\
+             SELECT account_id \
+             FROM passkey_credentials \
+             GROUP BY account_id \
+             HAVING COUNT(DISTINCT webauthn_user_id) > 1\
+         ) multi_webauthn_user_id_accounts",
+    )
+    .await?;
+    let credential_account_auth_user_id_mismatches = count_scalar(
+        pool,
+        "SELECT COUNT(*) FROM (\
+             SELECT p.account_id \
+             FROM passkey_credentials p \
+             JOIN domain_accounts a ON a.id = p.account_id \
+             WHERE a.webauthn_user_id IS NOT NULL \
+               AND p.webauthn_user_id <> a.webauthn_user_id \
+             GROUP BY p.account_id\
+         ) credential_account_uuid_mismatches",
+    )
+    .await?;
+
+    Ok(AuthUserIdBackfillAudit {
+        accounts_total,
+        accounts_missing_auth_user_id,
+        credential_rows_total,
+        credential_account_ids_distinct,
+        credential_accounts_missing_auth_user_id,
+        credential_accounts_without_domain_account,
+        credential_accounts_with_multiple_auth_user_ids,
+        credential_account_auth_user_id_mismatches,
+    })
+}
+
 pub async fn load_accounts_from_postgres(pool: &PgPool) -> Result<AccountStore> {
     let rows: Vec<AccountRow> = sqlx::query_as(
         "SELECT id, kind, title, mode, radius_m, disabled, \

--- a/apps/api/tests/db_webauthn_user_id_backfill_audit.rs
+++ b/apps/api/tests/db_webauthn_user_id_backfill_audit.rs
@@ -9,14 +9,22 @@ use weltgewebe_api::domain_db::{audit_auth_user_id_backfill_readiness, AuthUserI
 
 fn direct_database_url() -> String {
     let url = std::env::var("DATABASE_URL").expect(
-        "DATABASE_URL must be set to run db_passkey_store_persistence tests; \
-         point it to direct PostgreSQL (port 5432)",
+        "DATABASE_URL must be set for this direct PostgreSQL proof; \
+         point it to a disposable direct PostgreSQL database (port 5432)",
     );
     assert!(
         !url.contains(":6432"),
         "DATABASE_URL must target direct PostgreSQL, not PgBouncer (port 6432)"
     );
     url
+}
+
+fn require_fixture_mutation_opt_in() {
+    let enabled = std::env::var("AUTH_PG_003_FIXTURE_MUTATION").unwrap_or_default();
+    assert_eq!(
+        enabled, "1",
+        "AUTH_PG_003_FIXTURE_MUTATION=1 must be set; this ignored proof runs migrations and inserts/deletes auth-pg-003-audit-proof* fixtures, so use a disposable direct PostgreSQL database"
+    );
 }
 
 async fn connect_pool() -> sqlx::PgPool {
@@ -66,9 +74,9 @@ fn delta(
         credential_accounts_with_multiple_auth_user_ids: after
             .credential_accounts_with_multiple_auth_user_ids
             - before.credential_accounts_with_multiple_auth_user_ids,
-        credential_account_auth_user_id_mismatches: after
-            .credential_account_auth_user_id_mismatches
-            - before.credential_account_auth_user_id_mismatches,
+        credential_accounts_with_account_credential_uuid_mismatch: after
+            .credential_accounts_with_account_credential_uuid_mismatch
+            - before.credential_accounts_with_account_credential_uuid_mismatch,
     }
 }
 
@@ -115,6 +123,7 @@ async fn insert_credential(pool: &sqlx::PgPool, id: &str, account_id: &str, user
 #[tokio::test]
 #[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
 async fn db_webauthn_user_id_backfill_audit_classifies_fixture_delta() {
+    require_fixture_mutation_opt_in();
     let pool = connect_pool().await;
     cleanup(&pool).await;
     let before = audit_auth_user_id_backfill_readiness(&pool)
@@ -178,7 +187,10 @@ async fn db_webauthn_user_id_backfill_audit_classifies_fixture_delta() {
     assert_eq!(d.credential_accounts_missing_auth_user_id, 1);
     assert_eq!(d.credential_accounts_without_domain_account, 1);
     assert_eq!(d.credential_accounts_with_multiple_auth_user_ids, 1);
-    assert_eq!(d.credential_account_auth_user_id_mismatches, 2);
+    assert_eq!(
+        d.credential_accounts_with_account_credential_uuid_mismatch,
+        2
+    );
     assert!(d.has_backfill_scope());
     assert!(d.has_cutover_blockers());
 

--- a/apps/api/tests/db_webauthn_user_id_backfill_audit.rs
+++ b/apps/api/tests/db_webauthn_user_id_backfill_audit.rs
@@ -1,0 +1,186 @@
+//! AUTH-PG-003 read-only DB proof.
+//! No backfill, no NOT NULL, no WebAuthn crypto: row/UUID coherence only.
+
+use std::{path::PathBuf, str::FromStr};
+
+use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
+use uuid::Uuid;
+use weltgewebe_api::domain_db::{audit_auth_user_id_backfill_readiness, AuthUserIdBackfillAudit};
+
+fn direct_database_url() -> String {
+    let url = std::env::var("DATABASE_URL").expect(
+        "DATABASE_URL must be set to run db_passkey_store_persistence tests; \
+         point it to direct PostgreSQL (port 5432)",
+    );
+    assert!(
+        !url.contains(":6432"),
+        "DATABASE_URL must target direct PostgreSQL, not PgBouncer (port 6432)"
+    );
+    url
+}
+
+async fn connect_pool() -> sqlx::PgPool {
+    let connect_opts = PgConnectOptions::from_str(&direct_database_url())
+        .expect("DATABASE_URL must be a valid postgres connection string");
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect_with(connect_opts)
+        .await
+        .expect("failed to connect to direct PostgreSQL");
+    ensure_migrations(&pool).await;
+    pool
+}
+
+async fn ensure_migrations(pool: &sqlx::PgPool) {
+    let migrations_dir: PathBuf = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("migrations");
+    let migrator = sqlx::migrate::Migrator::new(migrations_dir)
+        .await
+        .expect("failed to load migrations");
+    migrator.run(pool).await.expect("failed to run migrations");
+}
+
+const PREFIX: &str = "auth-pg-003-audit-proof";
+const STABLE: &str = "auth-pg-003-audit-proof-stable";
+const NULL_NO_CREDENTIAL: &str = "auth-pg-003-audit-proof-null-no-credential";
+const NULL_WITH_CREDENTIAL: &str = "auth-pg-003-audit-proof-null-with-credential";
+const MISMATCH: &str = "auth-pg-003-audit-proof-mismatch";
+const MULTI_UUID: &str = "auth-pg-003-audit-proof-multi-uuid";
+const ORPHAN: &str = "auth-pg-003-audit-proof-orphan";
+
+fn delta(
+    before: AuthUserIdBackfillAudit,
+    after: AuthUserIdBackfillAudit,
+) -> AuthUserIdBackfillAudit {
+    AuthUserIdBackfillAudit {
+        accounts_total: after.accounts_total - before.accounts_total,
+        accounts_missing_auth_user_id: after.accounts_missing_auth_user_id
+            - before.accounts_missing_auth_user_id,
+        credential_rows_total: after.credential_rows_total - before.credential_rows_total,
+        credential_account_ids_distinct: after.credential_account_ids_distinct
+            - before.credential_account_ids_distinct,
+        credential_accounts_missing_auth_user_id: after.credential_accounts_missing_auth_user_id
+            - before.credential_accounts_missing_auth_user_id,
+        credential_accounts_without_domain_account: after
+            .credential_accounts_without_domain_account
+            - before.credential_accounts_without_domain_account,
+        credential_accounts_with_multiple_auth_user_ids: after
+            .credential_accounts_with_multiple_auth_user_ids
+            - before.credential_accounts_with_multiple_auth_user_ids,
+        credential_account_auth_user_id_mismatches: after
+            .credential_account_auth_user_id_mismatches
+            - before.credential_account_auth_user_id_mismatches,
+    }
+}
+
+async fn cleanup(pool: &sqlx::PgPool) {
+    sqlx::query("DELETE FROM passkey_credentials WHERE account_id LIKE $1")
+        .bind(format!("{PREFIX}%"))
+        .execute(pool)
+        .await
+        .expect("cleanup passkey_credentials");
+    sqlx::query("DELETE FROM domain_accounts WHERE id LIKE $1")
+        .bind(format!("{PREFIX}%"))
+        .execute(pool)
+        .await
+        .expect("cleanup domain_accounts");
+}
+
+async fn insert_account(pool: &sqlx::PgPool, id: &str, user_id: Option<Uuid>) {
+    sqlx::query(
+        "INSERT INTO domain_accounts \
+            (id, kind, title, mode, radius_m, role, webauthn_user_id, public_payload, private_payload) \
+         VALUES ($1, 'garnrolle', $2, 'ron', 0, 'gast', $3::uuid, '{}'::jsonb, '{}'::jsonb)",
+    )
+    .bind(id)
+    .bind(id)
+    .bind(user_id.map(|value| value.to_string()))
+    .execute(pool)
+    .await
+    .expect("insert domain account fixture");
+}
+
+async fn insert_credential(pool: &sqlx::PgPool, id: &str, account_id: &str, user_id: Uuid) {
+    sqlx::query(
+        "INSERT INTO passkey_credentials (credential_id, account_id, webauthn_user_id, credential) \
+         VALUES ($1, $2, $3::uuid, '{}'::jsonb)",
+    )
+    .bind(id)
+    .bind(account_id)
+    .bind(user_id.to_string())
+    .execute(pool)
+    .await
+    .expect("insert credential fixture");
+}
+
+#[tokio::test]
+#[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
+async fn db_webauthn_user_id_backfill_audit_classifies_fixture_delta() {
+    let pool = connect_pool().await;
+    cleanup(&pool).await;
+    let before = audit_auth_user_id_backfill_readiness(&pool)
+        .await
+        .expect("baseline audit");
+
+    let stable_uuid = Uuid::new_v4();
+    let null_with_credential_uuid = Uuid::new_v4();
+    let mismatch_account_uuid = Uuid::new_v4();
+    let mismatch_credential_uuid = Uuid::new_v4();
+    let multi_account_uuid = Uuid::new_v4();
+    let multi_credential_uuid_a = Uuid::new_v4();
+    let multi_credential_uuid_b = Uuid::new_v4();
+    let orphan_uuid = Uuid::new_v4();
+
+    insert_account(&pool, STABLE, Some(stable_uuid)).await;
+    insert_credential(&pool, &format!("{STABLE}-credential"), STABLE, stable_uuid).await;
+    insert_account(&pool, NULL_NO_CREDENTIAL, None).await;
+    insert_account(&pool, NULL_WITH_CREDENTIAL, None).await;
+    insert_credential(
+        &pool,
+        &format!("{NULL_WITH_CREDENTIAL}-credential"),
+        NULL_WITH_CREDENTIAL,
+        null_with_credential_uuid,
+    )
+    .await;
+    insert_account(&pool, MISMATCH, Some(mismatch_account_uuid)).await;
+    insert_credential(
+        &pool,
+        &format!("{MISMATCH}-credential"),
+        MISMATCH,
+        mismatch_credential_uuid,
+    )
+    .await;
+    insert_account(&pool, MULTI_UUID, Some(multi_account_uuid)).await;
+    insert_credential(
+        &pool,
+        &format!("{MULTI_UUID}-credential-a"),
+        MULTI_UUID,
+        multi_credential_uuid_a,
+    )
+    .await;
+    insert_credential(
+        &pool,
+        &format!("{MULTI_UUID}-credential-b"),
+        MULTI_UUID,
+        multi_credential_uuid_b,
+    )
+    .await;
+    insert_credential(&pool, &format!("{ORPHAN}-credential"), ORPHAN, orphan_uuid).await;
+
+    let after = audit_auth_user_id_backfill_readiness(&pool)
+        .await
+        .expect("audit after fixtures");
+    let d = delta(before, after);
+
+    assert_eq!(d.accounts_total, 5);
+    assert_eq!(d.accounts_missing_auth_user_id, 2);
+    assert_eq!(d.credential_rows_total, 6);
+    assert_eq!(d.credential_account_ids_distinct, 5);
+    assert_eq!(d.credential_accounts_missing_auth_user_id, 1);
+    assert_eq!(d.credential_accounts_without_domain_account, 1);
+    assert_eq!(d.credential_accounts_with_multiple_auth_user_ids, 1);
+    assert_eq!(d.credential_account_auth_user_id_mismatches, 2);
+    assert!(d.has_backfill_scope());
+    assert!(d.has_cutover_blockers());
+
+    cleanup(&pool).await;
+}

--- a/docs/reports/auth-pg-003-backfill-readiness.md
+++ b/docs/reports/auth-pg-003-backfill-readiness.md
@@ -96,7 +96,11 @@ Ein späterer Implementierungs-PR sollte zunächst nur diese Belege liefern:
 - Negativtest: widersprüchliche Credential-UUIDs blockieren fail-closed.
 - Report-Update mit Zählergebnis und Nicht-Beweisen.
 
-## 6. Nicht-Beweise
+## 6. Umgesetzter Audit-Proof
+
+AUTH-PG-003-AUDIT-001 ergaenzt einen read-only Audit-Helfer und einen ignored DB-Proof. Der Proof zaehlt Account-, Credential-, Orphan-, Multi-UUID- und Mismatch-Faelle, mutiert aber keine Daten und bleibt kein Backfill.
+
+## 7. Nicht-Beweise
 
 Dieser Bericht beweist nicht:
 
@@ -107,10 +111,10 @@ Dieser Bericht beweist nicht:
 - dass `passkey_credentials.account_id -> domain_accounts(id)` schon als FK
   aktiviert werden kann.
 
-## 7. Nächste Aktion
+## 8. Nächste Aktion
 
-Nächster sinnvoller PR-Schnitt: `AUTH-PG-003-AUDIT-001` als read-only Audit- und
-Fixture-Proof. Erst danach Backfill-Migration planen. Danach erst `NOT NULL`.
+`AUTH-PG-003-AUDIT-001` ist als read-only Audit- und Fixture-Proof vorbereitet.
+Nächster PR-Schnitt: Backfill-Regeln aus Audit-Zählern ableiten; danach erst Backfill-Migration und `NOT NULL` prüfen.
 
 Humorlos gesagt: Erst zählen, dann füllen, dann verriegeln. Wer zuerst verriegelt,
 baut ein Museum für ausgesperrte Nutzer.

--- a/docs/reports/auth-pg-003-backfill-readiness.md
+++ b/docs/reports/auth-pg-003-backfill-readiness.md
@@ -98,7 +98,11 @@ Ein späterer Implementierungs-PR sollte zunächst nur diese Belege liefern:
 
 ## 6. Umgesetzter Audit-Proof
 
-AUTH-PG-003-AUDIT-001 ergaenzt einen read-only Audit-Helfer und einen ignored DB-Proof. Der Proof zaehlt Account-, Credential-, Orphan-, Multi-UUID- und Mismatch-Faelle, mutiert aber keine Daten und bleibt kein Backfill.
+AUTH-PG-003-AUDIT-001 ergänzt einen read-only Audit-Helfer und einen ignored DB-Proof. Der Audit-Helfer zählt Account-, Credential-, Orphan-, Multi-UUID- und Mismatch-Fälle, mutiert aber keine Daten und bleibt kein Backfill.
+
+Der ignored DB-Proof selbst ist fixture-mutierend: Er führt Migrationen aus und legt Testzeilen mit dem Prefix `auth-pg-003-audit-proof` in `domain_accounts` und `passkey_credentials` an, bevor er sie wieder löscht. Er darf nur gegen eine disposable direkte PostgreSQL-Testdatenbank laufen und verlangt zusätzlich `AUTH_PG_003_FIXTURE_MUTATION=1`.
+
+Die Zähler sind nicht zwingend disjunkt; Multi-UUID-Fälle können zusätzlich als Account-/Credential-UUID-Mismatch erscheinen. Der Audit beweist auch keine Race-Freiheit während eines späteren Backfills.
 
 ## 7. Nicht-Beweise
 
@@ -113,7 +117,7 @@ Dieser Bericht beweist nicht:
 
 ## 8. Nächste Aktion
 
-`AUTH-PG-003-AUDIT-001` ist als read-only Audit- und Fixture-Proof vorbereitet.
+`AUTH-PG-003-AUDIT-001` ist als read-only Audit-Helfer und explizit fixture-mutierender Scratch-DB-Proof vorbereitet.
 Nächster PR-Schnitt: Backfill-Regeln aus Audit-Zählern ableiten; danach erst Backfill-Migration und `NOT NULL` prüfen.
 
 Humorlos gesagt: Erst zählen, dann füllen, dann verriegeln. Wer zuerst verriegelt,

--- a/docs/tasks/board.md
+++ b/docs/tasks/board.md
@@ -73,7 +73,7 @@ Die optimierte TODO-Liste wurde gegen den Repo-Stand abgeglichen und einsortiert
 |---|---|---|---|
 | OPT-ARC-001 | Step-up-E-Mail-Persistenz und WebAuthn-User-ID-Writeback offen; Runtime-Smoke und Cutover ausstehend; JSONL-Demontage ausstehend | Offene Migrationsteile bzw. Cutover-Proof vorbereiten | JSONL bleibt Default-Lesequelle und Write-Truth bis vollständiger Cutover; POST /accounts, PATCH /nodes und POST /edges schreiben optional PostgreSQL; Schema- und Backfill-Proof sind belegt; der geänderte Read-Path-Proof-Harness wartet auf frische PR-CI-Evidence |
 | DOMAIN-PG-001 | Edge-Referenz-Policy (FK oder Guard) hängt am Edge-Orphan-Audit | DB-PROOF-001 ist nur partial; repräsentativer Runtime-/Deployment-Datenlauf mit auditable_edges_total > 0 und FK-vs-Guard-Policyentscheidung fehlen. | Kein FK-/Referenz-Cutover vor Audit; Orphans dürfen nicht still verworfen werden |
-| AUTH-PG-003 | `webauthn_user_id`-Backfill und späteres `NOT NULL` hängen an WebAuthn-Persistenz | AUTH-PG-002 Store/Runtime-Facade und Cutover-Plan sind belegt; Readiness-Strategie dokumentiert (`docs/reports/auth-pg-003-backfill-readiness.md`); Live-NULL-Audit, Backfill-Fixture und Backfill-Test fehlen | Kein `NOT NULL` vor Audit + Backfill; keine stille UUID-Neuerzeugung bei Reload |
+| AUTH-PG-003 | `webauthn_user_id`-Backfill und späteres `NOT NULL` hängen an WebAuthn-Persistenz | AUTH-PG-002 Store/Runtime-Facade und Cutover-Plan sind belegt; Readiness-Strategie dokumentiert (`docs/reports/auth-pg-003-backfill-readiness.md`); Audit-Proof vorbereitet; Live-Audit und Backfill fehlen weiter | Kein `NOT NULL` vor Audit + Backfill; keine stille UUID-Neuerzeugung bei Reload |
 
 ## Nächste PR-Kandidaten
 

--- a/docs/tasks/index.json
+++ b/docs/tasks/index.json
@@ -1196,12 +1196,14 @@
       "owner": "unknown",
       "evidence": [
         "apps/api/src/routes/accounts.rs",
-        "docs/reports/auth-pg-003-backfill-readiness.md"
+        "docs/reports/auth-pg-003-backfill-readiness.md",
+        "apps/api/src/domain_db.rs",
+        "apps/api/tests/db_webauthn_user_id_backfill_audit.rs"
       ],
       "missing_evidence": [
         "legacy_webauthn_user_id_backfill und webauthn_user_id_not_null sind ausdrueckliche Non-Goals von OPT-ARC-001 (docs/reports/opt-arc-001-db-proof-matrix.json)",
-        "Kein Audit, wie viele Accounts webauthn_user_id IS NULL haben, und kein Backfill-Test",
-        "Readiness-Strategie ist dokumentiert; Live-NULL-Audit, Backfill-Fixture und Backfill-Test fehlen weiterhin"
+        "Audit-Proof vorbereitet; Live-Produktions-Audit und Backfill fehlen weiter",
+        "Kein NOT NULL vor erfolgreichem Backfill-Proof und Cutover-Entscheidung"
       ],
       "acceptance": [
         "Audit der Accounts mit fehlender webauthn_user_id liegt vor; Backfill-Strategie ist dokumentiert und testbar",


### PR DESCRIPTION
## Summary
- Add a read-only AUTH-PG-003 audit helper for `webauthn_user_id` backfill readiness.
- Add an ignored direct-PostgreSQL DB proof covering stable, NULL, mismatch, multi-UUID, and orphan credential fixtures.
- Harden the proof boundary: the helper is read-only, but the ignored proof is explicitly fixture-mutating and now requires `AUTH_PG_003_FIXTURE_MUTATION=1` plus a disposable direct PostgreSQL database.
- Update AUTH-PG-003 readiness/task docs while keeping Backfill, NOT NULL, and production cutover blocked.

## Tests
- `cargo fmt --all -- --check`
- `cargo test --locked -p weltgewebe-api --test db_webauthn_user_id_backfill_audit`
- `cargo test --locked -p weltgewebe-api --test db_webauthn_user_id_backfill_audit -- --list`
- `python3 -m scripts.docmeta.validate_task_index docs/tasks/index.json`
- `python3 -m scripts.docmeta.check_links`
- `python3 -m scripts.docmeta.generate_task_index --check`
- `git diff --check`

## Not run locally
- `AUTH_PG_003_FIXTURE_MUTATION=1 cargo test --locked -p weltgewebe-api --test db_webauthn_user_id_backfill_audit -- --include-ignored --test-threads=1`
  - Reason: this environment has no `DATABASE_URL` set. The test is intentionally ignored and fixture-mutating; it must run only against a disposable direct PostgreSQL database.

## Non-goals
- No production backfill.
- No NOT NULL migration.
- No passkey cutover.
- No FK change.

Operator-Lab-Run: not created — local remediation/proof run; no run-card path added in this repo.
