### PR TITLE
feat(auth): add webauthn user id runtime audit

### DIFF
--- a/docs/reports/auth-pg-003-backfill-readiness.md
+++ b/docs/reports/auth-pg-003-backfill-readiness.md
@@ -104,7 +104,38 @@ Der ignored DB-Proof selbst ist fixture-mutierend: Er führt Migrationen aus und
 
 Die Zähler sind nicht zwingend disjunkt; Multi-UUID-Fälle können zusätzlich als Account-/Credential-UUID-Mismatch erscheinen. Der Audit beweist auch keine Race-Freiheit während eines späteren Backfills.
 
-## 7. Nicht-Beweise
+## 7. Runtime-Audit-Werkzeug
+
+AUTH-PG-003-AUDIT-002 ergänzt ein read-only Runtime-Audit-Werkzeug:
+
+```bash
+python3 -m scripts.docmeta.audit_webauthn_user_id_backfill_runtime \
+  --database-url-env DATABASE_URL \
+  --source-label runtime-postgres \
+  --pretty
+```
+
+Das Werkzeug benötigt lokal verfügbare PostgreSQL-Client-Tools (`psql`); ohne
+einen echten Client bricht es fail-closed ab, statt ein Pseudo-Audit auszugeben.
+
+Das Werkzeug läuft in `BEGIN TRANSACTION READ ONLY`, gibt keine Account-IDs,
+Credential-IDs, WebAuthn-User-IDs oder Credential-Payloads aus und hasht
+Account-Samples als `account:sha256:<12>`. Vor der eigentlichen Zählung prüft es
+`domain_accounts` und `passkey_credentials` per `to_regclass`; fehlende Tabellen
+werden als Audit-Blocker ausgegeben, nicht als leerer Audit.
+
+Die Runtime-Ausgabe klassifiziert vier nächste Schritte:
+
+- `fix_runtime_schema_before_backfill_audit`: benötigte Tabellen fehlen.
+- `review_identity_blockers_before_backfill`: Orphan-, Multi-UUID-,
+  NULL-Credential- oder Mismatch-Fälle blockieren einen mechanischen Backfill.
+- `prepare_idempotent_backfill_proof`: keine Blocker, aber NULL-Scope vorhanden.
+- `counts_ready_for_not_null_review`: keine NULLs und keine Count-Blocker; das
+  ist nur Count-Readiness, kein automatisches `NOT NULL`.
+
+AUTH-PG-003-AUDIT-002 mutiert keine Daten und enthält weiterhin keinen Backfill.
+
+## 8. Nicht-Beweise
 
 Dieser Bericht beweist nicht:
 
@@ -115,10 +146,11 @@ Dieser Bericht beweist nicht:
 - dass `passkey_credentials.account_id -> domain_accounts(id)` schon als FK
   aktiviert werden kann.
 
-## 8. Nächste Aktion
+## 9. Nächste Aktion
 
 `AUTH-PG-003-AUDIT-001` ist als read-only Audit-Helfer und explizit fixture-mutierender Scratch-DB-Proof vorbereitet.
-Nächster PR-Schnitt: Backfill-Regeln aus Audit-Zählern ableiten; danach erst Backfill-Migration und `NOT NULL` prüfen.
+`AUTH-PG-003-AUDIT-002` ist als read-only Runtime-Audit-Werkzeug vorbereitet.
+Nächster PR-Schnitt: Runtime-Audit gegen die Zielumgebung ausführen und daraus erst den idempotenten Backfill-Proof ableiten; danach erst Backfill-Migration und `NOT NULL` prüfen.
 
 Humorlos gesagt: Erst zählen, dann füllen, dann verriegeln. Wer zuerst verriegelt,
 baut ein Museum für ausgesperrte Nutzer.

--- a/docs/reports/auth-pg-003-runtime-audit-wg-pg-proof-2026-07-01.md
+++ b/docs/reports/auth-pg-003-runtime-audit-wg-pg-proof-2026-07-01.md
@@ -1,0 +1,94 @@
+---
+id: reports.auth-pg-003-runtime-audit-wg-pg-proof-2026-07-01
+title: "AUTH-PG-003 Runtime Audit Smoke: wg-pg-proof 2026-07-01"
+doc_type: report
+status: active
+lifecycle_state: active
+lifecycle: proof
+owner_task: AUTH-PG-003
+review_after: 2026-09-30
+canonicality: evidence
+created: 2026-07-01
+lang: de
+summary: >
+  Read-only Smoke des AUTH-PG-003 Runtime-Audit-Werkzeugs gegen den lokalen
+  PostgreSQL-Proof-Container wg-pg-proof. Kein Produktionsaudit, kein Backfill,
+  kein NOT NULL.
+relations:
+  - type: relates_to
+    target: docs/reports/auth-pg-003-backfill-readiness.md
+  - type: relates_to
+    target: docs/reports/auth-pg-002-runtime-schema-readiness-heimserver-2026-07-01.md
+---
+
+# AUTH-PG-003 Runtime Audit Smoke: wg-pg-proof 2026-07-01
+
+## 1. Entscheidung
+
+**These:** Das neue Runtime-Audit-Werkzeug soll fehlende Tabellen als Blocker
+klassifizieren, nicht als leeres Ergebnis.
+
+**Antithese:** Dieser Lauf ist kein Produktionsaudit. `wg-pg-proof` ist ein
+lokaler Proof-Container und ersetzt weder Heimserver-Runtime noch Cutover-Daten.
+
+**Synthese:** Der Smoke ist als Werkzeugbeleg nützlich: Das Audit läuft read-only
+und gibt bei fehlender Schemaoberfläche `fix_runtime_schema_before_backfill_audit`
+aus. AUTH-PG-003 bleibt blocked.
+
+## 2. Laufgrenze
+
+- Quelle: lokaler Container `wg-pg-proof`.
+- Ausführung: Container-`psql`; der Host-`psql`-Wrapper hatte keinen installierten
+  Client und wurde deshalb nicht als Belegkanal genutzt.
+- Mutation: keine.
+- Redaktion: keine Account-IDs, Credential-IDs, WebAuthn-User-IDs oder Credential-
+  Payloads ausgegeben.
+
+## 3. Redigierte Ausgabe
+
+```json
+{
+  "audit": "webauthn_user_id_backfill_runtime",
+  "findings": {
+    "has_backfill_scope": null,
+    "has_cutover_blockers": true,
+    "next_step": "fix_runtime_schema_before_backfill_audit",
+    "not_null_count_ready": false,
+    "schema_ready_for_audit": false
+  },
+  "mutation_performed": false,
+  "read_only": true,
+  "redaction": {
+    "account_ids": "sha256-prefix-12",
+    "credential_ids": "not_emitted",
+    "credentials": "not_emitted",
+    "webauthn_user_ids": "not_emitted"
+  },
+  "sample_limit": 5,
+  "samples": [],
+  "schema": {
+    "domain_accounts_exists": false,
+    "passkey_credentials_exists": false
+  },
+  "schema_version": 1,
+  "source_label": "wg-pg-proof",
+  "totals": null
+}
+```
+
+## 4. Nicht-Beweise
+
+Dieser Smoke beweist nicht:
+
+- dass Produktionsdaten auditierbar vorliegen,
+- dass Heimserver dieselbe Schemaoberfläche hat,
+- dass ein Backfill sicher ausführbar ist,
+- dass `NOT NULL` geprüft oder gesetzt werden darf,
+- dass der spätere Backfill idempotent ist.
+
+## 5. Nächste Aktion
+
+Runtime-Audit gegen die tatsächliche Zielumgebung ausführen, sobald der sichere
+Datenbankzugriff geklärt ist. Erst danach Backfill-Proof ableiten.
+
+Kurz: Das Messgerät piept korrekt. Es hat aber noch nicht den Patienten gesehen.

--- a/docs/tasks/board.md
+++ b/docs/tasks/board.md
@@ -73,7 +73,7 @@ Die optimierte TODO-Liste wurde gegen den Repo-Stand abgeglichen und einsortiert
 |---|---|---|---|
 | OPT-ARC-001 | Step-up-E-Mail-Persistenz und WebAuthn-User-ID-Writeback offen; Runtime-Smoke und Cutover ausstehend; JSONL-Demontage ausstehend | Offene Migrationsteile bzw. Cutover-Proof vorbereiten | JSONL bleibt Default-Lesequelle und Write-Truth bis vollständiger Cutover; POST /accounts, PATCH /nodes und POST /edges schreiben optional PostgreSQL; Schema- und Backfill-Proof sind belegt; der geänderte Read-Path-Proof-Harness wartet auf frische PR-CI-Evidence |
 | DOMAIN-PG-001 | Edge-Referenz-Policy (FK oder Guard) hängt am Edge-Orphan-Audit | DB-PROOF-001 ist nur partial; repräsentativer Runtime-/Deployment-Datenlauf mit auditable_edges_total > 0 und FK-vs-Guard-Policyentscheidung fehlen. | Kein FK-/Referenz-Cutover vor Audit; Orphans dürfen nicht still verworfen werden |
-| AUTH-PG-003 | `webauthn_user_id`-Backfill und späteres `NOT NULL` hängen an WebAuthn-Persistenz | AUTH-PG-002 Store/Runtime-Facade und Cutover-Plan sind belegt; Readiness-Strategie dokumentiert (`docs/reports/auth-pg-003-backfill-readiness.md`); Audit-Proof vorbereitet; Live-Audit und Backfill fehlen weiter | Kein `NOT NULL` vor Audit + Backfill; keine stille UUID-Neuerzeugung bei Reload |
+| AUTH-PG-003 | `webauthn_user_id`-Backfill und späteres `NOT NULL` hängen an WebAuthn-Persistenz | AUTH-PG-002 Store/Runtime-Facade und Cutover-Plan sind belegt; Readiness-Strategie dokumentiert (`docs/reports/auth-pg-003-backfill-readiness.md`); Audit-Proof und read-only Runtime-Audit-Werkzeug vorbereitet; Live-Ausführung und Backfill fehlen weiter | Kein `NOT NULL` vor Audit + Backfill; keine stille UUID-Neuerzeugung bei Reload |
 
 ## Nächste PR-Kandidaten
 

--- a/docs/tasks/index.json
+++ b/docs/tasks/index.json
@@ -1200,11 +1200,12 @@
         "apps/api/src/domain_db.rs",
         "apps/api/tests/db_webauthn_user_id_backfill_audit.rs",
         "scripts/docmeta/audit_webauthn_user_id_backfill_runtime.py",
-        "scripts/docmeta/tests/test_audit_webauthn_user_id_backfill_runtime.py"
+        "scripts/docmeta/tests/test_audit_webauthn_user_id_backfill_runtime.py",
+        "docs/reports/auth-pg-003-runtime-audit-wg-pg-proof-2026-07-01.md"
       ],
       "missing_evidence": [
         "legacy_webauthn_user_id_backfill und webauthn_user_id_not_null sind ausdrueckliche Non-Goals von OPT-ARC-001 (docs/reports/opt-arc-001-db-proof-matrix.json)",
-        "Audit-Proof und Runtime-Audit-Werkzeug vorbereitet; Live-Produktions-Audit und Backfill fehlen weiter",
+        "Audit-Proof, Runtime-Audit-Werkzeug und lokaler wg-pg-proof-Smoke vorbereitet; Live-Produktions-Audit und Backfill fehlen weiter",
         "Kein NOT NULL vor erfolgreichem Backfill-Proof und Cutover-Entscheidung"
       ],
       "acceptance": [
@@ -1221,7 +1222,8 @@
           "docs/reports/opt-arc-001-db-proof-matrix.json",
           "docs/reports/auth-pg-003-backfill-readiness.md",
           "docs/reports/auth-pg-002-passkey-runtime-facade.md",
-          "docs/reports/auth-pg-002-cutover-plan.md"
+          "docs/reports/auth-pg-002-cutover-plan.md",
+          "docs/reports/auth-pg-003-runtime-audit-wg-pg-proof-2026-07-01.md"
         ]
       },
       "updated_at": "2026-07-01"

--- a/docs/tasks/index.json
+++ b/docs/tasks/index.json
@@ -1198,15 +1198,18 @@
         "apps/api/src/routes/accounts.rs",
         "docs/reports/auth-pg-003-backfill-readiness.md",
         "apps/api/src/domain_db.rs",
-        "apps/api/tests/db_webauthn_user_id_backfill_audit.rs"
+        "apps/api/tests/db_webauthn_user_id_backfill_audit.rs",
+        "scripts/docmeta/audit_webauthn_user_id_backfill_runtime.py",
+        "scripts/docmeta/tests/test_audit_webauthn_user_id_backfill_runtime.py"
       ],
       "missing_evidence": [
         "legacy_webauthn_user_id_backfill und webauthn_user_id_not_null sind ausdrueckliche Non-Goals von OPT-ARC-001 (docs/reports/opt-arc-001-db-proof-matrix.json)",
-        "Audit-Proof vorbereitet; Live-Produktions-Audit und Backfill fehlen weiter",
+        "Audit-Proof und Runtime-Audit-Werkzeug vorbereitet; Live-Produktions-Audit und Backfill fehlen weiter",
         "Kein NOT NULL vor erfolgreichem Backfill-Proof und Cutover-Entscheidung"
       ],
       "acceptance": [
         "Audit der Accounts mit fehlender webauthn_user_id liegt vor; Backfill-Strategie ist dokumentiert und testbar",
+        "Runtime-Audit klassifiziert Schema-, Backfill- und Cutover-Blocker read-only und redigiert Account-Samples",
         "Reload erzeugt keine neue Identitaet (keine stille UUID-Neuerzeugung)",
         "NOT NULL wird erst nach Audit und erfolgreichem Backfill geprueft; Migration ist nachvollziehbar"
       ],

--- a/scripts/docmeta/audit_webauthn_user_id_backfill_runtime.py
+++ b/scripts/docmeta/audit_webauthn_user_id_backfill_runtime.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+"""Read-only runtime audit for AUTH-PG-003 webauthn_user_id backfill readiness.
+
+The audit classifies live PostgreSQL state before any future
+`domain_accounts.webauthn_user_id` backfill or NOT NULL decision. It performs no
+writes, emits only redacted account identifiers, and treats missing runtime
+schema as an audit blocker rather than as an empty result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from typing import Any
+from urllib.parse import parse_qs, unquote, urlparse
+
+MAX_PSQL_STDERR_LOG_BYTES = 500
+AUDIT_NAME = "webauthn_user_id_backfill_runtime"
+
+
+def hash_account_id(account_id: str) -> str:
+    digest = hashlib.sha256(account_id.encode("utf-8")).hexdigest()[:12]
+    return f"account:sha256:{digest}"
+
+
+def postgres_env_from_database_url(database_url: str) -> dict[str, str]:
+    parsed = urlparse(database_url)
+    if parsed.scheme not in {"postgres", "postgresql"}:
+        raise ValueError("DATABASE_URL must use scheme postgres or postgresql")
+
+    env = os.environ.copy()
+    for key in list(env):
+        if key == "DATABASE_URL" or key.startswith("PG"):
+            env.pop(key, None)
+
+    if parsed.hostname:
+        env["PGHOST"] = parsed.hostname
+    if parsed.port:
+        env["PGPORT"] = str(parsed.port)
+    if parsed.username:
+        env["PGUSER"] = unquote(parsed.username)
+    if parsed.password:
+        env["PGPASSWORD"] = unquote(parsed.password)
+    if parsed.path and parsed.path != "/":
+        env["PGDATABASE"] = unquote(parsed.path.lstrip("/"))
+
+    query = parse_qs(parsed.query, keep_blank_values=False)
+    query_env_map = {
+        "sslmode": "PGSSLMODE",
+        "connect_timeout": "PGCONNECT_TIMEOUT",
+        "application_name": "PGAPPNAME",
+        "sslrootcert": "PGSSLROOTCERT",
+        "sslcert": "PGSSLCERT",
+        "sslkey": "PGSSLKEY",
+    }
+    for key, env_key in query_env_map.items():
+        values = query.get(key)
+        if values:
+            env[env_key] = values[-1]
+
+    env["PGAPPNAME"] = env.get("PGAPPNAME", "weltgewebe-auth-pg-003-runtime-audit")
+    return env
+
+
+def sanitize_psql_stderr(stderr: str, database_url: str | None) -> str:
+    text = stderr or ""
+    if database_url:
+        text = text.replace(database_url, "<redacted>")
+        parsed = urlparse(database_url)
+        for value in [
+            parsed.hostname,
+            parsed.username,
+            parsed.password,
+            parsed.path.lstrip("/") if parsed.path else None,
+        ]:
+            if value:
+                text = text.replace(value, "<redacted>")
+    text = re.sub(r"postgres(?:ql)?://\S+", "postgresql://<redacted>", text)
+    text = re.sub(r"(?i)(password=)[^ \n\t]+", r"\1<redacted>", text)
+    text = re.sub(r"(?i)(PGPASSWORD=)[^ \n\t]+", r"\1<redacted>", text)
+    return text[:MAX_PSQL_STDERR_LOG_BYTES]
+
+
+def build_schema_probe_sql() -> str:
+    return """
+BEGIN TRANSACTION READ ONLY;
+SELECT json_build_object(
+    'schema_version', 1,
+    'audit', 'webauthn_user_id_backfill_runtime_schema_probe',
+    'tables', json_build_object(
+        'domain_accounts_exists', to_regclass('public.domain_accounts') IS NOT NULL,
+        'passkey_credentials_exists', to_regclass('public.passkey_credentials') IS NOT NULL
+    )
+)::text;
+ROLLBACK;
+"""
+
+
+def build_audit_sql(sample_limit: int) -> str:
+    if sample_limit < 0:
+        raise ValueError("sample_limit must be non-negative")
+
+    return f"""
+BEGIN TRANSACTION READ ONLY;
+WITH credential_accounts AS (
+    SELECT
+        p.account_id,
+        COUNT(*)::bigint AS credential_count,
+        COUNT(DISTINCT p.webauthn_user_id)::bigint AS distinct_credential_webauthn_user_ids
+    FROM passkey_credentials p
+    GROUP BY p.account_id
+),
+credential_accounts_missing_domain_uuid AS (
+    SELECT ca.account_id, ca.credential_count, ca.distinct_credential_webauthn_user_ids
+    FROM credential_accounts ca
+    JOIN domain_accounts a ON a.id = ca.account_id
+    WHERE a.webauthn_user_id IS NULL
+),
+credential_derived_candidates AS (
+    SELECT account_id
+    FROM credential_accounts_missing_domain_uuid
+    WHERE distinct_credential_webauthn_user_ids = 1
+),
+accounts_missing_without_credentials AS (
+    SELECT a.id AS account_id
+    FROM domain_accounts a
+    LEFT JOIN credential_accounts ca ON ca.account_id = a.id
+    WHERE a.webauthn_user_id IS NULL
+      AND ca.account_id IS NULL
+),
+orphan_credential_accounts AS (
+    SELECT ca.account_id, ca.credential_count, ca.distinct_credential_webauthn_user_ids
+    FROM credential_accounts ca
+    LEFT JOIN domain_accounts a ON a.id = ca.account_id
+    WHERE a.id IS NULL
+),
+multi_webauthn_user_id_accounts AS (
+    SELECT account_id, credential_count, distinct_credential_webauthn_user_ids
+    FROM credential_accounts
+    WHERE distinct_credential_webauthn_user_ids > 1
+),
+credential_account_uuid_mismatches AS (
+    SELECT
+        p.account_id,
+        COUNT(*)::bigint AS credential_count,
+        COUNT(DISTINCT p.webauthn_user_id)::bigint AS distinct_credential_webauthn_user_ids
+    FROM passkey_credentials p
+    JOIN domain_accounts a ON a.id = p.account_id
+    WHERE a.webauthn_user_id IS NOT NULL
+      AND p.webauthn_user_id <> a.webauthn_user_id
+    GROUP BY p.account_id
+),
+sample_rows AS (
+    SELECT class, account_id, credential_count, distinct_credential_webauthn_user_ids
+    FROM (
+        SELECT
+            class,
+            account_id,
+            credential_count,
+            distinct_credential_webauthn_user_ids,
+            row_number() OVER (PARTITION BY class ORDER BY credential_count DESC, account_id) AS rn
+        FROM (
+            SELECT
+                'credential_account_missing_auth_user_id' AS class,
+                account_id,
+                credential_count,
+                distinct_credential_webauthn_user_ids
+            FROM credential_accounts_missing_domain_uuid
+            UNION ALL
+            SELECT
+                'orphan_credential_account' AS class,
+                account_id,
+                credential_count,
+                distinct_credential_webauthn_user_ids
+            FROM orphan_credential_accounts
+            UNION ALL
+            SELECT
+                'multi_credential_uuid_account' AS class,
+                account_id,
+                credential_count,
+                distinct_credential_webauthn_user_ids
+            FROM multi_webauthn_user_id_accounts
+            UNION ALL
+            SELECT
+                'account_credential_uuid_mismatch' AS class,
+                account_id,
+                credential_count,
+                distinct_credential_webauthn_user_ids
+            FROM credential_account_uuid_mismatches
+        ) unioned_samples
+    ) ranked_samples
+    WHERE rn <= {sample_limit}
+),
+counts AS (
+    SELECT
+        (SELECT COUNT(*)::bigint FROM domain_accounts) AS accounts_total,
+        (SELECT COUNT(*)::bigint FROM domain_accounts WHERE webauthn_user_id IS NULL) AS accounts_missing_auth_user_id,
+        (SELECT COUNT(*)::bigint FROM passkey_credentials) AS credential_rows_total,
+        (SELECT COUNT(DISTINCT account_id)::bigint FROM passkey_credentials) AS credential_account_ids_distinct,
+        (SELECT COUNT(*)::bigint FROM credential_accounts_missing_domain_uuid) AS credential_accounts_missing_auth_user_id,
+        (SELECT COUNT(*)::bigint FROM credential_derived_candidates) AS credential_derived_backfill_candidate_accounts,
+        (SELECT COUNT(*)::bigint FROM accounts_missing_without_credentials) AS generated_uuid_candidate_accounts,
+        (SELECT COUNT(*)::bigint FROM orphan_credential_accounts) AS credential_accounts_without_domain_account,
+        (SELECT COUNT(*)::bigint FROM multi_webauthn_user_id_accounts) AS credential_accounts_with_multiple_auth_user_ids,
+        (SELECT COUNT(*)::bigint FROM credential_account_uuid_mismatches) AS credential_accounts_with_account_credential_uuid_mismatch
+)
+SELECT json_build_object(
+    'schema_version', 1,
+    'audit', 'webauthn_user_id_backfill_runtime',
+    'read_only', true,
+    'mutation_performed', false,
+    'totals', json_build_object(
+        'accounts_total', accounts_total,
+        'accounts_missing_auth_user_id', accounts_missing_auth_user_id,
+        'credential_rows_total', credential_rows_total,
+        'credential_account_ids_distinct', credential_account_ids_distinct,
+        'credential_accounts_missing_auth_user_id', credential_accounts_missing_auth_user_id,
+        'credential_derived_backfill_candidate_accounts', credential_derived_backfill_candidate_accounts,
+        'generated_uuid_candidate_accounts', generated_uuid_candidate_accounts,
+        'credential_accounts_without_domain_account', credential_accounts_without_domain_account,
+        'credential_accounts_with_multiple_auth_user_ids', credential_accounts_with_multiple_auth_user_ids,
+        'credential_accounts_with_account_credential_uuid_mismatch', credential_accounts_with_account_credential_uuid_mismatch
+    ),
+    'samples', COALESCE(
+        (SELECT json_agg(json_build_object(
+            'class', class,
+            'account_id', account_id,
+            'credential_count', credential_count,
+            'distinct_credential_webauthn_user_ids', distinct_credential_webauthn_user_ids
+        ) ORDER BY class, account_id) FROM sample_rows),
+        '[]'::json
+    )
+)::text
+FROM counts;
+ROLLBACK;
+"""
+
+
+def run_psql_json(sql: str, postgres_env: dict[str, str], database_url: str) -> dict[str, Any]:
+    if shutil.which("psql") is None:
+        raise RuntimeError("psql executable not found; install PostgreSQL client tools")
+
+    proc = subprocess.run(
+        ["psql", "-X", "-qAt", "-v", "ON_ERROR_STOP=1"],
+        input=sql,
+        env=postgres_env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            "psql audit query failed: " + sanitize_psql_stderr(proc.stderr, database_url)
+        )
+
+    json_lines = [line.strip() for line in proc.stdout.splitlines() if line.strip().startswith("{")]
+    if len(json_lines) != 1:
+        raise RuntimeError(f"expected exactly one JSON result line from psql, got {len(json_lines)}")
+    return json.loads(json_lines[0])
+
+
+def classify_backfill_readiness(
+    totals: dict[str, Any], *, schema_ready_for_audit: bool
+) -> dict[str, Any]:
+    if not schema_ready_for_audit:
+        return {
+            "schema_ready_for_audit": False,
+            "has_backfill_scope": None,
+            "has_cutover_blockers": True,
+            "not_null_count_ready": False,
+            "next_step": "fix_runtime_schema_before_backfill_audit",
+        }
+
+    accounts_missing = int(totals.get("accounts_missing_auth_user_id", 0))
+    blocker_keys = [
+        "credential_accounts_missing_auth_user_id",
+        "credential_accounts_without_domain_account",
+        "credential_accounts_with_multiple_auth_user_ids",
+        "credential_accounts_with_account_credential_uuid_mismatch",
+    ]
+    has_cutover_blockers = any(int(totals.get(key, 0)) > 0 for key in blocker_keys)
+    has_backfill_scope = accounts_missing > 0
+
+    if has_cutover_blockers:
+        next_step = "review_identity_blockers_before_backfill"
+    elif has_backfill_scope:
+        next_step = "prepare_idempotent_backfill_proof"
+    else:
+        next_step = "counts_ready_for_not_null_review"
+
+    return {
+        "schema_ready_for_audit": True,
+        "has_backfill_scope": has_backfill_scope,
+        "has_cutover_blockers": has_cutover_blockers,
+        "not_null_count_ready": accounts_missing == 0 and not has_cutover_blockers,
+        "credential_derived_backfill_candidate_accounts": int(
+            totals.get("credential_derived_backfill_candidate_accounts", 0)
+        ),
+        "generated_uuid_candidate_accounts": int(totals.get("generated_uuid_candidate_accounts", 0)),
+        "next_step": next_step,
+    }
+
+
+def redacted_missing_schema_audit(
+    schema_probe: dict[str, Any], *, source_label: str, sample_limit: int
+) -> dict[str, Any]:
+    tables = schema_probe.get("tables") or {}
+    result = {
+        "schema_version": 1,
+        "audit": AUDIT_NAME,
+        "source_label": source_label,
+        "read_only": True,
+        "mutation_performed": False,
+        "sample_limit": sample_limit,
+        "schema": {
+            "domain_accounts_exists": bool(tables.get("domain_accounts_exists", False)),
+            "passkey_credentials_exists": bool(tables.get("passkey_credentials_exists", False)),
+        },
+        "redaction": redaction_policy(),
+        "totals": None,
+        "samples": [],
+    }
+    result["findings"] = classify_backfill_readiness({}, schema_ready_for_audit=False)
+    return result
+
+
+def redaction_policy() -> dict[str, str]:
+    return {
+        "account_ids": "sha256-prefix-12",
+        "credential_ids": "not_emitted",
+        "webauthn_user_ids": "not_emitted",
+        "credentials": "not_emitted",
+    }
+
+
+def redact_audit(raw: dict[str, Any], *, source_label: str, sample_limit: int) -> dict[str, Any]:
+    totals = {key: int(value) for key, value in (raw.get("totals") or {}).items()}
+    samples = raw.get("samples") or []
+    redacted_samples = [
+        {
+            "class": str(sample["class"]),
+            "account_id_hash": hash_account_id(str(sample["account_id"])),
+            "credential_count": int(sample["credential_count"]),
+            "distinct_credential_webauthn_user_ids": int(
+                sample["distinct_credential_webauthn_user_ids"]
+            ),
+        }
+        for sample in samples
+    ]
+
+    return {
+        "schema_version": 1,
+        "audit": AUDIT_NAME,
+        "source_label": source_label,
+        "read_only": True,
+        "mutation_performed": False,
+        "sample_limit": sample_limit,
+        "schema": {
+            "domain_accounts_exists": True,
+            "passkey_credentials_exists": True,
+        },
+        "redaction": redaction_policy(),
+        "totals": totals,
+        "samples": redacted_samples,
+        "findings": classify_backfill_readiness(totals, schema_ready_for_audit=True),
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--database-url-env",
+        default="DATABASE_URL",
+        help="environment variable containing the PostgreSQL URL (default: DATABASE_URL)",
+    )
+    parser.add_argument(
+        "--source-label",
+        default="runtime-postgres",
+        help="non-secret label for the audited database/source",
+    )
+    parser.add_argument(
+        "--sample-limit",
+        type=int,
+        default=10,
+        help="maximum redacted samples to emit per finding class",
+    )
+    parser.add_argument("--pretty", action="store_true", help="pretty-print JSON output")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    database_url = os.environ.get(args.database_url_env)
+    if not database_url:
+        print(f"ERROR: {args.database_url_env} is not set", file=sys.stderr)
+        return 2
+
+    try:
+        postgres_env = postgres_env_from_database_url(database_url)
+        schema_probe = run_psql_json(build_schema_probe_sql(), postgres_env, database_url)
+        tables = schema_probe.get("tables") or {}
+        schema_ready = bool(tables.get("domain_accounts_exists")) and bool(
+            tables.get("passkey_credentials_exists")
+        )
+        if schema_ready:
+            raw = run_psql_json(build_audit_sql(args.sample_limit), postgres_env, database_url)
+            redacted = redact_audit(raw, source_label=args.source_label, sample_limit=args.sample_limit)
+        else:
+            redacted = redacted_missing_schema_audit(
+                schema_probe, source_label=args.source_label, sample_limit=args.sample_limit
+            )
+    except Exception as exc:  # noqa: BLE001 - CLI must redact and exit cleanly.
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    indent = 2 if args.pretty else None
+    print(json.dumps(redacted, indent=indent, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/docmeta/tests/test_audit_webauthn_user_id_backfill_runtime.py
+++ b/scripts/docmeta/tests/test_audit_webauthn_user_id_backfill_runtime.py
@@ -1,0 +1,224 @@
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT))
+
+from scripts.docmeta import audit_webauthn_user_id_backfill_runtime as audit  # noqa: E402
+
+
+def test_hash_account_id_is_stable_and_redacted() -> None:
+    first = audit.hash_account_id("account-a")
+    second = audit.hash_account_id("account-a")
+
+    assert first == second
+    assert first.startswith("account:sha256:")
+    assert "account-a" not in first
+    assert len(first.rsplit(":", 1)[-1]) == 12
+
+
+def test_schema_probe_sql_is_read_only_and_avoids_runtime_table_references() -> None:
+    sql = audit.build_schema_probe_sql()
+    lowered = sql.lower()
+
+    assert "begin transaction read only" in lowered
+    assert "rollback" in lowered
+    assert "to_regclass('public.domain_accounts')" in lowered
+    assert "to_regclass('public.passkey_credentials')" in lowered
+    assert " from passkey_credentials" not in lowered
+    for forbidden in [" insert ", " update ", " delete ", " drop ", " alter ", " create "]:
+        assert forbidden not in lowered
+
+
+def test_build_audit_sql_is_read_only_and_contains_no_mutation_statements() -> None:
+    sql = audit.build_audit_sql(5)
+    lowered = sql.lower()
+
+    assert "begin transaction read only" in lowered
+    assert "rollback" in lowered
+    assert "domain_accounts" in lowered
+    assert "passkey_credentials" in lowered
+    assert "row_number() over" in lowered
+    for forbidden in [" insert ", " update ", " delete ", " drop ", " alter ", " create "]:
+        assert forbidden not in lowered
+
+
+def test_build_audit_sql_rejects_negative_sample_limit() -> None:
+    try:
+        audit.build_audit_sql(-1)
+    except ValueError as exc:
+        assert "sample_limit" in str(exc)
+    else:  # pragma: no cover - easier failure message than pytest.raises import.
+        raise AssertionError("negative sample limit must fail")
+
+
+def test_classify_missing_schema_blocks_backfill_audit() -> None:
+    findings = audit.classify_backfill_readiness({}, schema_ready_for_audit=False)
+
+    assert findings == {
+        "schema_ready_for_audit": False,
+        "has_backfill_scope": None,
+        "has_cutover_blockers": True,
+        "not_null_count_ready": False,
+        "next_step": "fix_runtime_schema_before_backfill_audit",
+    }
+
+
+def test_classify_blockers_before_backfill() -> None:
+    findings = audit.classify_backfill_readiness(
+        {
+            "accounts_missing_auth_user_id": 3,
+            "credential_accounts_missing_auth_user_id": 1,
+            "credential_accounts_without_domain_account": 0,
+            "credential_accounts_with_multiple_auth_user_ids": 0,
+            "credential_accounts_with_account_credential_uuid_mismatch": 0,
+            "credential_derived_backfill_candidate_accounts": 1,
+            "generated_uuid_candidate_accounts": 2,
+        },
+        schema_ready_for_audit=True,
+    )
+
+    assert findings["schema_ready_for_audit"] is True
+    assert findings["has_backfill_scope"] is True
+    assert findings["has_cutover_blockers"] is True
+    assert findings["not_null_count_ready"] is False
+    assert findings["next_step"] == "review_identity_blockers_before_backfill"
+    assert findings["credential_derived_backfill_candidate_accounts"] == 1
+    assert findings["generated_uuid_candidate_accounts"] == 2
+
+
+def test_classify_backfill_scope_without_blockers_prepares_proof() -> None:
+    findings = audit.classify_backfill_readiness(
+        {
+            "accounts_missing_auth_user_id": 2,
+            "credential_accounts_missing_auth_user_id": 0,
+            "credential_accounts_without_domain_account": 0,
+            "credential_accounts_with_multiple_auth_user_ids": 0,
+            "credential_accounts_with_account_credential_uuid_mismatch": 0,
+            "credential_derived_backfill_candidate_accounts": 0,
+            "generated_uuid_candidate_accounts": 2,
+        },
+        schema_ready_for_audit=True,
+    )
+
+    assert findings["has_backfill_scope"] is True
+    assert findings["has_cutover_blockers"] is False
+    assert findings["not_null_count_ready"] is False
+    assert findings["next_step"] == "prepare_idempotent_backfill_proof"
+
+
+def test_classify_zero_missing_zero_blockers_is_count_ready_for_review() -> None:
+    findings = audit.classify_backfill_readiness(
+        {
+            "accounts_missing_auth_user_id": 0,
+            "credential_accounts_missing_auth_user_id": 0,
+            "credential_accounts_without_domain_account": 0,
+            "credential_accounts_with_multiple_auth_user_ids": 0,
+            "credential_accounts_with_account_credential_uuid_mismatch": 0,
+            "credential_derived_backfill_candidate_accounts": 0,
+            "generated_uuid_candidate_accounts": 0,
+        },
+        schema_ready_for_audit=True,
+    )
+
+    assert findings["has_backfill_scope"] is False
+    assert findings["has_cutover_blockers"] is False
+    assert findings["not_null_count_ready"] is True
+    assert findings["next_step"] == "counts_ready_for_not_null_review"
+
+
+def test_redact_audit_removes_raw_account_and_user_ids() -> None:
+    raw = {
+        "totals": {
+            "accounts_total": 5,
+            "accounts_missing_auth_user_id": 2,
+            "credential_rows_total": 4,
+            "credential_account_ids_distinct": 3,
+            "credential_accounts_missing_auth_user_id": 1,
+            "credential_derived_backfill_candidate_accounts": 1,
+            "generated_uuid_candidate_accounts": 1,
+            "credential_accounts_without_domain_account": 1,
+            "credential_accounts_with_multiple_auth_user_ids": 1,
+            "credential_accounts_with_account_credential_uuid_mismatch": 1,
+        },
+        "samples": [
+            {
+                "class": "orphan_credential_account",
+                "account_id": "real-account-id",
+                "credential_count": 2,
+                "distinct_credential_webauthn_user_ids": 1,
+            }
+        ],
+    }
+
+    redacted = audit.redact_audit(raw, source_label="heimserver", sample_limit=10)
+    serialized = json.dumps(redacted, sort_keys=True)
+
+    assert redacted["audit"] == "webauthn_user_id_backfill_runtime"
+    assert redacted["read_only"] is True
+    assert redacted["mutation_performed"] is False
+    assert redacted["source_label"] == "heimserver"
+    assert redacted["samples"] == [
+        {
+            "class": "orphan_credential_account",
+            "account_id_hash": audit.hash_account_id("real-account-id"),
+            "credential_count": 2,
+            "distinct_credential_webauthn_user_ids": 1,
+        }
+    ]
+    assert redacted["findings"]["next_step"] == "review_identity_blockers_before_backfill"
+    assert "real-account-id" not in serialized
+    assert "webauthn-user-id" not in serialized
+
+
+def test_redacted_missing_schema_audit_has_no_counts_but_blocks() -> None:
+    result = audit.redacted_missing_schema_audit(
+        {
+            "tables": {
+                "domain_accounts_exists": True,
+                "passkey_credentials_exists": False,
+            }
+        },
+        source_label="heimserver",
+        sample_limit=5,
+    )
+
+    assert result["schema"] == {
+        "domain_accounts_exists": True,
+        "passkey_credentials_exists": False,
+    }
+    assert result["totals"] is None
+    assert result["samples"] == []
+    assert result["findings"]["has_cutover_blockers"] is True
+    assert result["findings"]["next_step"] == "fix_runtime_schema_before_backfill_audit"
+
+
+def test_postgres_env_from_database_url_redacts_ambient_pg(monkeypatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgres://ambient:bad@example.invalid/ambient")
+    monkeypatch.setenv("PGPASSWORD", "ambient-secret")
+    env = audit.postgres_env_from_database_url(
+        "postgres://user:secret@db.example.invalid:5432/welt?sslmode=require&connect_timeout=5"
+    )
+
+    assert env["PGHOST"] == "db.example.invalid"
+    assert env["PGPORT"] == "5432"
+    assert env["PGUSER"] == "user"
+    assert env["PGPASSWORD"] == "secret"
+    assert env["PGDATABASE"] == "welt"
+    assert env["PGSSLMODE"] == "require"
+    assert env["PGCONNECT_TIMEOUT"] == "5"
+    assert env["PGAPPNAME"] == "weltgewebe-auth-pg-003-runtime-audit"
+    assert env.get("DATABASE_URL") is None
+
+
+def test_sanitize_psql_stderr_redacts_url_parts() -> None:
+    url = "postgres://user:secret@db.example.invalid:5432/welt"
+    stderr = f"could not connect to {url}; password=secret; PGPASSWORD=secret"
+
+    sanitized = audit.sanitize_psql_stderr(stderr, url)
+
+    assert url not in sanitized
+    assert "secret" not in sanitized
+    assert "db.example.invalid" not in sanitized
+    assert "<redacted>" in sanitized


### PR DESCRIPTION
## Summary
- Add a read-only AUTH-PG-003 runtime audit tool for `domain_accounts.webauthn_user_id` backfill readiness.
- Classify missing runtime schema, NULL scope, credential-derived candidates, generated-UUID candidates, orphan credentials, multi-UUID accounts, and account/credential UUID mismatches.
- Redact account samples as SHA-256 prefixes and emit no credential IDs, WebAuthn user IDs, or credential payloads.
- Record a local `wg-pg-proof` smoke: missing schema is classified as `fix_runtime_schema_before_backfill_audit`, not as success.
- Keep AUTH-PG-003 blocked: no production backfill, no NOT NULL migration, no passkey cutover, no FK change.

## Tests
- `python3 -m py_compile scripts/docmeta/audit_webauthn_user_id_backfill_runtime.py scripts/docmeta/tests/test_audit_webauthn_user_id_backfill_runtime.py`
- `python3 -m pytest -q scripts/docmeta/tests/test_audit_webauthn_user_id_backfill_runtime.py scripts/docmeta/tests/test_audit_passkey_fk_runtime.py`
- `ruff check scripts/docmeta/audit_webauthn_user_id_backfill_runtime.py scripts/docmeta/tests/test_audit_webauthn_user_id_backfill_runtime.py`
- `python3 -m scripts.docmeta.audit_webauthn_user_id_backfill_runtime --help`
- no-env failure check: audit exits 2 with `DATABASE_URL is not set`
- `python3 -m scripts.docmeta.validate_task_index docs/tasks/index.json`
- `python3 -m scripts.docmeta.check_links`
- `python3 -m scripts.docmeta.generate_task_index --check`
- `git diff --check`

## Runtime smoke
- Source: local `wg-pg-proof` container via container `psql`.
- Result: `domain_accounts_exists=false`, `passkey_credentials_exists=false`, `next_step=fix_runtime_schema_before_backfill_audit`.
- Boundary: this is not a production/Heimserver audit and does not prove backfill readiness.

## Non-goals
- No production backfill.
- No NOT NULL migration.
- No passkey cutover.
- No FK change.

Operator-Lab-Run: not created — Vibe-Lab run-card command was blocked by the toolfilter; no target-repo evidence path is claimed.
