### PR TITLE
chore(shell): satisfy repository shell lint

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -2,9 +2,9 @@
 set -euxo pipefail
 
 CURL_COMMON=(-fsS --proto '=https' --tlsv1.2 --retry 3 --retry-delay 2)
-if curl --help all 2>/dev/null | grep -q -- '--retry-all-errors'; then
+if curl --help all 2> /dev/null | grep -q -- '--retry-all-errors'; then
   CURL_COMMON+=(--retry-all-errors)
-elif curl --help 2>/dev/null | grep -q -- '--retry-all-errors'; then
+elif curl --help 2> /dev/null | grep -q -- '--retry-all-errors'; then
   CURL_COMMON+=(--retry-all-errors)
 fi
 
@@ -22,7 +22,7 @@ install_vale() {
     x86_64)
       vale_os="Linux_64-bit"
       ;;
-    aarch64|arm64)
+    aarch64 | arm64)
       vale_os="Linux_arm64"
       ;;
     *)
@@ -67,7 +67,7 @@ install_hadolint() {
     x86_64)
       hadolint_arch="x86_64"
       ;;
-    aarch64|arm64)
+    aarch64 | arm64)
       hadolint_arch="arm64"
       ;;
     *)

--- a/.devcontainer/ssh-agent-guard.sh
+++ b/.devcontainer/ssh-agent-guard.sh
@@ -38,7 +38,7 @@ Fix on host:
 Do not copy private keys into the container."
 fi
 
-if ! ssh-add -l >/dev/null 2>&1; then
+if ! ssh-add -l > /dev/null 2>&1; then
   fail_or_warn 69 "SSH-AGENT-GUARD: forwarded SSH agent is available, but no identities are loaded.
 
 Fix on host:
@@ -54,14 +54,14 @@ if [ ! -f "$HOME/.ssh/known_hosts" ]; then
   chmod 600 "$HOME/.ssh/known_hosts"
 fi
 
-if ! ssh-keygen -F github.com -f "$HOME/.ssh/known_hosts" >/dev/null 2>&1; then
+if ! ssh-keygen -F github.com -f "$HOME/.ssh/known_hosts" > /dev/null 2>&1; then
   echo "SSH-AGENT-GUARD: github.com missing from known_hosts; adding via ssh-keyscan TOFU." >&2
-  ssh-keyscan github.com >> "$HOME/.ssh/known_hosts" 2>/dev/null || true
+  ssh-keyscan github.com >> "$HOME/.ssh/known_hosts" 2> /dev/null || true
   chmod 600 "$HOME/.ssh/known_hosts" || true
 fi
 
 agent_ssh_command="${GIT_SSH_COMMAND:-ssh -F /dev/null -o IdentityAgent=${SSH_AUTH_SOCK} -o IdentitiesOnly=no}"
-git config --global --unset-all core.sshCommand >/dev/null 2>&1 || true
+git config --global --unset-all core.sshCommand > /dev/null 2>&1 || true
 git config --global core.sshCommand "$agent_ssh_command"
 echo "SSH-AGENT-GUARD: git core.sshCommand uses forwarded agent."
 
@@ -75,7 +75,7 @@ if [ "$mode" = "github" ]; then
 
       remote="${SSH_AGENT_GUARD_GIT_REMOTE:-git@github.com:heimgewebe/weltgewebe.git}"
       if GIT_SSH_COMMAND="${GIT_SSH_COMMAND:-ssh -F /dev/null -o IdentityAgent=/ssh-agent -o IdentitiesOnly=no}" \
-        git ls-remote "$remote" HEAD >/dev/null 2>&1; then
+        git ls-remote "$remote" HEAD > /dev/null 2>&1; then
         echo "SSH-AGENT-GUARD: ok Git transport works for $remote."
       else
         echo "SSH-AGENT-GUARD: Git transport was not proven for $remote." >&2

--- a/.devcontainer/uid-guard.sh
+++ b/.devcontainer/uid-guard.sh
@@ -14,7 +14,7 @@ current_uid="$(id -u)"
 current_gid="$(id -g)"
 
 if [ "$current_uid" != "$workspace_uid" ] || [ "$current_gid" != "$workspace_gid" ]; then
-  cat >&2 <<EOF
+  cat >&2 << EOF
 UID-GUARD: mismatch detected.
 container uid/gid: ${current_uid}:${current_gid}
 workspace uid/gid: ${workspace_uid}:${workspace_gid}

--- a/apps/api/entrypoint.sh
+++ b/apps/api/entrypoint.sh
@@ -16,43 +16,43 @@ ENABLE_SEEDING="${GEWEBE_SEED_DEMO:-false}"
 # Guard: real and demo seeding are mutually exclusive. Mixing a real first
 # account with demo Garnrollen makes "which data is real?" unanswerable.
 if [[ "$ENABLE_REAL_SEEDING" =~ ^(true|1|yes)$ ]] && [[ "$ENABLE_SEEDING" =~ ^(true|1|yes)$ ]]; then
-    echo "Error: GEWEBE_SEED_REAL and GEWEBE_SEED_DEMO must not both be enabled." >&2
-    echo "       For a real deployment set GEWEBE_SEED_REAL=true and GEWEBE_SEED_DEMO=false." >&2
-    exit 1
+  echo "Error: GEWEBE_SEED_REAL and GEWEBE_SEED_DEMO must not both be enabled." >&2
+  echo "       For a real deployment set GEWEBE_SEED_REAL=true and GEWEBE_SEED_DEMO=false." >&2
+  exit 1
 fi
 
 if [[ "$ENABLE_REAL_SEEDING" =~ ^(true|1|yes)$ ]]; then
-    echo "Ensuring REAL seed data in $DATA_DIR (GEWEBE_SEED_REAL=$ENABLE_REAL_SEEDING)..."
-    mkdir -p "$DATA_DIR"
-    if command -v bootstrap-first-account >/dev/null 2>&1; then
-        bootstrap-first-account "$DATA_DIR"
-    else
-        echo "Error: bootstrap-first-account not found, cannot perform GEWEBE_SEED_REAL." >&2
-        exit 1
-    fi
+  echo "Ensuring REAL seed data in $DATA_DIR (GEWEBE_SEED_REAL=$ENABLE_REAL_SEEDING)..."
+  mkdir -p "$DATA_DIR"
+  if command -v bootstrap-first-account > /dev/null 2>&1; then
+    bootstrap-first-account "$DATA_DIR"
+  else
+    echo "Error: bootstrap-first-account not found, cannot perform GEWEBE_SEED_REAL." >&2
+    exit 1
+  fi
 fi
 
 if [[ "$ENABLE_SEEDING" =~ ^(true|1|yes)$ ]]; then
-    # Sentinel check: If core files exist and are not empty, we assume data is present.
-    if [ -s "$DATA_DIR/demo.nodes.jsonl" ] && \
-       [ -s "$DATA_DIR/demo.accounts.jsonl" ] && \
-       [ -s "$DATA_DIR/demo.edges.jsonl" ]; then
-        echo "Data files found in $DATA_DIR. Skipping generation."
+  # Sentinel check: If core files exist and are not empty, we assume data is present.
+  if [ -s "$DATA_DIR/demo.nodes.jsonl" ] &&
+    [ -s "$DATA_DIR/demo.accounts.jsonl" ] &&
+    [ -s "$DATA_DIR/demo.edges.jsonl" ]; then
+    echo "Data files found in $DATA_DIR. Skipping generation."
+  else
+    echo "Ensuring data in $DATA_DIR (Seeding Enabled)..."
+
+    # Ensure directory exists
+    mkdir -p "$DATA_DIR"
+
+    # Run generation script to seed data if missing
+    if command -v generate-demo-data > /dev/null 2>&1; then
+      generate-demo-data "$DATA_DIR"
     else
-        echo "Ensuring data in $DATA_DIR (Seeding Enabled)..."
-
-        # Ensure directory exists
-        mkdir -p "$DATA_DIR"
-
-        # Run generation script to seed data if missing
-        if command -v generate-demo-data >/dev/null 2>&1; then
-            generate-demo-data "$DATA_DIR"
-        else
-            echo "Warning: generate-demo-data not found, skipping data seeding."
-        fi
+      echo "Warning: generate-demo-data not found, skipping data seeding."
     fi
+  fi
 else
-    echo "Skipping data seeding (GEWEBE_SEED_DEMO=$ENABLE_SEEDING)"
+  echo "Skipping data seeding (GEWEBE_SEED_DEMO=$ENABLE_SEEDING)"
 fi
 
 # Exec the passed command (e.g. the API server)

--- a/ci/scripts/db-wait.sh
+++ b/ci/scripts/db-wait.sh
@@ -9,7 +9,7 @@ INTERVAL=${DB_WAIT_INTERVAL:-2}
 declare -i end=$((SECONDS + TIMEOUT))
 
 while ((SECONDS < end)); do
-  if echo >"/dev/tcp/$HOST/$PORT" 2>/dev/null; then
+  if echo > "/dev/tcp/$HOST/$PORT" 2> /dev/null; then
     printf 'Postgres is available at %s:%s\n' "$HOST" "$PORT"
     exit 0
   fi

--- a/scripts/basemap/build-germany-pmtiles.sh
+++ b/scripts/basemap/build-germany-pmtiles.sh
@@ -11,8 +11,8 @@ set -euo pipefail
 # - Pinned historical OSM snapshot with self-determined SHA256 integrity
 
 # 1. Resolve repo root securely
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../.." >/dev/null 2>&1 && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." > /dev/null 2>&1 && pwd)"
 BASEMAP_DIR="$REPO_ROOT/build/basemap"
 
 # 2. Pin tools and OSM input for reproducible input provenance
@@ -40,15 +40,15 @@ echo "Format:  PMTiles"
 echo "=================================="
 
 # 3. Tool checks
-if ! command -v docker >/dev/null 2>&1; then
+if ! command -v docker > /dev/null 2>&1; then
   echo "Error: 'docker' is required but not installed or not in PATH." >&2
   exit 1
 fi
 
 DOWNLOADER=""
-if command -v wget >/dev/null 2>&1; then
+if command -v wget > /dev/null 2>&1; then
   DOWNLOADER="wget"
-elif command -v curl >/dev/null 2>&1; then
+elif command -v curl > /dev/null 2>&1; then
   DOWNLOADER="curl"
 else
   echo "Error: Neither 'wget' nor 'curl' is available for downloading the OSM data." >&2
@@ -63,18 +63,24 @@ cd "$BASEMAP_DIR"
 if [ ! -f "$OSM_FILE" ]; then
   echo "=> Downloading OSM data for Germany ($OSM_FILE)..."
   if [ "$DOWNLOADER" = "wget" ]; then
-    wget -qO "$OSM_FILE" "$OSM_URL" || { rm -f "$OSM_FILE"; exit 1; }
+    wget -qO "$OSM_FILE" "$OSM_URL" || {
+      rm -f "$OSM_FILE"
+      exit 1
+    }
   else
-    curl -fL -o "$OSM_FILE" "$OSM_URL" || { rm -f "$OSM_FILE"; exit 1; }
+    curl -fL -o "$OSM_FILE" "$OSM_URL" || {
+      rm -f "$OSM_FILE"
+      exit 1
+    }
   fi
 else
   echo "=> OSM data '$OSM_FILE' already exists locally, skipping download."
 fi
 
 echo "=> Verifying integrity of $OSM_FILE..."
-if command -v sha256sum >/dev/null 2>&1; then
+if command -v sha256sum > /dev/null 2>&1; then
   SHA256_CMD=(sha256sum)
-elif command -v shasum >/dev/null 2>&1; then
+elif command -v shasum > /dev/null 2>&1; then
   SHA256_CMD=(shasum -a 256)
 else
   echo "Error: 'sha256sum' or 'shasum' is required for artifact verification but not installed." >&2
@@ -138,7 +144,7 @@ else
   BUILD_TIMESTAMP_JSON=""
 fi
 
-cat <<MANIFEST > "$BASEMAP_DIR/$OUTPUT_META"
+cat << MANIFEST > "$BASEMAP_DIR/$OUTPUT_META"
 {
   "version": "${BASEMAP_VERSION}",
   "region": "germany",

--- a/scripts/basemap/build-hamburg-pmtiles.sh
+++ b/scripts/basemap/build-hamburg-pmtiles.sh
@@ -11,8 +11,8 @@ set -euo pipefail
 # - OSM input is currently volatile (outputs are not yet strictly reproducible)
 
 # 1. Resolve repo root securely
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../.." >/dev/null 2>&1 && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." > /dev/null 2>&1 && pwd)"
 BASEMAP_DIR="$REPO_ROOT/build/basemap"
 
 # 2. Pin tools and OSM input for reproducible input provenance
@@ -39,15 +39,15 @@ echo "Format:  PMTiles"
 echo "=================================="
 
 # 3. Tool checks
-if ! command -v docker >/dev/null 2>&1; then
+if ! command -v docker > /dev/null 2>&1; then
   echo "Error: 'docker' is required but not installed or not in PATH." >&2
   exit 1
 fi
 
 DOWNLOADER=""
-if command -v wget >/dev/null 2>&1; then
+if command -v wget > /dev/null 2>&1; then
   DOWNLOADER="wget"
-elif command -v curl >/dev/null 2>&1; then
+elif command -v curl > /dev/null 2>&1; then
   DOWNLOADER="curl"
 else
   echo "Error: Neither 'wget' nor 'curl' is available for downloading the OSM data." >&2
@@ -62,18 +62,24 @@ cd "$BASEMAP_DIR"
 if [ ! -f "$OSM_FILE" ]; then
   echo "=> Downloading OSM data for Hamburg ($OSM_FILE)..."
   if [ "$DOWNLOADER" = "wget" ]; then
-    wget -qO "$OSM_FILE" "$OSM_URL" || { rm -f "$OSM_FILE"; exit 1; }
+    wget -qO "$OSM_FILE" "$OSM_URL" || {
+      rm -f "$OSM_FILE"
+      exit 1
+    }
   else
-    curl -fL -o "$OSM_FILE" "$OSM_URL" || { rm -f "$OSM_FILE"; exit 1; }
+    curl -fL -o "$OSM_FILE" "$OSM_URL" || {
+      rm -f "$OSM_FILE"
+      exit 1
+    }
   fi
 else
   echo "=> OSM data '$OSM_FILE' already exists locally, skipping download."
 fi
 
 echo "=> Verifying integrity of $OSM_FILE..."
-if command -v sha256sum >/dev/null 2>&1; then
+if command -v sha256sum > /dev/null 2>&1; then
   SHA256_CMD=(sha256sum)
-elif command -v shasum >/dev/null 2>&1; then
+elif command -v shasum > /dev/null 2>&1; then
   SHA256_CMD=(shasum -a 256)
 else
   echo "Error: 'sha256sum' or 'shasum' is required for artifact verification but not installed." >&2
@@ -108,7 +114,6 @@ if ! docker run --rm \
   exit 1
 fi
 
-
 # 7. Generate Metadata Manifest
 echo "=> Generating metadata manifest..."
 
@@ -126,7 +131,6 @@ if [ -z "$PMTILES_SHA256" ] || [ "$PMTILES_SIZE" -eq 0 ]; then
   exit 1
 fi
 
-
 BUILD_TIMESTAMP_VALUE=""
 
 if [ "${NON_REPRODUCIBLE_BUILD_TIMESTAMP:-}" = "1" ]; then
@@ -141,7 +145,7 @@ else
   BUILD_TIMESTAMP_JSON=""
 fi
 
-cat <<EOF > "$BASEMAP_DIR/$OUTPUT_META"
+cat << EOF > "$BASEMAP_DIR/$OUTPUT_META"
 {
   "version": "${BASEMAP_VERSION}",
   "region": "hamburg",

--- a/scripts/basemap/fetch-glyphs.sh
+++ b/scripts/basemap/fetch-glyphs.sh
@@ -9,8 +9,8 @@ set -euo pipefail
 # - SHA256 integrity verification of the downloaded archive
 # - Extracted assets placed in reproducible local paths
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../.." >/dev/null 2>&1 && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." > /dev/null 2>&1 && pwd)"
 GLYPHS_DIR="$REPO_ROOT/map-style/glyphs"
 TARGET_FONT_DIR="$GLYPHS_DIR/Noto Sans Regular"
 
@@ -29,29 +29,28 @@ echo "=================================="
 
 # Tool checks
 DOWNLOADER=""
-if command -v wget >/dev/null 2>&1; then
+if command -v wget > /dev/null 2>&1; then
   DOWNLOADER="wget"
-elif command -v curl >/dev/null 2>&1; then
+elif command -v curl > /dev/null 2>&1; then
   DOWNLOADER="curl"
 else
   echo "Error: Neither 'wget' nor 'curl' is available for downloading the assets." >&2
   exit 1
 fi
 
-if ! command -v unzip >/dev/null 2>&1; then
+if ! command -v unzip > /dev/null 2>&1; then
   echo "Error: 'unzip' is required to extract the font archive." >&2
   exit 1
 fi
 
-if command -v sha256sum >/dev/null 2>&1; then
+if command -v sha256sum > /dev/null 2>&1; then
   SHA256_CMD=(sha256sum)
-elif command -v shasum >/dev/null 2>&1; then
+elif command -v shasum > /dev/null 2>&1; then
   SHA256_CMD=(shasum -a 256)
 else
   echo "Error: 'sha256sum' or 'shasum' is required for artifact verification but not installed." >&2
   exit 1
 fi
-
 
 echo "=> Preparing target directory ($TARGET_FONT_DIR)..."
 mkdir -p "$TARGET_FONT_DIR"
@@ -64,7 +63,7 @@ if [ -f "$TARGET_FONT_DIR/.complete" ]; then
 
   # Validate that STORED_COUNT is strictly numeric to safely use -eq
   case "$STORED_COUNT" in
-    ''|*[!0-9]*) STORED_COUNT=-1 ;;
+    '' | *[!0-9]*) STORED_COUNT=-1 ;;
   esac
 
   if [ "$STORED_HASH" = "$ASSET_SHA256" ] && [ "$STORED_COUNT" -ge 0 ]; then
@@ -131,9 +130,6 @@ cat << EOF_SENTINEL > "$TARGET_FONT_DIR/.complete"
 HASH=$ASSET_SHA256
 COUNT=$EXTRACTED_COUNT
 EOF_SENTINEL
-
-
-
 
 echo "=> Glyph fetching complete!"
 echo "Artifacts are now available in: $TARGET_FONT_DIR"

--- a/scripts/basemap/publish-basemap.sh
+++ b/scripts/basemap/publish-basemap.sh
@@ -52,14 +52,14 @@ if [[ ! -d "$TARGET_DIR" ]]; then
 fi
 
 # Determine verification tools
-if ! command -v python3 >/dev/null 2>&1; then
+if ! command -v python3 > /dev/null 2>&1; then
   echo "ERROR: 'python3' is required for sentinel verification but not installed." >&2
   exit 1
 fi
 
-if command -v sha256sum >/dev/null 2>&1; then
+if command -v sha256sum > /dev/null 2>&1; then
   SHA256_CMD=(sha256sum)
-elif command -v shasum >/dev/null 2>&1; then
+elif command -v shasum > /dev/null 2>&1; then
   SHA256_CMD=(shasum -a 256)
 else
   echo "ERROR: 'sha256sum' or 'shasum' is required for artifact verification but not installed." >&2
@@ -95,12 +95,12 @@ except Exception as e:
     print(str(e), file=sys.stderr)
     sys.exit(5)
 PY
-    :
+  :
 else
-    PY_STATUS=$?
-    echo "ERROR: Sentinel contract validation failed (Exit Code: $PY_STATUS)." >&2
-    rm -f "$VERIFY_OUTPUT"
-    exit 1
+  PY_STATUS=$?
+  echo "ERROR: Sentinel contract validation failed (Exit Code: $PY_STATUS)." >&2
+  rm -f "$VERIFY_OUTPUT"
+  exit 1
 fi
 
 META_ARTIFACT_NAME=$(sed -n '1p' "$VERIFY_OUTPUT")
@@ -109,7 +109,7 @@ META_SIZE=$(sed -n '3p' "$VERIFY_OUTPUT")
 rm -f "$VERIFY_OUTPUT"
 
 case "$META_SIZE" in
-  ''|*[!0-9]*)
+  '' | *[!0-9]*)
     echo "ERROR: META_SIZE from sentinel is missing or non-numeric: '$META_SIZE'" >&2
     exit 1
     ;;
@@ -120,8 +120,8 @@ echo "   [✓] Schema valid. Status is 'ready'. Size parsed: $META_SIZE bytes."
 # Check if the filename in meta matches the provided pmtiles filename
 BASENAME_PMTILES=$(basename "$SOURCE_PMTILES")
 if [[ "$META_ARTIFACT_NAME" != "$BASENAME_PMTILES" ]]; then
-   echo "ERROR: artifact_name in meta ($META_ARTIFACT_NAME) does not match the provided PMTiles filename ($BASENAME_PMTILES)." >&2
-   exit 1
+  echo "ERROR: artifact_name in meta ($META_ARTIFACT_NAME) does not match the provided PMTiles filename ($BASENAME_PMTILES)." >&2
+  exit 1
 fi
 
 # 3. Artifact Verification
@@ -129,7 +129,7 @@ echo ">> Verifying PMTiles Artifact ($SOURCE_PMTILES)..."
 
 ACTUAL_SIZE=$(wc -c < "$SOURCE_PMTILES" | tr -d '[:space:]')
 case "$ACTUAL_SIZE" in
-  ''|*[!0-9]*)
+  '' | *[!0-9]*)
     echo "ERROR: Could not determine valid size for $SOURCE_PMTILES." >&2
     exit 1
     ;;
@@ -195,7 +195,7 @@ echo "   [✓] Artifacts are now verified and visible in target directory."
 # We fallback to a generic name if parsing fails, but typical is basemap-hamburg.pmtiles
 REGION=$(echo "$META_ARTIFACT_NAME" | grep -oE "basemap-[a-zA-Z0-9_-]+" | sed 's/-v[0-9].*//g' | sed 's/\.pmtiles//g' || true)
 if [[ -z "$REGION" ]]; then
-    REGION="basemap"
+  REGION="basemap"
 fi
 
 ALIAS_PMTILES="${REGION}.pmtiles"

--- a/scripts/basemap/rollback-basemap.sh
+++ b/scripts/basemap/rollback-basemap.sh
@@ -68,15 +68,15 @@ if [[ ! -f "$TARGET_DIR/$META_FILENAME" ]]; then
 fi
 
 # Determine verification tools
-if ! command -v python3 >/dev/null 2>&1; then
+if ! command -v python3 > /dev/null 2>&1; then
   echo "ERROR: 'python3' is required for sentinel verification but not installed." >&2
   EXIT_CODE=1
   exit $EXIT_CODE
 fi
 
-if command -v sha256sum >/dev/null 2>&1; then
+if command -v sha256sum > /dev/null 2>&1; then
   SHA256_CMD=(sha256sum)
-elif command -v shasum >/dev/null 2>&1; then
+elif command -v shasum > /dev/null 2>&1; then
   SHA256_CMD=(shasum -a 256)
 else
   echo "ERROR: 'sha256sum' or 'shasum' is required for artifact verification but not installed." >&2
@@ -113,13 +113,13 @@ except Exception as e:
     print(str(e), file=sys.stderr)
     sys.exit(5)
 PY
-    :
+  :
 else
-    PY_STATUS=$?
-    echo "ERROR: Sentinel contract validation failed (Exit Code: $PY_STATUS)." >&2
-    rm -f "$VERIFY_OUTPUT"
-    EXIT_CODE=1
-    exit $EXIT_CODE
+  PY_STATUS=$?
+  echo "ERROR: Sentinel contract validation failed (Exit Code: $PY_STATUS)." >&2
+  rm -f "$VERIFY_OUTPUT"
+  EXIT_CODE=1
+  exit $EXIT_CODE
 fi
 
 META_ARTIFACT_NAME=$(sed -n '1p' "$VERIFY_OUTPUT")
@@ -128,7 +128,7 @@ META_SIZE=$(sed -n '3p' "$VERIFY_OUTPUT")
 rm -f "$VERIFY_OUTPUT"
 
 case "$META_SIZE" in
-  ''|*[!0-9]*)
+  '' | *[!0-9]*)
     echo "ERROR: META_SIZE from sentinel is missing or non-numeric: '$META_SIZE'" >&2
     EXIT_CODE=1
     exit $EXIT_CODE
@@ -138,9 +138,9 @@ esac
 echo "   [✓] Schema valid. Status is 'ready'. Size parsed: $META_SIZE bytes."
 
 if [[ "$META_ARTIFACT_NAME" != "$PMTILES_FILENAME" ]]; then
-   echo "ERROR: artifact_name in meta ($META_ARTIFACT_NAME) does not match the provided PMTiles filename ($PMTILES_FILENAME)." >&2
-   EXIT_CODE=1
-   exit $EXIT_CODE
+  echo "ERROR: artifact_name in meta ($META_ARTIFACT_NAME) does not match the provided PMTiles filename ($PMTILES_FILENAME)." >&2
+  EXIT_CODE=1
+  exit $EXIT_CODE
 fi
 
 # 3. Artifact Verification
@@ -148,7 +148,7 @@ echo ">> Verifying PMTiles Artifact ($TARGET_DIR/$PMTILES_FILENAME)..."
 
 ACTUAL_SIZE=$(wc -c < "$TARGET_DIR/$PMTILES_FILENAME" | tr -d '[:space:]')
 case "$ACTUAL_SIZE" in
-  ''|*[!0-9]*)
+  '' | *[!0-9]*)
     echo "ERROR: Could not determine valid size for $TARGET_DIR/$PMTILES_FILENAME." >&2
     EXIT_CODE=1
     exit $EXIT_CODE
@@ -179,7 +179,7 @@ echo "   [✓] Integrity verified (SHA256 and Size match)."
 # We fallback to a generic name if parsing fails, but typical is basemap-hamburg.pmtiles
 REGION=$(echo "$META_ARTIFACT_NAME" | grep -oE "basemap-[a-zA-Z0-9_-]+" | sed 's/-v[0-9].*//g' | sed 's/\.pmtiles//g' || true)
 if [[ -z "$REGION" ]]; then
-    REGION="basemap"
+  REGION="basemap"
 fi
 
 ALIAS_PMTILES="${REGION}.pmtiles"

--- a/scripts/ci/wait-for-api.sh
+++ b/scripts/ci/wait-for-api.sh
@@ -13,7 +13,7 @@ check_endpoint() {
   local temp_out
   temp_out=$(mktemp)
 
-  if curl -sSf "$url" > "$temp_out" 2>/dev/null; then
+  if curl -sSf "$url" > "$temp_out" 2> /dev/null; then
     # Check if response is not empty (e.g. > 2 bytes, minimal for JSON "[]")
     if [ -s "$temp_out" ] && [ "$(wc -c < "$temp_out")" -gt 2 ]; then
       rm "$temp_out"
@@ -31,9 +31,9 @@ while [ $count -lt $MAX_RETRIES ]; do
     exit 0
   fi
 
-  echo "API not yet ready (or empty response). Retrying in ${SLEEP_SECONDS}s... ($((count+1))/$MAX_RETRIES)"
+  echo "API not yet ready (or empty response). Retrying in ${SLEEP_SECONDS}s... ($((count + 1))/$MAX_RETRIES)"
   sleep $SLEEP_SECONDS
-  count=$((count+1))
+  count=$((count + 1))
 done
 
 echo "❌ API failed to become ready within $((MAX_RETRIES * SLEEP_SECONDS)) seconds."

--- a/scripts/ci/wait-for-preview.sh
+++ b/scripts/ci/wait-for-preview.sh
@@ -19,7 +19,7 @@ if [[ ! "$PREVIEW_PID" =~ ^[0-9]+$ ]]; then
 fi
 
 check_preview_ready() {
-  curl -sSf "http://127.0.0.1:${PREVIEW_PORT}" >/dev/null 2>&1
+  curl -sSf "http://127.0.0.1:${PREVIEW_PORT}" > /dev/null 2>&1
 }
 
 show_preview_logs() {
@@ -45,7 +45,7 @@ verify_port_binding() {
 declare -i end=$((SECONDS + PREVIEW_WAIT_DURATION))
 
 while [ "$SECONDS" -lt "$end" ]; do
-  if ! kill -0 "$PREVIEW_PID" 2>/dev/null; then
+  if ! kill -0 "$PREVIEW_PID" 2> /dev/null; then
     printf 'Preview server process (PID %s) exited early\n' "$PREVIEW_PID" >&2
     show_preview_logs
     exit 1

--- a/scripts/contracts-agent-check.sh
+++ b/scripts/contracts-agent-check.sh
@@ -27,9 +27,9 @@ AJV_OUTPUT="$TMP_DIR/agent-contract-invalid.out"
 trap 'rm -rf -- "${TMP_DIR:?}"' EXIT
 
 INVALID_HANDOFF="$INVALID_HANDOFF" \
-INVALID_VALIDATION="$INVALID_VALIDATION" \
-INVALID_RUN_RESULT="$INVALID_RUN_RESULT" \
-python3 - <<'PY'
+  INVALID_VALIDATION="$INVALID_VALIDATION" \
+  INVALID_RUN_RESULT="$INVALID_RUN_RESULT" \
+  python3 - << 'PY'
 import json
 import os
 from pathlib import Path
@@ -75,7 +75,7 @@ expect_invalid() {
   local label="$3"
   echo "==> require $label to fail schema validation"
   set +e
-  "$AJV_BIN" validate -s "$schema" -d "$fixture" --spec=draft7 --strict=false >"$AJV_OUTPUT" 2>&1
+  "$AJV_BIN" validate -s "$schema" -d "$fixture" --spec=draft7 --strict=false > "$AJV_OUTPUT" 2>&1
   local rc=$?
   set -e
   if [[ "$rc" -ne 1 ]]; then

--- a/scripts/contracts-domain-check.sh
+++ b/scripts/contracts-domain-check.sh
@@ -16,7 +16,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 AJV_BIN=""
-if command -v ajv >/dev/null 2>&1; then
+if command -v ajv > /dev/null 2>&1; then
   AJV_BIN="$(command -v ajv)"
 elif [ -f "node_modules/.bin/ajv" ]; then
   AJV_BIN="node_modules/.bin/ajv"

--- a/scripts/deploy-snapshot.sh
+++ b/scripts/deploy-snapshot.sh
@@ -5,10 +5,10 @@ set -euo pipefail
 # Configuration (sane defaults)
 # -----------------------------
 # (Note: Infra updates (Edge/Public Login/Trusted Proxy/Drift Fix/Caddy Rate Limit Disabled/Basemap CSP Fix/Basemap PMTiles Hosting) require the pinned Caddy build (see infra/caddy/Dockerfile) and a strict upstream env; ensure snapshot captures this context)
-SNAPSHOT_MODE="${SNAPSHOT_MODE:-dry}"          # dry | live
+SNAPSHOT_MODE="${SNAPSHOT_MODE:-dry}" # dry | live
 COMPOSE_FILE="${COMPOSE_FILE:-infra/compose/compose.prod.yml}"
 COMPOSE_PROJECT="${COMPOSE_PROJECT:-compose}"
-HEALTH_MODE="${HEALTH_MODE:-container}"        # container | url
+HEALTH_MODE="${HEALTH_MODE:-container}" # container | url
 HEALTH_URL="${HEALTH_URL:-}"
 OUT_DIR="${OUT_DIR:-artifacts}"
 OUT_FILE="${OUT_DIR}/deploy.snapshot.json"
@@ -19,16 +19,16 @@ OUT_FILE="${OUT_DIR}/deploy.snapshot.json"
 iso_ts() { date -Is; }
 sha256() { sha256sum "$1" | awk '{print $1}'; }
 
-have() { command -v "$1" >/dev/null 2>&1; }
+have() { command -v "$1" > /dev/null 2>&1; }
 
 collect_compose_config() {
   local out
-  if have docker && docker compose version >/dev/null 2>&1; then
+  if have docker && docker compose version > /dev/null 2>&1; then
     set +e
     if [[ -n "${COMPOSE_ARGS:-}" ]]; then
       # Robustly parse args into an array (handles spaces/globbing better than unquoted expansion)
       local -a args=()
-      read -r -a args <<<"${COMPOSE_ARGS}"
+      read -r -a args <<< "${COMPOSE_ARGS}"
       out="$(docker compose "${args[@]}" config 2>&1)"
     else
       out="$(docker compose -f "$COMPOSE_FILE" config 2>&1)"
@@ -51,11 +51,11 @@ REPO_PATH="$(pwd)"
 REPO_SHA=""
 REPO_DIRTY="null"
 
-if have git && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-  REPO_SHA="$(git rev-parse --short HEAD 2>/dev/null || echo "")"
+if have git && git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+  REPO_SHA="$(git rev-parse --short HEAD 2> /dev/null || echo "")"
   # Robust dirty check: staged + unstaged changes
-  if git rev-parse --verify HEAD >/dev/null 2>&1; then
-    if git diff-index --quiet HEAD -- 2>/dev/null; then
+  if git rev-parse --verify HEAD > /dev/null 2>&1; then
+    if git diff-index --quiet HEAD -- 2> /dev/null; then
       REPO_DIRTY="false"
     else
       REPO_DIRTY="true"
@@ -126,7 +126,8 @@ if [[ "$SNAPSHOT_MODE" == "live" ]]; then
   export DB_CONTAINER="${COMPOSE_PROJECT}-db-1"
 
   # Pass service mapping to python via environment to avoid injection
-  export SVC_MAP_JSON="$(python3 - <<'PY'
+  SVC_MAP_JSON="$(
+    python3 - << 'PY'
 import json, os
 print(json.dumps({
   "api": os.environ["API_CONTAINER"],
@@ -134,9 +135,11 @@ print(json.dumps({
   "db": os.environ["DB_CONTAINER"],
 }))
 PY
-)"
+  )"
+  export SVC_MAP_JSON
 
-  CONTAINERS_JSON="$(python3 - <<'PY'
+  CONTAINERS_JSON="$(
+    python3 - << 'PY'
 import json, subprocess, os
 
 service_map = json.loads(os.environ['SVC_MAP_JSON'])
@@ -232,12 +235,13 @@ except Exception:
 out.sort(key=lambda x: x["service"])
 print(json.dumps(out, indent=2))
 PY
-)"
+  )"
 
   # Dynamic Volume Discovery
   # List all volumes starting with project prefix
   export PROJ_PREFIX="${COMPOSE_PROJECT}_"
-  VOLUMES_JSON="$(python3 - <<'PY'
+  VOLUMES_JSON="$(
+    python3 - << 'PY'
 import json, subprocess, os
 
 prefix = os.environ['PROJ_PREFIX']
@@ -262,11 +266,12 @@ except Exception:
 
 print(json.dumps(out, indent=2))
 PY
-)"
+  )"
 
   # Mounts for specific containers
   # We use the same service map to inspect mounts
-  MOUNTS_JSON="$(python3 - <<'PY'
+  MOUNTS_JSON="$(
+    python3 - << 'PY'
 import json, subprocess, os
 
 service_map = json.loads(os.environ['SVC_MAP_JSON'])
@@ -290,7 +295,7 @@ for c in containers:
         pass
 print(json.dumps(out, indent=2))
 PY
-)"
+  )"
 
   # Health Check
   if [[ "$HEALTH_MODE" == "container" ]]; then
@@ -309,35 +314,37 @@ PY
     "
 
     # Check if container is running using exact match via inspect
-    if docker inspect --format '{{.State.Running}}' "$TARGET_CONTAINER" 2>/dev/null | grep -q "true"; then
-       RES=$(docker exec "$TARGET_CONTAINER" sh -c "$HEALTH_CMD" 2>/dev/null || echo "exec_fail")
-       if [[ "$RES" == "ok" ]]; then
-         HEALTH_JSON='{ "mode":"container","url":null,"ok":true,"http_code":200,"reason":null }'
-       elif [[ "$RES" == "unknown" ]]; then
-         HEALTH_JSON='{ "mode":"container","url":null,"ok":null,"http_code":null,"reason":"neither wget nor curl available" }'
-       else
-         HEALTH_JSON='{ "mode":"container","url":null,"ok":false,"http_code":500,"reason":"health endpoint failed or exec error" }'
-       fi
+    if docker inspect --format '{{.State.Running}}' "$TARGET_CONTAINER" 2> /dev/null | grep -q "true"; then
+      RES=$(docker exec "$TARGET_CONTAINER" sh -c "$HEALTH_CMD" 2> /dev/null || echo "exec_fail")
+      if [[ "$RES" == "ok" ]]; then
+        HEALTH_JSON='{ "mode":"container","url":null,"ok":true,"http_code":200,"reason":null }'
+      elif [[ "$RES" == "unknown" ]]; then
+        HEALTH_JSON='{ "mode":"container","url":null,"ok":null,"http_code":null,"reason":"neither wget nor curl available" }'
+      else
+        HEALTH_JSON='{ "mode":"container","url":null,"ok":false,"http_code":500,"reason":"health endpoint failed or exec error" }'
+      fi
     else
-       HEALTH_JSON='{ "mode":"container","url":null,"ok":false,"http_code":null,"reason":"container not running" }'
+      HEALTH_JSON='{ "mode":"container","url":null,"ok":false,"http_code":null,"reason":"container not running" }'
     fi
   elif [[ "$HEALTH_MODE" == "url" ]]; then
-      if [[ -n "$HEALTH_URL" ]]; then
-          export HEALTH_URL
-          if curl -fsS "$HEALTH_URL" >/dev/null 2>&1; then
-             HEALTH_JSON="$(python3 - <<'PY'
+    if [[ -n "$HEALTH_URL" ]]; then
+      export HEALTH_URL
+      if curl -fsS "$HEALTH_URL" > /dev/null 2>&1; then
+        HEALTH_JSON="$(
+          python3 - << 'PY'
 import json, os
 print(json.dumps({"mode":"url","url":os.environ["HEALTH_URL"],"ok":True,"http_code":200,"reason":None}))
 PY
-)"
-          else
-             HEALTH_JSON="$(python3 - <<'PY'
+        )"
+      else
+        HEALTH_JSON="$(
+          python3 - << 'PY'
 import json, os
 print(json.dumps({"mode":"url","url":os.environ["HEALTH_URL"],"ok":False,"http_code":None,"reason":"connection failed"}))
 PY
-)"
-          fi
+        )"
       fi
+    fi
   fi
 fi
 
@@ -352,7 +359,7 @@ export ISO_TS HOSTNAME REPO_PATH REPO_SHA REPO_DIRTY
 export COMPOSE_FILE COMPOSE_FILE_SHA CONFIG_SHA RENDER_DEGRADED
 export WARNINGS_JSON CONTAINERS_JSON VOLUMES_JSON MOUNTS_JSON HEALTH_JSON
 
-python3 - <<'PY' > "$OUT_FILE"
+python3 - << 'PY' > "$OUT_FILE"
 import json, sys, os
 
 # Safe boolean parsing

--- a/scripts/deploy_vps.sh
+++ b/scripts/deploy_vps.sh
@@ -3,9 +3,10 @@ set -euo pipefail
 
 # Load environment variables robustly
 if [ -f .env ]; then
-    set -a
-    source .env
-    set +a
+  set -a
+  # shellcheck disable=SC1091
+  source .env
+  set +a
 fi
 
 echo "Deploying to VPS..."
@@ -13,29 +14,29 @@ echo "Deploying to VPS..."
 # --- Validation ---
 
 if [ ! -f "infra/compose/compose.prod.yml" ]; then
-    echo "Error: infra/compose/compose.prod.yml not found."
-    exit 1
+  echo "Error: infra/compose/compose.prod.yml not found."
+  exit 1
 fi
 
 if [ -z "${WEB_UPSTREAM_HOST:-}" ]; then
-    echo "Error: WEB_UPSTREAM_HOST is not set in .env or environment."
-    exit 1
+  echo "Error: WEB_UPSTREAM_HOST is not set in .env or environment."
+  exit 1
 fi
 
 if [[ "${WEB_UPSTREAM_HOST:-}" =~ ^https?:// ]]; then
-    echo "Error: WEB_UPSTREAM_HOST should not contain http:// or https:// (just the domain)."
-    exit 1
+  echo "Error: WEB_UPSTREAM_HOST should not contain http:// or https:// (just the domain)."
+  exit 1
 fi
 
 if [[ ! "${WEB_UPSTREAM_URL:-}" =~ ^https:// ]]; then
-    echo "Error: WEB_UPSTREAM_URL is not set or does not start with 'https://'."
-    exit 1
+  echo "Error: WEB_UPSTREAM_URL is not set or does not start with 'https://'."
+  exit 1
 fi
 
 # --- Deployment ---
 
 # Generate robust API version tag (fallback to date if git fails or no .git)
-API_VERSION=$(git rev-parse --short HEAD 2>/dev/null || date +%F-%s)
+API_VERSION=$(git rev-parse --short HEAD 2> /dev/null || date +%F-%s)
 export API_VERSION
 echo "Deploying with API_VERSION=${API_VERSION}"
 
@@ -52,10 +53,10 @@ docker compose -f infra/compose/compose.prod.yml up -d --build
 PRUNE_IMAGES=${PRUNE_IMAGES:-0}
 
 if [ "$PRUNE_IMAGES" -eq 1 ]; then
-    echo "Pruning unused images..."
-    docker image prune -f
+  echo "Pruning unused images..."
+  docker image prune -f
 else
-    echo "Skipping image prune (set PRUNE_IMAGES=1 to enable)."
+  echo "Skipping image prune (set PRUNE_IMAGES=1 to enable)."
 fi
 
 echo "Deployment complete."

--- a/scripts/dev/bootstrap-first-account.sh
+++ b/scripts/dev/bootstrap-first-account.sh
@@ -123,7 +123,7 @@ _validate_no_control_chars() {
   # First check for common control characters using bash pattern matching
   # (more reliable than grep for detecting LF/CR in shell variables)
   case "$val" in
-    *$'\n'*|*$'\r'*|*$'\t'*)
+    *$'\n'* | *$'\r'* | *$'\t'*)
       echo "Error: $name contains control characters (CR, LF, TAB), which are not allowed." >&2
       exit 1
       ;;

--- a/scripts/dev/generate-demo-data.sh
+++ b/scripts/dev/generate-demo-data.sh
@@ -57,35 +57,35 @@ ensure_jsonl_line() {
     count=$(grep -c "$match_pattern" "$file" || true)
 
     if [ "$count" -eq 0 ]; then
-       # Case: ID missing completely
-       echo "→ updating: adding $id to $(basename "$file")"
-       echo "$canonical_json" >> "$file"
-       return 0
+      # Case: ID missing completely
+      echo "→ updating: adding $id to $(basename "$file")"
+      echo "$canonical_json" >> "$file"
+      return 0
     elif [ "$count" -gt 1 ]; then
-       # Case: Duplicates found
-       echo "→ migrating: deduplicating $id in $(basename "$file")"
-       needs_migration=1
+      # Case: Duplicates found
+      echo "→ migrating: deduplicating $id in $(basename "$file")"
+      needs_migration=1
     else
-       # Case: Exactly one match. Check semantics/staleness.
-       if [ -n "$check_field" ]; then
-         local existing_line
-         # Do NOT use -F here either.
-         existing_line=$(grep "$match_pattern" "$file")
+      # Case: Exactly one match. Check semantics/staleness.
+      if [ -n "$check_field" ]; then
+        local existing_line
+        # Do NOT use -F here either.
+        existing_line=$(grep "$match_pattern" "$file")
 
-         if command -v jq >/dev/null 2>&1; then
-           # Robust check using jq
-           if echo "$existing_line" | jq -e "has(\"$check_field\") | not" >/dev/null 2>&1; then
-              echo "→ migrating: fixing stale entry (missing $check_field) $id in $(basename "$file")"
-              needs_migration=1
-           fi
-         else
-           # Fallback: simple text check
-           if ! echo "$existing_line" | grep -q "\"$check_field\"[[:space:]]*:"; then
-              echo "→ migrating: fixing stale entry (missing $check_field) $id in $(basename "$file")"
-              needs_migration=1
-           fi
-         fi
-       fi
+        if command -v jq > /dev/null 2>&1; then
+          # Robust check using jq
+          if echo "$existing_line" | jq -e "has(\"$check_field\") | not" > /dev/null 2>&1; then
+            echo "→ migrating: fixing stale entry (missing $check_field) $id in $(basename "$file")"
+            needs_migration=1
+          fi
+        else
+          # Fallback: simple text check
+          if ! echo "$existing_line" | grep -q "\"$check_field\"[[:space:]]*:"; then
+            echo "→ migrating: fixing stale entry (missing $check_field) $id in $(basename "$file")"
+            needs_migration=1
+          fi
+        fi
+      fi
     fi
   else
     # Case: File does not exist or is empty
@@ -115,7 +115,6 @@ ACCOUNT_JSON='{"id":"7d97a42e-3704-4a33-a61f-0e0a6b4d65d8","type":"garnrolle","t
 touch "$DIR/demo.accounts.jsonl"
 ensure_jsonl_line "$DIR/demo.accounts.jsonl" "$ACCOUNT_ID" "$ACCOUNT_JSON" "location"
 
-
 # --- NODES ---
 NODE_ID="b52be17c-4ab7-4434-98ce-520f86290cf0"
 NODE_LINE='{"id":"b52be17c-4ab7-4434-98ce-520f86290cf0","kind":"Knoten","title":"fairschenkbox","summary":"Öffentliche Fair-Schenk-Box","info":"Dies ist eine **Demo-Info** für den Test.","created_at":"2025-12-22T00:00:00Z","updated_at":"2025-12-22T00:00:00Z","location":{"lat":53.558894813662505,"lon":10.060228407382967}}'
@@ -123,7 +122,7 @@ NODE_LINE='{"id":"b52be17c-4ab7-4434-98ce-520f86290cf0","kind":"Knoten","title":
 # Pre-seed bulk data if missing
 if [ ! -s "$DIR/demo.nodes.jsonl" ]; then
   echo "→ seeds: nodes"
-  cat > "$DIR/demo.nodes.jsonl" <<EOF
+  cat > "$DIR/demo.nodes.jsonl" << EOF
 {"id":"00000000-0000-0000-0000-000000000001","kind":"Ort","title":"Marktplatz Hamburg","created_at":"2025-01-01T12:00:00Z","updated_at":"2025-11-01T09:00:00Z","location":{"lon":9.9937,"lat":53.5511}}
 {"id":"00000000-0000-0000-0000-000000000002","kind":"Initiative","title":"Nachbarschaftshaus","created_at":"2025-01-01T12:00:00Z","updated_at":"2025-11-02T12:15:00Z","location":{"lon":10.0002,"lat":53.5523}}
 {"id":"00000000-0000-0000-0000-000000000003","kind":"Projekt","title":"Tauschbox Altona","created_at":"2025-01-01T12:00:00Z","updated_at":"2025-10-30T18:45:00Z","location":{"lon":9.9813,"lat":53.5456}}
@@ -138,7 +137,6 @@ remove_line_by_id "$DIR/demo.nodes.jsonl" "00000000-0000-0000-0000-000000000006"
 # Ensure canonical node
 ensure_jsonl_line "$DIR/demo.nodes.jsonl" "$NODE_ID" "$NODE_LINE"
 
-
 # --- EDGES ---
 EDGE_ID="00000000-0000-0000-0000-00000000E001"
 EDGE_LINE='{"id":"00000000-0000-0000-0000-00000000E001","source_type":"account","source_id":"7d97a42e-3704-4a33-a61f-0e0a6b4d65d8","target_type":"node","target_id":"b52be17c-4ab7-4434-98ce-520f86290cf0","edge_kind":"reference","note":"faden","created_at":"2025-12-22T00:00:00Z"}'
@@ -146,7 +144,7 @@ EDGE_LINE='{"id":"00000000-0000-0000-0000-00000000E001","source_type":"account",
 # Pre-seed bulk data if missing
 if [ ! -s "$DIR/demo.edges.jsonl" ]; then
   echo "→ seeds: edges"
-  cat > "$DIR/demo.edges.jsonl" <<EOF
+  cat > "$DIR/demo.edges.jsonl" << EOF
 {"id":"00000000-0000-0000-0000-000000000101","source_type":"node","source_id":"00000000-0000-0000-0000-000000000001","target_type":"node","target_id":"00000000-0000-0000-0000-000000000002","edge_kind":"reference","note":"Kooperation Marktplatz ↔ Nachbarschaftshaus","created_at":"2025-01-01T12:00:00Z"}
 {"id":"00000000-0000-0000-0000-000000000102","source_type":"node","source_id":"00000000-0000-0000-0000-000000000002","target_type":"node","target_id":"00000000-0000-0000-0000-000000000004","edge_kind":"reference","note":"Gemeinschaftsaktion Gartenpflege","created_at":"2025-01-01T12:00:00Z"}
 {"id":"00000000-0000-0000-0000-000000000103","source_type":"node","source_id":"00000000-0000-0000-0000-000000000001","target_type":"node","target_id":"00000000-0000-0000-0000-000000000003","edge_kind":"reference","note":"Tauschbox liefert Material","created_at":"2025-01-01T12:00:00Z"}

--- a/scripts/docmeta/coverage-guard.sh
+++ b/scripts/docmeta/coverage-guard.sh
@@ -5,11 +5,11 @@ set -euo pipefail
 echo "Checking implementation coverage..."
 
 CRITICAL_PATHS=(
-    "apps/api"
-    "apps/web"
-    "infra/compose"
-    ".github/workflows"
-    "contracts/domain"
+  "apps/api"
+  "apps/web"
+  "infra/compose"
+  ".github/workflows"
+  "contracts/domain"
 )
 
 FAIL=0
@@ -17,20 +17,20 @@ FAIL=0
 REGISTERED_PATHS=$(grep -E '^[[:space:]]*path:' audit/impl-registry.yaml | awk -F ': ' '{print $2}' | tr -d '"' | tr -d "'" | sed 's/\/$//')
 
 for path in "${CRITICAL_PATHS[@]}"; do
-    if [ -d "$path" ] || [ -f "$path" ]; then
-        found=0
-        for reg in $REGISTERED_PATHS; do
-            if [[ "$reg" == "$path" ]]; then
-                found=1
-                break
-            fi
-        done
+  if [ -d "$path" ] || [ -f "$path" ]; then
+    found=0
+    for reg in $REGISTERED_PATHS; do
+      if [[ "$reg" == "$path" ]]; then
+        found=1
+        break
+      fi
+    done
 
-        if [ "$found" -eq 0 ]; then
-            echo "ERROR: Critical implementation missing from registry: $path"
-            FAIL=1
-        fi
+    if [ "$found" -eq 0 ]; then
+      echo "ERROR: Critical implementation missing from registry: $path"
+      FAIL=1
     fi
+  fi
 done
 
 # Verify that documented_by links exist
@@ -58,14 +58,14 @@ except Exception:
 ")
 
 for doc in $DOC_REFS; do
-    if [ ! -f "$doc" ]; then
-        echo "ERROR: Registered implementation points to dead doc link: $doc"
-        FAIL=1
-    fi
+  if [ ! -f "$doc" ]; then
+    echo "ERROR: Registered implementation points to dead doc link: $doc"
+    FAIL=1
+  fi
 done
 
 if [ "$FAIL" -eq 1 ]; then
-    exit 1
+  exit 1
 fi
 
 echo "coverage-guard pass."

--- a/scripts/docmeta/docs-relations-guard.sh
+++ b/scripts/docmeta/docs-relations-guard.sh
@@ -8,8 +8,8 @@ FAIL=0
 
 # Dynamic check for required frontmatter fields using a python parser for robustness
 while IFS= read -r -d '' file; do
-    # Use python to extract frontmatter
-    python3 -c "
+  # Use python to extract frontmatter
+  python3 -c "
 import sys
 import os
 
@@ -86,7 +86,7 @@ sys.exit(0)
 done < <(find docs -type f -name "*.md" ! -path "docs/_generated/*" -print0)
 
 if [ "$FAIL" -eq 1 ]; then
-    exit 1
+  exit 1
 fi
 
 echo "docs-relations-guard pass."

--- a/scripts/docmeta/generate-doc-index.sh
+++ b/scripts/docmeta/generate-doc-index.sh
@@ -26,20 +26,20 @@ HEADER
 TEMP_ENTRIES=$(mktemp)
 
 find docs -type f -name "*.md" ! -path "docs/_generated/*" -print0 | while IFS= read -r -d '' file; do
-    # Skip files without frontmatter
-    if ! head -n 1 "$file" | grep -q "^---$"; then
-        continue
-    fi
+  # Skip files without frontmatter
+  if ! head -n 1 "$file" | grep -q "^---$"; then
+    continue
+  fi
 
-    # Extract fields with basic sed
-    id=$(sed -n -e '/^---$/,/^---$/ p' "$file" | grep "^id:" | sed 's/^id: *//' | tr -d '"'\''')
-    title=$(sed -n -e '/^---$/,/^---$/ p' "$file" | grep "^title:" | sed 's/^title: *//' | tr -d '"'\''')
-    doc_type=$(sed -n -e '/^---$/,/^---$/ p' "$file" | grep "^doc_type:" | sed 's/^doc_type: *//' | tr -d '"'\''')
-    status=$(sed -n -e '/^---$/,/^---$/ p' "$file" | grep "^status:" | sed 's/^status: *//' | tr -d '"'\''')
+  # Extract fields with basic sed
+  id=$(sed -n -e '/^---$/,/^---$/ p' "$file" | grep "^id:" | sed 's/^id: *//' | tr -d '"'\''')
+  title=$(sed -n -e '/^---$/,/^---$/ p' "$file" | grep "^title:" | sed 's/^title: *//' | tr -d '"'\''')
+  doc_type=$(sed -n -e '/^---$/,/^---$/ p' "$file" | grep "^doc_type:" | sed 's/^doc_type: *//' | tr -d '"'\''')
+  status=$(sed -n -e '/^---$/,/^---$/ p' "$file" | grep "^status:" | sed 's/^status: *//' | tr -d '"'\''')
 
-    if [ -n "$id" ]; then
-        echo "| $id | $title | $doc_type | $status | $file |" >> "$TEMP_ENTRIES"
-    fi
+  if [ -n "$id" ]; then
+    echo "| $id | $title | $doc_type | $status | $file |" >> "$TEMP_ENTRIES"
+  fi
 done
 
 # Sort entries deterministically and append to output

--- a/scripts/docmeta/generated-files-guard.sh
+++ b/scripts/docmeta/generated-files-guard.sh
@@ -7,59 +7,59 @@ echo "Checking generated files guard..."
 FAIL=0
 
 if [ ! -d "docs/_generated" ]; then
-    echo "ERROR: docs/_generated missing."
-    FAIL=1
+  echo "ERROR: docs/_generated missing."
+  FAIL=1
 fi
 
 REQUIRED_FILES=(
-    "doc-index.md"
-    "system-map.md"
-    "backlinks.md"
-    "impl-index.md"
-    "orphans.md"
-    "supersession-map.md"
-    "architecture-drift.md"
-    "doc-coverage.md"
-    "knowledge-gaps.md"
-    "implicit-dependencies.md"
-    "change-resonance.md"
-    "staleness-report.md"
-    "agent-readiness.md"
-    "claim-evidence-map.md"
-    "report-lifecycle-inventory.md"
-    "report-lifecycle.md"
+  "doc-index.md"
+  "system-map.md"
+  "backlinks.md"
+  "impl-index.md"
+  "orphans.md"
+  "supersession-map.md"
+  "architecture-drift.md"
+  "doc-coverage.md"
+  "knowledge-gaps.md"
+  "implicit-dependencies.md"
+  "change-resonance.md"
+  "staleness-report.md"
+  "agent-readiness.md"
+  "claim-evidence-map.md"
+  "report-lifecycle-inventory.md"
+  "report-lifecycle.md"
 )
 
 for req in "${REQUIRED_FILES[@]}"; do
-    if [ ! -f "docs/_generated/$req" ]; then
-        echo "ERROR: Missing expected generated file docs/_generated/$req"
-        FAIL=1
-    fi
+  if [ ! -f "docs/_generated/$req" ]; then
+    echo "ERROR: Missing expected generated file docs/_generated/$req"
+    FAIL=1
+  fi
 done
 
 for file in docs/_generated/*.md; do
-    if [ -f "$file" ]; then
-        if ! grep -q "Generated automatically." "$file"; then
-            echo "ERROR: Generated file $file missing 'Generated automatically.' string."
-            FAIL=1
-        fi
-        if ! head -n 1 "$file" | grep -q "^---$"; then
-            echo "ERROR: Generated file $file missing frontmatter block."
-            FAIL=1
-        fi
+  if [ -f "$file" ]; then
+    if ! grep -q "Generated automatically." "$file"; then
+      echo "ERROR: Generated file $file missing 'Generated automatically.' string."
+      FAIL=1
     fi
+    if ! head -n 1 "$file" | grep -q "^---$"; then
+      echo "ERROR: Generated file $file missing frontmatter block."
+      FAIL=1
+    fi
+  fi
 done
 
 if [ ! -f ".wgx/generated-artifacts.yml" ]; then
-    echo "ERROR: .wgx/generated-artifacts.yml missing."
-    FAIL=1
+  echo "ERROR: .wgx/generated-artifacts.yml missing."
+  FAIL=1
 elif ! python3 -m scripts.docmeta.validate_generated_artifacts --check; then
-    echo "ERROR: generated artifact control validation failed."
-    FAIL=1
+  echo "ERROR: generated artifact control validation failed."
+  FAIL=1
 fi
 
 if [ "$FAIL" -eq 1 ]; then
-    exit 1
+  exit 1
 fi
 
 echo "generated-files-guard pass."

--- a/scripts/docmeta/repo-structure-guard.sh
+++ b/scripts/docmeta/repo-structure-guard.sh
@@ -14,11 +14,11 @@ echo "Checking repo structure..."
 FAIL=0
 
 if [ ! -f "repo.meta.yaml" ]; then
-    echo "ERROR: repo.meta.yaml missing."
-    FAIL=1
+  echo "ERROR: repo.meta.yaml missing."
+  FAIL=1
 else
-    # parse yaml keys via python basic string parsing
-    python3 -c "
+  # parse yaml keys via python basic string parsing
+  python3 -c "
 import sys
 try:
     with open('repo.meta.yaml', 'r', encoding='utf-8') as f:
@@ -43,17 +43,17 @@ except Exception as e:
 fi
 
 if [ ! -f "docs/index.md" ]; then
-    echo "ERROR: docs/index.md missing."
-    FAIL=1
+  echo "ERROR: docs/index.md missing."
+  FAIL=1
 fi
 
 if [ ! -d "docs/_generated" ]; then
-    echo "ERROR: docs/_generated missing."
-    FAIL=1
+  echo "ERROR: docs/_generated missing."
+  FAIL=1
 fi
 
 if [ "$FAIL" -eq 1 ]; then
-    exit 1
+  exit 1
 fi
 
 echo "repo-structure-guard pass."

--- a/scripts/guard-compose-no-relative-volumes.sh
+++ b/scripts/guard-compose-no-relative-volumes.sh
@@ -15,8 +15,8 @@ fi
 #  - named volumes (db_data:/var/lib/...)
 #  - absolute paths (/opt/...)
 bad_lines="$(
-  sed 's/[[:space:]]#.*$//' "$COMPOSE_FILE" \
-  | grep -nE '^[[:space:]]*-[[:space:]]*(\./|\.\./)[^:]*:[^:]+'
+  sed 's/[[:space:]]#.*$//' "$COMPOSE_FILE" |
+    grep -nE '^[[:space:]]*-[[:space:]]*(\./|\.\./)[^:]*:[^:]+'
 )" || true
 
 # Fast path: no relative mounts at all

--- a/scripts/guard/basemap-runtime-proof.sh
+++ b/scripts/guard/basemap-runtime-proof.sh
@@ -53,8 +53,8 @@ set -euo pipefail
 #   0 — Artefact absent and BASEMAP_PROOF_MODE=skip (NOT_PROVEN, explicitly skipped)
 #   1 — Proof failed or artefact absent in "require" mode
 
-SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-REPO_ROOT="${REPO_ROOT:-$(cd -- "${SCRIPT_DIR}/../.." >/dev/null 2>&1 && pwd)}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd -- "${SCRIPT_DIR}/../.." > /dev/null 2>&1 && pwd)}"
 
 BASEMAP_PROOF_SCOPE="${BASEMAP_PROOF_SCOPE:-range-delivery}"
 BASEMAP_PROOF_MODE="${BASEMAP_PROOF_MODE:-require}"
@@ -70,12 +70,12 @@ require_http_range_proof() {
 
   http_status="$({
     curl --silent \
-         --max-time 10 \
-         --header 'Range: bytes=0-511' \
-         --output /dev/null \
-         --dump-header "${header_tmp}" \
-         --write-out '%{http_code}' \
-         "${full_url}" 2>/dev/null
+      --max-time 10 \
+      --header 'Range: bytes=0-511' \
+      --output /dev/null \
+      --dump-header "${header_tmp}" \
+      --write-out '%{http_code}' \
+      "${full_url}" 2> /dev/null
   })" || {
     rm -f "${header_tmp}"
     printf 'ERROR: curl request to %s failed\n' "${full_url}" >&2
@@ -167,7 +167,7 @@ if [[ "${BASEMAP_PROOF_SCOPE}" == "pmtiles-content" ]]; then
     while IFS= read -r -d '' f; do
       PMTILES_FILE="${f}"
       break
-    done < <(find "${BASEMAP_ARTIFACT_DIR}" -maxdepth 1 -name '*.pmtiles' -print0 2>/dev/null)
+    done < <(find "${BASEMAP_ARTIFACT_DIR}" -maxdepth 1 -name '*.pmtiles' -print0 2> /dev/null)
     if [[ -n "${PMTILES_FILE}" ]]; then
       printf 'Auto-detected PMTiles file: %s\n' "${PMTILES_FILE}"
     fi
@@ -187,7 +187,7 @@ if [[ "${BASEMAP_PROOF_SCOPE}" == "pmtiles-content" ]]; then
   fi
 
   # Check non-empty
-  FILE_SIZE="$(stat -c '%s' "${PMTILES_FILE}" 2>/dev/null || echo 0)"
+  FILE_SIZE="$(stat -c '%s' "${PMTILES_FILE}" 2> /dev/null || echo 0)"
   if [[ "${FILE_SIZE}" -eq 0 ]]; then
     printf 'ERROR: PMTiles file is empty: %s\n' "${PMTILES_FILE}" >&2
     exit 1
@@ -196,7 +196,7 @@ if [[ "${BASEMAP_PROOF_SCOPE}" == "pmtiles-content" ]]; then
 
   # Verify PMTiles magic header (bytes 0-6 must be ASCII "PMTiles")
   MAGIC_EXPECTED="PMTiles"
-  MAGIC_ACTUAL="$(dd if="${PMTILES_FILE}" bs=1 count=7 skip=0 2>/dev/null | tr -d '\0')"
+  MAGIC_ACTUAL="$(dd if="${PMTILES_FILE}" bs=1 count=7 skip=0 2> /dev/null | tr -d '\0')"
   if [[ "${MAGIC_ACTUAL}" != "${MAGIC_EXPECTED}" ]]; then
     printf 'ERROR: Magic header mismatch in %s\n' "${PMTILES_FILE}" >&2
     printf '  Expected: %s\n' "${MAGIC_EXPECTED}" >&2
@@ -235,13 +235,13 @@ if [[ "${BASEMAP_PROOF_SCOPE}" == "pmtiles-content" ]]; then
   # Step 1: Verify HTTP-served PMTiles magic bytes (0-6)
   printf 'Step 1: Verifying HTTP magic bytes (Range: bytes=0-6)...\n'
   http_magic_tmp="$(mktemp)"
-  http_magic_status="$({ \
+  http_magic_status="$({
     curl --silent \
-         --max-time 10 \
-         --range 0-6 \
-         --output "${http_magic_tmp}" \
-         --write-out '%{http_code}' \
-         "${FULL_URL}" 2>/dev/null; \
+      --max-time 10 \
+      --range 0-6 \
+      --output "${http_magic_tmp}" \
+      --write-out '%{http_code}' \
+      "${FULL_URL}" 2> /dev/null
   })"
   http_magic_exit=$?
   if [[ ${http_magic_exit} -ne 0 ]]; then
@@ -259,7 +259,7 @@ if [[ "${BASEMAP_PROOF_SCOPE}" == "pmtiles-content" ]]; then
     exit 1
   fi
 
-  http_magic="$(cat "${http_magic_tmp}" 2>/dev/null | tr -d '\0')"
+  http_magic="$(tr -d '\0' < "${http_magic_tmp}" 2> /dev/null)"
   rm -f "${http_magic_tmp}"
 
   if [[ "${http_magic}" != "PMTiles" ]]; then
@@ -320,7 +320,7 @@ else
     while IFS= read -r -d '' f; do
       PMTILES_FILE="${f}"
       break
-    done < <(find "${BASEMAP_ARTIFACT_DIR}" -maxdepth 1 -name '*.pmtiles' -print0 2>/dev/null)
+    done < <(find "${BASEMAP_ARTIFACT_DIR}" -maxdepth 1 -name '*.pmtiles' -print0 2> /dev/null)
   fi
 
   if [[ -z "${PMTILES_FILE}" ]]; then

--- a/scripts/guard/caddy-basemap-route-guard.sh
+++ b/scripts/guard/caddy-basemap-route-guard.sh
@@ -26,8 +26,8 @@ set -euo pipefail
 # Regression protection: prevents silent re-introduction of the old /basemap/*
 # route, which caused the sovereign hosting path to be factually inactive.
 
-SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-REPO_ROOT="${REPO_ROOT:-$(cd -- "${SCRIPT_DIR}/../.." >/dev/null 2>&1 && pwd)}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd -- "${SCRIPT_DIR}/../.." > /dev/null 2>&1 && pwd)}"
 
 FAILED=0
 

--- a/scripts/guard/metrics-ref-guard.sh
+++ b/scripts/guard/metrics-ref-guard.sh
@@ -7,8 +7,8 @@ set -euo pipefail
 # workflow always point to the same immutable ref.  This prevents silent
 # drift when one value is bumped but the other is forgotten.
 
-SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-REPO_ROOT="${REPO_ROOT:-$(cd -- "${SCRIPT_DIR}/../.." >/dev/null 2>&1 && pwd)}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd -- "${SCRIPT_DIR}/../.." > /dev/null 2>&1 && pwd)}"
 
 WORKFLOW="${REPO_ROOT}/.github/workflows/metrics.yml"
 
@@ -19,8 +19,8 @@ fi
 
 # Extract the ref after the @ in the uses: line
 # Pattern: uses: heimgewebe/metarepo/...@<REF>
-USES_REF="$(grep -E '^\s+uses:\s+heimgewebe/metarepo/' "$WORKFLOW" \
-  | head -n1 | sed 's/.*@//' | tr -d '[:space:]')"
+USES_REF="$(grep -E '^\s+uses:\s+heimgewebe/metarepo/' "$WORKFLOW" |
+  head -n1 | sed 's/.*@//' | tr -d '[:space:]')"
 
 if [[ -z "$USES_REF" ]]; then
   echo "ERROR: could not extract uses: ref from $WORKFLOW" >&2
@@ -29,8 +29,8 @@ fi
 
 # Extract the metarepo_ref input value
 # Pattern: metarepo_ref: "<VALUE>" or metarepo_ref: <VALUE>
-METAREPO_REF="$(grep -E '^\s+metarepo_ref:' "$WORKFLOW" \
-  | head -n1 | sed 's/.*metarepo_ref:[[:space:]]*//' | tr -d "\"' ")"
+METAREPO_REF="$(grep -E '^\s+metarepo_ref:' "$WORKFLOW" |
+  head -n1 | sed 's/.*metarepo_ref:[[:space:]]*//' | tr -d "\"' ")"
 
 if [[ -z "$METAREPO_REF" ]]; then
   echo "ERROR: could not extract metarepo_ref from $WORKFLOW" >&2

--- a/scripts/guard/prod-public-base-url-guard.sh
+++ b/scripts/guard/prod-public-base-url-guard.sh
@@ -2,11 +2,11 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(
-  cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1
+  cd -- "$(dirname -- "${BASH_SOURCE[0]}")" > /dev/null 2>&1
   pwd
 )"
 REPO_ROOT="${REPO_ROOT:-$(
-  cd -- "${SCRIPT_DIR}/../.." >/dev/null 2>&1
+  cd -- "${SCRIPT_DIR}/../.." > /dev/null 2>&1
   pwd
 )}"
 
@@ -20,12 +20,12 @@ for required_file in "$BASE_FILE" "$OVERRIDE_FILE"; do
   fi
 done
 
-if ! command -v docker >/dev/null 2>&1 || ! docker compose version >/dev/null 2>&1; then
+if ! command -v docker > /dev/null 2>&1 || ! docker compose version > /dev/null 2>&1; then
   echo "ERROR: docker compose is required" >&2
   exit 2
 fi
 
-if ! command -v python3 >/dev/null 2>&1; then
+if ! command -v python3 > /dev/null 2>&1; then
   echo "ERROR: python3 is required" >&2
   exit 2
 fi
@@ -39,7 +39,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-cat >"$TMP_ENV" <<'EOF_ENV'
+cat > "$TMP_ENV" << 'EOF_ENV'
 DATABASE_URL=postgres://dummy:dummy@localhost:5432/dummy
 POSTGRES_USER=dummy
 POSTGRES_PASSWORD=dummy
@@ -51,17 +51,16 @@ EOF_ENV
 if ! WELTGEWEBE_ENV_FILE="$TMP_ENV" \
   REPO_DIR="$REPO_ROOT" \
   docker compose \
-    --env-file "$TMP_ENV" \
-    -f "$BASE_FILE" \
-    -f "$OVERRIDE_FILE" \
-    config --format json >"$TMP_JSON" 2>"$TMP_ERR"
-then
+  --env-file "$TMP_ENV" \
+  -f "$BASE_FILE" \
+  -f "$OVERRIDE_FILE" \
+  config --format json > "$TMP_JSON" 2> "$TMP_ERR"; then
   echo "ERROR: docker compose config failed" >&2
   cat "$TMP_ERR" >&2
   exit 2
 fi
 
-python3 - "$TMP_JSON" <<'PY'
+python3 - "$TMP_JSON" << 'PY'
 import json
 import sys
 from pathlib import Path

--- a/scripts/guard/run.sh
+++ b/scripts/guard/run.sh
@@ -8,8 +8,8 @@ set -euo pipefail
 # Guards that need Docker Compose or other environment-specific tooling
 # are non-core and live outside this orchestration (see guard_api_alias.sh).
 
-SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." >/dev/null 2>&1 && pwd)"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." > /dev/null 2>&1 && pwd)"
 
 echo "== guard: compose no relative volumes =="
 "${REPO_ROOT}/scripts/guard-compose-no-relative-volumes.sh" \

--- a/scripts/guard/token-leak-guard.sh
+++ b/scripts/guard/token-leak-guard.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-REPO_ROOT="${REPO_ROOT:-$(cd -- "${SCRIPT_DIR}/../.." >/dev/null 2>&1 && pwd)}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd -- "${SCRIPT_DIR}/../.." > /dev/null 2>&1 && pwd)}"
 
 echo "Checking for accidental token/secret leaks in text files..."
 
@@ -30,13 +30,13 @@ EXIT_CODE=$?
 set -e
 
 if [ $EXIT_CODE -eq 0 ]; then
-    echo "ERROR: Found potential token leaks or secrets in repository files:"
-    echo "$MATCHES"
-    exit 1
+  echo "ERROR: Found potential token leaks or secrets in repository files:"
+  echo "$MATCHES"
+  exit 1
 elif [ $EXIT_CODE -eq 1 ]; then
-    echo "OK: No token leaks detected."
-    exit 0
+  echo "OK: No token leaks detected."
+  exit 0
 else
-    echo "ERROR: git grep failed with exit code $EXIT_CODE."
-    exit $EXIT_CODE
+  echo "ERROR: git grep failed with exit code $EXIT_CODE."
+  exit $EXIT_CODE
 fi

--- a/scripts/guard_api_alias.sh
+++ b/scripts/guard_api_alias.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 # Guard scripts are executable, not meant to be sourced.
 if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
   echo "ERROR: scripts/guard_api_alias.sh must not be sourced. Run it as an executable."
-  return 2 2>/dev/null || exit 2
+  return 2 2> /dev/null || exit 2
 fi
 
 # Ensure we are operating relative to the repo root
@@ -16,22 +16,22 @@ REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_DIR"
 
 # Check if docker and docker compose command are available
-if ! command -v docker >/dev/null 2>&1; then
-    if [[ "${GUARD_STRICT:-0}" == "1" ]]; then
-        echo "ERROR: Docker not found, but GUARD_STRICT=1. Aborting."
-        exit 1
-    fi
-    echo "NOTE: Docker not found. Guard skipped."
-    exit 0
+if ! command -v docker > /dev/null 2>&1; then
+  if [[ "${GUARD_STRICT:-0}" == "1" ]]; then
+    echo "ERROR: Docker not found, but GUARD_STRICT=1. Aborting."
+    exit 1
+  fi
+  echo "NOTE: Docker not found. Guard skipped."
+  exit 0
 fi
 
-if ! docker compose version >/dev/null 2>&1; then
-    if [[ "${GUARD_STRICT:-0}" == "1" ]]; then
-        echo "ERROR: Docker Compose not found, but GUARD_STRICT=1. Aborting."
-        exit 1
-    fi
-    echo "NOTE: Docker Compose not found or not working. Guard skipped."
-    exit 0
+if ! docker compose version > /dev/null 2>&1; then
+  if [[ "${GUARD_STRICT:-0}" == "1" ]]; then
+    echo "ERROR: Docker Compose not found, but GUARD_STRICT=1. Aborting."
+    exit 1
+  fi
+  echo "NOTE: Docker Compose not found or not working. Guard skipped."
+  exit 0
 fi
 
 # Note: We intentionally DO NOT check for a running docker daemon (docker info).
@@ -42,30 +42,30 @@ fi
 # If a .env file exists in the repo root, use it. This helps with variable substitution.
 COMPOSE_ARGS=()
 if [[ -f "$REPO_DIR/.env" ]]; then
-    COMPOSE_ARGS+=("--env-file" "$REPO_DIR/.env")
+  COMPOSE_ARGS+=("--env-file" "$REPO_DIR/.env")
 fi
 
 # Render the compose config
 # We provide dummy values for known required environment variables to ensure config rendering succeeds
 # even if .env is missing or partial.
 # Capture stderr for better diagnostics on failure.
-if command -v mktemp >/dev/null 2>&1; then
-    ERR_FILE="$(mktemp)"
+if command -v mktemp > /dev/null 2>&1; then
+  ERR_FILE="$(mktemp)"
 else
-    ERR_FILE="${TMPDIR:-/tmp}/guard_api_alias.$$"
-    : > "$ERR_FILE"
+  ERR_FILE="${TMPDIR:-/tmp}/guard_api_alias.$$"
+  : > "$ERR_FILE"
 fi
 
 CONFIG=$(WEB_UPSTREAM_URL="dummy" WEB_UPSTREAM_HOST="dummy" \
-    docker compose "${COMPOSE_ARGS[@]}" \
-    -f "$REPO_DIR/infra/compose/compose.prod.yml" config 2> "$ERR_FILE" || true)
+  docker compose "${COMPOSE_ARGS[@]}" \
+  -f "$REPO_DIR/infra/compose/compose.prod.yml" config 2> "$ERR_FILE" || true)
 
 if [[ -z "$CONFIG" ]]; then
-    echo "ERROR: Docker Compose config failed to render. Please ensure required environment variables are set or .env is present."
-    echo "Diagnostic output (stderr):"
-    head -n 20 "$ERR_FILE" 2>/dev/null || true
-    rm -f "$ERR_FILE"
-    exit 1
+  echo "ERROR: Docker Compose config failed to render. Please ensure required environment variables are set or .env is present."
+  echo "Diagnostic output (stderr):"
+  head -n 20 "$ERR_FILE" 2> /dev/null || true
+  rm -f "$ERR_FILE"
+  exit 1
 fi
 rm -f "$ERR_FILE"
 
@@ -82,28 +82,28 @@ SERVICE_BLOCK=$(echo "$CONFIG" | awk '
 ')
 
 if [[ -z "$SERVICE_BLOCK" ]]; then
-    echo "ERROR: Service 'api' not found in rendered compose config."
-    # Dump config snippet for debugging if verbose
-    # echo "$CONFIG" | head -n 20
-    exit 1
+  echo "ERROR: Service 'api' not found in rendered compose config."
+  # Dump config snippet for debugging if verbose
+  # echo "$CONFIG" | head -n 20
+  exit 1
 fi
 
 # Check for "aliases:" and "weltgewebe-api" within the api block.
 FAIL=0
 if ! echo "$SERVICE_BLOCK" | grep -q "aliases:"; then
-     echo "ERROR: No 'aliases' section found for service 'api'. The alias is mandatory."
-     FAIL=1
+  echo "ERROR: No 'aliases' section found for service 'api'. The alias is mandatory."
+  FAIL=1
 fi
 
 if ! echo "$SERVICE_BLOCK" | grep -qw "weltgewebe-api"; then
-    echo "ERROR: compose.prod.yml: services.api.networks.default.aliases must include 'weltgewebe-api'"
-    FAIL=1
+  echo "ERROR: compose.prod.yml: services.api.networks.default.aliases must include 'weltgewebe-api'"
+  FAIL=1
 fi
 
 if [[ "$FAIL" == "1" ]]; then
-    echo
-    echo "--- Extracted API Service Block ---"
-    echo "$SERVICE_BLOCK"
-    echo "-----------------------------------"
-    exit 1
+  echo
+  echo "--- Extracted API Service Block ---"
+  echo "$SERVICE_BLOCK"
+  echo "-----------------------------------"
+  exit 1
 fi

--- a/scripts/preflight/csp_contract_static.sh
+++ b/scripts/preflight/csp_contract_static.sh
@@ -63,7 +63,6 @@ while IFS= read -r tag; do
   fi
 done <<< "$SCRIPT_TAGS"
 
-
 if [[ "$HAS_INLINE_SCRIPT" == "1" ]]; then
 
   # Extract the configuration block for the target site.
@@ -80,8 +79,8 @@ if [[ "$HAS_INLINE_SCRIPT" == "1" ]]; then
   ' "$CADDYFILE" || true)
 
   if [[ -z "$TARGET_BLOCK" ]]; then
-     echo "ERROR: csp_contract_static could not find the host block for '$CADDY_TARGET_SITE' in $CADDYFILE." >&2
-     exit 1
+    echo "ERROR: csp_contract_static could not find the host block for '$CADDY_TARGET_SITE' in $CADDYFILE." >&2
+    exit 1
   fi
 
   # Extract CSP lines from the target block
@@ -89,32 +88,32 @@ if [[ "$HAS_INLINE_SCRIPT" == "1" ]]; then
   CSP_LINES=$(echo "$TARGET_BLOCK" | grep -i "Content-Security-Policy" || true)
 
   if [[ -z "$CSP_LINES" ]]; then
-     echo "csp_contract_static: No CSP found for $CADDY_TARGET_SITE in $CADDYFILE, assuming safe (or no CSP)."
-     exit 0
+    echo "csp_contract_static: No CSP found for $CADDY_TARGET_SITE in $CADDYFILE, assuming safe (or no CSP)."
+    exit 0
   fi
 
   # Handle multiple CSP lines: If ANY line satisfies the requirement, we pass.
   # This prevents false positives in multi-site Caddyfiles without needing a full parser.
   while IFS= read -r CSP_LINE; do
-      if [[ -z "$CSP_LINE" ]]; then
-          continue
+    if [[ -z "$CSP_LINE" ]]; then
+      continue
+    fi
+
+    # Look specifically within the script-src directive
+    if echo "$CSP_LINE" | grep -qi "script-src"; then
+      # Extract just the script-src part (up to the next semicolon or end of string) using sed for portability
+      SCRIPT_SRC=$(echo "$CSP_LINE" | sed -n 's/.*\([sS][cC][rR][iI][pP][tT]-[sS][rR][cC][^;]*\).*/\1/p')
+
+      if echo "$SCRIPT_SRC" | grep -qF "'unsafe-inline'"; then
+        echo "csp_contract_static: OK ('unsafe-inline' present in script-src of $CADDYFILE)"
+        exit 0
       fi
 
-      # Look specifically within the script-src directive
-      if echo "$CSP_LINE" | grep -qi "script-src"; then
-          # Extract just the script-src part (up to the next semicolon or end of string) using sed for portability
-          SCRIPT_SRC=$(echo "$CSP_LINE" | sed -n 's/.*\([sS][cC][rR][iI][pP][tT]-[sS][rR][cC][^;]*\).*/\1/p')
-
-          if echo "$SCRIPT_SRC" | grep -qF "'unsafe-inline'"; then
-              echo "csp_contract_static: OK ('unsafe-inline' present in script-src of $CADDYFILE)"
-              exit 0
-          fi
-
-          if echo "$SCRIPT_SRC" | grep -qE "'nonce-|'sha256-"; then
-              echo "csp_contract_static: OK (nonce/hash present in script-src of $CADDYFILE)"
-              exit 0
-          fi
+      if echo "$SCRIPT_SRC" | grep -qE "'nonce-|'sha256-"; then
+        echo "csp_contract_static: OK (nonce/hash present in script-src of $CADDYFILE)"
+        exit 0
       fi
+    fi
   done <<< "$CSP_LINES"
 
   echo "ERROR: Inline <script> detected in INDEX_HTML ($INDEX_HTML), but no matching Content-Security-Policy in CADDYFILE_PATH ($CADDYFILE) allows 'unsafe-inline' or nonce/hash." >&2

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Function to check if a command exists
 command_exists() {
-  command -v "$1" >/dev/null 2>&1
+  command -v "$1" > /dev/null 2>&1
 }
 
 # Install rustup if not installed
@@ -11,6 +11,7 @@ if ! command_exists rustup; then
   echo "Rustup not found. Installing..."
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
   # Add cargo to path for the current session
+  # shellcheck disable=SC1091
   . "$HOME/.cargo/env"
 else
   echo "Rustup is already installed."

--- a/scripts/tests/test_basemap_mode_guard.sh
+++ b/scripts/tests/test_basemap_mode_guard.sh
@@ -62,27 +62,27 @@ echo "PASS: PUBLIC_BASEMAP_MODE=remote-style accepted"
 # Part 2: validate_basemap_mode — invalid values are rejected
 # ===========================================================================
 
-if validate_basemap_mode "local_sovereign" 2>/dev/null; then
+if validate_basemap_mode "local_sovereign" 2> /dev/null; then
   fail "local_sovereign (underscore typo) must be rejected"
 fi
 echo "PASS: PUBLIC_BASEMAP_MODE=local_sovereign rejected"
 
-if validate_basemap_mode "garbage" 2>/dev/null; then
+if validate_basemap_mode "garbage" 2> /dev/null; then
   fail "garbage must be rejected"
 fi
 echo "PASS: PUBLIC_BASEMAP_MODE=garbage rejected"
 
-if validate_basemap_mode "local" 2>/dev/null; then
+if validate_basemap_mode "local" 2> /dev/null; then
   fail "partial value 'local' must be rejected"
 fi
 echo "PASS: PUBLIC_BASEMAP_MODE=local rejected"
 
-if validate_basemap_mode "REMOTE-STYLE" 2>/dev/null; then
+if validate_basemap_mode "REMOTE-STYLE" 2> /dev/null; then
   fail "uppercase REMOTE-STYLE must be rejected (case-sensitive)"
 fi
 echo "PASS: PUBLIC_BASEMAP_MODE=REMOTE-STYLE rejected (case-sensitive)"
 
-if validate_basemap_mode " local-sovereign" 2>/dev/null; then
+if validate_basemap_mode " local-sovereign" 2> /dev/null; then
   fail "leading-space value must be rejected"
 fi
 echo "PASS: PUBLIC_BASEMAP_MODE=' local-sovereign' (leading space) rejected"

--- a/scripts/tests/test_compose_volumes_guard.sh
+++ b/scripts/tests/test_compose_volumes_guard.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Verifies that the compose volume guard correctly detects
 # relative host volume paths and enforces the prod allowlist.
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
 REPO_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
 GUARD_SCRIPT="$REPO_ROOT/scripts/guard-compose-no-relative-volumes.sh"
 
@@ -26,7 +26,7 @@ report() {
 }
 
 # Case 1: No relative volumes — should pass
-cat > "$TEMP_DIR/compose-clean.yml" <<'YAML'
+cat > "$TEMP_DIR/compose-clean.yml" << 'YAML'
 services:
   api:
     image: api:latest
@@ -35,14 +35,14 @@ services:
       - /opt/weltgewebe/policies:/app/policies:ro
 YAML
 
-if bash "$GUARD_SCRIPT" "$TEMP_DIR/compose-clean.yml" >/dev/null 2>&1; then
+if bash "$GUARD_SCRIPT" "$TEMP_DIR/compose-clean.yml" > /dev/null 2>&1; then
   report 0 "No relative volumes passes"
 else
   report 1 "No relative volumes should pass"
 fi
 
 # Case 2: Relative volume in non-prod file — should fail
-cat > "$TEMP_DIR/compose-bad.yml" <<'YAML'
+cat > "$TEMP_DIR/compose-bad.yml" << 'YAML'
 services:
   api:
     image: api:latest
@@ -50,14 +50,14 @@ services:
       - ./data:/app/data
 YAML
 
-if bash "$GUARD_SCRIPT" "$TEMP_DIR/compose-bad.yml" >/dev/null 2>&1; then
+if bash "$GUARD_SCRIPT" "$TEMP_DIR/compose-bad.yml" > /dev/null 2>&1; then
   report 1 "Relative volume in non-prod should fail"
 else
   report 0 "Relative volume in non-prod correctly rejected"
 fi
 
 # Case 3: Parent-relative volume — should fail
-cat > "$TEMP_DIR/compose-parent.yml" <<'YAML'
+cat > "$TEMP_DIR/compose-parent.yml" << 'YAML'
 services:
   web:
     image: web:latest
@@ -65,14 +65,14 @@ services:
       - ../config/app.conf:/etc/app/app.conf:ro
 YAML
 
-if bash "$GUARD_SCRIPT" "$TEMP_DIR/compose-parent.yml" >/dev/null 2>&1; then
+if bash "$GUARD_SCRIPT" "$TEMP_DIR/compose-parent.yml" > /dev/null 2>&1; then
   report 1 "Parent-relative volume should fail"
 else
   report 0 "Parent-relative volume correctly rejected"
 fi
 
 # Case 4: Allowed Caddy mounts in compose.prod.yml — should pass
-cat > "$TEMP_DIR/compose.prod.yml" <<'YAML'
+cat > "$TEMP_DIR/compose.prod.yml" << 'YAML'
 services:
   caddy:
     image: caddy:latest
@@ -85,14 +85,14 @@ services:
       - ../../apps/web/build:/srv/weltgewebe-web:ro
 YAML
 
-if bash "$GUARD_SCRIPT" "$TEMP_DIR/compose.prod.yml" >/dev/null 2>&1; then
+if bash "$GUARD_SCRIPT" "$TEMP_DIR/compose.prod.yml" > /dev/null 2>&1; then
   report 0 "Allowed Caddy mounts in compose.prod.yml pass"
 else
   report 1 "Allowed Caddy mounts in compose.prod.yml should pass"
 fi
 
 # Case 5: Non-allowed relative volume in compose.prod.yml — should fail
-cat > "$TEMP_DIR/compose.prod.yml" <<'YAML'
+cat > "$TEMP_DIR/compose.prod.yml" << 'YAML'
 services:
   caddy:
     image: caddy:latest
@@ -101,21 +101,21 @@ services:
       - ./secrets:/app/secrets
 YAML
 
-if bash "$GUARD_SCRIPT" "$TEMP_DIR/compose.prod.yml" >/dev/null 2>&1; then
+if bash "$GUARD_SCRIPT" "$TEMP_DIR/compose.prod.yml" > /dev/null 2>&1; then
   report 1 "Non-allowed relative volume in compose.prod.yml should fail"
 else
   report 0 "Non-allowed relative volume in compose.prod.yml correctly rejected"
 fi
 
 # Case 6: Missing compose file — should exit 2
-if bash "$GUARD_SCRIPT" "$TEMP_DIR/nonexistent.yml" >/dev/null 2>&1; then
+if bash "$GUARD_SCRIPT" "$TEMP_DIR/nonexistent.yml" > /dev/null 2>&1; then
   report 1 "Missing compose file should fail"
 else
   report 0 "Missing compose file correctly detected"
 fi
 
 # Case 7: Named volumes only — should pass
-cat > "$TEMP_DIR/compose-named.yml" <<'YAML'
+cat > "$TEMP_DIR/compose-named.yml" << 'YAML'
 services:
   db:
     image: postgres:16
@@ -125,14 +125,14 @@ volumes:
   pgdata:
 YAML
 
-if bash "$GUARD_SCRIPT" "$TEMP_DIR/compose-named.yml" >/dev/null 2>&1; then
+if bash "$GUARD_SCRIPT" "$TEMP_DIR/compose-named.yml" > /dev/null 2>&1; then
   report 0 "Named volumes pass"
 else
   report 1 "Named volumes should pass"
 fi
 
 # Case 8: Caddy mounts without :ro — should also pass
-cat > "$TEMP_DIR/compose.prod.yml" <<'YAML'
+cat > "$TEMP_DIR/compose.prod.yml" << 'YAML'
 services:
   caddy:
     image: caddy:latest
@@ -141,7 +141,7 @@ services:
       - ../caddy/heimserver:/etc/caddy/heimserver
 YAML
 
-if bash "$GUARD_SCRIPT" "$TEMP_DIR/compose.prod.yml" >/dev/null 2>&1; then
+if bash "$GUARD_SCRIPT" "$TEMP_DIR/compose.prod.yml" > /dev/null 2>&1; then
   report 0 "Caddy mounts without :ro pass (optional suffix)"
 else
   report 1 "Caddy mounts without :ro should pass"

--- a/scripts/tests/test_csp_contract_static.sh
+++ b/scripts/tests/test_csp_contract_static.sh
@@ -79,7 +79,7 @@ export CADDY_TARGET_SITE="weltgewebe.home.arpa"
 
 # Test 8: Target host strict, other host lenient -> FAIL
 echo '<script>console.log("inline")</script>' > "$INDEX_HTML"
-cat <<EOF > "$CADDYFILE_PATH"
+cat << EOF > "$CADDYFILE_PATH"
 weltgewebe.home.arpa {
   Content-Security-Policy "default-src 'self'; script-src 'self';"
 }
@@ -91,7 +91,7 @@ run_test "Target host strict, other host lenient -> FAIL" 1
 
 # Test 9: Target host lenient, other host strict -> PASS
 echo '<script>console.log("inline")</script>' > "$INDEX_HTML"
-cat <<EOF > "$CADDYFILE_PATH"
+cat << EOF > "$CADDYFILE_PATH"
 other.host {
   Content-Security-Policy "default-src 'self'; script-src 'self';"
 }

--- a/scripts/tests/test_guard_cleanup.sh
+++ b/scripts/tests/test_guard_cleanup.sh
@@ -16,7 +16,7 @@ echo "Running test in $TEMP_DIR"
 
 # Mock docker
 mkdir -p "$TEMP_DIR/bin"
-cat > "$TEMP_DIR/bin/docker" <<EOF
+cat > "$TEMP_DIR/bin/docker" << EOF
 #!/bin/sh
 # Mock 'docker compose version'
 if [ "\$1" = "compose" ] && [ "\$2" = "version" ]; then
@@ -54,7 +54,7 @@ export PATH="$TEMP_DIR/bin:$PATH"
 export TMPDIR="$TEMP_DIR"
 
 echo ">>> Test 1: Successful config rendering (should cleanup)"
-"$SCRIPT_TO_TEST" >/dev/null
+"$SCRIPT_TO_TEST" > /dev/null
 
 # Check for leaked files (pattern guard_api_alias.* or tmp.* depending on mktemp)
 # Since we control TMPDIR, any file created there by mktemp should be gone.
@@ -73,7 +73,7 @@ fi
 echo ">>> Test 2: Failed config rendering (should cleanup)"
 touch "$TEMP_DIR/FAIL_CONFIG"
 # Script should exit 1, so we allow failure
-"$SCRIPT_TO_TEST" >/dev/null 2>&1 || true
+"$SCRIPT_TO_TEST" > /dev/null 2>&1 || true
 
 LEAK_COUNT=$(find "$TEMP_DIR" -maxdepth 1 -type f \( -name "tmp.*" -o -name "guard_api_alias.*" \) | wc -l)
 

--- a/scripts/tests/test_metrics_ref_guard.sh
+++ b/scripts/tests/test_metrics_ref_guard.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # Tests call the REAL guard and snapshot scripts — no shadow
 # reimplementation of production logic.
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
 REPO_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
 GUARD_SCRIPT="$REPO_ROOT/scripts/guard/metrics-ref-guard.sh"
 SNAPSHOT_SCRIPT="$REPO_ROOT/scripts/wgx-metrics-snapshot.sh"
@@ -32,7 +32,7 @@ report() {
 
 # Case 1: Matching refs — should pass
 mkdir -p "$TEMP_DIR/case1/.github/workflows"
-cat > "$TEMP_DIR/case1/.github/workflows/metrics.yml" <<'YAML'
+cat > "$TEMP_DIR/case1/.github/workflows/metrics.yml" << 'YAML'
 name: Metrics
 on:
   workflow_dispatch:
@@ -44,7 +44,7 @@ jobs:
       post_url: https://example.com
 YAML
 
-if REPO_ROOT="$TEMP_DIR/case1" bash "$GUARD_SCRIPT" >/dev/null 2>&1; then
+if REPO_ROOT="$TEMP_DIR/case1" bash "$GUARD_SCRIPT" > /dev/null 2>&1; then
   report 0 "Matching refs pass"
 else
   report 1 "Matching refs should pass"
@@ -52,7 +52,7 @@ fi
 
 # Case 2: Mismatched refs — should fail with exit 1
 mkdir -p "$TEMP_DIR/case2/.github/workflows"
-cat > "$TEMP_DIR/case2/.github/workflows/metrics.yml" <<'YAML'
+cat > "$TEMP_DIR/case2/.github/workflows/metrics.yml" << 'YAML'
 name: Metrics
 on:
   workflow_dispatch:
@@ -64,14 +64,14 @@ jobs:
       post_url: https://example.com
 YAML
 
-if REPO_ROOT="$TEMP_DIR/case2" bash "$GUARD_SCRIPT" >/dev/null 2>&1; then
+if REPO_ROOT="$TEMP_DIR/case2" bash "$GUARD_SCRIPT" > /dev/null 2>&1; then
   report 1 "Mismatched refs should fail"
 else
   report 0 "Mismatched refs correctly detected"
 fi
 
 # Case 3: Missing workflow file — should fail with exit 2
-if REPO_ROOT="$TEMP_DIR/nonexistent" bash "$GUARD_SCRIPT" >/dev/null 2>&1; then
+if REPO_ROOT="$TEMP_DIR/nonexistent" bash "$GUARD_SCRIPT" > /dev/null 2>&1; then
   report 1 "Missing workflow should fail"
 else
   report 0 "Missing workflow correctly detected"
@@ -79,7 +79,7 @@ fi
 
 # Case 4: Quoted metarepo_ref — should still match
 mkdir -p "$TEMP_DIR/case4/.github/workflows"
-cat > "$TEMP_DIR/case4/.github/workflows/metrics.yml" <<'YAML'
+cat > "$TEMP_DIR/case4/.github/workflows/metrics.yml" << 'YAML'
 name: Metrics
 on:
   workflow_dispatch:
@@ -91,7 +91,7 @@ jobs:
       post_url: https://example.com
 YAML
 
-if REPO_ROOT="$TEMP_DIR/case4" bash "$GUARD_SCRIPT" >/dev/null 2>&1; then
+if REPO_ROOT="$TEMP_DIR/case4" bash "$GUARD_SCRIPT" > /dev/null 2>&1; then
   report 0 "Quoted metarepo_ref correctly matches"
 else
   report 1 "Quoted metarepo_ref should be stripped and match"
@@ -100,10 +100,10 @@ fi
 # Case 5: Default snapshot mode writes the file and exits successfully without stdout
 snapshot_output="$TEMP_DIR/snapshot.json"
 snapshot_stdout="$TEMP_DIR/snapshot.stdout"
-if WGX_METRICS_OUTPUT="$snapshot_output" bash "$SNAPSHOT_SCRIPT" >"$snapshot_stdout"; then
-  if [ -s "$snapshot_output" ] && [ ! -s "$snapshot_stdout" ] && \
+if WGX_METRICS_OUTPUT="$snapshot_output" bash "$SNAPSHOT_SCRIPT" > "$snapshot_stdout"; then
+  if [ -s "$snapshot_output" ] && [ ! -s "$snapshot_stdout" ] &&
     jq -e '.ts and .host and .updates and .backup and .drift' \
-      "$snapshot_output" >/dev/null; then
+      "$snapshot_output" > /dev/null; then
     report 0 "Default snapshot mode writes valid JSON and exits zero"
   else
     report 1 "Default snapshot mode output contract should hold"

--- a/scripts/tests/test_prod_public_base_url_guard.sh
+++ b/scripts/tests/test_prod_public_base_url_guard.sh
@@ -2,11 +2,11 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(
-  cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1
+  cd -- "$(dirname -- "${BASH_SOURCE[0]}")" > /dev/null 2>&1
   pwd
 )"
 REPO_ROOT="$(
-  cd -- "${SCRIPT_DIR}/../.." >/dev/null 2>&1
+  cd -- "${SCRIPT_DIR}/../.." > /dev/null 2>&1
   pwd
 )"
 GUARD_SCRIPT="${REPO_ROOT}/scripts/guard/prod-public-base-url-guard.sh"
@@ -40,7 +40,7 @@ write_override() {
   local auth_login="$6"
   local auth_token="$7"
 
-  cat >"$TEST_TMP/infra/compose/compose.prod.override.yml" <<EOF_OVERRIDE
+  cat > "$TEST_TMP/infra/compose/compose.prod.override.yml" << EOF_OVERRIDE
 services:
   api:
     environment:

--- a/scripts/tests/test_runtime_contract.sh
+++ b/scripts/tests/test_runtime_contract.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2155,SC2188
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
 REPO_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
 PREFLIGHT_SCRIPT="$REPO_ROOT/scripts/preflight/runtime_contract.sh"
 
@@ -15,7 +16,7 @@ trap cleanup EXIT
 # Helper to create valid state
 setup_valid() {
   mkdir -p "$ROOT/policies" "$ROOT/apps/web/build/_app"
-  cat > "$ROOT/policies/limits.yaml" <<'YAML'
+  cat > "$ROOT/policies/limits.yaml" << 'YAML'
 ---
 max_nodes_jsonl_mb: 10
 max_edges_jsonl_mb: 10
@@ -27,57 +28,62 @@ YAML
 export REQUIRE_FRONTEND=1
 setup_valid
 rm "$ROOT/policies/limits.yaml"
-if bash "$PREFLIGHT_SCRIPT" 2>/dev/null; then
+if bash "$PREFLIGHT_SCRIPT" 2> /dev/null; then
   echo "FAIL: Should have exited 1 on missing limits.yaml"
   exit 1
 fi
 
 # Case 2: empty index.html with REQUIRE_FRONTEND=1
-cleanup; ROOT="$(mktemp -d)"
+cleanup
+ROOT="$(mktemp -d)"
 setup_valid
 > "$ROOT/apps/web/build/index.html"
-if bash "$PREFLIGHT_SCRIPT" 2>/dev/null; then
+if bash "$PREFLIGHT_SCRIPT" 2> /dev/null; then
   echo "FAIL: Should have exited 1 on empty index.html"
   exit 1
 fi
 
 # Case 3: missing index.html with REQUIRE_FRONTEND=1
-cleanup; ROOT="$(mktemp -d)"
+cleanup
+ROOT="$(mktemp -d)"
 setup_valid
 rm "$ROOT/apps/web/build/index.html"
-if bash "$PREFLIGHT_SCRIPT" 2>/dev/null; then
+if bash "$PREFLIGHT_SCRIPT" 2> /dev/null; then
   echo "FAIL: Should have exited 1 on missing index.html when REQUIRE_FRONTEND=1"
   exit 1
 fi
 
 # Case 4: missing _app with REQUIRE_FRONTEND=1
-cleanup; ROOT="$(mktemp -d)"
+cleanup
+ROOT="$(mktemp -d)"
 setup_valid
 rm -rf "$ROOT/apps/web/build/_app"
-if bash "$PREFLIGHT_SCRIPT" 2>/dev/null; then
+if bash "$PREFLIGHT_SCRIPT" 2> /dev/null; then
   echo "FAIL: Should have exited 1 on missing _app when REQUIRE_FRONTEND=1"
   exit 1
 fi
 
 # Case 5: API-only deploy (REQUIRE_FRONTEND=0) missing frontend artifacts
 export REQUIRE_FRONTEND=0
-cleanup; ROOT="$(mktemp -d)"
+cleanup
+ROOT="$(mktemp -d)"
 mkdir -p "$ROOT/policies"
-cat > "$ROOT/policies/limits.yaml" <<'YAML'
+cat > "$ROOT/policies/limits.yaml" << 'YAML'
 ---
 max_nodes_jsonl_mb: 10
 max_edges_jsonl_mb: 10
 YAML
-if ! bash "$PREFLIGHT_SCRIPT" >/dev/null; then
+if ! bash "$PREFLIGHT_SCRIPT" > /dev/null; then
   echo "FAIL: API-only deploy should pass without frontend artifacts"
   exit 1
 fi
 
 # Case 6: success (REQUIRE_FRONTEND=1)
 export REQUIRE_FRONTEND=1
-cleanup; ROOT="$(mktemp -d)"
+cleanup
+ROOT="$(mktemp -d)"
 setup_valid
-if ! bash "$PREFLIGHT_SCRIPT" >/dev/null; then
+if ! bash "$PREFLIGHT_SCRIPT" > /dev/null; then
   echo "FAIL: Should have exited 0 on valid structure"
   exit 1
 fi

--- a/scripts/tests/test_token_leak_guard.sh
+++ b/scripts/tests/test_token_leak_guard.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # Tests call the REAL guard script via REPO_ROOT override — no
 # shadow reimplementation of guard logic.
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
 REPO_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
 GUARD_SCRIPT="$REPO_ROOT/scripts/guard/token-leak-guard.sh"
 
@@ -42,7 +42,7 @@ setup_git_repo() {
 setup_git_repo
 echo "Hello world" > file.txt
 git add . && git commit -q -m "clean"
-if REPO_ROOT="$TEMP_DIR/repo" bash "$GUARD_SCRIPT" >/dev/null 2>&1; then
+if REPO_ROOT="$TEMP_DIR/repo" bash "$GUARD_SCRIPT" > /dev/null 2>&1; then
   report 0 "Clean repo passes"
 else
   report 1 "Clean repo should pass"
@@ -52,7 +52,7 @@ fi
 setup_git_repo
 echo "config token=abcdefghij1234567890" > config.txt
 git add . && git commit -q -m "with leak"
-if REPO_ROOT="$TEMP_DIR/repo" bash "$GUARD_SCRIPT" >/dev/null 2>&1; then
+if REPO_ROOT="$TEMP_DIR/repo" bash "$GUARD_SCRIPT" > /dev/null 2>&1; then
   report 1 "File with token= leak should fail"
 else
   report 0 "File with token= leak correctly detected"
@@ -62,7 +62,7 @@ fi
 setup_git_repo
 echo "database password=supersecret123password" > db.txt
 git add . && git commit -q -m "with password"
-if REPO_ROOT="$TEMP_DIR/repo" bash "$GUARD_SCRIPT" >/dev/null 2>&1; then
+if REPO_ROOT="$TEMP_DIR/repo" bash "$GUARD_SCRIPT" > /dev/null 2>&1; then
   report 1 "File with password= leak should fail"
 else
   report 0 "File with password= leak correctly detected"
@@ -72,7 +72,7 @@ fi
 setup_git_repo
 echo "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9" > api.txt
 git add . && git commit -q -m "with bearer"
-if REPO_ROOT="$TEMP_DIR/repo" bash "$GUARD_SCRIPT" >/dev/null 2>&1; then
+if REPO_ROOT="$TEMP_DIR/repo" bash "$GUARD_SCRIPT" > /dev/null 2>&1; then
   report 1 "File with Bearer token leak should fail"
 else
   report 0 "File with Bearer token leak correctly detected"
@@ -82,7 +82,7 @@ fi
 setup_git_repo
 echo "token=abc12345x" > short.txt
 git add . && git commit -q -m "short token"
-if REPO_ROOT="$TEMP_DIR/repo" bash "$GUARD_SCRIPT" >/dev/null 2>&1; then
+if REPO_ROOT="$TEMP_DIR/repo" bash "$GUARD_SCRIPT" > /dev/null 2>&1; then
   report 0 "Short token (9 chars, under threshold) correctly passes"
 else
   report 1 "Short token (9 chars) should not trigger detection"
@@ -92,7 +92,7 @@ fi
 setup_git_repo
 echo "/api/auth/magic-link/consume" > route.txt
 git add . && git commit -q -m "route only"
-if REPO_ROOT="$TEMP_DIR/repo" bash "$GUARD_SCRIPT" >/dev/null 2>&1; then
+if REPO_ROOT="$TEMP_DIR/repo" bash "$GUARD_SCRIPT" > /dev/null 2>&1; then
   report 0 "Route-only magic-link consume path passes"
 else
   report 1 "Route-only magic-link consume path should pass"
@@ -102,7 +102,7 @@ fi
 setup_git_repo
 echo "https://example.test/api/auth/magic-link/consume?token=abcdefghij1234567890" > url.txt
 git add . && git commit -q -m "url token"
-if REPO_ROOT="$TEMP_DIR/repo" bash "$GUARD_SCRIPT" >/dev/null 2>&1; then
+if REPO_ROOT="$TEMP_DIR/repo" bash "$GUARD_SCRIPT" > /dev/null 2>&1; then
   report 1 "Magic-link consume URL with token should fail"
 else
   report 0 "Magic-link consume URL with token correctly detected"

--- a/scripts/tests/test_verify_deployment.sh
+++ b/scripts/tests/test_verify_deployment.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2155
 # ------------------------------------------------------------------
 # Local Mock Test for Deployment Logic
 # Not intended for CI execution without mock setup.
@@ -12,7 +13,7 @@ cd "$(dirname "$0")/../.."
 cleanup() {
   rm -rf mock_bin test.env custom_state
   if [[ -n "${MOCK_PORT_CALLS_FILE:-}" ]]; then
-      rm -f "$MOCK_PORT_CALLS_FILE"
+    rm -f "$MOCK_PORT_CALLS_FILE"
   fi
   unset HEALTH_URL API_INTERNAL_PORT MOCK_HEALTH_EXISTS MOCK_PORT_CALLS_FILE
 }
@@ -215,7 +216,7 @@ echo "WEB_UPSTREAM_HOST=example.com" >> "$ENV_FILE"
 # 1. Test Project Validation
 echo ">>> Test 1: Project Validation (fail case)"
 export COMPOSE_PROJECT="compose"
-if ./scripts/weltgewebe-up --no-pull --no-build >/dev/null 2>&1; then
+if ./scripts/weltgewebe-up --no-pull --no-build > /dev/null 2>&1; then
   echo "FAIL: COMPOSE_PROJECT=compose check failed."
   exit 1
 else
@@ -232,19 +233,19 @@ OUTPUT=$(./scripts/weltgewebe-up --no-pull --no-build 2>&1 || true)
 
 # Robust assertions: Check for key markers instead of exact full string
 if echo "$OUTPUT" | grep -q "ERROR: Detected foreign compose project"; then
-   if echo "$OUTPUT" | grep -q "Repo dir:" && \
-      echo "$OUTPUT" | grep -q "Expected project name:" && \
-      echo "$OUTPUT" | grep -q "docker compose -p <foreign_project> down"; then
-         echo "PASS: Detailed error message found (robust check)."
-   else
-      echo "FAIL: Missing remediation hints or context info."
-      echo "$OUTPUT"
-      exit 1
-   fi
+  if echo "$OUTPUT" | grep -q "Repo dir:" &&
+    echo "$OUTPUT" | grep -q "Expected project name:" &&
+    echo "$OUTPUT" | grep -q "docker compose -p <foreign_project> down"; then
+    echo "PASS: Detailed error message found (robust check)."
+  else
+    echo "FAIL: Missing remediation hints or context info."
+    echo "$OUTPUT"
+    exit 1
+  fi
 else
-   echo "FAIL: Zombie detection failed or error message mismatch."
-   echo "$OUTPUT"
-   exit 1
+  echo "FAIL: Zombie detection failed or error message mismatch."
+  echo "$OUTPUT"
+  exit 1
 fi
 
 # 3. Test Zombie Guard (Purge)
@@ -343,18 +344,18 @@ unset REPO_DIR COMPOSE_BAKE WELTGEWEBE_COMPOSE_BAKE WELTGEWEBE_APPS_PROBE VERIFY
 # We rely on CWD/Git fallback since we are in repo root (managed by test setup cd)
 # Ensure we are in a path that has the config file
 if [[ ! -f "infra/compose/compose.prod.yml" ]]; then
-    echo "FAIL: Test setup error - config file not found in CWD."
-    exit 1
+  echo "FAIL: Test setup error - config file not found in CWD."
+  exit 1
 fi
 
 # We expect success (exit 0) and validation that correct repo was picked
 OUTPUT=$(./scripts/weltgewebe-up --no-pull --no-build 2>&1)
 if echo "$OUTPUT" | grep -qF "Repo:    $(pwd)"; then
-    echo "PASS: Auto-detection worked and selected current directory."
+  echo "PASS: Auto-detection worked and selected current directory."
 else
-    echo "FAIL: Auto-detection failed or selected wrong repo."
-    echo "$OUTPUT"
-    exit 1
+  echo "FAIL: Auto-detection failed or selected wrong repo."
+  echo "$OUTPUT"
+  exit 1
 fi
 
 # 9. Test REPO_DIR Strictness (Invalid Path)
@@ -363,17 +364,17 @@ export REPO_DIR="/invalid/path/to/repo"
 OUTPUT=$(./scripts/weltgewebe-up --no-pull --no-build 2>&1 || true)
 
 if echo "$OUTPUT" | grep -q "ERROR: REPO_DIR explicitly set"; then
-   if echo "$OUTPUT" | grep -q "Refusing fallback"; then
-      echo "PASS: Strict check rejected invalid REPO_DIR."
-   else
-      echo "FAIL: Error message missing 'Refusing fallback'."
-      echo "$OUTPUT"
-      exit 1
-   fi
+  if echo "$OUTPUT" | grep -q "Refusing fallback"; then
+    echo "PASS: Strict check rejected invalid REPO_DIR."
+  else
+    echo "FAIL: Error message missing 'Refusing fallback'."
+    echo "$OUTPUT"
+    exit 1
+  fi
 else
-   echo "FAIL: Script did not fail on invalid REPO_DIR."
-   echo "$OUTPUT"
-   exit 1
+  echo "FAIL: Script did not fail on invalid REPO_DIR."
+  echo "$OUTPUT"
+  exit 1
 fi
 unset REPO_DIR
 
@@ -387,17 +388,17 @@ export MOCK_EXEC_FAIL="0"
 OUTPUT=$(./scripts/weltgewebe-up --no-pull --no-build 2>&1 || true)
 
 if echo "$OUTPUT" | grep -q "Health strategy selected: Docker Native Health"; then
-    if echo "$OUTPUT" | grep -q "Health OK (Docker Native Health)"; then
-        echo "PASS: Fell back to Docker Native check."
-    else
-        echo "FAIL: Docker Native check failed."
-        echo "$OUTPUT"
-        exit 1
-    fi
-else
-    echo "FAIL: Did not use Docker Native check."
+  if echo "$OUTPUT" | grep -q "Health OK (Docker Native Health)"; then
+    echo "PASS: Fell back to Docker Native check."
+  else
+    echo "FAIL: Docker Native check failed."
     echo "$OUTPUT"
     exit 1
+  fi
+else
+  echo "FAIL: Did not use Docker Native check."
+  echo "$OUTPUT"
+  exit 1
 fi
 
 # 12. Test Health: Host Port (Valid)
@@ -408,17 +409,17 @@ export MOCK_HEALTH_EXISTS="0"
 OUTPUT=$(./scripts/weltgewebe-up --no-pull --no-build 2>&1 || true)
 
 if echo "$OUTPUT" | grep -q "Health strategy selected: HTTP Health"; then
-    if echo "$OUTPUT" | grep -q "Using Host Port Mapping"; then
-        echo "PASS: Used Host Port check when valid."
-    else
-        echo "FAIL: Did not output Host Port mapping."
-        echo "$OUTPUT"
-        exit 1
-    fi
-else
-    echo "FAIL: Did not use HTTP Health check."
+  if echo "$OUTPUT" | grep -q "Using Host Port Mapping"; then
+    echo "PASS: Used Host Port check when valid."
+  else
+    echo "FAIL: Did not output Host Port mapping."
     echo "$OUTPUT"
     exit 1
+  fi
+else
+  echo "FAIL: Did not use HTTP Health check."
+  echo "$OUTPUT"
+  exit 1
 fi
 unset MOCK_HEALTH_EXISTS
 
@@ -430,17 +431,17 @@ export MOCK_HEALTH_EXISTS="0"
 OUTPUT=$(./scripts/weltgewebe-up --no-pull --no-build 2>&1 || true)
 
 if echo "$OUTPUT" | grep -q "Health strategy selected: HTTP Health"; then
-    if echo "$OUTPUT" | grep -q "Using explicit health URL: http://explicit-url:8080/health"; then
-        echo "PASS: Used explicit HEALTH_URL."
-    else
-        echo "FAIL: Did not use explicit HEALTH_URL."
-        echo "$OUTPUT"
-        exit 1
-    fi
-else
-    echo "FAIL: Did not use HTTP Health check."
+  if echo "$OUTPUT" | grep -q "Using explicit health URL: http://explicit-url:8080/health"; then
+    echo "PASS: Used explicit HEALTH_URL."
+  else
+    echo "FAIL: Did not use explicit HEALTH_URL."
     echo "$OUTPUT"
     exit 1
+  fi
+else
+  echo "FAIL: Did not use HTTP Health check."
+  echo "$OUTPUT"
+  exit 1
 fi
 unset HEALTH_URL
 unset MOCK_HEALTH_EXISTS
@@ -453,17 +454,17 @@ mkdir -p "$WELTGEWEBE_STATE_DIR"
 OUTPUT=$(./scripts/weltgewebe-up --no-build 2>&1)
 
 if [[ -f "$WELTGEWEBE_STATE_DIR/weltgewebe-up.state" ]]; then
-    CONTENT=$(cat "$WELTGEWEBE_STATE_DIR/weltgewebe-up.state")
-    if [[ "$CONTENT" == "mock-sha-12345" ]]; then
-        echo "PASS: State file created in custom directory with correct SHA."
-    else
-        echo "FAIL: State file content incorrect. Got: $CONTENT"
-        exit 1
-    fi
-else
-    echo "FAIL: State file not found in custom directory."
-    echo "$OUTPUT"
+  CONTENT=$(cat "$WELTGEWEBE_STATE_DIR/weltgewebe-up.state")
+  if [[ "$CONTENT" == "mock-sha-12345" ]]; then
+    echo "PASS: State file created in custom directory with correct SHA."
+  else
+    echo "FAIL: State file content incorrect. Got: $CONTENT"
     exit 1
+  fi
+else
+  echo "FAIL: State file not found in custom directory."
+  echo "$OUTPUT"
+  exit 1
 fi
 rm -rf "$WELTGEWEBE_STATE_DIR"
 unset WELTGEWEBE_STATE_DIR
@@ -480,11 +481,11 @@ export EXPECT_INTERNAL_PORT="9090"
 OUTPUT=$(./scripts/weltgewebe-up --no-pull --no-build 2>&1 || true)
 
 if echo "$OUTPUT" | grep -q "Health strategy selected: HTTP Health" && echo "$OUTPUT" | grep -q "Using Host Port Mapping"; then
-     echo "PASS: Script ran successfully with custom internal port."
+  echo "PASS: Script ran successfully with custom internal port."
 else
-     echo "FAIL: Script failed or wrong strategy."
-     echo "$OUTPUT"
-     exit 1
+  echo "FAIL: Script failed or wrong strategy."
+  echo "$OUTPUT"
+  exit 1
 fi
 unset API_INTERNAL_PORT
 unset EXPECT_INTERNAL_PORT
@@ -499,25 +500,25 @@ export MOCK_INSPECT_FAIL="0"  # Ensure inspect succeeds so it's a true missing c
 OUTPUT=$(./scripts/weltgewebe-up --no-pull --no-build 2>&1 || true)
 
 if echo "$OUTPUT" | grep -q "Docker HEALTHCHECK not defined for container 'api'"; then
-    if echo "$OUTPUT" | grep -q "Waiting for health..."; then
-        echo "FAIL: Script did not fail fast (retried despite missing healthcheck)."
-        echo "$OUTPUT"
-        exit 1
-    elif echo "$OUTPUT" | grep -q "Health check failed after"; then
-        echo "FAIL: Script printed misleading 'failed after X seconds' summary despite fail fast."
-        echo "$OUTPUT"
-        exit 1
-    elif ! echo "$OUTPUT" | grep -Fq "Docker HEALTHCHECK not defined for container 'api'"; then
-        echo "FAIL: Did not find expected HEALTHCHECK-missing message substring."
-        echo "$OUTPUT"
-        exit 1
-    else
-        echo "PASS: Detected missing HEALTHCHECK, failed fast, and printed correct summary."
-    fi
-else
-    echo "FAIL: Did not detect missing HEALTHCHECK."
+  if echo "$OUTPUT" | grep -q "Waiting for health..."; then
+    echo "FAIL: Script did not fail fast (retried despite missing healthcheck)."
     echo "$OUTPUT"
     exit 1
+  elif echo "$OUTPUT" | grep -q "Health check failed after"; then
+    echo "FAIL: Script printed misleading 'failed after X seconds' summary despite fail fast."
+    echo "$OUTPUT"
+    exit 1
+  elif ! echo "$OUTPUT" | grep -Fq "Docker HEALTHCHECK not defined for container 'api'"; then
+    echo "FAIL: Did not find expected HEALTHCHECK-missing message substring."
+    echo "$OUTPUT"
+    exit 1
+  else
+    echo "PASS: Detected missing HEALTHCHECK, failed fast, and printed correct summary."
+  fi
+else
+  echo "FAIL: Did not detect missing HEALTHCHECK."
+  echo "$OUTPUT"
+  exit 1
 fi
 unset MOCK_HEALTH_EXISTS
 unset MOCK_INSPECT_FAIL
@@ -533,27 +534,27 @@ rm -f "$MOCK_PORT_CALLS_FILE"
 OUTPUT=$(./scripts/weltgewebe-up --no-pull --no-build 2>&1 || true)
 
 if ! echo "$OUTPUT" | grep -q "WARN: docker inspect failed during health strategy probe; falling back to HTTP Health"; then
-    echo "FAIL: Missing expected warning message for strategy inspect fail."
-    echo "$OUTPUT"
-    exit 1
+  echo "FAIL: Missing expected warning message for strategy inspect fail."
+  echo "$OUTPUT"
+  exit 1
 fi
 
 if echo "$OUTPUT" | grep -q "Health strategy selected: HTTP Health" && echo "$OUTPUT" | grep -q "Using Host Port Mapping"; then
-    if echo "$OUTPUT" | grep -q "Health OK"; then
-        if [ ! -s "$MOCK_PORT_CALLS_FILE" ]; then
-            echo "FAIL: Strategy fell back to HTTP Health but no port probe occurred."
-            exit 1
-        fi
-        echo "PASS: Detected strategy inspect failure and fell back correctly."
-    else
-        echo "FAIL: Detected strategy inspect failure but did not attempt fallback."
-        echo "$OUTPUT"
-        exit 1
+  if echo "$OUTPUT" | grep -q "Health OK"; then
+    if [ ! -s "$MOCK_PORT_CALLS_FILE" ]; then
+      echo "FAIL: Strategy fell back to HTTP Health but no port probe occurred."
+      exit 1
     fi
-else
-    echo "FAIL: Did not fallback to HTTP Health / Host Port Mapping on strategy inspect failure."
+    echo "PASS: Detected strategy inspect failure and fell back correctly."
+  else
+    echo "FAIL: Detected strategy inspect failure but did not attempt fallback."
     echo "$OUTPUT"
     exit 1
+  fi
+else
+  echo "FAIL: Did not fallback to HTTP Health / Host Port Mapping on strategy inspect failure."
+  echo "$OUTPUT"
+  exit 1
 fi
 unset MOCK_INSPECT_FAIL_STRATEGY
 unset MOCK_HEALTH_EXISTS
@@ -568,22 +569,22 @@ export MOCK_INSPECT_FAIL_STATUS="1"
 OUTPUT=$(./scripts/weltgewebe-up --no-pull --no-build 2>&1 || true)
 
 if echo "$OUTPUT" | grep -q "docker inspect failed"; then
-    if echo "$OUTPUT" | grep -q "Waiting for health... (1/10)"; then
-        if echo "$OUTPUT" | grep -q "Health check aborted: missing Docker HEALTHCHECK"; then
-            echo "FAIL: Failed fast instead of retrying."
-            echo "$OUTPUT"
-            exit 1
-        fi
-        echo "PASS: Detected status inspect failure and retried correctly."
-    else
-        echo "FAIL: Detected status inspect failure but did not retry."
-        echo "$OUTPUT"
-        exit 1
+  if echo "$OUTPUT" | grep -q "Waiting for health... (1/10)"; then
+    if echo "$OUTPUT" | grep -q "Health check aborted: missing Docker HEALTHCHECK"; then
+      echo "FAIL: Failed fast instead of retrying."
+      echo "$OUTPUT"
+      exit 1
     fi
-else
-    echo "FAIL: Did not detect status inspect failure."
+    echo "PASS: Detected status inspect failure and retried correctly."
+  else
+    echo "FAIL: Detected status inspect failure but did not retry."
     echo "$OUTPUT"
     exit 1
+  fi
+else
+  echo "FAIL: Did not detect status inspect failure."
+  echo "$OUTPUT"
+  exit 1
 fi
 unset MOCK_INSPECT_FAIL_STATUS
 unset MOCK_HEALTH_EXISTS
@@ -598,22 +599,22 @@ rm -f "$MOCK_PORT_CALLS_FILE"
 OUTPUT=$(./scripts/weltgewebe-up --no-pull --no-build 2>&1 || true)
 
 if echo "$OUTPUT" | grep -q "Health strategy selected: Docker Native Health"; then
-    if [ -s "$MOCK_PORT_CALLS_FILE" ]; then
-        echo "FAIL: Attempted port mapping detection despite having a Docker native strategy."
-        echo "$OUTPUT"
-        exit 1
-    fi
-    if echo "$OUTPUT" | grep -q "Health OK (Docker Native Health)"; then
-        echo "PASS: Ignored missing port correctly with Docker Native Health Check."
-    else
-        echo "FAIL: Did not succeed with Docker Native Health."
-        echo "$OUTPUT"
-        exit 1
-    fi
-else
-    echo "FAIL: Did not use Docker Native Health Check strategy."
+  if [ -s "$MOCK_PORT_CALLS_FILE" ]; then
+    echo "FAIL: Attempted port mapping detection despite having a Docker native strategy."
     echo "$OUTPUT"
     exit 1
+  fi
+  if echo "$OUTPUT" | grep -q "Health OK (Docker Native Health)"; then
+    echo "PASS: Ignored missing port correctly with Docker Native Health Check."
+  else
+    echo "FAIL: Did not succeed with Docker Native Health."
+    echo "$OUTPUT"
+    exit 1
+  fi
+else
+  echo "FAIL: Did not use Docker Native Health Check strategy."
+  echo "$OUTPUT"
+  exit 1
 fi
 unset MOCK_HEALTH_EXISTS
 unset MOCK_PORT_MODE
@@ -624,16 +625,16 @@ export MOCK_MISSING_API="1"
 OUTPUT=$(./scripts/weltgewebe-up --no-pull --no-build 2>&1 || true)
 
 if echo "$OUTPUT" | grep -q "ERROR: Container 'api' not found."; then
-    if echo "$OUTPUT" | grep -q "HEALTHCHECK not defined"; then
-        echo "FAIL: Emitted 'missing healthcheck' despite missing container."
-        echo "$OUTPUT"
-        exit 1
-    fi
-    echo "PASS: Detected missing container before checking strategy."
-else
-    echo "FAIL: Did not detect missing container correctly."
+  if echo "$OUTPUT" | grep -q "HEALTHCHECK not defined"; then
+    echo "FAIL: Emitted 'missing healthcheck' despite missing container."
     echo "$OUTPUT"
     exit 1
+  fi
+  echo "PASS: Detected missing container before checking strategy."
+else
+  echo "FAIL: Did not detect missing container correctly."
+  echo "$OUTPUT"
+  exit 1
 fi
 unset MOCK_MISSING_API
 
@@ -666,11 +667,11 @@ export EDGE_CA="$PWD/mock_edge_ca.crt"
 export MOCK_HEALTH_EXISTS="1"
 OUTPUT=$(./scripts/weltgewebe-up --no-pull --no-build 2>&1 || true)
 if echo "$OUTPUT" | grep -q ">> Guard 5: Frontend Reachability..."; then
-    echo "PASS: DNS Guard succeeded and script progressed through guards."
+  echo "PASS: DNS Guard succeeded and script progressed through guards."
 else
-    echo "FAIL: Script did not reach Guard 5 as expected."
-    echo "$OUTPUT"
-    exit 1
+  echo "FAIL: Script did not reach Guard 5 as expected."
+  echo "$OUTPUT"
+  exit 1
 fi
 unset MOCK_HEALTH_EXISTS
 
@@ -687,17 +688,17 @@ export EDGE_CA="$PWD/mock_edge_ca.crt"
 export MOCK_HEALTH_EXISTS="1"
 OUTPUT=$(./scripts/weltgewebe-up --no-pull --no-build 2>&1 || true)
 if echo "$OUTPUT" | grep -q "DNS Guard failed"; then
-    if echo "$OUTPUT" | grep -q "Diagnostics saved:"; then
-        echo "PASS: DNS Guard failed and generated bundle as expected."
-    else
-        echo "FAIL: DNS Guard failed but did not generate failure bundle."
-        echo "$OUTPUT"
-        exit 1
-    fi
-else
-    echo "FAIL: DNS Guard succeeded unexpectedly."
+  if echo "$OUTPUT" | grep -q "Diagnostics saved:"; then
+    echo "PASS: DNS Guard failed and generated bundle as expected."
+  else
+    echo "FAIL: DNS Guard failed but did not generate failure bundle."
     echo "$OUTPUT"
     exit 1
+  fi
+else
+  echo "FAIL: DNS Guard succeeded unexpectedly."
+  echo "$OUTPUT"
+  exit 1
 fi
 unset MOCK_HEALTH_EXISTS
 
@@ -756,16 +757,16 @@ OUTPUT=$(./scripts/weltgewebe-up --no-pull --no-build 2>&1)
 STATUS=$?
 set -e
 if [ "$STATUS" -eq 0 ]; then
-    echo "FAIL: Expected failure due to missing HTML cache headers, but got success."
-    echo "$OUTPUT"
-    exit 1
+  echo "FAIL: Expected failure due to missing HTML cache headers, but got success."
+  echo "$OUTPUT"
+  exit 1
 fi
 if echo "$OUTPUT" | grep -q "Frontend Cache Guard failed: /map route did not return 'no-cache, must-revalidate' header"; then
-    echo "PASS: Detected missing HTML cache headers correctly."
+  echo "PASS: Detected missing HTML cache headers correctly."
 else
-    echo "FAIL: Did not detect missing HTML cache headers."
-    echo "$OUTPUT"
-    exit 1
+  echo "FAIL: Did not detect missing HTML cache headers."
+  echo "$OUTPUT"
+  exit 1
 fi
 
 # Sub-test 22b: Missing Asset Cache Header
@@ -813,16 +814,16 @@ OUTPUT=$(./scripts/weltgewebe-up --no-pull --no-build 2>&1)
 STATUS=$?
 set -e
 if [ "$STATUS" -eq 0 ]; then
-    echo "FAIL: Expected failure due to missing immutable asset headers, but got success."
-    echo "$OUTPUT"
-    exit 1
+  echo "FAIL: Expected failure due to missing immutable asset headers, but got success."
+  echo "$OUTPUT"
+  exit 1
 fi
 if echo "$OUTPUT" | grep -q "Frontend Cache Guard failed: Immutable asset .* did not return 'max-age=31536000, immutable' header"; then
-    echo "PASS: Detected missing immutable asset headers correctly."
+  echo "PASS: Detected missing immutable asset headers correctly."
 else
-    echo "FAIL: Did not detect missing immutable asset headers."
-    echo "$OUTPUT"
-    exit 1
+  echo "FAIL: Did not detect missing immutable asset headers."
+  echo "$OUTPUT"
+  exit 1
 fi
 
 # Sub-test 22c: Valid Cache Headers (Positive Path)
@@ -900,18 +901,18 @@ OUTPUT=$(./scripts/weltgewebe-up --no-pull --no-build 2>&1)
 STATUS=$?
 set -e
 if [ "$STATUS" -ne 0 ]; then
-    echo "FAIL: Expected success but got exit code $STATUS."
-    echo "$OUTPUT"
-    exit 1
+  echo "FAIL: Expected success but got exit code $STATUS."
+  echo "$OUTPUT"
+  exit 1
 fi
-if echo "$OUTPUT" | grep -q "OK (frontend route /map cache-control verified)" && \
-   echo "$OUTPUT" | grep -q "verified with immutable cache headers" && \
-   echo "$OUTPUT" | grep -q "OK (Version: mock-artifact-id, Build-ID: mock-build-id-123 verified via /_app/version.json with no-store)"; then
-    echo "PASS: Valid cache headers and version.json correctly passed the guards."
+if echo "$OUTPUT" | grep -q "OK (frontend route /map cache-control verified)" &&
+  echo "$OUTPUT" | grep -q "verified with immutable cache headers" &&
+  echo "$OUTPUT" | grep -q "OK (Version: mock-artifact-id, Build-ID: mock-build-id-123 verified via /_app/version.json with no-store)"; then
+  echo "PASS: Valid cache headers and version.json correctly passed the guards."
 else
-    echo "FAIL: Positive cache header validation path failed."
-    echo "$OUTPUT"
-    exit 1
+  echo "FAIL: Positive cache header validation path failed."
+  echo "$OUTPUT"
+  exit 1
 fi
 
 # Sub-test 22d: Missing no-store header for version.json
@@ -988,16 +989,16 @@ OUTPUT=$(./scripts/weltgewebe-up --no-pull --no-build 2>&1)
 STATUS=$?
 set -e
 if [ "$STATUS" -eq 0 ]; then
-    echo "FAIL: Expected failure due to missing no-store header, but got success."
-    echo "$OUTPUT"
-    exit 1
+  echo "FAIL: Expected failure due to missing no-store header, but got success."
+  echo "$OUTPUT"
+  exit 1
 fi
 if echo "$OUTPUT" | grep -q "Frontend Guard failed: /_app/version.json did not return 'no-store' header."; then
-    echo "PASS: Detected missing version.json cache headers correctly."
+  echo "PASS: Detected missing version.json cache headers correctly."
 else
-    echo "FAIL: Did not detect missing version.json cache headers."
-    echo "$OUTPUT"
-    exit 1
+  echo "FAIL: Did not detect missing version.json cache headers."
+  echo "$OUTPUT"
+  exit 1
 fi
 
 # Sub-test 22e: Missing canonical version for version.json
@@ -1076,16 +1077,16 @@ OUTPUT=$(./scripts/weltgewebe-up --no-pull --no-build 2>&1)
 STATUS=$?
 set -e
 if [ "$STATUS" -eq 0 ]; then
-    echo "FAIL: Expected failure due to missing canonical version, but got success."
-    echo "$OUTPUT"
-    exit 1
+  echo "FAIL: Expected failure due to missing canonical version, but got success."
+  echo "$OUTPUT"
+  exit 1
 fi
 if echo "$OUTPUT" | grep -q "Frontend Guard failed: /_app/version.json missing valid canonical 'version' field."; then
-    echo "PASS: Detected missing canonical version in version.json correctly."
+  echo "PASS: Detected missing canonical version in version.json correctly."
 else
-    echo "FAIL: Did not detect missing canonical version in version.json."
-    echo "$OUTPUT"
-    exit 1
+  echo "FAIL: Did not detect missing canonical version in version.json."
+  echo "$OUTPUT"
+  exit 1
 fi
 
 unset REQUIRE_FRONTEND
@@ -1106,11 +1107,11 @@ export EDGE_CA="$PWD/mock_edge_ca.crt"
 export MOCK_HEALTH_EXISTS="1"
 OUTPUT=$(./scripts/weltgewebe-up --no-pull --no-build 2>&1 || true)
 if echo "$OUTPUT" | grep -q "Container Health Guard failed"; then
-    echo "PASS: Container Health Guard failed as expected."
+  echo "PASS: Container Health Guard failed as expected."
 else
-    echo "FAIL: Container Health Guard succeeded unexpectedly."
-    echo "$OUTPUT"
-    exit 1
+  echo "FAIL: Container Health Guard succeeded unexpectedly."
+  echo "$OUTPUT"
+  exit 1
 fi
 unset MOCK_EXEC_FAIL
 unset MOCK_HEALTH_EXISTS

--- a/scripts/tests/test_version_guard.sh
+++ b/scripts/tests/test_version_guard.sh
@@ -32,7 +32,7 @@ run_guard() {
 
   local out rc
   set +e
-  out=$(python3 "$PARSE_HELPER" "$tmpfile" 2>/dev/null)
+  out=$(python3 "$PARSE_HELPER" "$tmpfile" 2> /dev/null)
   rc=$?
   set -e
 
@@ -43,8 +43,8 @@ run_guard() {
 # _read_version_json: mirrors the helper wrapper used in weltgewebe-up.
 # Returns the version string (line 1 of parser output), or empty on any error.
 _read_version_json() {
-    local json_file="$1"
-    python3 "$PARSE_HELPER" "$json_file" 2>/dev/null | head -n1 || true
+  local json_file="$1"
+  python3 "$PARSE_HELPER" "$json_file" 2> /dev/null | head -n1 || true
 }
 
 # ===========================================================================
@@ -74,8 +74,8 @@ rc="${result%%|*}"
 output="${result#*|}"
 [[ "$rc" == "0" ]] || fail "Test 3: expected exit 0, got $rc"
 commit_line=$(printf '%s' "$output" | sed -n '3p')
-[[ "$commit_line" == "c67aaa6730b78c5ab5cfbacb272eb60a06347473" ]] \
-    || fail "Test 3: commit not on 3rd line, got '$commit_line'"
+[[ "$commit_line" == "c67aaa6730b78c5ab5cfbacb272eb60a06347473" ]] ||
+  fail "Test 3: commit not on 3rd line, got '$commit_line'"
 echo "PASS: commit field output as 3rd line"
 
 # --- Test 4: missing 'version' field → exit 2 ---
@@ -141,15 +141,15 @@ echo "PASS: _read_version_json returns empty for blank version"
 # --- Test 11: stale → rebuild condition triggered ---
 _BUILT="17314c6a"
 _HEAD="c67aaa67"
-[[ "$_BUILT" != "$_HEAD" ]] \
-    || fail "Test 11: stale versions should differ"
+[[ "$_BUILT" != "$_HEAD" ]] ||
+  fail "Test 11: stale versions should differ"
 echo "PASS: staleness comparison contract — stale version triggers rebuild condition"
 
 # --- Test 12: matching → no rebuild ---
 _BUILT="c67aaa67"
 _HEAD="c67aaa67"
-[[ "$_BUILT" == "$_HEAD" ]] \
-    || fail "Test 12: matching versions should be equal"
+[[ "$_BUILT" == "$_HEAD" ]] ||
+  fail "Test 12: matching versions should be equal"
 echo "PASS: staleness comparison contract — matching version does not trigger rebuild"
 
 # --- Test 13: end-to-end stale detection via _read_version_json ---
@@ -158,8 +158,8 @@ printf '{"version":"17314c6a","build_id":"old"}' > "$_tmpf"
 _bv=$(_read_version_json "$_tmpf")
 rm -f "$_tmpf"
 _sha="c67aaa67"
-[[ -n "$_bv" && "$_bv" != "$_sha" ]] \
-    || fail "Test 13: expected stale detection (bv=$_bv sha=$_sha)"
+[[ -n "$_bv" && "$_bv" != "$_sha" ]] ||
+  fail "Test 13: expected stale detection (bv=$_bv sha=$_sha)"
 echo "PASS: staleness comparison contract — stale version.json detected end-to-end"
 
 # --- Test 14: end-to-end up-to-date detection ---
@@ -168,8 +168,8 @@ printf '{"version":"c67aaa67","build_id":"new"}' > "$_tmpf"
 _bv=$(_read_version_json "$_tmpf")
 rm -f "$_tmpf"
 _sha="c67aaa67"
-[[ -n "$_bv" && "$_bv" == "$_sha" ]] \
-    || fail "Test 14: expected up-to-date detection (bv=$_bv sha=$_sha)"
+[[ -n "$_bv" && "$_bv" == "$_sha" ]] ||
+  fail "Test 14: expected up-to-date detection (bv=$_bv sha=$_sha)"
 echo "PASS: staleness comparison contract — up-to-date build does not trigger rebuild"
 
 # ===========================================================================

--- a/scripts/tests/test_weltgewebe_up_git_branch.sh
+++ b/scripts/tests/test_weltgewebe_up_git_branch.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2012
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
 REPO_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
 SCRIPT_SOURCE="$REPO_ROOT/scripts/weltgewebe-up"
 REAL_GIT="$(command -v git)"
@@ -22,7 +23,7 @@ fail() {
 assert_contains() {
   local haystack="$1"
   local needle="$2"
-  if ! grep -Fq "$needle" <<<"$haystack"; then
+  if ! grep -Fq "$needle" <<< "$haystack"; then
     fail "expected output to contain: $needle"
   fi
 }
@@ -34,8 +35,8 @@ new_repo() {
   local repo="$root/repo"
 
   mkdir -p "$root"
-  git init --bare "$origin" >/dev/null
-  git clone "$origin" "$repo" >/dev/null 2>&1
+  git init --bare "$origin" > /dev/null
+  git clone "$origin" "$repo" > /dev/null 2>&1
 
   (
     cd "$repo"
@@ -46,41 +47,41 @@ new_repo() {
     cp "$SCRIPT_SOURCE" scripts/weltgewebe-up
     chmod +x scripts/weltgewebe-up
 
-    cat > .env <<'EOF'
+    cat > .env << 'EOF'
 WEB_UPSTREAM_URL=https://example.com
 WEB_UPSTREAM_HOST=example.com
 EOF
 
-    cat > infra/compose/compose.prod.yml <<'EOF'
+    cat > infra/compose/compose.prod.yml << 'EOF'
 services:
   api:
     image: busybox
 EOF
 
-    cat > infra/compose/compose.prod.override.yml <<'EOF'
+    cat > infra/compose/compose.prod.override.yml << 'EOF'
 services:
   api:
     image: busybox
 EOF
 
-    cat > apps/web/build/index.html <<'EOF'
+    cat > apps/web/build/index.html << 'EOF'
 <!doctype html><html><body><script src="/_app/immutable/test.js"></script></body></html>
 EOF
 
-    cat > apps/web/build/_app/version.json <<'EOF'
+    cat > apps/web/build/_app/version.json << 'EOF'
 {"version":"test-build"}
 EOF
 
     git add .
-    git commit -m "test: initial main" >/dev/null
+    git commit -m "test: initial main" > /dev/null
     git branch -M main
-    git push -u origin main >/dev/null
+    git push -u origin main > /dev/null
 
-    git checkout -b feat/x >/dev/null
+    git checkout -b feat/x > /dev/null
     echo "feature" > feature.txt
     git add feature.txt
-    git commit -m "feat: x" >/dev/null
-    git push -u origin feat/x >/dev/null
+    git commit -m "feat: x" > /dev/null
+    git push -u origin feat/x > /dev/null
   )
 
   echo "$repo"
@@ -91,16 +92,16 @@ advance_remote_branch() {
   local branch="$2"
   local tmp_clone
   tmp_clone="$(mktemp -d "$WORKDIR_ROOT/tmp-remote-XXXXXX")"
-  git clone "$origin" "$tmp_clone" >/dev/null 2>&1
+  git clone "$origin" "$tmp_clone" > /dev/null 2>&1
   (
     cd "$tmp_clone"
     git config user.name "Weltgewebe Test"
     git config user.email "tests@weltgewebe.local"
-    git checkout "$branch" >/dev/null 2>&1 || git checkout -b "$branch" "origin/$branch" >/dev/null
+    git checkout "$branch" > /dev/null 2>&1 || git checkout -b "$branch" "origin/$branch" > /dev/null
     printf '%s\n' "remote-${RANDOM}" >> remote.txt
     git add remote.txt
-    git commit -m "chore: advance $branch" >/dev/null
-    git push origin "$branch" >/dev/null
+    git commit -m "chore: advance $branch" > /dev/null
+    git push origin "$branch" > /dev/null
   )
   rm -rf "$tmp_clone"
 }
@@ -114,7 +115,7 @@ setup_mocks() {
 
   mkdir -p "$mock_bin" "$wrapper_bin"
 
-  cat > "$mock_bin/docker" <<'EOF'
+  cat > "$mock_bin/docker" << 'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 ARGS="$*"
@@ -185,7 +186,7 @@ fi
 exit 0
 EOF
 
-  cat > "$mock_bin/curl" <<'EOF'
+  cat > "$mock_bin/curl" << 'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 ARGS="$*"
@@ -205,18 +206,18 @@ echo '{"status":"ok"}'
 exit 0
 EOF
 
-  cat > "$mock_bin/pnpm" <<'EOF'
+  cat > "$mock_bin/pnpm" << 'EOF'
 #!/usr/bin/env bash
 exit 0
 EOF
 
-  cat > "$mock_bin/getent" <<'EOF'
+  cat > "$mock_bin/getent" << 'EOF'
 #!/usr/bin/env bash
 echo "127.0.0.1 localhost"
 exit 0
 EOF
 
-  cat > "$wrapper_bin/git" <<'EOF'
+  cat > "$wrapper_bin/git" << 'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 if [[ -n "${GIT_LOG_FILE:-}" ]]; then
@@ -245,14 +246,14 @@ run_up() {
   (
     cd "$repo"
     PATH="$wrapper_bin:$mock_bin:$PATH" \
-    REAL_GIT="$REAL_GIT" \
-    GIT_LOG_FILE="$git_log_file" \
-    REPO_DIR="$repo" \
-    ENV_FILE="$repo/.env" \
-    EDGE_CA="$EDGE_CA_FIXTURE" \
-    DEPLOY_FRONTEND_MODE=off \
-    WELTGEWEBE_STATE_DIR="$repo/.ops" \
-    bash scripts/weltgewebe-up "$@"
+      REAL_GIT="$REAL_GIT" \
+      GIT_LOG_FILE="$git_log_file" \
+      REPO_DIR="$repo" \
+      ENV_FILE="$repo/.env" \
+      EDGE_CA="$EDGE_CA_FIXTURE" \
+      DEPLOY_FRONTEND_MODE=off \
+      WELTGEWEBE_STATE_DIR="$repo/.ops" \
+      bash scripts/weltgewebe-up "$@"
   )
 }
 
@@ -260,7 +261,7 @@ run_up() {
 repo_default="$(new_repo default-main)"
 (
   cd "$repo_default"
-  git checkout feat/x >/dev/null
+  git checkout feat/x > /dev/null
 )
 if ! out_default="$(run_up "$repo_default" "$WORKDIR_ROOT/default-main.git.log" 2>&1)"; then
   echo "$out_default" >&2
@@ -294,7 +295,7 @@ echo "PASS: explicit --branch works"
 repo_current="$(new_repo current-branch)"
 (
   cd "$repo_current"
-  git checkout feat/x >/dev/null
+  git checkout feat/x > /dev/null
 )
 out_current="$(run_up "$repo_current" "$WORKDIR_ROOT/current-branch.git.log" --current-branch 2>&1)" || fail "--current-branch deploy should succeed"
 assert_contains "$out_current" "Git Branch Mode: current-branch (explicit)"
@@ -349,7 +350,7 @@ echo "PASS: refs/* branch path is rejected"
 repo_dirty="$(new_repo dirty-worktree)"
 (
   cd "$repo_dirty"
-  git checkout feat/x >/dev/null
+  git checkout feat/x > /dev/null
   echo "dirty" > dirty.txt
 )
 set +e
@@ -370,8 +371,8 @@ echo "PASS: dirty worktree blocks deploy"
 repo_detached="$(new_repo detached-head)"
 (
   cd "$repo_detached"
-  git checkout feat/x >/dev/null
-  git checkout --detach HEAD >/dev/null
+  git checkout feat/x > /dev/null
+  git checkout --detach HEAD > /dev/null
 )
 out_detached="$(run_up "$repo_detached" "$WORKDIR_ROOT/detached-head.git.log" 2>&1)" || fail "detached-head deploy should succeed"
 (
@@ -389,7 +390,7 @@ echo "PASS: detached head resolves via deploy-branch contract"
 repo_no_pull="$(new_repo no-pull)"
 (
   cd "$repo_no_pull"
-  git checkout feat/x >/dev/null
+  git checkout feat/x > /dev/null
 )
 out_no_pull="$(run_up "$repo_no_pull" "$WORKDIR_ROOT/no-pull.git.log" --no-pull 2>&1)" || fail "--no-pull run should succeed"
 assert_contains "$out_no_pull" "Git mode: no-pull"
@@ -425,15 +426,15 @@ repo_nonff="$(new_repo non-ff)"
 origin_nonff="$WORKDIR_ROOT/non-ff/origin.git"
 (
   cd "$repo_nonff"
-  git checkout main >/dev/null
+  git checkout main > /dev/null
   echo "local-only" > local-diverge.txt
   git add local-diverge.txt
-  git commit -m "local diverge" >/dev/null
+  git commit -m "local diverge" > /dev/null
 )
 advance_remote_branch "$origin_nonff" main
 (
   cd "$repo_nonff"
-  git checkout feat/x >/dev/null
+  git checkout feat/x > /dev/null
 )
 set +e
 out_nonff="$(run_up "$repo_nonff" "$WORKDIR_ROOT/non-ff.git.log" 2>&1)"
@@ -448,7 +449,7 @@ echo "PASS: non-fast-forward pull aborts"
 repo_bundle="$(new_repo failure-bundle)"
 (
   cd "$repo_bundle"
-  git checkout feat/x >/dev/null
+  git checkout feat/x > /dev/null
 )
 set +e
 out_bundle="$(MOCK_FAIL_CONFIG_GUARD=1 run_up "$repo_bundle" "$WORKDIR_ROOT/failure-bundle.git.log" 2>&1)"
@@ -457,7 +458,7 @@ set -e
 [[ "$rc_bundle" -ne 0 ]] || fail "failure-bundle case must fail"
 assert_contains "$out_bundle" "ERROR: Deploy failed."
 
-latest_bundle="$(ls -1dt "$repo_bundle"/.ops/failures/* 2>/dev/null | head -n1 || true)"
+latest_bundle="$(ls -1dt "$repo_bundle"/.ops/failures/* 2> /dev/null | head -n1 || true)"
 [[ -n "$latest_bundle" ]] || fail "expected a failure bundle directory"
 
 bundle_state="$(cat "$latest_bundle/git_state.txt")"

--- a/scripts/tools/yq-pin.sh
+++ b/scripts/tools/yq-pin.sh
@@ -149,7 +149,7 @@ download_yq() {
   curl "${CURL_COMMON[@]}" "${CURL_RETRY[@]}" "${CURL_DOWNLOAD[@]}" "${CURL_FAIL[@]}" "${url_base}/${asset}" -o "${asset_path}"
 
   # Try individual sha256 first, then 'checksums'
-  if ! curl "${CURL_COMMON[@]}" "${CURL_RETRY[@]}" "${CURL_DOWNLOAD[@]}" "${CURL_FAIL[@]}" "${url_base}/${asset}.sha256" -o "${sha_path}" 2>/dev/null; then
+  if ! curl "${CURL_COMMON[@]}" "${CURL_RETRY[@]}" "${CURL_DOWNLOAD[@]}" "${CURL_FAIL[@]}" "${url_base}/${asset}.sha256" -o "${sha_path}" 2> /dev/null; then
     echo "Individual sha256 not found, trying 'checksums'..." >&2
     if ! curl "${CURL_COMMON[@]}" "${CURL_RETRY[@]}" "${CURL_DOWNLOAD[@]}" "${CURL_FAIL[@]}" "${url_base}/checksums" -o "${sha_path}"; then
       echo "checksums file not found at ${url_base}/checksums" >&2

--- a/scripts/wgx-metrics-snapshot.sh
+++ b/scripts/wgx-metrics-snapshot.sh
@@ -50,7 +50,7 @@ updates_pkg=${UPDATES_PKG:-0}
 updates_flatpak=${UPDATES_FLATPAK:-0}
 age_days=${BACKUP_AGE_DAYS:-1}
 [[ "$age_days" =~ ^[0-9]+$ ]] || age_days=1
-if date -d "yesterday" +%F >/dev/null 2>&1; then
+if date -d "yesterday" +%F > /dev/null 2>&1; then
   # GNU date
   last_ok=$(date -d "${age_days} day ago" +%F)
 else

--- a/tools/drill-smoke.sh
+++ b/tools/drill-smoke.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 printf "[drill] Starting disaster recovery smoke sequence...\n"
 
 # Placeholder: ensure core services are up
-if ! docker compose -f infra/compose/compose.core.yml ps >/dev/null 2>&1; then
+if ! docker compose -f infra/compose/compose.core.yml ps > /dev/null 2>&1; then
   printf "[drill] Hinweis: Compose-Stack scheint nicht zu laufen. Bitte zuerst 'just up' ausführen.\n"
   exit 1
 fi
@@ -17,7 +17,7 @@ printf "[drill] Running smoke tests on API endpoints...\n"
 API_BASE="${API_BASE:-http://localhost:8081}"
 
 # Test /api/nodes (Proxy strips /api -> API receives /nodes)
-if curl -fsS "${API_BASE}/api/nodes?limit=1" >/dev/null; then
+if curl -fsS "${API_BASE}/api/nodes?limit=1" > /dev/null; then
   printf "  [ok] GET /api/nodes\n"
 else
   printf "  [fail] GET /api/nodes - Check if API is running and routing is correct.\n"
@@ -25,7 +25,7 @@ else
 fi
 
 # Test /api/edges
-if curl -fsS "${API_BASE}/api/edges?limit=1" >/dev/null; then
+if curl -fsS "${API_BASE}/api/edges?limit=1" > /dev/null; then
   printf "  [ok] GET /api/edges\n"
 else
   printf "  [fail] GET /api/edges\n"


### PR DESCRIPTION
## Summary
- Normalize repository shell scripts with the configured shfmt style.
- Resolve repository shellcheck findings so `just lint` passes again.
- Add narrow shellcheck directives in test scripts for existing test-only patterns that are intentionally tolerated.

## Evidence
- `just lint` passed
- `python3 - <<'PY' ... pytest.main(['-q']) ... PY` passed: 1001 tests
- `/home/alex/.cargo/bin/cargo fmt --all -- --check` passed
- `/home/alex/.cargo/bin/cargo check --locked --workspace --all-targets` passed
- `/home/alex/.cargo/bin/cargo test --locked --workspace --all-targets --no-run` passed
- `bash scripts/tests/test_runtime_contract.sh` passed

## Notes
- `cargo clippy` was not re-run after the shell-only patch because the tool channel blocked that invocation; no Rust source changed, and `cargo check` plus `cargo test --no-run` passed.
- The broader `test_weltgewebe_up_git_branch.sh` was probed and failed in its fixture Git setup while pulling `origin/main`; this appears unrelated to this shell-lint patch and remains a visible pre-existing test-environment gap.
- Operator-Lab-Run: not applicable — mechanical shell lint repair, no new operator/agent behavior claim.
