### PR TITLE
fix: remove defunct seed recipe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,8 @@
 NODE_ENV=development
 RUST_LOG=info
 
-# Web application
-WEB_PORT=5173
+# Web application: Der Vite-Dev-Server läuft auf Port 5173
+# (Konfiguration in apps/web, kein Env-Schalter).
 
 # API service
 API_BIND=0.0.0.0:8080

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ change.
 | Layer | Technology |
 |---|---|
 | Frontend | SvelteKit 2 / Svelte 5 (TypeScript, static adapter) |
-| Backend | Rust / Axum 0.7 (async, tokio) |
+| Backend | Rust / Axum 0.8 (async, tokio) |
 | Database | PostgreSQL 16 + PgBouncer 1.20 |
 | Messaging | NATS JetStream (optional, Gate C) |
 | Proxy | Caddy |
@@ -129,7 +129,6 @@ just check           # Hygiene: fmt + clippy + test + contracts + cargo-deny
 just lint            # Lint shell scripts (bash -n, shfmt, shellcheck)
 just db-wait         # Wait for Postgres readiness
 just db-migrate      # Run database migrations
-just seed            # Seed initial data
 just contracts-domain-check  # Validate JSON Schema contracts
 just demo-data       # Generate demo data (if not present)
 just serve-demo      # Start demo API server (PORT=8080 default)
@@ -180,7 +179,6 @@ Copy `.env.example` to `.env` for local development. Key variables:
 ```bash
 NODE_ENV=development
 RUST_LOG=info
-WEB_PORT=5173
 API_BIND=0.0.0.0:8080
 AUTH_DEV_LOGIN=0
 AUTH_COOKIE_SECURE=1

--- a/Justfile
+++ b/Justfile
@@ -98,9 +98,9 @@ proof-auth-session-sqlx-direct:    # run ignored SQLx direct-Postgres session CR
 	fi
 	DATABASE_URL="${PG_DIRECT_URL}" PG_DIRECT_URL="${PG_DIRECT_URL}" cargo test --locked -p weltgewebe-api --test sqlx_postgres_direct_session_crud -- --include-ignored
 
-seed:          # seed database with initial data
-	cargo run -p api -- seed
-
+# Hinweis: Ein API-seitiger `seed`-Subcommand existiert nicht.
+# Für Demo-Daten: `just demo-data`; für den ersten echten Account:
+# `just bootstrap-first-account` (siehe Abschnitt "Real seed" unten).
 # Lokaler Helper: Schnelltests & Linter – sicher mit Null-Trennung und Quoting
 lint:
 	@set -euo pipefail; \


### PR DESCRIPTION
## Summary
- Remove the defunct `just seed` recipe that pointed at a non-existent API package/subcommand.
- Align CLAUDE.md with the actual backend stack and supported data-bootstrap commands.
- Replace the unused `.env.example` `WEB_PORT` knob with a note that the Vite dev server port is configured in `apps/web`.

## Evidence
- `just --list` succeeds and no longer lists `seed`.
- `just lint` passes.
- `make validate-core` passes.
- Stale-reference scan found no remaining `just seed`, `WEB_PORT=5173`, or `Axum 0.7` entries in the checked root/docs entry points.

## Scope
No app logic, migrations, generated docs, or lockfiles changed.

Operator-Lab-Run: not applicable — small repo hygiene fix, no new operator/agent behavior claim.
