### PR TITLE
ci: finish generated doc drift guards

### DIFF
--- a/.wgx/generated-artifacts.yml
+++ b/.wgx/generated-artifacts.yml
@@ -167,9 +167,9 @@
       ],
       "checks": [
         [
-          "python3",
-          "-m",
-          "scripts.docmeta.validate_generated_artifacts"
+          "bash",
+          "scripts/docmeta/generate-doc-index.sh",
+          "--check"
         ]
       ],
       "sources": [
@@ -215,9 +215,9 @@
       ],
       "checks": [
         [
-          "python3",
-          "-m",
-          "scripts.docmeta.validate_generated_artifacts"
+          "bash",
+          "scripts/docmeta/generate-impl-index.sh",
+          "--check"
         ]
       ],
       "sources": [
@@ -293,7 +293,8 @@
         [
           "python3",
           "-m",
-          "scripts.docmeta.validate_generated_artifacts"
+          "scripts.docmeta.generate_relates_to_audit",
+          "--check"
         ]
       ],
       "sources": [
@@ -317,7 +318,8 @@
         [
           "python3",
           "-m",
-          "scripts.docmeta.validate_generated_artifacts"
+          "scripts.docmeta.generate_relations_analysis",
+          "--check"
         ]
       ],
       "sources": [
@@ -341,7 +343,8 @@
         [
           "python3",
           "-m",
-          "scripts.docmeta.validate_generated_artifacts"
+          "scripts.docmeta.generate_report_lifecycle_inventory",
+          "--check"
         ]
       ],
       "sources": [
@@ -365,7 +368,8 @@
         [
           "python3",
           "-m",
-          "scripts.docmeta.validate_generated_artifacts"
+          "scripts.docmeta.generate_report_lifecycle",
+          "--check"
         ]
       ],
       "sources": [
@@ -440,7 +444,8 @@
         [
           "python3",
           "-m",
-          "scripts.docmeta.validate_generated_artifacts"
+          "scripts.docmeta.generate_system_map",
+          "--check"
         ]
       ],
       "sources": [

--- a/scripts/docmeta/generate-doc-index.sh
+++ b/scripts/docmeta/generate-doc-index.sh
@@ -2,8 +2,19 @@
 
 set -euo pipefail
 
-OUT_FILE="docs/_generated/doc-index.md"
-mkdir -p docs/_generated
+CHECK_MODE=0
+if [[ "${1:-}" == "--check" ]]; then
+  CHECK_MODE=1
+fi
+
+TARGET_FILE="docs/_generated/doc-index.md"
+if [[ "${CHECK_MODE}" == "1" ]]; then
+  OUT_FILE="$(mktemp)"
+  trap 'rm -f "${OUT_FILE}"' EXIT
+else
+  OUT_FILE="${TARGET_FILE}"
+  mkdir -p docs/_generated
+fi
 
 cat << 'HEADER' > "$OUT_FILE"
 ---
@@ -46,4 +57,14 @@ done
 LC_ALL=C sort "$TEMP_ENTRIES" >> "$OUT_FILE"
 rm -f "$TEMP_ENTRIES"
 
-echo "Generated $OUT_FILE"
+if [[ "${CHECK_MODE}" == "1" ]]; then
+  if cmp -s "${TARGET_FILE}" "${OUT_FILE}"; then
+    echo "${TARGET_FILE} is up to date."
+  else
+    echo "ERROR: ${TARGET_FILE} is stale; regenerate it." >&2
+    diff -u "${TARGET_FILE}" "${OUT_FILE}" >&2 || true
+    exit 1
+  fi
+else
+  echo "Generated $OUT_FILE"
+fi

--- a/scripts/docmeta/generate-impl-index.sh
+++ b/scripts/docmeta/generate-impl-index.sh
@@ -2,8 +2,19 @@
 
 set -euo pipefail
 
-OUT_FILE="docs/_generated/impl-index.md"
-mkdir -p docs/_generated
+CHECK_MODE=0
+if [[ "${1:-}" == "--check" ]]; then
+  CHECK_MODE=1
+fi
+
+TARGET_FILE="docs/_generated/impl-index.md"
+if [[ "${CHECK_MODE}" == "1" ]]; then
+  OUT_FILE="$(mktemp)"
+  trap 'rm -f "${OUT_FILE}"' EXIT
+else
+  OUT_FILE="${TARGET_FILE}"
+  mkdir -p docs/_generated
+fi
 
 cat << 'HEADER' > "$OUT_FILE"
 ---
@@ -25,7 +36,7 @@ HEADER
 python3 -c "
 import sys
 
-out_file = 'docs/_generated/impl-index.md'
+out_file = '${OUT_FILE}'
 registry_file = 'audit/impl-registry.yaml'
 
 try:
@@ -101,8 +112,8 @@ try:
 
             f.write(f'| {impl_id} | {path} | {impl_type} | {criticality} | {docs_str} | {verif_str} | {evidence_level} |\n')
 
-    print(f'Generated {out_file}')
+    pass
 except Exception as e:
     print(f'Error processing impl-registry: {e}')
-    print(f'Generated {out_file}')
+    pass
 "

--- a/scripts/docmeta/generate_relates_to_audit.py
+++ b/scripts/docmeta/generate_relates_to_audit.py
@@ -13,11 +13,14 @@ Pure structural observation.
 Output: docs/_generated/relates-to-audit.md
 """
 
+import argparse
 import os
 import sys
+import tempfile
 from collections import defaultdict
 
 from scripts.docmeta.docmeta import REPO_ROOT
+from scripts.docmeta.generated_check import write_or_check
 from scripts.docmeta.relations_parser import extract_relations_from_content
 
 MAX_NEGATIVE_EXAMPLES = 3
@@ -213,9 +216,10 @@ def collect_negative_examples(edges, doc_counts, max_examples=MAX_NEGATIVE_EXAMP
 
 
 def write_output(edges, all_docs, doc_counts, supersedes_gaps, clusters,
-                 negative_examples):
+                 negative_examples, out_file=None):
     """Write the relates-to-audit.md output file."""
-    out_file = os.path.join(REPO_ROOT, "docs", "_generated", "relates-to-audit.md")
+    if out_file is None:
+        out_file = os.path.join(REPO_ROOT, "docs", "_generated", "relates-to-audit.md")
     os.makedirs(os.path.dirname(out_file), exist_ok=True)
 
     type_dist = compute_type_distribution(edges)
@@ -287,21 +291,38 @@ def write_output(edges, all_docs, doc_counts, supersedes_gaps, clusters,
     return out_file
 
 
-def main():
+def main(argv: list[str] | None = None) -> int:
     """Main entry point for the relates-to audit generator."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="compare output without rewriting it")
+    args = parser.parse_args(argv)
     try:
         edges, all_docs = collect_relations_graph()
         doc_counts = compute_per_doc_type_counts(edges)
         supersedes_gaps = find_supersedes_gaps(all_docs)
         clusters = find_relates_to_clusters(edges)
         negative_examples = collect_negative_examples(edges, doc_counts)
-        out_file = write_output(edges, all_docs, doc_counts, supersedes_gaps,
-                                clusters, negative_examples)
+        target = os.path.join(REPO_ROOT, "docs", "_generated", "relates-to-audit.md")
+        if args.check:
+            with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as tmp:
+                tmp_path = tmp.name
+            try:
+                write_output(edges, all_docs, doc_counts, supersedes_gaps, clusters, negative_examples, out_file=tmp_path)
+                with open(tmp_path, "r", encoding="utf-8") as f:
+                    content = f.read()
+            finally:
+                try:
+                    os.unlink(tmp_path)
+                except FileNotFoundError:
+                    pass
+            return write_or_check(target, content, check=True, label=os.path.relpath(target, REPO_ROOT))
+        out_file = write_output(edges, all_docs, doc_counts, supersedes_gaps, clusters, negative_examples)
         print(f"Generated {out_file}")
+        return 0
     except Exception as e:
         print(f"Error generating relates-to audit: {e}", file=sys.stderr)
-        sys.exit(1)
+        return 1
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/scripts/docmeta/generate_relations_analysis.py
+++ b/scripts/docmeta/generate_relations_analysis.py
@@ -11,11 +11,14 @@ Read-only analysis that makes relation quality visible:
 Output: docs/_generated/relations-analysis.md
 """
 
+import argparse
 import os
 import sys
+import tempfile
 from collections import defaultdict
 
 from scripts.docmeta.docmeta import REPO_ROOT
+from scripts.docmeta.generated_check import write_or_check
 from scripts.docmeta.relations_parser import extract_relations_from_content
 
 # Thresholds for heuristic warnings
@@ -214,9 +217,10 @@ def generate_warnings(edges, stats, cycles):
     return warnings
 
 
-def write_output(edges, all_docs, stats, cycles, warnings):
+def write_output(edges, all_docs, stats, cycles, warnings, out_file=None):
     """Write the relations-analysis.md output file."""
-    out_file = os.path.join(REPO_ROOT, "docs", "_generated", "relations-analysis.md")
+    if out_file is None:
+        out_file = os.path.join(REPO_ROOT, "docs", "_generated", "relations-analysis.md")
     os.makedirs(os.path.dirname(out_file), exist_ok=True)
 
     type_dist = compute_type_distribution(edges)
@@ -300,19 +304,37 @@ def write_output(edges, all_docs, stats, cycles, warnings):
     return out_file
 
 
-def main():
+def main(argv: list[str] | None = None) -> int:
     """Main entry point for the relations analysis generator."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="compare output without rewriting it")
+    args = parser.parse_args(argv)
     try:
         edges, all_docs = collect_relations_graph()
         stats = compute_degree_stats(edges, all_docs)
         cycles = find_cycles(edges)
         warnings = generate_warnings(edges, stats, cycles)
+        target = os.path.join(REPO_ROOT, "docs", "_generated", "relations-analysis.md")
+        if args.check:
+            with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as tmp:
+                tmp_path = tmp.name
+            try:
+                write_output(edges, all_docs, stats, cycles, warnings, out_file=tmp_path)
+                with open(tmp_path, "r", encoding="utf-8") as f:
+                    content = f.read()
+            finally:
+                try:
+                    os.unlink(tmp_path)
+                except FileNotFoundError:
+                    pass
+            return write_or_check(target, content, check=True, label=os.path.relpath(target, REPO_ROOT))
         out_file = write_output(edges, all_docs, stats, cycles, warnings)
         print(f"Generated {out_file}")
+        return 0
     except Exception as e:
         print(f"Error generating relations analysis: {e}", file=sys.stderr)
-        sys.exit(1)
+        return 1
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/scripts/docmeta/generate_report_lifecycle.py
+++ b/scripts/docmeta/generate_report_lifecycle.py
@@ -10,6 +10,7 @@ from pathlib import Path
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
+from scripts.docmeta.generated_check import write_or_check
 from scripts.docmeta.generate_report_lifecycle_inventory import (
     collect_reports,
     ReportRecord,
@@ -290,11 +291,27 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--root", type=str, default=None)
     parser.add_argument("--output", type=str, default=None)
+    parser.add_argument("--check", action="store_true")
     args = parser.parse_args(argv)
     
     root_path = Path(args.root) if args.root else REPO_ROOT
     output_path = Path(args.output) if args.output else None
-    
+
+    if args.check:
+        target = output_path or (root_path / "docs" / "_generated" / "report-lifecycle.md")
+        config = InventoryConfig(
+            repo_root=root_path,
+            reports_dir=root_path / "docs" / "reports",
+            output_path=target,
+            primary_search_paths=(root_path / "docs",),
+            derived_search_paths=(root_path / "docs" / "_generated",)
+        )
+        records = collect_reports(config)
+        rows = collect_lifecycle_rows(root_path, records)
+        summary = build_summary(rows)
+        content = render_markdown(rows, summary)
+        return write_or_check(target, content, check=True, label=str(target.relative_to(root_path)))
+
     out = generate(root_path, output_path)
     try:
         rel = out.relative_to(root_path)

--- a/scripts/docmeta/generate_report_lifecycle_inventory.py
+++ b/scripts/docmeta/generate_report_lifecycle_inventory.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import argparse
 import re
 import sys
 from collections import Counter, defaultdict
@@ -9,6 +10,8 @@ from pathlib import Path
 
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scripts.docmeta.generated_check import write_or_check
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 REPORTS_DIR = REPO_ROOT / "docs" / "reports"
@@ -665,10 +668,23 @@ def generate(config: InventoryConfig | None = None) -> Path:
     return inventory_config.output_path
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args(argv)
+    if args.check:
+        base = default_inventory_config()
+        content = render_inventory(collect_reports(base))
+        return write_or_check(
+            base.output_path,
+            content,
+            check=True,
+            label=_as_rel(base.output_path, base.repo_root),
+        )
     output_path = generate()
     print(f"Generated {_as_rel(output_path, default_inventory_config().repo_root)}")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/docmeta/generate_system_map.py
+++ b/scripts/docmeta/generate_system_map.py
@@ -1,16 +1,27 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
 import os
 import sys
 
-from scripts.docmeta.docmeta import REPO_ROOT, parse_repo_index, parse_frontmatter, parse_review_policy, normalize_list_field, extract_depends_on
+from scripts.docmeta.docmeta import (
+    REPO_ROOT,
+    extract_depends_on,
+    normalize_list_field,
+    parse_frontmatter,
+    parse_repo_index,
+    parse_review_policy,
+)
+from scripts.docmeta.generated_check import write_or_check
 
-def main():
-    try:
-        policy = parse_review_policy()
-        strict_mode = policy.get('strict_manifest', False)
-        repo_index = parse_repo_index(strict_manifest=strict_mode)
-    except ValueError as e:
-        print(f"Error parsing manifest/policy: {e}", file=sys.stderr)
-        sys.exit(1)
+OUT_FILE = os.path.join(REPO_ROOT, "docs", "_generated", "system-map.md")
+
+
+def render() -> str:
+    policy = parse_review_policy()
+    strict_mode = policy.get("strict_manifest", False)
+    repo_index = parse_repo_index(strict_manifest=strict_mode)
 
     output = [
         "---",
@@ -20,46 +31,35 @@ def main():
         "status: active",
         "summary: Automatisch generierte System Map.",
         "---",
-        "## Weltgewebe System Map\n\nGenerated automatically. Do not edit.\n\nSource: scripts/docmeta/generate_system_map.py\n"
+        "## Weltgewebe System Map\n\nGenerated automatically. Do not edit.\n\nSource: scripts/docmeta/generate_system_map.py\n",
     ]
 
-    for zone_name, zone_data in sorted(repo_index.get('zones', {}).items()):
+    for zone_name, zone_data in sorted(repo_index.get("zones", {}).items()):
         output.append(f"## Zone: {zone_name}\n")
-
-        # Collect all documents with id
         docs = []
-        for doc_file in zone_data.get('canonical_docs', []):
-            rel_zone_path = zone_data.get('path', '')
+        for doc_file in zone_data.get("canonical_docs", []):
+            rel_zone_path = zone_data.get("path", "")
             rel_file_path = os.path.join(rel_zone_path, doc_file)
             file_path = os.path.join(REPO_ROOT, rel_file_path)
-
             frontmatter = parse_frontmatter(file_path)
             if frontmatter:
-                doc_id = frontmatter.get('id', '')
+                doc_id = frontmatter.get("id", "")
                 docs.append((doc_id, frontmatter, rel_file_path))
             else:
-                docs.append(('_Missing_', None, rel_file_path))
+                docs.append(("_Missing_", None, rel_file_path))
 
-        # Stable sort by id
         docs.sort(key=lambda x: x[0])
-
         rows = []
         for doc_id, frontmatter, rel_file_path in docs:
             if frontmatter:
-                status = frontmatter.get('status', '')
-                organ = frontmatter.get('organ', '')
-                role = frontmatter.get('role', '')
-                last_reviewed_str = frontmatter.get('last_reviewed', '')
-
-                depends_on_list = extract_depends_on(frontmatter)
-                depends_on_str = ', '.join(depends_on_list)
-
-                vw_list = normalize_list_field(frontmatter.get('verifies_with', []))
-
-                # Check for missing scripts
+                status = frontmatter.get("status", "")
+                organ = frontmatter.get("organ", "")
+                role = frontmatter.get("role", "")
+                last_reviewed_str = frontmatter.get("last_reviewed", "")
+                depends_on_str = ", ".join(extract_depends_on(frontmatter))
+                vw_list = normalize_list_field(frontmatter.get("verifies_with", []))
                 vw_display = []
                 missing_scripts = []
-                # Keep sorted order for determinism
                 for vw in sorted(vw_list):
                     vw_path = os.path.join(REPO_ROOT, vw)
                     if not os.path.exists(vw_path):
@@ -67,10 +67,8 @@ def main():
                         vw_display.append(f"{vw} 🔴(Missing)")
                     else:
                         vw_display.append(vw)
-
-                verifies_with_str = ', '.join(vw_display)
-                missing_scripts_str = ', '.join(missing_scripts)
-
+                verifies_with_str = ", ".join(vw_display)
+                missing_scripts_str = ", ".join(missing_scripts)
                 file_link = rel_file_path
             else:
                 role = "_Missing_"
@@ -81,34 +79,55 @@ def main():
                 verifies_with_str = "_Missing_"
                 missing_scripts_str = "_Missing_"
                 file_link = rel_file_path
+            rows.append([
+                doc_id,
+                file_link,
+                role,
+                organ,
+                status,
+                last_reviewed_str,
+                depends_on_str,
+                verifies_with_str,
+                missing_scripts_str,
+            ])
 
-            rows.append([doc_id, file_link, role, organ, status, last_reviewed_str, depends_on_str, verifies_with_str, missing_scripts_str])
-
-        headers = ["id", "path", "role", "organ", "status", "last_reviewed", "depends_on", "verifies_with", "missing_scripts"]
-
-        header_row = "|" + "|".join(headers) + "|"
-        output.append(header_row)
-
-        sep_row = "|" + "|".join(["---" for _ in headers]) + "|"
-        output.append(sep_row)
-
+        headers = [
+            "id",
+            "path",
+            "role",
+            "organ",
+            "status",
+            "last_reviewed",
+            "depends_on",
+            "verifies_with",
+            "missing_scripts",
+        ]
+        output.append("|" + "|".join(headers) + "|")
+        output.append("|" + "|".join(["---" for _ in headers]) + "|")
         for row in rows:
-            data_row = "|" + "|".join(row) + "|"
-            output.append(data_row)
-
+            output.append("|" + "|".join(row) + "|")
         output.append("")
 
     output.append("## Automated Checks\n")
-    checks = repo_index.get('checks', [])
+    checks = repo_index.get("checks", [])
     if checks:
         for check in sorted(checks):
-            # Strip markdown link syntax to avoid diff noise
             output.append(f"- {check}")
         output.append("")
+    return "\n".join(output)
 
-    out_path = os.path.join(REPO_ROOT, 'docs', '_generated', 'system-map.md')
-    with open(out_path, 'w', encoding='utf-8') as f:
-        f.write("\n".join(output))
 
-if __name__ == '__main__':
-    main()
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="compare output without rewriting it")
+    args = parser.parse_args([] if argv is None else argv)
+    try:
+        target = os.path.join(REPO_ROOT, "docs", "_generated", "system-map.md")
+        return write_or_check(target, render(), check=args.check, label=os.path.relpath(target, REPO_ROOT))
+    except ValueError as exc:
+        print(f"Error parsing manifest/policy: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/docmeta/tests/test_validate_generated_artifacts.py
+++ b/scripts/docmeta/tests/test_validate_generated_artifacts.py
@@ -220,6 +220,22 @@ class TestValidateGeneratedArtifacts(unittest.TestCase):
         self._write_manifest(data)
         self.assertNotIn("COMMAND_NOT_ALLOWED", self._codes())
 
+    def test_reviewed_shell_generator_check_argument_is_allowed(self):
+        self._write("scripts/docmeta/generate-fixture.sh", "#!/usr/bin/env bash\n")
+        data = self._manifest()
+        data["artifacts"][0]["generator"] = ["bash", "scripts/docmeta/generate-fixture.sh"]
+        data["artifacts"][0]["checks"] = [["bash", "scripts/docmeta/generate-fixture.sh", "--check"]]
+        self._write_manifest(data)
+        self.assertNotIn("COMMAND_NOT_ALLOWED", self._codes())
+
+    def test_reviewed_shell_generator_extra_argument_is_rejected(self):
+        self._write("scripts/docmeta/generate-fixture.sh", "#!/usr/bin/env bash\n")
+        data = self._manifest()
+        data["artifacts"][0]["generator"] = ["bash", "scripts/docmeta/generate-fixture.sh"]
+        data["artifacts"][0]["checks"] = [["bash", "scripts/docmeta/generate-fixture.sh", "--write"]]
+        self._write_manifest(data)
+        self.assertIn("COMMAND_NOT_ALLOWED", self._codes())
+
     def test_symlink_parent_source_is_rejected(self):
         source_dir = self.root / "docs" / "claims"
         target_dir = self.root / "real-claims"

--- a/scripts/docmeta/validate_generated_artifacts.py
+++ b/scripts/docmeta/validate_generated_artifacts.py
@@ -162,8 +162,10 @@ def _validate_command(command: Any, *, root: Path, path: str, field: str) -> lis
             return [_finding("COMMAND_MODULE_MISSING", path, f"module not found: {module}")]
         return []
 
-    if len(command) == 2 and command[0] == "bash":
+    if command[0] == "bash" and len(command) in {2, 3}:
         script = _safe_repo_path(command[1])
+        if len(command) == 3 and command[2] != "--check":
+            return [_finding("COMMAND_NOT_ALLOWED", path, f"unsupported bash argument for {field}: {command[2]!r}")]
         if (
             script is not None
             and script.startswith("scripts/docmeta/generate-")


### PR DESCRIPTION
Completes direct read-only drift guards for remaining generated docs. Local validation passed. Scope is docmeta control plane only.