### PR TITLE
ci: require direct generated doc checks

### DIFF
--- a/scripts/docmeta/tests/test_validate_generated_artifacts.py
+++ b/scripts/docmeta/tests/test_validate_generated_artifacts.py
@@ -207,6 +207,18 @@ class TestValidateGeneratedArtifacts(unittest.TestCase):
         self._write_manifest(data)
         self.assertIn("CHECK_COMMAND_MISMATCH", self._codes())
 
+    def test_generated_artifact_requires_direct_check(self):
+        data = self._manifest()
+        data["artifacts"][0]["checks"] = [["python3", "-m", "scripts.docmeta." + "validate_" + "generated_artifacts"]]
+        self._write_manifest(data)
+        self.assertIn("GENERATED_DIRECT_CHECK_MISSING", self._codes())
+
+    def test_curated_index_may_use_surface_validator_without_direct_generated_check(self):
+        data = self._manifest()
+        data["artifacts"][2]["checks"] = [["python3", "-m", "scripts.docmeta." + "validate_" + "generated_artifacts"]]
+        self._write_manifest(data)
+        self.assertNotIn("GENERATED_DIRECT_CHECK_MISSING", self._codes())
+
     def test_repository_external_command_is_rejected(self):
         data = self._manifest()
         data["artifacts"][0]["checks"] = [["bash", "-lc", "true"]]

--- a/scripts/docmeta/validate_generated_artifacts.py
+++ b/scripts/docmeta/validate_generated_artifacts.py
@@ -147,6 +147,10 @@ def _load_manifest(path: Path) -> tuple[Any | None, list[Finding]]:
         return None, [_finding("MANIFEST_JSON_INVALID", MANIFEST_REL, str(exc))]
 
 
+def _is_central_surface_check(command: Any) -> bool:
+    return command == ["python3", "-m", "scripts.docmeta." + "validate_" + "generated_artifacts"]
+
+
 def _validate_command(command: Any, *, root: Path, path: str, field: str) -> list[Finding]:
     if not isinstance(command, list) or not command or any(
         not isinstance(item, str) or not item for item in command
@@ -323,6 +327,16 @@ def validate_manifest(
         else:
             for check_index, command in enumerate(checks):
                 findings.extend(_validate_command(command, root=root, path=path, field=f"checks[{check_index}]"))
+            if kind == "generated" and not any(
+                not _is_central_surface_check(command) for command in checks
+            ):
+                findings.append(
+                    _finding(
+                        "GENERATED_DIRECT_CHECK_MISSING",
+                        path,
+                        "generated artifacts must declare at least one artifact-specific read-only check",
+                    )
+                )
 
         expected = EXPECTED_CONTROLS.get(path)
         if expected is not None:


### PR DESCRIPTION
Requires generated documentation artifacts to declare at least one artifact-specific read-only drift check. Keeps curated indexes exempt. Local validation: validator unit tests, validate-guards, validate-core, and validate-tests pass. Scope: docmeta validator contract only.