### PR TITLE
fix: make VPS HTTP smoke host-aware

### DIFF
--- a/docs/deploy/vps-http-smoke.md
+++ b/docs/deploy/vps-http-smoke.md
@@ -26,6 +26,8 @@ The VPS target keeps `infra/caddy/Caddyfile.vps` as the production default. For 
 
 The smoke file intentionally exposes only an HTTP listener and contains no TLS site blocks. This keeps the first
 pre-cutover test away from automatic certificate issuance while still allowing local Host-header checks through Caddy.
+It uses an explicit `http://weltgewebe.net` site address so the static CSP preflight validates the same host target
+as the VPS deploy wrapper without enabling automatic HTTPS.
 
 ## Scope
 

--- a/infra/caddy/Caddyfile.http-smoke
+++ b/infra/caddy/Caddyfile.http-smoke
@@ -1,7 +1,8 @@
 # DNS-free HTTP-only smoke configuration.
-# No TLS site blocks. Pre-cutover Host-header smoke only.
+# Explicit http:// host block keeps automatic HTTPS/ACME off.
+# Pre-cutover Host-header smoke only.
 
-:80 {
+http://weltgewebe.net {
 	handle /health/proxy {
 		respond 200
 	}

--- a/scripts/ci/tests/test_vps_http_smoke_csp_contract.py
+++ b/scripts/ci/tests/test_vps_http_smoke_csp_contract.py
@@ -1,0 +1,54 @@
+"""Coverage for the VPS HTTP smoke Caddy preflight contract."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+
+class VpsHttpSmokeCspContractTest(unittest.TestCase):
+    def test_vps_http_smoke_caddyfile_matches_static_csp_guard_target(self) -> None:
+        repo = pathlib.Path(__file__).resolve().parents[3]
+        guard = repo / "scripts" / "preflight" / "csp_contract_static.sh"
+        smoke_caddyfile = repo / "infra" / "caddy" / "Caddyfile.http-smoke"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            build_dir = root / "apps" / "web" / "build"
+            build_dir.mkdir(parents=True)
+            (build_dir / "index.html").write_text(
+                '<html><head><script>console.log("inline")</script></head></html>',
+                encoding="utf-8",
+            )
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "ROOT": str(root),
+                    "REQUIRE_FRONTEND": "1",
+                    "CADDYFILE_PATH": str(smoke_caddyfile),
+                    "CADDY_TARGET_SITE": "weltgewebe.net",
+                }
+            )
+
+            result = subprocess.run(
+                ["bash", str(guard)],
+                cwd=repo,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+        self.assertEqual(
+            result.returncode,
+            0,
+            result.stdout + result.stderr,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes the VPS HTTP smoke preflight shape introduced in #1346 by changing `infra/caddy/Caddyfile.http-smoke` from a catch-all `:80` block to an explicit `http://weltgewebe.net` site block.

This keeps the smoke configuration HTTP-only while giving `scripts/preflight/csp_contract_static.sh` the same host target that `scripts/weltgewebe-up` selects for `DEPLOY_TARGET=vps` (`CADDY_TARGET_SITE=weltgewebe.net`).

Docs now state why the smoke file uses an explicit `http://` site address: host-header smoke, no automatic HTTPS/ACME, no DNS/INWX action.

## Validation

Current head: `8ab3d59ac962962d804b7a944933386e5eed71a0`

- GitHub compare: branch is 3 commits ahead of `main`, 0 behind.
- Static path review:
  - `scripts/weltgewebe-up` sets `CADDY_TARGET_SITE=weltgewebe.net` for VPS.
  - `csp_contract_static.sh` requires a matching host block when inline script exists.
  - `infra/caddy/Caddyfile.http-smoke` now contains `http://weltgewebe.net { ... }`.
- Added `scripts/ci/tests/test_vps_http_smoke_csp_contract.py`.
  - The test creates a temporary web build with an inline script.
  - It runs the real static CSP preflight script against `infra/caddy/Caddyfile.http-smoke` with the VPS target host.
- CI on current head is green:
  - CI
  - Deploy Check
  - Deploy Drift Guard
  - python-tooling
  - infra
  - docs-style
  - policies
  - CI (heavy on demand)
  - Basemap Runtime Proof
  - seo-archive

## Not performed

- No deploy.
- No DNS or INWX change.
- No secrets read or printed.
- No runtime smoke executed.

## Self-review

The Codex P3 finding about missing dedicated coverage is addressed through a Python unittest in the existing CI test discovery path instead of editing workflow YAML directly. Risk is low: the change keeps the smoke path HTTP-only, matches the existing static preflight target, and does not change production `Caddyfile.vps`. The main remaining limitation is runtime Caddy/compose validation, which belongs to the later DNS-free VPS smoke before any cutover.