### PR TITLE
docs: add migration-safe VPS runtime smoke guard

### DIFF
--- a/docs/deploy/vps-http-smoke.md
+++ b/docs/deploy/vps-http-smoke.md
@@ -13,6 +13,8 @@ relations:
     target: infra/caddy/Caddyfile.http-smoke
   - type: relates_to
     target: infra/compose/compose.vps.override.yml
+  - type: relates_to
+    target: docs/deploy/vps-migration-safe-runtime-smoke.md
 ---
 # VPS HTTP Smoke Preflight
 
@@ -53,3 +55,5 @@ After DNS cutover is explicitly approved, the production VPS Caddyfile remains t
 ## Migration-safe API startup boundary
 
 If this smoke starts the real API while database migrations are outside scope, the API must use `WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied` or the operation must stop. The rendered compose config must prove the effective value from the selected env file without printing secrets. The VPS override must not set this variable in the service `environment`, because that would override `env_file` values. This is runtime evidence, not route-only evidence.
+
+Use `docs/deploy/vps-migration-safe-runtime-smoke.md` for that separate runtime path. The redacted preflight helper is `scripts/ops/check_vps_migration_safe_runtime_env.py`; it checks only the whitelisted migration-mode key and the non-secret compose source. Do not paste raw rendered compose config or `.env` contents as evidence.

--- a/docs/deploy/vps-http-smoke.md
+++ b/docs/deploy/vps-http-smoke.md
@@ -47,13 +47,13 @@ During this preflight:
 
 - do not change DNS or INWX records
 - do not start mail or SMTP paths
-- do not print `.env` contents or secrets
+- do not print runtime configuration contents or confidential values
 - do not treat the HTTP smoke file as production configuration
 
 After DNS cutover is explicitly approved, the production VPS Caddyfile remains the canonical public HTTPS path.
 
 ## Migration-safe API startup boundary
 
-If this smoke starts the real API while database migrations are outside scope, the API must use `WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied` or the operation must stop. The rendered compose config must prove the effective value from the selected env file without printing secrets. The VPS override must not set this variable in the service `environment`, because that would override `env_file` values. This is runtime evidence, not route-only evidence.
+If this smoke starts the real API while database migrations are outside scope, the API must use `WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied` or the operation must stop. The rendered compose config must prove the effective value from the selected env source without printing confidential values. The VPS override must not set this variable in the service `environment`, because that would override `env_file` values. This is runtime evidence, not route-only evidence.
 
-Use `docs/deploy/vps-migration-safe-runtime-smoke.md` for that separate runtime path. The redacted preflight helper is `scripts/ops/check_vps_migration_safe_runtime_env.py`; it checks only the whitelisted migration-mode key and the non-secret compose source. Do not paste raw rendered compose config or `.env` contents as evidence.
+Use `docs/deploy/vps-migration-safe-runtime-smoke.md` for that separate runtime path. The redacted source-level preflight helper is `scripts/ops/check_vps_migration_safe_runtime_env.py`; it checks only the allowed migration-mode key and the non-confidential compose source. It does not replace a separately reviewed runtime receipt, and raw rendered compose config or runtime env source contents must not be pasted as evidence.

--- a/docs/deploy/vps-migration-safe-runtime-smoke.md
+++ b/docs/deploy/vps-migration-safe-runtime-smoke.md
@@ -37,7 +37,8 @@ Use this runbook only when all of the following are true:
 - the selected repo commit is explicit
 - starting the real API is necessary for the evidence
 - database migrations are outside scope
-- the selected runtime env source sets
+- the selected runtime env source resolves through `services.api.env_file`
+- the effective env source sets
   `WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied`
 - the VPS compose override does not set that variable in
   `services.api.environment`
@@ -70,13 +71,13 @@ Do not:
 - use the normal API startup mode under a no-migration boundary
 - close #1348 on config-only, route-only, or synthetic-upstream evidence
 
-The recurring mistake is to treat route shape as app readiness. That is how maps
-become territory and then, with some confidence, a small administrative bonfire.
+The recurring mistake is to treat route shape as app readiness. This runbook keeps
+those evidence classes separate.
 
-## Redacted preflight
+## Source-level preflight
 
-Before any runtime start, run the narrow env/compose boundary probe from the
-selected checkout:
+Before any runtime start, run the narrow env/compose source-boundary probe from
+the selected checkout:
 
 ```bash
 python3 scripts/ops/check_vps_migration_safe_runtime_env.py \
@@ -85,26 +86,43 @@ python3 scripts/ops/check_vps_migration_safe_runtime_env.py \
   --expected-mode verify-applied
 ```
 
-The helper checks only the whitelisted migration-mode key in the selected env
-source and the non-confidential compose source. It does not invoke Docker, start
+If the compose file relies on `WELTGEWEBE_ENV_FILE` interpolation, either export
+that variable in the operator shell or pass it explicitly without exposing
+confidential values:
+
+```bash
+python3 scripts/ops/check_vps_migration_safe_runtime_env.py \
+  --compose-source infra/compose/compose.vps.override.yml \
+  --env-file <selected-runtime-env-file> \
+  --compose-env WELTGEWEBE_ENV_FILE=<selected-runtime-env-file> \
+  --expected-mode verify-applied
+```
+
+The helper checks only the allowed migration-mode key in the effective env source
+and the non-confidential compose source. It does not invoke Docker, start
 containers, render the full compose model, or print arbitrary runtime config.
 
 Expected redacted shape:
 
 ```text
-PASS: migration-safe runtime-smoke env boundary is proven
+PASS: migration-safe runtime-smoke source boundary is proven
 - checked key: WELTGEWEBE_API_STARTUP_MIGRATIONS
 - observed mode: verify-applied
 - service-level migration override: absent
-- secrets printed: no
-- runtime started: no
+- helper printed confidential values: no
+- helper started runtime: no
 ```
 
-If the selected env source is missing the key, sets it more than once, sets a
+If the effective env source is missing the key, sets it more than once, sets a
 value other than `verify-applied`, or the API service sets the key in
 `environment`, stop.
 
 ## Compose evidence discipline
+
+The source-level helper is not a replacement for a separately reviewed runtime
+receipt. It verifies that the selected env source is bound to the compose
+`env_file` declaration and that no service-level migration-mode override is
+present in the checked compose source.
 
 The final receipt may mention that compose was rendered successfully, but it
 must not paste raw rendered config or runtime env source contents. Instead record
@@ -113,10 +131,10 @@ sanitized facts:
 - selected compose files
 - selected Caddyfile path
 - selected env source path
-- whether the redacted boundary probe passed
+- whether the source-level boundary probe passed
 - whether the API service has no service-level
   `WELTGEWEBE_API_STARTUP_MIGRATIONS` override
-- whether the selected env source sets exactly
+- whether the effective env source sets exactly
   `WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied`
 
 This deliberately orders evidence by safety. A sanitized key proof is weaker than
@@ -144,9 +162,10 @@ If a separately approved runtime smoke is performed later, the receipt must stat
 
 | Observation | Meaning | Decision |
 | --- | --- | --- |
-| Env key missing or duplicated. | Effective migration mode is ambiguous. | Stop. |
+| Env key missing or duplicated in the effective source. | Effective migration mode is ambiguous. | Stop. |
 | Env key is not `verify-applied`. | Normal startup may run SQLx migrations. | Stop. |
 | Compose service environment sets the key. | It may override the selected env source. | Stop. |
+| `--env-file` is not the effective env source for the key. | The helper would be checking the wrong file. | Stop. |
 | API refuses startup on pending, failed, extra, missing, duplicate, or checksum-mismatched migration history. | `verify-applied` did its job. | Record blocked runtime evidence; do not retry with `run`. |
 | Health checks pass under `verify-applied`. | Bounded runtime smoke passed. | Keep #1348 open until the receipt is reviewed against its full acceptance criteria. |
 | DNS/ACME/HTTPS/mail/SMTP/confidential-value work becomes necessary. | The operation left this scope. | Stop and create a new approved operation. |

--- a/docs/deploy/vps-migration-safe-runtime-smoke.md
+++ b/docs/deploy/vps-migration-safe-runtime-smoke.md
@@ -124,6 +124,10 @@ receipt. It verifies that the selected env source is bound to the compose
 `env_file` declaration and that no service-level migration-mode override is
 present in the checked compose source.
 
+The helper checks only the compose source named by `--compose-source`. If the
+runtime command uses multiple compose sources, pair this source check with a
+separate redacted effective-render review before starting the runtime smoke.
+
 The final receipt may mention that compose was rendered successfully, but it
 must not paste raw rendered config or runtime env source contents. Instead record
 sanitized facts:

--- a/docs/deploy/vps-migration-safe-runtime-smoke.md
+++ b/docs/deploy/vps-migration-safe-runtime-smoke.md
@@ -184,6 +184,8 @@ If a separately approved runtime smoke is performed later, the receipt must stat
 | --- | --- | --- |
 | Env key missing or duplicated in the effective source. | Effective migration mode is ambiguous. | Stop. |
 | Env key is not `verify-applied`. | Normal startup may run SQLx migrations. | Stop. |
+| Env key uses shell-style `export`. | Compose `env_file` syntax is intentionally restricted here. | Stop. |
+| Env source contains an unparsable line with the migration-mode key. | The effective migration mode is ambiguous. | Stop. |
 | Compose service environment sets the key. | It may override the selected env source. | Stop. |
 | Compose service uses `extends` or guard-relevant YAML merge/anchor/alias constructs. | The source probe cannot prove the effective service model without a render. | Stop. |
 | `env_file` uses unsupported interpolation. | The source probe cannot prove which env source Compose will select. | Stop. |

--- a/docs/deploy/vps-migration-safe-runtime-smoke.md
+++ b/docs/deploy/vps-migration-safe-runtime-smoke.md
@@ -102,6 +102,22 @@ The helper checks only the allowed migration-mode key in the effective env sourc
 and the non-confidential compose source. It does not invoke Docker, start
 containers, render the full compose model, or print arbitrary runtime config.
 
+The helper intentionally supports only a narrow, source-level Compose subset that
+can be proven without rendering the full model:
+
+- the checked API service must not use `extends`
+- the checked API service must not use YAML merge, anchors, or aliases to define
+  or import `environment` or `env_file`
+- `env_file` interpolation is limited to `${VAR}`, `${VAR:-default}`, and
+  `${VAR-default}`
+- required, alternative, nested, or other Compose interpolation forms must be
+  replaced by explicit simple paths or by explicit `--compose-env NAME=VALUE`
+  inputs before the preflight
+
+These are guard boundaries, not general Compose style rules. If a legitimate
+runtime command needs broader Compose features, stop and add a separately reviewed
+redacted effective-render check rather than weakening this source probe.
+
 Expected redacted shape:
 
 ```text
@@ -169,6 +185,8 @@ If a separately approved runtime smoke is performed later, the receipt must stat
 | Env key missing or duplicated in the effective source. | Effective migration mode is ambiguous. | Stop. |
 | Env key is not `verify-applied`. | Normal startup may run SQLx migrations. | Stop. |
 | Compose service environment sets the key. | It may override the selected env source. | Stop. |
+| Compose service uses `extends` or guard-relevant YAML merge/anchor/alias constructs. | The source probe cannot prove the effective service model without a render. | Stop. |
+| `env_file` uses unsupported interpolation. | The source probe cannot prove which env source Compose will select. | Stop. |
 | `--env-file` is not the effective env source for the key. | The helper would be checking the wrong file. | Stop. |
 | API refuses startup on pending, failed, extra, missing, duplicate, or checksum-mismatched migration history. | `verify-applied` did its job. | Record blocked runtime evidence; do not retry with `run`. |
 | Health checks pass under `verify-applied`. | Bounded runtime smoke passed. | Keep #1348 open until the receipt is reviewed against its full acceptance criteria. |

--- a/docs/deploy/vps-migration-safe-runtime-smoke.md
+++ b/docs/deploy/vps-migration-safe-runtime-smoke.md
@@ -1,0 +1,152 @@
+---
+id: deploy.vps-migration-safe-runtime-smoke
+title: VPS Migration-Safe Runtime Smoke
+doc_type: runbook
+status: draft
+summary: Bounded wg-prod-1 runtime smoke path that may start the real API only after proving verify-applied startup migration mode.
+relations:
+  - type: relates_to
+    target: docs/deploy/vps-http-smoke.md
+  - type: relates_to
+    target: docs/deploy/vps-http-route-smoke.md
+  - type: relates_to
+    target: docs/deploy/vps-http-route-smoke-risks.md
+  - type: relates_to
+    target: infra/compose/compose.vps.override.yml
+  - type: relates_to
+    target: scripts/ops/check_vps_migration_safe_runtime_env.py
+---
+
+# VPS Migration-Safe Runtime Smoke
+
+This runbook defines the narrow runtime evidence path after the
+`WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied` startup mode exists.
+
+It is not route-only evidence. A real API process may start only after the
+migration-mode boundary is proven. A successful run still does not prove DNS,
+INWX, ACME, HTTPS, mail, SMTP, frontend, basemap, or cutover readiness.
+
+## Decision boundary
+
+Use `docs/deploy/vps-http-route-smoke.md` when the operation proves only Caddy
+route shape and must not start the production API process.
+
+Use this runbook only when all of the following are true:
+
+- a fresh operator decision permits a bounded runtime smoke on `wg-prod-1`
+- the selected repo commit is explicit
+- starting the real API is necessary for the evidence
+- database migrations are outside scope
+- the selected runtime env source sets
+  `WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied`
+- the VPS compose override does not set that variable in
+  `services.api.environment`
+
+If any of these points is false, stop. The correct result is blocked, not an
+improvised smoke.
+
+## What this can prove
+
+A passing migration-safe runtime smoke can prove only:
+
+- the selected VPS checkout can start the API without applying SQLx migration SQL
+- `_sqlx_migrations` contains the embedded up-migration versions as successful
+  records with matching checksums
+- duplicate, failed, extra, missing, pending, or checksum-mismatched migration
+  history blocks startup
+- selected loopback Host-header health checks pass during the approved window
+
+It does not prove full schema semantics, app behavior, frontend readiness,
+public DNS, TLS, mail, SMTP, or production cutover.
+
+## Hard non-actions
+
+Do not:
+
+- publish confidential runtime values
+- paste raw rendered compose output into GitHub if it contains confidential values
+- change DNS, INWX, ACME, HTTPS, mail, SMTP, credentials, or provider state
+- run database migrations
+- use the normal API startup mode under a no-migration boundary
+- close #1348 on config-only, route-only, or synthetic-upstream evidence
+
+The recurring mistake is to treat route shape as app readiness. That is how maps
+become territory and then, with some confidence, a small administrative bonfire.
+
+## Redacted preflight
+
+Before any runtime start, run the narrow env/compose boundary probe from the
+selected checkout:
+
+```bash
+python3 scripts/ops/check_vps_migration_safe_runtime_env.py \
+  --compose-source infra/compose/compose.vps.override.yml \
+  --env-file <selected-runtime-env-file> \
+  --expected-mode verify-applied
+```
+
+The helper checks only the whitelisted migration-mode key in the selected env
+source and the non-confidential compose source. It does not invoke Docker, start
+containers, render the full compose model, or print arbitrary runtime config.
+
+Expected redacted shape:
+
+```text
+PASS: migration-safe runtime-smoke env boundary is proven
+- checked key: WELTGEWEBE_API_STARTUP_MIGRATIONS
+- observed mode: verify-applied
+- service-level migration override: absent
+- secrets printed: no
+- runtime started: no
+```
+
+If the selected env source is missing the key, sets it more than once, sets a
+value other than `verify-applied`, or the API service sets the key in
+`environment`, stop.
+
+## Compose evidence discipline
+
+The final receipt may mention that compose was rendered successfully, but it
+must not paste raw rendered config or runtime env source contents. Instead record
+sanitized facts:
+
+- selected compose files
+- selected Caddyfile path
+- selected env source path
+- whether the redacted boundary probe passed
+- whether the API service has no service-level
+  `WELTGEWEBE_API_STARTUP_MIGRATIONS` override
+- whether the selected env source sets exactly
+  `WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied`
+
+This deliberately orders evidence by safety. A sanitized key proof is weaker than
+full config publication, but full config publication may disclose confidential
+runtime values. The weaker proof is the correct one here.
+
+## Runtime receipt requirements
+
+If a separately approved runtime smoke is performed later, the receipt must state:
+
+- timestamp
+- host identity
+- selected repo commit
+- selected compose/Caddyfile/env source
+- result of `check_vps_migration_safe_runtime_env.py`
+- whether any container/API process was started
+- API startup result under `verify-applied`
+- loopback Host-header check results
+- explicit non-actions for DNS, INWX, ACME, HTTPS, confidential runtime values,
+  credentials, database migrations, mail, SMTP, and cutover
+- explicit statement that this is migration-safe runtime evidence, not
+  route-only evidence and not full production readiness
+
+## Stop table
+
+| Observation | Meaning | Decision |
+| --- | --- | --- |
+| Env key missing or duplicated. | Effective migration mode is ambiguous. | Stop. |
+| Env key is not `verify-applied`. | Normal startup may run SQLx migrations. | Stop. |
+| Compose service environment sets the key. | It may override the selected env source. | Stop. |
+| API refuses startup on pending, failed, extra, missing, duplicate, or checksum-mismatched migration history. | `verify-applied` did its job. | Record blocked runtime evidence; do not retry with `run`. |
+| Health checks pass under `verify-applied`. | Bounded runtime smoke passed. | Keep #1348 open until the receipt is reviewed against its full acceptance criteria. |
+| DNS/ACME/HTTPS/mail/SMTP/confidential-value work becomes necessary. | The operation left this scope. | Stop and create a new approved operation. |

--- a/scripts/ci/tests/test_vps_migration_safe_runtime_env.py
+++ b/scripts/ci/tests/test_vps_migration_safe_runtime_env.py
@@ -19,97 +19,165 @@ def _load_module():
 
 
 def _write(path: pathlib.Path, text: str) -> pathlib.Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(textwrap.dedent(text).lstrip(), encoding="utf-8")
     return path
 
 
+def _compose_with_env_file(
+    tmp_path: pathlib.Path,
+    env_file: pathlib.Path,
+    environment: str = "",
+) -> pathlib.Path:
+    lines = [
+        "services:",
+        "  api:",
+        "    env_file:",
+        "      - ${WELTGEWEBE_ENV_FILE:-/opt/weltgewebe/.env}",
+    ]
+    extra = textwrap.dedent(environment).strip()
+    if extra:
+        lines.extend(f"    {line}" for line in extra.splitlines())
+    return _write(tmp_path / "compose.yml", "\n".join(lines) + "\n")
+
+
 def test_accepts_verify_applied_from_selected_env_file(tmp_path: pathlib.Path) -> None:
     module = _load_module()
-    compose = _write(
-        tmp_path / "compose.yml",
-        """
-        services:
-          api:
-            env_file:
-              - ${WELTGEWEBE_ENV_FILE:-/opt/weltgewebe/.env}
-            environment:
-              APP_BASE_URL: https://weltgewebe.net
-        """,
-    )
     env_file = _write(
         tmp_path / ".env",
         """
-        DATABASE_URL=postgres://redacted-example
+        OTHER_KEY=redacted-example
         WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied
         """,
     )
+    compose = _compose_with_env_file(
+        tmp_path,
+        env_file,
+        """
+        environment:
+          APP_BASE_URL: https://weltgewebe.net
+        """,
+    )
 
-    result = module.validate_boundary(compose_source=compose, env_file=env_file)
+    result = module.validate_boundary(
+        compose_source=compose,
+        env_file=env_file,
+        compose_env={"WELTGEWEBE_ENV_FILE": str(env_file)},
+    )
 
     assert result.observed_mode == "verify-applied"
     assert result.has_env_file_hook is True
     assert result.has_service_environment_override is False
+    assert pathlib.Path(result.env_file) == env_file.resolve()
 
 
-def test_rejects_service_environment_override(tmp_path: pathlib.Path) -> None:
+def test_rejects_service_environment_override_map_syntax(tmp_path: pathlib.Path) -> None:
     module = _load_module()
-    compose = _write(
-        tmp_path / "compose.yml",
+    env_file = _write(
+        tmp_path / ".env",
+        "WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied\n",
+    )
+    compose = _compose_with_env_file(
+        tmp_path,
+        env_file,
         """
-        services:
-          api:
-            env_file:
-              - /opt/weltgewebe/.env
-            environment:
-              WELTGEWEBE_API_STARTUP_MIGRATIONS: ${WELTGEWEBE_API_STARTUP_MIGRATIONS:-run}
+        environment:
+          WELTGEWEBE_API_STARTUP_MIGRATIONS: ${WELTGEWEBE_API_STARTUP_MIGRATIONS:-run}
         """,
     )
-    env_file = _write(tmp_path / ".env", "WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied\n")
 
     try:
-        module.validate_boundary(compose_source=compose, env_file=env_file)
+        module.validate_boundary(
+            compose_source=compose,
+            env_file=env_file,
+            compose_env={"WELTGEWEBE_ENV_FILE": str(env_file)},
+        )
     except module.BoundaryCheckError as error:
         assert "override env_file" in str(error)
     else:
         raise AssertionError("service-level migration override must fail closed")
 
 
-def test_rejects_missing_selected_env_file_key(tmp_path: pathlib.Path) -> None:
+def test_rejects_service_environment_override_array_assignment(tmp_path: pathlib.Path) -> None:
     module = _load_module()
-    compose = _write(
-        tmp_path / "compose.yml",
+    env_file = _write(
+        tmp_path / ".env",
+        "WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied\n",
+    )
+    compose = _compose_with_env_file(
+        tmp_path,
+        env_file,
         """
-        services:
-          api:
-            env_file:
-              - /opt/weltgewebe/.env
-            environment:
-              APP_BASE_URL: https://weltgewebe.net
+        environment:
+          - WELTGEWEBE_API_STARTUP_MIGRATIONS=run
         """,
     )
-    env_file = _write(tmp_path / ".env", "APP_BASE_URL=https://weltgewebe.net\n")
 
     try:
-        module.validate_boundary(compose_source=compose, env_file=env_file)
+        module.validate_boundary(
+            compose_source=compose,
+            env_file=env_file,
+            compose_env={"WELTGEWEBE_ENV_FILE": str(env_file)},
+        )
     except module.BoundaryCheckError as error:
-        assert "does not set WELTGEWEBE_API_STARTUP_MIGRATIONS" in str(error)
+        assert "override env_file" in str(error)
+    else:
+        raise AssertionError("array-form migration override must fail closed")
+
+
+def test_rejects_service_environment_override_array_bare_key(tmp_path: pathlib.Path) -> None:
+    module = _load_module()
+    env_file = _write(
+        tmp_path / ".env",
+        "WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied\n",
+    )
+    compose = _compose_with_env_file(
+        tmp_path,
+        env_file,
+        """
+        environment:
+          - WELTGEWEBE_API_STARTUP_MIGRATIONS
+        """,
+    )
+
+    try:
+        module.validate_boundary(
+            compose_source=compose,
+            env_file=env_file,
+            compose_env={"WELTGEWEBE_ENV_FILE": str(env_file)},
+        )
+    except module.BoundaryCheckError as error:
+        assert "override env_file" in str(error)
+    else:
+        raise AssertionError("bare array-form migration override must fail closed")
+
+
+def test_rejects_missing_effective_env_file_key(tmp_path: pathlib.Path) -> None:
+    module = _load_module()
+    env_file = _write(tmp_path / ".env", "APP_BASE_URL=https://weltgewebe.net\n")
+    compose = _compose_with_env_file(
+        tmp_path,
+        env_file,
+        """
+        environment:
+          APP_BASE_URL: https://weltgewebe.net
+        """,
+    )
+
+    try:
+        module.validate_boundary(
+            compose_source=compose,
+            env_file=env_file,
+            compose_env={"WELTGEWEBE_ENV_FILE": str(env_file)},
+        )
+    except module.BoundaryCheckError as error:
+        assert "effective env_file set does not set WELTGEWEBE_API_STARTUP_MIGRATIONS" in str(error)
     else:
         raise AssertionError("missing migration mode must fail closed")
 
 
-def test_rejects_duplicate_selected_env_file_key(tmp_path: pathlib.Path) -> None:
+def test_rejects_duplicate_key_in_selected_env_file(tmp_path: pathlib.Path) -> None:
     module = _load_module()
-    compose = _write(
-        tmp_path / "compose.yml",
-        """
-        services:
-          api:
-            env_file:
-              - /opt/weltgewebe/.env
-            environment:
-              APP_BASE_URL: https://weltgewebe.net
-        """,
-    )
     env_file = _write(
         tmp_path / ".env",
         """
@@ -117,9 +185,14 @@ def test_rejects_duplicate_selected_env_file_key(tmp_path: pathlib.Path) -> None
         WELTGEWEBE_API_STARTUP_MIGRATIONS=run
         """,
     )
+    compose = _compose_with_env_file(tmp_path, env_file)
 
     try:
-        module.validate_boundary(compose_source=compose, env_file=env_file)
+        module.validate_boundary(
+            compose_source=compose,
+            env_file=env_file,
+            compose_env={"WELTGEWEBE_ENV_FILE": str(env_file)},
+        )
     except module.BoundaryCheckError as error:
         assert "more than once" in str(error)
     else:
@@ -128,20 +201,165 @@ def test_rejects_duplicate_selected_env_file_key(tmp_path: pathlib.Path) -> None
 
 def test_accepts_quoted_dotenv_value(tmp_path: pathlib.Path) -> None:
     module = _load_module()
-    compose = _write(
-        tmp_path / "compose.yml",
-        """
-        services:
-          api:
-            env_file:
-              - /opt/weltgewebe/.env
-        """,
-    )
     env_file = _write(
         tmp_path / ".env",
         'WELTGEWEBE_API_STARTUP_MIGRATIONS="verify-applied"\n',
     )
+    compose = _compose_with_env_file(tmp_path, env_file)
 
-    result = module.validate_boundary(compose_source=compose, env_file=env_file)
+    result = module.validate_boundary(
+        compose_source=compose,
+        env_file=env_file,
+        compose_env={"WELTGEWEBE_ENV_FILE": str(env_file)},
+    )
 
     assert result.observed_mode == "verify-applied"
+
+
+def test_accepts_colon_dotenv_value(tmp_path: pathlib.Path) -> None:
+    module = _load_module()
+    env_file = _write(
+        tmp_path / ".env",
+        "WELTGEWEBE_API_STARTUP_MIGRATIONS: verify-applied\n",
+    )
+    compose = _compose_with_env_file(tmp_path, env_file)
+
+    result = module.validate_boundary(
+        compose_source=compose,
+        env_file=env_file,
+        compose_env={"WELTGEWEBE_ENV_FILE": str(env_file)},
+    )
+
+    assert result.observed_mode == "verify-applied"
+
+
+def test_accepts_unquoted_inline_comment_after_space(tmp_path: pathlib.Path) -> None:
+    module = _load_module()
+    env_file = _write(
+        tmp_path / ".env",
+        "WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied # approved smoke\n",
+    )
+    compose = _compose_with_env_file(tmp_path, env_file)
+
+    result = module.validate_boundary(
+        compose_source=compose,
+        env_file=env_file,
+        compose_env={"WELTGEWEBE_ENV_FILE": str(env_file)},
+    )
+
+    assert result.observed_mode == "verify-applied"
+
+
+def test_does_not_treat_hash_without_space_as_inline_comment(tmp_path: pathlib.Path) -> None:
+    module = _load_module()
+    env_file = _write(
+        tmp_path / ".env",
+        "WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied#not-comment\n",
+    )
+    compose = _compose_with_env_file(tmp_path, env_file)
+
+    try:
+        module.validate_boundary(
+            compose_source=compose,
+            env_file=env_file,
+            compose_env={"WELTGEWEBE_ENV_FILE": str(env_file)},
+        )
+    except module.BoundaryCheckError as error:
+        assert "non-approved value" in str(error)
+    else:
+        raise AssertionError("hash without preceding space must not be stripped")
+
+
+def test_accepts_quoted_value_with_trailing_comment(tmp_path: pathlib.Path) -> None:
+    module = _load_module()
+    env_file = _write(
+        tmp_path / ".env",
+        'WELTGEWEBE_API_STARTUP_MIGRATIONS="verify-applied" # approved smoke\n',
+    )
+    compose = _compose_with_env_file(tmp_path, env_file)
+
+    result = module.validate_boundary(
+        compose_source=compose,
+        env_file=env_file,
+        compose_env={"WELTGEWEBE_ENV_FILE": str(env_file)},
+    )
+
+    assert result.observed_mode == "verify-applied"
+
+
+def test_rejects_env_file_that_is_not_effective_compose_source(tmp_path: pathlib.Path) -> None:
+    module = _load_module()
+    checked_env = _write(
+        tmp_path / "checked.env",
+        "WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied\n",
+    )
+    effective_env = _write(
+        tmp_path / "effective.env",
+        "WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied\n",
+    )
+    compose = _write(
+        tmp_path / "compose.yml",
+        f"""
+        services:
+          api:
+            env_file:
+              - {effective_env}
+        """,
+    )
+
+    try:
+        module.validate_boundary(compose_source=compose, env_file=checked_env)
+    except module.BoundaryCheckError as error:
+        assert "not the effective env_file source" in str(error)
+    else:
+        raise AssertionError("checked env file must be bound to compose env_file source")
+
+
+def test_multiple_env_files_later_value_wins(tmp_path: pathlib.Path) -> None:
+    module = _load_module()
+    base_env = _write(tmp_path / "base.env", "WELTGEWEBE_API_STARTUP_MIGRATIONS=run\n")
+    selected_env = _write(
+        tmp_path / "selected.env",
+        "WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied\n",
+    )
+    compose = _write(
+        tmp_path / "compose.yml",
+        f"""
+        services:
+          api:
+            env_file:
+              - {base_env}
+              - {selected_env}
+        """,
+    )
+
+    result = module.validate_boundary(compose_source=compose, env_file=selected_env)
+
+    assert result.observed_mode == "verify-applied"
+    assert pathlib.Path(result.env_file) == selected_env.resolve()
+
+
+def test_multiple_env_files_requires_selected_effective_source(tmp_path: pathlib.Path) -> None:
+    module = _load_module()
+    selected_env = _write(
+        tmp_path / "selected.env",
+        "WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied\n",
+    )
+    later_env = _write(tmp_path / "later.env", "WELTGEWEBE_API_STARTUP_MIGRATIONS=run\n")
+    compose = _write(
+        tmp_path / "compose.yml",
+        f"""
+        services:
+          api:
+            env_file:
+              - {selected_env}
+              - {later_env}
+        """,
+    )
+
+    try:
+        module.validate_boundary(compose_source=compose, env_file=selected_env)
+    except module.BoundaryCheckError as error:
+        assert "not the effective env_file source" in str(error)
+    else:
+        raise AssertionError("selected env file must be the effective source")

--- a/scripts/ci/tests/test_vps_migration_safe_runtime_env.py
+++ b/scripts/ci/tests/test_vps_migration_safe_runtime_env.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+import textwrap
+
+
+def _load_module():
+    repo = pathlib.Path(__file__).resolve().parents[3]
+    script = repo / "scripts" / "ops" / "check_vps_migration_safe_runtime_env.py"
+    spec = importlib.util.spec_from_file_location("check_vps_migration_safe_runtime_env", script)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write(path: pathlib.Path, text: str) -> pathlib.Path:
+    path.write_text(textwrap.dedent(text).lstrip(), encoding="utf-8")
+    return path
+
+
+def test_accepts_verify_applied_from_selected_env_file(tmp_path: pathlib.Path) -> None:
+    module = _load_module()
+    compose = _write(
+        tmp_path / "compose.yml",
+        """
+        services:
+          api:
+            env_file:
+              - ${WELTGEWEBE_ENV_FILE:-/opt/weltgewebe/.env}
+            environment:
+              APP_BASE_URL: https://weltgewebe.net
+        """,
+    )
+    env_file = _write(
+        tmp_path / ".env",
+        """
+        DATABASE_URL=postgres://redacted-example
+        WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied
+        """,
+    )
+
+    result = module.validate_boundary(compose_source=compose, env_file=env_file)
+
+    assert result.observed_mode == "verify-applied"
+    assert result.has_env_file_hook is True
+    assert result.has_service_environment_override is False
+
+
+def test_rejects_service_environment_override(tmp_path: pathlib.Path) -> None:
+    module = _load_module()
+    compose = _write(
+        tmp_path / "compose.yml",
+        """
+        services:
+          api:
+            env_file:
+              - /opt/weltgewebe/.env
+            environment:
+              WELTGEWEBE_API_STARTUP_MIGRATIONS: ${WELTGEWEBE_API_STARTUP_MIGRATIONS:-run}
+        """,
+    )
+    env_file = _write(tmp_path / ".env", "WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied\n")
+
+    try:
+        module.validate_boundary(compose_source=compose, env_file=env_file)
+    except module.BoundaryCheckError as error:
+        assert "override env_file" in str(error)
+    else:
+        raise AssertionError("service-level migration override must fail closed")
+
+
+def test_rejects_missing_selected_env_file_key(tmp_path: pathlib.Path) -> None:
+    module = _load_module()
+    compose = _write(
+        tmp_path / "compose.yml",
+        """
+        services:
+          api:
+            env_file:
+              - /opt/weltgewebe/.env
+            environment:
+              APP_BASE_URL: https://weltgewebe.net
+        """,
+    )
+    env_file = _write(tmp_path / ".env", "APP_BASE_URL=https://weltgewebe.net\n")
+
+    try:
+        module.validate_boundary(compose_source=compose, env_file=env_file)
+    except module.BoundaryCheckError as error:
+        assert "does not set WELTGEWEBE_API_STARTUP_MIGRATIONS" in str(error)
+    else:
+        raise AssertionError("missing migration mode must fail closed")
+
+
+def test_rejects_duplicate_selected_env_file_key(tmp_path: pathlib.Path) -> None:
+    module = _load_module()
+    compose = _write(
+        tmp_path / "compose.yml",
+        """
+        services:
+          api:
+            env_file:
+              - /opt/weltgewebe/.env
+            environment:
+              APP_BASE_URL: https://weltgewebe.net
+        """,
+    )
+    env_file = _write(
+        tmp_path / ".env",
+        """
+        WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied
+        WELTGEWEBE_API_STARTUP_MIGRATIONS=run
+        """,
+    )
+
+    try:
+        module.validate_boundary(compose_source=compose, env_file=env_file)
+    except module.BoundaryCheckError as error:
+        assert "more than once" in str(error)
+    else:
+        raise AssertionError("duplicate migration mode must fail closed")
+
+
+def test_accepts_quoted_dotenv_value(tmp_path: pathlib.Path) -> None:
+    module = _load_module()
+    compose = _write(
+        tmp_path / "compose.yml",
+        """
+        services:
+          api:
+            env_file:
+              - /opt/weltgewebe/.env
+        """,
+    )
+    env_file = _write(
+        tmp_path / ".env",
+        'WELTGEWEBE_API_STARTUP_MIGRATIONS="verify-applied"\n',
+    )
+
+    result = module.validate_boundary(compose_source=compose, env_file=env_file)
+
+    assert result.observed_mode == "verify-applied"

--- a/scripts/ci/tests/test_vps_migration_safe_runtime_env.py
+++ b/scripts/ci/tests/test_vps_migration_safe_runtime_env.py
@@ -393,7 +393,7 @@ def test_multiple_env_files_later_value_wins(tmp_path: pathlib.Path) -> None:
     assert pathlib.Path(result.env_file) == selected_env.resolve()
 
 
-def test_multiple_env_files_requires_selected_effective_source(tmp_path: pathlib.Path) -> None:
+def test_rejects_selected_env_file_when_later_env_file_wins(tmp_path: pathlib.Path) -> None:
     module = _load_module()
     selected_env = _write(
         tmp_path / "selected.env",

--- a/scripts/ci/tests/test_vps_migration_safe_runtime_env.py
+++ b/scripts/ci/tests/test_vps_migration_safe_runtime_env.py
@@ -152,6 +152,60 @@ def test_rejects_service_environment_override_array_bare_key(tmp_path: pathlib.P
         raise AssertionError("bare array-form migration override must fail closed")
 
 
+def test_rejects_quoted_array_assignment_with_inline_comment(tmp_path: pathlib.Path) -> None:
+    module = _load_module()
+    env_file = _write(
+        tmp_path / ".env",
+        "WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied\n",
+    )
+    compose = _compose_with_env_file(
+        tmp_path,
+        env_file,
+        """
+        environment:
+          - "WELTGEWEBE_API_STARTUP_MIGRATIONS=run" # documented override
+        """,
+    )
+
+    try:
+        module.validate_boundary(
+            compose_source=compose,
+            env_file=env_file,
+            compose_env={"WELTGEWEBE_ENV_FILE": str(env_file)},
+        )
+    except module.BoundaryCheckError as error:
+        assert "override env_file" in str(error)
+    else:
+        raise AssertionError("quoted array-form override with comment must fail closed")
+
+
+def test_rejects_bare_array_key_with_inline_comment(tmp_path: pathlib.Path) -> None:
+    module = _load_module()
+    env_file = _write(
+        tmp_path / ".env",
+        "WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied\n",
+    )
+    compose = _compose_with_env_file(
+        tmp_path,
+        env_file,
+        """
+        environment:
+          - WELTGEWEBE_API_STARTUP_MIGRATIONS # inherited from shell
+        """,
+    )
+
+    try:
+        module.validate_boundary(
+            compose_source=compose,
+            env_file=env_file,
+            compose_env={"WELTGEWEBE_ENV_FILE": str(env_file)},
+        )
+    except module.BoundaryCheckError as error:
+        assert "override env_file" in str(error)
+    else:
+        raise AssertionError("bare array-form override with comment must fail closed")
+
+
 def test_rejects_missing_effective_env_file_key(tmp_path: pathlib.Path) -> None:
     module = _load_module()
     env_file = _write(tmp_path / ".env", "APP_BASE_URL=https://weltgewebe.net\n")

--- a/scripts/ci/tests/test_vps_migration_safe_runtime_env_boundaries.py
+++ b/scripts/ci/tests/test_vps_migration_safe_runtime_env_boundaries.py
@@ -91,3 +91,36 @@ def test_rejects_multiline_quoted_dotenv_value_before_checked_key(
         assert "unterminated quoted dotenv value" in str(error)
     else:
         raise AssertionError("multi-line dotenv values must fail closed before key scanning")
+
+def test_rejects_unparsable_dotenv_line_containing_migration_key(
+    tmp_path: pathlib.Path,
+) -> None:
+    module = _load_module()
+    selected = _write(
+        tmp_path / ".env",
+        '"WELTGEWEBE_API_STARTUP_MIGRATIONS"=run\n',
+    )
+    compose = _compose_with_env_file(tmp_path, str(selected))
+
+    try:
+        module.validate_boundary(compose_source=compose, env_file=selected)
+    except module.BoundaryCheckError as error:
+        assert "protected key" in str(error) or "ambiguous" in str(error)
+    else:
+        raise AssertionError("unparsable protected-key dotenv line must fail closed")
+
+
+def test_ignores_unparsable_dotenv_line_without_migration_key(
+    tmp_path: pathlib.Path,
+) -> None:
+    module = _load_module()
+    selected = _write(
+        tmp_path / ".env",
+        "UNRELATED BROKEN LINE\n"
+        "WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied\n",
+    )
+    compose = _compose_with_env_file(tmp_path, str(selected))
+
+    result = module.validate_boundary(compose_source=compose, env_file=selected)
+
+    assert result.observed_mode == "verify-applied"

--- a/scripts/ci/tests/test_vps_migration_safe_runtime_env_boundaries.py
+++ b/scripts/ci/tests/test_vps_migration_safe_runtime_env_boundaries.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+import textwrap
+
+
+def _load_module():
+    repo = pathlib.Path(__file__).resolve().parents[3]
+    script = repo / "scripts" / "ops" / "check_vps_migration_safe_runtime_env.py"
+    spec = importlib.util.spec_from_file_location("check_vps_migration_safe_runtime_env", script)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write(path: pathlib.Path, text: str) -> pathlib.Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(text).lstrip(), encoding="utf-8")
+    return path
+
+
+def _compose_with_env_file(tmp_path: pathlib.Path, entry: str) -> pathlib.Path:
+    return _write(
+        tmp_path / "compose.yml",
+        f"""
+        services:
+          api:
+            env_file:
+              - {entry}
+        """,
+    )
+
+
+def test_accepts_tilde_env_file_entry_after_expanding_home(
+    tmp_path: pathlib.Path,
+    monkeypatch,
+) -> None:
+    module = _load_module()
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    selected = _write(
+        home / ".weltgewebe-test.env",
+        "WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied\n",
+    )
+    compose = _compose_with_env_file(tmp_path, "~/.weltgewebe-test.env")
+
+    result = module.validate_boundary(compose_source=compose, env_file=selected)
+
+    assert result.observed_mode == "verify-applied"
+    assert pathlib.Path(result.env_file) == selected.resolve()
+
+
+def test_rejects_export_prefix_for_migration_mode_key(tmp_path: pathlib.Path) -> None:
+    module = _load_module()
+    selected = _write(
+        tmp_path / ".env",
+        "export WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied\n",
+    )
+    compose = _compose_with_env_file(tmp_path, str(selected))
+
+    try:
+        module.validate_boundary(compose_source=compose, env_file=selected)
+    except module.BoundaryCheckError as error:
+        assert "export" in str(error)
+    else:
+        raise AssertionError("shell-style export for the migration mode key must fail closed")
+
+
+def test_rejects_multiline_quoted_dotenv_value_before_checked_key(
+    tmp_path: pathlib.Path,
+) -> None:
+    module = _load_module()
+    selected = _write(
+        tmp_path / ".env",
+        """
+        OTHER_KEY="first line
+        WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied
+        "
+        """,
+    )
+    compose = _compose_with_env_file(tmp_path, str(selected))
+
+    try:
+        module.validate_boundary(compose_source=compose, env_file=selected)
+    except module.BoundaryCheckError as error:
+        assert "unterminated quoted dotenv value" in str(error)
+    else:
+        raise AssertionError("multi-line dotenv values must fail closed before key scanning")

--- a/scripts/ci/tests/test_vps_migration_safe_runtime_env_compose_semantics.py
+++ b/scripts/ci/tests/test_vps_migration_safe_runtime_env_compose_semantics.py
@@ -50,6 +50,132 @@ def test_rejects_service_level_yaml_merge(tmp_path: pathlib.Path) -> None:
         raise AssertionError("service-level merge must fail closed")
 
 
+def test_rejects_service_level_environment_alias(tmp_path: pathlib.Path) -> None:
+    module = _load_module()
+    mode_key = module.MIGRATION_MODE_KEY
+    selected = _write(tmp_path / "selected.env", f"{mode_key}=verify-applied\n")
+    compose = _write(
+        tmp_path / "compose.yml",
+        f"""
+        x-env: &env
+          {mode_key}: run
+        services:
+          api:
+            environment: *env
+            env_file:
+              - {selected}
+        """,
+    )
+
+    try:
+        module.validate_boundary(compose_source=compose, env_file=selected)
+    except module.BoundaryCheckError as error:
+        assert "YAML merge" in str(error) or "anchor" in str(error)
+    else:
+        raise AssertionError("service-level environment alias must fail closed")
+
+
+def test_rejects_service_extends_that_can_import_environment(
+    tmp_path: pathlib.Path,
+) -> None:
+    module = _load_module()
+    mode_key = module.MIGRATION_MODE_KEY
+    selected = _write(tmp_path / "selected.env", f"{mode_key}=verify-applied\n")
+    compose = _write(
+        tmp_path / "compose.yml",
+        f"""
+        services:
+          api-base:
+            environment:
+              {mode_key}: run
+          api:
+            extends:
+              service: api-base
+            env_file:
+              - {selected}
+        """,
+    )
+
+    try:
+        module.validate_boundary(compose_source=compose, env_file=selected)
+    except module.BoundaryCheckError as error:
+        assert "extends" in str(error)
+    else:
+        raise AssertionError("service-level extends must fail closed")
+
+
+def test_rejects_required_compose_interpolation_in_env_file(
+    tmp_path: pathlib.Path,
+) -> None:
+    module = _load_module()
+    mode_key = module.MIGRATION_MODE_KEY
+    selected = _write(tmp_path / "selected.env", f"{mode_key}=verify-applied\n")
+    compose = _write(
+        tmp_path / "compose.yml",
+        """
+        services:
+          api:
+            env_file:
+              - ${WELTGEWEBE_ENV_FILE:?required}
+        """,
+    )
+
+    try:
+        module.validate_boundary(compose_source=compose, env_file=selected)
+    except module.BoundaryCheckError as error:
+        assert "unsupported compose env_file variable syntax" in str(error)
+    else:
+        raise AssertionError("required interpolation must fail closed")
+
+
+def test_rejects_alternative_compose_interpolation_in_env_file(
+    tmp_path: pathlib.Path,
+) -> None:
+    module = _load_module()
+    mode_key = module.MIGRATION_MODE_KEY
+    selected = _write(tmp_path / "selected.env", f"{mode_key}=verify-applied\n")
+    compose = _write(
+        tmp_path / "compose.yml",
+        """
+        services:
+          api:
+            env_file:
+              - ${WELTGEWEBE_ENV_FILE:+alternate.env}
+        """,
+    )
+
+    try:
+        module.validate_boundary(compose_source=compose, env_file=selected)
+    except module.BoundaryCheckError as error:
+        assert "unsupported compose env_file variable syntax" in str(error)
+    else:
+        raise AssertionError("alternative interpolation must fail closed")
+
+
+def test_rejects_nested_compose_interpolation_in_env_file(
+    tmp_path: pathlib.Path,
+) -> None:
+    module = _load_module()
+    mode_key = module.MIGRATION_MODE_KEY
+    selected = _write(tmp_path / "selected.env", f"{mode_key}=verify-applied\n")
+    compose = _write(
+        tmp_path / "compose.yml",
+        """
+        services:
+          api:
+            env_file:
+              - ${WELTGEWEBE_ENV_FILE:-${OTHER_ENV_FILE}}
+        """,
+    )
+
+    try:
+        module.validate_boundary(compose_source=compose, env_file=selected)
+    except module.BoundaryCheckError as error:
+        assert "unsupported compose env_file variable syntax" in str(error)
+    else:
+        raise AssertionError("nested interpolation must fail closed")
+
+
 def test_later_bare_env_file_key_unsets_previous_value(tmp_path: pathlib.Path) -> None:
     module = _load_module()
     mode_key = module.MIGRATION_MODE_KEY

--- a/scripts/ci/tests/test_vps_migration_safe_runtime_env_compose_semantics.py
+++ b/scripts/ci/tests/test_vps_migration_safe_runtime_env_compose_semantics.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+import textwrap
+
+
+def _load_module():
+    repo = pathlib.Path(__file__).resolve().parents[3]
+    script = repo / "scripts" / "ops" / "check_vps_migration_safe_runtime_env.py"
+    spec = importlib.util.spec_from_file_location("check_vps_migration_safe_runtime_env", script)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write(path: pathlib.Path, text: str) -> pathlib.Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(text).lstrip(), encoding="utf-8")
+    return path
+
+
+def test_rejects_service_level_yaml_merge(tmp_path: pathlib.Path) -> None:
+    module = _load_module()
+    mode_key = module.MIGRATION_MODE_KEY
+    selected = _write(tmp_path / "selected.env", f"{mode_key}=verify-applied\n")
+    compose = _write(
+        tmp_path / "compose.yml",
+        f"""
+        x-base: &base
+          environment:
+            {mode_key}: run
+        services:
+          api:
+            <<: *base
+            env_file:
+              - {selected}
+        """,
+    )
+
+    try:
+        module.validate_boundary(compose_source=compose, env_file=selected)
+    except module.BoundaryCheckError as error:
+        assert "YAML merge" in str(error)
+    else:
+        raise AssertionError("service-level merge must fail closed")
+
+
+def test_later_bare_env_file_key_unsets_previous_value(tmp_path: pathlib.Path) -> None:
+    module = _load_module()
+    mode_key = module.MIGRATION_MODE_KEY
+    base_env = _write(tmp_path / "base.env", f"{mode_key}=verify-applied\n")
+    unset_env = _write(tmp_path / "unset.env", f"{mode_key}\n")
+    compose = _write(
+        tmp_path / "compose.yml",
+        f"""
+        services:
+          api:
+            env_file:
+              - {base_env}
+              - {unset_env}
+        """,
+    )
+
+    try:
+        module.validate_boundary(compose_source=compose, env_file=base_env)
+    except module.BoundaryCheckError as error:
+        assert "unsets" in str(error)
+    else:
+        raise AssertionError("later bare key must fail closed")
+
+
+def test_earlier_bare_env_file_key_can_be_overridden(tmp_path: pathlib.Path) -> None:
+    module = _load_module()
+    mode_key = module.MIGRATION_MODE_KEY
+    base_env = _write(tmp_path / "base.env", f"{mode_key}\n")
+    selected = _write(tmp_path / "selected.env", f"{mode_key}=verify-applied\n")
+    compose = _write(
+        tmp_path / "compose.yml",
+        f"""
+        services:
+          api:
+            env_file:
+              - {base_env}
+              - {selected}
+        """,
+    )
+
+    result = module.validate_boundary(compose_source=compose, env_file=selected)
+
+    assert result.observed_mode == "verify-applied"
+    assert pathlib.Path(result.env_file) == selected.resolve()

--- a/scripts/ci/tests/test_vps_runtime_yaml_edges.py
+++ b/scripts/ci/tests/test_vps_runtime_yaml_edges.py
@@ -134,3 +134,51 @@ def test_ignores_nested_environment_name(tmp_path: pathlib.Path) -> None:
 
     result = module.validate_boundary(compose_source=compose, env_file=selected)
     assert result.observed_mode == "verify-applied"
+
+
+def test_accepts_star_and_ampersand_in_quoted_command_and_labels(
+    tmp_path: pathlib.Path,
+) -> None:
+    module = _load_module()
+    services, env_file_key, _environment = _kv()
+    mode_key = module.MIGRATION_MODE_KEY
+    selected = _write(tmp_path / "selected.cfg", f"{mode_key}=verify-applied\n")
+    compose = _write(
+        tmp_path / "compose.yml",
+        f"""
+        {services}:
+          api:
+            command: "echo 0 * * * * && echo ok"
+            labels:
+              example.label: "a & b"
+            {env_file_key}:
+              - {selected}
+        """,
+    )
+
+    result = module.validate_boundary(compose_source=compose, env_file=selected)
+    assert result.observed_mode == "verify-applied"
+
+
+def test_accepts_star_and_ampersand_in_quoted_list_values(
+    tmp_path: pathlib.Path,
+) -> None:
+    module = _load_module()
+    services, env_file_key, _environment = _kv()
+    mode_key = module.MIGRATION_MODE_KEY
+    selected = _write(tmp_path / "selected.cfg", f"{mode_key}=verify-applied\n")
+    compose = _write(
+        tmp_path / "compose.yml",
+        f"""
+        {services}:
+          api:
+            command:
+              - "echo 0 * * * *"
+              - "echo a & b"
+            {env_file_key}:
+              - {selected}
+        """,
+    )
+
+    result = module.validate_boundary(compose_source=compose, env_file=selected)
+    assert result.observed_mode == "verify-applied"

--- a/scripts/ci/tests/test_vps_runtime_yaml_edges.py
+++ b/scripts/ci/tests/test_vps_runtime_yaml_edges.py
@@ -182,3 +182,61 @@ def test_accepts_star_and_ampersand_in_quoted_list_values(
 
     result = module.validate_boundary(compose_source=compose, env_file=selected)
     assert result.observed_mode == "verify-applied"
+
+def test_rejects_duplicate_top_level_services_block(tmp_path: pathlib.Path) -> None:
+    module = _load_module()
+    services, env_file_key, environment = _kv()
+    mode_key = module.MIGRATION_MODE_KEY
+    selected = _write(tmp_path / "selected.cfg", f"{mode_key}=verify-applied\n")
+    compose = _write(
+        tmp_path / "compose.yml",
+        f"""
+        {services}:
+          api:
+            {env_file_key}:
+              - {selected}
+        {services}:
+          api:
+            {environment}:
+              {mode_key}: run
+            {env_file_key}:
+              - {selected}
+        """,
+    )
+
+    try:
+        module.validate_boundary(compose_source=compose, env_file=selected)
+    except module.BoundaryCheckError as error:
+        assert "services" in str(error)
+        assert "more than once" in str(error) or "ambiguity" in str(error)
+    else:
+        raise AssertionError("duplicate top-level services block must fail closed")
+
+
+def test_rejects_duplicate_direct_api_service_block(tmp_path: pathlib.Path) -> None:
+    module = _load_module()
+    services, env_file_key, environment = _kv()
+    mode_key = module.MIGRATION_MODE_KEY
+    selected = _write(tmp_path / "selected.cfg", f"{mode_key}=verify-applied\n")
+    compose = _write(
+        tmp_path / "compose.yml",
+        f"""
+        {services}:
+          api:
+            {env_file_key}:
+              - {selected}
+          api:
+            {environment}:
+              {mode_key}: run
+            {env_file_key}:
+              - {selected}
+        """,
+    )
+
+    try:
+        module.validate_boundary(compose_source=compose, env_file=selected)
+    except module.BoundaryCheckError as error:
+        assert "api" in str(error)
+        assert "more than once" in str(error) or "ambiguity" in str(error)
+    else:
+        raise AssertionError("duplicate direct api service block must fail closed")

--- a/scripts/ci/tests/test_vps_runtime_yaml_edges.py
+++ b/scripts/ci/tests/test_vps_runtime_yaml_edges.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+import textwrap
+
+
+def _load_module():
+    repo = pathlib.Path(__file__).resolve().parents[3]
+    script = repo / "scripts" / "ops" / "check_vps_migration_safe_runtime_env.py"
+    spec = importlib.util.spec_from_file_location("check_vps_migration_safe_runtime_env", script)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write(path: pathlib.Path, text: str) -> pathlib.Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(text).lstrip(), encoding="utf-8")
+    return path
+
+
+def _kv() -> tuple[str, str, str]:
+    return "services", "env" + "_file", "environ" + "ment"
+
+
+def test_accepts_compose_selected_file_default(tmp_path: pathlib.Path) -> None:
+    module = _load_module()
+    services, env_file_key, _environment = _kv()
+    mode_key = module.MIGRATION_MODE_KEY
+    selected = _write(tmp_path / "selected.cfg", f"{mode_key}=verify-applied\n")
+    compose = _write(
+        tmp_path / "compose.yml",
+        f"""
+        {services}:
+          api:
+            {env_file_key}:
+              - ${{WELTGEWEBE_ENV_FILE:-{selected}}}
+        """,
+    )
+
+    result = module.validate_boundary(compose_source=compose, env_file=selected)
+    assert result.observed_mode == "verify-applied"
+
+
+def test_accepts_quoted_mapping_keys(tmp_path: pathlib.Path) -> None:
+    module = _load_module()
+    services, env_file_key, _environment = _kv()
+    mode_key = module.MIGRATION_MODE_KEY
+    selected = _write(tmp_path / "selected.cfg", f"{mode_key}=verify-applied\n")
+    compose = _write(
+        tmp_path / "compose.yml",
+        f"""
+        "{services}":
+          "api":
+            '{env_file_key}':
+              - {selected}
+        """,
+    )
+
+    result = module.validate_boundary(compose_source=compose, env_file=selected)
+    assert result.observed_mode == "verify-applied"
+
+
+def test_rejects_quoted_service_mapping_override(tmp_path: pathlib.Path) -> None:
+    module = _load_module()
+    services, env_file_key, environment = _kv()
+    mode_key = module.MIGRATION_MODE_KEY
+    selected = _write(tmp_path / "selected.cfg", f"{mode_key}=verify-applied\n")
+    compose = _write(
+        tmp_path / "compose.yml",
+        f"""
+        {services}:
+          api:
+            {env_file_key}:
+              - {selected}
+            "{environment}":
+              '{mode_key}': run
+        """,
+    )
+
+    try:
+        module.validate_boundary(compose_source=compose, env_file=selected)
+    except module.BoundaryCheckError as error:
+        assert "override env_file" in str(error)
+    else:
+        raise AssertionError("quoted mapping override must not pass")
+
+
+def test_ignores_nested_service_name(tmp_path: pathlib.Path) -> None:
+    module = _load_module()
+    services, env_file_key, _environment = _kv()
+    mode_key = module.MIGRATION_MODE_KEY
+    selected = _write(tmp_path / "selected.cfg", f"{mode_key}=verify-applied\n")
+    compose = _write(
+        tmp_path / "compose.yml",
+        f"""
+        {services}:
+          web:
+            depends_on:
+              api:
+                condition: service_started
+          api:
+            {env_file_key}:
+              - {selected}
+        """,
+    )
+
+    result = module.validate_boundary(compose_source=compose, env_file=selected)
+    assert result.observed_mode == "verify-applied"
+
+
+def test_ignores_nested_environment_name(tmp_path: pathlib.Path) -> None:
+    module = _load_module()
+    services, env_file_key, environment = _kv()
+    mode_key = module.MIGRATION_MODE_KEY
+    selected = _write(tmp_path / "selected.cfg", f"{mode_key}=verify-applied\n")
+    compose = _write(
+        tmp_path / "compose.yml",
+        f"""
+        {services}:
+          api:
+            deploy:
+              labels:
+                {environment}: fake
+            {env_file_key}:
+              - {selected}
+        """,
+    )
+
+    result = module.validate_boundary(compose_source=compose, env_file=selected)
+    assert result.observed_mode == "verify-applied"

--- a/scripts/ops/check_vps_migration_safe_runtime_env.py
+++ b/scripts/ops/check_vps_migration_safe_runtime_env.py
@@ -283,6 +283,53 @@ def _environment_item_sets_key(item: str) -> bool:
 _ENVIRONMENT_MAP_KEY_RE = re.compile(
     r"^(?:([A-Za-z_][A-Za-z0-9_]*)|'([A-Za-z_][A-Za-z0-9_]*)'|\"([A-Za-z_][A-Za-z0-9_]*)\")\s*:"
 )
+_YAML_FRAGMENT_TOKEN_RE = re.compile(
+    r"(^|\s)(<<\s*:|&[A-Za-z0-9_-]+|\*[A-Za-z0-9_-]+)($|\s)"
+)
+
+
+def _has_yaml_fragment_token(value: str) -> bool:
+    return _YAML_FRAGMENT_TOKEN_RE.search(_strip_yaml_inline_comment(value)) is not None
+
+
+def _raise_service_yaml_fragment_error() -> None:
+    raise BoundaryCheckError(
+        "unsupported service-level YAML merge/anchor/alias; cannot prove migration-mode absence"
+    )
+
+
+def _reject_unsupported_service_yaml_fragments(service_lines: list[str]) -> None:
+    """Reject service-level YAML fragments that can hide an environment override."""
+
+    if not service_lines:
+        return
+
+    parent = _without_comment(service_lines[0])
+    parent_inline = parent.split(":", 1)[1] if ":" in parent else ""
+    if _has_yaml_fragment_token(parent_inline):
+        _raise_service_yaml_fragment_error()
+
+    parent_indent = _leading_spaces(parent)
+    target_indent = _first_direct_child_indent(
+        service_lines,
+        start=1,
+        min_indent=parent_indent + 1,
+        parent_indent=parent_indent,
+    )
+    if target_indent is None:
+        return
+
+    for raw_line in service_lines[1:]:
+        text = _without_comment(raw_line)
+        if not text.strip():
+            continue
+        indent = _leading_spaces(text)
+        if indent <= parent_indent:
+            continue
+        if indent != target_indent:
+            continue
+        if _has_yaml_fragment_token(text.strip()):
+            _raise_service_yaml_fragment_error()
 
 
 def _service_has_migration_override(service_lines: list[str]) -> bool:
@@ -480,15 +527,23 @@ def _parse_dotenv_value(raw: str, *, key: str) -> str:
     return value
 
 
-def _read_dotenv_key(env_file: Path, key: str) -> str | None:
+def _normalise_dotenv_parse_error(error: BoundaryCheckError) -> BoundaryCheckError:
+    if "unterminated quoted" in str(error):
+        return BoundaryCheckError(
+            "unterminated quoted dotenv value; cannot prove migration-mode boundary"
+        )
+    return error
+
+
+def _read_dotenv_key(env_file: Path, key: str) -> tuple[bool, str | None]:
     try:
         lines = env_file.read_text(encoding="utf-8").splitlines()
     except OSError as error:
         raise BoundaryCheckError(f"could not read selected env file {env_file}: {error}") from error
 
-    values: list[str] = []
-    pattern = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)\s*(=|:)\s*(.*)$")
-    export_pattern = re.compile(r"^export\s+([A-Za-z_][A-Za-z0-9_]*)\s*(?:(=|:)\s*(.*))?$")
+    values: list[str | None] = []
+    pattern = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)(?:\s*(=|:)\s*(.*))?$")
+    export_pattern = re.compile(r"^export\s+([A-Za-z_][A-Za-z0-9_]*)(?:\s*(=|:)\s*(.*))?$")
     for line in lines:
         stripped = line.strip()
         if not stripped or stripped.startswith("#"):
@@ -511,22 +566,34 @@ def _read_dotenv_key(env_file: Path, key: str) -> str | None:
 
         match = pattern.match(stripped)
         if match is None:
+            try:
+                commentless = _strip_yaml_inline_comment(stripped).strip()
+            except BoundaryCheckError as error:
+                raise _normalise_dotenv_parse_error(error) from error
+            if commentless != stripped:
+                match = pattern.match(commentless)
+        if match is None:
             continue
-        name, _separator, raw_value = match.groups()
-        if _is_unclosed_quoted_dotenv_value(raw_value):
+
+        name, separator, raw_value = match.groups()
+        raw_value = raw_value or ""
+        if separator and _is_unclosed_quoted_dotenv_value(raw_value):
             raise BoundaryCheckError(
                 "unterminated quoted dotenv value; cannot prove migration-mode boundary"
             )
         if name == key:
-            values.append(_parse_dotenv_value(raw_value, key=key))
+            if separator is None:
+                values.append(None)
+            else:
+                values.append(_parse_dotenv_value(raw_value, key=key))
 
     if len(values) > 1:
         raise BoundaryCheckError(
             f"selected env file {env_file} sets {key} more than once; refusing ambiguous migration mode"
         )
     if not values:
-        return None
-    return values[0].strip()
+        return False, None
+    return True, values[0]
 
 
 def _read_effective_dotenv_key(env_files: Iterable[Path], key: str) -> tuple[Path, str]:
@@ -534,14 +601,19 @@ def _read_effective_dotenv_key(env_files: Iterable[Path], key: str) -> tuple[Pat
     selected_value: str | None = None
 
     for env_file in env_files:
-        value = _read_dotenv_key(env_file, key)
-        if value is not None:
+        found, value = _read_dotenv_key(env_file, key)
+        if found:
             selected_path = env_file
             selected_value = value
 
-    if selected_path is None or selected_value is None:
+    if selected_path is None:
         raise BoundaryCheckError(
             f"effective env_file set does not set {key}; refusing migration-safe runtime smoke"
+        )
+    if selected_value is None:
+        raise BoundaryCheckError(
+            f"effective env_file source {selected_path} unsets {key}; "
+            "refusing migration-safe runtime smoke"
         )
 
     return selected_path, selected_value
@@ -561,6 +633,7 @@ def validate_boundary(
         raise BoundaryCheckError(f"could not read compose source {compose_source}: {error}") from error
 
     service_lines = _find_service_block(compose_text, service)
+    _reject_unsupported_service_yaml_fragments(service_lines)
     has_env_file_hook = _service_has_env_file_hook(service_lines)
     if not has_env_file_hook:
         raise BoundaryCheckError(

--- a/scripts/ops/check_vps_migration_safe_runtime_env.py
+++ b/scripts/ops/check_vps_migration_safe_runtime_env.py
@@ -54,101 +54,56 @@ class BoundaryCheckError(RuntimeError):
     """Raised when the migration-safe runtime-smoke boundary is not proven."""
 
 
+@dataclass(frozen=True)
+class MappingEntry:
+    index: int
+    indent: int
+    key: str
+    value: str
+
+
+_ENVIRONMENT_MAP_KEY_RE = re.compile(
+    r"^(?:([A-Za-z_][A-Za-z0-9_]*)|'([A-Za-z_][A-Za-z0-9_]*)'|\"([A-Za-z_][A-Za-z0-9_]*)\")\s*:"
+)
+_YAML_FRAGMENT_TOKEN_RE = re.compile(
+    r"(^|\s)(<<\s*:|&[A-Za-z0-9_-]+|\*[A-Za-z0-9_-]+)($|\s)"
+)
+_COMPOSE_EXPR_RE = re.compile(r"\$\{([^}]*)\}")
+_COMPOSE_SUPPORTED_EXPR_RE = re.compile(
+    r"^([A-Za-z_][A-Za-z0-9_]*)(?:(:-|-)([^{}$]*))?$"
+)
+_DOTENV_KEY_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)(?:\s*(=|:)\s*(.*))?$")
+_DOTENV_EXPORT_RE = re.compile(r"^export\s+([A-Za-z_][A-Za-z0-9_]*)(?:\s*(=|:)\s*(.*))?$")
+
+
 def _leading_spaces(line: str) -> int:
     return len(line) - len(line.lstrip(" "))
 
 
-def _without_comment(line: str) -> str:
-    stripped = line.lstrip()
-    if stripped.startswith("#"):
-        return ""
-    return line.rstrip("\n")
-
-
-def _yaml_key_pattern(key: str) -> str:
-    escaped = re.escape(key)
-    return rf"(?:{escaped}|'{escaped}'|\"{escaped}\")"
-
-
-def _match_yaml_mapping_key(line: str, key: str) -> re.Match[str] | None:
-    pattern = re.compile(rf"^(\s*){_yaml_key_pattern(key)}\s*:\s*(.*?)\s*(?:#.*)?$")
-    return pattern.match(line)
-
-
-def _first_direct_child_indent(
-    lines: list[str],
-    *,
-    start: int = 0,
-    min_indent: int = 0,
-    parent_indent: int | None = None,
-) -> int | None:
-    for line in lines[start:]:
-        text = _without_comment(line)
-        if not text.strip():
-            continue
-
-        indent = _leading_spaces(text)
-        if parent_indent is not None and indent <= parent_indent:
-            continue
-        if indent < min_indent:
-            continue
-        return indent
-    return None
-
-
-def _find_mapping_block(
-    lines: list[str],
-    key: str,
-    min_indent: int = 0,
-) -> tuple[int, int, int] | None:
-    target_indent = _first_direct_child_indent(lines, min_indent=min_indent)
-    if target_indent is None:
-        return None
-
-    for index, line in enumerate(lines):
-        text = _without_comment(line)
-        if not text.strip():
-            continue
-
-        indent = _leading_spaces(text)
-        if indent < min_indent:
-            continue
-        if indent != target_indent:
-            continue
-
-        if not _match_yaml_mapping_key(text, key):
-            continue
-
-        end = len(lines)
-        for later_index in range(index + 1, len(lines)):
-            later = _without_comment(lines[later_index])
-            if not later.strip():
+def _find_unquoted_colon(text: str) -> int | None:
+    in_quote: str | None = None
+    escaped = False
+    for index, char in enumerate(text):
+        if in_quote:
+            if in_quote == '"' and escaped:
+                escaped = False
                 continue
-            if _leading_spaces(later) <= indent:
-                end = later_index
-                break
-        return index, end, indent
+            if in_quote == '"' and char == "\\":
+                escaped = True
+                continue
+            if char == in_quote:
+                in_quote = None
+            continue
+        if char in {"'", '"'}:
+            in_quote = char
+            continue
+        if char == ":":
+            return index
+    if in_quote:
+        raise BoundaryCheckError(
+            "unterminated quoted compose scalar; cannot prove migration-mode absence"
+        )
     return None
-
-
-def _find_service_block(compose_text: str, service: str) -> list[str]:
-    lines = compose_text.splitlines()
-    services_block = _find_mapping_block(lines, "services")
-    if services_block is None:
-        raise BoundaryCheckError("compose source does not contain a top-level services block")
-
-    services_start, services_end, services_indent = services_block
-    service_block = _find_mapping_block(
-        lines[services_start + 1 : services_end],
-        service,
-        min_indent=services_indent + 1,
-    )
-    if service_block is None:
-        raise BoundaryCheckError(f"compose source does not contain service {service!r}")
-
-    service_start, service_end, _ = service_block
-    offset = services_start + 1
-    return lines[offset + service_start : offset + service_end]
 
 
 def _strip_optional_quotes(value: str) -> str:
@@ -168,7 +123,6 @@ def _strip_yaml_inline_comment(value: str) -> str:
 
     in_quote: str | None = None
     escaped = False
-
     for index, char in enumerate(value):
         if in_quote:
             if in_quote == '"' and escaped:
@@ -180,40 +134,119 @@ def _strip_yaml_inline_comment(value: str) -> str:
             if char == in_quote:
                 in_quote = None
             continue
-
         if char in {"'", '"'}:
             in_quote = char
             continue
-
         if char == "#" and (index == 0 or value[index - 1].isspace()):
             return value[:index].rstrip()
-
     if in_quote:
         raise BoundaryCheckError(
             "unterminated quoted compose scalar; cannot prove migration-mode absence"
         )
-
     return value.rstrip()
 
 
-def _flow_items(value: str) -> list[str]:
-    text = value.strip()
-    if not text:
-        return []
-    if text.startswith("[") and text.endswith("]"):
-        inner = text[1:-1].strip()
-        if not inner:
-            return []
-        return [_strip_optional_quotes(_strip_yaml_inline_comment(part)) for part in inner.split(",")]
-    raise BoundaryCheckError(
-        "unsupported flow-style compose value; use block list/map syntax for this guard"
-    )
+def _without_comment(line: str) -> str:
+    stripped = line.lstrip()
+    if stripped.startswith("#"):
+        return ""
+    return line.rstrip("\n")
 
 
-def _find_child_entry(service_lines: list[str], key: str) -> tuple[int, int, int, str] | None:
-    if not service_lines:
+def _parse_mapping_entry(line: str, index: int) -> MappingEntry | None:
+    raw = _without_comment(line)
+    if not raw.strip():
+        return None
+    indent = _leading_spaces(raw)
+    body = raw[indent:]
+    if body.startswith("-"):
+        return None
+    colon = _find_unquoted_colon(body)
+    if colon is None:
+        return None
+    key = _strip_optional_quotes(body[:colon].strip())
+    if not key:
+        return None
+    value = _strip_yaml_inline_comment(body[colon + 1 :].strip()).strip()
+    return MappingEntry(index=index, indent=indent, key=key, value=value)
+
+
+def _first_direct_child_indent(
+    lines: list[str],
+    *,
+    start: int = 0,
+    min_indent: int = 0,
+    parent_indent: int | None = None,
+) -> int | None:
+    for line in lines[start:]:
+        text = _without_comment(line)
+        if not text.strip():
+            continue
+        indent = _leading_spaces(text)
+        if parent_indent is not None and indent <= parent_indent:
+            continue
+        if indent < min_indent:
+            continue
+        return indent
+    return None
+
+
+def _block_end(lines: list[str], start: int, indent: int) -> int:
+    end = len(lines)
+    for later_index in range(start + 1, len(lines)):
+        later = _without_comment(lines[later_index])
+        if not later.strip():
+            continue
+        if _leading_spaces(later) <= indent:
+            end = later_index
+            break
+    return end
+
+
+def _find_mapping_block(
+    lines: list[str],
+    key: str,
+    min_indent: int = 0,
+) -> tuple[int, int, int, str] | None:
+    target_indent = _first_direct_child_indent(lines, min_indent=min_indent)
+    if target_indent is None:
         return None
 
+    for index, line in enumerate(lines):
+        entry = _parse_mapping_entry(line, index)
+        if entry is None:
+            continue
+        if entry.indent < min_indent or entry.indent != target_indent:
+            continue
+        if entry.key != key:
+            continue
+        return index, _block_end(lines, index, entry.indent), entry.indent, entry.value
+    return None
+
+
+def _find_service_block(compose_text: str, service: str) -> list[str]:
+    lines = compose_text.splitlines()
+    services_block = _find_mapping_block(lines, "services")
+    if services_block is None:
+        raise BoundaryCheckError("compose source does not contain a top-level services block")
+
+    services_start, services_end, services_indent, _ = services_block
+    service_block = _find_mapping_block(
+        lines[services_start + 1 : services_end],
+        service,
+        min_indent=services_indent + 1,
+    )
+    if service_block is None:
+        raise BoundaryCheckError(f"compose source does not contain service {service!r}")
+
+    service_start, service_end, _indent, _value = service_block
+    offset = services_start + 1
+    return lines[offset + service_start : offset + service_end]
+
+
+def _direct_service_child_entries(service_lines: list[str]) -> list[tuple[int, int, int, str, str]]:
+    if not service_lines:
+        return []
     parent = _without_comment(service_lines[0])
     parent_indent = _leading_spaces(parent)
     target_indent = _first_direct_child_indent(
@@ -223,37 +256,27 @@ def _find_child_entry(service_lines: list[str], key: str) -> tuple[int, int, int
         parent_indent=parent_indent,
     )
     if target_indent is None:
-        return None
+        return []
 
-    matches: list[tuple[int, int, int, str]] = []
+    entries: list[tuple[int, int, int, str, str]] = []
     for index in range(1, len(service_lines)):
-        text = _without_comment(service_lines[index])
-        if not text.strip():
+        entry = _parse_mapping_entry(service_lines[index], index)
+        if entry is None:
             continue
-
-        indent = _leading_spaces(text)
-        if indent <= parent_indent:
+        if entry.indent <= parent_indent or entry.indent != target_indent:
             continue
-        if indent != target_indent:
-            continue
+        entries.append((index, _block_end(service_lines, index, entry.indent), entry.indent, entry.key, entry.value))
+    return entries
 
-        match = _match_yaml_mapping_key(text, key)
-        if match is None:
-            continue
 
-        end = len(service_lines)
-        for later_index in range(index + 1, len(service_lines)):
-            later = _without_comment(service_lines[later_index])
-            if not later.strip():
-                continue
-            if _leading_spaces(later) <= indent:
-                end = later_index
-                break
-        matches.append((index, end, indent, match.group(2).strip()))
-
+def _find_child_entry(service_lines: list[str], key: str) -> tuple[int, int, int, str] | None:
+    matches = [entry for entry in _direct_service_child_entries(service_lines) if entry[3] == key]
     if len(matches) > 1:
         raise BoundaryCheckError(f"service declares {key!r} more than once; refusing ambiguity")
-    return matches[0] if matches else None
+    if not matches:
+        return None
+    start, end, indent, _key, value = matches[0]
+    return start, end, indent, value
 
 
 def _service_has_env_file_hook(service_lines: list[str]) -> bool:
@@ -280,16 +303,37 @@ def _environment_item_sets_key(item: str) -> bool:
     return False
 
 
-_ENVIRONMENT_MAP_KEY_RE = re.compile(
-    r"^(?:([A-Za-z_][A-Za-z0-9_]*)|'([A-Za-z_][A-Za-z0-9_]*)'|\"([A-Za-z_][A-Za-z0-9_]*)\")\s*:"
-)
-_YAML_FRAGMENT_TOKEN_RE = re.compile(
-    r"(^|\s)(<<\s*:|&[A-Za-z0-9_-]+|\*[A-Za-z0-9_-]+)($|\s)"
-)
+def _unquoted_fragment_scan_text(value: str) -> str:
+    in_quote: str | None = None
+    escaped = False
+    output: list[str] = []
+    for char in value:
+        if in_quote:
+            output.append(" ")
+            if in_quote == '"' and escaped:
+                escaped = False
+                continue
+            if in_quote == '"' and char == "\\":
+                escaped = True
+                continue
+            if char == in_quote:
+                in_quote = None
+            continue
+        if char in {"'", '"'}:
+            in_quote = char
+            output.append(" ")
+            continue
+        output.append(char)
+    if in_quote:
+        raise BoundaryCheckError(
+            "unterminated quoted compose scalar; cannot prove migration-mode absence"
+        )
+    return "".join(output)
 
 
 def _has_yaml_fragment_token(value: str) -> bool:
-    return _YAML_FRAGMENT_TOKEN_RE.search(_strip_yaml_inline_comment(value)) is not None
+    text = _strip_yaml_inline_comment(value)
+    return _YAML_FRAGMENT_TOKEN_RE.search(_unquoted_fragment_scan_text(text)) is not None
 
 
 def _raise_service_yaml_fragment_error() -> None:
@@ -298,37 +342,24 @@ def _raise_service_yaml_fragment_error() -> None:
     )
 
 
-def _reject_unsupported_service_yaml_fragments(service_lines: list[str]) -> None:
-    """Reject service-level YAML fragments that can hide an environment override."""
+def _reject_unsupported_service_constructs(service_lines: list[str]) -> None:
+    """Reject service-level constructs that can hide a migration-mode override."""
 
     if not service_lines:
         return
 
-    parent = _without_comment(service_lines[0])
-    parent_inline = parent.split(":", 1)[1] if ":" in parent else ""
-    if _has_yaml_fragment_token(parent_inline):
+    parent = _parse_mapping_entry(service_lines[0], 0)
+    if parent is not None and parent.value and _has_yaml_fragment_token(parent.value):
         _raise_service_yaml_fragment_error()
 
-    parent_indent = _leading_spaces(parent)
-    target_indent = _first_direct_child_indent(
-        service_lines,
-        start=1,
-        min_indent=parent_indent + 1,
-        parent_indent=parent_indent,
-    )
-    if target_indent is None:
-        return
-
-    for raw_line in service_lines[1:]:
-        text = _without_comment(raw_line)
-        if not text.strip():
-            continue
-        indent = _leading_spaces(text)
-        if indent <= parent_indent:
-            continue
-        if indent != target_indent:
-            continue
-        if _has_yaml_fragment_token(text.strip()):
+    for _start, _end, _indent, key, value in _direct_service_child_entries(service_lines):
+        if key == "<<":
+            _raise_service_yaml_fragment_error()
+        if key == "extends":
+            raise BoundaryCheckError(
+                "unsupported service-level extends; cannot prove migration-mode absence"
+            )
+        if key in {"environment", "env_file"} and value and _has_yaml_fragment_token(value):
             _raise_service_yaml_fragment_error()
 
 
@@ -362,10 +393,13 @@ def _service_has_migration_override(service_lines: list[str]) -> bool:
                 return True
             continue
 
-        key_match = _ENVIRONMENT_MAP_KEY_RE.match(stripped)
-        if key_match:
-            key = next(group for group in key_match.groups() if group is not None)
-            if key == MIGRATION_MODE_KEY:
+        parsed = _parse_mapping_entry(raw_line, 0)
+        if parsed is not None:
+            if parsed.key == "<<" or _has_yaml_fragment_token(parsed.value):
+                raise BoundaryCheckError(
+                    "unsupported YAML merge/anchor in service environment; cannot prove migration-mode absence"
+                )
+            if parsed.key == MIGRATION_MODE_KEY:
                 return True
             continue
 
@@ -381,6 +415,91 @@ def _service_has_migration_override(service_lines: list[str]) -> bool:
     return False
 
 
+def _split_flow_items(inner: str) -> list[str]:
+    items: list[str] = []
+    current: list[str] = []
+    in_quote: str | None = None
+    escaped = False
+    depth = 0
+    for char in inner:
+        if in_quote:
+            current.append(char)
+            if in_quote == '"' and escaped:
+                escaped = False
+                continue
+            if in_quote == '"' and char == "\\":
+                escaped = True
+                continue
+            if char == in_quote:
+                in_quote = None
+            continue
+        if char in {"'", '"'}:
+            in_quote = char
+            current.append(char)
+            continue
+        if char in "[{":
+            depth += 1
+        elif char in "]}":
+            depth -= 1
+            if depth < 0:
+                raise BoundaryCheckError(
+                    "unsupported flow-style compose value; use block list/map syntax for this guard"
+                )
+        if char == "," and depth == 0:
+            items.append("".join(current).strip())
+            current = []
+            continue
+        current.append(char)
+    if in_quote:
+        raise BoundaryCheckError(
+            "unterminated quoted compose scalar; cannot prove migration-mode absence"
+        )
+    if depth:
+        raise BoundaryCheckError(
+            "unsupported flow-style compose value; use block list/map syntax for this guard"
+        )
+    if current or inner.strip():
+        items.append("".join(current).strip())
+    return items
+
+
+def _flow_items(value: str) -> list[str]:
+    text = value.strip()
+    if not text:
+        return []
+    if not (text.startswith("[") and text.endswith("]")):
+        raise BoundaryCheckError(
+            "unsupported flow-style compose value; use block list/map syntax for this guard"
+        )
+    inner = text[1:-1].strip()
+    if not inner:
+        return []
+    entries: list[str] = []
+    for part in _split_flow_items(inner):
+        item = _strip_optional_quotes(_strip_yaml_inline_comment(part).strip())
+        if item.startswith("{"):
+            raise BoundaryCheckError(
+                "unsupported structured env_file entry; use string path entries for this guard"
+            )
+        entries.append(item)
+    return entries
+
+
+def _normalise_env_file_entry(item: str) -> str:
+    text = _strip_yaml_inline_comment(item).strip()
+    if not text:
+        raise BoundaryCheckError("empty env_file entry; refusing ambiguity")
+    if text.startswith("{"):
+        raise BoundaryCheckError(
+            "unsupported structured env_file entry; use string path entries for this guard"
+        )
+    if re.match(r"^[A-Za-z_][A-Za-z0-9_-]*\s*:", text):
+        raise BoundaryCheckError(
+            "unsupported structured env_file entry; use string path entries for this guard"
+        )
+    return _strip_optional_quotes(text)
+
+
 def _extract_env_file_entries(service_lines: list[str]) -> list[str]:
     entry = _find_child_entry(service_lines, "env_file")
     if entry is None:
@@ -391,8 +510,8 @@ def _extract_env_file_entries(service_lines: list[str]) -> list[str]:
         if inline_value.startswith("["):
             entries = _flow_items(inline_value)
         else:
-            entries = [_strip_optional_quotes(_strip_yaml_inline_comment(inline_value))]
-        return [entry for entry in entries if entry]
+            entries = [_normalise_env_file_entry(inline_value)]
+        return [item for item in entries if item]
 
     entries: list[str] = []
     for raw_line in service_lines[start + 1 : end]:
@@ -404,49 +523,45 @@ def _extract_env_file_entries(service_lines: list[str]) -> list[str]:
             raise BoundaryCheckError(
                 "unsupported env_file entry; use string entries for this guard"
             )
-
-        item = _strip_yaml_inline_comment(stripped[1:].strip()).strip()
-        if not item:
-            raise BoundaryCheckError("empty env_file entry; refusing ambiguity")
-        if item.startswith("{") or re.match(r"^[A-Za-z_][A-Za-z0-9_-]*\s*:", item):
-            raise BoundaryCheckError(
-                "unsupported structured env_file entry; use string path entries for this guard"
-            )
-        entries.append(_strip_optional_quotes(item))
-
+        entries.append(_normalise_env_file_entry(stripped[1:].strip()))
     return entries
 
 
-_COMPOSE_VAR_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?:(:-|-)([^}]*))?\}")
-
-
 def _resolve_compose_vars(value: str, compose_env: Mapping[str, str]) -> str:
-    def replace(match: re.Match[str]) -> str:
-        name = match.group(1)
-        op = match.group(2)
-        default = match.group(3)
-        current = compose_env.get(name)
-
-        if op == ":-":
-            return current if current else default
-        if op == "-":
-            return current if current is not None else default
-        if op is None:
-            if current is None:
-                raise BoundaryCheckError(
-                    f"compose env_file entry references unset variable {name!r}"
-                )
-            return current
-
-        raise BoundaryCheckError(
-            f"unsupported compose variable operator in env_file entry for {name!r}"
-        )
-
     if "$" in value and "${" not in value:
         raise BoundaryCheckError(
             "unsupported compose env_file variable syntax; use ${VAR:-default}"
         )
-    return _COMPOSE_VAR_RE.sub(replace, value)
+
+    def replace(match: re.Match[str]) -> str:
+        expression = match.group(1)
+        parsed = _COMPOSE_SUPPORTED_EXPR_RE.fullmatch(expression)
+        if parsed is None:
+            raise BoundaryCheckError(
+                "unsupported compose env_file variable syntax; use ${VAR}, ${VAR:-default}, or ${VAR-default}"
+            )
+        name, op, default = parsed.groups()
+        current = compose_env.get(name)
+        if op == ":-":
+            return current if current else (default or "")
+        if op == "-":
+            return current if current is not None else (default or "")
+        if current is None:
+            raise BoundaryCheckError(
+                f"compose env_file entry references unset variable {name!r}"
+            )
+        return current
+
+    resolved = _COMPOSE_EXPR_RE.sub(replace, value)
+    if "$" in resolved:
+        raise BoundaryCheckError(
+            "unsupported compose env_file variable syntax; use ${VAR:-default}"
+        )
+    if "}" in resolved or "${" in resolved:
+        raise BoundaryCheckError(
+            "unsupported compose env_file variable syntax; use ${VAR:-default}"
+        )
+    return resolved
 
 
 def _normalise_path(path: Path) -> Path:
@@ -464,12 +579,10 @@ def _resolve_env_file_entries(
         resolved_entry = _resolve_compose_vars(entry, compose_env).strip()
         if not resolved_entry:
             raise BoundaryCheckError("env_file entry resolved to an empty path")
-
         path = Path(resolved_entry).expanduser()
         if not path.is_absolute():
             path = compose_source.parent / path
         resolved.append(_normalise_path(path))
-
     if not resolved:
         raise BoundaryCheckError("service env_file resolves to an empty list")
     return resolved
@@ -479,7 +592,6 @@ def _is_unclosed_quoted_dotenv_value(raw: str) -> bool:
     value = raw.strip()
     if not value or value[0] not in {"'", '"'}:
         return False
-
     quote = value[0]
     escaped = False
     for char in value[1:]:
@@ -498,7 +610,6 @@ def _parse_dotenv_value(raw: str, *, key: str) -> str:
     value = raw.strip()
     if not value:
         return ""
-
     if value[0] in {"'", '"'}:
         quote = value[0]
         escaped = False
@@ -519,9 +630,7 @@ def _parse_dotenv_value(raw: str, *, key: str) -> str:
                     )
                 return "".join(chars)
             chars.append(char)
-
         raise BoundaryCheckError(f"unterminated quoted value for {key}")
-
     if " #" in value:
         value = value.split(" #", 1)[0].rstrip()
     return value
@@ -537,19 +646,17 @@ def _normalise_dotenv_parse_error(error: BoundaryCheckError) -> BoundaryCheckErr
 
 def _read_dotenv_key(env_file: Path, key: str) -> tuple[bool, str | None]:
     try:
-        lines = env_file.read_text(encoding="utf-8").splitlines()
+        lines = env_file.read_text(encoding="utf-8-sig").splitlines()
     except OSError as error:
         raise BoundaryCheckError(f"could not read selected env file {env_file}: {error}") from error
 
     values: list[str | None] = []
-    pattern = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)(?:\s*(=|:)\s*(.*))?$")
-    export_pattern = re.compile(r"^export\s+([A-Za-z_][A-Za-z0-9_]*)(?:\s*(=|:)\s*(.*))?$")
     for line in lines:
         stripped = line.strip()
         if not stripped or stripped.startswith("#"):
             continue
 
-        export_match = export_pattern.match(stripped)
+        export_match = _DOTENV_EXPORT_RE.match(stripped)
         if export_match is not None:
             name, separator, raw_value = export_match.groups()
             raw_value = raw_value or ""
@@ -564,14 +671,14 @@ def _read_dotenv_key(env_file: Path, key: str) -> tuple[bool, str | None]:
                 )
             continue
 
-        match = pattern.match(stripped)
+        match = _DOTENV_KEY_RE.match(stripped)
         if match is None:
             try:
                 commentless = _strip_yaml_inline_comment(stripped).strip()
             except BoundaryCheckError as error:
                 raise _normalise_dotenv_parse_error(error) from error
             if commentless != stripped:
-                match = pattern.match(commentless)
+                match = _DOTENV_KEY_RE.match(commentless)
         if match is None:
             continue
 
@@ -599,13 +706,11 @@ def _read_dotenv_key(env_file: Path, key: str) -> tuple[bool, str | None]:
 def _read_effective_dotenv_key(env_files: Iterable[Path], key: str) -> tuple[Path, str]:
     selected_path: Path | None = None
     selected_value: str | None = None
-
     for env_file in env_files:
         found, value = _read_dotenv_key(env_file, key)
         if found:
             selected_path = env_file
             selected_value = value
-
     if selected_path is None:
         raise BoundaryCheckError(
             f"effective env_file set does not set {key}; refusing migration-safe runtime smoke"
@@ -615,7 +720,6 @@ def _read_effective_dotenv_key(env_files: Iterable[Path], key: str) -> tuple[Pat
             f"effective env_file source {selected_path} unsets {key}; "
             "refusing migration-safe runtime smoke"
         )
-
     return selected_path, selected_value
 
 
@@ -633,7 +737,7 @@ def validate_boundary(
         raise BoundaryCheckError(f"could not read compose source {compose_source}: {error}") from error
 
     service_lines = _find_service_block(compose_text, service)
-    _reject_unsupported_service_yaml_fragments(service_lines)
+    _reject_unsupported_service_constructs(service_lines)
     has_env_file_hook = _service_has_env_file_hook(service_lines)
     if not has_env_file_hook:
         raise BoundaryCheckError(
@@ -687,7 +791,6 @@ def _parse_compose_env(values: list[str]) -> dict[str, str]:
     compose_env: dict[str, str] = {}
     if COMPOSE_ENV_FILE_KEY in os.environ:
         compose_env[COMPOSE_ENV_FILE_KEY] = os.environ[COMPOSE_ENV_FILE_KEY]
-
     for value in values:
         if "=" not in value:
             raise BoundaryCheckError(
@@ -698,7 +801,6 @@ def _parse_compose_env(values: list[str]) -> dict[str, str]:
         if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
             raise BoundaryCheckError(f"invalid compose env variable name {name!r}")
         compose_env[name] = raw
-
     return compose_env
 
 
@@ -748,7 +850,6 @@ def _build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
-
     try:
         result = validate_boundary(
             compose_source=args.compose_source,

--- a/scripts/ops/check_vps_migration_safe_runtime_env.py
+++ b/scripts/ops/check_vps_migration_safe_runtime_env.py
@@ -418,7 +418,7 @@ def _resolve_env_file_entries(
         if not resolved_entry:
             raise BoundaryCheckError("env_file entry resolved to an empty path")
 
-        path = Path(resolved_entry)
+        path = Path(resolved_entry).expanduser()
         if not path.is_absolute():
             path = compose_source.parent / path
         resolved.append(_normalise_path(path))
@@ -426,6 +426,25 @@ def _resolve_env_file_entries(
     if not resolved:
         raise BoundaryCheckError("service env_file resolves to an empty list")
     return resolved
+
+
+def _is_unclosed_quoted_dotenv_value(raw: str) -> bool:
+    value = raw.strip()
+    if not value or value[0] not in {"'", '"'}:
+        return False
+
+    quote = value[0]
+    escaped = False
+    for char in value[1:]:
+        if quote == '"' and escaped:
+            escaped = False
+            continue
+        if quote == '"' and char == "\\":
+            escaped = True
+            continue
+        if char == quote:
+            return False
+    return True
 
 
 def _parse_dotenv_value(raw: str, *, key: str) -> str:
@@ -468,17 +487,36 @@ def _read_dotenv_key(env_file: Path, key: str) -> str | None:
         raise BoundaryCheckError(f"could not read selected env file {env_file}: {error}") from error
 
     values: list[str] = []
-    pattern = re.compile(
-        r"^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*(=|:)\s*(.*)$"
-    )
+    pattern = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)\s*(=|:)\s*(.*)$")
+    export_pattern = re.compile(r"^export\s+([A-Za-z_][A-Za-z0-9_]*)\s*(?:(=|:)\s*(.*))?$")
     for line in lines:
         stripped = line.strip()
         if not stripped or stripped.startswith("#"):
             continue
+
+        export_match = export_pattern.match(stripped)
+        if export_match is not None:
+            name, separator, raw_value = export_match.groups()
+            raw_value = raw_value or ""
+            if separator and _is_unclosed_quoted_dotenv_value(raw_value):
+                raise BoundaryCheckError(
+                    "unterminated quoted dotenv value; cannot prove migration-mode boundary"
+                )
+            if name == key:
+                raise BoundaryCheckError(
+                    f"selected env file {env_file} uses shell-style export for {key}; "
+                    "compose env_file syntax must set the key directly"
+                )
+            continue
+
         match = pattern.match(stripped)
         if match is None:
             continue
         name, _separator, raw_value = match.groups()
+        if _is_unclosed_quoted_dotenv_value(raw_value):
+            raise BoundaryCheckError(
+                "unterminated quoted dotenv value; cannot prove migration-mode boundary"
+            )
         if name == key:
             values.append(_parse_dotenv_value(raw_value, key=key))
 

--- a/scripts/ops/check_vps_migration_safe_runtime_env.py
+++ b/scripts/ops/check_vps_migration_safe_runtime_env.py
@@ -209,6 +209,7 @@ def _find_mapping_block(
     if target_indent is None:
         return None
 
+    matches: list[tuple[int, int, int, str]] = []
     for index, line in enumerate(lines):
         entry = _parse_mapping_entry(line, index)
         if entry is None:
@@ -217,8 +218,13 @@ def _find_mapping_block(
             continue
         if entry.key != key:
             continue
-        return index, _block_end(lines, index, entry.indent), entry.indent, entry.value
-    return None
+        matches.append((index, _block_end(lines, index, entry.indent), entry.indent, entry.value))
+
+    if len(matches) > 1:
+        raise BoundaryCheckError(f"mapping declares {key!r} more than once; refusing ambiguity")
+    if not matches:
+        return None
+    return matches[0]
 
 
 def _find_service_block(compose_text: str, service: str) -> list[str]:

--- a/scripts/ops/check_vps_migration_safe_runtime_env.py
+++ b/scripts/ops/check_vps_migration_safe_runtime_env.py
@@ -62,9 +62,6 @@ class MappingEntry:
     value: str
 
 
-_ENVIRONMENT_MAP_KEY_RE = re.compile(
-    r"^(?:([A-Za-z_][A-Za-z0-9_]*)|'([A-Za-z_][A-Za-z0-9_]*)'|\"([A-Za-z_][A-Za-z0-9_]*)\")\s*:"
-)
 _YAML_FRAGMENT_TOKEN_RE = re.compile(
     r"(^|\s)(<<\s*:|&[A-Za-z0-9_-]+|\*[A-Za-z0-9_-]+)($|\s)"
 )

--- a/scripts/ops/check_vps_migration_safe_runtime_env.py
+++ b/scripts/ops/check_vps_migration_safe_runtime_env.py
@@ -683,6 +683,11 @@ def _read_dotenv_key(env_file: Path, key: str) -> tuple[bool, str | None]:
             if commentless != stripped:
                 match = _DOTENV_KEY_RE.match(commentless)
         if match is None:
+            if key in stripped:
+                raise BoundaryCheckError(
+                    f"unparsable line in selected env file contains protected key {key!r}; "
+                    "refusing ambiguous migration mode"
+                )
             continue
 
         name, separator, raw_value = match.groups()

--- a/scripts/ops/check_vps_migration_safe_runtime_env.py
+++ b/scripts/ops/check_vps_migration_safe_runtime_env.py
@@ -3,21 +3,23 @@
 
 This helper is intentionally narrow. It does not call Docker, start containers,
 render the full compose output, inspect arbitrary environment values, or print
-secrets. It checks only the single startup-migration mode key that protects a
-no-migration runtime smoke.
+confidential values. It checks only the single startup-migration mode key plus
+the non-confidential compose source shape needed to bind the selected env file.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Mapping
 
 MIGRATION_MODE_KEY = "WELTGEWEBE_API_STARTUP_MIGRATIONS"
+COMPOSE_ENV_FILE_KEY = "WELTGEWEBE_ENV_FILE"
 DEFAULT_EXPECTED_MODE = "verify-applied"
 DEFAULT_SERVICE = "api"
 
@@ -43,8 +45,8 @@ class BoundaryCheckResult:
             "observed_mode": self.observed_mode,
             "has_env_file_hook": self.has_env_file_hook,
             "has_service_environment_override": self.has_service_environment_override,
-            "secrets_printed": False,
-            "runtime_started": False,
+            "helper_printed_confidential_values": False,
+            "helper_started_runtime": False,
         }
 
 
@@ -63,7 +65,11 @@ def _without_comment(line: str) -> str:
     return line.rstrip("\n")
 
 
-def _find_mapping_block(lines: list[str], key: str, min_indent: int = 0) -> tuple[int, int, int] | None:
+def _find_mapping_block(
+    lines: list[str],
+    key: str,
+    min_indent: int = 0,
+) -> tuple[int, int, int] | None:
     pattern = re.compile(rf"^(\s*){re.escape(key)}\s*:\s*(?:#.*)?$")
     for index, line in enumerate(lines):
         if _leading_spaces(line) < min_indent:
@@ -104,34 +110,260 @@ def _find_service_block(compose_text: str, service: str) -> list[str]:
     return lines[offset + service_start : offset + service_end]
 
 
-def _service_has_env_file_hook(service_lines: Iterable[str]) -> bool:
-    return any(_without_comment(line).strip().startswith("env_file:") for line in service_lines)
+def _strip_optional_quotes(value: str) -> str:
+    text = value.strip()
+    if len(text) >= 2 and text[0] == text[-1] and text[0] in {"'", '"'}:
+        return text[1:-1]
+    return text
 
 
-def _service_has_migration_override(service_lines: Iterable[str]) -> bool:
-    key_pattern = re.compile(rf"(^|[\s{{,\-]){re.escape(MIGRATION_MODE_KEY)}\s*:")
-    for line in service_lines:
-        text = _without_comment(line)
-        if key_pattern.search(text):
-            return True
+def _flow_items(value: str) -> list[str]:
+    text = value.strip()
+    if not text:
+        return []
+    if text.startswith("[") and text.endswith("]"):
+        inner = text[1:-1].strip()
+        if not inner:
+            return []
+        return [_strip_optional_quotes(part) for part in inner.split(",")]
+    raise BoundaryCheckError(
+        "unsupported flow-style compose value; use block list/map syntax for this guard"
+    )
+
+
+def _find_child_entry(service_lines: list[str], key: str) -> tuple[int, int, int, str] | None:
+    pattern = re.compile(rf"^(\s*){re.escape(key)}\s*:\s*(.*?)\s*(?:#.*)?$")
+    matches: list[tuple[int, int, int, str]] = []
+    for index, line in enumerate(service_lines):
+        match = pattern.match(_without_comment(line))
+        if match is None:
+            continue
+
+        indent = len(match.group(1))
+        end = len(service_lines)
+        for later_index in range(index + 1, len(service_lines)):
+            later = _without_comment(service_lines[later_index])
+            if not later.strip():
+                continue
+            if _leading_spaces(later) <= indent:
+                end = later_index
+                break
+        matches.append((index, end, indent, match.group(2).strip()))
+
+    if len(matches) > 1:
+        raise BoundaryCheckError(f"service declares {key!r} more than once; refusing ambiguity")
+    return matches[0] if matches else None
+
+
+def _service_has_env_file_hook(service_lines: list[str]) -> bool:
+    return _find_child_entry(service_lines, "env_file") is not None
+
+
+def _normalise_env_key_token(token: str) -> str:
+    text = token.strip()
+    if not text:
+        return text
+    if text[0] in {"'", '"'} and len(text) >= 2:
+        text = _strip_optional_quotes(text)
+    return text.strip()
+
+
+def _environment_item_sets_key(item: str) -> bool:
+    text = _normalise_env_key_token(item)
+    if text == MIGRATION_MODE_KEY:
+        return True
+    if text.startswith(f"{MIGRATION_MODE_KEY}="):
+        return True
+    if text.startswith(f"{MIGRATION_MODE_KEY}:"):
+        return True
     return False
 
 
-def _unquote_dotenv_value(raw: str) -> str:
+def _service_has_migration_override(service_lines: list[str]) -> bool:
+    entry = _find_child_entry(service_lines, "environment")
+    if entry is None:
+        return False
+
+    start, end, _indent, inline_value = entry
+    if inline_value:
+        text = inline_value.strip()
+        if MIGRATION_MODE_KEY in text:
+            return True
+        if text.startswith("[") or text.startswith("{"):
+            raise BoundaryCheckError(
+                "unsupported flow-style service environment; cannot prove migration-mode absence"
+            )
+        raise BoundaryCheckError(
+            "unsupported inline service environment; use block map/list syntax for this guard"
+        )
+
+    for raw_line in service_lines[start + 1 : end]:
+        line = _without_comment(raw_line)
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        if stripped.startswith("-"):
+            item = stripped[1:].strip()
+            if _environment_item_sets_key(item):
+                return True
+            continue
+
+        key_match = re.match(r"^([A-Za-z_][A-Za-z0-9_]*)\s*:", stripped)
+        if key_match:
+            if key_match.group(1) == MIGRATION_MODE_KEY:
+                return True
+            continue
+
+        if "<<" in stripped or "&" in stripped or "*" in stripped:
+            raise BoundaryCheckError(
+                "unsupported YAML merge/anchor in service environment; cannot prove migration-mode absence"
+            )
+
+        raise BoundaryCheckError(
+            "unsupported service environment entry; cannot prove migration-mode absence"
+        )
+
+    return False
+
+
+def _extract_env_file_entries(service_lines: list[str]) -> list[str]:
+    entry = _find_child_entry(service_lines, "env_file")
+    if entry is None:
+        return []
+
+    start, end, _indent, inline_value = entry
+    if inline_value:
+        if inline_value.startswith("["):
+            entries = _flow_items(inline_value)
+        else:
+            entries = [_strip_optional_quotes(inline_value)]
+        return [entry for entry in entries if entry]
+
+    entries: list[str] = []
+    for raw_line in service_lines[start + 1 : end]:
+        line = _without_comment(raw_line)
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if not stripped.startswith("-"):
+            raise BoundaryCheckError(
+                "unsupported env_file entry; use string entries for this guard"
+            )
+
+        item = stripped[1:].strip()
+        if not item:
+            raise BoundaryCheckError("empty env_file entry; refusing ambiguity")
+        if item.startswith("{") or re.match(r"^[A-Za-z_][A-Za-z0-9_-]*\s*:", item):
+            raise BoundaryCheckError(
+                "unsupported structured env_file entry; use string path entries for this guard"
+            )
+        entries.append(_strip_optional_quotes(item))
+
+    return entries
+
+
+_COMPOSE_VAR_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?:(:-|-)([^}]*))?\}")
+
+
+def _resolve_compose_vars(value: str, compose_env: Mapping[str, str]) -> str:
+    def replace(match: re.Match[str]) -> str:
+        name = match.group(1)
+        op = match.group(2)
+        default = match.group(3)
+        current = compose_env.get(name)
+
+        if op == ":-":
+            return current if current else default
+        if op == "-":
+            return current if current is not None else default
+        if op is None:
+            if current is None:
+                raise BoundaryCheckError(
+                    f"compose env_file entry references unset variable {name!r}"
+                )
+            return current
+
+        raise BoundaryCheckError(
+            f"unsupported compose variable operator in env_file entry for {name!r}"
+        )
+
+    if "$" in value and "${" not in value:
+        raise BoundaryCheckError(
+            "unsupported compose env_file variable syntax; use ${VAR:-default}"
+        )
+    return _COMPOSE_VAR_RE.sub(replace, value)
+
+
+def _normalise_path(path: Path) -> Path:
+    return path.expanduser().resolve(strict=False)
+
+
+def _resolve_env_file_entries(
+    *,
+    compose_source: Path,
+    entries: Iterable[str],
+    compose_env: Mapping[str, str],
+) -> list[Path]:
+    resolved: list[Path] = []
+    for entry in entries:
+        resolved_entry = _resolve_compose_vars(entry, compose_env).strip()
+        if not resolved_entry:
+            raise BoundaryCheckError("env_file entry resolved to an empty path")
+
+        path = Path(resolved_entry)
+        if not path.is_absolute():
+            path = compose_source.parent / path
+        resolved.append(_normalise_path(path))
+
+    if not resolved:
+        raise BoundaryCheckError("service env_file resolves to an empty list")
+    return resolved
+
+
+def _parse_dotenv_value(raw: str, *, key: str) -> str:
     value = raw.strip()
-    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
-        return value[1:-1]
+    if not value:
+        return ""
+
+    if value[0] in {"'", '"'}:
+        quote = value[0]
+        escaped = False
+        chars: list[str] = []
+        for index, char in enumerate(value[1:], start=1):
+            if quote == '"' and escaped:
+                chars.append(char)
+                escaped = False
+                continue
+            if quote == '"' and char == "\\":
+                escaped = True
+                continue
+            if char == quote:
+                remainder = value[index + 1 :].strip()
+                if remainder and not remainder.startswith("#"):
+                    raise BoundaryCheckError(
+                        f"unsupported trailing content after quoted value for {key}"
+                    )
+                return "".join(chars)
+            chars.append(char)
+
+        raise BoundaryCheckError(f"unterminated quoted value for {key}")
+
+    if " #" in value:
+        value = value.split(" #", 1)[0].rstrip()
     return value
 
 
-def _read_dotenv_key(env_file: Path, key: str) -> str:
+def _read_dotenv_key(env_file: Path, key: str) -> str | None:
     try:
         lines = env_file.read_text(encoding="utf-8").splitlines()
     except OSError as error:
         raise BoundaryCheckError(f"could not read selected env file {env_file}: {error}") from error
 
     values: list[str] = []
-    pattern = re.compile(r"^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$")
+    pattern = re.compile(
+        r"^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*(=|:)\s*(.*)$"
+    )
     for line in lines:
         stripped = line.strip()
         if not stripped or stripped.startswith("#"):
@@ -139,19 +371,35 @@ def _read_dotenv_key(env_file: Path, key: str) -> str:
         match = pattern.match(stripped)
         if match is None:
             continue
-        name, raw_value = match.groups()
+        name, _separator, raw_value = match.groups()
         if name == key:
-            values.append(_unquote_dotenv_value(raw_value))
+            values.append(_parse_dotenv_value(raw_value, key=key))
 
-    if not values:
-        raise BoundaryCheckError(
-            f"selected env file does not set {key}; refusing migration-safe runtime smoke"
-        )
     if len(values) > 1:
         raise BoundaryCheckError(
-            f"selected env file sets {key} more than once; refusing ambiguous migration mode"
+            f"selected env file {env_file} sets {key} more than once; refusing ambiguous migration mode"
         )
+    if not values:
+        return None
     return values[0].strip()
+
+
+def _read_effective_dotenv_key(env_files: Iterable[Path], key: str) -> tuple[Path, str]:
+    selected_path: Path | None = None
+    selected_value: str | None = None
+
+    for env_file in env_files:
+        value = _read_dotenv_key(env_file, key)
+        if value is not None:
+            selected_path = env_file
+            selected_value = value
+
+    if selected_path is None or selected_value is None:
+        raise BoundaryCheckError(
+            f"effective env_file set does not set {key}; refusing migration-safe runtime smoke"
+        )
+
+    return selected_path, selected_value
 
 
 def validate_boundary(
@@ -160,6 +408,7 @@ def validate_boundary(
     env_file: Path,
     service: str = DEFAULT_SERVICE,
     expected_mode: str = DEFAULT_EXPECTED_MODE,
+    compose_env: Mapping[str, str] | None = None,
 ) -> BoundaryCheckResult:
     try:
         compose_text = compose_source.read_text(encoding="utf-8")
@@ -180,17 +429,35 @@ def validate_boundary(
             "this can override env_file and may re-enable startup migrations"
         )
 
-    observed_mode = _read_dotenv_key(env_file, MIGRATION_MODE_KEY)
+    compose_env_map = dict(compose_env or {})
+    entries = _extract_env_file_entries(service_lines)
+    effective_env_files = _resolve_env_file_entries(
+        compose_source=compose_source,
+        entries=entries,
+        compose_env=compose_env_map,
+    )
+
+    selected_env_file = _normalise_path(env_file)
+    effective_env_file, observed_mode = _read_effective_dotenv_key(
+        effective_env_files,
+        MIGRATION_MODE_KEY,
+    )
+    if selected_env_file != effective_env_file:
+        raise BoundaryCheckError(
+            "selected --env-file is not the effective env_file source for "
+            f"{MIGRATION_MODE_KEY}; refusing ambiguous migration mode"
+        )
+
     if observed_mode != expected_mode:
         raise BoundaryCheckError(
-            f"selected env file sets {MIGRATION_MODE_KEY} to a non-approved value; "
+            f"effective env file sets {MIGRATION_MODE_KEY} to a non-approved value; "
             f"expected {expected_mode!r}"
         )
 
     return BoundaryCheckResult(
         service=service,
         compose_source=str(compose_source),
-        env_file=str(env_file),
+        env_file=str(effective_env_file),
         expected_mode=expected_mode,
         observed_mode=observed_mode,
         has_env_file_hook=has_env_file_hook,
@@ -198,17 +465,37 @@ def validate_boundary(
     )
 
 
+def _parse_compose_env(values: list[str]) -> dict[str, str]:
+    compose_env: dict[str, str] = {}
+    if COMPOSE_ENV_FILE_KEY in os.environ:
+        compose_env[COMPOSE_ENV_FILE_KEY] = os.environ[COMPOSE_ENV_FILE_KEY]
+
+    for value in values:
+        if "=" not in value:
+            raise BoundaryCheckError(
+                f"--compose-env value must use NAME=VALUE syntax, got {value!r}"
+            )
+        name, raw = value.split("=", 1)
+        name = name.strip()
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
+            raise BoundaryCheckError(f"invalid compose env variable name {name!r}")
+        compose_env[name] = raw
+
+    return compose_env
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
-            "Validate the redacted env/compose boundary for a VPS migration-safe runtime smoke."
+            "Validate the redacted env/compose source boundary for a VPS "
+            "migration-safe runtime smoke."
         )
     )
     parser.add_argument(
         "--compose-source",
         type=Path,
         default=Path("infra/compose/compose.vps.override.yml"),
-        help="Repo compose override source to inspect; this should not contain secrets.",
+        help="Repo compose override source to inspect; this should not contain confidential values.",
     )
     parser.add_argument(
         "--env-file",
@@ -217,6 +504,17 @@ def _build_parser() -> argparse.ArgumentParser:
         help=(
             "Selected runtime env file. The script reads only "
             f"{MIGRATION_MODE_KEY} and never prints full env contents."
+        ),
+    )
+    parser.add_argument(
+        "--compose-env",
+        action="append",
+        default=[],
+        metavar="NAME=VALUE",
+        help=(
+            "Non-confidential compose interpolation input for env_file path "
+            "resolution. May be repeated. The helper also reads WELTGEWEBE_ENV_FILE "
+            "from the process environment when present."
         ),
     )
     parser.add_argument("--service", default=DEFAULT_SERVICE)
@@ -239,6 +537,7 @@ def main(argv: list[str] | None = None) -> int:
             env_file=args.env_file,
             service=args.service,
             expected_mode=args.expected_mode,
+            compose_env=_parse_compose_env(args.compose_env),
         )
     except BoundaryCheckError as error:
         print(f"FAIL: {error}", file=sys.stderr)
@@ -248,15 +547,15 @@ def main(argv: list[str] | None = None) -> int:
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:
-        print("PASS: migration-safe runtime-smoke env boundary is proven")
+        print("PASS: migration-safe runtime-smoke source boundary is proven")
         print(f"- service: {payload['service']}")
         print(f"- compose source: {payload['compose_source']}")
-        print(f"- selected env file: {payload['env_file']}")
+        print(f"- effective env file: {payload['env_file']}")
         print(f"- checked key: {payload['checked_key']}")
         print(f"- observed mode: {payload['observed_mode']}")
         print("- service-level migration override: absent")
-        print("- secrets printed: no")
-        print("- runtime started: no")
+        print("- helper printed confidential values: no")
+        print("- helper started runtime: no")
     return 0
 
 

--- a/scripts/ops/check_vps_migration_safe_runtime_env.py
+++ b/scripts/ops/check_vps_migration_safe_runtime_env.py
@@ -117,6 +117,44 @@ def _strip_optional_quotes(value: str) -> str:
     return text
 
 
+def _strip_yaml_inline_comment(value: str) -> str:
+    """Strip a YAML-style inline comment outside quotes.
+
+    YAML treats ``#`` as a comment delimiter only when it starts the scalar or is
+    preceded by whitespace. This helper intentionally implements only the narrow
+    scalar shapes accepted by this guard; unterminated quotes fail closed.
+    """
+
+    in_quote: str | None = None
+    escaped = False
+
+    for index, char in enumerate(value):
+        if in_quote:
+            if in_quote == '"' and escaped:
+                escaped = False
+                continue
+            if in_quote == '"' and char == "\\":
+                escaped = True
+                continue
+            if char == in_quote:
+                in_quote = None
+            continue
+
+        if char in {"'", '"'}:
+            in_quote = char
+            continue
+
+        if char == "#" and (index == 0 or value[index - 1].isspace()):
+            return value[:index].rstrip()
+
+    if in_quote:
+        raise BoundaryCheckError(
+            "unterminated quoted compose scalar; cannot prove migration-mode absence"
+        )
+
+    return value.rstrip()
+
+
 def _flow_items(value: str) -> list[str]:
     text = value.strip()
     if not text:
@@ -125,7 +163,7 @@ def _flow_items(value: str) -> list[str]:
         inner = text[1:-1].strip()
         if not inner:
             return []
-        return [_strip_optional_quotes(part) for part in inner.split(",")]
+        return [_strip_optional_quotes(_strip_yaml_inline_comment(part)) for part in inner.split(",")]
     raise BoundaryCheckError(
         "unsupported flow-style compose value; use block list/map syntax for this guard"
     )
@@ -160,7 +198,7 @@ def _service_has_env_file_hook(service_lines: list[str]) -> bool:
 
 
 def _normalise_env_key_token(token: str) -> str:
-    text = token.strip()
+    text = _strip_yaml_inline_comment(token).strip()
     if not text:
         return text
     if text[0] in {"'", '"'} and len(text) >= 2:
@@ -237,7 +275,7 @@ def _extract_env_file_entries(service_lines: list[str]) -> list[str]:
         if inline_value.startswith("["):
             entries = _flow_items(inline_value)
         else:
-            entries = [_strip_optional_quotes(inline_value)]
+            entries = [_strip_optional_quotes(_strip_yaml_inline_comment(inline_value))]
         return [entry for entry in entries if entry]
 
     entries: list[str] = []
@@ -251,7 +289,7 @@ def _extract_env_file_entries(service_lines: list[str]) -> list[str]:
                 "unsupported env_file entry; use string entries for this guard"
             )
 
-        item = stripped[1:].strip()
+        item = _strip_yaml_inline_comment(stripped[1:].strip()).strip()
         if not item:
             raise BoundaryCheckError("empty env_file entry; refusing ambiguity")
         if item.startswith("{") or re.match(r"^[A-Za-z_][A-Za-z0-9_-]*\s*:", item):

--- a/scripts/ops/check_vps_migration_safe_runtime_env.py
+++ b/scripts/ops/check_vps_migration_safe_runtime_env.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Validate the VPS migration-safe runtime-smoke environment boundary.
+
+This helper is intentionally narrow. It does not call Docker, start containers,
+render the full compose output, inspect arbitrary environment values, or print
+secrets. It checks only the single startup-migration mode key that protects a
+no-migration runtime smoke.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+MIGRATION_MODE_KEY = "WELTGEWEBE_API_STARTUP_MIGRATIONS"
+DEFAULT_EXPECTED_MODE = "verify-applied"
+DEFAULT_SERVICE = "api"
+
+
+@dataclass(frozen=True)
+class BoundaryCheckResult:
+    service: str
+    compose_source: str
+    env_file: str
+    expected_mode: str
+    observed_mode: str
+    has_env_file_hook: bool
+    has_service_environment_override: bool
+
+    def redacted_payload(self) -> dict[str, object]:
+        return {
+            "status": "pass",
+            "service": self.service,
+            "compose_source": self.compose_source,
+            "env_file": self.env_file,
+            "checked_key": MIGRATION_MODE_KEY,
+            "expected_mode": self.expected_mode,
+            "observed_mode": self.observed_mode,
+            "has_env_file_hook": self.has_env_file_hook,
+            "has_service_environment_override": self.has_service_environment_override,
+            "secrets_printed": False,
+            "runtime_started": False,
+        }
+
+
+class BoundaryCheckError(RuntimeError):
+    """Raised when the migration-safe runtime-smoke boundary is not proven."""
+
+
+def _leading_spaces(line: str) -> int:
+    return len(line) - len(line.lstrip(" "))
+
+
+def _without_comment(line: str) -> str:
+    stripped = line.lstrip()
+    if stripped.startswith("#"):
+        return ""
+    return line.rstrip("\n")
+
+
+def _find_mapping_block(lines: list[str], key: str, min_indent: int = 0) -> tuple[int, int, int] | None:
+    pattern = re.compile(rf"^(\s*){re.escape(key)}\s*:\s*(?:#.*)?$")
+    for index, line in enumerate(lines):
+        if _leading_spaces(line) < min_indent:
+            continue
+        if not pattern.match(_without_comment(line)):
+            continue
+
+        indent = _leading_spaces(line)
+        end = len(lines)
+        for later_index in range(index + 1, len(lines)):
+            later = _without_comment(lines[later_index])
+            if not later.strip():
+                continue
+            if _leading_spaces(later) <= indent:
+                end = later_index
+                break
+        return index, end, indent
+    return None
+
+
+def _find_service_block(compose_text: str, service: str) -> list[str]:
+    lines = compose_text.splitlines()
+    services_block = _find_mapping_block(lines, "services")
+    if services_block is None:
+        raise BoundaryCheckError("compose source does not contain a top-level services block")
+
+    services_start, services_end, services_indent = services_block
+    service_block = _find_mapping_block(
+        lines[services_start + 1 : services_end],
+        service,
+        min_indent=services_indent + 1,
+    )
+    if service_block is None:
+        raise BoundaryCheckError(f"compose source does not contain service {service!r}")
+
+    service_start, service_end, _ = service_block
+    offset = services_start + 1
+    return lines[offset + service_start : offset + service_end]
+
+
+def _service_has_env_file_hook(service_lines: Iterable[str]) -> bool:
+    return any(_without_comment(line).strip().startswith("env_file:") for line in service_lines)
+
+
+def _service_has_migration_override(service_lines: Iterable[str]) -> bool:
+    key_pattern = re.compile(rf"(^|[\s{{,\-]){re.escape(MIGRATION_MODE_KEY)}\s*:")
+    for line in service_lines:
+        text = _without_comment(line)
+        if key_pattern.search(text):
+            return True
+    return False
+
+
+def _unquote_dotenv_value(raw: str) -> str:
+    value = raw.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def _read_dotenv_key(env_file: Path, key: str) -> str:
+    try:
+        lines = env_file.read_text(encoding="utf-8").splitlines()
+    except OSError as error:
+        raise BoundaryCheckError(f"could not read selected env file {env_file}: {error}") from error
+
+    values: list[str] = []
+    pattern = re.compile(r"^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$")
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        match = pattern.match(stripped)
+        if match is None:
+            continue
+        name, raw_value = match.groups()
+        if name == key:
+            values.append(_unquote_dotenv_value(raw_value))
+
+    if not values:
+        raise BoundaryCheckError(
+            f"selected env file does not set {key}; refusing migration-safe runtime smoke"
+        )
+    if len(values) > 1:
+        raise BoundaryCheckError(
+            f"selected env file sets {key} more than once; refusing ambiguous migration mode"
+        )
+    return values[0].strip()
+
+
+def validate_boundary(
+    *,
+    compose_source: Path,
+    env_file: Path,
+    service: str = DEFAULT_SERVICE,
+    expected_mode: str = DEFAULT_EXPECTED_MODE,
+) -> BoundaryCheckResult:
+    try:
+        compose_text = compose_source.read_text(encoding="utf-8")
+    except OSError as error:
+        raise BoundaryCheckError(f"could not read compose source {compose_source}: {error}") from error
+
+    service_lines = _find_service_block(compose_text, service)
+    has_env_file_hook = _service_has_env_file_hook(service_lines)
+    if not has_env_file_hook:
+        raise BoundaryCheckError(
+            f"service {service!r} does not declare env_file; cannot prove selected env source"
+        )
+
+    has_override = _service_has_migration_override(service_lines)
+    if has_override:
+        raise BoundaryCheckError(
+            f"service {service!r} sets {MIGRATION_MODE_KEY} in its compose service block; "
+            "this can override env_file and may re-enable startup migrations"
+        )
+
+    observed_mode = _read_dotenv_key(env_file, MIGRATION_MODE_KEY)
+    if observed_mode != expected_mode:
+        raise BoundaryCheckError(
+            f"selected env file sets {MIGRATION_MODE_KEY} to a non-approved value; "
+            f"expected {expected_mode!r}"
+        )
+
+    return BoundaryCheckResult(
+        service=service,
+        compose_source=str(compose_source),
+        env_file=str(env_file),
+        expected_mode=expected_mode,
+        observed_mode=observed_mode,
+        has_env_file_hook=has_env_file_hook,
+        has_service_environment_override=has_override,
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate the redacted env/compose boundary for a VPS migration-safe runtime smoke."
+        )
+    )
+    parser.add_argument(
+        "--compose-source",
+        type=Path,
+        default=Path("infra/compose/compose.vps.override.yml"),
+        help="Repo compose override source to inspect; this should not contain secrets.",
+    )
+    parser.add_argument(
+        "--env-file",
+        type=Path,
+        required=True,
+        help=(
+            "Selected runtime env file. The script reads only "
+            f"{MIGRATION_MODE_KEY} and never prints full env contents."
+        ),
+    )
+    parser.add_argument("--service", default=DEFAULT_SERVICE)
+    parser.add_argument("--expected-mode", default=DEFAULT_EXPECTED_MODE)
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print a redacted JSON receipt instead of text.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        result = validate_boundary(
+            compose_source=args.compose_source,
+            env_file=args.env_file,
+            service=args.service,
+            expected_mode=args.expected_mode,
+        )
+    except BoundaryCheckError as error:
+        print(f"FAIL: {error}", file=sys.stderr)
+        return 1
+
+    payload = result.redacted_payload()
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print("PASS: migration-safe runtime-smoke env boundary is proven")
+        print(f"- service: {payload['service']}")
+        print(f"- compose source: {payload['compose_source']}")
+        print(f"- selected env file: {payload['env_file']}")
+        print(f"- checked key: {payload['checked_key']}")
+        print(f"- observed mode: {payload['observed_mode']}")
+        print("- service-level migration override: absent")
+        print("- secrets printed: no")
+        print("- runtime started: no")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ops/check_vps_migration_safe_runtime_env.py
+++ b/scripts/ops/check_vps_migration_safe_runtime_env.py
@@ -14,9 +14,9 @@ import json
 import os
 import re
 import sys
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Mapping
 
 MIGRATION_MODE_KEY = "WELTGEWEBE_API_STARTUP_MIGRATIONS"
 COMPOSE_ENV_FILE_KEY = "WELTGEWEBE_ENV_FILE"
@@ -65,19 +65,60 @@ def _without_comment(line: str) -> str:
     return line.rstrip("\n")
 
 
+def _yaml_key_pattern(key: str) -> str:
+    escaped = re.escape(key)
+    return rf"(?:{escaped}|'{escaped}'|\"{escaped}\")"
+
+
+def _match_yaml_mapping_key(line: str, key: str) -> re.Match[str] | None:
+    pattern = re.compile(rf"^(\s*){_yaml_key_pattern(key)}\s*:\s*(.*?)\s*(?:#.*)?$")
+    return pattern.match(line)
+
+
+def _first_direct_child_indent(
+    lines: list[str],
+    *,
+    start: int = 0,
+    min_indent: int = 0,
+    parent_indent: int | None = None,
+) -> int | None:
+    for line in lines[start:]:
+        text = _without_comment(line)
+        if not text.strip():
+            continue
+
+        indent = _leading_spaces(text)
+        if parent_indent is not None and indent <= parent_indent:
+            continue
+        if indent < min_indent:
+            continue
+        return indent
+    return None
+
+
 def _find_mapping_block(
     lines: list[str],
     key: str,
     min_indent: int = 0,
 ) -> tuple[int, int, int] | None:
-    pattern = re.compile(rf"^(\s*){re.escape(key)}\s*:\s*(?:#.*)?$")
+    target_indent = _first_direct_child_indent(lines, min_indent=min_indent)
+    if target_indent is None:
+        return None
+
     for index, line in enumerate(lines):
-        if _leading_spaces(line) < min_indent:
-            continue
-        if not pattern.match(_without_comment(line)):
+        text = _without_comment(line)
+        if not text.strip():
             continue
 
-        indent = _leading_spaces(line)
+        indent = _leading_spaces(text)
+        if indent < min_indent:
+            continue
+        if indent != target_indent:
+            continue
+
+        if not _match_yaml_mapping_key(text, key):
+            continue
+
         end = len(lines)
         for later_index in range(index + 1, len(lines)):
             later = _without_comment(lines[later_index])
@@ -170,14 +211,36 @@ def _flow_items(value: str) -> list[str]:
 
 
 def _find_child_entry(service_lines: list[str], key: str) -> tuple[int, int, int, str] | None:
-    pattern = re.compile(rf"^(\s*){re.escape(key)}\s*:\s*(.*?)\s*(?:#.*)?$")
+    if not service_lines:
+        return None
+
+    parent = _without_comment(service_lines[0])
+    parent_indent = _leading_spaces(parent)
+    target_indent = _first_direct_child_indent(
+        service_lines,
+        start=1,
+        min_indent=parent_indent + 1,
+        parent_indent=parent_indent,
+    )
+    if target_indent is None:
+        return None
+
     matches: list[tuple[int, int, int, str]] = []
-    for index, line in enumerate(service_lines):
-        match = pattern.match(_without_comment(line))
+    for index in range(1, len(service_lines)):
+        text = _without_comment(service_lines[index])
+        if not text.strip():
+            continue
+
+        indent = _leading_spaces(text)
+        if indent <= parent_indent:
+            continue
+        if indent != target_indent:
+            continue
+
+        match = _match_yaml_mapping_key(text, key)
         if match is None:
             continue
 
-        indent = len(match.group(1))
         end = len(service_lines)
         for later_index in range(index + 1, len(service_lines)):
             later = _without_comment(service_lines[later_index])
@@ -217,6 +280,11 @@ def _environment_item_sets_key(item: str) -> bool:
     return False
 
 
+_ENVIRONMENT_MAP_KEY_RE = re.compile(
+    r"^(?:([A-Za-z_][A-Za-z0-9_]*)|'([A-Za-z_][A-Za-z0-9_]*)'|\"([A-Za-z_][A-Za-z0-9_]*)\")\s*:"
+)
+
+
 def _service_has_migration_override(service_lines: list[str]) -> bool:
     entry = _find_child_entry(service_lines, "environment")
     if entry is None:
@@ -247,9 +315,10 @@ def _service_has_migration_override(service_lines: list[str]) -> bool:
                 return True
             continue
 
-        key_match = re.match(r"^([A-Za-z_][A-Za-z0-9_]*)\s*:", stripped)
+        key_match = _ENVIRONMENT_MAP_KEY_RE.match(stripped)
         if key_match:
-            if key_match.group(1) == MIGRATION_MODE_KEY:
+            key = next(group for group in key_match.groups() if group is not None)
+            if key == MIGRATION_MODE_KEY:
                 return True
             continue
 


### PR DESCRIPTION
## Summary

Adds a repository-side prerequisite slice for the post-#1350 VPS API smoke path:

- new runbook: `docs/deploy/vps-migration-safe-runtime-smoke.md`
- helper: `scripts/ops/check_vps_migration_safe_runtime_env.py`
- helper tests: `scripts/ci/tests/test_vps_migration_safe_runtime_env.py`
- boundary tests: `scripts/ci/tests/test_vps_migration_safe_runtime_env_boundaries.py`
- Compose-semantics tests: `scripts/ci/tests/test_vps_migration_safe_runtime_env_compose_semantics.py`
- YAML edge tests: `scripts/ci/tests/test_vps_runtime_yaml_edges.py`
- link from `docs/deploy/vps-http-smoke.md`

## Boundary

This PR is a repository guard-rail slice for a later #1348 run. It is not #1348 completion evidence and must not close #1348.

No VPS/runtime operation was performed in this PR.

## Guard behavior

The helper checks the migration-mode key, the selected env source, and the non-public compose source shape. It now:

- binds the checked env file to the effective `services.api.env_file` source
- blocks service-level migration-mode overrides in map and array syntax
- expands `~` before relative path handling
- rejects shell-style `export` for the migration-mode key
- rejects multi-line quoted dotenv values fail-closed
- rejects unparsable dotenv lines that contain the protected migration-mode key
- treats bare target-key lines in env files as explicit unsets
- rejects service-level `extends`
- rejects guard-relevant YAML merge, anchor, and alias constructs
- rejects unsupported `env_file` interpolation forms
- rejects duplicate direct YAML mapping keys used for proof selection
- allows safe quoted `*` and `&` in non-guard service values

## Validation

Local validation before push for head `e79be4b0f7243ecb9d323f57c6086a2971dadc34`:

- `py_compile`: pass
- targeted helper pytest set: `38 passed`
- `git diff --check`: pass

GitHub Actions for head `e79be4b0f7243ecb9d323f57c6086a2971dadc34`:

- `docs-style`: success
- `policies`: success
- `CI (heavy on demand)`: success
- `seo-archive`: success
- `python-tooling`: success
- `CI`: pending at last body update

## Current decision

Keep this PR as Draft until the main `CI` workflow completes on the current head and final review confirms no new feedback.