### PR TITLE
fix: add VPS DB history preflight guard

### DIFF
--- a/.github/workflows/vps-db-history-preflight.yml
+++ b/.github/workflows/vps-db-history-preflight.yml
@@ -1,0 +1,66 @@
+---
+name: VPS DB history preflight
+
+"on":
+  pull_request:
+    branches: [main]
+    paths:
+      - "docs/deploy/vps-migration-safe-runtime-smoke.md"
+      - "scripts/ops/check_vps_db_migration_history_shape.py"
+      - "scripts/ci/tests/test_vps_db_history_preflight_docs.py"
+      - "scripts/ci/tests/test_vps_db_migration_history_shape.py"
+      - "scripts/ci/tests/test_vps_migration_safe_runtime_env.py"
+      - "scripts/ci/tests/test_vps_migration_safe_runtime_env_boundaries.py"
+      - "scripts/ci/tests/test_vps_migration_safe_runtime_env_compose_semantics.py"
+      - "scripts/ci/tests/test_vps_runtime_yaml_edges.py"
+      - ".github/workflows/vps-db-history-preflight.yml"
+  push:
+    branches: [main]
+    paths:
+      - "docs/deploy/vps-migration-safe-runtime-smoke.md"
+      - "scripts/ops/check_vps_db_migration_history_shape.py"
+      - "scripts/ci/tests/test_vps_db_history_preflight_docs.py"
+      - "scripts/ci/tests/test_vps_db_migration_history_shape.py"
+      - "scripts/ci/tests/test_vps_migration_safe_runtime_env.py"
+      - "scripts/ci/tests/test_vps_migration_safe_runtime_env_boundaries.py"
+      - "scripts/ci/tests/test_vps_migration_safe_runtime_env_compose_semantics.py"
+      - "scripts/ci/tests/test_vps_runtime_yaml_edges.py"
+      - ".github/workflows/vps-db-history-preflight.yml"
+  workflow_dispatch: {}
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: VPS DB history preflight tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # tag: v7.0.0
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # tag: v5
+        with:
+          python-version-file: ".python-version"
+
+      - name: Install pytest
+        run: python -m pip install pytest==8.3.4
+
+      - name: Run VPS DB history preflight tests
+        run: |
+          set -euo pipefail
+          python -m pytest \
+            scripts/ci/tests/test_vps_db_migration_history_shape.py \
+            scripts/ci/tests/test_vps_db_history_preflight_docs.py \
+            scripts/ci/tests/test_vps_migration_safe_runtime_env.py \
+            scripts/ci/tests/test_vps_migration_safe_runtime_env_boundaries.py \
+            scripts/ci/tests/test_vps_migration_safe_runtime_env_compose_semantics.py \
+            scripts/ci/tests/test_vps_runtime_yaml_edges.py \
+            -q

--- a/docs/deploy/vps-migration-safe-runtime-smoke.md
+++ b/docs/deploy/vps-migration-safe-runtime-smoke.md
@@ -133,6 +133,41 @@ If the effective env source is missing the key, sets it more than once, sets a
 value other than `verify-applied`, or the API service sets the key in
 `environment`, stop.
 
+## DB migration-history preflight
+
+Before any further bounded runtime attempt on `wg-prod-1`, run the DB history
+shape preflight against the already-running PostgreSQL container:
+
+```bash
+python3 scripts/ops/check_vps_db_migration_history_shape.py --json
+```
+
+This helper is intentionally narrower than a runtime retry:
+
+- it reads PostgreSQL catalog shape through the selected DB container
+- it does not start the API
+- it does not start or restart Compose services
+- it does not apply migrations
+- it does not read runtime env files
+- it does not print confidential values
+
+A `blocked` result is a hard stop for #1348 runtime work. In particular, stop
+when `public._sqlx_migrations` is absent, when the app schema appears empty,
+when migration history is empty, when failed history rows exist, or when duplicate
+migration versions exist. Do not retry the API in normal `run` mode to get past
+that condition, because normal startup may apply SQLx migrations.
+
+If this preflight blocks, the next path must be one of two explicitly reviewed
+operations:
+
+1. an approved DB initialization or repair window, outside this no-migration smoke
+   boundary; or
+2. a genuinely DB-free route smoke that does not claim API/database readiness.
+
+The runtime receipt must include the preflight status and must not report #1348
+as passed unless later loopback/runtime checks actually succeed under
+`WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied`.
+
 ## Compose evidence discipline
 
 The source-level helper is not a replacement for a separately reviewed runtime

--- a/scripts/ci/tests/test_vps_db_history_preflight_docs.py
+++ b/scripts/ci/tests/test_vps_db_history_preflight_docs.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RUNBOOK = REPO_ROOT / "docs" / "deploy" / "vps-migration-safe-runtime-smoke.md"
+HELPER = REPO_ROOT / "scripts" / "ops" / "check_vps_db_migration_history_shape.py"
+
+
+def test_runtime_runbook_requires_db_history_preflight_before_retry() -> None:
+    text = RUNBOOK.read_text(encoding="utf-8")
+
+    assert "## DB migration-history preflight" in text
+    assert "check_vps_db_migration_history_shape.py --json" in text
+    assert "A `blocked` result is a hard stop for #1348 runtime work." in text
+    assert "Do not retry the API in normal `run` mode" in text
+    assert "genuinely DB-free route smoke that does not claim API/database readiness" in text
+
+
+def test_runtime_runbook_db_history_preflight_boundary_matches_helper() -> None:
+    runbook = RUNBOOK.read_text(encoding="utf-8")
+    helper = HELPER.read_text(encoding="utf-8")
+
+    for expected in [
+        "helper_started_api",
+        "helper_applied_migrations",
+        "helper_read_env_file",
+        "helper_printed_confidential_values",
+        "migration_history_table_absent",
+        "app_schema_empty_or_migration_history_absent",
+        "app_schema_empty",
+        "migration_history_empty",
+        "failed_migration_history_rows",
+        "duplicate_migration_versions",
+    ]:
+        assert expected in helper
+
+    for expected in [
+        "does not start the API",
+        "does not apply migrations",
+        "does not read runtime env files",
+        "does not print confidential values",
+        "when `public._sqlx_migrations` is absent",
+        "when migration history is empty",
+        "when failed history rows exist",
+        "when duplicate",
+        "migration versions exist",
+    ]:
+        assert expected in runbook

--- a/scripts/ci/tests/test_vps_db_migration_history_shape.py
+++ b/scripts/ci/tests/test_vps_db_migration_history_shape.py
@@ -1,0 +1,236 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "ops" / "check_vps_db_migration_history_shape.py"
+
+
+def _fake_docker(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "docker"
+    path.write_text("#!/usr/bin/env python3\n" + body, encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+def _run(fake_docker: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--docker-bin", str(fake_docker), "--json"],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def test_missing_history_table_blocks_before_api_start(tmp_path):
+    fake = _fake_docker(
+        tmp_path,
+        """
+print('history_table=absent')
+print('user_relation_count=0')
+print('base_table_count=0')
+""",
+    )
+
+    result = _run(fake)
+    payload = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert payload["status"] == "blocked"
+    assert payload["history_table"] == "absent"
+    assert payload["reason"] == "app_schema_empty_or_migration_history_absent"
+    assert payload["helper_started_api"] is False
+    assert payload["helper_applied_migrations"] is False
+    assert payload["helper_read_env_file"] is False
+
+
+def test_present_nonempty_clean_history_passes(tmp_path):
+    fake = _fake_docker(
+        tmp_path,
+        """
+import sys
+script = sys.argv[-1]
+if 'history_row_count' in script:
+    print('history_row_count=5')
+    print('failed_history_count=0')
+    print('duplicate_version_count=0')
+else:
+    print('history_table=present')
+    print('user_relation_count=10')
+    print('base_table_count=9')
+""",
+    )
+
+    result = _run(fake)
+    payload = json.loads(result.stdout)
+
+    assert result.returncode == 0
+    assert payload["status"] == "pass"
+    assert payload["history_table"] == "present"
+    assert payload["history_row_count"] == 5
+    assert payload["failed_history_count"] == 0
+    assert payload["duplicate_version_count"] == 0
+
+
+def test_present_but_empty_history_blocks(tmp_path):
+    fake = _fake_docker(
+        tmp_path,
+        """
+import sys
+script = sys.argv[-1]
+if 'history_row_count' in script:
+    print('history_row_count=0')
+    print('failed_history_count=0')
+    print('duplicate_version_count=0')
+else:
+    print('history_table=present')
+    print('user_relation_count=1')
+    print('base_table_count=1')
+""",
+    )
+
+    result = _run(fake)
+    payload = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert payload["status"] == "blocked"
+    assert payload["reason"] == "migration_history_empty"
+
+
+def test_failed_history_blocks(tmp_path):
+    fake = _fake_docker(
+        tmp_path,
+        """
+import sys
+script = sys.argv[-1]
+if 'history_row_count' in script:
+    print('history_row_count=3')
+    print('failed_history_count=1')
+    print('duplicate_version_count=0')
+else:
+    print('history_table=present')
+    print('user_relation_count=3')
+    print('base_table_count=3')
+""",
+    )
+
+    result = _run(fake)
+    payload = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert payload["status"] == "blocked"
+    assert payload["reason"] == "failed_migration_history_rows"
+
+
+def test_catalog_probe_error_is_nonpassing(tmp_path):
+    fake = _fake_docker(
+        tmp_path,
+        """
+import sys
+print('catalog unavailable', file=sys.stderr)
+sys.exit(2)
+""",
+    )
+
+    result = _run(fake)
+    payload = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert payload["status"] == "error"
+    assert payload["reason"] == "catalog_probe_failed"
+    assert "catalog unavailable" in payload["command_error"]
+
+
+def test_history_only_schema_blocks(tmp_path):
+    fake = _fake_docker(
+        tmp_path,
+        """
+import sys
+script = sys.argv[-1]
+if 'history_row_count' in script:
+    print('history_row_count=4')
+    print('failed_history_count=0')
+    print('duplicate_version_count=0')
+else:
+    print('history_table=present')
+    print('user_relation_count=0')
+    print('base_table_count=0')
+""",
+    )
+
+    result = _run(fake)
+    payload = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert payload["status"] == "blocked"
+    assert payload["reason"] == "app_schema_empty"
+
+
+def test_duplicate_history_versions_block(tmp_path):
+    fake = _fake_docker(
+        tmp_path,
+        """
+import sys
+script = sys.argv[-1]
+if 'history_row_count' in script:
+    print('history_row_count=4')
+    print('failed_history_count=0')
+    print('duplicate_version_count=1')
+else:
+    print('history_table=present')
+    print('user_relation_count=4')
+    print('base_table_count=4')
+""",
+    )
+
+    result = _run(fake)
+    payload = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert payload["status"] == "blocked"
+    assert payload["reason"] == "duplicate_migration_versions"
+
+
+def test_noninteger_catalog_count_is_error(tmp_path):
+    fake = _fake_docker(
+        tmp_path,
+        """
+print('history_table=present')
+print('user_relation_count=not-a-number')
+print('base_table_count=1')
+""",
+    )
+
+    result = _run(fake)
+    payload = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert payload["status"] == "error"
+    assert payload["reason"] == "catalog_probe_failed"
+
+
+def test_noninteger_history_count_is_error(tmp_path):
+    fake = _fake_docker(
+        tmp_path,
+        """
+import sys
+script = sys.argv[-1]
+if 'history_row_count' in script:
+    print('history_row_count=not-a-number')
+    print('failed_history_count=0')
+    print('duplicate_version_count=0')
+else:
+    print('history_table=present')
+    print('user_relation_count=2')
+    print('base_table_count=2')
+""",
+    )
+
+    result = _run(fake)
+    payload = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert payload["status"] == "error"
+    assert payload["reason"] == "history_probe_failed"

--- a/scripts/ops/check_vps_db_migration_history_shape.py
+++ b/scripts/ops/check_vps_db_migration_history_shape.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Check PostgreSQL migration-history shape before a VPS API smoke.
+
+The helper reads only PostgreSQL catalog shape through an already-running database
+container. It does not start the API and it does not apply migrations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Sequence
+
+DEFAULT_CONTAINER = "weltgewebe-db-1"
+
+CATALOG_QUERY = r"""
+psql -v ON_ERROR_STOP=1 -qAt -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<'SQL'
+SELECT 'history_table=' || CASE
+  WHEN to_regclass('public._sqlx_migrations') IS NULL THEN 'absent'
+  ELSE 'present'
+END;
+SELECT 'user_relation_count=' || count(*)
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+  AND n.nspname NOT LIKE 'pg_toast%'
+  AND NOT (n.nspname = 'public' AND c.relname = '_sqlx_migrations')
+  AND c.relkind IN ('r', 'p', 'v', 'm', 'S', 'f');
+SELECT 'base_table_count=' || count(*)
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+  AND n.nspname NOT LIKE 'pg_toast%'
+  AND NOT (n.nspname = 'public' AND c.relname = '_sqlx_migrations')
+  AND c.relkind IN ('r', 'p');
+SQL
+""".strip()
+
+HISTORY_QUERY = r"""
+psql -v ON_ERROR_STOP=1 -qAt -U "$POSTGRES_USER" -d "$POSTGRES_DB" <<'SQL'
+SELECT 'history_row_count=' || count(*) FROM public._sqlx_migrations;
+SELECT 'failed_history_count=' || count(*) FROM public._sqlx_migrations WHERE success IS NOT TRUE;
+SELECT 'duplicate_version_count=' || count(*)
+FROM (
+  SELECT version
+  FROM public._sqlx_migrations
+  GROUP BY version
+  HAVING count(*) > 1
+) duplicates;
+SQL
+""".strip()
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    status: str
+    container: str
+    history_table: str
+    user_relation_count: int | None
+    base_table_count: int | None
+    history_row_count: int | None
+    failed_history_count: int | None
+    duplicate_version_count: int | None
+    reason: str | None = None
+    command_error: str | None = None
+
+    def payload(self) -> dict[str, object]:
+        data: dict[str, object] = {
+            "status": self.status,
+            "container": self.container,
+            "history_table": self.history_table,
+            "user_relation_count": self.user_relation_count,
+            "base_table_count": self.base_table_count,
+            "history_row_count": self.history_row_count,
+            "failed_history_count": self.failed_history_count,
+            "duplicate_version_count": self.duplicate_version_count,
+            "helper_started_api": False,
+            "helper_applied_migrations": False,
+            "helper_read_env_file": False,
+            "helper_printed_confidential_values": False,
+        }
+        if self.reason:
+            data["reason"] = self.reason
+        if self.command_error:
+            data["command_error"] = self.command_error
+        return data
+
+
+def _run_docker_psql(docker_bin: str, container: str, script: str) -> str:
+    proc = subprocess.run(
+        [docker_bin, "exec", container, "sh", "-lc", script],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if proc.returncode != 0:
+        detail = proc.stderr.strip() or proc.stdout.strip() or f"docker exec exited with {proc.returncode}"
+        raise RuntimeError(detail)
+    return proc.stdout
+
+
+def _parse_key_values(output: str) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if "=" not in line:
+            raise RuntimeError(f"unexpected probe output line: {line!r}")
+        key, value = line.split("=", 1)
+        parsed[key.strip()] = value.strip()
+    return parsed
+
+
+def _optional_int(values: dict[str, str], key: str) -> int | None:
+    value = values.get(key)
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise RuntimeError(f"probe output {key!r} must be an integer, got {value!r}") from exc
+
+
+def probe(docker_bin: str, container: str) -> ProbeResult:
+    try:
+        catalog = _parse_key_values(_run_docker_psql(docker_bin, container, CATALOG_QUERY))
+    except Exception as exc:
+        return ProbeResult(
+            status="error",
+            container=container,
+            history_table="unknown",
+            user_relation_count=None,
+            base_table_count=None,
+            history_row_count=None,
+            failed_history_count=None,
+            duplicate_version_count=None,
+            reason="catalog_probe_failed",
+            command_error=str(exc),
+        )
+
+    history_table = catalog.get("history_table", "unknown")
+    try:
+        user_relation_count = _optional_int(catalog, "user_relation_count")
+        base_table_count = _optional_int(catalog, "base_table_count")
+    except Exception as exc:
+        return ProbeResult(
+            status="error",
+            container=container,
+            history_table=history_table,
+            user_relation_count=None,
+            base_table_count=None,
+            history_row_count=None,
+            failed_history_count=None,
+            duplicate_version_count=None,
+            reason="catalog_probe_failed",
+            command_error=str(exc),
+        )
+
+    if history_table != "present":
+        reason = "migration_history_table_absent"
+        if user_relation_count == 0 or base_table_count == 0:
+            reason = "app_schema_empty_or_migration_history_absent"
+        return ProbeResult(
+            status="blocked",
+            container=container,
+            history_table=history_table,
+            user_relation_count=user_relation_count,
+            base_table_count=base_table_count,
+            history_row_count=None,
+            failed_history_count=None,
+            duplicate_version_count=None,
+            reason=reason,
+        )
+
+    try:
+        history = _parse_key_values(_run_docker_psql(docker_bin, container, HISTORY_QUERY))
+    except Exception as exc:
+        return ProbeResult(
+            status="error",
+            container=container,
+            history_table=history_table,
+            user_relation_count=user_relation_count,
+            base_table_count=base_table_count,
+            history_row_count=None,
+            failed_history_count=None,
+            duplicate_version_count=None,
+            reason="history_probe_failed",
+            command_error=str(exc),
+        )
+
+    try:
+        history_row_count = _optional_int(history, "history_row_count")
+        failed_history_count = _optional_int(history, "failed_history_count")
+        duplicate_version_count = _optional_int(history, "duplicate_version_count")
+    except Exception as exc:
+        return ProbeResult(
+            status="error",
+            container=container,
+            history_table=history_table,
+            user_relation_count=user_relation_count,
+            base_table_count=base_table_count,
+            history_row_count=None,
+            failed_history_count=None,
+            duplicate_version_count=None,
+            reason="history_probe_failed",
+            command_error=str(exc),
+        )
+
+    if user_relation_count == 0 or base_table_count == 0:
+        status = "blocked"
+        reason = "app_schema_empty"
+    elif history_row_count == 0:
+        status = "blocked"
+        reason = "migration_history_empty"
+    elif (failed_history_count or 0) > 0:
+        status = "blocked"
+        reason = "failed_migration_history_rows"
+    elif (duplicate_version_count or 0) > 0:
+        status = "blocked"
+        reason = "duplicate_migration_versions"
+    else:
+        status = "pass"
+        reason = None
+
+    return ProbeResult(
+        status=status,
+        container=container,
+        history_table=history_table,
+        user_relation_count=user_relation_count,
+        base_table_count=base_table_count,
+        history_row_count=history_row_count,
+        failed_history_count=failed_history_count,
+        duplicate_version_count=duplicate_version_count,
+        reason=reason,
+    )
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Check VPS DB migration-history shape.")
+    parser.add_argument("--container", default=DEFAULT_CONTAINER)
+    parser.add_argument("--docker-bin", default="docker")
+    parser.add_argument("--json", action="store_true", help="print only JSON output")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    result = probe(args.docker_bin, args.container)
+    payload = result.payload()
+    if args.json:
+        print(json.dumps(payload, sort_keys=True))
+    else:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0 if result.status == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a no-migration DB history shape preflight for #1348 follow-up work.

What changed:
- adds scripts/ops/check_vps_db_migration_history_shape.py
- checks public._sqlx_migrations presence and history shape via the already-running DB container
- blocks missing/empty/failed/duplicate history and history-only app schemas
- documents the hard stop in docs/deploy/vps-migration-safe-runtime-smoke.md
- adds helper and runbook tests

Safety boundary:
- does not start the API
- does not start or restart Compose services
- does not apply migrations
- does not read runtime env files
- does not print confidential values

Validation:
- python3 -m pytest scripts/ci/tests/test_vps_db_migration_history_shape.py scripts/ci/tests/test_vps_db_history_preflight_docs.py -q
- python3 -m pytest scripts/ci/tests/test_vps_migration_safe_runtime_env.py scripts/ci/tests/test_vps_migration_safe_runtime_env_boundaries.py scripts/ci/tests/test_vps_migration_safe_runtime_env_compose_semantics.py scripts/ci/tests/test_vps_runtime_yaml_edges.py -q

This is not a #1348 runtime receipt. No deploy, smoke retry, API start, database migration, DNS, HTTPS, mail, SMTP, credential-source, or cutover action was performed.
