### PR TITLE
docs: define VPS DB initialization boundary

### DIFF
--- a/.github/workflows/vps-db-history-preflight.yml
+++ b/.github/workflows/vps-db-history-preflight.yml
@@ -5,9 +5,11 @@ name: VPS DB history preflight
   pull_request:
     branches: [main]
     paths:
+      - "docs/deploy/vps-db-initialization-boundary.md"
       - "docs/deploy/vps-migration-safe-runtime-smoke.md"
       - "scripts/ops/check_vps_db_migration_history_shape.py"
       - "scripts/ci/tests/test_vps_db_history_preflight_docs.py"
+      - "scripts/ci/tests/test_vps_db_initialization_boundary_docs.py"
       - "scripts/ci/tests/test_vps_db_migration_history_shape.py"
       - "scripts/ci/tests/test_vps_migration_safe_runtime_env.py"
       - "scripts/ci/tests/test_vps_migration_safe_runtime_env_boundaries.py"
@@ -17,9 +19,11 @@ name: VPS DB history preflight
   push:
     branches: [main]
     paths:
+      - "docs/deploy/vps-db-initialization-boundary.md"
       - "docs/deploy/vps-migration-safe-runtime-smoke.md"
       - "scripts/ops/check_vps_db_migration_history_shape.py"
       - "scripts/ci/tests/test_vps_db_history_preflight_docs.py"
+      - "scripts/ci/tests/test_vps_db_initialization_boundary_docs.py"
       - "scripts/ci/tests/test_vps_db_migration_history_shape.py"
       - "scripts/ci/tests/test_vps_migration_safe_runtime_env.py"
       - "scripts/ci/tests/test_vps_migration_safe_runtime_env_boundaries.py"
@@ -59,6 +63,7 @@ jobs:
           python -m pytest \
             scripts/ci/tests/test_vps_db_migration_history_shape.py \
             scripts/ci/tests/test_vps_db_history_preflight_docs.py \
+            scripts/ci/tests/test_vps_db_initialization_boundary_docs.py \
             scripts/ci/tests/test_vps_migration_safe_runtime_env.py \
             scripts/ci/tests/test_vps_migration_safe_runtime_env_boundaries.py \
             scripts/ci/tests/test_vps_migration_safe_runtime_env_compose_semantics.py \

--- a/docs/deploy/vps-db-initialization-boundary.md
+++ b/docs/deploy/vps-db-initialization-boundary.md
@@ -1,0 +1,120 @@
+---
+id: deploy.vps-db-initialization-boundary
+title: VPS DB Initialization Boundary
+doc_type: runbook
+status: active
+summary: Decision and evidence boundary for initializing or repairing wg-prod-1 PostgreSQL outside the no-migration smoke scope.
+relations:
+  - type: relates_to
+    target: docs/deploy/vps-migration-safe-runtime-smoke.md
+  - type: relates_to
+    target: scripts/ops/check_vps_db_migration_history_shape.py
+---
+# VPS DB Initialization Boundary
+
+This runbook defines the decision boundary for `wg-prod-1` database
+initialization or repair after the DB-history preflight blocks #1348.
+
+GitHub tracking context: #1348 is the DNS-free VPS HTTP smoke issue and #1359 is
+the DB initialization boundary decision issue. These issue references are kept in
+body text rather than `relations`, because docmeta relations require
+repo-relative targets that exist in the checkout.
+
+It is not a deploy instruction and not an authorization to mutate production
+state. It exists to prevent an empty database from being initialized implicitly
+by a normal API or smoke retry.
+
+## Current trigger
+
+Use this boundary only after the no-migration DB-history preflight reports a
+blocking shape such as:
+
+```text
+status=blocked
+history_table=absent
+user_relation_count=0
+base_table_count=0
+reason=app_schema_empty_or_migration_history_absent
+```
+
+That result means the selected database does not currently prove that SQLx
+migration history exists. A normal API startup or compose retry must not be used
+to get past it.
+
+## Hard stop for #1348
+
+When the preflight blocks because the app schema or migration-history table is
+absent, #1348 remains blocked. Do not treat a database initialization as part of
+the DNS-free HTTP smoke.
+
+A DB initialization or repair window is a separate operation class. It may apply
+migration SQL and therefore sits outside the no-migration boundary of #1348.
+
+## Allowed next decisions
+
+Exactly one of these decisions must be recorded before continuing:
+
+1. **Approve a bounded DB initialization or repair window.**
+   This may initialize schema state or repair migration-history state, but only
+   inside an explicit receipt-bound window.
+2. **Select a genuinely DB-free route-only smoke.**
+   This may collect routing evidence only. It must not claim API readiness,
+   database readiness, or completion of #1348 as full runtime evidence.
+
+## Forbidden shortcuts
+
+Do not:
+
+- start the production API to force database creation
+- run `docker compose up` to see whether startup repairs the DB
+- run the normal API startup migration path as a workaround
+- change DNS, INWX, ACME, HTTPS, mail, SMTP, credential-source, or cutover state
+- print `.env`, database URLs, passwords, tokens, or secret-bearing command lines
+- close #1348 using route-only or DB-initialization evidence alone
+
+## Pre-window evidence
+
+Before any approved DB initialization or repair window, record:
+
+- timestamp
+- host identity, expected `wg-prod-1`
+- selected repo commit
+- current `/opt/weltgewebe` worktree state, without secret output
+- DB-history preflight JSON payload
+- whether the operation is initialization or repair
+- exact command class to be used, without secret values
+- rollback or restore stance, if available
+
+## Window constraints
+
+During the approved window:
+
+- run only the selected DB operation class
+- do not start Caddy as part of the DB operation
+- do not perform DNS, HTTPS, mail, SMTP, credential-source, or cutover work
+- do not print secret-bearing environment files
+- keep stdout/stderr suitable for public issue receipts
+
+If the selected DB operation applies migration SQL, state that explicitly in the
+receipt. Do not describe it as a no-migration smoke action.
+
+## Post-window evidence
+
+After the window, record:
+
+- post-state DB-history preflight JSON payload
+- whether migration SQL was applied
+- whether the database now has non-history app tables
+- whether failed or duplicate migration-history rows exist
+- explicit non-actions for DNS, HTTPS, mail, SMTP, credentials, and cutover
+- follow-up status for #1348:
+  - still blocked
+  - ready for a separately reviewed runtime retry
+  - completed only if later loopback/runtime checks pass
+
+## Completion boundary
+
+This runbook is complete when the repository documents the decision boundary and
+CI guards ensure that #1348 documentation does not bypass it.
+
+It does not complete #1348 and it does not approve DB mutation by itself.

--- a/docs/deploy/vps-migration-safe-runtime-smoke.md
+++ b/docs/deploy/vps-migration-safe-runtime-smoke.md
@@ -12,6 +12,8 @@ relations:
   - type: relates_to
     target: docs/deploy/vps-http-route-smoke-risks.md
   - type: relates_to
+    target: docs/deploy/vps-db-initialization-boundary.md
+  - type: relates_to
     target: infra/compose/compose.vps.override.yml
   - type: relates_to
     target: scripts/ops/check_vps_migration_safe_runtime_env.py
@@ -163,6 +165,10 @@ operations:
 1. an approved DB initialization or repair window, outside this no-migration smoke
    boundary; or
 2. a genuinely DB-free route smoke that does not claim API/database readiness.
+
+See `docs/deploy/vps-db-initialization-boundary.md` before selecting DB
+initialization or repair. DB initialization or repair must not be treated as part
+of the no-migration #1348 smoke.
 
 The runtime receipt must include the preflight status and must not report #1348
 as passed unless later loopback/runtime checks actually succeed under

--- a/scripts/ci/tests/test_vps_db_initialization_boundary_docs.py
+++ b/scripts/ci/tests/test_vps_db_initialization_boundary_docs.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+BOUNDARY = REPO_ROOT / "docs" / "deploy" / "vps-db-initialization-boundary.md"
+SMOKE_RUNBOOK = REPO_ROOT / "docs" / "deploy" / "vps-migration-safe-runtime-smoke.md"
+
+
+def test_db_initialization_boundary_defines_hard_stop_for_empty_db_shape() -> None:
+    text = BOUNDARY.read_text(encoding="utf-8")
+
+    for expected in [
+        "history_table=absent",
+        "user_relation_count=0",
+        "base_table_count=0",
+        "reason=app_schema_empty_or_migration_history_absent",
+        "A normal API startup or compose retry must not be used",
+        "outside the no-migration boundary of #1348",
+    ]:
+        assert expected in text
+
+
+def test_db_initialization_boundary_lists_required_evidence_and_non_actions() -> None:
+    text = BOUNDARY.read_text(encoding="utf-8")
+
+    for expected in [
+        "DB-history preflight JSON payload",
+        "whether migration SQL was applied",
+        "post-state DB-history preflight JSON payload",
+        "failed or duplicate migration-history rows",
+        "explicit non-actions for DNS, HTTPS, mail, SMTP, credentials, and cutover",
+        "It does not complete #1348 and it does not approve DB mutation by itself.",
+    ]:
+        assert expected in text
+
+
+def test_migration_safe_runtime_runbook_links_to_db_initialization_boundary() -> None:
+    smoke = SMOKE_RUNBOOK.read_text(encoding="utf-8")
+
+    assert "vps-db-initialization-boundary.md" in smoke
+    assert "DB initialization or repair" in smoke
+    assert "must not be treated as part" in smoke
+    assert "of the no-migration #1348 smoke" in smoke


### PR DESCRIPTION
Closes #1359.

This documents the explicit DB initialization/repair decision boundary after the #1358 DB-history preflight blocks #1348 with an empty DB/history shape.

What changed:
- adds `docs/deploy/vps-db-initialization-boundary.md`
- links the migration-safe runtime-smoke runbook to the new boundary
- extends the VPS DB preflight workflow to run the new boundary-doc test
- adds tests that the boundary remains explicit about hard stops, evidence, and non-actions

Validation:
- `python3 -m pytest scripts/ci/tests/test_vps_db_migration_history_shape.py scripts/ci/tests/test_vps_db_history_preflight_docs.py scripts/ci/tests/test_vps_db_initialization_boundary_docs.py scripts/ci/tests/test_vps_migration_safe_runtime_env.py scripts/ci/tests/test_vps_migration_safe_runtime_env_boundaries.py scripts/ci/tests/test_vps_migration_safe_runtime_env_compose_semantics.py scripts/ci/tests/test_vps_runtime_yaml_edges.py -q` -> 52 passed

Safety boundary:
- no DB change
- no migration
- no deploy
- no compose start/restart
- no API start
- no secrets read or printed
- no DNS/INWX/ACME/HTTPS/mail/SMTP/credential-source/cutover action