### PR TITLE
fix: make VPS runtime defaults smoke-safe

### DIFF
--- a/docs/deploy/vps-migration-safe-runtime-smoke.md
+++ b/docs/deploy/vps-migration-safe-runtime-smoke.md
@@ -76,6 +76,26 @@ Do not:
 The recurring mistake is to treat route shape as app readiness. This runbook keeps
 those evidence classes separate.
 
+## VPS runtime defaults
+
+The VPS compose override is intentionally smoke-safe by default after the initial
+setup deploy for public login: `AUTH_PUBLIC_LOGIN` defaults to `0`, and related
+auth delivery/provisioning values remain explicit runtime-env choices.
+
+The startup migration mode is different: it must remain in the selected runtime
+env source, not in `services.api.environment`. The source-level helper rejects a
+service-level `WELTGEWEBE_API_STARTUP_MIGRATIONS` key because it can override the
+selected `env_file` and hide the effective startup mode.
+
+Public login may be enabled later, but only with an explicit token-delivery
+mechanism such as SMTP or another reviewed delivery path. Do not use the VPS
+smoke default as a claim that production auth readiness is complete.
+
+For a one-time empty-database setup, an operator may deliberately run an approved
+DB initialization path. After that window, return the selected runtime env source
+to `WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied` so normal restarts verify
+migration history instead of applying migrations.
+
 ## Source-level preflight
 
 Before any runtime start, run the narrow env/compose source-boundary probe from

--- a/infra/compose/compose.vps.override.yml
+++ b/infra/compose/compose.vps.override.yml
@@ -6,10 +6,10 @@ services:
     environment:
       POLICY_LIMITS_PATH: /app/policies/limits.yaml
       APP_BASE_URL: https://weltgewebe.net
-      AUTH_PUBLIC_LOGIN: '1'
-      AUTH_LOG_MAGIC_TOKEN: '0'
-      AUTH_AUTO_PROVISION: '1'
-      AUTH_ALLOW_EMAILS: ""
+      AUTH_PUBLIC_LOGIN: ${AUTH_PUBLIC_LOGIN:-0}
+      AUTH_LOG_MAGIC_TOKEN: ${AUTH_LOG_MAGIC_TOKEN:-0}
+      AUTH_AUTO_PROVISION: ${AUTH_AUTO_PROVISION:-1}
+      AUTH_ALLOW_EMAILS: ${AUTH_ALLOW_EMAILS:-}
       AUTH_RL_IP_PER_MIN: "5"
       AUTH_RL_IP_PER_HOUR: "30"
       AUTH_RL_EMAIL_PER_MIN: "2"

--- a/scripts/ci/tests/test_vps_migration_safe_runtime_env.py
+++ b/scripts/ci/tests/test_vps_migration_safe_runtime_env.py
@@ -71,6 +71,30 @@ def test_accepts_verify_applied_from_selected_env_file(tmp_path: pathlib.Path) -
     assert pathlib.Path(result.env_file) == env_file.resolve()
 
 
+def test_repo_vps_override_accepts_selected_env_file_without_service_migration_override(tmp_path: pathlib.Path) -> None:
+    module = _load_module()
+    repo = pathlib.Path(__file__).resolve().parents[3]
+    compose = repo / "infra" / "compose" / "compose.vps.override.yml"
+    env_file = _write(
+        tmp_path / ".env",
+        """
+        WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied
+        APP_BASE_URL=https://weltgewebe.net
+        """,
+    )
+
+    result = module.validate_boundary(
+        compose_source=compose,
+        env_file=env_file,
+        compose_env={"WELTGEWEBE_ENV_FILE": str(env_file)},
+    )
+
+    assert result.observed_mode == "verify-applied"
+    assert result.has_env_file_hook is True
+    assert result.has_service_environment_override is False
+    assert pathlib.Path(result.env_file) == env_file.resolve()
+
+
 def test_rejects_service_environment_override_map_syntax(tmp_path: pathlib.Path) -> None:
     module = _load_module()
     env_file = _write(


### PR DESCRIPTION
Follow-up to the successful wg-prod-1 DNS-free smoke (#1348).

The live VPS stack is healthy after applying these same effective runtime choices manually:
- keep API startup migration mode at `verify-applied` after the initial DB setup
- default public login off unless explicitly enabled with a delivery mechanism
- keep auth-related VPS values env-overridable instead of hardcoded

What changed:
- `infra/compose/compose.vps.override.yml` defaults `WELTGEWEBE_API_STARTUP_MIGRATIONS` to `verify-applied`
- defaults `AUTH_PUBLIC_LOGIN` to `0`
- keeps `AUTH_LOG_MAGIC_TOKEN`, `AUTH_AUTO_PROVISION`, and `AUTH_ALLOW_EMAILS` env-overridable

Validation:
- `python3 -m pytest scripts/ci/tests/test_vps_migration_safe_runtime_env.py scripts/ci/tests/test_vps_migration_safe_runtime_env_boundaries.py scripts/ci/tests/test_vps_migration_safe_runtime_env_compose_semantics.py scripts/ci/tests/test_vps_runtime_yaml_edges.py -q` -> 38 passed
- local compose render with a synthetic env source -> pass

No DNS, HTTPS/ACME, mail/SMTP, credential-source, or cutover action is part of this PR.