### PR TITLE
fix: bind deploy API image tag to selected head

### DIFF
--- a/scripts/ci/tests/test_weltgewebe_up_api_version_contract.py
+++ b/scripts/ci/tests/test_weltgewebe_up_api_version_contract.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[3]
+SCRIPT = REPO / "scripts" / "weltgewebe-up"
+COMPOSE = REPO / "infra" / "compose" / "compose.prod.yml"
+
+
+def test_api_image_tag_is_bound_to_selected_deploy_head_before_compose_config() -> None:
+    script = SCRIPT.read_text(encoding="utf-8")
+
+    git_summary = script.index('echo "   Target HEAD after pull: $HEAD_AFTER"')
+    export_tag = script.index('export API_VERSION="$HEAD_AFTER"')
+    compose_base_args = script.index('BASE_ARGS=("--env-file" "$ENV_FILE"')
+    compose_up = script.index('CMD_BASE=("docker" "compose"')
+
+    assert git_summary < export_tag < compose_base_args < compose_up
+    assert 'if [[ "$HEAD_AFTER" == "unknown" ]]' in script
+    assert 'refusing to select an API image tag' in script
+
+
+def test_prod_compose_uses_api_version_for_api_image_tag() -> None:
+    compose = COMPOSE.read_text(encoding="utf-8")
+
+    assert "image: weltgewebe-api:${API_VERSION:-latest}" in compose

--- a/scripts/weltgewebe-up
+++ b/scripts/weltgewebe-up
@@ -516,6 +516,17 @@ echo "   Branch switch: $([[ "$BRANCH_SWITCH_ATTEMPTED" == "yes" ]] && echo "yes
 echo "   Previous HEAD: $HEAD_BEFORE"
 echo "   Target HEAD after pull: $HEAD_AFTER"
 
+if [[ "$HEAD_AFTER" == "unknown" ]]; then
+  echo "ERROR: Cannot resolve deploy HEAD; refusing to select an API image tag." >&2
+  exit 1
+fi
+
+# Keep the API image tag bound to the selected checkout. This intentionally
+# overrides stale API_VERSION values from the runtime env file for Compose
+# interpolation, while still leaving container runtime env values untouched.
+export API_VERSION="$HEAD_AFTER"
+echo "   API image tag: $API_VERSION"
+
 # 3. Preflight: Docker Compose Config (Strict)
 # Run AFTER pull to validate new config
 echo


### PR DESCRIPTION
Post-live follow-up after the public HTTPS cutover.

Problem observed on wg-prod-1:
- repo/web build were on `86139d5e`
- Docker image ID was correct, but Compose displayed the API container as `weltgewebe-api:463fa0b0`
- cause: `compose.prod.yml` interpolates `API_VERSION`, and a stale runtime value can make Compose select an old tag name

Fix:
- `scripts/weltgewebe-up` now refuses to deploy when the selected deploy HEAD cannot be resolved
- it exports `API_VERSION=$HEAD_AFTER` before `docker compose config` and `docker compose up`
- this binds the API image tag to the selected checkout and overrides stale env-file values only for Compose interpolation

Validation:
- `bash -n scripts/weltgewebe-up`
- `python3 -m pytest scripts/ci/tests/test_weltgewebe_up_api_version_contract.py scripts/ci/tests/test_vps_migration_safe_runtime_env.py -q` -> 19 passed

No runtime mutation, DNS, mail, SMTP, public-login, or credential-source change is part of this PR.