### PR TITLE
fix: resolve deploy head in no-pull mode

### DIFF
--- a/scripts/ci/tests/test_weltgewebe_up_api_version_contract.py
+++ b/scripts/ci/tests/test_weltgewebe_up_api_version_contract.py
@@ -25,3 +25,14 @@ def test_prod_compose_uses_api_version_for_api_image_tag() -> None:
     compose = COMPOSE.read_text(encoding="utf-8")
 
     assert "image: weltgewebe-api:${API_VERSION:-latest}" in compose
+
+
+def test_no_pull_path_resolves_current_checkout_head_before_api_tag_guard() -> None:
+    script = SCRIPT.read_text(encoding="utf-8")
+
+    no_pull = script.index('echo ">> Git: Skipped (--no-pull)"')
+    resolve_current_head = script.index('HEAD_AFTER=$(git rev-parse --short HEAD', no_pull)
+    unknown_guard = script.index('if [[ "$HEAD_AFTER" == "unknown" ]]')
+    export_tag = script.index('export API_VERSION="$HEAD_AFTER"')
+
+    assert no_pull < resolve_current_head < unknown_guard < export_tag

--- a/scripts/weltgewebe-up
+++ b/scripts/weltgewebe-up
@@ -501,6 +501,8 @@ else
   GIT_PULL_SKIPPED_REASON="--no-pull"
   DEPLOY_BRANCH_RESOLVED="$DEPLOY_BRANCH"
   BRANCH_SWITCH_RESULT="skipped_no_pull"
+  CURRENT_BRANCH_AFTER=$(git symbolic-ref -q --short HEAD 2> /dev/null || echo "DETACHED")
+  HEAD_AFTER=$(git rev-parse --short HEAD 2> /dev/null || echo "unknown")
 fi
 
 echo


### PR DESCRIPTION
Follow-up to #1363.

Problem observed while applying the new deploy API_VERSION guard on wg-prod-1:
- `scripts/weltgewebe-up --no-pull` intentionally skips git branch/pull operations
- the new guard from #1363 then saw `HEAD_AFTER=unknown` and correctly refused to select an API image tag
- for no-pull deploys, the selected deploy head is the current checkout head

Fix:
- in the `--no-pull` branch, resolve `CURRENT_BRANCH_AFTER` from the current checkout
- resolve `HEAD_AFTER` from `git rev-parse --short HEAD`
- keep the existing fail-closed guard for genuinely unresolved heads

Validation:
- `bash -n scripts/weltgewebe-up`
- `python3 -m pytest scripts/ci/tests/test_weltgewebe_up_api_version_contract.py scripts/ci/tests/test_vps_migration_safe_runtime_env.py -q` -> 20 passed

No runtime, DNS, mail, SMTP, public-login, or credential-source change is part of this PR.