### PR TITLE
ops: add public live readiness check

### DIFF
--- a/.github/workflows/public-live-readiness.yml
+++ b/.github/workflows/public-live-readiness.yml
@@ -1,0 +1,47 @@
+---
+name: Public live readiness
+
+"on":
+  pull_request:
+    branches: [main]
+    paths:
+      - "docs/deploy/vps.md"
+      - "scripts/ops/check_public_live_readiness.py"
+      - "scripts/ci/tests/test_public_live_readiness.py"
+      - ".github/workflows/public-live-readiness.yml"
+  push:
+    branches: [main]
+    paths:
+      - "docs/deploy/vps.md"
+      - "scripts/ops/check_public_live_readiness.py"
+      - "scripts/ci/tests/test_public_live_readiness.py"
+      - ".github/workflows/public-live-readiness.yml"
+  workflow_dispatch: {}
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Public live readiness tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # tag: v7.0.0
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # tag: v5
+        with:
+          python-version-file: ".python-version"
+
+      - name: Compile public live readiness checker
+        run: python -m py_compile scripts/ops/check_public_live_readiness.py
+
+      - name: Run public live readiness unit tests
+        run: python -m unittest scripts/ci/tests/test_public_live_readiness.py -v

--- a/docs/deploy/vps.md
+++ b/docs/deploy/vps.md
@@ -7,15 +7,15 @@ summary: Dokumentation zum VPS-basierten Deployment.
 relations:
   - type: relates_to
     target: docs/deploy/README.md
+  - type: relates_to
+    target: scripts/ops/check_public_live_readiness.py
 ---
-# VPS Deployment Runbook (Alternatives Modell)
+# VPS Deployment Runbook
 
-> [!NOTE]
-> Dieses Runbook beschreibt ein **alternatives** Deployment-Modell auf einem klassischen VPS mit fester IP. Die aktuelle Weltgewebe-Produktion nutzt stattdessen ein Heimserver-Setup mit dynamischer IP (DDNS).
-
-Dieses Runbook beschreibt die Schritte zur Bereitstellung der Weltgewebe-Infrastruktur (API, Datenbank, Proxy)
-auf einem VPS. Das Frontend wird weiterhin über einen externen Provider (z.B. Vercel oder Cloudflare Pages) ausgeliefert,
-aber über den Caddy-Proxy auf dem VPS unter der Domain eingebunden.
+Dieses Runbook beschreibt den aktuellen Public-VPS-Pfad für `weltgewebe.net`.
+Der VPS stellt API, Datenbank, NATS und den Caddy-Frontdoor bereit. Das
+Frontend wird im VPS-Checkout gebaut und vom Stack-internen Caddy unter der
+Domain ausgeliefert.
 
 ## Voraussetzungen
 
@@ -28,10 +28,12 @@ aber über den Caddy-Proxy auf dem VPS unter der Domain eingebunden.
 Richte folgende DNS-Records ein, damit die Domain auf deinen VPS zeigt:
 
 * **A-Record**: `weltgewebe.net` -> `<VPS_IPV4_ADRESSE>`
-* **AAAA-Record** (falls IPv6 verfügbar): `weltgewebe.net` -> `<VPS_IPV6_ADRESSE>`
+* **A-Record**: `www.weltgewebe.net` -> `<VPS_IPV4_ADRESSE>`
+* **A-Record**: `api.weltgewebe.net` -> `<VPS_IPV4_ADRESSE>`
+* **AAAA-Record** (nur falls IPv6 geprüft und freigegeben ist): entsprechende Hostnamen -> `<VPS_IPV6_ADRESSE>`
 
-Die Subdomain `api.weltgewebe.net` ist **nicht** erforderlich, da die API unter `weltgewebe.net/api`
-erreichbar sein wird.
+Die Subdomain `api.weltgewebe.net` ist Teil des aktuellen Public-VPS-Zielbilds
+und muss auf dieselbe VPS-IPv4 zeigen wie Root und `www`.
 
 ## 2. Server Vorbereitung
 
@@ -160,3 +162,24 @@ Nach dem DNS-Cutover sind zusätzlich die öffentlichen HTTPS-Pfade zu prüfen:
 curl -fsS https://weltgewebe.net/api/health/ready
 curl -fsS https://api.weltgewebe.net/health/ready
 ```
+
+### Public live readiness receipt
+
+Nach einem Public-Cutover kann der öffentliche Zustand mit einem read-only
+Operator-Check reproduzierbar geprüft werden:
+
+```bash
+python3 scripts/ops/check_public_live_readiness.py \
+  --expected-ip 94.16.121.119 \
+  --expected-version "$(git rev-parse --short HEAD)" \
+  --expected-commit "$(git rev-parse HEAD)" \
+  --authoritative-server ns.inwx.de \
+  --authoritative-server ns2.inwx.de \
+  --authoritative-server ns3.inwx.eu
+```
+
+Der Check liest keine Runtime-Secrets und verändert keinen Serverzustand. Er
+prüft DNS-A-Records, HTTP-zu-HTTPS-Redirect, Root-/`www`-HTTPS, `/map`,
+`api.weltgewebe.net/health/ready`, `/_app/version.json`, lokale Basemap-Style-,
+Glyph- und PMTiles-Auslieferung. Ein PASS ist ein Public-HTTP(S)-/Basemap-Receipt,
+aber kein Beweis für IPv6, Mail/SMTP, Public Login oder Credential-Cutover.

--- a/scripts/ci/tests/test_public_live_readiness.py
+++ b/scripts/ci/tests/test_public_live_readiness.py
@@ -5,7 +5,7 @@ import json
 import sys
 import unittest
 from pathlib import Path
-from typing import Mapping, Sequence
+from typing import Mapping
 
 
 REPO = Path(__file__).resolve().parents[3]
@@ -30,7 +30,7 @@ class FakeWorld:
         self.commit = "51d8061a6920e4bf1dd6dda9784c4fc928f43bb9"
         self.requests: list[tuple[str, Mapping[str, str] | None]] = []
 
-    def resolver(self, host: str, _servers: Sequence[str]) -> set[str]:
+    def resolver(self, host: str) -> set[str]:
         return {self.ip}
 
     def fetcher(
@@ -38,7 +38,6 @@ class FakeWorld:
         url: str,
         headers: Mapping[str, str] | None,
         _timeout: float,
-        _max_bytes: int,
     ):
         self.requests.append((url, headers))
         FetchResult = self.module.FetchResult
@@ -122,11 +121,11 @@ class PublicLiveReadinessTest(unittest.TestCase):
     def test_api_ready_requires_database_nats_and_policy(self) -> None:
         fake = FakeWorld()
 
-        def bad_fetcher(url: str, headers: Mapping[str, str] | None, timeout: float, max_bytes: int):
+        def bad_fetcher(url: str, headers: Mapping[str, str] | None, timeout: float):
             if url == "https://api.weltgewebe.net/health/ready":
                 body = {"status": "ok", "checks": {"database": True, "nats": False, "policy": True}}
                 return fake.module.FetchResult(url, 200, {}, json.dumps(body).encode())
-            return fake.fetcher(url, headers, timeout, max_bytes)
+            return fake.fetcher(url, headers, timeout)
 
         checker = fake.module.PublicLiveChecker(resolver=fake.resolver, fetcher=bad_fetcher)
         api_result = [result for result in checker.run() if result.name == "api-ready"][0]
@@ -137,10 +136,10 @@ class PublicLiveReadinessTest(unittest.TestCase):
     def test_pmtiles_header_must_start_with_pmtiles_signature(self) -> None:
         fake = FakeWorld()
 
-        def bad_fetcher(url: str, headers: Mapping[str, str] | None, timeout: float, max_bytes: int):
+        def bad_fetcher(url: str, headers: Mapping[str, str] | None, timeout: float):
             if url.endswith(".pmtiles"):
                 return fake.module.FetchResult(url, 200, {}, b"not-pmtiles")
-            return fake.fetcher(url, headers, timeout, max_bytes)
+            return fake.fetcher(url, headers, timeout)
 
         checker = fake.module.PublicLiveChecker(resolver=fake.resolver, fetcher=bad_fetcher)
         pmtiles_result = [result for result in checker.run() if result.name == "pmtiles-header"][0]

--- a/scripts/ci/tests/test_public_live_readiness.py
+++ b/scripts/ci/tests/test_public_live_readiness.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import unittest
+from pathlib import Path
+from typing import Mapping, Sequence
+
+
+REPO = Path(__file__).resolve().parents[3]
+SCRIPT = REPO / "scripts" / "ops" / "check_public_live_readiness.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_public_live_readiness", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("could not load public live readiness module")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeWorld:
+    def __init__(self, *, ip: str = "94.16.121.119", version: str = "51d8061a") -> None:
+        self.module = _load_module()
+        self.ip = ip
+        self.version = version
+        self.commit = "51d8061a6920e4bf1dd6dda9784c4fc928f43bb9"
+        self.requests: list[tuple[str, Mapping[str, str] | None]] = []
+
+    def resolver(self, host: str, _servers: Sequence[str]) -> set[str]:
+        return {self.ip}
+
+    def fetcher(
+        self,
+        url: str,
+        headers: Mapping[str, str] | None,
+        _timeout: float,
+        _max_bytes: int,
+    ):
+        self.requests.append((url, headers))
+        FetchResult = self.module.FetchResult
+        if url == "http://weltgewebe.net/":
+            return FetchResult(url, 308, {"Location": "https://weltgewebe.net/"}, b"")
+        if url in {"https://weltgewebe.net/", "https://www.weltgewebe.net/", "https://weltgewebe.net/map"}:
+            return FetchResult(url, 200, {"Content-Type": "text/html"}, b'<!doctype html><script src="/_app/x.js"></script>')
+        if url == "https://api.weltgewebe.net/health/ready":
+            body = {"status": "ok", "checks": {"database": True, "nats": True, "policy": True}}
+            return FetchResult(url, 200, {"Content-Type": "application/json"}, json.dumps(body).encode())
+        if url == "https://weltgewebe.net/_app/version.json":
+            body = {"version": self.version, "commit": self.commit, "build_id": f"{self.version}-test"}
+            return FetchResult(url, 200, {"Content-Type": "application/json"}, json.dumps(body).encode())
+        if url == "https://weltgewebe.net/local-basemap/style.json":
+            body = {"glyphs": "/local-basemap/glyphs/{fontstack}/{range}.pbf"}
+            return FetchResult(url, 200, {"Content-Type": "application/json"}, json.dumps(body).encode())
+        if url == "https://weltgewebe.net/local-basemap/glyphs/Noto%20Sans%20Regular/0-255.pbf":
+            return FetchResult(url, 200, {}, b"glyph-bytes")
+        if url == "https://weltgewebe.net/local-basemap/basemap-hamburg-v0.1.0.pmtiles":
+            return FetchResult(url, 206, {"Content-Range": "bytes 0-15/100"}, b"PMTiles\x03fake")
+        return FetchResult(url, 404, {}, b"")
+
+    def checker(self):
+        return self.module.PublicLiveChecker(
+            expected_version=self.version,
+            expected_commit=self.commit,
+            resolver=self.resolver,
+            fetcher=self.fetcher,
+        )
+
+
+class PublicLiveReadinessTest(unittest.TestCase):
+    def test_successful_public_live_receipt_checks_expected_surfaces(self) -> None:
+        fake = FakeWorld()
+        results = fake.checker().run()
+
+        self.assertTrue(all(result.ok for result in results), [result.payload() for result in results])
+        names = {result.name for result in results}
+        self.assertEqual(
+            names,
+            {
+                "dns:weltgewebe.net",
+                "dns:www.weltgewebe.net",
+                "dns:api.weltgewebe.net",
+                "http-redirect",
+                "https-root:weltgewebe.net",
+                "https-root:www.weltgewebe.net",
+                "map-route",
+                "api-ready",
+                "version-json",
+                "basemap-style",
+                "glyph-range",
+                "pmtiles-header",
+            },
+        )
+        pmtiles_requests = [headers for url, headers in fake.requests if url.endswith(".pmtiles")]
+        self.assertEqual(pmtiles_requests, [{"Range": "bytes=0-15"}])
+
+    def test_wrong_dns_ip_fails(self) -> None:
+        fake = FakeWorld(ip="213.21.44.105")
+        results = fake.checker().run()
+
+        failed_dns = [result for result in results if result.name.startswith("dns:")]
+        self.assertTrue(failed_dns)
+        self.assertTrue(all(not result.ok for result in failed_dns))
+
+    def test_version_mismatch_fails(self) -> None:
+        fake = FakeWorld(version="old")
+        checker = fake.module.PublicLiveChecker(
+            expected_version="51d8061a",
+            expected_commit=fake.commit,
+            resolver=fake.resolver,
+            fetcher=fake.fetcher,
+        )
+
+        failures = [result for result in checker.run() if result.name == "version-json"]
+        self.assertEqual(len(failures), 1)
+        self.assertFalse(failures[0].ok)
+        self.assertIn("mismatch", failures[0].detail)
+
+    def test_api_ready_requires_database_nats_and_policy(self) -> None:
+        fake = FakeWorld()
+
+        def bad_fetcher(url: str, headers: Mapping[str, str] | None, timeout: float, max_bytes: int):
+            if url == "https://api.weltgewebe.net/health/ready":
+                body = {"status": "ok", "checks": {"database": True, "nats": False, "policy": True}}
+                return fake.module.FetchResult(url, 200, {}, json.dumps(body).encode())
+            return fake.fetcher(url, headers, timeout, max_bytes)
+
+        checker = fake.module.PublicLiveChecker(resolver=fake.resolver, fetcher=bad_fetcher)
+        api_result = [result for result in checker.run() if result.name == "api-ready"][0]
+
+        self.assertFalse(api_result.ok)
+        self.assertEqual(api_result.data["missing"], ["nats"])
+
+    def test_pmtiles_header_must_start_with_pmtiles_signature(self) -> None:
+        fake = FakeWorld()
+
+        def bad_fetcher(url: str, headers: Mapping[str, str] | None, timeout: float, max_bytes: int):
+            if url.endswith(".pmtiles"):
+                return fake.module.FetchResult(url, 200, {}, b"not-pmtiles")
+            return fake.fetcher(url, headers, timeout, max_bytes)
+
+        checker = fake.module.PublicLiveChecker(resolver=fake.resolver, fetcher=bad_fetcher)
+        pmtiles_result = [result for result in checker.run() if result.name == "pmtiles-header"][0]
+
+        self.assertFalse(pmtiles_result.ok)
+        self.assertIn("missing", pmtiles_result.detail)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ops/check_public_live_readiness.py
+++ b/scripts/ops/check_public_live_readiness.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Check the public weltgewebe VPS live-readiness surface.
+
+The checker is intentionally read-only. It performs DNS lookups and public HTTP(S)
+requests only. It does not read env files, connect to the VPS, mutate runtime
+state, or print confidential values.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import socket
+import ssl
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Callable, Mapping, Sequence
+
+DEFAULT_DOMAIN = "weltgewebe.net"
+DEFAULT_WWW_DOMAIN = "www.weltgewebe.net"
+DEFAULT_API_DOMAIN = "api.weltgewebe.net"
+DEFAULT_EXPECTED_IP = "94.16.121.119"
+DEFAULT_GLYPH_PATH = "/local-basemap/glyphs/Noto%20Sans%20Regular/0-255.pbf"
+DEFAULT_PMTILES_PATH = "/local-basemap/basemap-hamburg-v0.1.0.pmtiles"
+API_REQUIRED_CHECKS = ("database", "nats", "policy")
+
+
+@dataclass(frozen=True)
+class FetchResult:
+    url: str
+    status: int
+    headers: Mapping[str, str]
+    body: bytes
+    final_url: str | None = None
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    name: str
+    ok: bool
+    detail: str
+    data: dict[str, object] = field(default_factory=dict)
+
+    def payload(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "status": "pass" if self.ok else "fail",
+            "detail": self.detail,
+            **({"data": self.data} if self.data else {}),
+        }
+
+
+class NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[no-untyped-def]
+        return None
+
+
+class PublicLiveCheckError(RuntimeError):
+    pass
+
+
+Resolver = Callable[[str, Sequence[str]], set[str]]
+Fetcher = Callable[[str, Mapping[str, str] | None, float, int], FetchResult]
+
+
+def _lower_headers(headers: Mapping[str, str]) -> dict[str, str]:
+    return {key.lower(): value for key, value in headers.items()}
+
+
+def socket_resolve_ipv4(host: str, authoritative_servers: Sequence[str] = ()) -> set[str]:
+    if authoritative_servers:
+        return dig_resolve_ipv4(host, authoritative_servers)
+    answers = socket.getaddrinfo(host, None, family=socket.AF_INET, type=socket.SOCK_STREAM)
+    return {item[4][0] for item in answers}
+
+
+def dig_resolve_ipv4(host: str, authoritative_servers: Sequence[str]) -> set[str]:
+    answers: set[str] = set()
+    for server in authoritative_servers:
+        proc = subprocess.run(
+            ["dig", "+short", f"@{server}", host, "A"],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if proc.returncode != 0:
+            raise PublicLiveCheckError(
+                f"dig failed for {host} via {server}: {(proc.stderr or proc.stdout).strip()}"
+            )
+        for line in proc.stdout.splitlines():
+            value = line.strip()
+            if value and all(part.isdigit() for part in value.split(".")):
+                answers.add(value)
+    return answers
+
+
+def fetch_url(
+    url: str,
+    headers: Mapping[str, str] | None = None,
+    timeout: float = 8.0,
+    max_bytes: int = 512_000,
+) -> FetchResult:
+    request = urllib.request.Request(url, headers=dict(headers or {}), method="GET")
+    context = ssl.create_default_context()
+    opener = urllib.request.build_opener(
+        NoRedirectHandler,
+        urllib.request.HTTPSHandler(context=context),
+    )
+    try:
+        with opener.open(request, timeout=timeout) as response:
+            body = response.read(max_bytes + 1)
+            return FetchResult(
+                url=url,
+                status=response.getcode(),
+                headers=dict(response.headers.items()),
+                body=body[:max_bytes],
+                final_url=response.geturl(),
+            )
+    except urllib.error.HTTPError as error:
+        body = error.read(max_bytes + 1)
+        return FetchResult(
+            url=url,
+            status=error.code,
+            headers=dict(error.headers.items()),
+            body=body[:max_bytes],
+            final_url=error.url,
+        )
+    except urllib.error.URLError as error:
+        raise PublicLiveCheckError(f"request failed for {url}: {error}") from error
+
+
+def pass_result(name: str, detail: str, **data: object) -> CheckResult:
+    return CheckResult(name=name, ok=True, detail=detail, data=dict(data))
+
+
+def fail_result(name: str, detail: str, **data: object) -> CheckResult:
+    return CheckResult(name=name, ok=False, detail=detail, data=dict(data))
+
+
+@dataclass
+class PublicLiveChecker:
+    domain: str = DEFAULT_DOMAIN
+    www_domain: str = DEFAULT_WWW_DOMAIN
+    api_domain: str = DEFAULT_API_DOMAIN
+    expected_ip: str = DEFAULT_EXPECTED_IP
+    expected_version: str | None = None
+    expected_commit: str | None = None
+    authoritative_servers: Sequence[str] = ()
+    timeout: float = 8.0
+    resolver: Resolver = socket_resolve_ipv4
+    fetcher: Fetcher = fetch_url
+    glyph_path: str = DEFAULT_GLYPH_PATH
+    pmtiles_path: str = DEFAULT_PMTILES_PATH
+
+    def run(self) -> list[CheckResult]:
+        checks = [
+            *self.check_dns(),
+            self.check_http_redirect(),
+            self.check_https_root(self.domain),
+            self.check_https_root(self.www_domain),
+            self.check_map_route(),
+            self.check_api_ready(),
+            self.check_version_json(),
+            self.check_basemap_style(),
+            self.check_glyph_range(),
+            self.check_pmtiles_header(),
+        ]
+        return checks
+
+    def check_dns(self) -> list[CheckResult]:
+        results: list[CheckResult] = []
+        for host in (self.domain, self.www_domain, self.api_domain):
+            try:
+                observed = sorted(self.resolver(host, self.authoritative_servers))
+            except Exception as exc:
+                results.append(fail_result(f"dns:{host}", str(exc)))
+                continue
+            if observed == [self.expected_ip]:
+                results.append(pass_result(f"dns:{host}", "A record matches expected VPS IPv4", observed=observed))
+            else:
+                results.append(
+                    fail_result(
+                        f"dns:{host}",
+                        "A record does not match expected VPS IPv4",
+                        observed=observed,
+                        expected=[self.expected_ip],
+                    )
+                )
+        return results
+
+    def check_http_redirect(self) -> CheckResult:
+        url = f"http://{self.domain}/"
+        try:
+            result = self.fetcher(url, None, self.timeout, 8_192)
+        except Exception as exc:
+            return fail_result("http-redirect", str(exc), url=url)
+        location = _lower_headers(result.headers).get("location", "")
+        if result.status in {301, 302, 307, 308} and location.startswith(f"https://{self.domain}"):
+            return pass_result("http-redirect", "HTTP redirects to HTTPS", status=result.status, location=location)
+        return fail_result("http-redirect", "HTTP did not redirect to the canonical HTTPS site", status=result.status, location=location)
+
+    def check_https_root(self, host: str) -> CheckResult:
+        url = f"https://{host}/"
+        try:
+            result = self.fetcher(url, None, self.timeout, 64_000)
+        except Exception as exc:
+            return fail_result(f"https-root:{host}", str(exc), url=url)
+        if result.status == 200 and b"_app/" in result.body:
+            return pass_result(f"https-root:{host}", "HTTPS root serves the app shell", status=result.status)
+        return fail_result(f"https-root:{host}", "HTTPS root did not serve the app shell", status=result.status)
+
+    def check_map_route(self) -> CheckResult:
+        url = f"https://{self.domain}/map"
+        try:
+            result = self.fetcher(url, None, self.timeout, 64_000)
+        except Exception as exc:
+            return fail_result("map-route", str(exc), url=url)
+        if result.status == 200 and b"_app/" in result.body:
+            return pass_result("map-route", "Map route serves the app shell", status=result.status)
+        return fail_result("map-route", "Map route did not serve the app shell", status=result.status)
+
+    def check_api_ready(self) -> CheckResult:
+        url = f"https://{self.api_domain}/health/ready"
+        try:
+            result = self.fetcher(url, None, self.timeout, 64_000)
+            payload = json.loads(result.body.decode("utf-8"))
+        except Exception as exc:
+            return fail_result("api-ready", str(exc), url=url)
+        checks = payload.get("checks") if isinstance(payload, dict) else None
+        if result.status == 200 and payload.get("status") == "ok" and isinstance(checks, dict):
+            missing = [key for key in API_REQUIRED_CHECKS if checks.get(key) is not True]
+            if not missing:
+                return pass_result("api-ready", "API ready endpoint reports database/nats/policy true", status=result.status)
+            return fail_result("api-ready", "API ready endpoint has failed checks", missing=missing, checks=checks)
+        return fail_result("api-ready", "API ready endpoint did not report ok", status=result.status, payload=payload)
+
+    def check_version_json(self) -> CheckResult:
+        url = f"https://{self.domain}/_app/version.json"
+        try:
+            result = self.fetcher(url, None, self.timeout, 64_000)
+            payload = json.loads(result.body.decode("utf-8"))
+        except Exception as exc:
+            return fail_result("version-json", str(exc), url=url)
+        if result.status != 200:
+            return fail_result("version-json", "version.json did not return 200", status=result.status)
+        version = payload.get("version")
+        commit = payload.get("commit")
+        if not isinstance(version, str) or not version:
+            return fail_result("version-json", "version.json has no valid version", payload=payload)
+        if self.expected_version and version != self.expected_version:
+            return fail_result("version-json", "version mismatch", observed=version, expected=self.expected_version)
+        if self.expected_commit and commit != self.expected_commit:
+            return fail_result("version-json", "commit mismatch", observed=commit, expected=self.expected_commit)
+        return pass_result("version-json", "version.json is current", version=version, commit=commit)
+
+    def check_basemap_style(self) -> CheckResult:
+        url = f"https://{self.domain}/local-basemap/style.json"
+        try:
+            result = self.fetcher(url, None, self.timeout, 128_000)
+            payload = json.loads(result.body.decode("utf-8"))
+        except Exception as exc:
+            return fail_result("basemap-style", str(exc), url=url)
+        glyphs = payload.get("glyphs") if isinstance(payload, dict) else None
+        if result.status == 200 and isinstance(glyphs, str) and "/local-basemap/glyphs/" in glyphs:
+            return pass_result("basemap-style", "Local basemap style is reachable and references local glyphs", glyphs=glyphs)
+        return fail_result("basemap-style", "Local basemap style missing local glyph reference", status=result.status, glyphs=glyphs)
+
+    def check_glyph_range(self) -> CheckResult:
+        url = f"https://{self.domain}{self.glyph_path}"
+        try:
+            result = self.fetcher(url, None, self.timeout, 128_000)
+        except Exception as exc:
+            return fail_result("glyph-range", str(exc), url=url)
+        if result.status == 200 and len(result.body) > 0:
+            return pass_result("glyph-range", "Glyph range PBF is publicly reachable", bytes=len(result.body))
+        return fail_result("glyph-range", "Glyph range PBF is not reachable", status=result.status, bytes=len(result.body))
+
+    def check_pmtiles_header(self) -> CheckResult:
+        url = f"https://{self.domain}{self.pmtiles_path}"
+        try:
+            result = self.fetcher(url, {"Range": "bytes=0-15"}, self.timeout, 32)
+        except Exception as exc:
+            return fail_result("pmtiles-header", str(exc), url=url)
+        if result.status in {200, 206} and result.body.startswith(b"PMTiles"):
+            return pass_result("pmtiles-header", "PMTiles artifact header is publicly reachable", status=result.status)
+        return fail_result("pmtiles-header", "PMTiles artifact header missing", status=result.status, prefix=result.body[:16].hex())
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Check public weltgewebe live-readiness.")
+    parser.add_argument("--domain", default=DEFAULT_DOMAIN)
+    parser.add_argument("--www-domain", default=DEFAULT_WWW_DOMAIN)
+    parser.add_argument("--api-domain", default=DEFAULT_API_DOMAIN)
+    parser.add_argument("--expected-ip", default=DEFAULT_EXPECTED_IP)
+    parser.add_argument("--expected-version")
+    parser.add_argument("--expected-commit")
+    parser.add_argument("--authoritative-server", action="append", default=[])
+    parser.add_argument("--timeout", type=float, default=8.0)
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    checker = PublicLiveChecker(
+        domain=args.domain,
+        www_domain=args.www_domain,
+        api_domain=args.api_domain,
+        expected_ip=args.expected_ip,
+        expected_version=args.expected_version,
+        expected_commit=args.expected_commit,
+        authoritative_servers=tuple(args.authoritative_server),
+        timeout=args.timeout,
+    )
+    results = checker.run()
+    ok = all(result.ok for result in results)
+    payload = {"status": "pass" if ok else "fail", "checks": [result.payload() for result in results]}
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        for result in results:
+            marker = "PASS" if result.ok else "FAIL"
+            print(f"{marker}: {result.name}: {result.detail}")
+        print(f"overall={payload['status']}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ops/check_public_live_readiness.py
+++ b/scripts/ops/check_public_live_readiness.py
@@ -13,7 +13,6 @@ import json
 import socket
 import ssl
 import subprocess
-import sys
 import urllib.error
 import urllib.request
 from dataclasses import dataclass, field
@@ -62,17 +61,15 @@ class PublicLiveCheckError(RuntimeError):
     pass
 
 
-Resolver = Callable[[str, Sequence[str]], set[str]]
-Fetcher = Callable[[str, Mapping[str, str] | None, float, int], FetchResult]
+Resolver = Callable[[str], set[str]]
+Fetcher = Callable[[str, Mapping[str, str] | None, float], FetchResult]
 
 
 def _lower_headers(headers: Mapping[str, str]) -> dict[str, str]:
     return {key.lower(): value for key, value in headers.items()}
 
 
-def socket_resolve_ipv4(host: str, authoritative_servers: Sequence[str] = ()) -> set[str]:
-    if authoritative_servers:
-        return dig_resolve_ipv4(host, authoritative_servers)
+def socket_resolve_ipv4(host: str) -> set[str]:
     answers = socket.getaddrinfo(host, None, family=socket.AF_INET, type=socket.SOCK_STREAM)
     return {item[4][0] for item in answers}
 
@@ -175,7 +172,7 @@ class PublicLiveChecker:
         results: list[CheckResult] = []
         for host in (self.domain, self.www_domain, self.api_domain):
             try:
-                observed = sorted(self.resolver(host, self.authoritative_servers))
+                observed = sorted(self.resolve_host(host))
             except Exception as exc:
                 results.append(fail_result(f"dns:{host}", str(exc)))
                 continue
@@ -192,10 +189,15 @@ class PublicLiveChecker:
                 )
         return results
 
+    def resolve_host(self, host: str) -> set[str]:
+        if self.authoritative_servers:
+            return dig_resolve_ipv4(host, self.authoritative_servers)
+        return self.resolver(host)
+
     def check_http_redirect(self) -> CheckResult:
         url = f"http://{self.domain}/"
         try:
-            result = self.fetcher(url, None, self.timeout, 8_192)
+            result = self.fetcher(url, None, self.timeout)
         except Exception as exc:
             return fail_result("http-redirect", str(exc), url=url)
         location = _lower_headers(result.headers).get("location", "")
@@ -206,7 +208,7 @@ class PublicLiveChecker:
     def check_https_root(self, host: str) -> CheckResult:
         url = f"https://{host}/"
         try:
-            result = self.fetcher(url, None, self.timeout, 64_000)
+            result = self.fetcher(url, None, self.timeout)
         except Exception as exc:
             return fail_result(f"https-root:{host}", str(exc), url=url)
         if result.status == 200 and b"_app/" in result.body:
@@ -216,7 +218,7 @@ class PublicLiveChecker:
     def check_map_route(self) -> CheckResult:
         url = f"https://{self.domain}/map"
         try:
-            result = self.fetcher(url, None, self.timeout, 64_000)
+            result = self.fetcher(url, None, self.timeout)
         except Exception as exc:
             return fail_result("map-route", str(exc), url=url)
         if result.status == 200 and b"_app/" in result.body:
@@ -226,7 +228,7 @@ class PublicLiveChecker:
     def check_api_ready(self) -> CheckResult:
         url = f"https://{self.api_domain}/health/ready"
         try:
-            result = self.fetcher(url, None, self.timeout, 64_000)
+            result = self.fetcher(url, None, self.timeout)
             payload = json.loads(result.body.decode("utf-8"))
         except Exception as exc:
             return fail_result("api-ready", str(exc), url=url)
@@ -241,7 +243,7 @@ class PublicLiveChecker:
     def check_version_json(self) -> CheckResult:
         url = f"https://{self.domain}/_app/version.json"
         try:
-            result = self.fetcher(url, None, self.timeout, 64_000)
+            result = self.fetcher(url, None, self.timeout)
             payload = json.loads(result.body.decode("utf-8"))
         except Exception as exc:
             return fail_result("version-json", str(exc), url=url)
@@ -260,7 +262,7 @@ class PublicLiveChecker:
     def check_basemap_style(self) -> CheckResult:
         url = f"https://{self.domain}/local-basemap/style.json"
         try:
-            result = self.fetcher(url, None, self.timeout, 128_000)
+            result = self.fetcher(url, None, self.timeout)
             payload = json.loads(result.body.decode("utf-8"))
         except Exception as exc:
             return fail_result("basemap-style", str(exc), url=url)
@@ -272,7 +274,7 @@ class PublicLiveChecker:
     def check_glyph_range(self) -> CheckResult:
         url = f"https://{self.domain}{self.glyph_path}"
         try:
-            result = self.fetcher(url, None, self.timeout, 128_000)
+            result = self.fetcher(url, None, self.timeout)
         except Exception as exc:
             return fail_result("glyph-range", str(exc), url=url)
         if result.status == 200 and len(result.body) > 0:
@@ -282,7 +284,7 @@ class PublicLiveChecker:
     def check_pmtiles_header(self) -> CheckResult:
         url = f"https://{self.domain}{self.pmtiles_path}"
         try:
-            result = self.fetcher(url, {"Range": "bytes=0-15"}, self.timeout, 32)
+            result = self.fetcher(url, {"Range": "bytes=0-15"}, self.timeout)
         except Exception as exc:
             return fail_result("pmtiles-header", str(exc), url=url)
         if result.status in {200, 206} and result.body.startswith(b"PMTiles"):


### PR DESCRIPTION
Post-live hardening follow-up after the public VPS cutover.

What this adds:
- `scripts/ops/check_public_live_readiness.py`, a read-only public-surface checker for DNS, HTTP->HTTPS redirect, root/www HTTPS, `/map`, API readiness, version.json, local basemap style, glyph PBF, and PMTiles header.
- Unit tests with fake DNS/HTTP layers, so CI does not depend on the live internet.
- A small workflow for the checker/tests.
- VPS runbook update for the public-readiness receipt command and updated VPS-public-runtime wording.

Validation:
- `python3 -m py_compile scripts/ops/check_public_live_readiness.py scripts/ci/tests/test_public_live_readiness.py`
- `python3 -m unittest scripts/ci/tests/test_public_live_readiness.py -v` -> 5 passed
- `python3 -m scripts.docmeta.validate_relations` -> pass
- `python3 scripts/ci/check_github_action_pinning.py` -> pass
- live read-only check against weltgewebe.net with INWX authoritative servers -> overall=pass

Known unrelated note:
- `scripts/ci/check_actions_node24_readiness.py` still reports an existing unrelated `claude.yml` env finding; the new workflow itself is reported as pinned SHA and `env=present` by both scanners.

Non-actions:
- no DNS mutation, no VPS mutation, no DB migration, no mail/SMTP, no public login, no credential-source cutover.