### PR TITLE
ops: prepare VPS IPv6 readiness

### DIFF
--- a/docs/deploy/vps.md
+++ b/docs/deploy/vps.md
@@ -186,6 +186,13 @@ Doku-/Tooling-PRs können `main` vor den live ausgelieferten App-Build setzen. F
 einen reinen Oberflächen-Receipt ohne Versionsbindung können `--expected-version`
 und `--expected-commit` weggelassen werden.
 
+Wenn IPv6 freigegeben und die AAAA-Records gesetzt sind, wird zusätzlich die
+IPv6-DNS-Erwartung geprüft:
+
+```bash
+  --expected-ipv6 2a03:4000:21:c74:b47a:7bff:fee6:70d
+```
+
 Der Check liest keine Runtime-Secrets und verändert keinen Serverzustand. Er
 prüft DNS-A-Records, HTTP-zu-HTTPS-Redirect, Root-/`www`-HTTPS, `/map`,
 `api.weltgewebe.net/health/ready`, `/_app/version.json`, lokale Basemap-Style-,

--- a/infra/compose/compose.vps.override.yml
+++ b/infra/compose/compose.vps.override.yml
@@ -21,6 +21,9 @@ services:
         read_only: true
 
   caddy:
+    ports:
+      - "${CADDY_IPV6_BIND:-[::]}:80:80"
+      - "${CADDY_IPV6_BIND:-[::]}:443:443"
     volumes:
       - ${WELTGEWEBE_CADDYFILE:-../caddy/Caddyfile.vps}:/etc/caddy/Caddyfile:ro
       - ../../build/basemap:/srv/weltgewebe-basemap:ro

--- a/scripts/ci/tests/test_public_live_readiness.py
+++ b/scripts/ci/tests/test_public_live_readiness.py
@@ -148,5 +148,50 @@ class PublicLiveReadinessTest(unittest.TestCase):
         self.assertIn("missing", pmtiles_result.detail)
 
 
+class PublicLiveReadinessIPv6Test(unittest.TestCase):
+    def test_ipv6_aaaa_checks_are_optional(self) -> None:
+        fake = FakeWorld()
+        results = fake.checker().run()
+
+        self.assertFalse(any(result.name.startswith("dns-aaaa:") for result in results))
+
+    def test_expected_ipv6_requires_matching_authoritative_aaaa_records(self) -> None:
+        fake = FakeWorld()
+        original = fake.module.dig_resolve_ipv6
+        try:
+            fake.module.dig_resolve_ipv6 = lambda host, servers: {"2a03:4000:21:c74:b47a:7bff:fee6:70d"}
+            checker = fake.module.PublicLiveChecker(
+                expected_ipv6="2a03:4000:21:c74:b47a:7bff:fee6:70d",
+                authoritative_servers=("ns.inwx.de",),
+                resolver=fake.resolver,
+                fetcher=fake.fetcher,
+            )
+            results = checker.run()
+        finally:
+            fake.module.dig_resolve_ipv6 = original
+
+        ipv6_results = [result for result in results if result.name.startswith("dns-aaaa:")]
+        self.assertEqual(len(ipv6_results), 3)
+        self.assertTrue(all(result.ok for result in ipv6_results))
+
+    def test_wrong_ipv6_aaaa_fails(self) -> None:
+        fake = FakeWorld()
+        original = fake.module.dig_resolve_ipv6
+        try:
+            fake.module.dig_resolve_ipv6 = lambda host, servers: {"2001:db8::1"}
+            checker = fake.module.PublicLiveChecker(
+                expected_ipv6="2a03:4000:21:c74:b47a:7bff:fee6:70d",
+                authoritative_servers=("ns.inwx.de",),
+                resolver=fake.resolver,
+                fetcher=fake.fetcher,
+            )
+            results = checker.run()
+        finally:
+            fake.module.dig_resolve_ipv6 = original
+
+        ipv6_results = [result for result in results if result.name.startswith("dns-aaaa:")]
+        self.assertEqual(len(ipv6_results), 3)
+        self.assertTrue(all(not result.ok for result in ipv6_results))
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/ci/tests/test_vps_ipv6_readiness.py
+++ b/scripts/ci/tests/test_vps_ipv6_readiness.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[3]
+VPS_OVERRIDE = REPO / "infra" / "compose" / "compose.vps.override.yml"
+VPS_RUNBOOK = REPO / "docs" / "deploy" / "vps.md"
+
+
+def test_vps_override_publishes_caddy_on_ipv6_host_ports() -> None:
+    text = VPS_OVERRIDE.read_text(encoding="utf-8")
+
+    assert '"${CADDY_IPV6_BIND:-[::]}:80:80"' in text
+    assert '"${CADDY_IPV6_BIND:-[::]}:443:443"' in text
+
+
+def test_vps_runbook_keeps_ipv6_separate_from_ipv4_public_cutover() -> None:
+    text = VPS_RUNBOOK.read_text(encoding="utf-8")
+
+    assert "AAAA-Record" in text
+    assert "nur falls IPv6 geprüft und freigegeben ist" in text
+    assert "--expected-ipv6" in text

--- a/scripts/ops/check_public_live_readiness.py
+++ b/scripts/ops/check_public_live_readiness.py
@@ -74,11 +74,11 @@ def socket_resolve_ipv4(host: str) -> set[str]:
     return {item[4][0] for item in answers}
 
 
-def dig_resolve_ipv4(host: str, authoritative_servers: Sequence[str]) -> set[str]:
+def dig_resolve_record(host: str, authoritative_servers: Sequence[str], record_type: str) -> set[str]:
     answers: set[str] = set()
     for server in authoritative_servers:
         proc = subprocess.run(
-            ["dig", "+short", f"@{server}", host, "A"],
+            ["dig", "+short", f"@{server}", host, record_type],
             check=False,
             text=True,
             stdout=subprocess.PIPE,
@@ -86,13 +86,25 @@ def dig_resolve_ipv4(host: str, authoritative_servers: Sequence[str]) -> set[str
         )
         if proc.returncode != 0:
             raise PublicLiveCheckError(
-                f"dig failed for {host} via {server}: {(proc.stderr or proc.stdout).strip()}"
+                f"dig failed for {host} {record_type} via {server}: {(proc.stderr or proc.stdout).strip()}"
             )
         for line in proc.stdout.splitlines():
             value = line.strip()
-            if value and all(part.isdigit() for part in value.split(".")):
+            if value:
                 answers.add(value)
     return answers
+
+
+def dig_resolve_ipv4(host: str, authoritative_servers: Sequence[str]) -> set[str]:
+    return {
+        value
+        for value in dig_resolve_record(host, authoritative_servers, "A")
+        if all(part.isdigit() for part in value.split("."))
+    }
+
+
+def dig_resolve_ipv6(host: str, authoritative_servers: Sequence[str]) -> set[str]:
+    return {value for value in dig_resolve_record(host, authoritative_servers, "AAAA") if ":" in value}
 
 
 def fetch_url(
@@ -144,6 +156,7 @@ class PublicLiveChecker:
     www_domain: str = DEFAULT_WWW_DOMAIN
     api_domain: str = DEFAULT_API_DOMAIN
     expected_ip: str = DEFAULT_EXPECTED_IP
+    expected_ipv6: str | None = None
     expected_version: str | None = None
     expected_commit: str | None = None
     authoritative_servers: Sequence[str] = ()
@@ -156,6 +169,7 @@ class PublicLiveChecker:
     def run(self) -> list[CheckResult]:
         checks = [
             *self.check_dns(),
+            *self.check_dns_ipv6(),
             self.check_http_redirect(),
             self.check_https_root(self.domain),
             self.check_https_root(self.www_domain),
@@ -185,6 +199,29 @@ class PublicLiveChecker:
                         "A record does not match expected VPS IPv4",
                         observed=observed,
                         expected=[self.expected_ip],
+                    )
+                )
+        return results
+
+    def check_dns_ipv6(self) -> list[CheckResult]:
+        if not self.expected_ipv6:
+            return []
+        results: list[CheckResult] = []
+        for host in (self.domain, self.www_domain, self.api_domain):
+            try:
+                observed = sorted(dig_resolve_ipv6(host, self.authoritative_servers))
+            except Exception as exc:
+                results.append(fail_result(f"dns-aaaa:{host}", str(exc)))
+                continue
+            if observed == [self.expected_ipv6]:
+                results.append(pass_result(f"dns-aaaa:{host}", "AAAA record matches expected VPS IPv6", observed=observed))
+            else:
+                results.append(
+                    fail_result(
+                        f"dns-aaaa:{host}",
+                        "AAAA record does not match expected VPS IPv6",
+                        observed=observed,
+                        expected=[self.expected_ipv6],
                     )
                 )
         return results
@@ -298,6 +335,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--www-domain", default=DEFAULT_WWW_DOMAIN)
     parser.add_argument("--api-domain", default=DEFAULT_API_DOMAIN)
     parser.add_argument("--expected-ip", default=DEFAULT_EXPECTED_IP)
+    parser.add_argument("--expected-ipv6")
     parser.add_argument("--expected-version")
     parser.add_argument("--expected-commit")
     parser.add_argument("--authoritative-server", action="append", default=[])
@@ -313,6 +351,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         www_domain=args.www_domain,
         api_domain=args.api_domain,
         expected_ip=args.expected_ip,
+        expected_ipv6=args.expected_ipv6,
         expected_version=args.expected_version,
         expected_commit=args.expected_commit,
         authoritative_servers=tuple(args.authoritative_server),


### PR DESCRIPTION
Post-live hardening slice for the IPv6 item.

Current live state:
- IPv4 public live readiness is green.
- No AAAA records are currently published for `weltgewebe.net`, `www.weltgewebe.net`, or `api.weltgewebe.net`.
- wg-prod-1 has IPv6 address `2a03:4000:21:c74:b47a:7bff:fee6:70d`.
- UFW allows IPv6 TCP 80/443.
- A temporary Docker probe confirmed dual-stack host-port publishing works on wg-prod-1: `0.0.0.0:18081 -> 200` and `[::]:18081 -> 200`.

Change:
- VPS Compose override publishes Caddy on IPv6 host ports `[::]:80` and `[::]:443` in addition to the existing IPv4 ports from the base compose render.
- Public readiness checker gets optional `--expected-ipv6` / AAAA checks. IPv6 remains opt-in; current IPv4 receipts are unchanged.
- VPS runbook documents the IPv6 expectation flag.
- Tests cover optional IPv6 checks and the VPS IPv6 port contract.

Validation:
- `python3 -m scripts.docmeta.validate_relations` -> pass
- `python3 -m py_compile scripts/ops/check_public_live_readiness.py scripts/ci/tests/test_public_live_readiness.py` -> pass
- `python3 -m unittest scripts/ci/tests/test_public_live_readiness.py -v` -> 8 passed
- `python3 -m pytest scripts/ci/tests/test_vps_ipv6_readiness.py scripts/ci/tests/test_public_live_readiness.py -q` -> 10 passed
- live IPv4-only public readiness check -> overall=pass
- compose render includes both `host_ip: 0.0.0.0` and `host_ip: '::'`

Deployment boundary:
- This PR does not publish AAAA DNS records.
- This PR does not claim external IPv6 reachability yet; the operator host currently has no outbound IPv6, so external IPv6 proof needs a separate vantage point or third-party check after server-side rollout and DNS.
- No mail/SMTP, public-login, credential-source, DB, or secret change is included.