### PR TITLE
ops: align VPS credential source default

### DIFF
--- a/.github/workflows/vps-db-history-preflight.yml
+++ b/.github/workflows/vps-db-history-preflight.yml
@@ -6,11 +6,15 @@ name: VPS DB history preflight
     branches: [main]
     paths:
       - "docs/deploy/vps-db-initialization-boundary.md"
+      - "docs/deploy/vps.md"
       - "docs/deploy/vps-migration-safe-runtime-smoke.md"
+      - "infra/compose/compose.vps.override.yml"
+      - "scripts/weltgewebe-up"
       - "scripts/ops/check_vps_db_migration_history_shape.py"
       - "scripts/ci/tests/test_vps_db_history_preflight_docs.py"
       - "scripts/ci/tests/test_vps_db_initialization_boundary_docs.py"
       - "scripts/ci/tests/test_vps_db_migration_history_shape.py"
+      - "scripts/ci/tests/test_vps_credential_source_defaults.py"
       - "scripts/ci/tests/test_vps_migration_safe_runtime_env.py"
       - "scripts/ci/tests/test_vps_migration_safe_runtime_env_boundaries.py"
       - "scripts/ci/tests/test_vps_migration_safe_runtime_env_compose_semantics.py"
@@ -20,11 +24,15 @@ name: VPS DB history preflight
     branches: [main]
     paths:
       - "docs/deploy/vps-db-initialization-boundary.md"
+      - "docs/deploy/vps.md"
       - "docs/deploy/vps-migration-safe-runtime-smoke.md"
+      - "infra/compose/compose.vps.override.yml"
+      - "scripts/weltgewebe-up"
       - "scripts/ops/check_vps_db_migration_history_shape.py"
       - "scripts/ci/tests/test_vps_db_history_preflight_docs.py"
       - "scripts/ci/tests/test_vps_db_initialization_boundary_docs.py"
       - "scripts/ci/tests/test_vps_db_migration_history_shape.py"
+      - "scripts/ci/tests/test_vps_credential_source_defaults.py"
       - "scripts/ci/tests/test_vps_migration_safe_runtime_env.py"
       - "scripts/ci/tests/test_vps_migration_safe_runtime_env_boundaries.py"
       - "scripts/ci/tests/test_vps_migration_safe_runtime_env_compose_semantics.py"
@@ -64,6 +72,7 @@ jobs:
             scripts/ci/tests/test_vps_db_migration_history_shape.py \
             scripts/ci/tests/test_vps_db_history_preflight_docs.py \
             scripts/ci/tests/test_vps_db_initialization_boundary_docs.py \
+            scripts/ci/tests/test_vps_credential_source_defaults.py \
             scripts/ci/tests/test_vps_migration_safe_runtime_env.py \
             scripts/ci/tests/test_vps_migration_safe_runtime_env_boundaries.py \
             scripts/ci/tests/test_vps_migration_safe_runtime_env_compose_semantics.py \

--- a/docs/deploy/vps-migration-safe-runtime-smoke.md
+++ b/docs/deploy/vps-migration-safe-runtime-smoke.md
@@ -82,6 +82,18 @@ The VPS compose override is intentionally smoke-safe by default after the initia
 setup deploy for public login: `AUTH_PUBLIC_LOGIN` defaults to `0`, and related
 auth delivery/provisioning values remain explicit runtime-env choices.
 
+After the Public-VPS credential-source cutover, the preferred selected runtime
+env source is:
+
+```text
+/etc/weltgewebe/weltgewebe.env
+```
+
+`scripts/weltgewebe-up` uses that file for `DEPLOY_TARGET=vps` when no explicit
+`ENV_FILE` is set and the file exists. An explicit `ENV_FILE=/path/to/runtime.env`
+still takes precedence. The legacy `/opt/weltgewebe/.env` path may exist as a
+rollback source, but it is not the preferred Public-VPS target path.
+
 The startup migration mode is different: it must remain in the selected runtime
 env source, not in `services.api.environment`. The source-level helper rejects a
 service-level `WELTGEWEBE_API_STARTUP_MIGRATIONS` key because it can override the

--- a/docs/deploy/vps.md
+++ b/docs/deploy/vps.md
@@ -53,26 +53,39 @@ sudo usermod -aG docker $USER
 
 Kopiere das Repository auf den VPS (z.B. nach `/opt/weltgewebe` oder `~/weltgewebe`).
 
-### B. Umgebungsvariablen (.env) & Secrets
+### B. Umgebungsvariablen und Secrets
 
-Erstelle eine `.env` Datei im Root-Verzeichnis (neben `infra/`), basierend auf `.env.prod.example`.
+Für den Public-VPS-Pfad liegt die Runtime-Secret-Quelle außerhalb des
+Git-Checkouts:
+
+```text
+/etc/weltgewebe/weltgewebe.env
+owner: root
+mode: 0600
+```
+
+Initial kann diese Datei aus `.env.prod.example` aufgebaut werden:
 
 ```bash
-cp .env.prod.example .env
-nano .env
+sudo install -d -m 700 -o root -g root /etc/weltgewebe
+sudo install -m 600 -o root -g root .env.prod.example /etc/weltgewebe/weltgewebe.env
+sudoedit /etc/weltgewebe/weltgewebe.env
 ```
 
 **WICHTIG (Secrets):**
 
-* Die `.env` Datei enthält sensible Daten (Passwörter). Sie darf **niemals** ins Git-Repository committet werden.
-* Auf dem VPS liegt sie nur lokal vor.
+* Die Runtime-Datei enthält sensible Daten. Sie darf **niemals** ins Git-Repository committet werden.
+* Secret-Werte gehören nicht in GitHub-Kommentare, Logs oder Chat.
+* `/opt/weltgewebe/.env` kann als Legacy-/Rollback-Quelle existieren.
 
 Anpassungen:
 
-* **Datenbank**: Wähle ein starkes Passwort für `POSTGRES_PASSWORD` und passe `DATABASE_URL` entsprechend an.
+* **Datenbank**: Wähle ein starkes Passwort für `POSTGRES_PASSWORD` und passe
+  `DATABASE_URL` entsprechend an.
 * **Web Upstream**: Konfiguriere den Host und die URL deines Frontends (Vercel oder Cloudflare).
   * `WEB_UPSTREAM_HOST`: **Nur die Domain** ohne Schema (z.B. `leitstand.pages.dev`).
-  * `WEB_UPSTREAM_URL`: Die volle Origin **ohne Pfad**, muss mit `https://` beginnen (z.B. `https://leitstand.pages.dev`).
+  * `WEB_UPSTREAM_URL`: Die volle Origin **ohne Pfad**, muss mit `https://` beginnen
+    (z.B. `https://leitstand.pages.dev`).
 
 ### C. Starten
 
@@ -137,7 +150,16 @@ Deploy-Wrapper. Der Zieltyp wird explizit gesetzt:
 
 ```bash
 cd /opt/weltgewebe
-DEPLOY_TARGET=vps ENV_FILE=/opt/weltgewebe/.env ./scripts/weltgewebe-up --branch main
+DEPLOY_TARGET=vps ./scripts/weltgewebe-up --branch main
+```
+
+Wenn `ENV_FILE` nicht gesetzt ist, bevorzugt der VPS-Zieltyp
+`/etc/weltgewebe/weltgewebe.env`, sofern die Datei existiert. Für Tests,
+Rollback oder abweichende Installationen kann die Quelle bewusst überschrieben
+werden:
+
+```bash
+DEPLOY_TARGET=vps ENV_FILE=/path/to/runtime.env ./scripts/weltgewebe-up --branch main
 ```
 
 Der VPS-Zieltyp unterscheidet sich vom historischen Heimserver-Ziel:
@@ -197,4 +219,7 @@ Der Check liest keine Runtime-Secrets und verändert keinen Serverzustand. Er
 prüft DNS-A-Records, HTTP-zu-HTTPS-Redirect, Root-/`www`-HTTPS, `/map`,
 `api.weltgewebe.net/health/ready`, `/_app/version.json`, lokale Basemap-Style-,
 Glyph- und PMTiles-Auslieferung. Ein PASS ist ein Public-HTTP(S)-/Basemap-Receipt,
-aber kein Beweis für IPv6, Mail/SMTP, Public Login oder Credential-Cutover.
+aber kein Beweis für IPv6, Mail/SMTP oder Public Login. Der
+Credential-Source-Cutover wird über den ausgewählten `ENV_FILE`-Pfad und die
+Dateimetadaten der Runtime-Secret-Quelle belegt, nicht über den HTTP(S)-Check
+allein.

--- a/infra/compose/compose.vps.override.yml
+++ b/infra/compose/compose.vps.override.yml
@@ -2,7 +2,7 @@
 services:
   api:
     env_file:
-      - ${WELTGEWEBE_ENV_FILE:-/opt/weltgewebe/.env}
+      - ${WELTGEWEBE_ENV_FILE:-/etc/weltgewebe/weltgewebe.env}
     environment:
       POLICY_LIMITS_PATH: /app/policies/limits.yaml
       APP_BASE_URL: https://weltgewebe.net

--- a/scripts/ci/tests/test_vps_credential_source_defaults.py
+++ b/scripts/ci/tests/test_vps_credential_source_defaults.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[3]
+SCRIPT = REPO / "scripts" / "weltgewebe-up"
+VPS_OVERRIDE = REPO / "infra" / "compose" / "compose.vps.override.yml"
+HEIMSERVER_OVERRIDE = REPO / "infra" / "compose" / "compose.prod.override.yml"
+VPS_RUNBOOK = REPO / "docs" / "deploy" / "vps.md"
+RUNTIME_SMOKE = REPO / "docs" / "deploy" / "vps-migration-safe-runtime-smoke.md"
+
+
+def test_vps_compose_prefers_host_managed_credential_source() -> None:
+    text = VPS_OVERRIDE.read_text(encoding="utf-8")
+
+    assert "${WELTGEWEBE_ENV_FILE:-/etc/weltgewebe/weltgewebe.env}" in text
+    assert "${WELTGEWEBE_ENV_FILE:-/opt/weltgewebe/.env}" not in text
+
+
+def test_heimserver_compose_keeps_legacy_host_local_env_source() -> None:
+    text = HEIMSERVER_OVERRIDE.read_text(encoding="utf-8")
+
+    assert "${WELTGEWEBE_ENV_FILE:-/opt/weltgewebe/.env}" in text
+
+
+def test_weltgewebe_up_selects_vps_credential_source_only_when_unset() -> None:
+    text = SCRIPT.read_text(encoding="utf-8")
+
+    assert 'ENV_FILE_WAS_SET="${ENV_FILE+x}"' in text
+    assert (
+        'VPS_DEFAULT_ENV_FILE="${VPS_DEFAULT_ENV_FILE:-/etc/weltgewebe/weltgewebe.env}"'
+        in text
+    )
+    assert (
+        '[[ "$DEPLOY_TARGET" == "vps" && -z "$ENV_FILE_WAS_SET" '
+        '&& -f "$VPS_DEFAULT_ENV_FILE" ]]'
+        in text
+    )
+    assert 'ENV_FILE="$VPS_DEFAULT_ENV_FILE"' in text
+
+    explicit_default = text.index('ENV_FILE="${ENV_FILE:-/opt/weltgewebe/.env}"')
+    vps_default = text.index(
+        'VPS_DEFAULT_ENV_FILE="${VPS_DEFAULT_ENV_FILE:-/etc/weltgewebe/weltgewebe.env}"'
+    )
+    deploy_target = text.index('DEPLOY_TARGET="${DEPLOY_TARGET:-heimserver}"')
+    switch_default = text.index('ENV_FILE="$VPS_DEFAULT_ENV_FILE"')
+    env_check = text.index('if [[ ! -f "$ENV_FILE" ]]')
+
+    assert explicit_default < vps_default < deploy_target < switch_default < env_check
+
+
+def test_vps_runbook_documents_post_cutover_credential_source() -> None:
+    text = VPS_RUNBOOK.read_text(encoding="utf-8")
+
+    assert "/etc/weltgewebe/weltgewebe.env" in text
+    assert "owner: root" in text
+    assert "mode: 0600" in text
+    assert "ENV_FILE=/path/to/runtime.env" in text
+
+
+def test_runtime_smoke_runbook_names_selected_vps_credential_source() -> None:
+    text = RUNTIME_SMOKE.read_text(encoding="utf-8")
+
+    assert "/etc/weltgewebe/weltgewebe.env" in text
+    assert "selected runtime env source" in text
+    assert "WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied" in text

--- a/scripts/ci/tests/test_vps_migration_safe_runtime_env.py
+++ b/scripts/ci/tests/test_vps_migration_safe_runtime_env.py
@@ -33,7 +33,7 @@ def _compose_with_env_file(
         "services:",
         "  api:",
         "    env_file:",
-        "      - ${WELTGEWEBE_ENV_FILE:-/opt/weltgewebe/.env}",
+        "      - ${WELTGEWEBE_ENV_FILE:-/etc/weltgewebe/weltgewebe.env}",
     ]
     extra = textwrap.dedent(environment).strip()
     if extra:

--- a/scripts/weltgewebe-up
+++ b/scripts/weltgewebe-up
@@ -10,7 +10,9 @@ set -euo pipefail
 #   weltgewebe-up [--with-caddy] [--no-pull] [--build-mode auto|force|no] [--branch BRANCH|--current-branch]
 
 # REPO_DIR defaults are handled in resolution logic below
+ENV_FILE_WAS_SET="${ENV_FILE+x}"
 ENV_FILE="${ENV_FILE:-/opt/weltgewebe/.env}"
+VPS_DEFAULT_ENV_FILE="${VPS_DEFAULT_ENV_FILE:-/etc/weltgewebe/weltgewebe.env}"
 COMPOSE_PROJECT="${COMPOSE_PROJECT:-weltgewebe}"
 REMOTE="${REMOTE:-origin}"
 WELTGEWEBE_COMPOSE_BAKE="${WELTGEWEBE_COMPOSE_BAKE:-auto}"
@@ -23,6 +25,10 @@ case "$DEPLOY_TARGET" in
     exit 1
     ;;
 esac
+
+if [[ "$DEPLOY_TARGET" == "vps" && -z "$ENV_FILE_WAS_SET" && -f "$VPS_DEFAULT_ENV_FILE" ]]; then
+  ENV_FILE="$VPS_DEFAULT_ENV_FILE"
+fi
 
 # Base Compose File (always required)
 BASE_COMPOSE_FILE="infra/compose/compose.prod.yml"


### PR DESCRIPTION
## Summary

Aligns the repository default with the live `wg-prod-1` credential-source cutover completed in #1371.

## Change

- `scripts/weltgewebe-up` now prefers `/etc/weltgewebe/weltgewebe.env` for `DEPLOY_TARGET=vps` when `ENV_FILE` is unset and the file exists.
- Explicit `ENV_FILE=/path/to/runtime.env` remains authoritative.
- Heimserver defaults remain unchanged.
- `infra/compose/compose.vps.override.yml` now defaults its API `env_file` to `/etc/weltgewebe/weltgewebe.env`.
- VPS runbooks document the host-managed runtime-secret source and rollback/override boundary.
- CI gains `test_vps_credential_source_defaults.py` and the VPS DB history preflight workflow now runs when this surface changes.

## Validation

```text
bash -n scripts/weltgewebe-up -> pass
shellcheck -S style scripts/weltgewebe-up -> pass
python3 -m py_compile scripts/ci/tests/test_vps_credential_source_defaults.py scripts/ci/tests/test_vps_migration_safe_runtime_env.py -> pass
python3 -m pytest scripts/ci/tests/test_vps_credential_source_defaults.py scripts/ci/tests/test_vps_migration_safe_runtime_env.py scripts/ci/tests/test_vps_migration_safe_runtime_env_boundaries.py scripts/ci/tests/test_vps_migration_safe_runtime_env_compose_semantics.py scripts/ci/tests/test_vps_runtime_yaml_edges.py -q -> 44 passed
python3 -m scripts.docmeta.validate_relations -> pass
bash scripts/tests/test_weltgewebe_up_git_branch.sh -> pass
check_vps_migration_safe_runtime_env.py against repo VPS override -> PASS
```

## Evidence

```text
base: aa6359ae314fb9b2a47a7e45a45e66c0b4f0161f
head: a21a404dbf712a7439823217923f61f751b7c6d4
diff_sha256: c44f39dac326dee26813bc38b57f554180d51d5324b71ecab624c23a15535e7f
```

## Boundary

No secret values printed. No VPS runtime change in this PR. No DNS, SMTP, public-login, database, credential-value, or rollback-source cleanup change.