### PR TITLE
ops: retire heimserver production target

### DIFF
--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -10,9 +10,7 @@ relations:
   - type: relates_to
     target: docs/deployment_governance.md
   - type: relates_to
-    target: docs/deploy/heimserver.deployment.md
-  - type: relates_to
-    target: docs/deploy/heimserver.integration.md
+    target: docs/deploy/vps.md
   - type: relates_to
     target: docs/deploy/security.md
   - type: relates_to
@@ -25,9 +23,13 @@ relations:
 Dieses Dokument beschreibt den **kanonischen Deployment-Stand** von Weltgewebe.
 Es ist normativ. Abweichungen davon gelten als Drift.
 
+**Aktuelle Produktion:** `wg-prod-1` über den Public-VPS-Pfad. Der historische
+Heimserver-Pfad ist retired/deprecated und kein Produktionsziel mehr.
+
 **Weitere Dokumente:**
 
-- [Domain-/Providerarchitektur und DDNS-Handoff](domain-mail-migration-ionos-to-inwx-mailbox-brevo.md) – aktueller Providerstand, Implementierungsbesitz und Runtime-Beweisgrenze
+- [VPS-Deployment](vps.md) – kanonisches Produktionsrunbook für `wg-prod-1`
+- [Domain-/Providerarchitektur und DDNS-Handoff](domain-mail-migration-ionos-to-inwx-mailbox-brevo.md) – historischer Providerstand, Implementierungsbesitz und Runtime-Beweisgrenze
 - [Sekundäre Domain-Webflächen](secondary-domain-web-surfaces.md) – Artefakt- und Handoff-Vertrag für die Weltweberei-Informationsfläche und den späteren Heimserver-Edge (keine öffentliche Einsatzbereitschaft)
 - [Deployment-Änderungsprotokoll](./CHANGELOG.md) – Infrastrukturänderungen und deren Auswirkungen
 - [Drift-Taxonomie & Guard-Policy](./DRIFT_POLICY.md) – Klassifizierung und Handling von Drift

--- a/docs/deploy/heimserver.deployment.md
+++ b/docs/deploy/heimserver.deployment.md
@@ -2,8 +2,8 @@
 id: deploy.heimserver.deployment
 title: Heimserver Deployment
 doc_type: reference
-status: active
-summary: Deployment-Runbook für Weltgewebe auf dem Heimserver.
+status: deprecated
+summary: Historisches Heimserver-Deployment-Runbook; nicht mehr Produktionsziel.
 relations:
   - type: relates_to
     target: docs/deploy/README.md
@@ -12,6 +12,12 @@ relations:
   - type: relates_to
     target: docs/deployment.md
 ---
+
+> [!WARNING]
+> Der Heimserver ist kein aktives Produktionsziel mehr. Kanonische Produktion
+> ist `wg-prod-1` über den Public-VPS-Pfad. Dieses Dokument bleibt nur als
+> historischer/Legacy-Kontext erhalten.
+
 # Weltgewebe – Deployment Runbook (Heimserver)
 
 ## Architektur (Ist)

--- a/docs/deploy/heimserver.integration.md
+++ b/docs/deploy/heimserver.integration.md
@@ -2,8 +2,8 @@
 id: deploy.heimserver.integration
 title: Heimserver Integration
 doc_type: reference
-status: active
-summary: API-Integrationsdokumentation für das Heimserver-Deployment.
+status: deprecated
+summary: Historischer Heimserver-Integrationsvertrag; nicht mehr Produktionsziel.
 relations:
   - type: relates_to
     target: docs/deploy/README.md
@@ -12,6 +12,12 @@ relations:
   - type: relates_to
     target: docs/deployment.md
 ---
+
+> [!WARNING]
+> Der Heimserver ist kein aktives Produktionsziel mehr. Kanonische Produktion
+> ist `wg-prod-1` über den Public-VPS-Pfad. Dieses Dokument bleibt nur als
+> historischer/Legacy-Kontext erhalten.
+
 # Weltgewebe API – Heimserver Integration
 
 ## 0. Zweck

--- a/docs/deploy/vps.md
+++ b/docs/deploy/vps.md
@@ -12,8 +12,8 @@ relations:
 ---
 # VPS Deployment Runbook
 
-Dieses Runbook beschreibt den aktuellen Public-VPS-Pfad für `weltgewebe.net`.
-Der VPS stellt API, Datenbank, NATS und den Caddy-Frontdoor bereit. Das
+Dieses Runbook beschreibt den kanonischen Public-Produktionspfad für `weltgewebe.net`.
+Der VPS `wg-prod-1` stellt API, Datenbank, NATS und den Caddy-Frontdoor bereit. Das
 Frontend wird im VPS-Checkout gebaut und vom Stack-internen Caddy unter der
 Domain ausgeliefert.
 
@@ -145,11 +145,17 @@ Richte einen Cronjob ein, um regelmäßig Dumps der Datenbank zu erstellen und a
 
 ## 4. Aktueller Zielpfad: VPS als Public Runtime
 
-Für den neuen Public-VPS-Pfad ist `scripts/weltgewebe-up` der bevorzugte
-Deploy-Wrapper. Der Zieltyp wird explizit gesetzt:
+Für den Public-VPS-Pfad ist `scripts/weltgewebe-up` der bevorzugte
+Deploy-Wrapper. `vps` ist der Default-Zieltyp:
 
 ```bash
 cd /opt/weltgewebe
+./scripts/weltgewebe-up --branch main
+```
+
+Der Zieltyp kann weiterhin explizit gesetzt werden:
+
+```bash
 DEPLOY_TARGET=vps ./scripts/weltgewebe-up --branch main
 ```
 

--- a/scripts/ci/tests/test_vps_credential_source_defaults.py
+++ b/scripts/ci/tests/test_vps_credential_source_defaults.py
@@ -18,10 +18,18 @@ def test_vps_compose_prefers_host_managed_credential_source() -> None:
     assert "${WELTGEWEBE_ENV_FILE:-/opt/weltgewebe/.env}" not in text
 
 
-def test_heimserver_compose_keeps_legacy_host_local_env_source() -> None:
+def test_heimserver_compose_keeps_legacy_host_local_env_source_when_explicitly_selected() -> None:
     text = HEIMSERVER_OVERRIDE.read_text(encoding="utf-8")
 
     assert "${WELTGEWEBE_ENV_FILE:-/opt/weltgewebe/.env}" in text
+
+
+def test_weltgewebe_up_defaults_to_vps_and_keeps_heimserver_legacy_target_explicit() -> None:
+    text = SCRIPT.read_text(encoding="utf-8")
+
+    assert 'DEPLOY_TARGET="${DEPLOY_TARGET:-vps}"' in text
+    assert 'vps | heimserver) ;;' in text
+    assert "vps (default) or heimserver (legacy)" in text
 
 
 def test_weltgewebe_up_selects_vps_credential_source_only_when_unset() -> None:
@@ -43,7 +51,7 @@ def test_weltgewebe_up_selects_vps_credential_source_only_when_unset() -> None:
     vps_default = text.index(
         'VPS_DEFAULT_ENV_FILE="${VPS_DEFAULT_ENV_FILE:-/etc/weltgewebe/weltgewebe.env}"'
     )
-    deploy_target = text.index('DEPLOY_TARGET="${DEPLOY_TARGET:-heimserver}"')
+    deploy_target = text.index('DEPLOY_TARGET="${DEPLOY_TARGET:-vps}"')
     switch_default = text.index('ENV_FILE="$VPS_DEFAULT_ENV_FILE"')
     env_check = text.index('if [[ ! -f "$ENV_FILE" ]]')
 

--- a/scripts/tests/test_weltgewebe_up_git_branch.sh
+++ b/scripts/tests/test_weltgewebe_up_git_branch.sh
@@ -65,6 +65,14 @@ services:
     image: busybox
 EOF
 
+    cat > infra/compose/compose.vps.override.yml << 'EOF'
+services:
+  api:
+    image: busybox
+  caddy:
+    image: busybox
+EOF
+
     cat > apps/web/build/index.html << 'EOF'
 <!doctype html><html><body><script src="/_app/immutable/test.js"></script></body></html>
 EOF
@@ -446,14 +454,14 @@ assert_contains "$out_nonff" "Git pull failed (fast-forward only)"
 
 echo "PASS: non-fast-forward pull aborts"
 
-# 9) Failure bundle contains deploy-branch metadata fields
+# 9) Legacy heimserver failure bundle contains deploy-branch metadata fields
 repo_bundle="$(new_repo failure-bundle)"
 (
   cd "$repo_bundle"
   git checkout feat/x > /dev/null
 )
 set +e
-out_bundle="$(MOCK_FAIL_CONFIG_GUARD=1 run_up "$repo_bundle" "$WORKDIR_ROOT/failure-bundle.git.log" 2>&1)"
+out_bundle="$(DEPLOY_TARGET=heimserver MOCK_FAIL_CONFIG_GUARD=1 run_up "$repo_bundle" "$WORKDIR_ROOT/failure-bundle.git.log" 2>&1)"
 rc_bundle=$?
 set -e
 [[ "$rc_bundle" -ne 0 ]] || fail "failure-bundle case must fail"
@@ -472,6 +480,6 @@ assert_contains "$bundle_state" "remote deploy branch:"
 assert_contains "$bundle_state" "branch switch attempted:"
 assert_contains "$bundle_state" "branch switch result:"
 
-echo "PASS: failure bundle contains deploy branch metadata"
+echo "PASS: legacy heimserver failure bundle contains deploy branch metadata"
 
 echo "test_weltgewebe_up_git_branch: OK"

--- a/scripts/weltgewebe-up
+++ b/scripts/weltgewebe-up
@@ -16,10 +16,10 @@ VPS_DEFAULT_ENV_FILE="${VPS_DEFAULT_ENV_FILE:-/etc/weltgewebe/weltgewebe.env}"
 COMPOSE_PROJECT="${COMPOSE_PROJECT:-weltgewebe}"
 REMOTE="${REMOTE:-origin}"
 WELTGEWEBE_COMPOSE_BAKE="${WELTGEWEBE_COMPOSE_BAKE:-auto}"
-DEPLOY_TARGET="${DEPLOY_TARGET:-heimserver}"
+DEPLOY_TARGET="${DEPLOY_TARGET:-vps}"
 
 case "$DEPLOY_TARGET" in
-  heimserver | vps) ;;
+  vps | heimserver) ;;
   *)
     echo "ERROR: Invalid DEPLOY_TARGET '$DEPLOY_TARGET'. Expected: heimserver|vps." >&2
     exit 1
@@ -63,7 +63,7 @@ usage() {
   echo
   echo "Options:"
   echo "  --with-caddy            Start the 'caddy' service (default: disabled/scale=0; vps target enables it)"
-  echo "  DEPLOY_TARGET=TARGET    Select runtime target: heimserver (default) or vps"
+  echo "  DEPLOY_TARGET=TARGET    Select runtime target: vps (default) or heimserver (legacy)"
   echo "  --no-pull               Skip git sync/branch operations (no fetch, switch, pull)"
   echo "  --branch BRANCH         Deploy explicit branch name (default: main, no origin/ prefix)"
   echo "  --current-branch        Deploy the currently checked-out branch intentionally"


### PR DESCRIPTION
## Summary

Treat the Heimserver path as dead/legacy and make the Public VPS path the active production default.

## Change

- `scripts/weltgewebe-up` now defaults `DEPLOY_TARGET` to `vps`.
- `heimserver` remains accepted only as an explicit legacy target.
- Usage text now says `vps (default) or heimserver (legacy)`.
- VPS runbook names `wg-prod-1` as the canonical public production path.
- Heimserver deployment/integration docs are marked `deprecated` with a warning that they are historical context only.
- Deployment README now points at `docs/deploy/vps.md` as the canonical production runbook.
- Tests pin the new default and keep the legacy failure-bundle path explicit.

## Validation

```text
bash -n scripts/weltgewebe-up -> pass
shellcheck -S style scripts/weltgewebe-up scripts/tests/test_weltgewebe_up_git_branch.sh -> pass
python3 -m py_compile scripts/ci/tests/test_vps_credential_source_defaults.py scripts/ci/tests/test_vps_migration_safe_runtime_env.py -> pass
python3 -m pytest scripts/ci/tests/test_vps_credential_source_defaults.py scripts/ci/tests/test_vps_migration_safe_runtime_env.py scripts/ci/tests/test_vps_migration_safe_runtime_env_boundaries.py scripts/ci/tests/test_vps_migration_safe_runtime_env_compose_semantics.py scripts/ci/tests/test_vps_runtime_yaml_edges.py -q -> 45 passed
bash scripts/tests/test_weltgewebe_up_git_branch.sh -> pass
python3 -m scripts.docmeta.validate_relations -> pass
```

## Evidence

```text
base: 01f2b507764a581621e77934c6649c476b8655b3
head: fe53e0c788891854d16a6b63f308dba0f282d3ff
diff_sha256: f63134d3a2ba56c0810d24f634627d3bb5b823ba59980d9f1899c45956be2c80
```

## Boundary

No VPS runtime change in this PR yet. No DNS, SMTP, public-login, DB, secret, or credential-source value change. Historical reports are left untouched as archival evidence.