### PR TITLE
ops: add public login SMTP readiness preflight

### DIFF
--- a/.github/workflows/public-login-smtp-readiness.yml
+++ b/.github/workflows/public-login-smtp-readiness.yml
@@ -40,6 +40,9 @@ jobs:
         with:
           python-version-file: ".python-version"
 
+      - name: Install pytest
+        run: python -m pip install pytest
+
       - name: Compile public-login SMTP readiness checker
         run: python -m py_compile scripts/ops/check_public_login_smtp_readiness.py
 

--- a/.github/workflows/public-login-smtp-readiness.yml
+++ b/.github/workflows/public-login-smtp-readiness.yml
@@ -1,0 +1,47 @@
+---
+name: Public login SMTP readiness
+
+"on":
+  pull_request:
+    branches: [main]
+    paths:
+      - "scripts/ops/check_public_login_smtp_readiness.py"
+      - "scripts/ci/tests/test_public_login_smtp_readiness.py"
+      - "docs/deploy/README.md"
+      - ".github/workflows/public-login-smtp-readiness.yml"
+  push:
+    branches: [main]
+    paths:
+      - "scripts/ops/check_public_login_smtp_readiness.py"
+      - "scripts/ci/tests/test_public_login_smtp_readiness.py"
+      - "docs/deploy/README.md"
+      - ".github/workflows/public-login-smtp-readiness.yml"
+  workflow_dispatch: {}
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Public login SMTP readiness tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # tag: v7.0.0
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # tag: v5
+        with:
+          python-version-file: ".python-version"
+
+      - name: Compile public-login SMTP readiness checker
+        run: python -m py_compile scripts/ops/check_public_login_smtp_readiness.py
+
+      - name: Run public-login SMTP readiness tests
+        run: python -m pytest scripts/ci/tests/test_public_login_smtp_readiness.py -q

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -259,26 +259,42 @@ Detaillierte Klassifizierung: [Drift-Taxonomie & Guard-Policy](./DRIFT_POLICY.md
 
 ## 9. Feature Flags (Public Login)
 
-Das System unterstützt einen öffentlichen "Magic Link" Login.
-Standardmäßig ist dieser **deaktiviert**.
+Das System unterstützt öffentlichen Magic-Link-Login. Standardmäßig bleibt dieser
+**deaktiviert**. Für den Public-VPS-Produktionspfad wird Public Login erst nach
+einem separaten SMTP-Delivery-Receipt aktiviert.
 
-### Aktivierung
-
-Um den Public Login zu aktivieren, müssen folgende Variablen in der `.env` gesetzt werden:
+### Produktionskonfiguration
 
 ```bash
 AUTH_PUBLIC_LOGIN=1
-APP_BASE_URL=https://mein-weltgewebe.de
-# Optional: Trusted Proxies konfigurieren (wichtig für Sicherheit hinter Caddy/Proxy)
-# Hinweis: wird aktuell nur konfiguriert (plumbing); Auswertung/Enforcement folgt in PR3 (Client-IP trust + Rate-Limit).
-AUTH_TRUSTED_PROXIES=172.16.0.0/12,127.0.0.1
+AUTH_LOG_MAGIC_TOKEN=0
+APP_BASE_URL=https://weltgewebe.net
+SMTP_HOST=<provider-host>
+SMTP_PORT=587
+SMTP_AUTH=on
+SMTP_USER=<secret>
+SMTP_PASS=<secret>
+SMTP_FROM=noreply@weltgewebe.net
 ```
 
-**Wichtig:**
+Vor einem Rollout wird die vorbereitete Runtime-Secret-Quelle read-only geprüft:
+
+```bash
+python3 scripts/ops/check_public_login_smtp_readiness.py \
+  --env-file /etc/weltgewebe/weltgewebe.env \
+  --production-public-login
+```
+
+Der Check gibt nur Status- und Presence-Metadaten aus, keine SMTP-Werte.
+
+### Regeln
 
 - Wenn `AUTH_PUBLIC_LOGIN=1` gesetzt ist, **muss** `APP_BASE_URL` gesetzt sein.
-  Andernfalls startet der API-Service nicht (Validierungsfehler beim Startup).
-- `APP_BASE_URL` wird verwendet, um korrekte Links in E-Mails/Logs zu generieren.
+- `APP_BASE_URL` muss `https://weltgewebe.net` sein.
+- Ohne SMTP ist Magic Link Login nicht zustellbar.
+- `AUTH_LOG_MAGIC_TOKEN=1` ist ausschließlich Debug/Development und kein Produktionsmodus.
+- `SMTP_AUTH=off` ist für den Public-VPS-Rollout nicht zulässig, außer ein bewusst
+  dokumentierter lokaler Relay-Sonderfall wird separat freigegeben.
 
 ---
 

--- a/scripts/ci/tests/test_public_login_smtp_readiness.py
+++ b/scripts/ci/tests/test_public_login_smtp_readiness.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[3]
+SCRIPT = REPO / "scripts" / "ops" / "check_public_login_smtp_readiness.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("check_public_login_smtp_readiness", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("could not load public-login smtp readiness module")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_env(path: Path, content: str) -> Path:
+    path.write_text(content.strip() + "\n", encoding="utf-8")
+    return path
+
+
+def test_production_public_login_passes_with_authenticated_smtp(tmp_path: Path) -> None:
+    module = load_module()
+    env = {
+        "AUTH_PUBLIC_LOGIN": "1",
+        "AUTH_LOG_MAGIC_TOKEN": "0",
+        "APP_BASE_URL": "https://weltgewebe.net",
+        "SMTP_HOST": "smtp.example.test",
+        "SMTP_PORT": "587",
+        "SMTP_AUTH": "on",
+        "SMTP_USER": "user-secret",
+        "SMTP_PASS": "pass-secret",
+        "SMTP_FROM": "noreply@weltgewebe.net",
+    }
+
+    results = module.run_checks(
+        env,
+        production_public_login=True,
+        expected_app_base_url="https://weltgewebe.net",
+        allow_unauthenticated_smtp=False,
+    )
+
+    assert all(result.ok for result in results), [result.payload() for result in results]
+
+
+def test_production_public_login_rejects_magic_token_logging(tmp_path: Path) -> None:
+    module = load_module()
+    env = {
+        "AUTH_PUBLIC_LOGIN": "1",
+        "AUTH_LOG_MAGIC_TOKEN": "1",
+        "APP_BASE_URL": "https://weltgewebe.net",
+        "SMTP_HOST": "smtp.example.test",
+        "SMTP_PORT": "587",
+        "SMTP_AUTH": "on",
+        "SMTP_USER": "user-secret",
+        "SMTP_PASS": "pass-secret",
+        "SMTP_FROM": "noreply@weltgewebe.net",
+    }
+
+    result = [
+        item
+        for item in module.run_checks(
+            env,
+            production_public_login=True,
+            expected_app_base_url="https://weltgewebe.net",
+            allow_unauthenticated_smtp=False,
+        )
+        if item.name == "auth-log-magic-token"
+    ][0]
+
+    assert not result.ok
+    assert "must not log tokens" in result.detail
+
+
+def test_production_public_login_requires_smtp_credentials_by_default() -> None:
+    module = load_module()
+    env = {
+        "AUTH_PUBLIC_LOGIN": "1",
+        "AUTH_LOG_MAGIC_TOKEN": "0",
+        "APP_BASE_URL": "https://weltgewebe.net",
+        "SMTP_HOST": "smtp.example.test",
+        "SMTP_PORT": "587",
+        "SMTP_FROM": "noreply@weltgewebe.net",
+        "SMTP_AUTH": "auto",
+    }
+
+    result = [
+        item
+        for item in module.run_checks(
+            env,
+            production_public_login=True,
+            expected_app_base_url="https://weltgewebe.net",
+            allow_unauthenticated_smtp=False,
+        )
+        if item.name == "smtp-auth"
+    ][0]
+
+    assert not result.ok
+    assert "no SMTP_USER/SMTP_PASS" in result.detail
+
+
+def test_production_public_login_rejects_partial_smtp_credentials() -> None:
+    module = load_module()
+    env = {
+        "AUTH_PUBLIC_LOGIN": "1",
+        "AUTH_LOG_MAGIC_TOKEN": "0",
+        "APP_BASE_URL": "https://weltgewebe.net",
+        "SMTP_HOST": "smtp.example.test",
+        "SMTP_PORT": "587",
+        "SMTP_FROM": "noreply@weltgewebe.net",
+        "SMTP_AUTH": "auto",
+        "SMTP_USER": "user-secret",
+    }
+
+    result = [
+        item
+        for item in module.run_checks(
+            env,
+            production_public_login=True,
+            expected_app_base_url="https://weltgewebe.net",
+            allow_unauthenticated_smtp=False,
+        )
+        if item.name == "smtp-auth"
+    ][0]
+
+    assert not result.ok
+    assert "partial credential pair" in result.detail
+
+
+def test_production_public_login_rejects_bad_app_base_url() -> None:
+    module = load_module()
+    env = {
+        "AUTH_PUBLIC_LOGIN": "1",
+        "AUTH_LOG_MAGIC_TOKEN": "0",
+        "APP_BASE_URL": "http://localhost",
+        "SMTP_HOST": "smtp.example.test",
+        "SMTP_PORT": "587",
+        "SMTP_AUTH": "on",
+        "SMTP_USER": "user-secret",
+        "SMTP_PASS": "pass-secret",
+        "SMTP_FROM": "noreply@weltgewebe.net",
+    }
+
+    result = [
+        item
+        for item in module.run_checks(
+            env,
+            production_public_login=True,
+            expected_app_base_url="https://weltgewebe.net",
+            allow_unauthenticated_smtp=False,
+        )
+        if item.name == "app-base-url"
+    ][0]
+
+    assert not result.ok
+    assert result.data["status"] == "mismatch"
+
+
+def test_cli_output_does_not_print_secret_values(tmp_path: Path) -> None:
+    env_file = write_env(
+        tmp_path / "runtime.env",
+        """
+        AUTH_PUBLIC_LOGIN=1
+        AUTH_LOG_MAGIC_TOKEN=0
+        APP_BASE_URL=https://weltgewebe.net
+        SMTP_HOST=smtp.example.test
+        SMTP_PORT=587
+        SMTP_AUTH=on
+        SMTP_USER=very-sensitive-user
+        SMTP_PASS=very-sensitive-pass
+        SMTP_FROM=noreply@weltgewebe.net
+        """,
+    )
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--env-file",
+            str(env_file),
+            "--production-public-login",
+            "--json",
+        ],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    payload = json.loads(proc.stdout)
+    assert payload["status"] == "pass"
+    assert "very-sensitive-user" not in proc.stdout
+    assert "very-sensitive-pass" not in proc.stdout
+    assert "present" in proc.stdout

--- a/scripts/ops/check_public_login_smtp_readiness.py
+++ b/scripts/ops/check_public_login_smtp_readiness.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Read-only public-login SMTP readiness preflight.
+
+The checker reads dotenv-style runtime env files and prints only pass/fail
+metadata. It never prints configured values, because some keys are secrets.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Mapping, Sequence
+
+EXPECTED_APP_BASE_URL = "https://weltgewebe.net"
+SECRET_KEYS = {"SMTP_PASS", "SMTP_USER"}
+REQUIRED_SMTP_KEYS = ("SMTP_HOST", "SMTP_PORT", "SMTP_FROM")
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    name: str
+    ok: bool
+    detail: str
+    data: dict[str, object] = field(default_factory=dict)
+
+    def payload(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "status": "pass" if self.ok else "fail",
+            "detail": self.detail,
+            **({"data": self.data} if self.data else {}),
+        }
+
+
+def pass_result(name: str, detail: str, **data: object) -> CheckResult:
+    return CheckResult(name=name, ok=True, detail=detail, data=dict(data))
+
+
+def fail_result(name: str, detail: str, **data: object) -> CheckResult:
+    return CheckResult(name=name, ok=False, detail=detail, data=dict(data))
+
+
+def parse_bool(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def parse_env_file(path: Path) -> dict[str, str]:
+    env: dict[str, str] = {}
+    for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].strip()
+        if "=" not in line:
+            raise ValueError(f"{path}:{line_number}: expected KEY=VALUE")
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if not re.fullmatch(r"[A-Z0-9_]+", key):
+            raise ValueError(f"{path}:{line_number}: invalid env key")
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {'\"', "'"}:
+            value = value[1:-1]
+        env[key] = value
+    return env
+
+
+def merged_env(paths: Sequence[Path]) -> dict[str, str]:
+    env: dict[str, str] = {}
+    for path in paths:
+        env.update(parse_env_file(path))
+    return env
+
+
+def present(env: Mapping[str, str], key: str) -> bool:
+    return bool(env.get(key, "").strip())
+
+
+def safe_presence_data(env: Mapping[str, str], keys: Sequence[str]) -> dict[str, str]:
+    return {key: "present" if present(env, key) else "absent" for key in keys}
+
+
+def check_public_login(env: Mapping[str, str], *, require_enabled: bool) -> CheckResult:
+    enabled = parse_bool(env.get("AUTH_PUBLIC_LOGIN"))
+    if require_enabled and not enabled:
+        return fail_result("auth-public-login", "AUTH_PUBLIC_LOGIN is not enabled", status="disabled")
+    if enabled:
+        return pass_result("auth-public-login", "AUTH_PUBLIC_LOGIN is enabled", status="enabled")
+    return pass_result("auth-public-login", "AUTH_PUBLIC_LOGIN is disabled", status="disabled")
+
+
+def check_log_magic_token(env: Mapping[str, str], *, require_disabled: bool) -> CheckResult:
+    enabled = parse_bool(env.get("AUTH_LOG_MAGIC_TOKEN"))
+    if require_disabled and enabled:
+        return fail_result(
+            "auth-log-magic-token",
+            "AUTH_LOG_MAGIC_TOKEN is enabled; production public login must not log tokens",
+            status="enabled",
+        )
+    if enabled:
+        return pass_result("auth-log-magic-token", "AUTH_LOG_MAGIC_TOKEN is enabled", status="enabled")
+    return pass_result("auth-log-magic-token", "AUTH_LOG_MAGIC_TOKEN is disabled", status="disabled")
+
+
+def check_app_base_url(env: Mapping[str, str], *, expected: str) -> CheckResult:
+    value = env.get("APP_BASE_URL", "").strip()
+    if value == expected:
+        return pass_result("app-base-url", "APP_BASE_URL matches public production URL", status="configured")
+    if not value:
+        return fail_result("app-base-url", "APP_BASE_URL is missing", status="absent")
+    return fail_result("app-base-url", "APP_BASE_URL does not match public production URL", status="mismatch")
+
+
+def check_smtp_presence(env: Mapping[str, str]) -> CheckResult:
+    missing = [key for key in REQUIRED_SMTP_KEYS if not present(env, key)]
+    if missing:
+        return fail_result(
+            "smtp-required-keys",
+            "required SMTP delivery keys are missing",
+            missing=missing,
+            presence=safe_presence_data(env, (*REQUIRED_SMTP_KEYS, "SMTP_USER", "SMTP_PASS")),
+        )
+    return pass_result(
+        "smtp-required-keys",
+        "required SMTP delivery keys are present",
+        presence=safe_presence_data(env, (*REQUIRED_SMTP_KEYS, "SMTP_USER", "SMTP_PASS")),
+    )
+
+
+def check_smtp_port(env: Mapping[str, str]) -> CheckResult:
+    raw = env.get("SMTP_PORT", "").strip()
+    try:
+        port = int(raw)
+    except ValueError:
+        return fail_result("smtp-port", "SMTP_PORT is not a number", status="invalid")
+    if port in {465, 587}:
+        return pass_result("smtp-port", "SMTP_PORT is a production TLS port", port=port)
+    if port == 25:
+        return fail_result("smtp-port", "SMTP_PORT 25 is not accepted for public-login rollout", port=port)
+    return fail_result("smtp-port", "SMTP_PORT is not an accepted production TLS port", port=port)
+
+
+def check_smtp_auth(env: Mapping[str, str], *, allow_unauthenticated: bool) -> CheckResult:
+    policy = env.get("SMTP_AUTH", "auto").strip().lower() or "auto"
+    if policy not in {"auto", "on", "off"}:
+        return fail_result("smtp-auth", "SMTP_AUTH must be auto, on, or off", policy="invalid")
+
+    has_user = present(env, "SMTP_USER")
+    has_pass = present(env, "SMTP_PASS")
+
+    if policy == "off":
+        if allow_unauthenticated:
+            return pass_result("smtp-auth", "SMTP_AUTH=off accepted by explicit override", policy="off")
+        return fail_result("smtp-auth", "SMTP_AUTH=off is not accepted for production public-login rollout", policy="off")
+
+    if policy == "on" and not (has_user and has_pass):
+        return fail_result(
+            "smtp-auth",
+            "SMTP_AUTH=on requires SMTP_USER and SMTP_PASS",
+            policy="on",
+            presence=safe_presence_data(env, ("SMTP_USER", "SMTP_PASS")),
+        )
+
+    if policy == "auto":
+        if has_user != has_pass:
+            return fail_result(
+                "smtp-auth",
+                "SMTP_AUTH=auto has a partial credential pair",
+                policy="auto",
+                presence=safe_presence_data(env, ("SMTP_USER", "SMTP_PASS")),
+            )
+        if has_user and has_pass:
+            return pass_result("smtp-auth", "SMTP_AUTH=auto will use the configured credential pair", policy="auto")
+        if allow_unauthenticated:
+            return pass_result("smtp-auth", "SMTP_AUTH=auto without credentials accepted by explicit override", policy="auto")
+        return fail_result(
+            "smtp-auth",
+            "SMTP_AUTH=auto has no SMTP_USER/SMTP_PASS pair for production public-login rollout",
+            policy="auto",
+            presence=safe_presence_data(env, ("SMTP_USER", "SMTP_PASS")),
+        )
+
+    return pass_result("smtp-auth", "SMTP_AUTH=on has SMTP_USER and SMTP_PASS", policy="on")
+
+
+def check_no_secret_values_leaked(results: Sequence[CheckResult]) -> CheckResult:
+    serialized = json.dumps([result.payload() for result in results], sort_keys=True)
+    leaked = [key for key in SECRET_KEYS if key in serialized and "present" not in serialized and "absent" not in serialized]
+    if leaked:
+        return fail_result("no-secret-values", "internal checker payload may leak secret-like values", keys=leaked)
+    return pass_result("no-secret-values", "checker output contains presence metadata only")
+
+
+def run_checks(
+    env: Mapping[str, str],
+    *,
+    production_public_login: bool,
+    expected_app_base_url: str,
+    allow_unauthenticated_smtp: bool,
+) -> list[CheckResult]:
+    results = [
+        check_public_login(env, require_enabled=production_public_login),
+        check_log_magic_token(env, require_disabled=production_public_login),
+        check_app_base_url(env, expected=expected_app_base_url),
+        check_smtp_presence(env),
+    ]
+    if present(env, "SMTP_PORT"):
+        results.append(check_smtp_port(env))
+    else:
+        results.append(fail_result("smtp-port", "SMTP_PORT is missing", status="absent"))
+    results.append(check_smtp_auth(env, allow_unauthenticated=allow_unauthenticated_smtp))
+    results.append(check_no_secret_values_leaked(results))
+    return results
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Check production public-login SMTP readiness.")
+    parser.add_argument("--env-file", action="append", type=Path, required=True)
+    parser.add_argument("--production-public-login", action="store_true")
+    parser.add_argument("--expected-app-base-url", default=EXPECTED_APP_BASE_URL)
+    parser.add_argument("--allow-unauthenticated-smtp", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    for path in args.env_file:
+        if not path.is_file():
+            print(f"ERROR: env file not found: {path}", file=sys.stderr)
+            return 2
+    try:
+        env = merged_env(args.env_file)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    results = run_checks(
+        env,
+        production_public_login=args.production_public_login,
+        expected_app_base_url=args.expected_app_base_url,
+        allow_unauthenticated_smtp=args.allow_unauthenticated_smtp,
+    )
+    ok = all(result.ok for result in results)
+    payload = {"status": "pass" if ok else "fail", "checks": [result.payload() for result in results]}
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        for result in results:
+            marker = "PASS" if result.ok else "FAIL"
+            print(f"{marker}: {result.name}: {result.detail}")
+        print(f"overall={payload['status']}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a read-only public-login SMTP readiness preflight before #1370 can be safely completed.

## Change

- Adds `scripts/ops/check_public_login_smtp_readiness.py`.
- The checker reads dotenv-style env files and reports only pass/fail and presence metadata; it does not print SMTP values.
- Adds tests for production-ready SMTP, token logging rejection, missing/partial SMTP credentials, bad `APP_BASE_URL`, and no secret value leakage.
- Adds a pinned GitHub Actions workflow for the checker.
- Updates the deploy README: Public Login is only enabled after SMTP delivery is configured and preflight passes.

## Production gate

For the Public VPS path, the intended candidate must pass:

```text
AUTH_PUBLIC_LOGIN=1
AUTH_LOG_MAGIC_TOKEN=0
APP_BASE_URL=https://weltgewebe.net
SMTP_HOST present
SMTP_PORT 465 or 587
SMTP_FROM present
SMTP_AUTH=on with SMTP_USER/SMTP_PASS present
```

`SMTP_AUTH=off` is rejected unless an explicit override is passed for a documented local relay exception.

## Validation

```text
python3 -m py_compile scripts/ops/check_public_login_smtp_readiness.py scripts/ci/tests/test_public_login_smtp_readiness.py -> pass
python3 -m pytest scripts/ci/tests/test_public_login_smtp_readiness.py -q -> 6 passed
python3 -m scripts.docmeta.validate_relations -> pass
python3 scripts/ci/check_github_action_pinning.py -> pass
new workflow is pinned and Node24-env covered
positive dummy env -> overall=pass
negative missing-SMTP env -> overall=fail
```

## Evidence

```text
base: 27cd95b3877a7d218bc0aac7c7533078527d60f8
head: 7de7d28f5ac48037840bf26a8c2f65cf5c9e5907
diff_sha256: f84355333e05bd0f6da9fc0e8b9ccf94b9912033a2ac754ca0217354ad1d6f49
```

## Boundary

No runtime change. No SMTP values added. No public-login enablement. No DNS, DB, credential-source value, or secret change.