### PR TITLE
docs: define garnrolle visibility model

### DIFF
--- a/docs/_generated/backlinks.md
+++ b/docs/_generated/backlinks.md
@@ -119,7 +119,7 @@ Generated automatically. Do not edit.
 
 ## docs/adr/ADR-0003__privacy-ungenauigkeitsradius-ron.md
 
-- [relates_to] docs/konzepte/garnrolle-und-verortung.md
+- [supersedes] docs/adr/ADR-0009__garnrolle-verortung-sichtbarkeit.md
 
 ## docs/adr/ADR-0005-auth.md
 
@@ -164,6 +164,15 @@ Generated automatically. Do not edit.
 
 - [relates_to] docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md
 - [relates_to] docs/runbooks/domain-mail-cutover.md
+
+## docs/adr/ADR-0009__garnrolle-verortung-sichtbarkeit.md
+
+- [relates_to] docs/adr/ADR-0003__privacy-ungenauigkeitsradius-ron.md
+- [relates_to] docs/blueprints/ui-roadmap.md
+- [relates_to] docs/konzepte/garnrolle-und-verortung.md
+- [relates_to] docs/reference/glossar.md
+- [relates_to] docs/specs/privacy-api.md
+- [relates_to] docs/specs/privacy-ui.md
 
 ## docs/architekturstruktur.md
 
@@ -281,6 +290,7 @@ Generated automatically. Do not edit.
 
 ## docs/blueprints/ui-roadmap.md
 
+- [relates_to] docs/adr/ADR-0009__garnrolle-verortung-sichtbarkeit.md
 - [relates_to] docs/blueprints/ui-blaupause.md
 - [relates_to] docs/blueprints/ui-interaction-doctrine.md
 - [relates_to] docs/blueprints/ui-state-machine.md
@@ -353,7 +363,6 @@ Generated automatically. Do not edit.
 
 ## docs/deploy/heimserver.deployment.md
 
-- [relates_to] docs/deploy/README.md
 - [relates_to] docs/deploy/heim-first-phase0.md
 - [relates_to] docs/deploy/heimserver.integration.md
 - [relates_to] docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md
@@ -361,7 +370,6 @@ Generated automatically. Do not edit.
 
 ## docs/deploy/heimserver.integration.md
 
-- [relates_to] docs/deploy/README.md
 - [relates_to] docs/deploy/heimserver.deployment.md
 
 ## docs/deploy/secondary-domain-web-surfaces.md
@@ -373,6 +381,10 @@ Generated automatically. Do not edit.
 - [relates_to] docs/deploy/README.md
 - [relates_to] docs/deployment.md
 - [relates_to] docs/runbooks/incident-response.md
+
+## docs/deploy/vps-db-initialization-boundary.md
+
+- [relates_to] docs/deploy/vps-migration-safe-runtime-smoke.md
 
 ## docs/deploy/vps-http-route-smoke-risks.md
 
@@ -392,10 +404,12 @@ Generated automatically. Do not edit.
 
 ## docs/deploy/vps-migration-safe-runtime-smoke.md
 
+- [relates_to] docs/deploy/vps-db-initialization-boundary.md
 - [relates_to] docs/deploy/vps-http-smoke.md
 
 ## docs/deploy/vps.md
 
+- [relates_to] docs/deploy/README.md
 - [relates_to] docs/deploy/vps-http-smoke.md
 
 ## docs/deployment.md
@@ -446,6 +460,7 @@ Generated automatically. Do not edit.
 ## docs/konzepte/garnrolle-und-verortung.md
 
 - [relates_to] docs/adr/ADR-0003__privacy-ungenauigkeitsradius-ron.md
+- [relates_to] docs/adr/ADR-0009__garnrolle-verortung-sichtbarkeit.md
 - [relates_to] docs/konzepte/garnrolle.md
 - [relates_to] docs/policies/architecture-critique.md
 - [relates_to] docs/specs/privacy-api.md
@@ -844,10 +859,12 @@ Generated automatically. Do not edit.
 
 ## docs/specs/privacy-api.md
 
+- [relates_to] docs/adr/ADR-0009__garnrolle-verortung-sichtbarkeit.md
 - [relates_to] docs/specs/privacy-ui.md
 
 ## docs/specs/privacy-ui.md
 
+- [relates_to] docs/adr/ADR-0009__garnrolle-verortung-sichtbarkeit.md
 - [relates_to] docs/specs/privacy-api.md
 
 ## docs/tasks/README.md
@@ -1045,6 +1062,14 @@ Generated automatically. Do not edit.
 ## scripts/guard/domain-single-instance-guard.sh
 
 - [relates_to] docs/reports/domain-postgres-instance-coherence-decision.md
+
+## scripts/ops/check_public_live_readiness.py
+
+- [relates_to] docs/deploy/vps.md
+
+## scripts/ops/check_vps_db_migration_history_shape.py
+
+- [relates_to] docs/deploy/vps-db-initialization-boundary.md
 
 ## scripts/ops/check_vps_migration_safe_runtime_env.py
 

--- a/docs/_generated/doc-index.md
+++ b/docs/_generated/doc-index.md
@@ -17,12 +17,13 @@ Generated automatically. Do not edit.
 | adr.0043-edge-vs-conversation | ADR-0043 — Edge vs. Conversation | reference | active | docs/adr/0043-edge-vs-conversation.md |
 | adr.ADR-0001__clean-slate-docs-monorepo | ADR-0001 — Clean Slate und Docs-Monorepo | reference | active | docs/adr/ADR-0001__clean-slate-docs-monorepo.md |
 | adr.ADR-0002__reentry-kriterien | ADR-0002 — Reentry-Kriterien | reference | active | docs/adr/ADR-0002__reentry-kriterien.md |
-| adr.ADR-0003__privacy-ungenauigkeitsradius-ron | ADR-0003 — Privacy-Ungenauigkeitsradius und RoN | reference | active | docs/adr/ADR-0003__privacy-ungenauigkeitsradius-ron.md |
+| adr.ADR-0003__privacy-ungenauigkeitsradius-ron | ADR-0003 — Historisches Privacy- und Startzustandsmodell | reference | superseded | docs/adr/ADR-0003__privacy-ungenauigkeitsradius-ron.md |
 | adr.ADR-0004__fahrplan-verweis | ADR-0004 — Fahrplan-Verweis | reference | active | docs/adr/ADR-0004__fahrplan-verweis.md |
 | adr.ADR-0005-auth | ADR-0005 — Auth (Cookie-basierte Sessions) | reference | active | docs/adr/ADR-0005-auth.md |
 | adr.ADR-0006-auth-magic-link-session-passkey | ADR-0006 — Auth: Magic Link, Session und optionaler Passkey | reference | active | docs/adr/ADR-0006__auth-magic-link-session-passkey.md |
 | adr.ADR-0007-auth-persistence-production-db-path | ADR-0007 — Auth-Persistenz Produktionspfad: Direkter PostgreSQL-Zugriff statt PgBouncer | reference | accepted | docs/adr/ADR-0007__auth-persistence-production-db-path.md |
 | adr.ADR-0008-domain-mail-provider-boundaries | ADR-0008 — Domain-, Mail- und SMTP-Providergrenzen | reference | accepted | docs/adr/ADR-0008__domain-mail-provider-boundaries.md |
+| adr.ADR-0009__garnrolle-verortung-sichtbarkeit | ADR-0009 — Garnrolle, Verortung und Sichtbarkeit | reference | active | docs/adr/ADR-0009__garnrolle-verortung-sichtbarkeit.md |
 | blueprint-doc-structure-task-control | Weltgewebe Dokumentationsstruktur und Task-Steuerung | blueprint | draft | docs/blueprints/doc-structure-task-control.md |
 | blueprint-doc-structure-task-control-examples | Dokumentationsstruktur und Task-Steuerung Beispiele | reference | draft | docs/blueprints/doc-structure-task-control-examples.md |
 | blueprint-doc-structure-task-control-roadmap | Dokumentationsstruktur und Task-Steuerung Roadmap | roadmap | draft | docs/blueprints/doc-structure-task-control-roadmap.md |
@@ -38,12 +39,13 @@ Generated automatically. Do not edit.
 | deploy.README | Deployment-Übersicht | reference | active | docs/deploy/README.md |
 | deploy.domain-mail-migration-ionos-inwx-mailbox-brevo | Architektur & Historie: Domain-/Mail-Migration IONOS zu INWX | reference | active | docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md |
 | deploy.heim-first-phase0 | Heim-First Phase 0 | reference | active | docs/deploy/heim-first-phase0.md |
-| deploy.heimserver.deployment | Heimserver Deployment | reference | active | docs/deploy/heimserver.deployment.md |
-| deploy.heimserver.integration | Heimserver Integration | reference | active | docs/deploy/heimserver.integration.md |
+| deploy.heimserver.deployment | Heimserver Deployment | reference | deprecated | docs/deploy/heimserver.deployment.md |
+| deploy.heimserver.integration | Heimserver Integration | reference | deprecated | docs/deploy/heimserver.integration.md |
 | deploy.public-app-base-url | Public APP_BASE_URL Contract | reference | active | docs/deploy/public-app-base-url.md |
 | deploy.secondary-domain-web-surfaces | Sekundäre Domain-Webflächen | reference | active | docs/deploy/secondary-domain-web-surfaces.md |
 | deploy.security | Deploy Security | architecture | active | docs/deploy/security.md |
 | deploy.vps | VPS-Deployment | reference | active | docs/deploy/vps.md |
+| deploy.vps-db-initialization-boundary | VPS DB Initialization Boundary | runbook | active | docs/deploy/vps-db-initialization-boundary.md |
 | deploy.vps-http-route-smoke | VPS HTTP Route Smoke | runbook | draft | docs/deploy/vps-http-route-smoke.md |
 | deploy.vps-http-route-smoke-risks | VPS HTTP Route Smoke Risks | note | draft | docs/deploy/vps-http-route-smoke-risks.md |
 | deploy.vps-http-smoke | VPS HTTP Smoke Preflight | runbook | draft | docs/deploy/vps-http-smoke.md |
@@ -81,8 +83,8 @@ Generated automatically. Do not edit.
 | edge.systemd.README | Edge Systemd | reference | active | docs/edge/systemd/README.md |
 | geist-und-plan | Geist und Plan | reference | active | docs/geist-und-plan.md |
 | inhalt | Inhalt | reference | active | docs/inhalt.md |
-| konzepte.garnrolle | Garnrolle | reference | deprecated | docs/konzepte/garnrolle.md |
-| konzepte.garnrolle-und-verortung | Weltgewebe – Garnrolle, Verortung und Rolle ohne Namen | concept | active | docs/konzepte/garnrolle-und-verortung.md |
+| konzepte.garnrolle | Garnrolle | concept | superseded | docs/konzepte/garnrolle.md |
+| konzepte.garnrolle-und-verortung | Weltgewebe – Garnrolle, Verortung und Sichtbarkeit | concept | active | docs/konzepte/garnrolle-und-verortung.md |
 | map-architekturkritik | Architekturkritik Map-Implementierung | report | active | docs/reports/map-architekturkritik.md |
 | map-basemap-proof-gap-reconciliation | MAP-PROOF-001 — Basemap Proof Gap Reconciliation | report | active | docs/reports/map-basemap-proof-gap-reconciliation.md |
 | map-blaupause | Basemap-Architektur-Blaupause | blueprint | active | docs/blueprints/map-blaupause.md |
@@ -155,8 +157,8 @@ Generated automatically. Do not edit.
 | specs.auth-ui | Auth UI Spec | reference | active | docs/specs/auth-ui.md |
 | specs.contract | Datenvertrag | reference | active | docs/specs/contract.md |
 | specs.list-pagination-api | List Pagination API Spec | reference | active | docs/specs/list-pagination-api.md |
-| specs.privacy-api | Privacy API | reference | active | docs/specs/privacy-api.md |
-| specs.privacy-ui | Privacy UI | reference | active | docs/specs/privacy-ui.md |
+| specs.privacy-api | Garnrollen-Sichtbarkeit API | reference | active | docs/specs/privacy-api.md |
+| specs.privacy-ui | Garnrollen-Sichtbarkeit UI | reference | active | docs/specs/privacy-ui.md |
 | tasks.board | Weltgewebe Task Board | task-board | active | docs/tasks/board.md |
 | tasks.readme | Task-Control – Einstieg | guide | active | docs/tasks/README.md |
 | ui-blaupause | Weltgewebe UI-Blaupause | blueprint | canonical | docs/blueprints/ui-blaupause.md |

--- a/docs/_generated/relates-to-audit.md
+++ b/docs/_generated/relates-to-audit.md
@@ -14,10 +14,10 @@ Generated automatically. Do not edit.
 
 | Metrik | Wert |
 | --- | --- |
-| Relationen gesamt | 531 |
+| Relationen gesamt | 544 |
 | — depends_on | 20 |
-| — relates_to | 508 |
-| — supersedes | 3 |
+| — relates_to | 520 |
+| — supersedes | 4 |
 | relates_to Anteil | 96% |
 
 ### Mögliche supersedes-Lücken
@@ -30,7 +30,7 @@ _Keine Lücken erkannt._
 
 > Zusammenhängende Gruppen im relates_to-Graphen.
 
-**Cluster 1** (204 Dokumente):
+**Cluster 1** (208 Dokumente):
 
 - `.github/workflows/api.yml`
 - `.github/workflows/basemap-runtime-proof.yml`
@@ -62,6 +62,7 @@ _Keine Lücken erkannt._
 - `docs/adr/ADR-0006__auth-magic-link-session-passkey.md`
 - `docs/adr/ADR-0007__auth-persistence-production-db-path.md`
 - `docs/adr/ADR-0008__domain-mail-provider-boundaries.md`
+- `docs/adr/ADR-0009__garnrolle-verortung-sichtbarkeit.md`
 - `docs/architekturstruktur.md`
 - `docs/blueprints/agent-operability-blaupause.md`
 - `docs/blueprints/auth-persistence-runtime-proof.md`
@@ -97,6 +98,7 @@ _Keine Lücken erkannt._
 - `docs/deploy/public-app-base-url.md`
 - `docs/deploy/secondary-domain-web-surfaces.md`
 - `docs/deploy/security.md`
+- `docs/deploy/vps-db-initialization-boundary.md`
 - `docs/deploy/vps-http-route-smoke-risks.md`
 - `docs/deploy/vps-http-route-smoke.md`
 - `docs/deploy/vps-http-smoke.md`
@@ -233,6 +235,8 @@ _Keine Lücken erkannt._
 - `scripts/docmeta/validate_report_lifecycle.py`
 - `scripts/guard/basemap-runtime-proof.sh`
 - `scripts/guard/domain-single-instance-guard.sh`
+- `scripts/ops/check_public_live_readiness.py`
+- `scripts/ops/check_vps_db_migration_history_shape.py`
 - `scripts/ops/check_vps_migration_safe_runtime_env.py`
 - `scripts/tests/test_domain_single_instance_guard.sh`
 - `tests/fixtures/agent/handoff-valid.json`

--- a/docs/_generated/relations-analysis.md
+++ b/docs/_generated/relations-analysis.md
@@ -14,13 +14,13 @@ Generated automatically. Do not edit.
 
 | Metrik | Wert |
 | --- | --- |
-| Dokumente gesamt | 157 |
-| Dokumente mit ausgehenden Relationen | 156 |
-| Dokumente als Ziel referenziert | 120 |
-| Relationen gesamt | 531 |
+| Dokumente gesamt | 159 |
+| Dokumente mit ausgehenden Relationen | 158 |
+| Dokumente als Ziel referenziert | 122 |
+| Relationen gesamt | 544 |
 | — depends_on | 20 |
-| — relates_to | 508 |
-| — supersedes | 3 |
+| — relates_to | 520 |
+| — supersedes | 4 |
 | Isolierte Dokumente | 0 |
 | depends_on Zyklen | 0 |
 

--- a/docs/_generated/supersession-map.md
+++ b/docs/_generated/supersession-map.md
@@ -10,6 +10,7 @@ summary: Automatisch generierte Karte der abgelösten Dokumente.
 
 Generated automatically. Do not edit.
 
+- docs/adr/ADR-0003__privacy-ungenauigkeitsradius-ron.md → superseded by → docs/adr/ADR-0009__garnrolle-verortung-sichtbarkeit.md
 - docs/konzepte/garnrolle.md → superseded by → docs/konzepte/garnrolle-und-verortung.md
 - docs/reports/auth-persistence-readiness.md → superseded by → docs/reports/auth-persistence-next-step.md
 - docs/reports/domain-edge-create-semantics-preflight.md → superseded by → docs/reports/domain-edge-write-path-proof.md

--- a/docs/adr/ADR-0003__privacy-ungenauigkeitsradius-ron.md
+++ b/docs/adr/ADR-0003__privacy-ungenauigkeitsradius-ron.md
@@ -1,74 +1,56 @@
 ---
 id: adr.ADR-0003__privacy-ungenauigkeitsradius-ron
-title: ADR-0003 — Privacy-Ungenauigkeitsradius und RoN
+title: ADR-0003 — Historisches Privacy- und Startzustandsmodell
 doc_type: reference
-status: active
-summary: Entscheidung zum Privacy-Konzept mit Ungenauigkeitsradius und Rolle ohne Namen (RoN).
+status: superseded
+summary: >
+  Historische Entscheidung zum früheren Privacy- und Startzustandsmodell. Als
+  Zielmodell abgelöst durch ADR-0009.
 relations:
   - type: relates_to
     target: docs/konzepte/garnrolle-und-verortung.md
+  - type: relates_to
+    target: docs/adr/ADR-0009__garnrolle-verortung-sichtbarkeit.md
 ---
-# ADR-0003 — Privacy: Ungenauigkeitsradius & RoN-Identitätsmodus (v2)
+
+# ADR-0003 — Historisches Privacy- und Startzustandsmodell
 
 Datum: 2025-09-13
-Status: Accepted
+Status: Superseded durch [ADR-0009](ADR-0009__garnrolle-verortung-sichtbarkeit.md)
 
-## Kontext
+## Revisionsentscheidung 2026-07-09
 
-Die Garnrolle ist am Wohnsitz verortet (Residence-Lock). Die Karte und die Fäden sollen ortsbasierte
-Sichtbarkeit ermöglichen, ohne den exakten Wohnsitz preiszugeben - sofern dies explizit vom Nutzer gewünscht
-ist.
+Diese Entscheidung ist als Zielmodell abgelöst.
 
-Bisher wurde die Rolle ohne Namen (RoN) teilweise als nachträglicher Privacy-Toggle behandelt. Dies führte zu
-ontologischen Widersprüchen (z. B. wenn eine Adresse vorhanden war, der Toggle aber umgelegt wurde) und einem
-zu komplexen Modell mit halbgaren Zuständen.
+Die frühere Modellierung trennte zu stark zwischen einem unverorteten
+Startzustand und einer verorteten Garnrolle. Diese Trennung führte in Konzept,
+UI und Contract zu einer unnötigen Identitätsmodus-Semantik.
 
-## Entscheidung
+Das neue Zielmodell ist einfacher:
 
-Das Konzept wird vereinfacht und kanonisiert. Es gibt nun genau zwei klare Identitätsmodi:
+> Jeder Account hat genau eine Garnrolle.
 
-1) **Verortete Garnrolle**
-   Wer seine genaue Adresse und Personenangaben ergänzt, vollzieht den Übergang zur verorteten Garnrolle.
-   Der Nutzer kann die öffentliche Genauigkeit seiner Garnrolle über einen **Ungenauigkeitsradius** (Meter) selbst
-   einstellen. Die **öffentliche Anzeige** nutzt eine **ungenaue Position innerhalb dieses Radius**.
-   Der Ungenauigkeitsradius steuert *nur* die öffentliche Anzeige, nicht die interne Verortungswahrheit.
+Verortung und öffentliche Sichtbarkeit sind Eigenschaften dieser Garnrolle. Sie
+sind kein eigener Identitätsmodus.
 
-2) **Rolle ohne Namen (RoN) als kanonischer Startzustand und Identitätsmodus**
-   Alle neu erstellten Nutzerkonten starten im System im RoN-Modus als sicherem Initialzustand.
-   Dieser Startzustand ist nicht als bewusste Entscheidung oder alternativer Einstiegsweg zu interpretieren, sondern als vorläufiger Zustand.
-   RoN ist *kein* bloßer nachträglicher Privacy-Toggle für verortete Garnrollen, sondern ein eigenständiger, kanonischer Identitätsmodus.
-   Wer keine Verortung vornimmt, verbleibt dauerhaft im RoN-Zustand.
+## Historischer Nutzen
 
-- Die Verortung ist ein expliziter späterer Übergang, kein impliziter Default und keine gleichrangige Anfangswahl.
+ADR-0003 bleibt nur relevant, um alte Codepfade, Fixture-Daten oder
+Migrationslogik zu verstehen. Neue Produktarbeit, neue UI-Sprache und neue
+Architekturentscheidungen folgen ADR-0009.
 
-## Alternativen
+## Nicht mehr gültig als Zielmodell
 
-Weitere Modi (z. B. "nur Stadtteil", "ohne Hausnummer") werden **nicht** eingeführt, da diese Zwischenstufen zu viele Grenzfälle und Widersprüche in der Dokumentation und Implementierung erzeugen.
-Auch Vertrauensbewertungen, Trust-Scores oder Pflichtverifikationen als Grundvoraussetzung werden verworfen, da Vertrauen ausschließlich sozial entstehen soll.
+Nicht mehr als Zielsemantik verwenden:
 
-## Konsequenzen
+- getrennte Identitätsmodi für dasselbe Konto
+- Privacy-Toggle als Account-Ontologie
+- Startzustand als eigenständige Rollenart
+- ungefähre Sichtbarkeit als impliziter Default
 
-- Die UI darf keinen verpflichtenden Zwei-Wege-Onboarding-Screen erzwingen.
-- Stattdessen muss der aktuelle Identitätszustand sichtbar gemacht werden.
-- Der Übergang zu einer verorteten Garnrolle muss als bewusste Handlung gestaltet werden.
-- **Einfaches UI**: Alle neu erstellten Nutzerkonten starten im RoN-Startzustand. Die UI macht den aktuellen Zustand sichtbar. Die Verortung wird als bewusster Übergang angeboten. Für verortete Garnrollen existiert ein **Slider** (Meter) für den Ungenauigkeitsradius.
-- **Konsistente Darstellung**: Verortete Garnrollen werden am exakten oder (bei Radius > 0) verfremdeten Ort angezeigt. RoN-Zuordnungen haben keine individuelle öffentliche Verortung (`public_pos = None`), sind aber nicht ortlos. Ihre öffentliche Wirksamkeit (das Weben von Fäden) erfolgt kollektiv über die Rolle ohne Namen des jeweiligen Stadtteils (technisch eine spätere Gruppierungs-/Darstellungsoption im Zentrum).
-- **Einfacher Contract**: Der Contract trägt nur noch die Modusunterscheidung (Verortet vs. RoN) und den Ungenauigkeitsradius.
+## Gültige Nachfolge
 
-- **Legacy-Kompatibilität:** Alte Datensätze mit `visibility = "private"` werden sicher in das neue System projiziert. Sie werden auf `mode = "verortet"` gemappt (behalten ihre individuelle Identität und interne Adresse), erhalten aber strikt keine öffentliche Position (`public_pos = None`), um nicht versehentlich ihre alte Privatsphäre-Stufe zu verletzen.
-- **Runtime-Mapping vs. Zielzustand:** Die Schema-Invarianten (`type="garnrolle" => mode="verortet"`) definieren den strikten kanonischen Zielzustand. Das API-Runtime-Mapping toleriert Legacy-Daten und projiziert diese sicher in diesen Zielzustand.
+Siehe:
 
-## Schnittstellen
-
-- **API/Modell**
-  - Accounts haben ein Modus-Feld (`mode`: `verortet` oder `ron`).
-  - `location` existiert intern nur für `verortete` Rollen.
-  - `radius_m` steuert die öffentliche Anzeige für verortete Rollen.
-- **Views**
-  - intern: exakte Position (nur für verortete Rollen).
-  - öffentlich: public view zeigt bei `mode=verortet` die Position gemäß Radius, und bei `mode=ron` keine individuelle Position (`public_pos` ist leer), sondern eine kollektive Stellvertretung über den Stadtteil.
-
-## Rollout
-
-- **Web**: Start-UI anpassen (RoN als kanonischer Startzustand), Zwei-Wege-Screen entfernen, RoN-Toggle aus den nachträglichen Privatsphäre-Einstellungen entfernen, Slider für verortete Rollen beibehalten.
-- **API**: Schema-Anpassung, Ersetzung von `visibility` und dem RoN-Toggle durch ein modusbasiertes Modell (`mode: "verortet" | "ron"`).
+- [ADR-0009 — Garnrolle, Verortung und Sichtbarkeit](ADR-0009__garnrolle-verortung-sichtbarkeit.md)
+- [Weltgewebe — Garnrolle, Verortung und Sichtbarkeit](../konzepte/garnrolle-und-verortung.md)

--- a/docs/adr/ADR-0004__fahrplan-verweis.md
+++ b/docs/adr/ADR-0004__fahrplan-verweis.md
@@ -34,4 +34,4 @@ stabile, versionierte Referenz auf diesen kanonischen Speicherort und vermeidet 
 
 ## Siehe auch
 
-- [ADR-0003 — Privacy: Ungenauigkeitsradius & RoN-Platzhalterrolle (v1)](ADR-0003__privacy-ungenauigkeitsradius-ron.md)
+- [ADR-0009 — Garnrolle, Verortung und Sichtbarkeit](ADR-0009__garnrolle-verortung-sichtbarkeit.md)

--- a/docs/adr/ADR-0006__auth-magic-link-session-passkey.md
+++ b/docs/adr/ADR-0006__auth-magic-link-session-passkey.md
@@ -29,7 +29,7 @@ Weltgewebe benötigt ein Authentifizierungsmodell, das:
 - wiederkehrende Nutzung ohne Reibung erlaubt
 - sichere Recovery garantiert
 - nicht auf Passwörtern basiert
-- mit dem RoN-Startmodus kompatibel ist
+- mit einer noch nicht auf der Karte stehenden Garnrolle kompatibel ist
 
 Das bisher implizite Modell (Magic Link) ist als alleinige Lösung für den Alltag nicht ausreichend.
 Es zwingt zu wiederholter Interaktion und erzeugt Reibung.
@@ -64,7 +64,7 @@ Zweck:
 ## Prinzipien
 
 - Kein Passwort als primärer Auth-Faktor
-- Authentifizierung ist getrennt vom Identitätsmodus (RoN vs. verortet)
+- Authentifizierung ist getrennt von Garnrollen-Verortung und öffentlicher Sichtbarkeit
 - Recovery muss immer möglich bleiben
 - Sicherheit wird kontextuell erhöht (Step-up Auth)
 
@@ -77,7 +77,7 @@ Zweck:
 - Jede sensitive Aktion erfordert zwingend Step-up Auth.
   Ein Step-up-Magic-Link ist strikt aktionsgebunden und session-neutral.
 - Auth (Wie komme ich rein?) ist strikt getrennt vom Identitätsmodus.
-  Der Identitätsmodus beantwortet die Frage, ob ein Nutzer RoN oder verortet ist.
+  Die Garnrollen-Sichtbarkeit beantwortet die Frage, ob und wie eine Garnrolle auf der Karte sichtbar ist.
 
 ## Zustandsmodell
 
@@ -131,9 +131,9 @@ Das System basiert auf folgenden expliziten Zuständen:
   - Mailänderung
   - sicherheitskritischen Aktionen
 
-## Zusammenhang mit RoN
+## Zusammenhang mit Garnrollen-Sichtbarkeit
 
-RoN ist ein Identitätsmodus, kein Authentifizierungsmechanismus.
+Garnrollen-Sichtbarkeit ist kein Authentifizierungsmechanismus.
 
 Das Auth-System beeinflusst nicht:
 

--- a/docs/adr/ADR-0009__garnrolle-verortung-sichtbarkeit.md
+++ b/docs/adr/ADR-0009__garnrolle-verortung-sichtbarkeit.md
@@ -1,0 +1,169 @@
+---
+id: adr.ADR-0009__garnrolle-verortung-sichtbarkeit
+title: ADR-0009 — Garnrolle, Verortung und Sichtbarkeit
+doc_type: reference
+status: active
+summary: >
+  Entscheidung zum Zielmodell: Jeder Account hat eine Garnrolle; Verortung und
+  Sichtbarkeit sind Eigenschaften dieser Garnrolle, keine getrennten
+  Identitätsmodi.
+relations:
+  - type: supersedes
+    target: docs/adr/ADR-0003__privacy-ungenauigkeitsradius-ron.md
+  - type: relates_to
+    target: docs/konzepte/garnrolle-und-verortung.md
+  - type: relates_to
+    target: docs/specs/privacy-api.md
+  - type: relates_to
+    target: docs/specs/privacy-ui.md
+  - type: relates_to
+    target: docs/blueprints/ui-roadmap.md
+---
+
+# ADR-0009 — Garnrolle, Verortung und Sichtbarkeit
+
+Datum: 2026-07-09
+Status: Accepted
+
+## Entscheidung
+
+Weltgewebe verwendet künftig ein einziges Accountmodell:
+
+> Jeder Account hat genau eine Garnrolle.
+
+Die Garnrolle ist die sichtbare und handelnde Rolle eines Menschen oder Akteurs
+im Gewebe. Sie ist der Ursprung von Fäden und kann Knoten weben.
+
+Verortung und öffentliche Sichtbarkeit sind Eigenschaften dieser Garnrolle. Sie
+sind kein Identitätsmodus und keine zweite Art von Account.
+
+## Zielmodell
+
+Eine Garnrolle hat einen Profilkern und optional eine Kartenposition.
+
+```text
+Garnrolle
+├─ Profil
+│  ├─ Anzeigename
+│  ├─ Beschreibung
+│  ├─ Fähigkeiten
+│  ├─ Güter
+│  └─ Interessen
+└─ Kartenposition
+   ├─ keine öffentliche Position
+   └─ öffentliche Position
+      ├─ exakt sichtbar
+      └─ im Umkreis sichtbar
+```
+
+Die zentrale Nutzerhandlung lautet:
+
+> Garnrolle auf die Karte setzen.
+
+Nicht:
+
+> Identitätsmodus wechseln.
+
+## Sichtbarkeit
+
+Sichtbarkeit ist im Weltgewebe ein positiver Wert. Ein genauer öffentlicher Ort
+ist kein Fehlerfall, sondern kann selbst ein Gemeingut sein: Menschen,
+Initiativen und Orte werden auffindbar, ansprechbar und anschlussfähig.
+
+Die Nutzerführung kennt drei einfache Zustände:
+
+| Zustand | Bedeutung |
+|---|---|
+| Noch nicht auf der Karte | Die Garnrolle hat keine öffentliche Kartenposition. |
+| Exakt sichtbar | Die angegebene Position wird öffentlich exakt angezeigt. |
+| Im Umkreis sichtbar | Die Garnrolle wird öffentlich nur ungefähr angezeigt. |
+
+Die exakte Sichtbarkeit ist der einfache Fall. Die ungefähre Sichtbarkeit ist
+eine bewusste Option, nicht der normative Default.
+
+## Knoten und Fäden
+
+Eine Garnrolle webt Knoten.
+
+Ein Knoten ist ein verortetes oder thematisch fassbares Bündel im Gewebe: Ort,
+Projekt, Bedarf, Angebot, Werkzeug, Ereignis, Gruppe oder Commons.
+
+Beim Weben eines Knotens entsteht mindestens ein Faden. Ein Faden beschreibt,
+was zwischen Garnrolle und Knoten gilt, zum Beispiel:
+
+- gebaut von
+- betreut von
+- vorgeschlagen von
+- nutzt
+- braucht
+- bietet an
+- gehört zu
+
+Die Nutzerführung sagt **Faden** und **Fadenart**. Technische Implementierungen
+dürfen intern weiter `edge` oder `edge_kind` verwenden, solange die Produkt- und
+Dokumentationssprache konsistent bleibt.
+
+## Beispiel: erstes organisches Weben
+
+1. Alexander legt seinen Account an.
+2. Seine Garnrolle entsteht.
+3. Er ergänzt Profilinformationen.
+4. Er setzt seine Garnrolle exakt sichtbar auf den Poelsweg 2.
+5. Er webt den Knoten "Fairschenkbox Caspar-Voght-Straße" an der exakten
+   Position der Box.
+6. Das System erzeugt einen Gestaltungsfaden:
+   "Alexander hat die Fairschenkbox gebaut / betreut sie".
+
+Damit entsteht kein Demo-Datensatz von außen, sondern der erste echte
+Weltgewebe-Akt aus einer Garnrolle heraus.
+
+## API-Zielrichtung
+
+Das Zielmodell sollte künftig durch klare Felder ausgedrückt werden:
+
+```text
+garnrolle.location = null
+```
+
+oder:
+
+```text
+garnrolle.location = {
+  address,
+  coordinates,
+  public_visibility: "exact" | "radius",
+  radius_m
+}
+```
+
+Alternativ ist ein expliziter Kartenzustand möglich:
+
+```text
+garnrolle.map_state = "not_on_map" | "exact" | "radius"
+```
+
+Die konkrete Migration ist nicht Bestandteil dieser ADR. Wichtig ist die
+semantische Richtung: keine separaten Identitätsmodi für dasselbe Nutzerkonto.
+
+## Konsequenzen
+
+- Onboarding beginnt mit "Deine Garnrolle".
+- Die erste große Handlung ist "Garnrolle auf Karte setzen".
+- Sichtbarkeit wird als positive, verständliche Auswahl geführt.
+- Die exakte Adresse ist ein regulärer Fall.
+- Das erste echte Produktziel ist organisches Weben aus der eigenen Garnrolle.
+- UI, Konzepte und Roadmaps verwenden **Fäden** statt **Kanten/Edges**.
+- Alte technische Begriffe bleiben nur als Migrations- oder Implementierungsdetail zulässig.
+
+## Nicht-Ziele
+
+- Kein Trust-Score.
+- Keine Pflichtverifikation als Einstiegshürde.
+- Kein anonymer Alternativaccount neben der Garnrolle.
+- Kein Privacy-Modus als Ersatz für klare Sichtbarkeit.
+- Keine seedartige Inhaltseinspielung als Ersatz für organisches Weben.
+
+## Abgelöste Entscheidung
+
+Diese ADR löst ADR-0003 als Zielmodell ab. ADR-0003 bleibt nur als historischer
+Migrationskontext erhalten. Neue Produkt- und Konzeptarbeit folgt dieser ADR.

--- a/docs/blueprints/auth-roadmap.md
+++ b/docs/blueprints/auth-roadmap.md
@@ -95,7 +95,7 @@ Diese Artefakte liefern reale Nachweise des implementierten Zustands:
 - Session ist der primäre Alltagszustand.
 - Passkey ist optionaler Komfort- und Sicherheitsgewinn, nicht Pflicht.
 - Step-up Auth ist aktionsgebunden und session-neutral.
-- Auth ist strikt getrennt vom Identitätsmodus (RoN vs. verortet).
+- Auth ist strikt getrennt von Garnrollen-Verortung und öffentlicher Sichtbarkeit.
 - Keine Architekturentscheidung ohne Runtime-Beleg oder explizite Offen-Markierung.
 - Kein Feature-Ausbau auf unstabiler Session-Basis.
 - Drift-Sichtbarkeit geht vor Vollständigkeitsrhetorik.

--- a/docs/blueprints/kartenklarheit.md
+++ b/docs/blueprints/kartenklarheit.md
@@ -251,8 +251,7 @@ Später als diskriminierte Union:
 type MapEntityViewModel =
   | { type: "node"; ... }
   | { type: "account"; ... }
-  | { type: "garnrolle"; ... }
-  | { type: "ron"; ... };
+  | { type: "garnrolle"; mapState: "not_on_map" | "exact" | "radius"; ... };
 ```
 
 ---
@@ -344,7 +343,6 @@ Ersetzen oder parallel einführen:
 - `node`
 - `account`
 - `garnrolle`
-- `ron`
 
 **5.10 Marker-Kategorisierung umstellen:**
 `nodes.ts` und verwandte Logik sollen nicht mehr Strings vermischen, sondern auf echte Varianten reagieren.

--- a/docs/blueprints/ui-interaction-doctrine.md
+++ b/docs/blueprints/ui-interaction-doctrine.md
@@ -247,7 +247,7 @@ ausdrücklich als veraltet markiert werden. Die Desktop-Ausprägung „rechte
 Seitenleiste" bleibt erlaubt, aber nur als Layoutform des Fokuspanels.
 
 Nicht betroffen sind fachlich legitime Slider, die nichts mit Drawer-Layout zu
-tun haben, etwa der Ungenauigkeitsradius-Slider (Privacy, ADR-0003) oder ein
+tun haben, etwa die Sichtbarkeitsauswahl der Garnrolle (ADR-0009) oder ein
 historischer Zeit-Slider in Fahrplänen.
 
 ## Nicht-Ziele

--- a/docs/blueprints/ui-roadmap.md
+++ b/docs/blueprints/ui-roadmap.md
@@ -9,6 +9,8 @@ relations:
     target: docs/blueprints/ui-blaupause.md
   - type: relates_to
     target: docs/blueprints/ui-state-machine.md
+  - type: relates_to
+    target: docs/adr/ADR-0009__garnrolle-verortung-sichtbarkeit.md
 ---
 
 # Weltgewebe UI Roadmap
@@ -134,7 +136,40 @@ Die Struktur der Panels steht, nun müssen echte Domänendaten aus der Blaupause
 
 ⸻
 
-## Phase 5 — Später / optional: Doku- und Strukturpflege
+## Phase 5 — Jetzt: Organisches Erstweben
+
+Der nächste produktive Hebel ist nicht mehr Kartentechnik, sondern der
+organische Eintritt ins Gewebe: Login → eigene Garnrolle → Garnrolle auf Karte
+setzen → ersten Knoten weben → Faden entsteht.
+
+Diese Phase folgt ADR-0009. Es gibt keine separate Nutzerkategorie neben der Garnrolle. Die UI spricht von einer Garnrolle, die beschrieben, auf die Karte gesetzt und zum Weben genutzt wird.
+
+### [ ] Roadmap PR 9 — Meine Garnrolle
+
+- [ ] Nach Login die eigene Garnrolle eindeutig anzeigen
+- [ ] Garnrolle ohne Kartenposition als "noch nicht auf der Karte" formulieren
+- [ ] Formular für Anzeigename, Kurzbeschreibung, Güter, Kompetenzen und Tags
+- [ ] Handlung "Garnrolle auf Karte setzen" anbieten
+- [ ] Sichtbarkeitsauswahl anbieten: exakt sichtbar, ungefähr sichtbar, noch nicht anzeigen
+- [ ] Exakte Sichtbarkeit als normalen positiven Fall behandeln
+
+### [ ] Roadmap PR 10 — Ersten Knoten weben
+
+- [ ] Knotenformular aus der eigenen Garnrolle heraus öffnen
+- [ ] Knotenart, Titel, Beschreibung, Status und exakte Position erfassen
+- [ ] Fairschenkbox Caspar-Voght-Straße als erster realer Webfluss abbilden
+- [ ] Nach Speichern den Knoten auf der Karte sichtbar machen
+
+### [ ] Roadmap PR 11 — Gestaltungsfaden automatisch erzeugen
+
+- [ ] Beim Weben eines Knotens automatisch einen Faden von Garnrolle zu Knoten erzeugen
+- [ ] UI spricht von Fäden
+- [ ] Fadenart für den ersten Fluss als Gestaltungsfaden modellieren
+- [ ] Detailpanel zeigt: wer hat den Knoten gewoben, welcher Faden besteht
+
+⸻
+
+## Phase 6 — Später / optional: Doku- und Strukturpflege
 
 Diese Punkte sind keine Blocker für den produktiven Fortschritt, aber wichtig für die langfristige Gesundheit.
 

--- a/docs/geist-und-plan.md
+++ b/docs/geist-und-plan.md
@@ -190,7 +190,7 @@ Extraktion: Geist der Weltweberei
   offene Abstimmungen.
 - Freiheit plus Absicherung: Jeder kann Ressourcen freigeben oder Aktionen starten, Anträge werden
   nur blockiert, wenn Widerspruch entsteht.
-- Datenschutz: Privacy by Design, RoN-System für Anonymisierung, Ungenauigkeitsradien für Ortsdaten.
+- Sichtbarkeit: Privacy by Design, freiwillige Garnrollen-Verortung und klare Auswahl zwischen exakt sichtbar, im Umkreis sichtbar oder noch nicht auf der Karte.
 
 ⸻
 
@@ -204,7 +204,7 @@ Extraktion: Plan der Weltweberei
    - Gewebekonto: Finanzverwaltung, sichtbar als Goldfäden.
    - Webrat: Governance-Ort für Anträge, Abstimmungen, Delegationen.
    - Nähstübchen: Allgemeine Kommunikation.
-   - RoN-Platzhalter: Sammelstelle für anonymisierte Inhalte.
+   - Archiv-/Tombstone-Knoten: Sammelstelle für gelöschte oder anonymisierte Inhalte ohne Rückbindung an eine sichtbare Garnrolle.
 3. Zeitlichkeit und Prozesse
    - Sieben-Sekunden-Sichtbarkeit bei Aktionen.
    - Sieben-Tage-Timer für Fäden, Knoten, Anträge.

--- a/docs/konzepte/garnrolle-und-verortung.md
+++ b/docs/konzepte/garnrolle-und-verortung.md
@@ -1,404 +1,185 @@
 ---
 id: konzepte.garnrolle-und-verortung
-title: "Weltgewebe – Garnrolle, Verortung und Rolle ohne Namen"
+title: "Weltgewebe – Garnrolle, Verortung und Sichtbarkeit"
 doc_type: concept
 status: active
-summary: "Kanonisches Konzept für Garnrolle, Verortung, Ungenauigkeitsradius und Rolle ohne Namen bei der Accounterstellung im Weltgewebe."
+summary: >
+  Kanonisches Konzept für Garnrolle, Verortung, öffentliche Sichtbarkeit,
+  Knotenweben und Fäden im Weltgewebe.
 relations:
   - type: relates_to
-    target: docs/adr/ADR-0003__privacy-ungenauigkeitsradius-ron.md
+    target: docs/adr/ADR-0009__garnrolle-verortung-sichtbarkeit.md
   - type: relates_to
     target: docs/konzepte/garnrolle.md
   - type: supersedes
     target: docs/konzepte/garnrolle.md
 ---
 
-# Weltgewebe – Garnrolle, Verortung und Rolle ohne Namen
+# Weltgewebe – Garnrolle, Verortung und Sichtbarkeit
 
-## 1. Dialektische Grundlegung
+## 1. Grundsatz
 
-### These
+Jeder Account hat genau eine Garnrolle.
 
-Vertrauen im Weltgewebe entsteht sozial:
-durch Zeit, Wiedererkennung und tatsächliche Nachbarschaftsinteraktion.
-Das System darf dieses Vertrauen weder berechnen noch simulieren.
+Die Garnrolle ist die Rolle, von der aus ein Mensch oder Akteur im Weltgewebe
+sichtbar wird, Knoten webt und Fäden zieht. Sie ist keine bloße Profilseite,
+sondern die handelnde Spule des Gewebes.
 
-### Antithese
-
-Ohne jede formale Struktur drohen Unklarheit, Täuschung und ein Mangel an lokaler Anschlussfähigkeit.
-Ein rein offenes System ohne Verortungslogik würde den nachbarschaftlichen Kern des Weltgewebes schwächen.
-
-### Synthese
-
-Das Weltgewebe setzt weder auf Vertrauensbewertung noch auf Verifikationszwang,
-sondern auf eine einfache Identitäts- und Verortungsordnung:
-
-- genaue Adresse angegeben → verortete Garnrolle
-- keine Personenangaben gemacht → Zuordnung zur Rolle ohne Namen
-- Ungenauigkeitsradius → steuert nur die öffentliche Darstellung
-
-So bleibt die Logik einfach, sichtbar und sozial verständlich.
-
----
+Verortung und Sichtbarkeit sind Eigenschaften dieser Garnrolle. Sie sind kein
+Identitätsmodus und keine zweite Accountart.
 
 ## 2. Begriffe
 
 ### Garnrolle
 
-**Garnrolle** ist die persistente Rolle eines Akteurs im Weltgewebe.
+Eine Garnrolle ist der dauerhafte Ursprung von Handlungen im Weltgewebe.
 
-Im Weltgewebe ist die Garnrolle die Spule, von der Fäden ausgehen.
+Sie bündelt:
 
-Eigenschaften:
-
-- persistent
-- wiedererkennbar
-- handlungsfähig
-- entweder verortet oder der Rolle ohne Namen zugeordnet
-
----
+- Anzeigename
+- Beschreibung
+- Fähigkeiten
+- Güter
+- Interessen
+- optional eine Kartenposition
+- die von ihr gewobenen Knoten
+- die von ihr ausgehenden Fäden
 
 ### Verortung
 
-**Verortung** bezeichnet die Bindung einer Garnrolle an einen konkreten Wohnsitz.
+Verortung bedeutet: Eine Garnrolle wird an einen realen Ort gebunden.
 
-Im Weltgewebe bedeutet Verortung:
-> Eine Garnrolle ist intern an einen realen Wohnsitz gebunden.
+Für Menschen ist das in der Regel der Wohnsitz. Für Gruppen oder Projekte kann
+es ein anderer verantworteter Ort sein. Die Verortung ist eine bewusste Handlung
+und wird in der UI als **Garnrolle auf Karte setzen** geführt.
 
----
+### Sichtbarkeit
 
-### Rolle ohne Namen (RoN)
+Sichtbarkeit beschreibt, wie die Garnrolle öffentlich auf der Karte erscheint.
 
-**RoN** bedeutet **Rolle ohne Namen**.
-
-RoN ist kein bloßer Tarnmodus, sondern ein eigenständiger Identitätsmodus für Nutzer,
-die keine Personenangaben machen.
-
----
-
-### Ungenauigkeitsradius
-
-**Ungenauigkeitsradius** bezeichnet den Radius in Metern, innerhalb dessen die öffentliche
-Position einer verorteten Garnrolle angezeigt wird.
-
-Er betrifft nur die **öffentliche Anzeige**, nicht die interne Verortung.
-
----
-
-## 3. Ontologischer Kern
-
-Grundsatz:
-
-> Eine Garnrolle ist entweder
->
-> 1. an einen konkreten Wohnsitz verortet
-> oder
-> 2. der Rolle ohne Namen zugeordnet.
-
-Das Weltgewebe kennt damit zwei klare Grundmodi:
-
-- **verortete Garnrolle**
-- **Rolle ohne Namen**
-
-Teilmodelle mit halber Adressschärfe werden bewusst verworfen.
-
----
-
-## 4. Startzustand und Übergang (kanonisch)
-
-Alle neu erstellten Accounts beginnen im System im **Startmodus**.
-
-Technisch entspricht dieser dem Modus **Rolle ohne Namen (RoN)**.
-
-Wichtig:
-Dieser Zustand ist **keine bewusste Entscheidung**, sondern ein
-vorläufiger, sicherer Initialzustand ohne personenbezogene Angaben.
-
-Der Startmodus dient dazu:
-
-- Einstiegshürden zu minimieren
-- sofortige Teilnahme zu ermöglichen
-- keine impliziten Entscheidungen zu erzwingen
-
-### Übergang zu verorteter Garnrolle
-
-Die Erstellung einer verorteten Garnrolle ist ein
-**bewusster Transformationsschritt**.
-
-Er erfordert zwingend:
-
-- Personenangaben
-- eine genaue Adresse
-
-Optional:
-
-- Ungenauigkeitsradius für die öffentliche Anzeige
-
-Der Übergang ist:
-
-- jederzeit möglich
-- explizit
-- nicht ohne semantische Verschiebung reversibel
-
-### Semantische Klarstellung
-
-RoN ist:
-
-- kein „anonymer Modus“
-- keine reduzierte Version der verorteten Garnrolle
-
-RoN ist eine eigenständige Rolle im System ohne individuelle räumliche Verankerung.
-
----
-
-## 5. Start und Ergänzung von Angaben
-
-Der Account beginnt im Startzustand RoN.
-
-### 5.1 Rolle ohne Namen (RoN) als Startzustand
-
-Alle neu erstellten Accounts starten in der Rolle ohne Namen. Wer keine Verortung ergänzt, bleibt dauerhaft dort.
-
-Im Startzustand gilt für RoN:
-
-- noch kein Name hinterlegt
-- noch keine Personenangaben ergänzt
-- noch keine Adresse angegeben
-- noch keine individuelle Verortung
-
-Wird dies nicht geändert, wird RoN zum dauerhaften Modus.
-
-RoN ist damit:
-
-- der kanonische Startmodus
-- ein valider Dauerzustand, keine Strafe
-- keine verdeckte Anonymisierung
-- keine bloße nachträgliche Privacy-Einstellung
-
----
-
-### 5.2 Übergang zur verorteten Garnrolle
-
-Wenn Personen- und Adressangaben ergänzt werden, erfolgt ein expliziter Übergang zur verorteten Garnrolle.
-
-Minimal dafür erforderlich:
-
-- Personenangaben
-- genaue Adresse
-
-Zusätzlich einstellbar:
-
-- Ungenauigkeitsradius
-
-Default:
-
-- Ungenauigkeitsradius = 0 m
-
-Bedeutung:
-
-- intern: exakte Verortung am Wohnsitz
-- öffentlich: Anzeige gemäß Ungenauigkeitsradius
-
----
-
-## 6. Anzeige-Logik
-
-Die Anzeige folgt aus dem aktuellen Modus der Garnrolle.
-
-### Fall A: Verortung vorgenommen
-
-Ergebnis:
-
-- verortete Garnrolle
-- öffentliche Anzeige:
-  - exakt bei 0 m
-  - ungenauer bei Radius > 0 m
-
-### Fall B: Keine Verortung vorgenommen (im RoN-Startmodus verblieben)
-
-Ergebnis:
-
-- Verbleib in der Rolle ohne Namen
-- öffentliche Anzeige:
-  - nicht individuelle Adresse
-  - stattdessen Rolle ohne Namen. Keine individuelle öffentliche Verortung, sondern kollektive Stellvertretung (Weben von der RoN des Stadtteils aus).
-
----
-
-## 7. Sichtbarkeit und Wahrheit
-
-### 7.1 Kanonisches Modell vs. Legacy-Kompatibilität
-
-Das oben beschriebene Zwei-Modi-Modell (verortet vs. RoN) ist der kanonische Zielzustand.
-Für bestehende Datensätze aus dem alten `visibility`-Modell gilt eine sichere Kompatibilitätsregel:
-Alte `private`-Accounts werden **nicht** ontologisch zu RoN umgedeutet. Sie behalten ihre individuelle Garnrollen-Semantik und interne Verortung (mode = `verortet`), jedoch wird ihre öffentliche individuelle Position strikt unterdrückt (`public_pos = None`), um ihren alten Privatsphäre-Wunsch zu respektieren, bis der Nutzer explizit in das neue Modell migriert.
-
-
-Zentrale Trennung:
-
-| Ebene | Bedeutung |
+| Sichtbarkeit | Bedeutung |
 |---|---|
-| interne Verortung | exakte Wohnsitzbindung einer verorteten Garnrolle |
-| öffentliche Anzeige | sichtbare Position gemäß Ungenauigkeitsradius oder RoN-Zentrum |
+| Noch nicht auf der Karte | Keine öffentliche Position. |
+| Exakt sichtbar | Die öffentliche Position entspricht der angegebenen Position. |
+| Im Umkreis sichtbar | Die öffentliche Position wird nur ungefähr angezeigt. |
 
-Prinzip:
+Exakte Sichtbarkeit ist ein regulärer Fall. Sie ist kein Fehler, keine Bürde und
+kein Warnzustand. Im Weltgewebe ist Sichtbarkeit häufig ein Gemeingut, weil sie
+Auffindbarkeit, Verantwortung und lokale Anschlussfähigkeit ermöglicht.
 
-> Die Wahrheit der Verortung ist intern.
-> Die Sichtbarkeit ist öffentlich gestaltet.
+### Knoten
 
-Für RoN gilt:
+Ein Knoten ist ein Bündel im Gewebe. Er kann ein Ort, Projekt, Bedarf, Angebot,
+Werkzeug, Ereignis, Commons, Gespräch oder Beschlussgegenstand sein.
 
-- keine individuelle interne Wohnsitzverortung im Sinne einer öffentlichen Rolle
-- öffentliche Darstellung über die Rolle ohne Namen
+Knoten können verortet sein, müssen es aber nicht immer. Eine Fairschenkbox ist
+ein verorteter Knoten.
 
----
+### Faden
 
-## 8. Vertrauen
+Ein Faden ist eine Beziehung oder Handlung zwischen Garnrollen und Knoten oder
+zwischen Knoten untereinander.
 
-Vertrauen ist kein Systemwert.
+Fäden ersetzen in der Produktsprache Begriffe wie Kante oder Edge.
 
-Es entsteht durch:
+Beispiele:
 
-1. Wiedererkennbarkeit
-2. Ko-Präsenz
-3. Interaktion
-4. Zeit
+- gebaut von
+- betreut von
+- vorgeschlagen von
+- nutzt
+- bietet an
+- braucht
+- gehört zu
+- antwortet auf
+- entscheidet über
 
-Das Weltgewebe:
+Ein Faden kann kurzlebig sein. Wenn er dauerhaft tragend wird, kann daraus Garn
+werden.
 
-- berechnet kein Vertrauen
-- speichert keine Reputation
-- vergibt keine Scores
+## 3. Nutzerfluss
 
-Stattdessen erzeugt es eine soziale Asymmetrie:
+Der ideale erste Fluss ist organisch:
 
-- verortete Garnrollen haben höhere lokale Anschlussfähigkeit
-- RoN erlaubt Teilnahme ohne individuelle Verortung, aber mit geringerer persönlicher Wiedererkennbarkeit
+1. Account anlegen.
+2. Eigene Garnrolle sehen.
+3. Garnrolle beschreiben.
+4. Garnrolle auf die Karte setzen.
+5. Ersten Knoten weben.
+6. Faden zwischen Garnrolle und Knoten erzeugen.
+7. Knoten auf der Karte und im Detailpanel sichtbar machen.
 
-Diese Differenz ist keine Sanktion, sondern Folge der gewählten Sichtbarkeit.
+Die UI soll diesen Fluss nicht als Verwaltung von Privacy- oder
+Identitätsmodi darstellen, sondern als Weben.
 
----
+## 4. Beispiel: Alexander und die Fairschenkbox
 
-## 9. Architekturprinzip
+Alexander wohnt am Poelsweg 2. Er setzt seine Garnrolle exakt sichtbar auf diese
+Adresse.
 
-Das Weltgewebe implementiert bewusst nicht:
+Danach webt er den ersten Knoten:
 
-- keine algorithmische Vertrauensbewertung
-- keine soziale Punktelogik
-- keine automatische Verdachtslogik
-- keine Pflichtverifikation als Grundvoraussetzung
+```text
+Titel: Fairschenkbox Caspar-Voght-Straße
+Art: Fairschenkbox / Commons-Ort
+Position: 53.55891074587864, 10.060308873653412
+Status: aktiv
+Beschreibung: Öffentlich zugängliche Box zum fairen Teilen brauchbarer Dinge.
+```
 
-Es implementiert stattdessen:
+Beim Speichern entsteht ein Gestaltungsfaden:
 
-- klare Modusunterscheidung
-- klare Anzeige-Logik
-- klare soziale Konsequenzen ohne Systemstrafe
+```text
+Alexander Garnrolle -- gebaut von / betreut von --> Fairschenkbox Caspar-Voght-Straße
+```
 
----
+Damit wird die Box nicht als Demo-Datum von außen eingefügt. Sie entsteht aus
+der Handlung einer Garnrolle heraus.
 
-## 10. Risiken und Grenzen
+## 5. Datenmodell-Ziel
 
-### Risiken
+Das Zielmodell braucht keine getrennten Identitätsmodi. Eine Garnrolle hat
+stattdessen optional eine Location-Struktur.
 
-- Täuschung bleibt möglich
-- RoN kann persönliche Wiedererkennbarkeit reduzieren
-- geringe Aktivität verhindert Vertrauensbildung unabhängig vom Modell
+```text
+garnrolle.location = null
+```
 
-### Nutzen
+oder:
 
-- einfache Logik
-- klare Accounterstellung
-- keine versteckte Bewertung
-- Wahrung des nachbarschaftlichen Kerns
-- Privacy ohne Ontologiebruch
+```text
+garnrolle.location = {
+  address,
+  coordinates,
+  public_visibility: "exact" | "radius",
+  radius_m
+}
+```
 
----
+Alternativ kann die UI mit einem abgeleiteten Kartenzustand arbeiten:
 
-## 11. Implikationen für UI und API
-
-### UI
-
-Die UI darf keinen Zwei-Wege-Onboarding-Screen erzwingen.
-
-- Der Startzustand (RoN) wird sichtbar kommuniziert.
-- Die Verortung (Eingabe von Personenangaben, genauer Adresse und Ungenauigkeitsradius) wird als bewusster späterer Transformationsschritt angeboten.
-
-Die UI darf RoN nicht mehr primär als bloßen Privacy-Toggle erklären, sondern als den sicheren Initialzustand.
-
----
-
-### API
-
-Die API muss diese Unterscheidung ausdrücken können:
-
-- verortete Garnrolle
-- RoN-Zuordnung
-
-Der Ungenauigkeitsradius bleibt ein eigener Parameter der öffentlichen Anzeige.
-
----
-
-## 12. Basale Contract-Folgen
-
-Der Contract soll basal bleiben.
-
-Er muss nur die Kernunterscheidung tragen:
-
-- ob eine Rolle verortet ist
-- ob sie der Rolle ohne Namen zugeordnet ist
-- welcher Ungenauigkeitsradius für die öffentliche Anzeige gilt
-
-Nicht in den basalen Contract gehören:
-
-- Vertrauenswert
-- Bewertungslogik
-- komplexe Zwischenstufen der Adressgranularität
-
----
-
-## 13. Essenz
-
-Das Weltgewebe kennt zwei klare Modi:
-
-- **verortete Garnrolle**
-- **Rolle ohne Namen**
-
-Alle neu erstellten Accounts beginnen in der Rolle ohne Namen. Die Verortung ist ein expliziter Übergang durch Ergänzung der Angaben.
-
-Der Ungenauigkeitsradius verfeinert nur die öffentliche Anzeige verorteter Garnrollen.
-Vertrauen entsteht nicht durch das System, sondern durch die Nachbarschaft.
-
----
-
-## 14. Unsicherheitsgrad
-
-0.12
-
-Ursachen:
-
-- empirische soziale Dynamiken bleiben offen
-- spätere technische Umsetzung kann neue Randfälle sichtbar machen
-
----
-
-## 15. Interpolationsgrad
-
-0.14
-
-Annahmen:
-
-- RoN wird als eigenständiger Einstiegsmodus kanonisiert
-- Stadtteilzentrum bleibt die öffentliche Raumlogik für RoN
-
----
-
-## 16. Schlussbemerkung
-
-Das Weltgewebe fragt nicht:
-„Wie vertrauenswürdig bist du?“
-
-Es bietet an:
-„Du kannst hier als verortete Person erscheinen, oder sicher in der Rolle ohne Namen bleiben.“
-
-Und die Nachbarschaft beantwortet den Rest mit der einzigen Währung, die dafür taugt:
-Zeit.
+```text
+garnrolle.map_state = "not_on_map" | "exact" | "radius"
+```
+
+Die entscheidende Semantik bleibt: Eine Garnrolle ist immer dieselbe Rolle;
+Kartenposition und Sichtbarkeit ändern nur, wie sie sichtbar wird.
+
+## 6. Produktregeln
+
+- Jeder eingeloggte Account hat eine Garnrolle.
+- Eine Garnrolle kann ohne öffentliche Position existieren.
+- Eine Garnrolle kann exakt sichtbar sein.
+- Eine Garnrolle kann im Umkreis sichtbar sein.
+- Eine exakte öffentliche Adresse ist zulässig und positiv formulierbar.
+- Knoten werden aus Garnrollen heraus gewoben.
+- Fäden beschreiben Beziehungen, Verantwortungen und Handlungen.
+- Nutzertexte verwenden Garnrolle, Knoten, Faden, weben und Sichtbarkeit.
+
+## 7. Nicht-Ziele
+
+- Keine Trust-Scores.
+- Keine Pflichtverifikation für den Einstieg.
+- Kein Privacy-Modus als Accountart.
+- Kein anonymer Alternativaccount neben der Garnrolle.
+- Keine Seed-Inhalte als Ersatz für organisches Weben.

--- a/docs/konzepte/garnrolle.md
+++ b/docs/konzepte/garnrolle.md
@@ -1,22 +1,29 @@
 ---
 id: konzepte.garnrolle
 title: Garnrolle
-doc_type: reference
-status: deprecated
-summary: Veraltetes Dokument. Bitte docs/konzepte/garnrolle-und-verortung.md nutzen.
+status: superseded
+doc_type: concept
+summary: >
+  Historisches Kurzkonzept zur Garnrolle. Das aktive Zielmodell steht in
+  docs/konzepte/garnrolle-und-verortung.md.
 relations:
   - type: relates_to
     target: docs/konzepte/garnrolle-und-verortung.md
 ---
-# Garnrolle (Veraltet)
 
-> **Hinweis:** Dieses Dokument ist **veraltet**. Das Modell wurde grundlegend vereinfacht.
-> Bitte konsumiere ausschließlich das neue kanonische Konzept unter:
-> [Weltgewebe – Garnrolle, Verortung und Rolle ohne Namen](./garnrolle-und-verortung.md)
+# Garnrolle
 
-Die alte Logik von `visibility` (public/private/approximate) und dem nachträglichen `ron_flag` (Rolle ohne Namen als Toggle) wurde durch ein striktes Zwei-Modi-Modell abgelöst:
+Dieses Kurzkonzept ist als Zielmodell abgelöst.
 
-- **Verortete Garnrolle** (mit exakter interner Adresse und einem Ungenauigkeitsradius für die öffentliche Anzeige)
-- **Rolle ohne Namen (RoN)** (kanonischer Einstiegsmodus ohne Personenangaben und ohne individuelle Verortung/`location`)
+Das aktive Zielmodell steht in:
 
-Für die aktuellen technischen Schnittstellen und Entscheidungen siehe [ADR-0003](../adr/ADR-0003__privacy-ungenauigkeitsradius-ron.md).
+> [Weltgewebe – Garnrolle, Verortung und Sichtbarkeit](./garnrolle-und-verortung.md)
+
+Kanonisch gilt jetzt:
+
+- Jeder Account hat genau eine Garnrolle.
+- Eine Garnrolle kann beschrieben werden.
+- Eine Garnrolle kann auf die Karte gesetzt werden.
+- Eine Garnrolle kann exakt sichtbar oder im Umkreis sichtbar sein.
+- Aus einer Garnrolle heraus werden Knoten gewoben.
+- Zwischen Garnrollen und Knoten entstehen Fäden.

--- a/docs/policies/architecture-critique.md
+++ b/docs/policies/architecture-critique.md
@@ -214,9 +214,9 @@ Achsen E und F: konditioniert — wenn inaktiv, explizit als „nicht anwendbar"
 
 → Pflichtstruktur §7 / Punkt 5 (Architekturkritik) + Punkt 8 (Alternative Sinnachse)
 
-### F. Identitätssystem *(aktiv nur bei: Garnrolle, RoN, Verortung, Auth-Identität, Sichtbarkeitslogik)*
+### F. Garnrollen- und Sichtbarkeitssystem *(aktiv nur bei: Garnrolle, Verortung, Auth-Identität, Sichtbarkeitslogik)*
 
-- Garnrolle-Modi konsistent (verortet vs. RoN)?
+- Garnrollen-Sichtbarkeit konsistent (nicht auf Karte, exakt sichtbar, im Umkreis sichtbar)?
 - Vertrauen als Systemwert modelliert? (im Weltgewebe verboten)
 
 → Pflichtstruktur §7 / Punkt 5 (Architekturkritik) + Punkt 8 (Alternative Sinnachse)

--- a/docs/policies/orientierung.md
+++ b/docs/policies/orientierung.md
@@ -55,7 +55,7 @@ Es beschreibt:
   - Operative Konsequenz: Ortswebereien mit eigenem Konto + föderalen Hooks.
 - **Privacy by Design**
   - Bedeutung: Sichtbar nur freiwillig Eingetragenes.
-  - Operative Konsequenz: Keine Cookies/Tracking; RoN-System für Anonymität.
+  - Operative Konsequenz: Keine Cookies/Tracking; Sichtbarkeit nur durch bewusst gesetzte Garnrollen-Verortung.
 
 ---
 
@@ -78,7 +78,7 @@ Es beschreibt:
 - **7-Tage-Verblassen** → nicht verzwirnte Fäden/Knoten lösen sich auf.
 - **7 + 7-Tage-Modell** → Anträge: Einspruch → Abstimmung.
 - **Delegation (Liquid Democracy)** → verfällt nach 4 Wochen Inaktivität.
-- **RoN-System** → anonymisierte Beiträge nach gewählter Frist.
+- **Tombstone-/Anonymisierungsprozess** → Beiträge verlieren nach gewählter Frist die sichtbare Rückbindung an die Garnrolle.
 
 ---
 
@@ -87,7 +87,7 @@ Es beschreibt:
 - Sichtbarkeit (`fade_days`)
   - Richtwert: 7 Tage laut zusammenstellung.md.
   - Herkunft: Funktionsbeschreibung, nicht Code.
-- Identität (`ron_alias_valid_days`)
+- Anonymisierung (`anonymization_valid_days`)
   - Richtwert: 28 Tage (Delegations-Analogon).
   - Herkunft: Geist & Plan-Ableitung.
 - Anonymisierung (`default_anonymized`)
@@ -120,9 +120,9 @@ Es beschreibt:
   - Dauer: 24 h.
   - Sichtbarkeit: eingeklappt.
   - Trigger: Moderations-Vote.
-- RoN-Anonymisierung
+- Tombstone-/Anonymisierungsprozess
   - Dauer: variable x Tage.
-  - Sichtbarkeit: „Rolle ohne Namen“.
+  - Sichtbarkeit: ohne sichtbare Rückbindung an die ursprüngliche Garnrolle.
   - Trigger: User-Opt-in.
 
 ---
@@ -134,7 +134,7 @@ Es beschreibt:
 - **Monitoring:** Prometheus + Grafana + Loki + Tempo.
 - **Security:** SBOM + cosign + Key-Rotation + DSGVO-Forget-Pipeline.
 - **HA & Cost Control:** Nomad Cluster · PgBouncer · Opex-KPIs < €1 / Session.
-- **Privacy UI (ADR-0003):** RoN-Toggle + Ungenauigkeitsradius-Slider (ab Phase C).
+- **Garnrollen-Sichtbarkeit (ADR-0009):** Garnrolle auf Karte setzen + Sichtbarkeitsauswahl (ab Phase C).
 
 ---
 
@@ -144,8 +144,8 @@ Es beschreibt:
 2. **Partizipative Interface-Metaphern:** Rollen drehen, Fäden fließen – Verantwortung wird
    sichtbar.
 3. **Reversible Aktionen:** Alles ist änder- oder verzwirnbar, aber nicht heimlich.
-4. **Privacy Controls Front and Center:** Slider / Toggles direkt im Profil.
-5. **Lokale Sichtbarkeit:** Zoom ≈ Vertraulichkeit; Ungenauigkeit nimmt mit Distanz zu.
+4. **Sichtbarkeitskontrollen direkt im Profil:** Noch nicht auf Karte, exakt sichtbar, im Umkreis sichtbar.
+5. **Lokale Sichtbarkeit:** Sichtbarkeit wird bewusst gewählt; Distanz- und Umkreislogik bleibt nachvollziehbar.
 6. **Keine versteckte Gamification:** Engagement wird nicht bewertet, nur sichtbar gemacht.
 
 ---

--- a/docs/process/fahrplan.md
+++ b/docs/process/fahrplan.md
@@ -16,7 +16,7 @@ relations:
 
 - ADR-0001 (Clean Slate & Monorepo)
 - ADR-0002 (Re-Entry-Kriterien)
-- ADR-0003 (Privacy: Ungenauigkeitsradius & RoN)
+- ADR-0009 (Garnrolle, Verortung und Sichtbarkeit)
 
 ## Prinzipien: mobile-first, audit-ready, klein schneiden, Metriken vor Features
 
@@ -215,11 +215,11 @@ relations:
 
 ---
 
-## Phase C (Woche 5–6): **Privacy-UI (ADR-0003) & 7-Tage-Verblassen**
+## Phase C (Woche 5–6): **Garnrollen-Sichtbarkeit (ADR-0009) & 7-Tage-Verblassen**
 
-- UI: **Ungenauigkeitsradius-Slider** + **RoN-Toggle** (Profil-State; Fake-Persist).
+- UI: **Garnrolle auf Karte setzen** + Sichtbarkeitsauswahl (noch nicht auf der Karte, exakt sichtbar, im Umkreis sichtbar; Fake-Persist).
 - Zeitleiste wirkt auf Sichtbarkeit (Fäden/Knoten blenden weich aus; Client-seitig).
-- `public_pos` im View-Modell (Fake-Backend oder Local-Derivation).
+- `public_pos` als öffentliche Projektion der gewählten Garnrollen-Sichtbarkeit (Fake-Backend oder Local-Derivation).
 
 **Akzeptanz:** Vorschau der öffentlichen Position reagiert; Zeitleiste verhält sich wie
 spezifiziert.
@@ -230,7 +230,7 @@ spezifiziert.
 
 - API: echte Writes für Rolle/Faden in PG; Outbox-Write (noch ohne NATS-Relay).
 - Worker-Stub: CLI liest Outbox und füllt Read-Model `public_role_view`.
-- Web: liest Read-Model, zeigt `public_pos`, respektiert RoN-Flag.
+- Web: liest Read-Model, zeigt `public_pos` gemäß Garnrollen-Sichtbarkeit.
 
 **Akzeptanz:** Neustart-fest; nach Write→Read-Model erscheint korrekte `public_pos`.
 

--- a/docs/reference/glossar.md
+++ b/docs/reference/glossar.md
@@ -7,11 +7,27 @@ summary: Schnellreferenz der zentralen Begriffe im Weltgewebe-Projekt.
 relations:
   - type: relates_to
     target: docs/domain/vocabulary.md
+  - type: relates_to
+    target: docs/adr/ADR-0009__garnrolle-verortung-sichtbarkeit.md
 ---
+
 # Glossar
 
-**Rolle** (Garnrolle): auf Wohnsitz verorteter Account.
-**Knoten:** lokalisierte Informationsbündel (Idee, Termin, Ort, Werkzeug…).
-**Faden/Garn:** temporäre/persistente Verbindung Rolle→Knoten (Verzwirnung = Garn).
-**RoN:** Rolle ohne Namen (Anonymisierung).
-**Ungenauigkeitsradius:** Öffentliche Genauigkeit in Metern.
+**Garnrolle:** Die sichtbare und handelnde Rolle eines Accounts im Weltgewebe.
+Von ihr gehen Fäden aus; aus ihr heraus werden Knoten gewoben.
+
+**Verortung:** Handlung, mit der eine Garnrolle auf einen realen Ort gesetzt
+wird.
+
+**Sichtbarkeit:** Öffentliche Kartenanzeige einer Garnrolle: noch nicht auf der
+Karte, exakt sichtbar oder im Umkreis sichtbar.
+
+**Knoten:** Bündel im Gewebe: Ort, Projekt, Bedarf, Angebot, Werkzeug, Ereignis,
+Commons, Gespräch oder Beschlussgegenstand.
+
+**Faden:** Beziehung oder Handlung zwischen Garnrollen und Knoten oder zwischen
+Knoten untereinander.
+
+**Garn:** Dauerhaft tragender Faden.
+
+**Weben:** Einen Knoten oder Faden aus einer Garnrolle heraus erzeugen.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -123,7 +123,8 @@ Reihenfolge: Kanonisierung → Step-up → Persistenz-Runtime-Proof → DbSessio
 - [x] Phase 2 — Zustandsdurchsetzung härten · [ui-roadmap Phase 2](blueprints/ui-roadmap.md)
 - [x] Phase 3 — Fokus-Panels (Node/Account/Edge) · [ui-roadmap Phase 3](blueprints/ui-roadmap.md)
 - [x] Phase 4 — Suche, Filter, A11y · [ui-roadmap Phase 4](blueprints/ui-roadmap.md)
-- [x] Phase 5 — Doku-/Strukturpflege · [ui-roadmap Phase 5](blueprints/ui-roadmap.md)
+- [~] Phase 5 — Organisches Erstweben: eigene Garnrolle, Garnrolle auf Karte setzen, ersten Knoten weben und Gestaltungsfaden erzeugen · [ui-roadmap Phase 5](blueprints/ui-roadmap.md), [ADR-0009](adr/ADR-0009__garnrolle-verortung-sichtbarkeit.md)
+- [x] Phase 6 — Doku-/Strukturpflege · [ui-roadmap Phase 6](blueprints/ui-roadmap.md)
 - [~] Auth-UI-Integration: Step-up-Consume + Passkey-Eintragspunkt · Step-up-Consume ist als eigener Pfad unter `/auth/step-up/consume` belegt; Passkey-Eintragspunkt ist als deaktivierter Stub in der `/settings`-Account-Sektion sichtbar. Aktivierung folgt aus Auth-Phase 4 · siehe [auth-roadmap §9](blueprints/auth-roadmap.md)
 
 ## Strang Karte (Basemap + Kartenklarheit)

--- a/docs/specs/contract.md
+++ b/docs/specs/contract.md
@@ -58,12 +58,13 @@ relations:
 - Wöchentliche Veröffentlichung eines **Transparency-Anchors** (Root-Hash der Woche).
 - Öffentliche Statistik: Anzahl Tombstones, Takedown-Holds, mediane Löschzeit.
 
-## 7. Identität & Verortung
+## 7. Garnrolle, Verortung & Sichtbarkeit
 
-- Der Contract trägt nur die basale Kernunterscheidung (keine Vertrauenswerte oder komplexe Zwischenstufen):
-  - **Modus (`mode`)**: Eine Garnrolle ist entweder "verortet" (hat eine genaue Adresse) oder der "ron" (Rolle ohne Namen) zugeordnet.
-  - **Ungenauigkeitsradius (`radius_m`)**: Steuert ausschließlich die öffentliche Anzeige von verorteten Garnrollen.
-  - **Interne Verortung**: Nur "verortete" Garnrollen besitzen eine `location`.
+- Der Contract trägt das Zielmodell einer einzigen Garnrolle pro Account:
+  - **Garnrolle**: Der handelnde Account-Ursprung im Gewebe.
+  - **Location**: Optionaler realer Ort der Garnrolle.
+  - **Sichtbarkeit**: Keine öffentliche Position, exakt sichtbar oder im Umkreis sichtbar.
+  - **Interne Verortung**: Exakte Adresse und Koordinate bleiben getrennt von der öffentlichen Projektion, sofern keine exakte Sichtbarkeit gewählt wurde.
 
 ---
 

--- a/docs/specs/privacy-api.md
+++ b/docs/specs/privacy-api.md
@@ -1,18 +1,100 @@
 ---
 id: specs.privacy-api
-title: Privacy API
+title: Garnrollen-Sichtbarkeit API
 doc_type: reference
 status: active
-summary: API-Spezifikation für datenschutzrelevante Endpunkte.
+summary: API-Zielbild für Verortung und öffentliche Sichtbarkeit einer Garnrolle.
 relations:
   - type: relates_to
     target: docs/specs/privacy-ui.md
   - type: relates_to
     target: docs/konzepte/garnrolle-und-verortung.md
+  - type: relates_to
+    target: docs/adr/ADR-0009__garnrolle-verortung-sichtbarkeit.md
 ---
-# Privacy API (ADR-0003)
 
-GET/PUT /me/visibility { radius_m } für verortete Garnrollen.
-Das Modell nutzt `mode: "verortet" | "ron"` als basalen Identitätsmodus anstelle eines nachträglichen RoN-Toggles oder visibility-Flags (`private`/`approximate`/`public`).
-View: public_role_view (id, public_pos, mode, radius_m).
-Bei `mode=ron` bleibt `public_pos` im individuellen Account leer (None); die spätere öffentliche Wirksamkeit/Projektion erfolgt kollektiv über die Rolle ohne Namen des Stadtteils.
+# Garnrollen-Sichtbarkeit API
+
+Diese Spezifikation beschreibt das Zielbild für die API rund um Verortung und
+öffentliche Sichtbarkeit einer Garnrolle.
+
+Der Pfadname bleibt vorerst aus Kompatibilitätsgründen bestehen. Fachlich geht
+es nicht um einen Privacy-Modus, sondern um eine klare Sichtbarkeitsentscheidung
+für eine Garnrolle.
+
+## Zielzustand
+
+Ein Account hat genau eine Garnrolle. Diese Garnrolle kann ohne öffentliche
+Position existieren oder auf die Karte gesetzt werden.
+
+Zielstruktur:
+
+```text
+garnrolle.location = null
+```
+
+oder:
+
+```text
+garnrolle.location = {
+  address,
+  coordinates,
+  public_visibility: "exact" | "radius",
+  radius_m
+}
+```
+
+## Öffentliche Projektion
+
+Die öffentliche Ansicht darf nur die gewählte Sichtbarkeit zeigen:
+
+| Sichtbarkeit | Öffentliche Projektion |
+|---|---|
+| keine Position | keine `public_pos` |
+| exakt sichtbar | `public_pos = coordinates` |
+| im Umkreis sichtbar | `public_pos` aus Radius-Projektion |
+
+Die interne Adresse und die exakten Koordinaten bleiben getrennt von der
+öffentlichen Projektion, sofern nicht exakt sichtbare Anzeige gewählt wurde.
+
+## Zielendpunkte
+
+Die endgültigen Namen sind noch offen. Semantisch braucht das System:
+
+```text
+GET /me/garnrolle
+PUT /me/garnrolle/profile
+PUT /me/garnrolle/location
+DELETE /me/garnrolle/location
+```
+
+`PUT /me/garnrolle/location` setzt die Garnrolle auf die Karte oder ändert ihre
+Sichtbarkeit.
+
+Beispiel exakt sichtbar:
+
+```json
+{
+  "address": "Poelsweg 2, Hamburg",
+  "coordinates": { "lat": 53.558..., "lon": 10.060... },
+  "public_visibility": "exact"
+}
+```
+
+Beispiel im Umkreis sichtbar:
+
+```json
+{
+  "address": "Poelsweg 2, Hamburg",
+  "coordinates": { "lat": 53.558..., "lon": 10.060... },
+  "public_visibility": "radius",
+  "radius_m": 250
+}
+```
+
+## Übergangsnotiz
+
+Bestehende technische Felder in API, Datenbank oder Fixtures dürfen bis zur
+Migration weiter gelesen werden. Neue Zielsemantik darf daraus aber keine
+zweite Accountart ableiten. Sie projiziert die Daten in eine Garnrolle mit
+Sichtbarkeitszustand.

--- a/docs/specs/privacy-ui.md
+++ b/docs/specs/privacy-ui.md
@@ -1,46 +1,96 @@
 ---
 id: specs.privacy-ui
-title: Privacy UI
+title: Garnrollen-Sichtbarkeit UI
 doc_type: reference
 status: active
-summary: UI-Spezifikation für datenschutzrelevante Oberflächen und Interaktionen.
+summary: UI-Zielbild für Profil, Verortung und öffentliche Sichtbarkeit der eigenen Garnrolle.
 relations:
   - type: relates_to
     target: docs/specs/privacy-api.md
   - type: relates_to
     target: docs/konzepte/garnrolle-und-verortung.md
+  - type: relates_to
+    target: docs/adr/ADR-0009__garnrolle-verortung-sichtbarkeit.md
 ---
-# Privacy UI (ADR-0003)
 
-Slider (r Meter) für verortete Garnrollen.
+# Garnrollen-Sichtbarkeit UI
 
-## Startzustand
+Diese UI-Spezifikation ersetzt die frühere Privacy-Modus-Sprache durch eine
+Garnrollen-Handlung:
 
-Beim ersten Einstieg (Onboarding neuer Accounts) befindet sich der Nutzer im RoN-Startmodus.
+> Garnrolle auf die Karte setzen.
 
-Die UI muss sichtbar machen:
+## Start nach Login
 
-- aktuellen Zustand (RoN)
-- Bedeutung dieses Zustands
-- Möglichkeit zur Verortung
+Nach dem Login sieht der Nutzer seine Garnrolle.
 
-## Übergang
+Empfohlener Text:
 
-Die Verortung wird angeboten als:
+```text
+Deine Garnrolle ist angelegt.
+Sie steht noch nicht auf der Karte.
+```
 
-→ „Verortete Garnrolle erstellen“
+Primäre Aktionen:
 
-Dabei wird erklärt:
+- Garnrolle beschreiben
+- Garnrolle auf Karte setzen
+- später: ersten Knoten weben
 
-- welche Daten benötigt werden
-- wie der Ungenauigkeitsradius wirkt
-- dass die interne Verortung exakt bleibt
+## Garnrolle beschreiben
+
+Felder:
+
+- Anzeigename
+- Kurzbeschreibung
+- Fähigkeiten
+- Güter
+- Interessen
+- Tags
+
+Die Beschreibung ist zuerst ein Profilakt, keine Kartenentscheidung.
+
+## Garnrolle auf Karte setzen
+
+Die UI fragt nach:
+
+- Adresse
+- Koordinate oder Adressauflösung
+- Sichtbarkeit
+
+Sichtbarkeitsauswahl:
+
+```text
+[ ] Noch nicht auf der Karte
+[x] Exakt sichtbar
+[ ] Im Umkreis sichtbar
+```
+
+Nur bei "Im Umkreis sichtbar" wird ein Radiusfeld angezeigt.
+
+## Exakte Sichtbarkeit
+
+Exakte Sichtbarkeit ist positiv zu formulieren:
+
+```text
+Deine Garnrolle wird an dieser Adresse sichtbar. Menschen in der Nähe können
+sehen, wo du im Gewebe ansprechbar bist.
+```
+
+Nicht als Warntext formulieren.
 
 ## Nicht erlaubt
 
-- versteckte Defaults ohne Anzeige
-- nachträglicher RoN-Toggle
-- Vermischung von Identität und Sichtbarkeit
+- Identitätsmodus-Auswahl im Onboarding
+- Privacy-Toggle als Accountart
+- technische Feldnamen in der Haupt-UI
+- Standardwarnung gegen exakte Sichtbarkeit
+- Kanten- oder Edge-Sprache in Nutzertexten
 
-Texte: Sicherer Einstieg im RoN-Startzustand ist Standard; Verortung ist optional und bewusst.
-Vorschau public_pos.
+## Nächster Schritt
+
+Nach einer gesetzten Garnrolle wird der erste produktive Call-to-Action:
+
+```text
+Ersten Knoten weben
+```

--- a/docs/zusammenstellung.md
+++ b/docs/zusammenstellung.md
@@ -66,24 +66,23 @@ Inhalte (Knoten, Fäden, Garn)
 - Webrat: Der Ort für Governance, Anträge und die Übersicht über Delegationen. Alle Abstimmungen sind hier ebenso
   einsehbar und man kann daran teilnehmen.
 - Nähstübchen: Ein ortsunabhängiger Raum für die allgemeine Kommunikation.
-- RoN-Platzhalter: Ein spezieller Knoten, an dem anonymisierte Inhalte nach 84 Tagen gesammelt werden.
+- Archiv-/Tombstone-Knoten: Ein spezieller Knoten, an dem gelöschte oder anonymisierte Inhalte ohne Rückbindung an eine sichtbare Garnrolle gesammelt werden.
 
 III. Zeitlichkeit, Sichtbarkeit und Pseudonymisierung
 
 - 7-Sekunden-Rotation: Nach jeder Aktion dreht sich die Garnrolle des Nutzers für 7 Sekunden sichtbar auf der Karte.
 - 7-Tage-Verblassen: Fäden, die nicht zu Garn verzwirnt werden, verblassen innerhalb von 7 Tagen sukzessive. Knoten, zu
   denen 7 Tage lang kein neuer Faden führt, lösen sich ebenfalls in diesem Zeitraum sukzessive auf.
-- Pseudonymisierung (RoN-System):
-  - Nutzer können per Opt-in festlegen, dass ihre Beiträge nach x Tagen automatisch anonymisiert werden. Der
-    Autorenname wird dann durch "RoN" (Rolle ohne Namen) ersetzt.
-  - Die anonymisierten Fäden führen dann nicht mehr zur ursprünglichen Garnrolle, sondern zum zentralen
-    RoN-Platzhalter. Das Wissen bleibt so im Gewebe erhalten.
-- Ausstiegsprozess: Wenn ein Nutzer die Plattform verlässt, durchlaufen alle seine Daten den RoN-Prozess.
+- Pseudonymisierung und Tombstone-Prozess:
+  - Nutzer können per Opt-in festlegen, dass ihre Beiträge nach x Tagen automatisch anonymisiert werden. Die
+    sichtbare Rückbindung an die Garnrolle wird dann entfernt.
+  - Die anonymisierten Fäden führen dann nicht mehr zur ursprünglichen Garnrolle, sondern zu einem
+    Archiv- oder Tombstone-Kontext. Das Wissen bleibt so im Gewebe erhalten.
+- Ausstiegsprozess: Wenn ein Nutzer die Plattform verlässt, durchlaufen alle seine Daten den Tombstone- oder Anonymisierungsprozess.
   Beiträge, die jünger als x Tage sind, bleiben so lange namentlich sichtbar, bis diese Frist erreicht ist.
   Am Ende wird die Garnrolle des Nutzers gelöscht.
 - Eigene Beiträge und Aktionen können per Tombstone + Key-Erase uneinsehbar gemacht werden.
-- Per Opt-in kann man die Verortung der eigenen Garnrolle ungenauer machen.
-  Der Ungenauigkeitsradius ist individuell einstellbar.
+- Per Opt-in kann man die eigene Garnrolle im Umkreis sichtbar machen. Der Radius ist individuell einstellbar.
 
 IV. Governance und Demokratische Prozesse
 
@@ -147,9 +146,9 @@ VI. Organisation und Technische Architektur
   /archive/YYYY-MM) sind hingegen als index, follow markiert und setzen ein rel="canonical"-Tag, um die
   Nachvollziehbarkeit zu gewährleisten.
 - Monitoring, Alarme und Betriebspläne:
-  - Metriken: Es werden Governance-Metriken (z.B. Teilnahmequote), RoN-Metriken (z.B. Transferrate) und Kosten-Metriken
+  - Metriken: Es werden Governance-Metriken (z.B. Teilnahmequote), Anonymisierungs-/Tombstone-Metriken (z.B. Transferrate) und Kosten-Metriken
     (z.B. €/aktiver Nutzer) überwacht. Es gibt Alarm-Regeln, z.B. bei Latenzen über 1000 ms oder wenn die Kosten in
     Phase A 200 € übersteigen.
   - Betriebspläne (Cronjobs): Governance-Timer laufen minütlich; Delegations-Prüfungen täglich um 01:00 Uhr;
-    RoN-Prozesse um 02:00 Uhr und Kosten-Analysen um 03:00 Uhr. Für die Systemgesundheit gibt es die Endpunkte
+    Anonymisierungs-/Tombstone-Prozesse um 02:00 Uhr und Kosten-Analysen um 03:00 Uhr. Für die Systemgesundheit gibt es die Endpunkte
     /health/live und /health/ready.

--- a/scripts/dev/bootstrap-first-account.sh
+++ b/scripts/dev/bootstrap-first-account.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Bootstrap the first real account with a public map position.
 #
 # The bootstrap account is always a verortete Garnrolle: the whole point is a
-# visible account with a public position on the map. (RoN accounts have no
+# visible account with a public position on the map. Accounts without
 # public_pos by contract and are therefore not produced by this path.)
 #
 # Reads account data from environment variables. See usage() below.


### PR DESCRIPTION
## Summary

Defines the target model for Garnrolle, location, visibility, nodes, and Fäden.

This is no longer a compromise where the old start-state concept remains in product language. The target semantics are now:

- Every account has exactly one Garnrolle.
- Location and visibility are properties of that Garnrolle, not separate identity modes.
- Public visibility is expressed as: not on the map, exactly visible, or visible within a radius.
- Exact visibility is a normal positive case, not a warning state.
- Nodes are woven from Garnrollen.
- Fäden are the user-facing relation language.
- The first organic product flow is: account -> my Garnrolle -> set Garnrolle on map -> weave first node -> create Faden.

## Main changes

- Replaces the previous ADR-0009 with `ADR-0009 — Garnrolle, Verortung und Sichtbarkeit`.
- Marks ADR-0003 as superseded historical context.
- Rewrites the canonical Garnrolle concept doc around one Garnrolle with visibility states.
- Rewrites the former Privacy API/UI specs as Garnrollen visibility API/UI target docs.
- Cleans glossary, roadmap, orientation, process, contract, auth, and map-clarity docs so active target language no longer uses the old RoN product semantics.
- Regenerates docmeta generated artifacts, including the supersession map.

## Validation

Passed:

- `python3 -m scripts.docmeta.validate_schema`
- `python3 -m scripts.docmeta.validate_relations`
- `python3 -m scripts.docmeta.check_links`
- `bash scripts/docmeta/repo-structure-guard.sh`
- `bash scripts/docmeta/docs-relations-guard.sh`
- `bash scripts/docmeta/coverage-guard.sh`
- `bash scripts/docmeta/generated-files-guard.sh`
- `git diff --check`

Residue check:

- Active target docs no longer contain `RoN`, `Rolle ohne Namen`, or `Ungenauigkeitsradius` as product terms.
- Remaining occurrences are only in historical file identifiers or false positives such as `cron` / `synchron`.

Known unrelated failure:

- `make validate` still fails in `test_validate_opt_arc_001_db_proof_matrix.py` because existing proof-matrix entries reference CI commit `e35488d5edafa76da23f761a44682951f516e63a`, which exists locally but is not an ancestor of current `origin/main`/HEAD. This is unrelated to this documentation PR.

## Notes

No runtime, deploy, schema, credential, or API behavior changes in this PR.
