### PR TITLE
feat(web): add my garnrolle settings flow

### DIFF
--- a/apps/web/src/lib/components/Garnrolle.svelte
+++ b/apps/web/src/lib/components/Garnrolle.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
-  import { ICONS, MARKER_SIZES } from '$lib/ui/icons';
-  import { authStore } from '$lib/auth/store';
-  import { browser } from '$app/environment';
+  import { createEventDispatcher } from "svelte";
+  import { ICONS, MARKER_SIZES } from "$lib/ui/icons";
+  import { authStore } from "$lib/auth/store";
+  import { browser } from "$app/environment";
 
-  export let label = 'Kontoeinstellungen';
+  export let label = "Kontoeinstellungen";
 
   const dispatch = createEventDispatcher<{ requestZoomToOwnGarnrolle: void }>();
   let menuOpen = false;
 
   function handleZoomToOwnGarnrolle() {
     menuOpen = false;
-    dispatch('requestZoomToOwnGarnrolle');
+    dispatch("requestZoomToOwnGarnrolle");
   }
 
   function toggleMenu() {
@@ -21,7 +21,7 @@
   function closeMenu(event: MouseEvent) {
     if (!menuOpen) return;
     const target = event.target as HTMLElement;
-    if (!target.closest('.garnrolle-container')) {
+    if (!target.closest(".garnrolle-container")) {
       menuOpen = false;
     }
   }
@@ -32,7 +32,7 @@
   // event.defaultPrevented and skips its own close logic accordingly.
   function handleKeydown(event: KeyboardEvent) {
     if (!menuOpen) return;
-    if (event.key === 'Escape') {
+    if (event.key === "Escape") {
       event.preventDefault();
       menuOpen = false;
     }
@@ -62,25 +62,46 @@
     <div class="menu">
       {#if $authStore.authenticated}
         <div class="menu-header">
-          <span class="role-badge" class:admin={$authStore.role === 'admin'} class:weber={$authStore.role === 'weber'} class:gast={$authStore.role === 'gast'}>
+          <span
+            class="role-badge"
+            class:admin={$authStore.role === "admin"}
+            class:weber={$authStore.role === "weber"}
+            class:gast={$authStore.role === "gast"}
+          >
             {$authStore.role}
           </span>
         </div>
-        <button class="menu-item" on:click={handleZoomToOwnGarnrolle}>Meine Garnrolle auf Karte zeigen</button>
-        <a href="/settings" class="menu-item" on:click={() => menuOpen = false}>Einstellungen</a>
+        <button class="menu-item" on:click={handleZoomToOwnGarnrolle}
+          >Meine Garnrolle auf Karte zeigen</button
+        >
+        <a
+          href="/settings#meine-garnrolle"
+          class="menu-item"
+          on:click={() => (menuOpen = false)}>Meine Garnrolle</a
+        >
+        <a
+          href="/settings"
+          class="menu-item"
+          on:click={() => (menuOpen = false)}>Konto & Sicherheit</a
+        >
         <button class="menu-item logout-btn" on:click={logout}>Logout</button>
       {:else}
         <div class="menu-header">
           <span class="role-badge gast">gast</span>
         </div>
-        <a href="/login" class="menu-item" on:click={() => menuOpen = false}>Login</a>
+        <a href="/login" class="menu-item" on:click={() => (menuOpen = false)}
+          >Login</a
+        >
       {/if}
     </div>
   {/if}
 </div>
 
 <style>
-  .wrap { position: relative; display: inline-block; }
+  .wrap {
+    position: relative;
+    display: inline-block;
+  }
   .wrap-btn {
     background: none;
     border: none;
@@ -91,7 +112,10 @@
     outline: none;
     appearance: none;
   }
-  .wrap-btn:focus-visible { outline: 2px solid var(--primary); border-radius: 4px; }
+  .wrap-btn:focus-visible {
+    outline: 2px solid var(--primary);
+    border-radius: 4px;
+  }
 
   .roll {
     display: block;
@@ -104,7 +128,9 @@
     object-fit: contain;
     display: block;
   }
-  .roll:active { transform: scale(0.95); }
+  .roll:active {
+    transform: scale(0.95);
+  }
 
   .menu {
     position: absolute;
@@ -113,7 +139,7 @@
     background: var(--panel);
     border: 1px solid var(--panel-border);
     border-radius: 8px;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     min-width: 150px;
     z-index: 50;
     display: flex;
@@ -137,9 +163,18 @@
     font-size: 0.7rem;
     display: inline-block;
   }
-  .role-badge.admin { background: var(--accent); color: var(--panel); }
-  .role-badge.weber { background: #54e1a6; color: var(--panel); }
-  .role-badge.gast { background: var(--muted); color: var(--bg); }
+  .role-badge.admin {
+    background: var(--accent);
+    color: var(--panel);
+  }
+  .role-badge.weber {
+    background: #54e1a6;
+    color: var(--panel);
+  }
+  .role-badge.gast {
+    background: var(--muted);
+    color: var(--bg);
+  }
 
   .menu-item {
     display: block;

--- a/apps/web/src/lib/components/MyGarnrolleSection.svelte
+++ b/apps/web/src/lib/components/MyGarnrolleSection.svelte
@@ -1,0 +1,366 @@
+<script lang="ts">
+  import { authStore } from "$lib/auth/store";
+  import type { Account } from "$lib/map/types";
+  import {
+    describeGarnrolleVisibility,
+    findOwnGarnrolle,
+  } from "$lib/garnrolle/visibility";
+
+  export let accounts: Account[] = [];
+  export let accountsLoadError: string | null = null;
+
+  let draftKey = "";
+  let displayName = "";
+  let summary = "";
+  let skills = "";
+  let goods = "";
+  let interests = "";
+  let address = "";
+  let visibilityChoice: "not_on_map" | "exact" | "radius" = "not_on_map";
+  let radiusM = 250;
+
+  $: ownGarnrolle = findOwnGarnrolle(accounts, $authStore.account_id);
+  $: visibility = describeGarnrolleVisibility(ownGarnrolle);
+  $: currentKey = `${$authStore.account_id ?? "guest"}:${ownGarnrolle?.id ?? "unlisted"}`;
+
+  $: if (currentKey !== draftKey) {
+    draftKey = currentKey;
+    displayName = ownGarnrolle?.title ?? "Meine Garnrolle";
+    summary = ownGarnrolle?.summary ?? "";
+    skills =
+      ownGarnrolle?.tags
+        ?.filter((tag) => tag !== "account" && tag !== "garnrolle")
+        .join(", ") ?? "";
+    goods = "";
+    interests = "";
+    address = "";
+    visibilityChoice = visibility.state;
+    radiusM =
+      ownGarnrolle?.radius_m && ownGarnrolle.radius_m > 0
+        ? ownGarnrolle.radius_m
+        : 250;
+  }
+
+  $: mapHref = ownGarnrolle?.public_pos
+    ? `/map?focus=garnrolle:${ownGarnrolle.id}`
+    : "/map";
+</script>
+
+<section
+  id="meine-garnrolle"
+  class="my-garnrolle"
+  data-testid="my-garnrolle-section"
+>
+  <div class="section-head">
+    <div>
+      <p class="eyebrow">Meine Garnrolle</p>
+      <h2>Deine Garnrolle ist dein Anfang im Gewebe.</h2>
+    </div>
+    <span class="state-pill" data-state={visibility.state}
+      >{visibility.label}</span
+    >
+  </div>
+
+  {#if !$authStore.authenticated}
+    <div class="empty-card" data-testid="my-garnrolle-anonymous">
+      <p>
+        Du bist noch nicht angemeldet. Nach dem Login entsteht deine Garnrolle.
+      </p>
+      <a class="btn btn-primary" href="/login">Login starten</a>
+    </div>
+  {:else}
+    <div class="status-card" data-testid="my-garnrolle-status">
+      <div>
+        <strong>{visibility.label}</strong>
+        <p>{visibility.description}</p>
+        {#if accountsLoadError}
+          <p class="warn">
+            Garnrollen-Daten konnten nicht geladen werden: {accountsLoadError}
+          </p>
+        {:else if !ownGarnrolle}
+          <p class="muted">
+            Deine Sitzung ist aktiv. Es gibt noch keinen öffentlichen
+            Garnrollen-Datensatz für diesen Account. Produktsprachlich heißt
+            das: Die Garnrolle ist angelegt, aber noch nicht auf der Karte.
+          </p>
+        {/if}
+      </div>
+      <a
+        class="btn"
+        href={mapHref}
+        aria-disabled={!visibility.canZoomToMap}
+        data-testid="my-garnrolle-map-link"
+      >
+        {visibility.canZoomToMap ? "Auf Karte zeigen" : "Karte öffnen"}
+      </a>
+    </div>
+
+    <form class="garnrolle-form" aria-describedby="my-garnrolle-save-note">
+      <fieldset>
+        <legend>Garnrolle beschreiben</legend>
+        <label>
+          Anzeigename
+          <input bind:value={displayName} placeholder="Meine Garnrolle" />
+        </label>
+        <label>
+          Kurzbeschreibung
+          <textarea
+            bind:value={summary}
+            rows="3"
+            placeholder="Was bringst du ins Gewebe ein?"></textarea>
+        </label>
+        <label>
+          Fähigkeiten
+          <input
+            bind:value={skills}
+            placeholder="z. B. Holzbau, Organisation, Kochen"
+          />
+        </label>
+        <label>
+          Güter
+          <input
+            bind:value={goods}
+            placeholder="z. B. Werkzeug, Raum, Lastenrad"
+          />
+        </label>
+        <label>
+          Interessen
+          <input
+            bind:value={interests}
+            placeholder="z. B. Fairschenken, Nachbarschaft, Commons"
+          />
+        </label>
+      </fieldset>
+
+      <fieldset>
+        <legend>Garnrolle auf Karte setzen</legend>
+        <label>
+          Adresse
+          <input bind:value={address} placeholder="Poelsweg 2, Hamburg" />
+        </label>
+
+        <div class="radio-group" role="radiogroup" aria-label="Sichtbarkeit">
+          <label class="radio-card">
+            <input
+              type="radio"
+              bind:group={visibilityChoice}
+              value="not_on_map"
+            />
+            <span>
+              <strong>Noch nicht auf der Karte</strong>
+              <small>Keine öffentliche Kartenposition.</small>
+            </span>
+          </label>
+          <label class="radio-card">
+            <input type="radio" bind:group={visibilityChoice} value="exact" />
+            <span>
+              <strong>Exakt sichtbar</strong>
+              <small
+                >Die angegebene Position wird sichtbar. Das ist ein regulärer
+                positiver Fall.</small
+              >
+            </span>
+          </label>
+          <label class="radio-card">
+            <input type="radio" bind:group={visibilityChoice} value="radius" />
+            <span>
+              <strong>Im Umkreis sichtbar</strong>
+              <small>Die Garnrolle erscheint nur ungefähr.</small>
+            </span>
+          </label>
+        </div>
+
+        {#if visibilityChoice === "radius"}
+          <label>
+            Radius in Metern
+            <input
+              type="number"
+              min="50"
+              max="5000"
+              step="50"
+              bind:value={radiusM}
+            />
+          </label>
+        {/if}
+      </fieldset>
+
+      <div class="actions">
+        <button type="button" class="btn btn-primary" disabled>Speichern</button
+        >
+        <a class="btn" href="/map?compose=node">Ersten Knoten weben</a>
+      </div>
+      <p id="my-garnrolle-save-note" class="muted">
+        Dieser Schnitt baut die Oberfläche und Semantik. Persistenz für Profil
+        und Verortung folgt im nächsten API-Schnitt.
+      </p>
+    </form>
+  {/if}
+</section>
+
+<style>
+  .my-garnrolle {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .section-head {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: flex-start;
+  }
+
+  .section-head h2 {
+    margin: 0.2rem 0 0;
+  }
+
+  .eyebrow {
+    margin: 0;
+    color: var(--muted, #9aa4b2);
+    font-size: 0.78rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .state-pill {
+    border: 1px solid var(--panel-border, rgba(255, 255, 255, 0.12));
+    border-radius: 999px;
+    color: var(--text, #e9eef5);
+    font-size: 0.8rem;
+    padding: 0.35rem 0.7rem;
+    white-space: nowrap;
+  }
+
+  .state-pill[data-state="exact"] {
+    background: rgba(84, 225, 166, 0.14);
+  }
+
+  .state-pill[data-state="radius"] {
+    background: rgba(106, 166, 255, 0.16);
+  }
+
+  .state-pill[data-state="not_on_map"] {
+    background: rgba(255, 255, 255, 0.05);
+  }
+
+  .status-card,
+  .empty-card {
+    border: 1px solid var(--panel-border, rgba(255, 255, 255, 0.08));
+    border-radius: 12px;
+    display: flex;
+    gap: 1rem;
+    justify-content: space-between;
+    padding: 1rem;
+  }
+
+  .status-card p,
+  .empty-card p {
+    margin: 0.35rem 0 0;
+  }
+
+  .warn {
+    color: #ffd28a;
+  }
+
+  .muted {
+    color: var(--muted, #9aa4b2);
+    font-size: 0.92rem;
+  }
+
+  .garnrolle-form {
+    display: grid;
+    gap: 1rem;
+  }
+
+  fieldset {
+    border: 1px solid var(--panel-border, rgba(255, 255, 255, 0.08));
+    border-radius: 12px;
+    display: grid;
+    gap: 0.9rem;
+    margin: 0;
+    padding: 1rem;
+  }
+
+  legend {
+    font-weight: 700;
+    padding: 0 0.35rem;
+  }
+
+  label {
+    display: grid;
+    gap: 0.35rem;
+    font-weight: 600;
+  }
+
+  input,
+  textarea {
+    background: var(--bg, #0f1115);
+    border: 1px solid var(--panel-border, rgba(255, 255, 255, 0.12));
+    border-radius: 8px;
+    color: var(--text, #e9eef5);
+    font: inherit;
+    padding: 0.7rem;
+  }
+
+  .radio-group {
+    display: grid;
+    gap: 0.7rem;
+  }
+
+  .radio-card {
+    align-items: flex-start;
+    border: 1px solid var(--panel-border, rgba(255, 255, 255, 0.08));
+    border-radius: 10px;
+    display: grid;
+    gap: 0.7rem;
+    grid-template-columns: auto 1fr;
+    padding: 0.75rem;
+  }
+
+  .radio-card small {
+    color: var(--muted, #9aa4b2);
+    display: block;
+    font-weight: 400;
+    margin-top: 0.25rem;
+  }
+
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .btn {
+    align-items: center;
+    background: var(--panel-border, rgba(255, 255, 255, 0.08));
+    border: 1px solid var(--panel-border, rgba(255, 255, 255, 0.12));
+    border-radius: 8px;
+    color: var(--text, #e9eef5);
+    cursor: pointer;
+    display: inline-flex;
+    font-weight: 700;
+    justify-content: center;
+    min-height: 42px;
+    padding: 0 0.9rem;
+    text-decoration: none;
+  }
+
+  .btn-primary {
+    background: var(--accent, #6aa6ff);
+    color: #0f1115;
+  }
+
+  .btn:disabled,
+  .btn[aria-disabled="true"] {
+    cursor: not-allowed;
+    opacity: 0.55;
+  }
+
+  @media (max-width: 640px) {
+    .section-head,
+    .status-card,
+    .empty-card {
+      display: grid;
+    }
+  }
+</style>

--- a/apps/web/src/lib/demo/demoData.ts
+++ b/apps/web/src/lib/demo/demoData.ts
@@ -41,7 +41,7 @@ export const demoAccounts = [
     type: "garnrolle",
     title: "weltgewebeknoten1",
     summary: "Lokale Garnrolle / Account",
-    // Public view: Internal location is hidden. Only public_pos is exposed.
+    // Public view: only public_pos is used by the map.
     location: {
       lat: 53.5604148,
       lon: 10.0629844,
@@ -50,8 +50,8 @@ export const demoAccounts = [
       lat: 53.5604148,
       lon: 10.0629844,
     },
-    mode: "verortet" as const,
     radius_m: 0,
+    map_state: "exact" as const,
     created_at: "2025-01-01T12:00:00Z",
     tags: ["account", "garnrolle", "demo"],
     modules: [
@@ -75,7 +75,7 @@ export const demoAccounts = [
     type: "garnrolle",
     title: "PrivateSpinner (Fuzzed)",
     summary: "Account with fuzziness enabled",
-    // Public view: internal location would be different, but here we only show the projected public_pos
+    // Public view: only the projected public_pos is shown.
     location: {
       lat: 53.561,
       lon: 10.063,
@@ -84,21 +84,20 @@ export const demoAccounts = [
       lat: 53.561,
       lon: 10.063,
     },
-    mode: "verortet" as const,
     radius_m: 250,
+    map_state: "radius" as const,
     created_at: "2025-01-01T12:00:00Z",
     tags: ["account", "garnrolle", "demo", "fuzzed"],
     modules: [],
   },
   {
     id: "00000000-0000-0000-0000-000000000003",
-    type: "ron",
-    title: "Rolle ohne Namen",
-    summary: "Ein Account ohne individuelle Verortung",
-    mode: "ron" as const,
-    radius_m: 0,
+    type: "garnrolle",
+    title: "Garnrolle noch nicht auf der Karte",
+    summary: "Ein Account mit Garnrolle, aber ohne öffentliche Kartenposition.",
+    map_state: "not_on_map" as const,
     created_at: "2025-01-01T12:00:00Z",
-    tags: ["account", "ron", "demo"],
+    tags: ["account", "garnrolle", "not-on-map", "demo"],
     modules: [],
   },
 ];

--- a/apps/web/src/lib/garnrolle/visibility.test.ts
+++ b/apps/web/src/lib/garnrolle/visibility.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import type { Account } from "$lib/map/types";
+import {
+  deriveGarnrolleMapState,
+  describeGarnrolleVisibility,
+  findOwnGarnrolle,
+} from "./visibility";
+
+const baseAccount: Account = {
+  id: "account-1",
+  type: "garnrolle",
+  title: "Test Garnrolle",
+  created_at: "2026-07-10T00:00:00Z",
+  tags: [],
+};
+
+describe("garnrolle visibility helpers", () => {
+  it("treats missing public position as not on the map", () => {
+    expect(deriveGarnrolleMapState(baseAccount)).toBe("not_on_map");
+    expect(describeGarnrolleVisibility(baseAccount).canZoomToMap).toBe(false);
+  });
+
+  it("treats radius zero as exact visibility", () => {
+    const account: Account = {
+      ...baseAccount,
+      public_pos: { lat: 53.56, lon: 10.06 },
+      radius_m: 0,
+    };
+    expect(deriveGarnrolleMapState(account)).toBe("exact");
+    expect(describeGarnrolleVisibility(account).label).toBe("Exakt sichtbar");
+  });
+
+  it("treats positive radius as radius visibility", () => {
+    const account: Account = {
+      ...baseAccount,
+      public_pos: { lat: 53.56, lon: 10.06 },
+      radius_m: 250,
+    };
+    expect(deriveGarnrolleMapState(account)).toBe("radius");
+    expect(describeGarnrolleVisibility(account).description).toContain("250 m");
+  });
+
+  it("finds the authenticated account's Garnrolle when present", () => {
+    expect(findOwnGarnrolle([baseAccount], "account-1")?.id).toBe("account-1");
+    expect(findOwnGarnrolle([baseAccount], "missing")).toBeNull();
+  });
+});

--- a/apps/web/src/lib/garnrolle/visibility.ts
+++ b/apps/web/src/lib/garnrolle/visibility.ts
@@ -1,0 +1,66 @@
+import type { Account, Location } from "$lib/map/types";
+
+export type GarnrolleMapState = "not_on_map" | "exact" | "radius";
+
+export type GarnrolleVisibilityView = {
+  state: GarnrolleMapState;
+  label: string;
+  description: string;
+  publicPos: Location | null;
+  radiusM: number | null;
+  canZoomToMap: boolean;
+};
+
+export function deriveGarnrolleMapState(
+  account: Account | null | undefined,
+): GarnrolleMapState {
+  if (!account?.public_pos) return "not_on_map";
+  if ((account.radius_m ?? 0) > 0) return "radius";
+  return "exact";
+}
+
+export function describeGarnrolleVisibility(
+  account: Account | null | undefined,
+): GarnrolleVisibilityView {
+  const state = deriveGarnrolleMapState(account);
+  if (state === "exact") {
+    return {
+      state,
+      label: "Exakt sichtbar",
+      description: "Deine Garnrolle steht exakt auf der Karte.",
+      publicPos: account?.public_pos ?? null,
+      radiusM: 0,
+      canZoomToMap: true,
+    };
+  }
+  if (state === "radius") {
+    const radiusM = account?.radius_m ?? null;
+    return {
+      state,
+      label: "Im Umkreis sichtbar",
+      description: radiusM
+        ? `Deine Garnrolle wird öffentlich im Umkreis von ${radiusM} m angezeigt.`
+        : "Deine Garnrolle wird öffentlich im Umkreis angezeigt.",
+      publicPos: account?.public_pos ?? null,
+      radiusM,
+      canZoomToMap: true,
+    };
+  }
+  return {
+    state,
+    label: "Noch nicht auf der Karte",
+    description:
+      "Deine Garnrolle ist angelegt, hat aber noch keine öffentliche Kartenposition.",
+    publicPos: null,
+    radiusM: null,
+    canZoomToMap: false,
+  };
+}
+
+export function findOwnGarnrolle(
+  accounts: Account[],
+  accountId: string | null | undefined,
+): Account | null {
+  if (!accountId) return null;
+  return accounts.find((account) => account.id === accountId) ?? null;
+}

--- a/apps/web/src/lib/map/scene.test.ts
+++ b/apps/web/src/lib/map/scene.test.ts
@@ -17,11 +17,11 @@ const makeAccount = (overrides: Partial<Account> = {}): Account =>
   ({
     id: "acc-1",
     type: "garnrolle",
-    mode: "verortet",
     title: "Test Account",
     created_at: "2025-01-01T00:00:00Z",
     tags: [],
     radius_m: 0,
+    map_state: "exact",
     public_pos: { lat: 53.56, lon: 10.06 },
     ...overrides,
   }) as Account;
@@ -84,18 +84,16 @@ describe("buildMapScene", () => {
     expect(scene.entities[0].lon).toBe(10.06);
   });
 
-  it("excludes accounts without public_pos (e.g. RoN)", () => {
-    const ronAccount = makeAccount({
-      id: "ron-1",
-      type: "ron",
-      mode: "ron",
-    } as any);
-    // Remove public_pos to simulate RoN account
-    delete (ronAccount as any).public_pos;
+  it("excludes Garnrollen without a public position", () => {
+    const account = makeAccount({
+      id: "account-without-position",
+      map_state: "not_on_map",
+    });
+    delete account.public_pos;
 
     const scene = buildMapScene({
       nodes: [],
-      accounts: [ronAccount],
+      accounts: [account],
       edges: [],
       loadState: "ok",
       resourceStatus: [],

--- a/apps/web/src/lib/map/types.ts
+++ b/apps/web/src/lib/map/types.ts
@@ -32,23 +32,15 @@ export interface AccountBase {
   modules?: Module[];
 }
 
-export interface AccountVerortet extends AccountBase {
+export type GarnrolleMapState = "not_on_map" | "exact" | "radius";
+
+export interface Account extends AccountBase {
   type: "garnrolle";
-  mode: "verortet";
-  location?: Location; // internal (omitted in public API responses)
-  public_pos?: Location; // projected
-  radius_m: number;
+  location?: Location; // internal when available to trusted/local code
+  public_pos?: Location; // public projection used by the map
+  radius_m?: number;
+  map_state?: GarnrolleMapState;
 }
-
-export interface AccountRon extends AccountBase {
-  type: "ron";
-  mode: "ron";
-  location?: never;
-  public_pos?: never;
-  radius_m: number;
-}
-
-export type Account = AccountVerortet | AccountRon;
 
 /**
  * @deprecated MapPoint uses lat/lng (inconsistent with domain's lat/lon).
@@ -89,7 +81,7 @@ export interface MapEntityNode {
   weight?: number;
 }
 
-/** A garnrolle (located account) entity rendered on the map. */
+/** A Garnrolle entity rendered on the map when it has a public position. */
 export interface MapEntityGarnrolle {
   type: "garnrolle";
   id: string;
@@ -106,7 +98,7 @@ export interface MapEntityGarnrolle {
 /**
  * Discriminated union of all map-renderable entities.
  * The `type` field is the discriminant – it is always present and determines the variant.
- * Ron accounts are excluded because they have no position.
+ * Garnrollen without a public position are excluded from map rendering.
  */
 export type MapEntityViewModel = MapEntityNode | MapEntityGarnrolle;
 

--- a/apps/web/src/lib/stores/mapView.test.ts
+++ b/apps/web/src/lib/stores/mapView.test.ts
@@ -1,13 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { get } from "svelte/store";
 import { buildMapScene, type MapSceneModel } from "$lib/map/scene";
-import type {
-  Account,
-  AccountVerortet,
-  Edge,
-  MapEntityViewModel,
-  Node,
-} from "$lib/map/types";
+import type { Account, Edge, MapEntityViewModel, Node } from "$lib/map/types";
 import {
   deriveFailedResourceLabels,
   deriveMarkerCounts,
@@ -33,16 +27,14 @@ const makeNode = (overrides: Partial<Node> = {}): Node => ({
   ...overrides,
 });
 
-const makeAccount = (
-  overrides: Partial<AccountVerortet> = {},
-): AccountVerortet => ({
+const makeAccount = (overrides: Partial<Account> = {}): Account => ({
   id: "acc-1",
   type: "garnrolle",
-  mode: "verortet",
   title: "Eine Garnrolle",
   created_at: "2025-01-01T00:00:00Z",
   tags: [],
   radius_m: 0,
+  map_state: "exact",
   public_pos: { lat: 53.56, lon: 10.06 },
   ...overrides,
 });

--- a/apps/web/src/routes/settings/+page.svelte
+++ b/apps/web/src/routes/settings/+page.svelte
@@ -1,27 +1,23 @@
 <script lang="ts">
-  import VersionDiagnostics from '$lib/components/VersionDiagnostics.svelte';
-  import AccountSection from '$lib/components/AccountSection.svelte';
+  import VersionDiagnostics from "$lib/components/VersionDiagnostics.svelte";
+  import AccountSection from "$lib/components/AccountSection.svelte";
+  import MyGarnrolleSection from "$lib/components/MyGarnrolleSection.svelte";
+  import type { PageData } from "./$types";
+
+  export let data: PageData;
 </script>
 
 <div class="container">
   <h1>Einstellungen</h1>
-  <p class="intro">Hier kannst du deine Privatsphäre und dein Konto verwalten.</p>
+  <p class="intro">
+    Hier verwaltest du deine Garnrolle, ihre Sichtbarkeit und dein Konto.
+  </p>
 
-  <div class="card">
-    <h2>Sichtbarkeit (Garnrolle)</h2>
-    <p>
-      Deine Garnrolle ist an deinem Wohnsitz verankert. Du kannst entscheiden, wie genau dieser Ort öffentlich angezeigt wird.
-    </p>
-
-    <div class="setting-row disabled">
-      <label for="radius">Ungenauigkeitsradius</label>
-      <input type="range" id="radius" min="0" max="1000" value="0" disabled />
-      <span>0m (exakt)</span>
-    </div>
-
-
-
-    <p class="coming-soon">🚧 Diese Einstellungen werden bald verfügbar sein.</p>
+  <div class="card primary-card">
+    <MyGarnrolleSection
+      accounts={data.accounts}
+      accountsLoadError={data.accountsLoadError}
+    />
   </div>
 
   <div class="card">
@@ -34,13 +30,40 @@
 </div>
 
 <style>
-  .container { max-width: 600px; margin: 40px auto; padding: 0 20px; color: var(--text); }
-  h1 { font-size: 2rem; margin-bottom: 1rem; }
-  .intro { margin-bottom: 2rem; opacity: 0.8; }
-  .card { background: var(--panel, #141a21); padding: 24px; border-radius: 12px; border: 1px solid var(--panel-border, rgba(255, 255, 255, 0.06)); }
-  h2 { font-size: 1.25rem; margin-bottom: 1rem; }
-  .setting-row { display: flex; align-items: center; gap: 16px; margin-bottom: 16px; opacity: 0.6; }
-  .disabled { pointer-events: none; }
-  .coming-soon { margin-top: 1rem; font-weight: bold; color: var(--accent); }
-  .diagnostics-card { margin-top: 24px; padding: 16px 24px; }
+  .container {
+    color: var(--text);
+    margin: 40px auto;
+    max-width: 760px;
+    padding: 0 20px;
+  }
+
+  h1 {
+    font-size: 2rem;
+    margin-bottom: 1rem;
+  }
+
+  .intro {
+    margin-bottom: 2rem;
+    opacity: 0.8;
+  }
+
+  .card {
+    background: var(--panel, #141a21);
+    border: 1px solid var(--panel-border, rgba(255, 255, 255, 0.06));
+    border-radius: 12px;
+    margin-bottom: 24px;
+    padding: 24px;
+  }
+
+  .primary-card {
+    padding: 0;
+  }
+
+  .primary-card :global(.my-garnrolle) {
+    padding: 24px;
+  }
+
+  .diagnostics-card {
+    padding: 16px 24px;
+  }
 </style>

--- a/apps/web/src/routes/settings/+page.ts
+++ b/apps/web/src/routes/settings/+page.ts
@@ -1,0 +1,23 @@
+import type { PageLoad } from "./$types";
+import type { Account } from "$lib/map/types";
+
+export const load: PageLoad = async ({ fetch }) => {
+  const apiUrl = import.meta.env.PUBLIC_GEWEBE_API_BASE ?? "";
+
+  try {
+    const response = await fetch(`${apiUrl}/api/accounts`);
+    if (!response.ok) {
+      return {
+        accounts: [] as Account[],
+        accountsLoadError: `HTTP ${response.status}`,
+      };
+    }
+    const accounts = (await response.json()) as Account[];
+    return { accounts, accountsLoadError: null };
+  } catch (error) {
+    return {
+      accounts: [] as Account[],
+      accountsLoadError: error instanceof Error ? error.message : String(error),
+    };
+  }
+};


### PR DESCRIPTION
## Summary

Implements the first UI slice after the Garnrolle visibility model cutover: `FLOW-001 — Meine Garnrolle`.

What this adds:

- Adds a `Meine Garnrolle` settings section.
- Loads public account/Garnrolle data on the settings route.
- Shows the authenticated account's Garnrolle state as:
  - `Noch nicht auf der Karte`
  - `Exakt sichtbar`
  - `Im Umkreis sichtbar`
- Adds a profile/location form scaffold for Anzeigename, Beschreibung, Fähigkeiten, Güter, Interessen, Adresse, and Sichtbarkeit.
- Makes clear that persistence follows in the next API slice; this PR is the UI/semantics layer.
- Updates the Garnrolle menu to link directly to `Meine Garnrolle`.
- Removes the old web/demo `ron` account variant from the map-facing TypeScript model and demo data.
- Adds pure visibility helpers plus unit tests.

## Why

After PR #1376, the target semantics are:

`Account -> Garnrolle -> Sichtbarkeit/Verortung -> Knoten weben -> Fäden entstehen`

This PR turns that into the first visible product surface without adding a database migration or changing the API contract.

## Validation

Passed locally:

- `pnpm run lint`
- `pnpm run check:ci`
- `pnpm run test:unit`
- `pnpm run build`
- `git diff --check`

Residue check:

- No `RoN`, `Rolle ohne Namen`, `Ungenauigkeitsradius`, `mode: "ron"`, or `type: "ron"` remains in the changed web-facing surfaces.

## Notes

No runtime deploy, DB migration, credential, or backend write-path change.
