### PR TITLE
fix(deploy): serve prerendered html routes on vps

### DIFF
--- a/docs/deploy/vps.md
+++ b/docs/deploy/vps.md
@@ -176,6 +176,18 @@ Der VPS-Zieltyp unterscheidet sich vom historischen Heimserver-Ziel:
 * er erzwingt keine `*.home.arpa`-DNS-Guards,
 * er verlangt kein `/opt/heimgewebe/edge` und kein `edge-ca.crt`.
 
+`Caddyfile.vps` dient den statischen SvelteKit-Build aus `apps/web/build`.
+Für vorgerenderte HTML-Routen muss der Catch-all neben exakten Dateien auch
+`{path}.html` versuchen, bevor er auf `/index.html` fällt. Andernfalls würde ein
+Pfad wie `/settings` den generischen App-Shell-Fallback statt `settings.html`
+ausliefern und könnte eine falsche oder veraltete Route initialisieren.
+
+Erwartete Reihenfolge:
+
+```caddy
+try_files {path} {path}.html /index.html
+```
+
 Vor dem INWX-DNS-Cutover darf der Stack lokal auf dem VPS über den HTTP-Host-Header
 geprüft werden, ohne öffentliche DNS-Records umzubiegen:
 

--- a/infra/caddy/Caddyfile.vps
+++ b/infra/caddy/Caddyfile.vps
@@ -54,7 +54,7 @@
 
 	handle {
 		root * /srv/weltgewebe-web
-		try_files {path} /index.html
+		try_files {path} {path}.html /index.html
 		header Cache-Control "no-cache, must-revalidate"
 		file_server
 	}

--- a/scripts/ci/tests/test_vps_http_route_smoke_docs.py
+++ b/scripts/ci/tests/test_vps_http_route_smoke_docs.py
@@ -98,7 +98,7 @@ class VpsHttpRouteSmokeDocsTest(unittest.TestCase):
             "tls ",
             "file_server",
             "root * /srv/weltgewebe-web",
-            "try_files {path} /index.html",
+            "try_files {path} {path}.html /index.html",
         ]:
             with self.subTest(forbidden=forbidden):
                 self.assertNotIn(forbidden, text)


### PR DESCRIPTION
## Summary

Fixes VPS static route resolution for prerendered SvelteKit HTML routes.

Before:

```caddy
try_files {path} /index.html
```

`/settings` fell back to `/index.html`, so the route loaded the generic app shell instead of the prerendered `settings.html` route shell.

After:

```caddy
try_files {path} {path}.html /index.html
```

This lets `/settings` resolve to `/settings.html` while keeping the SPA fallback for unknown client-side routes.

## Runtime evidence

Hot-applied on `wg-prod-1` before this PR to fix the live issue:

- `/settings` now references the settings route chunk `nodes/12...`.
- Marker scan over `/settings` + referenced route chunks:
  - `Meine Garnrolle`: 3
  - old settings stub markers: 0
- public build version: `82ef45c2`
- `https://weltgewebe.net/settings`: 200
- `https://weltgewebe.net/map`: 200
- `https://api.weltgewebe.net/health/ready`: 200

## Validation

- `python3 -m unittest scripts.ci.tests.test_vps_http_route_smoke_docs`
- `python3 -m unittest scripts.ci.tests.test_vps_http_smoke_csp_contract`
- `git diff --check`

## Notes

No API, DB, migration, credential, or SMTP change.
