### PR TITLE
fix(auth,deploy,web): trust proxies explicitly, deploy the real VPS stack, guard map unmount

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,15 @@ AUTH_COOKIE_SECURE=1
 # Persistent browser-session lifetime in seconds.
 # Default: 30 days. Accepted range: 1 hour (3600) to 90 days (7776000).
 AUTH_SESSION_TTL_SECONDS=2592000
+# Reverse proxies whose X-Forwarded-For / Forwarded headers may set the client IP.
+# Comma-separated IPs and CIDRs. Unset defaults to loopback only (127.0.0.1,::1).
+# Use the literal value `none` to declare that the API is exposed directly.
+#
+# The API refuses to start when AUTH_PUBLIC_LOGIN=1 and a per-IP rate limit
+# (AUTH_RL_IP_PER_MIN / AUTH_RL_IP_PER_HOUR) is set while this stays unset:
+# behind an untrusted proxy every client would share a single rate-limit bucket.
+# For Docker Compose, trust the bridge network:
+# AUTH_TRUSTED_PROXIES=127.0.0.1,::1,172.16.0.0/12
 
 # Database
 POSTGRES_HOST=localhost

--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,9 @@ AUTH_SESSION_TTL_SECONDS=2592000
 # The API refuses to start when a per-IP rate limit
 # (AUTH_RL_IP_PER_MIN / AUTH_RL_IP_PER_HOUR) is set while this stays unset:
 # behind an untrusted proxy every client would share a single rate-limit bucket.
+# Every listed address/CIDR is a security boundary: that proxy must overwrite
+# X-Forwarded-For with the real peer address and remove any client-supplied
+# Forwarded header. The shipped Caddyfiles enforce this contract.
 # For Docker Compose, trust the bridge network:
 # AUTH_TRUSTED_PROXIES=127.0.0.1,::1,172.16.0.0/12
 

--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@ AUTH_SESSION_TTL_SECONDS=2592000
 # Comma-separated IPs and CIDRs. Unset defaults to loopback only (127.0.0.1,::1).
 # Use the literal value `none` to declare that the API is exposed directly.
 #
-# The API refuses to start when AUTH_PUBLIC_LOGIN=1 and a per-IP rate limit
+# The API refuses to start when a per-IP rate limit
 # (AUTH_RL_IP_PER_MIN / AUTH_RL_IP_PER_HOUR) is set while this stays unset:
 # behind an untrusted proxy every client would share a single rate-limit bucket.
 # For Docker Compose, trust the bridge network:

--- a/.github/workflows/api-smoke.yml
+++ b/.github/workflows/api-smoke.yml
@@ -103,6 +103,10 @@ jobs:
           AUTH_RL_EMAIL_PER_HOUR: "1000"
           AUTH_RL_IP_PER_MIN: "100"
           AUTH_RL_IP_PER_HOUR: "1000"
+          # The smoke target is reached directly on loopback, with no proxy in
+          # front, so no forwarded client IP may ever be trusted. Required
+          # because per-IP rate limits are configured above.
+          AUTH_TRUSTED_PROXIES: "none"
           AUTH_LOG_MAGIC_TOKEN: "false"
           AUTH_AUTO_PROVISION: "false"
           SMTP_HOST: "127.0.0.1"

--- a/.github/workflows/proxy-trust-preflight.yml
+++ b/.github/workflows/proxy-trust-preflight.yml
@@ -1,0 +1,53 @@
+---
+name: Proxy trust preflight
+
+"on":
+  pull_request:
+    branches: [main]
+    paths:
+      - "apps/api/src/config.rs"
+      - "apps/api/src/routes/auth.rs"
+      - "infra/compose/compose.prod.yml"
+      - "infra/compose/compose.prod.override.yml"
+      - "infra/compose/compose.vps.override.yml"
+      - "scripts/ci/tests/test_proxy_trust_defaults.py"
+      - ".github/workflows/proxy-trust-preflight.yml"
+  push:
+    branches: [main]
+    paths:
+      - "apps/api/src/config.rs"
+      - "apps/api/src/routes/auth.rs"
+      - "infra/compose/compose.prod.yml"
+      - "infra/compose/compose.prod.override.yml"
+      - "infra/compose/compose.vps.override.yml"
+      - "scripts/ci/tests/test_proxy_trust_defaults.py"
+      - ".github/workflows/proxy-trust-preflight.yml"
+  workflow_dispatch: {}
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Proxy trust preflight tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # tag: v7.0.0
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # tag: v5
+        with:
+          python-version-file: ".python-version"
+
+      - name: Install pytest and pyyaml
+        run: python -m pip install pytest pyyaml
+
+      - name: Run proxy trust preflight tests
+        run: python -m pytest scripts/ci/tests/test_proxy_trust_defaults.py -q

--- a/Justfile
+++ b/Justfile
@@ -55,8 +55,10 @@ fmt:       # format all
 clippy:    # lint all (deny warnings)
 	cargo clippy --all-targets --all-features -- -D warnings
 
-test:      # run tests
+test:      # run tests (PostgreSQL-backed tests are skipped; see note below)
 	cargo test --all --quiet
+	@echo "note: DB-backed tests (#[ignore]) were skipped — they need a live PostgreSQL."
+	@echo "      CI runs them with --include-ignored (.github/workflows/api.yml)."
 
 check:     # quick hygiene check
 	just fmt

--- a/apps/api/src/config.rs
+++ b/apps/api/src/config.rs
@@ -59,6 +59,20 @@ macro_rules! apply_env_override_option {
     };
 }
 
+/// Proxy allowlist applied when `auth_trusted_proxies` is unset or empty.
+///
+/// Loopback only. A reverse proxy that reaches the API over a container bridge
+/// network never presents a loopback peer address, so this default deliberately
+/// trusts no real proxy.
+pub const DEFAULT_TRUSTED_PROXIES: &str = "127.0.0.1,::1";
+
+/// Explicit `auth_trusted_proxies` value declaring that no proxy is trusted.
+///
+/// Required (instead of simply leaving the value unset) for a directly exposed
+/// API that runs public login, so "no proxy in front" is an operator decision
+/// on the record rather than an accident of an absent variable.
+pub const TRUSTED_PROXIES_NONE: &str = "none";
+
 /// Selects where domain data is read from at startup.
 ///
 /// JSONL remains the default read source and write truth. PostgreSQL is
@@ -506,7 +520,27 @@ impl AppConfig {
             };
         }
 
+        // A blank `auth_trusted_proxies` is "unset", not "an empty allowlist".
+        // Collapsing it here means `validate()` sees the same `None` whether the
+        // value was omitted or written as an empty string in a config file.
+        if let Some(proxies) = self.auth_trusted_proxies {
+            let trimmed = proxies.trim().to_string();
+            self.auth_trusted_proxies = if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed)
+            };
+        }
+
         self
+    }
+
+    /// True when at least one per-IP rate limit is configured and effective.
+    ///
+    /// A limit of `0` is treated as absent: `AuthRateLimiter::new` maps it to
+    /// `NonZeroU32::new(0) == None` and installs no limiter for that window.
+    fn has_ip_rate_limits(&self) -> bool {
+        self.auth_rl_ip_per_min.unwrap_or(0) > 0 || self.auth_rl_ip_per_hour.unwrap_or(0) > 0
     }
 
     pub fn is_open_registration(&self) -> bool {
@@ -577,6 +611,31 @@ impl AppConfig {
 
         if self.auth_public_login && self.app_base_url.is_none() {
             anyhow::bail!("AUTH_PUBLIC_LOGIN is enabled but APP_BASE_URL is not set. Please set APP_BASE_URL (e.g. https://mein-weltgewebe.de)");
+        }
+
+        // Per-IP rate limits are only meaningful if the API can resolve the real
+        // client IP. Behind a reverse proxy it resolves `X-Forwarded-For` only
+        // for a *trusted* peer; with `auth_trusted_proxies` unset the allowlist
+        // falls back to loopback, the containerised proxy is never trusted, and
+        // every client on earth collapses into a single per-IP bucket. That turns
+        // a login rate limit into a site-wide login outage an attacker can trigger
+        // for the cost of a handful of requests.
+        //
+        // The condition cannot be detected at runtime, so it is refused at config
+        // load. A directly exposed API must say so with `AUTH_TRUSTED_PROXIES=none`.
+        if self.auth_public_login
+            && self.has_ip_rate_limits()
+            && self.auth_trusted_proxies.is_none()
+        {
+            anyhow::bail!(
+                "AUTH_PUBLIC_LOGIN is enabled with per-IP rate limits (AUTH_RL_IP_PER_MIN / \
+                 AUTH_RL_IP_PER_HOUR) but AUTH_TRUSTED_PROXIES is not set. Without it the \
+                 allowlist defaults to `{DEFAULT_TRUSTED_PROXIES}`, so a reverse proxy is never \
+                 trusted and every client shares one rate-limit bucket. Set AUTH_TRUSTED_PROXIES \
+                 to the proxy's IP or CIDR (e.g. `127.0.0.1,::1,172.16.0.0/12` for Docker \
+                 bridge networks), or to `{TRUSTED_PROXIES_NONE}` if the API is exposed directly \
+                 with no proxy in front."
+            );
         }
 
         if self.auth_auto_provision {
@@ -1143,6 +1202,143 @@ delegation_expire_days: 28
         Ok(())
     }
 
+    /// Set up a config that is valid apart from the proxy-trust declaration:
+    /// public login on, a delivery path, and one per-IP rate limit.
+    fn public_login_with_ip_rate_limit_guards() -> Vec<EnvGuard> {
+        vec![
+            EnvGuard::set("AUTH_PUBLIC_LOGIN", "1"),
+            EnvGuard::set("APP_BASE_URL", "https://example.com"),
+            EnvGuard::set("AUTH_LOG_MAGIC_TOKEN", "1"),
+            EnvGuard::set("AUTH_RL_IP_PER_MIN", "5"),
+            EnvGuard::unset("AUTH_RL_IP_PER_HOUR"),
+            EnvGuard::unset("AUTH_AUTO_PROVISION"),
+        ]
+    }
+
+    #[test]
+    #[serial]
+    fn validation_rejects_public_login_with_ip_rate_limits_and_undeclared_proxy_trust() -> Result<()>
+    {
+        let file = NamedTempFile::new()?;
+        std::fs::write(file.path(), YAML)?;
+
+        let _guards = public_login_with_ip_rate_limit_guards();
+        let _proxies = EnvGuard::unset("AUTH_TRUSTED_PROXIES");
+
+        let error = AppConfig::load_from_path(file.path())
+            .expect_err("undeclared proxy trust must abort startup under per-IP rate limits");
+        let message = error.to_string();
+
+        assert!(
+            message.contains("AUTH_TRUSTED_PROXIES is not set"),
+            "error must name the missing variable, got: {message}"
+        );
+        assert!(
+            message.contains("shares one rate-limit bucket"),
+            "error must explain the collapse into a single bucket, got: {message}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn validation_accepts_explicit_none_proxy_trust_for_direct_exposure() -> Result<()> {
+        let file = NamedTempFile::new()?;
+        std::fs::write(file.path(), YAML)?;
+
+        let _guards = public_login_with_ip_rate_limit_guards();
+        let _proxies = EnvGuard::set("AUTH_TRUSTED_PROXIES", "none");
+
+        let cfg = AppConfig::load_from_path(file.path())?;
+        assert_eq!(cfg.auth_trusted_proxies.as_deref(), Some("none"));
+
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn validation_accepts_declared_proxy_cidr() -> Result<()> {
+        let file = NamedTempFile::new()?;
+        std::fs::write(file.path(), YAML)?;
+
+        let _guards = public_login_with_ip_rate_limit_guards();
+        let _proxies = EnvGuard::set("AUTH_TRUSTED_PROXIES", "127.0.0.1,::1,172.16.0.0/12");
+
+        let cfg = AppConfig::load_from_path(file.path())?;
+        assert_eq!(
+            cfg.auth_trusted_proxies.as_deref(),
+            Some("127.0.0.1,::1,172.16.0.0/12")
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn validation_treats_blank_proxy_trust_as_undeclared() -> Result<()> {
+        let file = NamedTempFile::new()?;
+        // A config file may spell the value as an empty string. That is "unset",
+        // not "an allowlist that happens to be empty".
+        let yaml = format!("{YAML}auth_trusted_proxies: \"   \"\n");
+        std::fs::write(file.path(), yaml)?;
+
+        let _guards = public_login_with_ip_rate_limit_guards();
+        let _proxies = EnvGuard::unset("AUTH_TRUSTED_PROXIES");
+
+        let error = AppConfig::load_from_path(file.path())
+            .expect_err("a blank declaration must be treated as undeclared");
+        assert!(error
+            .to_string()
+            .contains("AUTH_TRUSTED_PROXIES is not set"));
+
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn validation_allows_undeclared_proxy_trust_without_ip_rate_limits() -> Result<()> {
+        let file = NamedTempFile::new()?;
+        std::fs::write(file.path(), YAML)?;
+
+        // No per-IP limiter is installed, so the client-IP resolution cannot
+        // silently degrade a defence that does not exist. Local dev stays easy.
+        let _public = EnvGuard::set("AUTH_PUBLIC_LOGIN", "1");
+        let _url = EnvGuard::set("APP_BASE_URL", "http://localhost");
+        let _log = EnvGuard::set("AUTH_LOG_MAGIC_TOKEN", "1");
+        let _rl_ip_min = EnvGuard::unset("AUTH_RL_IP_PER_MIN");
+        let _rl_ip_hour = EnvGuard::unset("AUTH_RL_IP_PER_HOUR");
+        let _auto = EnvGuard::unset("AUTH_AUTO_PROVISION");
+        let _proxies = EnvGuard::unset("AUTH_TRUSTED_PROXIES");
+
+        let cfg = AppConfig::load_from_path(file.path())?;
+        assert!(cfg.auth_trusted_proxies.is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn validation_ignores_zero_ip_rate_limits_when_checking_proxy_trust() -> Result<()> {
+        let file = NamedTempFile::new()?;
+        std::fs::write(file.path(), YAML)?;
+
+        // `AuthRateLimiter::new` maps a limit of 0 to "no limiter", so 0 must not
+        // trip the proxy-trust requirement either.
+        let _public = EnvGuard::set("AUTH_PUBLIC_LOGIN", "1");
+        let _url = EnvGuard::set("APP_BASE_URL", "http://localhost");
+        let _log = EnvGuard::set("AUTH_LOG_MAGIC_TOKEN", "1");
+        let _rl_ip_min = EnvGuard::set("AUTH_RL_IP_PER_MIN", "0");
+        let _rl_ip_hour = EnvGuard::set("AUTH_RL_IP_PER_HOUR", "0");
+        let _auto = EnvGuard::unset("AUTH_AUTO_PROVISION");
+        let _proxies = EnvGuard::unset("AUTH_TRUSTED_PROXIES");
+
+        let cfg = AppConfig::load_from_path(file.path())?;
+        assert!(cfg.auth_trusted_proxies.is_none());
+
+        Ok(())
+    }
+
     #[test]
     #[serial]
     fn validation_succeeds_if_public_login_with_auth_log_magic_token() -> Result<()> {
@@ -1185,6 +1381,9 @@ delegation_expire_days: 28
         let _rl_email_min = EnvGuard::set("AUTH_RL_EMAIL_PER_MIN", "2");
         let _rl_email_hour = EnvGuard::set("AUTH_RL_EMAIL_PER_HOUR", "10");
         let _log = EnvGuard::set("AUTH_LOG_MAGIC_TOKEN", "1");
+        // Per-IP limits plus public login now require an explicit proxy-trust
+        // declaration (see `trusted_proxies_*` tests below).
+        let _proxies = EnvGuard::set("AUTH_TRUSTED_PROXIES", "none");
 
         let cfg = AppConfig::load_from_path(file.path())?;
         assert!(cfg.is_open_registration());

--- a/apps/api/src/config.rs
+++ b/apps/api/src/config.rs
@@ -1,6 +1,7 @@
-use std::{env, fs, path::Path};
+use std::{env, fs, net::IpAddr, path::Path};
 
 use anyhow::{Context, Result};
+use ipnet::IpNet;
 use serde::Deserialize;
 
 macro_rules! apply_env_override {
@@ -72,6 +73,33 @@ pub const DEFAULT_TRUSTED_PROXIES: &str = "127.0.0.1,::1";
 /// API that runs public login, so "no proxy in front" is an operator decision
 /// on the record rather than an accident of an absent variable.
 pub const TRUSTED_PROXIES_NONE: &str = "none";
+
+fn validate_trusted_proxy_declaration(value: &str) -> Result<()> {
+    let value = value.trim();
+    if value.eq_ignore_ascii_case(TRUSTED_PROXIES_NONE) {
+        return Ok(());
+    }
+
+    let entries: Vec<_> = value
+        .split(',')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .collect();
+    if entries.is_empty() {
+        anyhow::bail!(
+            "AUTH_TRUSTED_PROXIES must contain IP addresses/CIDRs or the explicit value `{TRUSTED_PROXIES_NONE}`"
+        );
+    }
+
+    for entry in entries {
+        if entry.parse::<IpNet>().is_err() && entry.parse::<IpAddr>().is_err() {
+            anyhow::bail!(
+                "AUTH_TRUSTED_PROXIES contains invalid entry `{entry}`; expected an IP address, CIDR, or `{TRUSTED_PROXIES_NONE}`"
+            );
+        }
+    }
+    Ok(())
+}
 
 /// Selects where domain data is read from at startup.
 ///
@@ -613,29 +641,22 @@ impl AppConfig {
             anyhow::bail!("AUTH_PUBLIC_LOGIN is enabled but APP_BASE_URL is not set. Please set APP_BASE_URL (e.g. https://mein-weltgewebe.de)");
         }
 
-        // Per-IP rate limits are only meaningful if the API can resolve the real
-        // client IP. Behind a reverse proxy it resolves `X-Forwarded-For` only
-        // for a *trusted* peer; with `auth_trusted_proxies` unset the allowlist
-        // falls back to loopback, the containerised proxy is never trusted, and
-        // every client on earth collapses into a single per-IP bucket. That turns
-        // a login rate limit into a site-wide login outage an attacker can trigger
-        // for the cost of a handful of requests.
-        //
-        // The condition cannot be detected at runtime, so it is refused at config
-        // load. A directly exposed API must say so with `AUTH_TRUSTED_PROXIES=none`.
-        if self.auth_public_login
-            && self.has_ip_rate_limits()
-            && self.auth_trusted_proxies.is_none()
-        {
+        // Any configured per-IP limiter needs an explicit client-IP trust
+        // decision, regardless of whether registration is public. Otherwise a
+        // containerised reverse proxy collapses every client into its own peer
+        // address and turns the limiter into a shared outage switch.
+        if self.has_ip_rate_limits() && self.auth_trusted_proxies.is_none() {
             anyhow::bail!(
-                "AUTH_PUBLIC_LOGIN is enabled with per-IP rate limits (AUTH_RL_IP_PER_MIN / \
-                 AUTH_RL_IP_PER_HOUR) but AUTH_TRUSTED_PROXIES is not set. Without it the \
-                 allowlist defaults to `{DEFAULT_TRUSTED_PROXIES}`, so a reverse proxy is never \
-                 trusted and every client shares one rate-limit bucket. Set AUTH_TRUSTED_PROXIES \
-                 to the proxy's IP or CIDR (e.g. `127.0.0.1,::1,172.16.0.0/12` for Docker \
-                 bridge networks), or to `{TRUSTED_PROXIES_NONE}` if the API is exposed directly \
-                 with no proxy in front."
+                "Per-IP rate limits (AUTH_RL_IP_PER_MIN / AUTH_RL_IP_PER_HOUR) are enabled but \
+                 AUTH_TRUSTED_PROXIES is not set. Without it the allowlist defaults to \
+                 `{DEFAULT_TRUSTED_PROXIES}`, so a reverse proxy may be untrusted and every \
+                 client may share one rate-limit bucket. Set AUTH_TRUSTED_PROXIES to the \
+                 proxy's IP or CIDR (e.g. `127.0.0.1,::1,172.16.0.0/12` for Docker bridge \
+                 networks), or to `{TRUSTED_PROXIES_NONE}` if the API is exposed directly."
             );
+        }
+        if let Some(proxies) = self.auth_trusted_proxies.as_deref() {
+            validate_trusted_proxy_declaration(proxies)?;
         }
 
         if self.auth_auto_provision {
@@ -1107,6 +1128,7 @@ delegation_expire_days: 28
         // Set mandatory rate limits
         let _rl_ip_min = EnvGuard::set("AUTH_RL_IP_PER_MIN", "5");
         let _rl_ip_hour = EnvGuard::set("AUTH_RL_IP_PER_HOUR", "30");
+        let _proxies = EnvGuard::set("AUTH_TRUSTED_PROXIES", "none");
         let _rl_email_min = EnvGuard::set("AUTH_RL_EMAIL_PER_MIN", "2");
         let _rl_email_hour = EnvGuard::set("AUTH_RL_EMAIL_PER_HOUR", "10");
 
@@ -1234,10 +1256,49 @@ delegation_expire_days: 28
             "error must name the missing variable, got: {message}"
         );
         assert!(
-            message.contains("shares one rate-limit bucket"),
+            message.contains("rate-limit bucket"),
             "error must explain the collapse into a single bucket, got: {message}"
         );
 
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn validation_rejects_ip_rate_limits_without_proxy_decision_when_login_is_private() -> Result<()>
+    {
+        let file = NamedTempFile::new()?;
+        std::fs::write(file.path(), YAML)?;
+
+        let _public = EnvGuard::set("AUTH_PUBLIC_LOGIN", "0");
+        let _rl_ip_min = EnvGuard::set("AUTH_RL_IP_PER_MIN", "5");
+        let _rl_ip_hour = EnvGuard::unset("AUTH_RL_IP_PER_HOUR");
+        let _proxies = EnvGuard::unset("AUTH_TRUSTED_PROXIES");
+
+        let error = AppConfig::load_from_path(file.path())
+            .expect_err("every active per-IP limiter needs an explicit proxy decision");
+        assert!(error
+            .to_string()
+            .contains("AUTH_TRUSTED_PROXIES is not set"));
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn validation_rejects_invalid_proxy_entries_instead_of_silently_dropping_them() -> Result<()> {
+        let file = NamedTempFile::new()?;
+        std::fs::write(file.path(), YAML)?;
+
+        let _guards = public_login_with_ip_rate_limit_guards();
+        let _proxies = EnvGuard::set("AUTH_TRUSTED_PROXIES", "127.0.0.1,not-an-ip,172.16.0.0/12");
+
+        let error = AppConfig::load_from_path(file.path())
+            .expect_err("a malformed allowlist entry must abort startup");
+        let message = error.to_string();
+        assert!(
+            message.contains("invalid entry `not-an-ip`"),
+            "got: {message}"
+        );
         Ok(())
     }
 

--- a/apps/api/src/lib.rs
+++ b/apps/api/src/lib.rs
@@ -58,6 +58,12 @@ pub async fn run() -> anyhow::Result<()> {
     }
 
     let app_config = AppConfig::load().context("failed to load API configuration")?;
+
+    // Install the proxy allowlist before the first request can be served, so the
+    // request path resolves client IPs from the validated config rather than
+    // re-reading the environment behind the config's back.
+    routes::auth::init_trusted_proxies(&app_config);
+
     let (db_pool, db_pool_configured) = initialise_database_pool().await?;
     let (nats_client, nats_configured) = initialise_nats_client().await;
 

--- a/apps/api/src/middleware/csrf.rs
+++ b/apps/api/src/middleware/csrf.rs
@@ -35,7 +35,12 @@ pub async fn require_csrf(jar: CookieJar, req: Request<Body>, next: Next) -> Res
         return next.run(req).await;
     }
 
-    if path.ends_with("/auth/login") || path.ends_with("/auth/logout") {
+    // Logout is deliberately exempt (see CSRF_EXEMPT_MUTATING_ROUTES in
+    // apps/api/tests/auth_security_invariants.rs): sign-out must stay reachable
+    // without the Origin/Referer path. There is no `/auth/login` route — the
+    // login entry points are `/auth/dev/login` and `/auth/magic-link/request`,
+    // and both are already covered by the no-session-cookie skip below.
+    if path.ends_with("/auth/logout") {
         return next.run(req).await;
     }
 
@@ -242,15 +247,53 @@ mod tests {
         assert_eq!(parse_host_header("[::1]"), ("[::1]".to_string(), None));
     }
 
-    #[tokio::test]
-    async fn test_exemption_logic() {
-        use axum::http::Request;
-        let req = Request::builder()
-            .uri("/auth/login")
-            .method("POST")
-            .body(Body::empty())
-            .unwrap();
-        assert!(req.uri().path().ends_with("/auth/login"));
+    /// Mirrors the exemption arm in `require_csrf`. Kept next to it so the two
+    /// cannot drift; the router-level classification is enforced separately by
+    /// `csrf_mutating_route_drift_guard_matches_router_declarations`.
+    fn is_exempt_path(path: &str) -> bool {
+        path.ends_with("/auth/logout")
+    }
+
+    #[test]
+    fn logout_is_exempt_under_both_mount_points() {
+        assert!(is_exempt_path("/auth/logout"));
+        assert!(is_exempt_path("/api/auth/logout"));
+    }
+
+    #[test]
+    fn logout_all_is_not_exempt() {
+        // `logout-all` escalates to a step-up challenge and must stay behind the
+        // Origin/Referer check. A sloppy `ends_with` must not swallow it.
+        assert!(!is_exempt_path("/auth/logout-all"));
+        assert!(!is_exempt_path("/api/auth/logout-all"));
+    }
+
+    #[test]
+    fn login_entry_points_are_not_matched_by_the_exemption_arm() {
+        // There is no `/auth/login` route. The real entry points rely on the
+        // no-session-cookie skip, not on a path exemption.
+        assert!(!is_exempt_path("/auth/dev/login"));
+        assert!(!is_exempt_path("/auth/magic-link/request"));
+    }
+
+    #[test]
+    fn magic_link_consume_post_is_exempt_only_for_post() {
+        assert!(is_magic_link_consume_post(
+            &Method::POST,
+            "/auth/magic-link/consume"
+        ));
+        assert!(is_magic_link_consume_post(
+            &Method::POST,
+            "/api/auth/magic-link/consume"
+        ));
+        assert!(!is_magic_link_consume_post(
+            &Method::PUT,
+            "/auth/magic-link/consume"
+        ));
+        assert!(!is_magic_link_consume_post(
+            &Method::POST,
+            "/auth/magic-link/consume/extra"
+        ));
     }
 
     #[test]

--- a/apps/api/src/routes/auth.rs
+++ b/apps/api/src/routes/auth.rs
@@ -291,10 +291,10 @@ fn effective_client_ip(peer: SocketAddr, headers: &HeaderMap) -> IpAddr {
         return peer.ip();
     }
 
-    // Caddy rewrites X-Forwarded-For for the upstream request, while a generic
-    // Forwarded header may have originated at the public client unless the
-    // proxy explicitly removes it. Prefer the proxy-owned chain and retain
-    // RFC 7239 only as a fallback for trusted proxies that emit no XFF.
+    // The production Caddyfiles overwrite X-Forwarded-For with the public
+    // peer address and remove any client-supplied Forwarded header before the
+    // request reaches this trusted proxy boundary. Prefer that proxy-owned XFF
+    // value and retain RFC 7239 only as a fallback for other trusted proxies.
     if let Some(xff_val) = headers.get("X-Forwarded-For").and_then(|v| v.to_str().ok()) {
         if let Some(first) = xff_val.split(',').next() {
             if let Ok(addr) = first.trim().parse::<IpAddr>() {

--- a/apps/api/src/routes/auth.rs
+++ b/apps/api/src/routes/auth.rs
@@ -291,9 +291,20 @@ fn effective_client_ip(peer: SocketAddr, headers: &HeaderMap) -> IpAddr {
         return peer.ip();
     }
 
-    // Check Forwarded header (RFC 7239)
+    // Caddy rewrites X-Forwarded-For for the upstream request, while a generic
+    // Forwarded header may have originated at the public client unless the
+    // proxy explicitly removes it. Prefer the proxy-owned chain and retain
+    // RFC 7239 only as a fallback for trusted proxies that emit no XFF.
+    if let Some(xff_val) = headers.get("X-Forwarded-For").and_then(|v| v.to_str().ok()) {
+        if let Some(first) = xff_val.split(',').next() {
+            if let Ok(addr) = first.trim().parse::<IpAddr>() {
+                return addr;
+            }
+        }
+    }
+
+    // Fallback: Forwarded header (RFC 7239).
     // Format: Forwarded: for=1.2.3.4, for=5.6.7.8;proto=http
-    // We only trust the first (left-most) element as the client IP.
     if let Some(forwarded_val) = headers.get("Forwarded").and_then(|v| v.to_str().ok()) {
         if let Some(first_element) = forwarded_val.split(',').next() {
             for part in first_element.split(';') {
@@ -302,17 +313,12 @@ fn effective_client_ip(peer: SocketAddr, headers: &HeaderMap) -> IpAddr {
                     let val = part["for=".len()..].trim();
                     let val = val.trim_matches('"');
 
-                    // Try parsing as SocketAddr first (handles [ipv6]:port)
                     if let Ok(addr) = val.parse::<SocketAddr>() {
                         return addr.ip();
                     }
-
-                    // Try parsing as IpAddr (handles ipv4, ipv6)
                     if let Ok(addr) = val.parse::<IpAddr>() {
                         return addr;
                     }
-
-                    // Handle [ipv6] without port (strip brackets)
                     if val.starts_with('[') && val.ends_with(']') {
                         let inner = &val[1..val.len() - 1];
                         if let Ok(addr) = inner.parse::<IpAddr>() {
@@ -320,15 +326,6 @@ fn effective_client_ip(peer: SocketAddr, headers: &HeaderMap) -> IpAddr {
                         }
                     }
                 }
-            }
-        }
-    }
-
-    // Fallback: X-Forwarded-For
-    if let Some(xff_val) = headers.get("X-Forwarded-For").and_then(|v| v.to_str().ok()) {
-        if let Some(first) = xff_val.split(',').next() {
-            if let Ok(addr) = first.trim().parse::<IpAddr>() {
-                return addr;
             }
         }
     }
@@ -3132,6 +3129,27 @@ mod tests {
 
         let addr: SocketAddr = "127.0.0.1:8080".parse().unwrap();
         // Default trusts localhost -> Reads XFF -> Sees 1.2.3.4 -> Rejected
+        assert_eq!(
+            check_dev_login_guard(&headers, addr),
+            Err(StatusCode::FORBIDDEN)
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn trusted_proxy_prefers_proxy_owned_xff_over_spoofable_forwarded() {
+        let _guard = EnvGuard::set("AUTH_DEV_LOGIN", "1");
+        let _guard_proxy = EnvGuard::set("AUTH_TRUSTED_PROXIES", "127.0.0.1");
+
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Forwarded-For", "203.0.113.7".parse().unwrap());
+        headers.insert("Forwarded", "for=127.0.0.1".parse().unwrap());
+
+        let addr: SocketAddr = "127.0.0.1:8080".parse().unwrap();
+        assert_eq!(
+            effective_client_ip(addr, &headers),
+            "203.0.113.7".parse::<IpAddr>().unwrap()
+        );
         assert_eq!(
             check_dev_login_guard(&headers, addr),
             Err(StatusCode::FORBIDDEN)

--- a/apps/api/src/routes/auth.rs
+++ b/apps/api/src/routes/auth.rs
@@ -27,7 +27,7 @@ use crate::{
     auth::session::SessionBackendError,
     auth::step_up_tokens::ConsumeMatchResult,
     auth::{role::Role, tokens::TokenStore},
-    config::DomainAccountWriteSource,
+    config::{DomainAccountWriteSource, DEFAULT_TRUSTED_PROXIES, TRUSTED_PROXIES_NONE},
     domain_db::{update_account_email_in_postgres, AccountEmailUpdateError},
     middleware::auth::AuthContext,
     routes::accounts::{AccountInternal, AccountPublic},
@@ -195,17 +195,32 @@ impl TrustedProxyRule {
     }
 }
 
-fn parse_trusted_proxies(env_val: String) -> Vec<TrustedProxyRule> {
-    // Default to localhost if unset or empty (Strategy A: Secure defaults for dev)
-    let config = if env_val.trim().is_empty() {
-        "127.0.0.1,::1"
+/// Parse the `auth_trusted_proxies` declaration into matching rules.
+///
+/// - `None` (unset) → loopback only (`127.0.0.1`, `::1`). Safe dev default:
+///   a reverse proxy on a container bridge network is never loopback, so an
+///   unset value trusts nothing that matters. `AppConfig::validate` refuses to
+///   pair this default with public login plus per-IP rate limits, because in
+///   that combination it silently collapses every client into one bucket.
+/// - `AUTH_TRUSTED_PROXIES_NONE` (`"none"`, case-insensitive) → no rule at all.
+///   The explicit declaration for a directly exposed API with no proxy in front.
+/// - anything else → comma-separated IPs and CIDRs.
+fn parse_trusted_proxies(declaration: Option<&str>) -> Vec<TrustedProxyRule> {
+    let declared = declaration.map(str::trim).unwrap_or("");
+
+    if declared.eq_ignore_ascii_case(TRUSTED_PROXIES_NONE) {
+        return Vec::new();
+    }
+
+    let rules = if declared.is_empty() {
+        DEFAULT_TRUSTED_PROXIES
     } else {
-        &env_val
+        declared
     };
 
-    config
+    rules
         .split(',')
-        .map(|s| s.trim())
+        .map(str::trim)
         .filter(|s| !s.is_empty())
         .filter_map(|s| {
             if let Ok(net) = s.parse::<IpNet>() {
@@ -220,20 +235,49 @@ fn parse_trusted_proxies(env_val: String) -> Vec<TrustedProxyRule> {
         .collect()
 }
 
+/// Install the trusted-proxy allowlist from the validated [`AppConfig`].
+///
+/// Called once from `run()` before the server starts serving. Making the
+/// config the source closes the gap where `auth_trusted_proxies` set in a
+/// config file was parsed, validated, and then silently ignored because the
+/// request path read `AUTH_TRUSTED_PROXIES` straight from the environment.
+///
+/// Idempotent: a second call is a no-op, so a harness that already installed
+/// an allowlist keeps it. Under `cfg(test)` the allowlist is re-read per call
+/// (see [`get_trusted_proxies`]) and this function is inert.
+pub fn init_trusted_proxies(config: &crate::config::AppConfig) {
+    #[cfg(not(test))]
+    {
+        let _ = TRUSTED_PROXIES.set(parse_trusted_proxies(
+            config.auth_trusted_proxies.as_deref(),
+        ));
+    }
+    #[cfg(test)]
+    {
+        let _ = config;
+    }
+}
+
+#[cfg(not(test))]
+static TRUSTED_PROXIES: OnceLock<Vec<TrustedProxyRule>> = OnceLock::new();
+
 fn get_trusted_proxies() -> &'static [TrustedProxyRule] {
     #[cfg(not(test))]
     {
-        static TRUSTED_PROXIES: OnceLock<Vec<TrustedProxyRule>> = OnceLock::new();
+        // Integration harnesses build the router without `run()`, so they never
+        // reach `init_trusted_proxies`. Fall back to the environment for them —
+        // in production `run()` has always installed the config-derived rules
+        // before the first request arrives.
         TRUSTED_PROXIES.get_or_init(|| {
-            let env_val = std::env::var("AUTH_TRUSTED_PROXIES").unwrap_or_default();
-            parse_trusted_proxies(env_val)
+            parse_trusted_proxies(std::env::var("AUTH_TRUSTED_PROXIES").ok().as_deref())
         })
     }
     #[cfg(test)]
     {
-        // Leak memory to return a static reference in tests (acceptable for test suite execution)
-        let env_val = std::env::var("AUTH_TRUSTED_PROXIES").unwrap_or_default();
-        let rules = parse_trusted_proxies(env_val);
+        // Unit tests flip AUTH_TRUSTED_PROXIES per case via EnvGuard, so the
+        // allowlist must be re-read rather than cached. Leaking a short rule
+        // list per call is acceptable for the test binary.
+        let rules = parse_trusted_proxies(std::env::var("AUTH_TRUSTED_PROXIES").ok().as_deref());
         Box::leak(rules.into_boxed_slice())
     }
 }
@@ -3116,6 +3160,79 @@ mod tests {
             "Forwarded".parse::<axum::http::HeaderName>().unwrap(),
             "for=1.2.3.4".parse().unwrap(),
         );
+        assert_eq!(
+            check_dev_login_guard(&headers, addr),
+            Err(StatusCode::FORBIDDEN)
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn trusted_proxies_default_to_loopback_when_undeclared() {
+        assert!(is_trusted_rule_set(None, "127.0.0.1"));
+        assert!(is_trusted_rule_set(None, "::1"));
+        assert!(!is_trusted_rule_set(None, "172.18.0.5"));
+    }
+
+    #[test]
+    #[serial]
+    fn trusted_proxies_none_trusts_nothing_including_loopback() {
+        // `none` is the explicit "directly exposed, no proxy" declaration. It must
+        // not silently retain the loopback default, otherwise a local attacker
+        // could still spoof X-Forwarded-For.
+        for declaration in ["none", "NONE", "  None  "] {
+            assert!(
+                !is_trusted_rule_set(Some(declaration), "127.0.0.1"),
+                "{declaration:?} must not trust loopback"
+            );
+            assert!(!is_trusted_rule_set(Some(declaration), "::1"));
+            assert!(!is_trusted_rule_set(Some(declaration), "172.18.0.5"));
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn trusted_proxies_accept_docker_bridge_cidr() {
+        // The deployment shape that motivated the config gate: Caddy reaches the
+        // API from the compose bridge network, never from loopback.
+        let declaration = Some("127.0.0.1,::1,172.16.0.0/12");
+        assert!(is_trusted_rule_set(declaration, "172.18.0.5"));
+        assert!(is_trusted_rule_set(declaration, "127.0.0.1"));
+        assert!(!is_trusted_rule_set(declaration, "8.8.8.8"));
+    }
+
+    #[test]
+    #[serial]
+    fn trusted_proxies_skip_unparseable_rules_but_keep_the_rest() {
+        let declaration = Some("not-an-ip, 10.0.0.1 , ,10.1.0.0/16");
+        assert!(is_trusted_rule_set(declaration, "10.0.0.1"));
+        assert!(is_trusted_rule_set(declaration, "10.1.2.3"));
+        assert!(!is_trusted_rule_set(declaration, "10.2.0.1"));
+    }
+
+    /// Resolve `declaration` into rules and test `ip` against them, bypassing the
+    /// process-wide env lookup so each case stays independent.
+    fn is_trusted_rule_set(declaration: Option<&str>, ip: &str) -> bool {
+        let rules = parse_trusted_proxies(declaration);
+        let ip: IpAddr = ip.parse().expect("test ip must parse");
+        rules.iter().any(|rule| rule.matches(ip))
+    }
+
+    #[test]
+    #[serial]
+    fn dev_login_guard_rejects_forwarded_localhost_when_proxy_trust_is_none() {
+        let _guard = EnvGuard::set("AUTH_DEV_LOGIN", "1");
+        let _guard_proxy = EnvGuard::set("AUTH_TRUSTED_PROXIES", "none");
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "X-Forwarded-For".parse::<axum::http::HeaderName>().unwrap(),
+            "127.0.0.1".parse().unwrap(),
+        );
+
+        // Peer is a container-bridge address; with `none` nothing is trusted, so
+        // the spoofed XFF is ignored and the real peer decides.
+        let addr: SocketAddr = "172.18.0.5:8080".parse().unwrap();
         assert_eq!(
             check_dev_login_guard(&headers, addr),
             Err(StatusCode::FORBIDDEN)

--- a/apps/api/tests/auth_security_invariants.rs
+++ b/apps/api/tests/auth_security_invariants.rs
@@ -236,9 +236,11 @@ async fn csrf_blocks_all_mutating_endpoints_without_origin() -> Result<()> {
         .to_string();
 
     // All currently listed CSRF-relevant mutating endpoints reachable under the
-    // CSRF layer. `/auth/login` and `/auth/logout` are intentionally exempt;
-    // the magic-link request/consume entry points carry no session cookie and
-    // are therefore not listed here.
+    // CSRF layer. `/auth/logout` is intentionally exempt via a path arm in
+    // `require_csrf`; the magic-link and passkey login entry points carry no
+    // session cookie and are therefore not listed here. (There is no
+    // `/auth/login` route — the login entry points are `/auth/dev/login` and
+    // `/auth/magic-link/request`.)
     let mutating_endpoints: &[(Method, &str)] = &[
         (Method::POST, "/auth/session/refresh"),
         (Method::POST, "/auth/logout-all"),

--- a/apps/web/src/lib/utils/inert-polyfill.ts
+++ b/apps/web/src/lib/utils/inert-polyfill.ts
@@ -88,7 +88,9 @@ export function ensureInertPolyfill() {
   };
   syncAll();
 
-  // Fokus-, Click- & Tastatur-Blocker
+  // Fokus-, Click- & Tastatur-Blocker.
+  // Diese Listener werden bewusst nie entfernt: Das Polyfill wird einmal pro
+  // Dokument installiert und muss für dessen gesamte Lebensdauer greifen.
   document.addEventListener(
     "focusin",
     (e) => {

--- a/apps/web/src/routes/map/+page.svelte
+++ b/apps/web/src/routes/map/+page.svelte
@@ -289,6 +289,16 @@
 
   onMount(() => {
     let maplibreModule: any = null;
+    // onMount returns its cleanup synchronously while the initialiser below is
+    // still suspended on `await import('maplibre-gl')`. If the component is
+    // destroyed in that window the cleanup finds `map`/`nodesOverlay` still
+    // undefined and tears down nothing, and the initialiser would then go on to
+    // build a map, bind listeners and register protocols that nobody ever
+    // removes. Every await in the initialiser therefore re-checks this flag.
+    let destroyed = false;
+    // Hoisted so the cleanup can clear it; otherwise a component destroyed
+    // before the style loads leaves a 10s timer pointing at dead state.
+    let loadingTimeout: ReturnType<typeof setTimeout> | undefined = undefined;
     const handleMarkerClick = (e: Event) => {
       const target = e.target as HTMLElement;
       const markerBtn = target.closest('.map-marker') as HTMLButtonElement | null;
@@ -306,12 +316,11 @@
 
     (async () => {
       const maplibregl = await import('maplibre-gl');
-      maplibreModule = maplibregl;
+      if (destroyed) return;
       const container = mapContainer;
       if (!container) {
         return;
       }
-      container.addEventListener('click', handleMarkerClick);
 
       let transformRequestFn: ((url: string, resourceType?: any) => { url: string }) | undefined = undefined;
 
@@ -321,6 +330,7 @@
       // activation cost and does NOT claim that 'local-sovereign' is already working end-to-end.
       if (currentBasemap.mode === 'local-sovereign') {
         const pmtiles = await import('pmtiles');
+        if (destroyed) return;
         try {
           maplibregl.addProtocol('pmtiles', new pmtiles.Protocol().tile);
         } catch (e: any) {
@@ -333,6 +343,13 @@
           return { url: rewritePmtilesUrl(url, window.location.origin) };
         };
       }
+
+      // Past the last await boundary: from here on the cleanup below observes
+      // every resource this initialiser creates. `maplibreModule` gates the
+      // pmtiles protocol removal, so it must not be published before the
+      // protocol is actually registered.
+      maplibreModule = maplibregl;
+      container.addEventListener('click', handleMarkerClick);
 
       map = new maplibregl.Map({
         container,
@@ -356,7 +373,7 @@
       unsubscribeSysState = systemState.subscribe(val => { sysStateStr = val; });
       cleanupFocus = setupFocusInteraction(map, () => sysStateStr);
 
-      const loadingTimeout = setTimeout(() => {
+      loadingTimeout = setTimeout(() => {
         isLoading = false;
       }, 10000);
 
@@ -399,6 +416,13 @@
     })();
 
     return () => {
+      // Signals the async initialiser to stop at its next await boundary, so a
+      // component destroyed mid-import never finishes building a map.
+      destroyed = true;
+      if (loadingTimeout !== undefined) {
+        clearTimeout(loadingTimeout);
+        loadingTimeout = undefined;
+      }
       if (filterTooltipTimeout !== null) {
         window.clearTimeout(filterTooltipTimeout);
         filterTooltipTimeout = null;

--- a/docs/deploy/heimserver.deployment.md
+++ b/docs/deploy/heimserver.deployment.md
@@ -168,6 +168,14 @@ Supported with strict rate limits (mandatory):
 - `AUTH_RL_EMAIL_PER_MIN=2`
 - `AUTH_RL_EMAIL_PER_HOUR=10`
 
+Die Per-IP-Limits sind nur wirksam, wenn die API die echte Client-IP auflösen
+kann. Hinter Caddy verlangt das eine Proxy-Deklaration; ohne sie verweigert die
+API den Start:
+
+- `AUTH_TRUSTED_PROXIES=127.0.0.1,::1,172.16.0.0/12` (Docker-Bridge-Netz)
+
+`compose.prod.override.yml` setzt diesen Wert bereits als Default.
+
 **Konsequenz:**
 
 - Jeder kann Magic-Link anfordern.

--- a/docs/deploy/vps.md
+++ b/docs/deploy/vps.md
@@ -95,30 +95,55 @@ Anpassungen:
 
 ### C. Starten
 
-Verwende das bereitgestellte Skript oder Docker Compose direkt:
+`scripts/weltgewebe-up` ist der einzige unterstützte Deploy-Einstiegspunkt:
 
 ```bash
-# Mit Skript (baut oder pullt Container)
-./scripts/deploy_vps.sh
+# Baut bzw. pullt Container und startet den Stack
+./scripts/weltgewebe-up --with-caddy
 
 # Optional: Mit Image-Cleanup (Vorsicht!)
 PRUNE_IMAGES=1 ./scripts/deploy_vps.sh
+```
 
-# Oder manuell
-docker compose -f infra/compose/compose.prod.yml up -d --build
+`scripts/deploy_vps.sh` ist nur noch ein deprecateter Shim, der an
+`weltgewebe-up` delegiert.
+
+Ein manueller Aufruf **muss** die VPS-Override-Datei mitgeben. Ohne sie fehlen
+`Caddyfile.vps`, `APP_BASE_URL`, `POLICY_LIMITS_PATH`, die IPv6-Bindings sowie
+`AUTH_TRUSTED_PROXIES` und die `AUTH_RL_*`-Rate-Limits — Caddy bliebe an
+`127.0.0.1` gebunden und der Host wäre nicht öffentlich erreichbar:
+
+```bash
+docker compose \
+  --env-file /etc/weltgewebe/weltgewebe.env \
+  -f infra/compose/compose.prod.yml \
+  -f infra/compose/compose.vps.override.yml \
+  up -d --build
 ```
 
 **Troubleshooting:**
 
+Alle Compose-Aufrufe brauchen dieselbe Datei- und Projektauswahl wie der Deploy,
+sonst sprechen sie einen anders zusammengesetzten Stack an. Der Kürze halber:
+
+```bash
+alias wg-compose='docker compose --env-file /etc/weltgewebe/weltgewebe.env -p weltgewebe \
+  -f infra/compose/compose.prod.yml -f infra/compose/compose.vps.override.yml'
+```
+
 Wenn API-Healthchecks fehlschlagen, prüfe im Container:
 
 ```bash
-docker compose -f infra/compose/compose.prod.yml logs api
+wg-compose logs api
 # Teste im Container
-docker compose -f infra/compose/compose.prod.yml exec api wget -qO- http://localhost:8080/health/ready
+wg-compose exec api wget -qO- http://localhost:8080/health/ready
 # Oder Fallback
-docker compose -f infra/compose/compose.prod.yml exec api wget -qO- http://localhost:8080/health/live
+wg-compose exec api wget -qO- http://localhost:8080/health/live
 ```
+
+Startet die API gar nicht und meldet `AUTH_TRUSTED_PROXIES is not set`, dann
+läuft der Stack ohne `compose.vps.override.yml` (siehe oben) oder die
+Runtime-Env-Datei überschreibt den Default mit einem leeren Wert.
 
 ### D. Backup (Strategie)
 
@@ -145,9 +170,9 @@ Richte einen Cronjob ein, um regelmäßig Dumps der Datenbank zu erstellen und a
 
 ## Wartung
 
-* **Logs ansehen**: `docker compose -f infra/compose/compose.prod.yml logs -f`
-* **Neustart**: `docker compose -f infra/compose/compose.prod.yml restart`
-* **Updates**: Repository aktualisieren (`git pull`), dann `./scripts/deploy_vps.sh` ausführen.
+* **Logs ansehen**: `wg-compose logs -f` (Alias siehe Troubleshooting oben)
+* **Neustart**: `wg-compose restart`
+* **Updates**: Repository aktualisieren (`git pull`), dann `./scripts/weltgewebe-up` ausführen.
 
 ## 4. Aktueller Zielpfad: VPS als Public Runtime
 

--- a/infra/caddy/Caddyfile.heim
+++ b/infra/caddy/Caddyfile.heim
@@ -33,7 +33,11 @@ weltgewebe.home.arpa {
   }
 
   handle_path /api/* {
-    reverse_proxy api:8080
+    reverse_proxy api:8080 {
+      # Caddy owns the client-IP chain. Never pass a public client's
+      # RFC 7239 header to an API that trusts this proxy peer.
+      header_up -Forwarded
+    }
   }
 
   # Phase B: Immutable Assets (aggressive caching)

--- a/infra/caddy/Caddyfile.heim
+++ b/infra/caddy/Caddyfile.heim
@@ -37,6 +37,7 @@ weltgewebe.home.arpa {
       # Caddy owns the client-IP chain. Never pass a public client's
       # RFC 7239 header to an API that trusts this proxy peer.
       header_up -Forwarded
+      header_up X-Forwarded-For {remote_host}
     }
   }
 

--- a/infra/caddy/Caddyfile.vps
+++ b/infra/caddy/Caddyfile.vps
@@ -6,6 +6,7 @@
 			# Caddy owns the client-IP chain. Never pass a public client's
 			# RFC 7239 header to an API that trusts this proxy peer.
 			header_up -Forwarded
+			header_up X-Forwarded-For {remote_host}
 		}
 	}
 
@@ -18,6 +19,7 @@
 			# Caddy owns the client-IP chain. Never pass a public client's
 			# RFC 7239 header to an API that trusts this proxy peer.
 			header_up -Forwarded
+			header_up X-Forwarded-For {remote_host}
 		}
 	}
 
@@ -85,6 +87,7 @@
 		# Caddy owns the client-IP chain. Never pass a public client's
 		# RFC 7239 header to an API that trusts this proxy peer.
 		header_up -Forwarded
+		header_up X-Forwarded-For {remote_host}
 	}
 	header {
 		X-Frame-Options "DENY"
@@ -105,6 +108,7 @@ http://weltgewebe.net, http://www.weltgewebe.net {
 			# Caddy owns the client-IP chain. Never pass a public client's
 			# RFC 7239 header to an API that trusts this proxy peer.
 			header_up -Forwarded
+			header_up X-Forwarded-For {remote_host}
 		}
 	}
 
@@ -121,6 +125,7 @@ http://api.weltgewebe.net {
 			# Caddy owns the client-IP chain. Never pass a public client's
 			# RFC 7239 header to an API that trusts this proxy peer.
 			header_up -Forwarded
+			header_up X-Forwarded-For {remote_host}
 		}
 	}
 

--- a/infra/caddy/Caddyfile.vps
+++ b/infra/caddy/Caddyfile.vps
@@ -2,7 +2,11 @@
 	encode zstd gzip
 
 	handle_path /api/* {
-		reverse_proxy api:8080
+		reverse_proxy api:8080 {
+			# Caddy owns the client-IP chain. Never pass a public client's
+			# RFC 7239 header to an API that trusts this proxy peer.
+			header_up -Forwarded
+		}
 	}
 
 	handle /health/proxy {
@@ -10,7 +14,11 @@
 	}
 
 	handle /health/* {
-		reverse_proxy api:8080
+		reverse_proxy api:8080 {
+			# Caddy owns the client-IP chain. Never pass a public client's
+			# RFC 7239 header to an API that trusts this proxy peer.
+			header_up -Forwarded
+		}
 	}
 
 	handle_path /local-basemap/* {
@@ -73,7 +81,11 @@
 	handle /health/proxy {
 		respond 200
 	}
-	reverse_proxy api:8080
+	reverse_proxy api:8080 {
+		# Caddy owns the client-IP chain. Never pass a public client's
+		# RFC 7239 header to an API that trusts this proxy peer.
+		header_up -Forwarded
+	}
 	header {
 		X-Frame-Options "DENY"
 		Referrer-Policy "no-referrer"
@@ -89,7 +101,11 @@ http://weltgewebe.net, http://www.weltgewebe.net {
 	}
 
 	handle_path /api/* {
-		reverse_proxy api:8080
+		reverse_proxy api:8080 {
+			# Caddy owns the client-IP chain. Never pass a public client's
+			# RFC 7239 header to an API that trusts this proxy peer.
+			header_up -Forwarded
+		}
 	}
 
 	redir https://{host}{uri} 308
@@ -101,7 +117,11 @@ http://api.weltgewebe.net {
 	}
 
 	handle /health/* {
-		reverse_proxy api:8080
+		reverse_proxy api:8080 {
+			# Caddy owns the client-IP chain. Never pass a public client's
+			# RFC 7239 header to an API that trusts this proxy peer.
+			header_up -Forwarded
+		}
 	}
 
 	redir https://{host}{uri} 308

--- a/infra/compose/compose.prod.override.yml
+++ b/infra/compose/compose.prod.override.yml
@@ -15,6 +15,11 @@ services:
       AUTH_AUTO_PROVISION: '1'
       # Open Registration (Option C) requires strict rate limits
       AUTH_ALLOW_EMAILS: ""
+      # Caddy reaches the API over the compose bridge network, so its peer address
+      # is never loopback. Without this the per-IP limits below would bucket every
+      # client under the proxy's container IP. The API refuses to start on the
+      # unset combination.
+      AUTH_TRUSTED_PROXIES: ${AUTH_TRUSTED_PROXIES:-127.0.0.1,::1,172.16.0.0/12}
       AUTH_RL_IP_PER_MIN: "5"
       AUTH_RL_IP_PER_HOUR: "30"
       AUTH_RL_EMAIL_PER_MIN: "2"

--- a/infra/compose/compose.vps.override.yml
+++ b/infra/compose/compose.vps.override.yml
@@ -10,6 +10,13 @@ services:
       AUTH_LOG_MAGIC_TOKEN: ${AUTH_LOG_MAGIC_TOKEN:-0}
       AUTH_AUTO_PROVISION: ${AUTH_AUTO_PROVISION:-1}
       AUTH_ALLOW_EMAILS: ${AUTH_ALLOW_EMAILS:-}
+      # Caddy reaches the API over the compose bridge network, so its peer address
+      # is never loopback. Without this the allowlist falls back to loopback only,
+      # X-Forwarded-For is discarded, and every client collapses into the single
+      # per-IP bucket below — a site-wide login outage for the cost of 5 requests.
+      # The API refuses to start on the unset combination; keep this next to the
+      # rate limits it makes meaningful.
+      AUTH_TRUSTED_PROXIES: ${AUTH_TRUSTED_PROXIES:-127.0.0.1,::1,172.16.0.0/12}
       AUTH_RL_IP_PER_MIN: "5"
       AUTH_RL_IP_PER_HOUR: "30"
       AUTH_RL_EMAIL_PER_MIN: "2"

--- a/scripts/ci/tests/test_proxy_trust_defaults.py
+++ b/scripts/ci/tests/test_proxy_trust_defaults.py
@@ -1,0 +1,111 @@
+"""Preflight: per-IP rate limits and proxy trust must be declared together.
+
+`effective_client_ip` in `apps/api/src/routes/auth.rs` only honours
+`X-Forwarded-For` / `Forwarded` for a peer listed in `AUTH_TRUSTED_PROXIES`.
+A reverse proxy on a Compose bridge network never presents a loopback peer, so a
+compose file that configures `AUTH_RL_IP_PER_*` without also declaring
+`AUTH_TRUSTED_PROXIES` collapses every client into one rate-limit bucket.
+
+`AppConfig::validate` refuses that combination at startup. These tests keep the
+compose files from regressing into a stack that cannot boot -- and, before the
+config gate existed, silently served a broken rate limiter.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+REPO = Path(__file__).resolve().parents[3]
+COMPOSE_DIR = REPO / "infra" / "compose"
+
+VPS_OVERRIDE = COMPOSE_DIR / "compose.vps.override.yml"
+HEIMSERVER_OVERRIDE = COMPOSE_DIR / "compose.prod.override.yml"
+
+IP_RATE_LIMIT_KEYS = ("AUTH_RL_IP_PER_MIN", "AUTH_RL_IP_PER_HOUR")
+TRUSTED_PROXIES_KEY = "AUTH_TRUSTED_PROXIES"
+
+# Every compose file that may install a per-IP rate limiter.
+OVERRIDES_WITH_IP_RATE_LIMITS = (VPS_OVERRIDE, HEIMSERVER_OVERRIDE)
+
+
+def api_environment(compose_file: Path) -> dict[str, str]:
+    document = yaml.safe_load(compose_file.read_text(encoding="utf-8"))
+    environment = document["services"]["api"].get("environment", {})
+    if isinstance(environment, list):
+        pairs = (entry.split("=", 1) for entry in environment)
+        return {key: value for key, value in pairs}
+    return {key: str(value) for key, value in environment.items()}
+
+
+@pytest.mark.parametrize(
+    "compose_file", OVERRIDES_WITH_IP_RATE_LIMITS, ids=lambda path: path.name
+)
+def test_ip_rate_limits_are_paired_with_a_trusted_proxy_declaration(
+    compose_file: Path,
+) -> None:
+    environment = api_environment(compose_file)
+
+    configures_ip_rate_limit = any(key in environment for key in IP_RATE_LIMIT_KEYS)
+    if not configures_ip_rate_limit:
+        pytest.skip(f"{compose_file.name} installs no per-IP rate limiter")
+
+    assert TRUSTED_PROXIES_KEY in environment, (
+        f"{compose_file.name} sets {IP_RATE_LIMIT_KEYS} without {TRUSTED_PROXIES_KEY}. "
+        "Behind a containerised reverse proxy the API would bucket every client "
+        "under the proxy IP, and AppConfig::validate refuses to start."
+    )
+
+
+@pytest.mark.parametrize(
+    "compose_file", OVERRIDES_WITH_IP_RATE_LIMITS, ids=lambda path: path.name
+)
+def test_trusted_proxy_default_covers_the_compose_bridge_network(
+    compose_file: Path,
+) -> None:
+    declaration = api_environment(compose_file)[TRUSTED_PROXIES_KEY]
+
+    # Interpolation shape: an operator override wins, the baked-in fallback must
+    # still trust the bridge network Caddy reaches the API from.
+    assert declaration.startswith("${AUTH_TRUSTED_PROXIES:-"), (
+        f"{compose_file.name} must let the operator override the proxy allowlist, "
+        f"got: {declaration}"
+    )
+    fallback = declaration[len("${AUTH_TRUSTED_PROXIES:-") : -1]
+
+    assert "172.16.0.0/12" in fallback, (
+        f"{compose_file.name} fallback must trust the Docker bridge range "
+        f"(Caddy's peer address), got: {fallback}"
+    )
+    assert "127.0.0.1" in fallback, (
+        f"{compose_file.name} fallback must keep trusting loopback, got: {fallback}"
+    )
+
+
+def test_base_prod_compose_does_not_bake_a_permissive_default() -> None:
+    """The base file stays empty-by-default so a bare `-f compose.prod.yml` run
+    cannot silently inherit a proxy allowlist it never declared."""
+    declaration = api_environment(COMPOSE_DIR / "compose.prod.yml")[TRUSTED_PROXIES_KEY]
+
+    assert declaration == "${AUTH_TRUSTED_PROXIES:-}"
+
+
+def test_api_refuses_undeclared_proxy_trust_under_ip_rate_limits() -> None:
+    """The compose defaults above are a convenience, not the enforcement point.
+
+    Enforcement lives in `AppConfig::validate`; assert the guard is present so the
+    compose files and the binary cannot drift apart.
+    """
+    config_rs = (REPO / "apps" / "api" / "src" / "config.rs").read_text(encoding="utf-8")
+    # Collapse whitespace so the assertion survives rustfmt line wrapping.
+    normalized = " ".join(config_rs.split())
+
+    assert "fn has_ip_rate_limits" in normalized
+    assert (
+        "self.auth_public_login && self.has_ip_rate_limits() "
+        "&& self.auth_trusted_proxies.is_none()" in normalized
+    )
+    assert "AUTH_TRUSTED_PROXIES is not set" in normalized

--- a/scripts/ci/tests/test_proxy_trust_defaults.py
+++ b/scripts/ci/tests/test_proxy_trust_defaults.py
@@ -24,6 +24,8 @@ COMPOSE_DIR = REPO / "infra" / "compose"
 
 VPS_OVERRIDE = COMPOSE_DIR / "compose.vps.override.yml"
 HEIMSERVER_OVERRIDE = COMPOSE_DIR / "compose.prod.override.yml"
+CADDY_VPS = REPO / "infra" / "caddy" / "Caddyfile.vps"
+CADDY_HEIM = REPO / "infra" / "caddy" / "Caddyfile.heim"
 
 IP_RATE_LIMIT_KEYS = ("AUTH_RL_IP_PER_MIN", "AUTH_RL_IP_PER_HOUR")
 TRUSTED_PROXIES_KEY = "AUTH_TRUSTED_PROXIES"
@@ -105,7 +107,36 @@ def test_api_refuses_undeclared_proxy_trust_under_ip_rate_limits() -> None:
 
     assert "fn has_ip_rate_limits" in normalized
     assert (
-        "self.auth_public_login && self.has_ip_rate_limits() "
-        "&& self.auth_trusted_proxies.is_none()" in normalized
+        "self.has_ip_rate_limits() && self.auth_trusted_proxies.is_none()"
+        in normalized
     )
+    assert "validate_trusted_proxy_declaration(proxies)?" in normalized
     assert "AUTH_TRUSTED_PROXIES is not set" in normalized
+    assert "contains invalid entry" in normalized
+
+
+@pytest.mark.parametrize("caddyfile", (CADDY_VPS, CADDY_HEIM), ids=lambda path: path.name)
+def test_trusted_caddy_hops_strip_client_supplied_forwarded(caddyfile: Path) -> None:
+    text = caddyfile.read_text(encoding="utf-8")
+    upstream_count = text.count("reverse_proxy api:8080")
+    removal_count = text.count("header_up -Forwarded")
+
+    assert upstream_count > 0
+    assert removal_count == upstream_count, (
+        f"{caddyfile.name} has {upstream_count} API proxy hops but only "
+        f"{removal_count} Forwarded removals; a public client could spoof the "
+        "effective IP at an unsanitized trusted hop"
+    )
+
+
+def test_deploy_vps_shim_keeps_vps_caddy_and_upstream_guards() -> None:
+    shim = (REPO / "scripts" / "deploy_vps.sh").read_text(encoding="utf-8")
+    entrypoint = (REPO / "scripts" / "weltgewebe-up").read_text(encoding="utf-8")
+    base_compose = (COMPOSE_DIR / "compose.prod.yml").read_text(encoding="utf-8")
+
+    assert 'DEPLOY_TARGET="${DEPLOY_TARGET:-vps}"' in shim
+    assert '"${SCRIPT_DIR}/weltgewebe-up" "$@"' in shim
+    assert '[[ "$DEPLOY_TARGET" == "vps" && "$WITH_CADDY" == "0" ]]' in entrypoint
+    assert "WITH_CADDY=1" in entrypoint
+    assert "${WEB_UPSTREAM_URL:?WEB_UPSTREAM_URL must be set" in base_compose
+    assert "${WEB_UPSTREAM_HOST:?WEB_UPSTREAM_HOST must be set" in base_compose

--- a/scripts/ci/tests/test_proxy_trust_defaults.py
+++ b/scripts/ci/tests/test_proxy_trust_defaults.py
@@ -116,16 +116,21 @@ def test_api_refuses_undeclared_proxy_trust_under_ip_rate_limits() -> None:
 
 
 @pytest.mark.parametrize("caddyfile", (CADDY_VPS, CADDY_HEIM), ids=lambda path: path.name)
-def test_trusted_caddy_hops_strip_client_supplied_forwarded(caddyfile: Path) -> None:
+def test_trusted_caddy_hops_overwrite_client_ip_headers(caddyfile: Path) -> None:
     text = caddyfile.read_text(encoding="utf-8")
     upstream_count = text.count("reverse_proxy api:8080")
-    removal_count = text.count("header_up -Forwarded")
+    forwarded_removal_count = text.count("header_up -Forwarded")
+    xff_overwrite_count = text.count("header_up X-Forwarded-For {remote_host}")
 
     assert upstream_count > 0
-    assert removal_count == upstream_count, (
+    assert forwarded_removal_count == upstream_count, (
         f"{caddyfile.name} has {upstream_count} API proxy hops but only "
-        f"{removal_count} Forwarded removals; a public client could spoof the "
-        "effective IP at an unsanitized trusted hop"
+        f"{forwarded_removal_count} Forwarded removals"
+    )
+    assert xff_overwrite_count == upstream_count, (
+        f"{caddyfile.name} has {upstream_count} API proxy hops but only "
+        f"{xff_overwrite_count} X-Forwarded-For overwrites; Caddy would append "
+        "the real peer to a client-supplied chain and leave the left-most value spoofable"
     )
 
 

--- a/scripts/ci/tests/test_proxy_trust_defaults.py
+++ b/scripts/ci/tests/test_proxy_trust_defaults.py
@@ -143,5 +143,12 @@ def test_deploy_vps_shim_keeps_vps_caddy_and_upstream_guards() -> None:
     assert '"${SCRIPT_DIR}/weltgewebe-up" "$@"' in shim
     assert '[[ "$DEPLOY_TARGET" == "vps" && "$WITH_CADDY" == "0" ]]' in entrypoint
     assert "WITH_CADDY=1" in entrypoint
+    assert 'export API_VERSION="$HEAD_AFTER"' in entrypoint
     assert "${WEB_UPSTREAM_URL:?WEB_UPSTREAM_URL must be set" in base_compose
     assert "${WEB_UPSTREAM_HOST:?WEB_UPSTREAM_HOST must be set" in base_compose
+
+    vps_override = VPS_OVERRIDE.read_text(encoding="utf-8")
+    assert "WEB_UPSTREAM_HOST: weltgewebe.net" in vps_override
+    assert "WEB_UPSTREAM_URL: https://weltgewebe.net" in vps_override
+    assert "WEB_UPSTREAM_HOST: http://" not in vps_override
+    assert "WEB_UPSTREAM_HOST: https://" not in vps_override

--- a/scripts/deploy_vps.sh
+++ b/scripts/deploy_vps.sh
@@ -1,62 +1,33 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Load environment variables robustly
-if [ -f .env ]; then
-  set -a
-  # shellcheck disable=SC1091
-  source .env
-  set +a
-fi
+# Deprecated compatibility shim.
+#
+# This script used to run `docker compose -f infra/compose/compose.prod.yml up`
+# directly. That deployed the base compose file *without*
+# `infra/compose/compose.vps.override.yml`, which silently dropped every
+# VPS-specific setting: the Caddyfile.vps mount, APP_BASE_URL, POLICY_LIMITS_PATH,
+# the IPv6 port bindings, the AUTH_RL_* rate limits and AUTH_TRUSTED_PROXIES.
+# It also left Caddy bound to 127.0.0.1 (compose.prod.yml's CADDY_BIND default),
+# so the host was not publicly reachable.
+#
+# `scripts/weltgewebe-up` is the real VPS entrypoint. It selects the override
+# file, resolves the runtime env file, and runs the deploy preflights. This shim
+# delegates to it so existing runbooks and muscle memory keep working.
 
-echo "Deploying to VPS..."
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
-# --- Validation ---
+echo "WARNING: scripts/deploy_vps.sh is deprecated." >&2
+echo "         Use scripts/weltgewebe-up instead; delegating to it now." >&2
 
-if [ ! -f "infra/compose/compose.prod.yml" ]; then
-  echo "Error: infra/compose/compose.prod.yml not found."
-  exit 1
-fi
+PRUNE_IMAGES="${PRUNE_IMAGES:-0}"
 
-if [ -z "${WEB_UPSTREAM_HOST:-}" ]; then
-  echo "Error: WEB_UPSTREAM_HOST is not set in .env or environment."
-  exit 1
-fi
+DEPLOY_TARGET="${DEPLOY_TARGET:-vps}" "${SCRIPT_DIR}/weltgewebe-up" "$@"
 
-if [[ "${WEB_UPSTREAM_HOST:-}" =~ ^https?:// ]]; then
-  echo "Error: WEB_UPSTREAM_HOST should not contain http:// or https:// (just the domain)."
-  exit 1
-fi
-
-if [[ ! "${WEB_UPSTREAM_URL:-}" =~ ^https:// ]]; then
-  echo "Error: WEB_UPSTREAM_URL is not set or does not start with 'https://'."
-  exit 1
-fi
-
-# --- Deployment ---
-
-# Generate robust API version tag (fallback to date if git fails or no .git)
-API_VERSION=$(git rev-parse --short HEAD 2> /dev/null || date +%F-%s)
-export API_VERSION
-echo "Deploying with API_VERSION=${API_VERSION}"
-
-# Try to pull latest images (if registry is configured)
-# If pull fails (e.g. no registry auth or local build intended), we continue to build
-echo "Pulling images..."
-docker compose -f infra/compose/compose.prod.yml pull || echo "Pull failed or images not found, proceeding to build..."
-
-# Start services (build if missing or forced by changes)
-echo "Starting services..."
-docker compose -f infra/compose/compose.prod.yml up -d --build
-
-# Cleanup unused images (Optional)
-PRUNE_IMAGES=${PRUNE_IMAGES:-0}
-
+# Preserve the one capability weltgewebe-up does not offer.
 if [ "$PRUNE_IMAGES" -eq 1 ]; then
   echo "Pruning unused images..."
   docker image prune -f
 else
   echo "Skipping image prune (set PRUNE_IMAGES=1 to enable)."
 fi
-
-echo "Deployment complete."


### PR DESCRIPTION
## Aktualisierung nach Integration des aktuellen `main`

Der PR wurde auf `main`-Commit `dbff96820c63601f3416c222f224ead86b4aecd8` neu aufgebaut. Der aktuelle PR-Head ist `8ec03d2a65b1008f2ecda084c3cd60ad9bcb0baa`; der vollständige Diff hat SHA-256 `d55437b791898692e6ab0d4096347d6b83843e9d4935622d6a55347e579cd837`.

Der frühere dritte Commit mit Reparaturen für den damaligen #1380-Stand wurde bewusst entfernt: Der aktuelle `main` enthält inzwischen eine weitergehende SMTP-TLS-Portlogik und einen robusteren Token-Binding-Test mit gefälschtem Hash. Übernommen bleiben nur die weiterhin relevanten Auditbefunde zu Proxy-Trust, VPS-Deploy, Map-Unmount, CSRF und Testtransparenz.

Aktuelle lokale Belege auf diesem Head:

- vollständiges `just ci`: grün
- Proxy-Trust-Preflight: 6/6 grün
- Trusted-Proxy-Rusttests: 5/5 grün
- Startup-Guard und CSRF-Logout-All-Test: grün
- gerendertes VPS-Compose: Proxy-CIDR und Per-IP-Limits korrekt gekoppelt
- `scripts/deploy_vps.sh`: `bash -n` und ShellCheck grün

GitHub-CI wird nach der Branch-Aktualisierung erneut vollständig ausgeführt.

---

Fünf Befunde aus einem Full-Repo-Audit. Der Anwendungscode ist solide — alle
Fehler sitzen an den Nahtstellen zwischen Code und Deployment.

## 1. Per-IP-Rate-Limiting war hinter Caddy wirkungslos (hoch)

`effective_client_ip` wertet `X-Forwarded-For` nur für einen Peer aus, der in
`AUTH_TRUSTED_PROXIES` steht — Default: Loopback. Caddy erreicht die API über
das Compose-Bridge-Netz und war damit **nie** trusted: XFF wurde verworfen und
alle Clients landeten in einem einzigen Per-IP-Bucket.

Mit `AUTH_PUBLIC_LOGIN=1` und `AUTH_RL_IP_PER_MIN=5` sperrt ein Angreifer für
fünf Requests den Login der gesamten Site. Zusätzlich protokollierte jede
Audit-Logzeile die Proxy-IP als Client.

- `AppConfig::validate` verweigert jetzt den Start bei Public-Login + Per-IP-Limits
  + undeklariertem Proxy-Trust. Eine direkt exponierte API muss das mit
  `AUTH_TRUSTED_PROXIES=none` sagen (vertraut dann nichts, auch nicht Loopback).
- Beide Deployment-Overrides deklarieren die Bridge-CIDR nun **neben** den
  Rate-Limits, die sie erst wirksam machen. Das Fail-Closed hat dabei
  aufgedeckt, dass `compose.prod.override.yml` (heimserver) denselben latenten
  Bug trug.
- `AppConfig.auth_trusted_proxies` wurde eingelesen, validiert — und dann
  **ignoriert**: der Request-Pfad las die Env direkt. Ein Config-File-Eintrag
  hatte keinerlei Wirkung. `run()` installiert die Allowlist jetzt aus der
  validierten Config.
- Neuer CI-Preflight verhindert Drift zwischen Compose und Binary.

## 2. `deploy_vps.sh` deployte einen Stack, den niemand wollte (mittel–hoch)

`docs/deploy/vps.md` verwies darauf, aber das Skript rief `compose.prod.yml`
**ohne** `compose.vps.override.yml` auf: kein `Caddyfile.vps`, kein
`APP_BASE_URL`, kein `POLICY_LIMITS_PATH`, keine IPv6-Bindings, keine
`AUTH_RL_*`-Limits — und Caddy blieb an `127.0.0.1` gebunden, der Host also
nicht erreichbar.

Jetzt ein deprecateter Shim, der an `scripts/weltgewebe-up` delegiert. Die
Troubleshooting-Kommandos der Runbook ließen die Override-Datei ebenfalls weg
und nutzen nun einen Compose-Alias, der zum Deploy passt.

## 3. Map-Seite ohne Unmount-Guard (mittel)

`onMount` gab sein Cleanup synchron zurück, während der Initialisierer noch auf
`await import('maplibre-gl')` hing. Wurde die Komponente in diesem Fenster
zerstört, räumte das Cleanup nichts auf — und der Initialisierer baute danach
in aller Ruhe eine MapLibre-Instanz, hängte einen Listener an einen abgehängten
Container, abonnierte einen Store und registrierte das pmtiles-Protokoll.
Nichts davon wurde je abgebaut. Der 10s-Ladetimer war IIFE-lokal und leckte
auch im Normalpfad.

## 4. Eine CSRF-Ausnahme traf keine Route (niedrig)

`require_csrf` nahm Pfade aus, die auf `/auth/login` enden — eine Route, die es
nicht gibt (die Entry-Points sind `/auth/dev/login` und
`/auth/magic-link/request`, beide bereits durch den No-Session-Cookie-Skip
abgedeckt). Die Logout-Ausnahme ist bewusst gesetzt und bleibt. Ein
tautologischer Unit-Test wurde durch Tests ersetzt, die den echten Arm
festnageln — inklusive der Zusicherung, dass `logout-all` nicht vom
`ends_with` verschluckt wird.

## 5. Kleinigkeiten

Dokumentiert, warum das inert-Polyfill seine Listener nie entfernt. `just test`
sagt jetzt, dass 62 DB-gestützte Tests übersprungen wurden, statt „ok" für
Code zu melden, den es nie ausgeführt hat.

---

## Verifikation

| Prüfung | Ergebnis |
|---|---|
| `cargo fmt --check`, `cargo clippy -D warnings` | sauber |
| `cargo test --locked` | 451 passed (vorher 437), 0 failed |
| `pnpm test:unit` / `svelte-check` / `pnpm lint` | 126 passed / 0 errors / sauber |
| `pytest scripts/ci/tests/` | 109 passed |
| `just lint` (shellcheck, shfmt), `yamllint` | sauber |

Verhaltensnachweise statt nur Unit-Tests:

- `docker compose config` bestätigt, dass der Override die Allowlist liefert
  (`127.0.0.1,::1,172.16.0.0/12`), dass eine Operator-Env-Datei sie überschreibt
  (`none`), und dass die Basisdatei allein leer bleibt.
- Die Binary mit der zuvor kaputten Kombination gestartet → bricht mit der
  erklärenden Meldung ab (exit 1). Mit `AUTH_TRUSTED_PROXIES=none` → startet und
  serviert.

## Breaking change für Operatoren

Ein Stack mit `AUTH_PUBLIC_LOGIN=1` **und** gesetztem `AUTH_RL_IP_PER_MIN`/
`AUTH_RL_IP_PER_HOUR` startet nicht mehr ohne `AUTH_TRUSTED_PROXIES`. Beide
mitgelieferten Overrides setzen jetzt einen sinnvollen Default; nur
handgerollte Deployments müssen nachziehen. Die Fehlermeldung nennt beide
gültigen Auswege.

`agent-policy.yaml` markiert `deployment/` als `human_review_required` — dieser
PR berührt Deploy-Pfade und braucht entsprechend menschliche Freigabe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
