### PR TITLE
fix(auth,deploy): enforce TLS and canonical VPS env

### DIFF
--- a/apps/api/src/mailer.rs
+++ b/apps/api/src/mailer.rs
@@ -103,7 +103,12 @@ impl Mailer {
             anyhow::bail!("invalid from address: {}", from);
         }
 
-        let transport = match smtp_security_for_port(port) {
+        let smtp_security = smtp_security_for_port(port);
+        if smtp_security == SmtpSecurity::Plaintext && creds.is_some() {
+            anyhow::bail!("refusing SMTP authentication without TLS on port {port}");
+        }
+
+        let transport = match smtp_security {
             SmtpSecurity::ImplicitTls => {
                 let mut builder = AsyncSmtpTransport::<Tokio1Executor>::relay(host)
                     .context("failed to init SMTP relay (implicit TLS, port 465)")?
@@ -239,6 +244,49 @@ mod tests {
         assert!(body.contains("Button not working?"));
         assert!(body.contains("&amp;next=&lt;home&gt;"));
         assert!(!body.contains("&next=<home>"));
+    }
+
+    #[test]
+    #[serial]
+    fn mailer_rejects_credentials_on_plaintext_port() {
+        let _smtp_auth = crate::test_helpers::EnvGuard::set("SMTP_AUTH", "on");
+        let config = AppConfig {
+            fade_days: 7,
+            ron_days: 84,
+            anonymize_opt_in: true,
+            delegation_expire_days: 28,
+            domain_read_source: crate::config::DomainReadSource::Jsonl,
+            domain_account_write_source: crate::config::DomainAccountWriteSource::Jsonl,
+            domain_node_write_source: crate::config::DomainNodeWriteSource::Jsonl,
+            domain_edge_write_source: crate::config::DomainEdgeWriteSource::Jsonl,
+            passkey_credential_source: crate::config::PasskeyCredentialSource::InMemory,
+            auth_public_login: false,
+            app_base_url: None,
+            auth_trusted_proxies: None,
+            auth_allow_emails: None,
+            auth_allow_email_domains: None,
+            auth_auto_provision: false,
+            auth_rl_ip_per_min: None,
+            auth_rl_ip_per_hour: None,
+            auth_rl_email_per_min: None,
+            auth_rl_email_per_hour: None,
+            smtp_host: Some("127.0.0.1".to_string()),
+            smtp_port: Some(1025),
+            smtp_user: Some("user".to_string()),
+            smtp_pass: Some("pass".to_string()),
+            smtp_from: Some("noreply@example.com".to_string()),
+            auth_log_magic_token: false,
+            webauthn_rp_id: None,
+            webauthn_rp_origin: None,
+            webauthn_rp_name: None,
+        };
+
+        let result = Mailer::new(&config);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("refusing SMTP authentication without TLS on port 1025"));
     }
 
     #[test]

--- a/apps/api/src/mailer.rs
+++ b/apps/api/src/mailer.rs
@@ -6,6 +6,21 @@ use lettre::{
     AsyncTransport, Message, Tokio1Executor,
 };
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SmtpSecurity {
+    ImplicitTls,
+    StartTls,
+    Plaintext,
+}
+
+fn smtp_security_for_port(port: u16) -> SmtpSecurity {
+    match port {
+        465 => SmtpSecurity::ImplicitTls,
+        587 | 2525 => SmtpSecurity::StartTls,
+        _ => SmtpSecurity::Plaintext,
+    }
+}
+
 #[derive(Debug)]
 pub struct Mailer {
     transport: AsyncSmtpTransport<Tokio1Executor>,
@@ -88,29 +103,33 @@ impl Mailer {
             anyhow::bail!("invalid from address: {}", from);
         }
 
-        let transport = if port == 465 {
-            let mut builder = AsyncSmtpTransport::<Tokio1Executor>::relay(host)
-                .context("failed to init SMTP relay (implicit TLS, port 465)")?
-                .port(port);
-            if let Some(creds) = creds.as_ref() {
-                builder = builder.credentials(creds.clone());
+        let transport = match smtp_security_for_port(port) {
+            SmtpSecurity::ImplicitTls => {
+                let mut builder = AsyncSmtpTransport::<Tokio1Executor>::relay(host)
+                    .context("failed to init SMTP relay (implicit TLS, port 465)")?
+                    .port(port);
+                if let Some(creds) = creds.as_ref() {
+                    builder = builder.credentials(creds.clone());
+                }
+                builder.build()
             }
-            builder.build()
-        } else if port == 587 {
-            let mut builder = AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(host)
-                .context("failed to init SMTP relay (STARTTLS, port 587)")?
-                .port(port);
-            if let Some(creds) = creds.as_ref() {
-                builder = builder.credentials(creds.clone());
+            SmtpSecurity::StartTls => {
+                let mut builder = AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(host)
+                    .with_context(|| format!("failed to init SMTP relay (STARTTLS, port {port})"))?
+                    .port(port);
+                if let Some(creds) = creds.as_ref() {
+                    builder = builder.credentials(creds.clone());
+                }
+                builder.build()
             }
-            builder.build()
-        } else {
-            let mut builder =
-                AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(host).port(port);
-            if let Some(creds) = creds.as_ref() {
-                builder = builder.credentials(creds.clone());
+            SmtpSecurity::Plaintext => {
+                let mut builder =
+                    AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(host).port(port);
+                if let Some(creds) = creds.as_ref() {
+                    builder = builder.credentials(creds.clone());
+                }
+                builder.build()
             }
-            builder.build()
         };
 
         Ok(Self {
@@ -199,6 +218,14 @@ mod tests {
     use crate::config::AppConfig;
     use chrono::TimeZone;
     use serial_test::serial;
+
+    #[test]
+    fn smtp_submission_ports_use_expected_tls_modes() {
+        assert_eq!(smtp_security_for_port(465), SmtpSecurity::ImplicitTls);
+        assert_eq!(smtp_security_for_port(587), SmtpSecurity::StartTls);
+        assert_eq!(smtp_security_for_port(2525), SmtpSecurity::StartTls);
+        assert_eq!(smtp_security_for_port(1025), SmtpSecurity::Plaintext);
+    }
 
     #[test]
     fn repeated_login_email_has_request_identity_and_fallback_link() {

--- a/docs/deploy/vps.md
+++ b/docs/deploy/vps.md
@@ -150,23 +150,32 @@ Deploy-Wrapper. `vps` ist der Default-Zieltyp:
 
 ```bash
 cd /opt/weltgewebe
-./scripts/weltgewebe-up --branch main
+sudo -n env \
+  GIT_CONFIG_COUNT=1 \
+  GIT_CONFIG_KEY_0=safe.directory \
+  GIT_CONFIG_VALUE_0=/opt/weltgewebe \
+  DEPLOY_TARGET=vps \
+  ./scripts/weltgewebe-up --branch main
 ```
 
-Der Zieltyp kann weiterhin explizit gesetzt werden:
+Der privilegierte Operatorpfad ist beabsichtigt: Die kanonische Runtime-Datei
+liegt in einem nur für `root` zugänglichen Verzeichnis. Ein unprivilegierter
+Aufruf bricht deshalb klar und ohne Legacy-Fallback ab.
 
-```bash
-DEPLOY_TARGET=vps ./scripts/weltgewebe-up --branch main
-```
-
-Wenn `ENV_FILE` nicht gesetzt ist, bevorzugt der VPS-Zieltyp
-`/etc/weltgewebe/weltgewebe.env`, sofern die Datei existiert. Für Tests,
-Rollback oder abweichende Installationen kann die Quelle bewusst überschrieben
-werden:
+Wenn `ENV_FILE` nicht oder leer gesetzt ist, wählt der VPS-Zieltyp immer
+`/etc/weltgewebe/weltgewebe.env`. Fehlt diese Datei oder ist sie für den
+aufrufenden Operator nicht lesbar, endet der Deploy fail-closed. Für Tests,
+Rollback oder abweichende Installationen kann eine andere, ausdrücklich
+gewählte Quelle verwendet werden:
 
 ```bash
 DEPLOY_TARGET=vps ENV_FILE=/path/to/runtime.env ./scripts/weltgewebe-up --branch main
 ```
+
+SMTP-Zugangsdaten werden nur über TLS übertragen: Port `465` nutzt implizites
+TLS, die Submission-Ports `587` und `2525` erzwingen STARTTLS. Auf anderen
+Ports verweigert die API SMTP-Authentifizierung, statt Zugangsdaten im Klartext
+zu senden.
 
 Der VPS-Zieltyp unterscheidet sich vom historischen Heimserver-Ziel:
 

--- a/scripts/ci/tests/test_public_login_smtp_readiness.py
+++ b/scripts/ci/tests/test_public_login_smtp_readiness.py
@@ -50,6 +50,30 @@ def test_production_public_login_passes_with_authenticated_smtp(tmp_path: Path) 
     assert all(result.ok for result in results), [result.payload() for result in results]
 
 
+def test_production_public_login_accepts_authenticated_starttls_on_port_2525() -> None:
+    module = load_module()
+    env = {
+        "AUTH_PUBLIC_LOGIN": "1",
+        "AUTH_LOG_MAGIC_TOKEN": "0",
+        "APP_BASE_URL": "https://weltgewebe.net",
+        "SMTP_HOST": "smtp.example.test",
+        "SMTP_PORT": "2525",
+        "SMTP_AUTH": "on",
+        "SMTP_USER": "user-secret",
+        "SMTP_PASS": "pass-secret",
+        "SMTP_FROM": "noreply@weltgewebe.net",
+    }
+
+    results = module.run_checks(
+        env,
+        production_public_login=True,
+        expected_app_base_url="https://weltgewebe.net",
+        allow_unauthenticated_smtp=False,
+    )
+
+    assert all(result.ok for result in results), [result.payload() for result in results]
+
+
 def test_production_public_login_rejects_magic_token_logging(tmp_path: Path) -> None:
     module = load_module()
     env = {

--- a/scripts/ci/tests/test_public_login_smtp_readiness.py
+++ b/scripts/ci/tests/test_public_login_smtp_readiness.py
@@ -74,6 +74,35 @@ def test_production_public_login_accepts_authenticated_starttls_on_port_2525() -
     assert all(result.ok for result in results), [result.payload() for result in results]
 
 
+def test_production_public_login_rejects_plaintext_smtp_ports() -> None:
+    module = load_module()
+
+    for port in (25, 2526):
+        env = {
+            "AUTH_PUBLIC_LOGIN": "1",
+            "AUTH_LOG_MAGIC_TOKEN": "0",
+            "APP_BASE_URL": "https://weltgewebe.net",
+            "SMTP_HOST": "smtp.example.test",
+            "SMTP_PORT": str(port),
+            "SMTP_AUTH": "on",
+            "SMTP_USER": "user-secret",
+            "SMTP_PASS": "pass-secret",
+            "SMTP_FROM": "noreply@weltgewebe.net",
+        }
+        smtp_port = [
+            item
+            for item in module.run_checks(
+                env,
+                production_public_login=True,
+                expected_app_base_url="https://weltgewebe.net",
+                allow_unauthenticated_smtp=False,
+            )
+            if item.name == "smtp-port"
+        ][0]
+
+        assert not smtp_port.ok
+
+
 def test_production_public_login_rejects_magic_token_logging(tmp_path: Path) -> None:
     module = load_module()
     env = {

--- a/scripts/ci/tests/test_vps_credential_source_defaults.py
+++ b/scripts/ci/tests/test_vps_credential_source_defaults.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import subprocess
 from pathlib import Path
 
 
@@ -35,7 +37,7 @@ def test_weltgewebe_up_defaults_to_vps_and_keeps_heimserver_legacy_target_explic
 def test_weltgewebe_up_selects_canonical_vps_credential_source_when_unset() -> None:
     text = SCRIPT.read_text(encoding="utf-8")
 
-    assert 'ENV_FILE_WAS_SET="${ENV_FILE+x}"' in text
+    assert 'ENV_FILE_WAS_SET="${ENV_FILE:+x}"' in text
     assert (
         'VPS_DEFAULT_ENV_FILE="${VPS_DEFAULT_ENV_FILE:-/etc/weltgewebe/weltgewebe.env}"'
         in text
@@ -50,9 +52,68 @@ def test_weltgewebe_up_selects_canonical_vps_credential_source_when_unset() -> N
     )
     deploy_target = text.index('DEPLOY_TARGET="${DEPLOY_TARGET:-vps}"')
     switch_default = text.index('ENV_FILE="$VPS_DEFAULT_ENV_FILE"')
-    env_check = text.index('if [[ ! -f "$ENV_FILE" ]]')
+    env_normalize = text.index('if [[ "$ENV_FILE" != /* ]]')
+    env_check = text.index('if [[ ! -r "$ENV_FILE" ]]')
 
-    assert explicit_default < vps_default < deploy_target < switch_default < env_check
+    assert explicit_default < vps_default < deploy_target < switch_default < env_normalize < env_check
+    assert 'ENV_FILE is missing or not readable' in text
+    assert 'documented privileged operator path' in text
+
+
+def run_until_env_guard(tmp_path: Path, *, env_file: str | None) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "DEPLOY_TARGET": "vps",
+            "REPO_DIR": str(REPO),
+            "VPS_DEFAULT_ENV_FILE": str(tmp_path / "canonical.env"),
+            "WELTGEWEBE_STATE_DIR": str(tmp_path / "state"),
+        }
+    )
+    if env_file is None:
+        env.pop("ENV_FILE", None)
+    else:
+        env["ENV_FILE"] = env_file
+
+    return subprocess.run(
+        [str(SCRIPT), "--no-pull"],
+        cwd=REPO,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+
+
+def test_empty_env_file_selects_canonical_source_and_fails_closed(tmp_path: Path) -> None:
+    proc = run_until_env_guard(tmp_path, env_file="")
+
+    assert proc.returncode == 2
+    assert str(tmp_path / "canonical.env") in proc.stdout
+    assert "/opt/weltgewebe/.env" not in proc.stdout
+    assert "missing or not readable" in proc.stdout
+
+
+def test_unreadable_canonical_source_fails_with_operator_guidance(tmp_path: Path) -> None:
+    canonical = tmp_path / "canonical.env"
+    canonical.write_text("APP_BASE_URL=https://weltgewebe.net\n", encoding="utf-8")
+    canonical.chmod(0)
+    try:
+        proc = run_until_env_guard(tmp_path, env_file=None)
+    finally:
+        canonical.chmod(0o600)
+
+    assert proc.returncode == 2
+    assert "missing or not readable" in proc.stdout
+    assert "documented privileged operator path" in proc.stdout
+
+
+def test_vps_binds_compose_env_mount_to_selected_env_file() -> None:
+    text = SCRIPT.read_text(encoding="utf-8")
+
+    assert 'if [[ "$DEPLOY_TARGET" == "vps" ]]' in text
+    assert 'export WELTGEWEBE_ENV_FILE="$ENV_FILE"' in text
 
 
 def test_vps_runbook_documents_post_cutover_credential_source() -> None:

--- a/scripts/ci/tests/test_vps_credential_source_defaults.py
+++ b/scripts/ci/tests/test_vps_credential_source_defaults.py
@@ -32,7 +32,7 @@ def test_weltgewebe_up_defaults_to_vps_and_keeps_heimserver_legacy_target_explic
     assert "vps (default) or heimserver (legacy)" in text
 
 
-def test_weltgewebe_up_selects_vps_credential_source_only_when_unset() -> None:
+def test_weltgewebe_up_selects_canonical_vps_credential_source_when_unset() -> None:
     text = SCRIPT.read_text(encoding="utf-8")
 
     assert 'ENV_FILE_WAS_SET="${ENV_FILE+x}"' in text
@@ -40,11 +40,8 @@ def test_weltgewebe_up_selects_vps_credential_source_only_when_unset() -> None:
         'VPS_DEFAULT_ENV_FILE="${VPS_DEFAULT_ENV_FILE:-/etc/weltgewebe/weltgewebe.env}"'
         in text
     )
-    assert (
-        '[[ "$DEPLOY_TARGET" == "vps" && -z "$ENV_FILE_WAS_SET" '
-        '&& -f "$VPS_DEFAULT_ENV_FILE" ]]'
-        in text
-    )
+    assert '[[ "$DEPLOY_TARGET" == "vps" && -z "$ENV_FILE_WAS_SET" ]]' in text
+    assert '&& -f "$VPS_DEFAULT_ENV_FILE"' not in text
     assert 'ENV_FILE="$VPS_DEFAULT_ENV_FILE"' in text
 
     explicit_default = text.index('ENV_FILE="${ENV_FILE:-/opt/weltgewebe/.env}"')

--- a/scripts/ops/check_public_login_smtp_readiness.py
+++ b/scripts/ops/check_public_login_smtp_readiness.py
@@ -137,7 +137,7 @@ def check_smtp_port(env: Mapping[str, str]) -> CheckResult:
         port = int(raw)
     except ValueError:
         return fail_result("smtp-port", "SMTP_PORT is not a number", status="invalid")
-    if port in {465, 587}:
+    if port in {465, 587, 2525}:
         return pass_result("smtp-port", "SMTP_PORT is a production TLS port", port=port)
     if port == 25:
         return fail_result("smtp-port", "SMTP_PORT 25 is not accepted for public-login rollout", port=port)

--- a/scripts/weltgewebe-up
+++ b/scripts/weltgewebe-up
@@ -10,7 +10,7 @@ set -euo pipefail
 #   weltgewebe-up [--with-caddy] [--no-pull] [--build-mode auto|force|no] [--branch BRANCH|--current-branch]
 
 # REPO_DIR defaults are handled in resolution logic below
-ENV_FILE_WAS_SET="${ENV_FILE+x}"
+ENV_FILE_WAS_SET="${ENV_FILE:+x}"
 ENV_FILE="${ENV_FILE:-/opt/weltgewebe/.env}"
 VPS_DEFAULT_ENV_FILE="${VPS_DEFAULT_ENV_FILE:-/etc/weltgewebe/weltgewebe.env}"
 COMPOSE_PROJECT="${COMPOSE_PROJECT:-weltgewebe}"
@@ -27,9 +27,9 @@ case "$DEPLOY_TARGET" in
 esac
 
 if [[ "$DEPLOY_TARGET" == "vps" && -z "$ENV_FILE_WAS_SET" ]]; then
-  # Select the canonical VPS credential source unconditionally. Whether the
-  # invoking user can read it is validated below; silently falling back to the
-  # repo-local legacy file would make deploy behaviour depend on user identity.
+  # Select the canonical VPS credential source unconditionally. Readability
+  # is validated below; silently falling back to the repo-local legacy file
+  # would make deploy behaviour depend on user identity.
   ENV_FILE="$VPS_DEFAULT_ENV_FILE"
 fi
 
@@ -254,6 +254,32 @@ fi
 
 export COMPOSE_PROJECT_NAME="$COMPOSE_PROJECT"
 
+# 1. Environment Check
+# Normalize ENV_FILE before checking it so relative overrides resolve against
+# the selected repository root rather than the caller's working directory.
+if [[ "$ENV_FILE" != /* ]]; then
+  ENV_FILE="${REPO_DIR}/${ENV_FILE}"
+fi
+
+if [[ ! -r "$ENV_FILE" ]]; then
+  echo
+  echo "ERROR: ENV_FILE is missing or not readable: $ENV_FILE"
+  if [[ "$DEPLOY_TARGET" == "vps" && "$ENV_FILE" == "$VPS_DEFAULT_ENV_FILE" ]]; then
+    echo "The canonical VPS env is root-managed; run the deploy through the documented privileged operator path."
+  else
+    echo "Create a readable runtime env file or set ENV_FILE=/path/to/runtime.env explicitly."
+  fi
+  exit 2
+fi
+
+if [[ "$DEPLOY_TARGET" == "vps" ]]; then
+  # Keep Compose interpolation and the container env_file mount bound to the
+  # same explicitly selected source. Use ENV_FILE for intentional overrides.
+  export WELTGEWEBE_ENV_FILE="$ENV_FILE"
+else
+  export WELTGEWEBE_ENV_FILE="${WELTGEWEBE_ENV_FILE:-$ENV_FILE}"
+fi
+
 # --- Bake Configuration ---
 # If running in 'auto' mode and /apps is missing, we disable bake to prevent
 # "resolve : lstat /apps: no such file or directory" errors in environments
@@ -350,21 +376,6 @@ echo "Repo:    $(pwd)"
 echo "Target:  $DEPLOY_TARGET"
 echo "Project: $COMPOSE_PROJECT"
 echo "Env:     $ENV_FILE"
-
-# 1. Environment Check
-if [[ ! -f "$ENV_FILE" ]]; then
-  echo
-  echo "ERROR: ENV_FILE not found: $ENV_FILE"
-  echo "Please create it (e.g. from .env.example) or set ENV_FILE=/path/to/.env"
-  exit 2
-fi
-
-# Normalize ENV_FILE to absolute path
-if [[ "$ENV_FILE" != /* ]]; then
-  ENV_FILE="${REPO_DIR}/${ENV_FILE}"
-fi
-
-export WELTGEWEBE_ENV_FILE="${WELTGEWEBE_ENV_FILE:-$ENV_FILE}"
 
 # Git State Tracking Variables
 GIT_FETCH_ATTEMPTED="no"

--- a/scripts/weltgewebe-up
+++ b/scripts/weltgewebe-up
@@ -26,7 +26,10 @@ case "$DEPLOY_TARGET" in
     ;;
 esac
 
-if [[ "$DEPLOY_TARGET" == "vps" && -z "$ENV_FILE_WAS_SET" && -f "$VPS_DEFAULT_ENV_FILE" ]]; then
+if [[ "$DEPLOY_TARGET" == "vps" && -z "$ENV_FILE_WAS_SET" ]]; then
+  # Select the canonical VPS credential source unconditionally. Whether the
+  # invoking user can read it is validated below; silently falling back to the
+  # repo-local legacy file would make deploy behaviour depend on user identity.
   ENV_FILE="$VPS_DEFAULT_ENV_FILE"
 fi
 


### PR DESCRIPTION
## Summary

- force SMTP submission port 2525 through STARTTLS instead of the plaintext fallback
- accept 2525 in the production public-login SMTP readiness checker
- make `weltgewebe-up` select the canonical VPS env source unconditionally when `ENV_FILE` is not explicitly set
- update regression tests for the TLS mode and fail-closed VPS env selection

## Why

Issue #1384 proved that privileged and unprivileged deploys could silently select different env files. The live SMTP endpoint is reachable with a verified STARTTLS certificate on port 2525, while ports 587 and 465 are unavailable. The previous mailer treated 2525 as a dangerous plaintext transport.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked -p weltgewebe-api mailer::tests:: -- --test-threads=1`
- `cargo check --locked -p weltgewebe-api`
- `cargo clippy --locked -p weltgewebe-api --all-targets -- -D warnings`
- `python3 -m pytest -q scripts/ci/tests/test_public_login_smtp_readiness.py scripts/ci/tests/test_vps_credential_source_defaults.py`
- `bash -n scripts/weltgewebe-up`
- `git diff --check`

Part of #1384. Runtime reconciliation and live Gmail proof follow after merge.
