### PR TITLE
ops: add safe public-login env reconciler

### DIFF
--- a/.github/workflows/public-login-smtp-readiness.yml
+++ b/.github/workflows/public-login-smtp-readiness.yml
@@ -6,15 +6,21 @@ name: Public login SMTP readiness
     branches: [main]
     paths:
       - "scripts/ops/check_public_login_smtp_readiness.py"
+      - "scripts/ops/reconcile_public_login_smtp_env.py"
       - "scripts/ci/tests/test_public_login_smtp_readiness.py"
+      - "scripts/ci/tests/test_reconcile_public_login_smtp_env.py"
       - "docs/deploy/README.md"
+      - "docs/deploy/vps.md"
       - ".github/workflows/public-login-smtp-readiness.yml"
   push:
     branches: [main]
     paths:
       - "scripts/ops/check_public_login_smtp_readiness.py"
+      - "scripts/ops/reconcile_public_login_smtp_env.py"
       - "scripts/ci/tests/test_public_login_smtp_readiness.py"
+      - "scripts/ci/tests/test_reconcile_public_login_smtp_env.py"
       - "docs/deploy/README.md"
+      - "docs/deploy/vps.md"
       - ".github/workflows/public-login-smtp-readiness.yml"
   workflow_dispatch: {}
 
@@ -43,8 +49,16 @@ jobs:
       - name: Install pytest
         run: python -m pip install pytest
 
-      - name: Compile public-login SMTP readiness checker
-        run: python -m py_compile scripts/ops/check_public_login_smtp_readiness.py
+      - name: Compile public-login SMTP operations
+        run: |
+          python -m py_compile \
+            scripts/ops/check_public_login_smtp_readiness.py \
+            scripts/ops/reconcile_public_login_smtp_env.py \
+            scripts/ci/tests/test_public_login_smtp_readiness.py \
+            scripts/ci/tests/test_reconcile_public_login_smtp_env.py
 
       - name: Run public-login SMTP readiness tests
-        run: python -m pytest scripts/ci/tests/test_public_login_smtp_readiness.py -q
+        run: |
+          python -m pytest -q \
+            scripts/ci/tests/test_public_login_smtp_readiness.py \
+            scripts/ci/tests/test_reconcile_public_login_smtp_env.py

--- a/.github/workflows/public-login-smtp-readiness.yml
+++ b/.github/workflows/public-login-smtp-readiness.yml
@@ -47,7 +47,7 @@ jobs:
           python-version-file: ".python-version"
 
       - name: Install pytest
-        run: python -m pip install pytest
+        run: python -m pip install pytest==8.3.4
 
       - name: Compile public-login SMTP operations
         run: |

--- a/docs/deploy/vps.md
+++ b/docs/deploy/vps.md
@@ -232,8 +232,7 @@ keine Secret-Werte aus. Der ausgegebene `plan_sha256` bindet Quell-, Ziel- und
 Backup-Pfad, Geräte- und Inode-Identitäten, Eigentümer, Modi, vollständigen
 Quelltext, bisherigen Zielinhalt und geplanten Zielinhalt. Dadurch kann die
 Vorschau weder auf eine andere Datei noch auf ein ausgetauschtes
-gleichlautendes File angewendet
-werden. Einzelne Wert-Hashes werden nicht ausgegeben. Ein bereits gehaltener
+gleichlautendes File angewendet werden. Einzelne Wert-Hashes werden nicht ausgegeben. Ein bereits gehaltener
 Reconcile-Lock führt nach spätestens 15 Sekunden zu einem Fehler statt zu
 unbegrenztem Warten.
 

--- a/docs/deploy/vps.md
+++ b/docs/deploy/vps.md
@@ -194,7 +194,6 @@ Nach erfolgreicher Vorschau wird dieselbe, gebundene Operation mit `--apply`
 ausgeführt. Sie übernimmt ausschließlich die dokumentierten Auth-/SMTP-Schlüssel,
 legt vor dem atomischen Austausch ein `0600`-Backup an und gibt keine Werte aus.
 
-
 Der VPS-Zieltyp unterscheidet sich vom historischen Heimserver-Ziel:
 
 * er nutzt `infra/compose/compose.vps.override.yml`,

--- a/docs/deploy/vps.md
+++ b/docs/deploy/vps.md
@@ -177,6 +177,24 @@ TLS, die Submission-Ports `587` und `2525` erzwingen STARTTLS. Auf anderen
 Ports verweigert die API SMTP-Authentifizierung, statt Zugangsdaten im Klartext
 zu senden.
 
+Eine bestehende Repo-lokale Runtime-Datei darf nicht vollständig über die
+kanonische Datei kopiert werden. Für die einmalige, selektive Übernahme der
+Public-Login- und SMTP-Schlüssel dient der wertredigierende Reconciler. Ohne
+`--apply` prüft er nur und verändert nichts:
+
+```bash
+sudo -n python3 scripts/ops/reconcile_public_login_smtp_env.py \
+  --source /opt/weltgewebe/.env \
+  --destination /etc/weltgewebe/weltgewebe.env \
+  --backup-dir /var/backups/weltgewebe/env \
+  --json
+```
+
+Nach erfolgreicher Vorschau wird dieselbe, gebundene Operation mit `--apply`
+ausgeführt. Sie übernimmt ausschließlich die dokumentierten Auth-/SMTP-Schlüssel,
+legt vor dem atomischen Austausch ein `0600`-Backup an und gibt keine Werte aus.
+
+
 Der VPS-Zieltyp unterscheidet sich vom historischen Heimserver-Ziel:
 
 * er nutzt `infra/compose/compose.vps.override.yml`,

--- a/docs/deploy/vps.md
+++ b/docs/deploy/vps.md
@@ -9,6 +9,12 @@ relations:
     target: docs/deploy/README.md
   - type: relates_to
     target: scripts/ops/check_public_live_readiness.py
+  - type: relates_to
+    target: scripts/ops/reconcile_public_login_smtp_env.py
+  - type: relates_to
+    target: scripts/ci/tests/test_reconcile_public_login_smtp_env.py
+  - type: relates_to
+    target: .github/workflows/public-login-smtp-readiness.yml
 ---
 # VPS Deployment Runbook
 
@@ -179,20 +185,75 @@ zu senden.
 
 Eine bestehende Repo-lokale Runtime-Datei darf nicht vollständig über die
 kanonische Datei kopiert werden. Für die einmalige, selektive Übernahme der
-Public-Login- und SMTP-Schlüssel dient der wertredigierende Reconciler. Ohne
-`--apply` prüft er nur und verändert nichts:
+Public-Login- und SMTP-Schlüssel dient der wertredigierende Reconciler.
+Quelle, Ziel und ihre Verzeichnisse müssen root-eigen und nicht gruppen- oder
+weltbeschreibbar sein. Das Backup-Verzeichnis wird einmalig als `0700`
+vorbereitet:
+
+```bash
+sudo -n install -d -m 0700 -o root -g root /var/backups/weltgewebe/env
+```
+
+Die Vorschau läuft ebenfalls als `root` und führt dieselben Pfad-, Eigentümer-,
+Modus-, Symlink- und Inhaltsprüfungen wie der Schreibvorgang aus. Sie verändert
+keine Runtime-Datei und gibt keine Werte aus:
+
+```bash
+cd /opt/weltgewebe
+PREVIEW="$(sudo -n python3 scripts/ops/reconcile_public_login_smtp_env.py \
+  --source /opt/weltgewebe/.env \
+  --destination /etc/weltgewebe/weltgewebe.env \
+  --backup-dir /var/backups/weltgewebe/env \
+  --json)"
+printf '%s\n' "$PREVIEW"
+PLAN_SHA256="$(printf '%s\n' "$PREVIEW" | python3 -c \
+  'import json,sys; print(json.load(sys.stdin)["plan_sha256"])')"
+```
+
+`--apply` akzeptiert ausschließlich den Hash dieser Vorschau. Ändert sich
+Quelle oder Ziel zwischen beiden Schritten, bricht der Vorgang vor Backup und
+Mutation ab:
 
 ```bash
 sudo -n python3 scripts/ops/reconcile_public_login_smtp_env.py \
   --source /opt/weltgewebe/.env \
   --destination /etc/weltgewebe/weltgewebe.env \
   --backup-dir /var/backups/weltgewebe/env \
+  --apply \
+  --expected-plan-sha256 "$PLAN_SHA256" \
   --json
 ```
 
-Nach erfolgreicher Vorschau wird dieselbe, gebundene Operation mit `--apply`
-ausgeführt. Sie übernimmt ausschließlich die dokumentierten Auth-/SMTP-Schlüssel,
-legt vor dem atomischen Austausch ein `0600`-Backup an und gibt keine Werte aus.
+Die Operation übernimmt ausschließlich die dokumentierten Auth-/SMTP-Schlüssel,
+kanonisiert die Runtime-Schalter auf die von API und Mailer tatsächlich
+verstandenen Werte, legt vor dem atomischen Austausch ein bytegenaues
+`0600`-Backup an, liest dieses vor dem Austausch bytegenau zurück und gibt
+keine Secret-Werte aus. Der ausgegebene `plan_sha256` bindet Quell-, Ziel- und
+Backup-Pfad, Geräte- und Inode-Identitäten, Eigentümer, Modi, vollständigen
+Quelltext, bisherigen Zielinhalt und geplanten Zielinhalt. Dadurch kann die
+Vorschau weder auf eine andere Datei noch auf ein ausgetauschtes
+gleichlautendes File angewendet
+werden. Einzelne Wert-Hashes werden nicht ausgegeben. Ein bereits gehaltener
+Reconcile-Lock führt nach spätestens 15 Sekunden zu einem Fehler statt zu
+unbegrenztem Warten.
+
+### Restore der kanonischen Env-Datei
+
+Der JSON-Receipt des Apply-Schritts nennt den erzeugten Backup-Pfad. Vor einem
+Restore wird die laufende fehlerhafte Konfiguration nicht editiert, sondern das
+Backup als neue `0600`-Datei vorbereitet und atomisch eingesetzt:
+
+```bash
+BACKUP=/var/backups/weltgewebe/env/weltgewebe.env.bak-<receipt-suffix>
+sudo -n install -m 0600 -o root -g root \
+  "$BACKUP" /etc/weltgewebe/.weltgewebe.env.restore
+sudo -n mv -f \
+  /etc/weltgewebe/.weltgewebe.env.restore \
+  /etc/weltgewebe/weltgewebe.env
+```
+
+Danach wird derselbe kanonische Deploy-Pfad erneut ausgeführt und die
+Readiness geprüft. Das Backup bleibt bis zum erfolgreichen Live-Smoke erhalten.
 
 Der VPS-Zieltyp unterscheidet sich vom historischen Heimserver-Ziel:
 

--- a/scripts/ci/tests/test_reconcile_public_login_smtp_env.py
+++ b/scripts/ci/tests/test_reconcile_public_login_smtp_env.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import stat
+import subprocess
+import sys
+
+import pytest
+
+
+REPO = Path(__file__).resolve().parents[3]
+SCRIPT = REPO / "scripts" / "ops" / "reconcile_public_login_smtp_env.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "reconcile_public_login_smtp_env", SCRIPT
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def valid_source(*, port: str = "2525") -> str:
+    return "\n".join(
+        (
+            "AUTH_PUBLIC_LOGIN=1",
+            "AUTH_LOG_MAGIC_TOKEN=0",
+            "SMTP_HOST=smtp.example.test",
+            f"SMTP_PORT={port}",
+            "SMTP_AUTH=on",
+            "SMTP_USER=test-user",
+            "SMTP_PASS=test-pass",
+            "SMTP_FROM=noreply@example.test",
+            "UNRELATED_SOURCE=must-not-copy",
+            "",
+        )
+    )
+
+
+def test_build_reconciles_only_approved_keys_and_preserves_unrelated_values() -> None:
+    module = load_module()
+    source = module.parse_env(valid_source(), label="source")
+    selected = module.validate_source(source.values)
+    destination = (
+        "DATABASE_URL=postgres://preserve\nAUTH_PUBLIC_LOGIN=0\nSMTP_HOST=old\n"
+    )
+
+    content = module.build_reconciled_content(destination, selected)
+    parsed = module.parse_env(content, label="result").values
+
+    assert parsed["DATABASE_URL"] == "postgres://preserve"
+    assert parsed["AUTH_PUBLIC_LOGIN"] == "1"
+    assert parsed["SMTP_HOST"] == "smtp.example.test"
+    assert "UNRELATED_SOURCE" not in parsed
+    assert content.count("AUTH_PUBLIC_LOGIN=") == 1
+    assert content.count("SMTP_HOST=") == 1
+
+
+def test_validate_source_rejects_missing_required_key_without_value_output() -> None:
+    module = load_module()
+    values = module.parse_env(
+        valid_source().replace("SMTP_PASS=test-pass\n", ""), label="source"
+    ).values
+
+    with pytest.raises(module.ReconcileError, match="SMTP_PASS") as exc_info:
+        module.validate_source(values)
+
+    assert "test-pass" not in str(exc_info.value)
+
+
+@pytest.mark.parametrize("port", ["25", "1025", "2526", "not-a-number"])
+def test_validate_source_rejects_non_tls_submission_ports(port: str) -> None:
+    module = load_module()
+    values = module.parse_env(valid_source(port=port), label="source").values
+
+    with pytest.raises(module.ReconcileError):
+        module.validate_source(values)
+
+
+@pytest.mark.parametrize("port", ["465", "587", "2525"])
+def test_validate_source_accepts_supported_tls_ports(port: str) -> None:
+    module = load_module()
+    values = module.parse_env(valid_source(port=port), label="source").values
+
+    selected = module.validate_source(values)
+
+    assert selected["SMTP_PORT"] == port
+
+
+def test_cli_dry_run_is_value_redacted_and_does_not_mutate(tmp_path: Path) -> None:
+    source = tmp_path / "legacy.env"
+    destination = tmp_path / "canonical.env"
+    backup_dir = tmp_path / "backups"
+    source.write_text(valid_source(), encoding="utf-8")
+    original = "DATABASE_URL=postgres://preserve\nAUTH_PUBLIC_LOGIN=0\n"
+    destination.write_text(original, encoding="utf-8")
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--source",
+            str(source),
+            "--destination",
+            str(destination),
+            "--backup-dir",
+            str(backup_dir),
+            "--json",
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    receipt = json.loads(proc.stdout)
+    assert receipt["status"] == "planned"
+    assert receipt["applied"] is False
+    assert receipt["values_redacted"] is True
+    assert destination.read_text(encoding="utf-8") == original
+    assert not backup_dir.exists()
+    assert "test-pass" not in proc.stdout
+    assert "test-pass" not in proc.stderr
+
+
+def test_apply_creates_backup_and_forces_mode_0600(tmp_path: Path) -> None:
+    module = load_module()
+    source = tmp_path / "legacy.env"
+    destination = tmp_path / "canonical.env"
+    backup_dir = tmp_path / "backups"
+    source.write_text(valid_source(), encoding="utf-8")
+    original = "DATABASE_URL=postgres://preserve\nAUTH_PUBLIC_LOGIN=0\n"
+    destination.write_text(original, encoding="utf-8")
+    destination.chmod(0o640)
+
+    receipt = module.reconcile(
+        source_path=source,
+        destination_path=destination,
+        backup_dir=backup_dir,
+        apply=True,
+        require_root=False,
+    )
+
+    assert receipt["status"] == "reconciled"
+    assert receipt["applied"] is True
+    assert receipt["values_redacted"] is True
+    assert receipt["mode"] == "0600"
+    assert stat.S_IMODE(destination.stat().st_mode) == 0o600
+    backup = Path(receipt["backup"])
+    assert backup.read_text(encoding="utf-8") == original
+    assert stat.S_IMODE(backup.stat().st_mode) == 0o600
+    parsed = module.parse_env(
+        destination.read_text(encoding="utf-8"), label="result"
+    ).values
+    assert parsed["DATABASE_URL"] == "postgres://preserve"
+    assert parsed["SMTP_PASS"] == "test-pass"
+
+
+def test_apply_is_idempotent_after_first_reconciliation(tmp_path: Path) -> None:
+    module = load_module()
+    source = tmp_path / "legacy.env"
+    destination = tmp_path / "canonical.env"
+    backup_dir = tmp_path / "backups"
+    source.write_text(valid_source(), encoding="utf-8")
+    destination.write_text("DATABASE_URL=postgres://preserve\n", encoding="utf-8")
+
+    first = module.reconcile(
+        source_path=source,
+        destination_path=destination,
+        backup_dir=backup_dir,
+        apply=True,
+        require_root=False,
+    )
+    second = module.reconcile(
+        source_path=source,
+        destination_path=destination,
+        backup_dir=backup_dir,
+        apply=True,
+        require_root=False,
+    )
+
+    assert first["status"] == "reconciled"
+    assert second["status"] == "already_reconciled"
+    assert len(list(backup_dir.iterdir())) == 1
+
+
+def test_symlink_source_is_rejected(tmp_path: Path) -> None:
+    module = load_module()
+    real_source = tmp_path / "real.env"
+    source = tmp_path / "legacy.env"
+    destination = tmp_path / "canonical.env"
+    real_source.write_text(valid_source(), encoding="utf-8")
+    source.symlink_to(real_source)
+    destination.write_text("DATABASE_URL=postgres://preserve\n", encoding="utf-8")
+
+    with pytest.raises(module.ReconcileError, match="must not be a symlink"):
+        module.reconcile(
+            source_path=source,
+            destination_path=destination,
+            backup_dir=tmp_path / "backups",
+            apply=False,
+            require_root=False,
+        )
+
+
+def test_non_root_apply_fails_before_backup_or_mutation(
+    tmp_path: Path, monkeypatch
+) -> None:
+    module = load_module()
+    source = tmp_path / "legacy.env"
+    destination = tmp_path / "canonical.env"
+    backup_dir = tmp_path / "backups"
+    source.write_text(valid_source(), encoding="utf-8")
+    original = "DATABASE_URL=postgres://preserve\n"
+    destination.write_text(original, encoding="utf-8")
+    monkeypatch.setattr(module.os, "geteuid", lambda: 1000)
+
+    with pytest.raises(module.ReconcileError, match="requires root"):
+        module.reconcile(
+            source_path=source,
+            destination_path=destination,
+            backup_dir=backup_dir,
+            apply=True,
+        )
+
+    assert destination.read_text(encoding="utf-8") == original
+    assert not backup_dir.exists()
+
+
+def test_backup_directory_symlink_is_rejected(tmp_path: Path) -> None:
+    module = load_module()
+    source = tmp_path / "legacy.env"
+    destination = tmp_path / "canonical.env"
+    real_backup_dir = tmp_path / "real-backups"
+    backup_dir = tmp_path / "backups"
+    source.write_text(valid_source(), encoding="utf-8")
+    destination.write_text("DATABASE_URL=postgres://preserve\n", encoding="utf-8")
+    real_backup_dir.mkdir()
+    backup_dir.symlink_to(real_backup_dir, target_is_directory=True)
+
+    with pytest.raises(module.ReconcileError, match="must not be a symlink"):
+        module.reconcile(
+            source_path=source,
+            destination_path=destination,
+            backup_dir=backup_dir,
+            apply=True,
+            require_root=False,
+        )
+
+    assert list(real_backup_dir.iterdir()) == []
+
+
+def test_source_and_destination_must_be_different_files(tmp_path: Path) -> None:
+    module = load_module()
+    shared = tmp_path / "shared.env"
+    shared.write_text(valid_source(), encoding="utf-8")
+
+    with pytest.raises(module.ReconcileError, match="must be different files"):
+        module.reconcile(
+            source_path=shared,
+            destination_path=shared,
+            backup_dir=tmp_path / "backups",
+            apply=False,
+            require_root=False,
+        )
+
+
+def test_quoted_whitespace_secret_is_rejected() -> None:
+    module = load_module()
+    values = module.parse_env(
+        valid_source().replace("SMTP_PASS=test-pass", 'SMTP_PASS="   "'),
+        label="source",
+    ).values
+
+    with pytest.raises(module.ReconcileError, match="SMTP_PASS is empty"):
+        module.validate_source(values)

--- a/scripts/ci/tests/test_reconcile_public_login_smtp_env.py
+++ b/scripts/ci/tests/test_reconcile_public_login_smtp_env.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 from pathlib import Path
 import stat
-import subprocess
 import sys
 
 import pytest
@@ -12,6 +12,7 @@ import pytest
 
 REPO = Path(__file__).resolve().parents[3]
 SCRIPT = REPO / "scripts" / "ops" / "reconcile_public_login_smtp_env.py"
+SECRET_SENTINEL = "secret-value-that-must-never-appear-in-a-receipt"
 
 
 def load_module():
@@ -25,16 +26,23 @@ def load_module():
     return module
 
 
-def valid_source(*, port: str = "2525") -> str:
+def valid_source(
+    *,
+    public_login: str = "1",
+    magic_log: str = "0",
+    smtp_auth: str = "on",
+    port: str = "2525",
+    password: str = SECRET_SENTINEL,
+) -> str:
     return "\n".join(
         (
-            "AUTH_PUBLIC_LOGIN=1",
-            "AUTH_LOG_MAGIC_TOKEN=0",
+            f"AUTH_PUBLIC_LOGIN={public_login}",
+            f"AUTH_LOG_MAGIC_TOKEN={magic_log}",
             "SMTP_HOST=smtp.example.test",
             f"SMTP_PORT={port}",
-            "SMTP_AUTH=on",
+            f"SMTP_AUTH={smtp_auth}",
             "SMTP_USER=test-user",
-            "SMTP_PASS=test-pass",
+            f"SMTP_PASS={password}",
             "SMTP_FROM=noreply@example.test",
             "UNRELATED_SOURCE=must-not-copy",
             "",
@@ -42,35 +50,107 @@ def valid_source(*, port: str = "2525") -> str:
     )
 
 
-def test_build_reconciles_only_approved_keys_and_preserves_unrelated_values() -> None:
-    module = load_module()
-    source = module.parse_env(valid_source(), label="source")
-    selected = module.validate_source(source.values)
-    destination = (
-        "DATABASE_URL=postgres://preserve\nAUTH_PUBLIC_LOGIN=0\nSMTP_HOST=old\n"
+def create_runtime_files(
+    tmp_path: Path,
+    *,
+    source_text: str | None = None,
+    destination_text: str = "DATABASE_URL=postgres://preserve\nAUTH_PUBLIC_LOGIN=0\n",
+) -> tuple[Path, Path, Path]:
+    source = tmp_path / "legacy.env"
+    destination = tmp_path / "canonical.env"
+    backup_dir = tmp_path / "backups"
+    source.write_text(source_text or valid_source(), encoding="utf-8")
+    destination.write_text(destination_text, encoding="utf-8")
+    backup_dir.mkdir(mode=0o700)
+    backup_dir.chmod(0o700)
+    return source, destination, backup_dir
+
+
+def preview(module, source: Path, destination: Path, backup_dir: Path):
+    return module.reconcile(
+        source_path=source,
+        destination_path=destination,
+        backup_dir=backup_dir,
+        apply=False,
+        require_root=False,
     )
 
-    content = module.build_reconciled_content(destination, selected)
-    parsed = module.parse_env(content, label="result").values
 
-    assert parsed["DATABASE_URL"] == "postgres://preserve"
-    assert parsed["AUTH_PUBLIC_LOGIN"] == "1"
-    assert parsed["SMTP_HOST"] == "smtp.example.test"
-    assert "UNRELATED_SOURCE" not in parsed
-    assert content.count("AUTH_PUBLIC_LOGIN=") == 1
-    assert content.count("SMTP_HOST=") == 1
+def apply_preview(module, source: Path, destination: Path, backup_dir: Path):
+    dry_run = preview(module, source, destination, backup_dir)
+    applied = module.reconcile(
+        source_path=source,
+        destination_path=destination,
+        backup_dir=backup_dir,
+        apply=True,
+        expected_plan_sha256=dry_run["plan_sha256"],
+        require_root=False,
+    )
+    return dry_run, applied
 
 
-def test_validate_source_rejects_missing_required_key_without_value_output() -> None:
+def stat_with(
+    original: os.stat_result,
+    *,
+    mode: int | None = None,
+    uid: int | None = None,
+    gid: int | None = None,
+) -> os.stat_result:
+    values = list(original)
+    if mode is not None:
+        values[0] = mode
+    if uid is not None:
+        values[4] = uid
+    if gid is not None:
+        values[5] = gid
+    return os.stat_result(values)
+
+
+def test_validate_source_canonicalizes_exact_runtime_values() -> None:
     module = load_module()
     values = module.parse_env(
-        valid_source().replace("SMTP_PASS=test-pass\n", ""), label="source"
+        valid_source(
+            public_login='"true"',
+            magic_log="FALSE",
+            smtp_auth="ON",
+            port="02525",
+        ),
+        label="source",
     ).values
 
-    with pytest.raises(module.ReconcileError, match="SMTP_PASS") as exc_info:
+    selected = module.validate_source(values)
+
+    assert selected["AUTH_PUBLIC_LOGIN"] == "1"
+    assert selected["AUTH_LOG_MAGIC_TOKEN"] == "0"
+    assert selected["SMTP_AUTH"] == "on"
+    assert selected["SMTP_PORT"] == "2525"
+
+
+@pytest.mark.parametrize("value", ["yes", "on", "2", "FALSE", "'   '"])
+def test_validate_source_rejects_non_runtime_public_login_values(value: str) -> None:
+    module = load_module()
+    values = module.parse_env(valid_source(public_login=value), label="source").values
+
+    with pytest.raises(module.ReconcileError, match="not enabled"):
         module.validate_source(values)
 
-    assert "test-pass" not in str(exc_info.value)
+
+@pytest.mark.parametrize("value", ["no", "off", "2", "TRUE", "'   '"])
+def test_validate_source_rejects_non_runtime_magic_log_values(value: str) -> None:
+    module = load_module()
+    values = module.parse_env(valid_source(magic_log=value), label="source").values
+
+    with pytest.raises(module.ReconcileError, match="not disabled"):
+        module.validate_source(values)
+
+
+@pytest.mark.parametrize("value", ["true", "1", "yes", "off", "'   '"])
+def test_validate_source_requires_exact_smtp_auth_on(value: str) -> None:
+    module = load_module()
+    values = module.parse_env(valid_source(smtp_auth=value), label="source").values
+
+    with pytest.raises(module.ReconcileError, match="exactly 'on'"):
+        module.validate_source(values)
 
 
 @pytest.mark.parametrize("port", ["25", "1025", "2526", "not-a-number"])
@@ -79,6 +159,15 @@ def test_validate_source_rejects_non_tls_submission_ports(port: str) -> None:
     values = module.parse_env(valid_source(port=port), label="source").values
 
     with pytest.raises(module.ReconcileError):
+        module.validate_source(values)
+
+
+@pytest.mark.parametrize("port", ["+2525", "2 525", "２５２５", "2525#comment"])
+def test_validate_source_rejects_non_ascii_or_decorated_ports(port: str) -> None:
+    module = load_module()
+    values = module.parse_env(valid_source(port=port), label="source").values
+
+    with pytest.raises(module.ReconcileError, match="ASCII digits"):
         module.validate_source(values)
 
 
@@ -92,18 +181,91 @@ def test_validate_source_accepts_supported_tls_ports(port: str) -> None:
     assert selected["SMTP_PORT"] == port
 
 
-def test_cli_dry_run_is_value_redacted_and_does_not_mutate(tmp_path: Path) -> None:
-    source = tmp_path / "legacy.env"
-    destination = tmp_path / "canonical.env"
-    backup_dir = tmp_path / "backups"
-    source.write_text(valid_source(), encoding="utf-8")
-    original = "DATABASE_URL=postgres://preserve\nAUTH_PUBLIC_LOGIN=0\n"
-    destination.write_text(original, encoding="utf-8")
+def test_validate_source_rejects_missing_required_key_without_secret_output() -> None:
+    module = load_module()
+    values = module.parse_env(
+        valid_source().replace(f"SMTP_PASS={SECRET_SENTINEL}\n", ""),
+        label="source",
+    ).values
 
-    proc = subprocess.run(
+    with pytest.raises(module.ReconcileError, match="SMTP_PASS") as exc_info:
+        module.validate_source(values)
+
+    assert SECRET_SENTINEL not in str(exc_info.value)
+
+
+def test_validate_source_rejects_quoted_whitespace_secret() -> None:
+    module = load_module()
+    values = module.parse_env(valid_source(password='"   "'), label="source").values
+
+    with pytest.raises(module.ReconcileError, match="SMTP_PASS is empty"):
+        module.validate_source(values)
+
+
+@pytest.mark.parametrize("value", ['"unterminated', "unterminated'", "'"])
+def test_validate_source_rejects_malformed_quotes(value: str) -> None:
+    module = load_module()
+    values = module.parse_env(valid_source(password=value), label="source").values
+
+    with pytest.raises(module.ReconcileError, match="malformed quoted value"):
+        module.validate_source(values)
+
+
+def test_build_reconciles_only_allowlisted_keys_and_preserves_unrelated_values() -> (
+    None
+):
+    module = load_module()
+    selected = module.validate_source(
+        module.parse_env(valid_source(), label="source").values
+    )
+    destination = (
+        "DATABASE_URL=postgres://preserve\n"
+        "AUTH_PUBLIC_LOGIN=0\n"
+        "SMTP_HOST=old\n"
+        "SMTP_HOST=duplicate\n"
+    )
+
+    with pytest.raises(module.ReconcileError, match="duplicate key"):
+        module.build_reconciled_content(destination, selected)
+
+    destination = destination.replace("SMTP_HOST=duplicate\n", "")
+    content = module.build_reconciled_content(destination, selected)
+    parsed = module.parse_env(content, label="result").values
+
+    assert parsed["DATABASE_URL"] == "postgres://preserve"
+    assert parsed["AUTH_PUBLIC_LOGIN"] == "1"
+    assert parsed["SMTP_HOST"] == "smtp.example.test"
+    assert "UNRELATED_SOURCE" not in parsed
+    assert content.count("AUTH_PUBLIC_LOGIN=") == 1
+    assert content.count("SMTP_HOST=") == 1
+
+
+def test_dry_run_is_value_redacted_and_does_not_mutate(tmp_path: Path) -> None:
+    module = load_module()
+    source, destination, backup_dir = create_runtime_files(tmp_path)
+    original = destination.read_bytes()
+
+    receipt = preview(module, source, destination, backup_dir)
+
+    serialized = json.dumps(receipt, sort_keys=True)
+    assert receipt["status"] == "planned"
+    assert receipt["applied"] is False
+    assert receipt["values_redacted"] is True
+    assert len(receipt["plan_sha256"]) == 64
+    assert destination.read_bytes() == original
+    assert list(backup_dir.iterdir()) == []
+    assert SECRET_SENTINEL not in serialized
+
+
+def test_dry_run_requires_root_in_production_mode(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    module = load_module()
+    source, destination, backup_dir = create_runtime_files(tmp_path)
+    monkeypatch.setattr(module.os, "geteuid", lambda: 1000)
+
+    rc = module.main(
         [
-            sys.executable,
-            str(SCRIPT),
             "--source",
             str(source),
             "--destination",
@@ -111,346 +273,604 @@ def test_cli_dry_run_is_value_redacted_and_does_not_mutate(tmp_path: Path) -> No
             "--backup-dir",
             str(backup_dir),
             "--json",
-        ],
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        check=False,
+        ]
     )
 
-    assert proc.returncode == 0, proc.stderr
-    receipt = json.loads(proc.stdout)
-    assert receipt["status"] == "planned"
-    assert receipt["applied"] is False
-    assert receipt["values_redacted"] is True
-    assert destination.read_text(encoding="utf-8") == original
-    assert not backup_dir.exists()
-    assert "test-pass" not in proc.stdout
-    assert "test-pass" not in proc.stderr
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "require root" in captured.err
+    assert SECRET_SENTINEL not in captured.out
+    assert SECRET_SENTINEL not in captured.err
 
 
-def test_apply_creates_backup_and_forces_mode_0600(tmp_path: Path) -> None:
+def test_dry_run_requires_precreated_mode_0700_backup_directory(
+    tmp_path: Path,
+) -> None:
     module = load_module()
-    source = tmp_path / "legacy.env"
-    destination = tmp_path / "canonical.env"
-    backup_dir = tmp_path / "backups"
-    source.write_text(valid_source(), encoding="utf-8")
-    original = "DATABASE_URL=postgres://preserve\nAUTH_PUBLIC_LOGIN=0\n"
-    destination.write_text(original, encoding="utf-8")
+    source, destination, backup_dir = create_runtime_files(tmp_path)
+    backup_dir.chmod(0o750)
+
+    with pytest.raises(module.ReconcileError, match="mode 0700"):
+        preview(module, source, destination, backup_dir)
+
+
+def test_apply_requires_plan_hash_from_dry_run(tmp_path: Path) -> None:
+    module = load_module()
+    source, destination, backup_dir = create_runtime_files(tmp_path)
+    original = destination.read_bytes()
+
+    with pytest.raises(module.ReconcileError, match="requires --expected-plan"):
+        module.reconcile(
+            source_path=source,
+            destination_path=destination,
+            backup_dir=backup_dir,
+            apply=True,
+            require_root=False,
+        )
+
+    assert destination.read_bytes() == original
+    assert list(backup_dir.iterdir()) == []
+
+
+def test_apply_rejects_stale_plan_after_destination_change(tmp_path: Path) -> None:
+    module = load_module()
+    source, destination, backup_dir = create_runtime_files(tmp_path)
+    receipt = preview(module, source, destination, backup_dir)
+    destination.write_text(
+        destination.read_text(encoding="utf-8") + "NEW_SETTING=changed\n",
+        encoding="utf-8",
+    )
+    changed = destination.read_bytes()
+
+    with pytest.raises(module.ReconcileError, match="does not match current inputs"):
+        module.reconcile(
+            source_path=source,
+            destination_path=destination,
+            backup_dir=backup_dir,
+            apply=True,
+            expected_plan_sha256=receipt["plan_sha256"],
+            require_root=False,
+        )
+
+    assert destination.read_bytes() == changed
+    assert list(backup_dir.iterdir()) == []
+
+
+def test_apply_rejects_stale_plan_after_source_change(tmp_path: Path) -> None:
+    module = load_module()
+    source, destination, backup_dir = create_runtime_files(tmp_path)
+    receipt = preview(module, source, destination, backup_dir)
+    source.write_text(valid_source(port="587"), encoding="utf-8")
+
+    with pytest.raises(module.ReconcileError, match="does not match current inputs"):
+        module.reconcile(
+            source_path=source,
+            destination_path=destination,
+            backup_dir=backup_dir,
+            apply=True,
+            expected_plan_sha256=receipt["plan_sha256"],
+            require_root=False,
+        )
+
+    assert list(backup_dir.iterdir()) == []
+
+
+def test_plan_hash_binds_all_effect_paths(tmp_path: Path) -> None:
+    module = load_module()
+    source, destination, backup_dir = create_runtime_files(tmp_path)
+    source_stat = source.stat()
+    destination_stat = destination.stat()
+    backup_stat = backup_dir.stat()
+    source_text = source.read_text(encoding="utf-8")
+    destination_text = destination.read_text(encoding="utf-8")
+    selected = module.validate_source(
+        module.parse_env(source_text, label="source").values
+    )
+    planned = module.build_reconciled_content(destination_text, selected)
+
+    def digest(source_path=source, destination_path=destination, backup_path=backup_dir):
+        return module.plan_sha256(
+            source_path=source_path,
+            destination_path=destination_path,
+            backup_dir=backup_path,
+            source_stat=source_stat,
+            destination_stat=destination_stat,
+            backup_dir_stat=backup_stat,
+            source_text=source_text,
+            destination_text=destination_text,
+            planned_content=planned,
+        )
+
+    baseline = digest()
+    assert digest(source_path=tmp_path / "other-source.env") != baseline
+    assert digest(destination_path=tmp_path / "other-destination.env") != baseline
+    assert digest(backup_path=tmp_path / "other-backups") != baseline
+
+
+def test_plan_hash_rejects_unrelated_source_text_change(tmp_path: Path) -> None:
+    module = load_module()
+    source, destination, backup_dir = create_runtime_files(tmp_path)
+    receipt = preview(module, source, destination, backup_dir)
+    source.write_text(
+        source.read_text(encoding="utf-8").replace(
+            "UNRELATED_SOURCE=must-not-copy", "UNRELATED_SOURCE=changed"
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(module.ReconcileError, match="does not match current inputs"):
+        module.reconcile(
+            source_path=source,
+            destination_path=destination,
+            backup_dir=backup_dir,
+            apply=True,
+            expected_plan_sha256=receipt["plan_sha256"],
+            require_root=False,
+        )
+
+    assert list(backup_dir.iterdir()) == []
+
+
+def test_plan_hash_binds_backup_path_and_identity(tmp_path: Path) -> None:
+    module = load_module()
+    source, destination, backup_dir = create_runtime_files(tmp_path)
+    receipt = preview(module, source, destination, backup_dir)
+    alternate_backup = tmp_path / "alternate-backups"
+    alternate_backup.mkdir(mode=0o700)
+
+    with pytest.raises(module.ReconcileError, match="does not match current inputs"):
+        module.reconcile(
+            source_path=source,
+            destination_path=destination,
+            backup_dir=alternate_backup,
+            apply=True,
+            expected_plan_sha256=receipt["plan_sha256"],
+            require_root=False,
+        )
+
+    assert destination.read_text(encoding="utf-8").startswith("DATABASE_URL=")
+    assert list(backup_dir.iterdir()) == []
+    assert list(alternate_backup.iterdir()) == []
+
+
+def test_plan_hash_rejects_identical_source_inode_replacement(tmp_path: Path) -> None:
+    module = load_module()
+    source, destination, backup_dir = create_runtime_files(tmp_path)
+    receipt = preview(module, source, destination, backup_dir)
+    replacement = tmp_path / "replacement.env"
+    replacement.write_bytes(source.read_bytes())
+    replacement.replace(source)
+
+    with pytest.raises(module.ReconcileError, match="does not match current inputs"):
+        module.reconcile(
+            source_path=source,
+            destination_path=destination,
+            backup_dir=backup_dir,
+            apply=True,
+            expected_plan_sha256=receipt["plan_sha256"],
+            require_root=False,
+        )
+
+    assert list(backup_dir.iterdir()) == []
+
+
+def test_apply_creates_exact_backup_preserves_owner_and_forces_mode_0600(
+    tmp_path: Path,
+) -> None:
+    module = load_module()
+    source, destination, backup_dir = create_runtime_files(tmp_path)
+    original = destination.read_bytes()
+    original_stat = destination.stat()
     destination.chmod(0o640)
 
-    receipt = module.reconcile(
-        source_path=source,
-        destination_path=destination,
-        backup_dir=backup_dir,
-        apply=True,
-        require_root=False,
-    )
+    dry_run, receipt = apply_preview(module, source, destination, backup_dir)
 
+    serialized = json.dumps(receipt, sort_keys=True)
+    backup = Path(receipt["backup"])
+    assert dry_run["status"] == "planned"
     assert receipt["status"] == "reconciled"
     assert receipt["applied"] is True
-    assert receipt["values_redacted"] is True
+    assert receipt["plan_sha256"] == dry_run["plan_sha256"]
     assert receipt["mode"] == "0600"
+    assert receipt["owner_uid"] == original_stat.st_uid
+    assert receipt["owner_gid"] == original_stat.st_gid
     assert stat.S_IMODE(destination.stat().st_mode) == 0o600
-    backup = Path(receipt["backup"])
-    assert backup.read_text(encoding="utf-8") == original
+    assert backup.read_bytes() == original
     assert stat.S_IMODE(backup.stat().st_mode) == 0o600
-    parsed = module.parse_env(
-        destination.read_text(encoding="utf-8"), label="result"
-    ).values
-    assert parsed["DATABASE_URL"] == "postgres://preserve"
-    assert parsed["SMTP_PASS"] == "test-pass"
+    assert SECRET_SENTINEL not in serialized
 
 
-def test_apply_is_idempotent_after_first_reconciliation(tmp_path: Path) -> None:
+def test_apply_reports_only_actually_changed_keys(tmp_path: Path) -> None:
     module = load_module()
-    source = tmp_path / "legacy.env"
-    destination = tmp_path / "canonical.env"
-    backup_dir = tmp_path / "backups"
-    source.write_text(valid_source(), encoding="utf-8")
-    destination.write_text("DATABASE_URL=postgres://preserve\n", encoding="utf-8")
-
-    first = module.reconcile(
-        source_path=source,
-        destination_path=destination,
-        backup_dir=backup_dir,
-        apply=True,
-        require_root=False,
+    selected = module.validate_source(
+        module.parse_env(valid_source(), label="source").values
     )
+    destination_text = "DATABASE_URL=postgres://preserve\n" + "\n".join(
+        f"{key}={value}" for key, value in selected.items() if key != "SMTP_PORT"
+    )
+    destination_text += "\nSMTP_PORT=587\n"
+    source, destination, backup_dir = create_runtime_files(
+        tmp_path, destination_text=destination_text
+    )
+
+    dry_run, applied = apply_preview(module, source, destination, backup_dir)
+
+    assert dry_run["updated_keys"] == ["SMTP_PORT"]
+    assert applied["updated_keys"] == ["SMTP_PORT"]
+
+
+def test_apply_is_idempotent_and_creates_no_second_backup(tmp_path: Path) -> None:
+    module = load_module()
+    source, destination, backup_dir = create_runtime_files(tmp_path)
+    _, first = apply_preview(module, source, destination, backup_dir)
+    second_preview = preview(module, source, destination, backup_dir)
     second = module.reconcile(
         source_path=source,
         destination_path=destination,
         backup_dir=backup_dir,
         apply=True,
+        expected_plan_sha256=second_preview["plan_sha256"],
         require_root=False,
     )
 
     assert first["status"] == "reconciled"
+    assert second_preview["status"] == "already_reconciled"
+    assert second_preview["updated_keys"] == []
     assert second["status"] == "already_reconciled"
+    assert second["updated_keys"] == []
     assert len(list(backup_dir.iterdir())) == 1
 
 
-def test_symlink_source_is_rejected(tmp_path: Path) -> None:
+@pytest.mark.parametrize("target", ["source", "destination"])
+def test_final_file_symlink_is_rejected(tmp_path: Path, target: str) -> None:
     module = load_module()
-    real_source = tmp_path / "real.env"
-    source = tmp_path / "legacy.env"
-    destination = tmp_path / "canonical.env"
-    real_source.write_text(valid_source(), encoding="utf-8")
-    source.symlink_to(real_source)
-    destination.write_text("DATABASE_URL=postgres://preserve\n", encoding="utf-8")
+    source, destination, backup_dir = create_runtime_files(tmp_path)
+    selected = source if target == "source" else destination
+    real = tmp_path / f"real-{target}.env"
+    selected.replace(real)
+    selected.symlink_to(real)
 
-    with pytest.raises(module.ReconcileError, match="must not be a symlink"):
-        module.reconcile(
-            source_path=source,
-            destination_path=destination,
-            backup_dir=tmp_path / "backups",
-            apply=False,
-            require_root=False,
-        )
+    with pytest.raises(module.ReconcileError, match=f"unable to open {target} safely"):
+        preview(module, source, destination, backup_dir)
 
 
-def test_non_root_apply_fails_before_backup_or_mutation(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_intermediate_directory_symlink_is_rejected(tmp_path: Path) -> None:
     module = load_module()
-    source = tmp_path / "legacy.env"
+    real_dir = tmp_path / "real"
+    linked_dir = tmp_path / "linked"
+    real_dir.mkdir()
+    linked_dir.symlink_to(real_dir, target_is_directory=True)
+    source = linked_dir / "legacy.env"
     destination = tmp_path / "canonical.env"
     backup_dir = tmp_path / "backups"
-    source.write_text(valid_source(), encoding="utf-8")
-    original = "DATABASE_URL=postgres://preserve\n"
-    destination.write_text(original, encoding="utf-8")
-    monkeypatch.setattr(module.os, "geteuid", lambda: 1000)
+    (real_dir / "legacy.env").write_text(valid_source(), encoding="utf-8")
+    destination.write_text("DATABASE_URL=postgres://preserve\n", encoding="utf-8")
+    backup_dir.mkdir(mode=0o700)
 
-    with pytest.raises(module.ReconcileError, match="requires root"):
-        module.reconcile(
-            source_path=source,
-            destination_path=destination,
-            backup_dir=backup_dir,
-            apply=True,
-        )
-
-    assert destination.read_text(encoding="utf-8") == original
-    assert not backup_dir.exists()
+    with pytest.raises(module.ReconcileError, match="source parent directory"):
+        preview(module, source, destination, backup_dir)
 
 
 def test_backup_directory_symlink_is_rejected(tmp_path: Path) -> None:
     module = load_module()
+    source, destination, backup_dir = create_runtime_files(tmp_path)
+    real_backup = tmp_path / "real-backups"
+    backup_dir.rmdir()
+    real_backup.mkdir(mode=0o700)
+    backup_dir.symlink_to(real_backup, target_is_directory=True)
+
+    with pytest.raises(module.ReconcileError, match="backup directory"):
+        preview(module, source, destination, backup_dir)
+
+
+def test_source_and_destination_hardlink_is_rejected(tmp_path: Path) -> None:
+    module = load_module()
     source = tmp_path / "legacy.env"
     destination = tmp_path / "canonical.env"
-    real_backup_dir = tmp_path / "real-backups"
     backup_dir = tmp_path / "backups"
     source.write_text(valid_source(), encoding="utf-8")
-    destination.write_text("DATABASE_URL=postgres://preserve\n", encoding="utf-8")
-    real_backup_dir.mkdir()
-    backup_dir.symlink_to(real_backup_dir, target_is_directory=True)
-
-    with pytest.raises(module.ReconcileError, match="must not be a symlink"):
-        module.reconcile(
-            source_path=source,
-            destination_path=destination,
-            backup_dir=backup_dir,
-            apply=True,
-            require_root=False,
-        )
-
-    assert list(real_backup_dir.iterdir()) == []
-
-
-def test_source_and_destination_must_be_different_files(tmp_path: Path) -> None:
-    module = load_module()
-    shared = tmp_path / "shared.env"
-    shared.write_text(valid_source(), encoding="utf-8")
+    os.link(source, destination)
+    backup_dir.mkdir(mode=0o700)
 
     with pytest.raises(module.ReconcileError, match="must be different files"):
-        module.reconcile(
-            source_path=shared,
-            destination_path=shared,
-            backup_dir=tmp_path / "backups",
-            apply=False,
-            require_root=False,
-        )
+        preview(module, source, destination, backup_dir)
 
 
-def test_quoted_whitespace_secret_is_rejected() -> None:
-    module = load_module()
-    values = module.parse_env(
-        valid_source().replace("SMTP_PASS=test-pass", 'SMTP_PASS="   "'),
-        label="source",
-    ).values
-
-    with pytest.raises(module.ReconcileError, match="SMTP_PASS is empty"):
-        module.validate_source(values)
-
-
-def test_apply_revalidates_source_after_lock(tmp_path: Path, monkeypatch) -> None:
-    module = load_module()
-    source = tmp_path / "legacy.env"
-    destination = tmp_path / "canonical.env"
-    backup_dir = tmp_path / "backups"
-    source.write_text(valid_source(), encoding="utf-8")
-    original = "DATABASE_URL=postgres://preserve\n"
-    destination.write_text(original, encoding="utf-8")
-
-    original_flock = module.fcntl.flock
-
-    def mutate_source_after_lock(fd, operation):
-        original_flock(fd, operation)
-        source.write_text(
-            valid_source().replace("AUTH_PUBLIC_LOGIN=1", "AUTH_PUBLIC_LOGIN=0"),
-            encoding="utf-8",
-        )
-
-    monkeypatch.setattr(module.fcntl, "flock", mutate_source_after_lock)
-
-    with pytest.raises(module.ReconcileError, match="not enabled"):
-        module.reconcile(
-            source_path=source,
-            destination_path=destination,
-            backup_dir=backup_dir,
-            apply=True,
-            require_root=False,
-        )
-
-    assert destination.read_text(encoding="utf-8") == original
-    assert not backup_dir.exists() or list(backup_dir.iterdir()) == []
-
-
-def test_root_apply_rejects_non_root_owned_backup_directory(
-    tmp_path: Path, monkeypatch
+@pytest.mark.parametrize("which", ["source", "destination"])
+def test_apply_rejects_inode_replacement_after_lock(
+    tmp_path: Path, monkeypatch, which: str
 ) -> None:
     module = load_module()
-    source = tmp_path / "legacy.env"
-    destination = tmp_path / "canonical.env"
-    backup_dir = tmp_path / "backups"
-    source.write_text(valid_source(), encoding="utf-8")
-    destination.write_text("DATABASE_URL=postgres://preserve\n", encoding="utf-8")
-    backup_dir.mkdir()
+    source, destination, backup_dir = create_runtime_files(tmp_path)
+    receipt = preview(module, source, destination, backup_dir)
+    replacement = tmp_path / f"replacement-{which}.env"
+    if which == "source":
+        replacement.write_text(valid_source(), encoding="utf-8")
+        replace_target = source
+    else:
+        replacement.write_bytes(destination.read_bytes())
+        replace_target = destination
+    original_destination = destination.read_bytes()
+    original_flock = module.fcntl.flock
 
-    real_stat = module.Path.stat
+    def replace_after_lock(fd, operation):
+        original_flock(fd, operation)
+        replacement.replace(replace_target)
 
-    def fake_stat(path, *args, **kwargs):
-        result = real_stat(path, *args, **kwargs)
-        if path == backup_dir:
-            values = list(result)
-            values[4] = 1000
-            return module.os.stat_result(values)
-        return result
+    monkeypatch.setattr(module.fcntl, "flock", replace_after_lock)
 
-    monkeypatch.setattr(module.Path, "stat", fake_stat)
-    monkeypatch.setattr(module.os, "geteuid", lambda: 0)
-    monkeypatch.setattr(
-        module, "_validate_root_owned_runtime_stat", lambda file_stat, label: None
-    )
-
-    with pytest.raises(module.ReconcileError, match="root-owned"):
+    with pytest.raises(module.ReconcileError, match=f"{which} file identity changed"):
         module.reconcile(
             source_path=source,
             destination_path=destination,
             backup_dir=backup_dir,
             apply=True,
+            expected_plan_sha256=receipt["plan_sha256"],
+            require_root=False,
         )
 
+    if which == "source":
+        assert destination.read_bytes() == original_destination
+    assert list(backup_dir.iterdir()) == []
 
-def test_root_apply_rejects_untrusted_source_owner(tmp_path: Path, monkeypatch) -> None:
+
+@pytest.mark.parametrize("which", ["source", "destination"])
+def test_apply_rejects_content_change_after_lock(
+    tmp_path: Path, monkeypatch, which: str
+) -> None:
     module = load_module()
-    source = tmp_path / "legacy.env"
-    destination = tmp_path / "canonical.env"
-    source.write_text(valid_source(), encoding="utf-8")
-    destination.write_text("DATABASE_URL=postgres://preserve\n", encoding="utf-8")
+    source, destination, backup_dir = create_runtime_files(tmp_path)
+    receipt = preview(module, source, destination, backup_dir)
+    original_flock = module.fcntl.flock
+
+    def mutate_after_lock(fd, operation):
+        original_flock(fd, operation)
+        target = source if which == "source" else destination
+        target.write_text(
+            target.read_text(encoding="utf-8") + "# changed\n", encoding="utf-8"
+        )
+
+    monkeypatch.setattr(module.fcntl, "flock", mutate_after_lock)
+
+    with pytest.raises(module.ReconcileError, match=f"{which} content changed"):
+        module.reconcile(
+            source_path=source,
+            destination_path=destination,
+            backup_dir=backup_dir,
+            apply=True,
+            expected_plan_sha256=receipt["plan_sha256"],
+            require_root=False,
+        )
+
+    assert list(backup_dir.iterdir()) == []
+
+
+def test_apply_revalidates_root_trust_after_lock(tmp_path: Path, monkeypatch) -> None:
+    module = load_module()
+    source, destination, backup_dir = create_runtime_files(tmp_path)
+    original_read = module._read_regular_at
+    read_calls = 0
+
+    def root_bound_read(parent_fd, name, *, label, require_root):
+        nonlocal read_calls
+        read_calls += 1
+        opened = original_read(parent_fd, name, label=label, require_root=False)
+        fake_uid = 1000 if read_calls == 3 else 0
+        fake_stat = stat_with(opened.file_stat, uid=fake_uid, gid=0)
+        if require_root:
+            module._validate_root_owned_stat(fake_stat, label=label)
+        return module.OpenedEnv(text=opened.text, file_stat=fake_stat)
+
+    original_open_dir = module._open_trusted_directory
+
+    def unprivileged_test_directory(path, *, label, require_root, exact_mode=None):
+        return original_open_dir(
+            path, label=label, require_root=False, exact_mode=exact_mode
+        )
+
+    monkeypatch.setattr(module, "_read_regular_at", root_bound_read)
+    monkeypatch.setattr(module, "_open_trusted_directory", unprivileged_test_directory)
     monkeypatch.setattr(module.os, "geteuid", lambda: 0)
+    original_validate = module._validate_root_owned_stat
+
+    def allow_lock_only(file_stat, *, label):
+        if label == "reconciliation lock":
+            return None
+        return original_validate(file_stat, label=label)
+
+    monkeypatch.setattr(module, "_validate_root_owned_stat", allow_lock_only)
+
+    receipt = module.reconcile(
+        source_path=source,
+        destination_path=destination,
+        backup_dir=backup_dir,
+        apply=False,
+        require_root=True,
+    )
+    read_calls = 0
 
     with pytest.raises(module.ReconcileError, match="source must be root-owned"):
         module.reconcile(
             source_path=source,
             destination_path=destination,
-            backup_dir=tmp_path / "backups",
+            backup_dir=backup_dir,
             apply=True,
+            expected_plan_sha256=receipt["plan_sha256"],
+            require_root=True,
         )
 
+    assert read_calls >= 3
+    assert list(backup_dir.iterdir()) == []
 
-def test_apply_file_guard_rejects_group_writable_file(
-    tmp_path: Path, monkeypatch
-) -> None:
+
+def test_apply_acquires_exclusive_lock(tmp_path: Path, monkeypatch) -> None:
     module = load_module()
-    path = tmp_path / "runtime.env"
-    path.write_text("KEY=value\n", encoding="utf-8")
-    real_stat = module.Path.stat
-
-    def fake_stat(candidate, *args, **kwargs):
-        result = real_stat(candidate, *args, **kwargs)
-        values = list(result)
-        values[0] = result.st_mode | stat.S_IWGRP
-        values[4] = 0
-        return module.os.stat_result(values)
-
-    monkeypatch.setattr(module.Path, "stat", fake_stat)
-
-    with pytest.raises(module.ReconcileError, match="group or others"):
-        module._validate_root_owned_runtime_stat(path.stat(), label="source")
-
-
-def test_secure_reader_rejects_symlink_swapped_after_path_check(
-    tmp_path: Path, monkeypatch
-) -> None:
-    module = load_module()
-    real_source = tmp_path / "real.env"
-    source = tmp_path / "legacy.env"
-    destination = tmp_path / "canonical.env"
-    real_source.write_text(valid_source(), encoding="utf-8")
-    source.write_text(valid_source(), encoding="utf-8")
-    destination.write_text("DATABASE_URL=postgres://preserve\n", encoding="utf-8")
-
-    original_checked = module._checked_regular_absolute
-    call_count = 0
-
-    def swap_after_check(path, *, label):
-        nonlocal call_count
-        checked = original_checked(path, label=label)
-        call_count += 1
-        if label == "source" and call_count == 1:
-            source.unlink()
-            source.symlink_to(real_source)
-        return checked
-
-    monkeypatch.setattr(module, "_checked_regular_absolute", swap_after_check)
-
-    with pytest.raises(module.ReconcileError, match="unable to open source safely"):
-        module.reconcile(
-            source_path=source,
-            destination_path=destination,
-            backup_dir=tmp_path / "backups",
-            apply=False,
-            require_root=False,
-        )
-
-
-def test_apply_rejects_source_inode_replacement_after_lock(
-    tmp_path: Path, monkeypatch
-) -> None:
-    module = load_module()
-    source = tmp_path / "legacy.env"
-    destination = tmp_path / "canonical.env"
-    replacement = tmp_path / "replacement.env"
-    source.write_text(valid_source(), encoding="utf-8")
-    replacement.write_text(valid_source(), encoding="utf-8")
-    destination.write_text("DATABASE_URL=postgres://preserve\n", encoding="utf-8")
-    original = destination.read_text(encoding="utf-8")
-
+    source, destination, backup_dir = create_runtime_files(tmp_path)
+    receipt = preview(module, source, destination, backup_dir)
+    operations: list[int] = []
     original_flock = module.fcntl.flock
 
-    def replace_source_after_lock(fd, operation):
-        original_flock(fd, operation)
-        replacement.replace(source)
+    def record_lock(fd, operation):
+        operations.append(operation)
+        return original_flock(fd, operation)
 
-    monkeypatch.setattr(module.fcntl, "flock", replace_source_after_lock)
+    monkeypatch.setattr(module.fcntl, "flock", record_lock)
 
-    with pytest.raises(module.ReconcileError, match="source file identity changed"):
+    module.reconcile(
+        source_path=source,
+        destination_path=destination,
+        backup_dir=backup_dir,
+        apply=True,
+        expected_plan_sha256=receipt["plan_sha256"],
+        require_root=False,
+    )
+
+    assert operations == [module.fcntl.LOCK_EX | module.fcntl.LOCK_NB]
+
+
+def test_lock_wait_times_out_without_mutation(tmp_path: Path, monkeypatch) -> None:
+    module = load_module()
+    source, destination, backup_dir = create_runtime_files(tmp_path)
+    receipt = preview(module, source, destination, backup_dir)
+    original = destination.read_bytes()
+    monkeypatch.setattr(module, "LOCK_TIMEOUT_SECONDS", 0.0)
+
+    def always_busy(fd, operation):
+        raise BlockingIOError("busy")
+
+    monkeypatch.setattr(module.fcntl, "flock", always_busy)
+
+    with pytest.raises(module.ReconcileError, match="timed out waiting"):
         module.reconcile(
             source_path=source,
             destination_path=destination,
-            backup_dir=tmp_path / "backups",
+            backup_dir=backup_dir,
             apply=True,
+            expected_plan_sha256=receipt["plan_sha256"],
             require_root=False,
         )
 
-    assert destination.read_text(encoding="utf-8") == original
+    assert destination.read_bytes() == original
+    assert list(backup_dir.iterdir()) == []
+
+
+def test_partial_temp_write_is_removed_before_error_returns(
+    tmp_path: Path, monkeypatch
+) -> None:
+    module = load_module()
+    source, destination, backup_dir = create_runtime_files(tmp_path)
+    receipt = preview(module, source, destination, backup_dir)
+    original = destination.read_bytes()
+    original_fchown = module.os.fchown
+    calls = 0
+
+    def fail_temp_chown(fd, uid, gid):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("injected temp write failure")
+        return original_fchown(fd, uid, gid)
+
+    monkeypatch.setattr(module.os, "fchown", fail_temp_chown)
+
+    with pytest.raises(OSError, match="injected temp write failure"):
+        module.reconcile(
+            source_path=source,
+            destination_path=destination,
+            backup_dir=backup_dir,
+            apply=True,
+            expected_plan_sha256=receipt["plan_sha256"],
+            require_root=False,
+        )
+
+    assert destination.read_bytes() == original
+    assert not list(destination.parent.glob(f".{destination.name}.reconcile-*"))
+    backups = list(backup_dir.iterdir())
+    assert len(backups) == 1
+    assert backups[0].read_bytes() == original
+
+
+def test_backup_is_read_back_before_destination_replace(
+    tmp_path: Path, monkeypatch
+) -> None:
+    module = load_module()
+    source, destination, backup_dir = create_runtime_files(tmp_path)
+    receipt = preview(module, source, destination, backup_dir)
+    original = destination.read_bytes()
+    original_read = module._read_regular_at
+
+    def corrupt_backup(parent_fd, name, *, label, require_root):
+        opened = original_read(
+            parent_fd, name, label=label, require_root=require_root
+        )
+        if label == "backup":
+            return module.OpenedEnv(
+                text=opened.text + "# corrupt\n", file_stat=opened.file_stat
+            )
+        return opened
+
+    monkeypatch.setattr(module, "_read_regular_at", corrupt_backup)
+
+    with pytest.raises(module.ReconcileError, match="backup verification failed"):
+        module.reconcile(
+            source_path=source,
+            destination_path=destination,
+            backup_dir=backup_dir,
+            apply=True,
+            expected_plan_sha256=receipt["plan_sha256"],
+            require_root=False,
+        )
+
+    assert destination.read_bytes() == original
+    assert list(backup_dir.iterdir()) == []
+
+
+def test_safe_orphan_temp_is_removed_under_lock(tmp_path: Path) -> None:
+    module = load_module()
+    source, destination, backup_dir = create_runtime_files(tmp_path)
+    orphan = destination.parent / f".{destination.name}.reconcile-stale"
+    orphan.write_text(SECRET_SENTINEL, encoding="utf-8")
+    orphan.chmod(0o600)
+
+    apply_preview(module, source, destination, backup_dir)
+
+    assert not orphan.exists()
+
+
+def test_unsafe_orphan_temp_is_not_removed(tmp_path: Path) -> None:
+    module = load_module()
+    source, destination, backup_dir = create_runtime_files(tmp_path)
+    orphan = destination.parent / f".{destination.name}.reconcile-unsafe"
+    orphan.write_text("preserve", encoding="utf-8")
+    orphan.chmod(0o644)
+
+    apply_preview(module, source, destination, backup_dir)
+
+    assert orphan.read_text(encoding="utf-8") == "preserve"
+
+
+def test_root_owned_stat_rejects_untrusted_owner_and_write_bits() -> None:
+    module = load_module()
+    base = os.stat(__file__)
+
+    with pytest.raises(module.ReconcileError, match="must be root-owned"):
+        module._validate_root_owned_stat(stat_with(base, uid=1000), label="source")
+    with pytest.raises(module.ReconcileError, match="group or others"):
+        module._validate_root_owned_stat(
+            stat_with(base, uid=0, mode=base.st_mode | stat.S_IWGRP),
+            label="source",
+        )
+
+
+def test_documented_workflow_relates_script_test_and_ci() -> None:
+    docs = (REPO / "docs" / "deploy" / "vps.md").read_text(encoding="utf-8")
+    workflow = (
+        REPO / ".github" / "workflows" / "public-login-smtp-readiness.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "scripts/ops/reconcile_public_login_smtp_env.py" in docs
+    assert "--expected-plan-sha256" in docs
+    assert "Restore" in docs
+    assert "scripts/ops/reconcile_public_login_smtp_env.py" in workflow
+    assert "scripts/ci/tests/test_reconcile_public_login_smtp_env.py" in workflow
+    assert "test_reconcile_public_login_smtp_env.py" in workflow

--- a/scripts/ci/tests/test_reconcile_public_login_smtp_env.py
+++ b/scripts/ci/tests/test_reconcile_public_login_smtp_env.py
@@ -338,6 +338,9 @@ def test_root_apply_rejects_non_root_owned_backup_directory(
 
     monkeypatch.setattr(module.Path, "stat", fake_stat)
     monkeypatch.setattr(module.os, "geteuid", lambda: 0)
+    monkeypatch.setattr(
+        module, "_validate_root_owned_runtime_file", lambda path, label: None
+    )
 
     with pytest.raises(module.ReconcileError, match="root-owned"):
         module.reconcile(
@@ -346,3 +349,41 @@ def test_root_apply_rejects_non_root_owned_backup_directory(
             backup_dir=backup_dir,
             apply=True,
         )
+
+
+def test_root_apply_rejects_untrusted_source_owner(tmp_path: Path, monkeypatch) -> None:
+    module = load_module()
+    source = tmp_path / "legacy.env"
+    destination = tmp_path / "canonical.env"
+    source.write_text(valid_source(), encoding="utf-8")
+    destination.write_text("DATABASE_URL=postgres://preserve\n", encoding="utf-8")
+    monkeypatch.setattr(module.os, "geteuid", lambda: 0)
+
+    with pytest.raises(module.ReconcileError, match="source must be root-owned"):
+        module.reconcile(
+            source_path=source,
+            destination_path=destination,
+            backup_dir=tmp_path / "backups",
+            apply=True,
+        )
+
+
+def test_apply_file_guard_rejects_group_writable_file(
+    tmp_path: Path, monkeypatch
+) -> None:
+    module = load_module()
+    path = tmp_path / "runtime.env"
+    path.write_text("KEY=value\n", encoding="utf-8")
+    real_stat = module.Path.stat
+
+    def fake_stat(candidate, *args, **kwargs):
+        result = real_stat(candidate, *args, **kwargs)
+        values = list(result)
+        values[0] = result.st_mode | stat.S_IWGRP
+        values[4] = 0
+        return module.os.stat_result(values)
+
+    monkeypatch.setattr(module.Path, "stat", fake_stat)
+
+    with pytest.raises(module.ReconcileError, match="group or others"):
+        module._validate_root_owned_runtime_file(path, label="source")

--- a/scripts/ci/tests/test_reconcile_public_login_smtp_env.py
+++ b/scripts/ci/tests/test_reconcile_public_login_smtp_env.py
@@ -339,7 +339,7 @@ def test_root_apply_rejects_non_root_owned_backup_directory(
     monkeypatch.setattr(module.Path, "stat", fake_stat)
     monkeypatch.setattr(module.os, "geteuid", lambda: 0)
     monkeypatch.setattr(
-        module, "_validate_root_owned_runtime_file", lambda path, label: None
+        module, "_validate_root_owned_runtime_stat", lambda file_stat, label: None
     )
 
     with pytest.raises(module.ReconcileError, match="root-owned"):
@@ -386,4 +386,71 @@ def test_apply_file_guard_rejects_group_writable_file(
     monkeypatch.setattr(module.Path, "stat", fake_stat)
 
     with pytest.raises(module.ReconcileError, match="group or others"):
-        module._validate_root_owned_runtime_file(path, label="source")
+        module._validate_root_owned_runtime_stat(path.stat(), label="source")
+
+
+def test_secure_reader_rejects_symlink_swapped_after_path_check(
+    tmp_path: Path, monkeypatch
+) -> None:
+    module = load_module()
+    real_source = tmp_path / "real.env"
+    source = tmp_path / "legacy.env"
+    destination = tmp_path / "canonical.env"
+    real_source.write_text(valid_source(), encoding="utf-8")
+    source.write_text(valid_source(), encoding="utf-8")
+    destination.write_text("DATABASE_URL=postgres://preserve\n", encoding="utf-8")
+
+    original_checked = module._checked_regular_absolute
+    call_count = 0
+
+    def swap_after_check(path, *, label):
+        nonlocal call_count
+        checked = original_checked(path, label=label)
+        call_count += 1
+        if label == "source" and call_count == 1:
+            source.unlink()
+            source.symlink_to(real_source)
+        return checked
+
+    monkeypatch.setattr(module, "_checked_regular_absolute", swap_after_check)
+
+    with pytest.raises(module.ReconcileError, match="unable to open source safely"):
+        module.reconcile(
+            source_path=source,
+            destination_path=destination,
+            backup_dir=tmp_path / "backups",
+            apply=False,
+            require_root=False,
+        )
+
+
+def test_apply_rejects_source_inode_replacement_after_lock(
+    tmp_path: Path, monkeypatch
+) -> None:
+    module = load_module()
+    source = tmp_path / "legacy.env"
+    destination = tmp_path / "canonical.env"
+    replacement = tmp_path / "replacement.env"
+    source.write_text(valid_source(), encoding="utf-8")
+    replacement.write_text(valid_source(), encoding="utf-8")
+    destination.write_text("DATABASE_URL=postgres://preserve\n", encoding="utf-8")
+    original = destination.read_text(encoding="utf-8")
+
+    original_flock = module.fcntl.flock
+
+    def replace_source_after_lock(fd, operation):
+        original_flock(fd, operation)
+        replacement.replace(source)
+
+    monkeypatch.setattr(module.fcntl, "flock", replace_source_after_lock)
+
+    with pytest.raises(module.ReconcileError, match="source file identity changed"):
+        module.reconcile(
+            source_path=source,
+            destination_path=destination,
+            backup_dir=tmp_path / "backups",
+            apply=True,
+            require_root=False,
+        )
+
+    assert destination.read_text(encoding="utf-8") == original

--- a/scripts/ci/tests/test_reconcile_public_login_smtp_env.py
+++ b/scripts/ci/tests/test_reconcile_public_login_smtp_env.py
@@ -194,6 +194,30 @@ def test_validate_source_rejects_missing_required_key_without_secret_output() ->
     assert SECRET_SENTINEL not in str(exc_info.value)
 
 
+@pytest.mark.parametrize("separator", ["\x0b", "\u2028"])
+def test_source_rejects_unsupported_line_separator_without_secret_output(
+    separator: str,
+) -> None:
+    module = load_module()
+    source = valid_source(password=f"prefix{separator}{SECRET_SENTINEL}")
+
+    with pytest.raises(
+        module.ReconcileError, match="unsupported line separator"
+    ) as exc_info:
+        module.parse_env(source, label="source")
+
+    assert SECRET_SENTINEL not in str(exc_info.value)
+
+
+@pytest.mark.parametrize("separator", ["\x0b", "\u2028"])
+def test_destination_rejects_unsupported_line_separator(separator: str) -> None:
+    module = load_module()
+    destination = f"DATABASE_URL=postgres://user:pass{separator}host/db\n"
+
+    with pytest.raises(module.ReconcileError, match="unsupported line separator"):
+        module.parse_env(destination, label="destination")
+
+
 def test_validate_source_rejects_quoted_whitespace_secret() -> None:
     module = load_module()
     values = module.parse_env(valid_source(password='"   "'), label="source").values
@@ -523,6 +547,57 @@ def test_apply_is_idempotent_and_creates_no_second_backup(tmp_path: Path) -> Non
     assert len(list(backup_dir.iterdir())) == 1
 
 
+def test_read_regular_at_preserves_raw_bytes_and_rejects_no_newline_translation(
+    tmp_path: Path,
+) -> None:
+    module = load_module()
+    path = tmp_path / "raw.env"
+    original = b"KEY=one\r\nOTHER=two\r"
+    path.write_bytes(original)
+    directory_fd = os.open(tmp_path, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        opened = module._read_regular_at(
+            directory_fd, path.name, label="raw", require_root=False
+        )
+    finally:
+        os.close(directory_fd)
+
+    assert opened.raw_bytes == original
+    assert opened.text == original.decode("utf-8")
+
+
+def test_destination_parent_open_failure_does_not_leak_source_directory_fd(
+    tmp_path: Path, monkeypatch
+) -> None:
+    module = load_module()
+    source, destination, backup_dir = create_runtime_files(tmp_path)
+    original_open = module._open_trusted_directory
+    opened_source_fd: int | None = None
+
+    def fail_destination(path, *, label, require_root, exact_mode=None):
+        nonlocal opened_source_fd
+        if label == "source parent directory":
+            opened_source_fd = original_open(
+                path, label=label, require_root=require_root, exact_mode=exact_mode
+            )
+            return opened_source_fd
+        if label == "destination parent directory":
+            raise module.ReconcileError("injected destination parent failure")
+        return original_open(
+            path, label=label, require_root=require_root, exact_mode=exact_mode
+        )
+
+    monkeypatch.setattr(module, "_open_trusted_directory", fail_destination)
+    with pytest.raises(
+        module.ReconcileError, match="injected destination parent failure"
+    ):
+        preview(module, source, destination, backup_dir)
+
+    assert opened_source_fd is not None
+    with pytest.raises(OSError):
+        os.fstat(opened_source_fd)
+
+
 @pytest.mark.parametrize("target", ["source", "destination"])
 def test_final_file_symlink_is_rejected(tmp_path: Path, target: str) -> None:
     module = load_module()
@@ -661,7 +736,9 @@ def test_apply_revalidates_root_trust_after_lock(tmp_path: Path, monkeypatch) ->
         fake_stat = stat_with(opened.file_stat, uid=fake_uid, gid=0)
         if require_root:
             module._validate_root_owned_stat(fake_stat, label=label)
-        return module.OpenedEnv(text=opened.text, file_stat=fake_stat)
+        return module.OpenedEnv(
+            raw_bytes=opened.raw_bytes, text=opened.text, file_stat=fake_stat
+        )
 
     original_open_dir = module._open_trusted_directory
 
@@ -805,7 +882,9 @@ def test_backup_is_read_back_before_destination_replace(
         opened = original_read(parent_fd, name, label=label, require_root=require_root)
         if label == "backup":
             return module.OpenedEnv(
-                text=opened.text + "# corrupt\n", file_stat=opened.file_stat
+                raw_bytes=opened.raw_bytes + b"# corrupt\n",
+                text=opened.text + "# corrupt\n",
+                file_stat=opened.file_stat,
             )
         return opened
 

--- a/scripts/ci/tests/test_reconcile_public_login_smtp_env.py
+++ b/scripts/ci/tests/test_reconcile_public_login_smtp_env.py
@@ -368,7 +368,9 @@ def test_plan_hash_binds_all_effect_paths(tmp_path: Path) -> None:
     )
     planned = module.build_reconciled_content(destination_text, selected)
 
-    def digest(source_path=source, destination_path=destination, backup_path=backup_dir):
+    def digest(
+        source_path=source, destination_path=destination, backup_path=backup_dir
+    ):
         return module.plan_sha256(
             source_path=source_path,
             destination_path=destination_path,
@@ -800,9 +802,7 @@ def test_backup_is_read_back_before_destination_replace(
     original_read = module._read_regular_at
 
     def corrupt_backup(parent_fd, name, *, label, require_root):
-        opened = original_read(
-            parent_fd, name, label=label, require_root=require_root
-        )
+        opened = original_read(parent_fd, name, label=label, require_root=require_root)
         if label == "backup":
             return module.OpenedEnv(
                 text=opened.text + "# corrupt\n", file_stat=opened.file_stat

--- a/scripts/ci/tests/test_reconcile_public_login_smtp_env.py
+++ b/scripts/ci/tests/test_reconcile_public_login_smtp_env.py
@@ -280,3 +280,69 @@ def test_quoted_whitespace_secret_is_rejected() -> None:
 
     with pytest.raises(module.ReconcileError, match="SMTP_PASS is empty"):
         module.validate_source(values)
+
+
+def test_apply_revalidates_source_after_lock(tmp_path: Path, monkeypatch) -> None:
+    module = load_module()
+    source = tmp_path / "legacy.env"
+    destination = tmp_path / "canonical.env"
+    backup_dir = tmp_path / "backups"
+    source.write_text(valid_source(), encoding="utf-8")
+    original = "DATABASE_URL=postgres://preserve\n"
+    destination.write_text(original, encoding="utf-8")
+
+    original_flock = module.fcntl.flock
+
+    def mutate_source_after_lock(fd, operation):
+        original_flock(fd, operation)
+        source.write_text(
+            valid_source().replace("AUTH_PUBLIC_LOGIN=1", "AUTH_PUBLIC_LOGIN=0"),
+            encoding="utf-8",
+        )
+
+    monkeypatch.setattr(module.fcntl, "flock", mutate_source_after_lock)
+
+    with pytest.raises(module.ReconcileError, match="not enabled"):
+        module.reconcile(
+            source_path=source,
+            destination_path=destination,
+            backup_dir=backup_dir,
+            apply=True,
+            require_root=False,
+        )
+
+    assert destination.read_text(encoding="utf-8") == original
+    assert not backup_dir.exists() or list(backup_dir.iterdir()) == []
+
+
+def test_root_apply_rejects_non_root_owned_backup_directory(
+    tmp_path: Path, monkeypatch
+) -> None:
+    module = load_module()
+    source = tmp_path / "legacy.env"
+    destination = tmp_path / "canonical.env"
+    backup_dir = tmp_path / "backups"
+    source.write_text(valid_source(), encoding="utf-8")
+    destination.write_text("DATABASE_URL=postgres://preserve\n", encoding="utf-8")
+    backup_dir.mkdir()
+
+    real_stat = module.Path.stat
+
+    def fake_stat(path, *args, **kwargs):
+        result = real_stat(path, *args, **kwargs)
+        if path == backup_dir:
+            values = list(result)
+            values[4] = 1000
+            return module.os.stat_result(values)
+        return result
+
+    monkeypatch.setattr(module.Path, "stat", fake_stat)
+    monkeypatch.setattr(module.os, "geteuid", lambda: 0)
+
+    with pytest.raises(module.ReconcileError, match="root-owned"):
+        module.reconcile(
+            source_path=source,
+            destination_path=destination,
+            backup_dir=backup_dir,
+            apply=True,
+        )

--- a/scripts/ops/reconcile_public_login_smtp_env.py
+++ b/scripts/ops/reconcile_public_login_smtp_env.py
@@ -164,6 +164,7 @@ def _write_file_exclusive(path: Path, content: bytes, *, uid: int, gid: int) -> 
             os.fsync(handle.fileno())
         os.fchown(fd, uid, gid)
         os.fchmod(fd, 0o600)
+        os.fsync(fd)
     finally:
         os.close(fd)
 
@@ -205,6 +206,9 @@ def reconcile(
     backup_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
     if backup_dir.is_symlink() or not backup_dir.is_dir():
         raise ReconcileError("backup directory is not a regular directory")
+    backup_dir_stat = backup_dir.stat()
+    if require_root and backup_dir_stat.st_uid != 0:
+        raise ReconcileError("backup directory must be root-owned")
     os.chmod(backup_dir, 0o700)
 
     lock_path = destination.parent / f".{destination.name}.reconcile.lock"
@@ -212,9 +216,25 @@ def reconcile(
     try:
         fcntl.flock(lock_fd, fcntl.LOCK_EX)
 
-        # Re-read after acquiring the lock so the write cannot silently erase a
-        # concurrent operator change made after the initial dry validation.
-        current_text = destination.read_text(encoding="utf-8")
+        # Re-resolve and re-read both files after acquiring the lock. This keeps
+        # an apply operation from using stale source values or silently replacing
+        # a destination path that another root operator changed after dry-run.
+        current_source = _checked_regular_absolute(source_path, label="source")
+        current_destination = _checked_regular_absolute(
+            destination_path, label="destination"
+        )
+        if current_source != source:
+            raise ReconcileError("source path changed during reconciliation")
+        if current_destination != destination:
+            raise ReconcileError("destination path changed during reconciliation")
+        if os.path.samefile(current_source, current_destination):
+            raise ReconcileError("source and destination must be different files")
+
+        current_source_text = current_source.read_text(encoding="utf-8")
+        selected = validate_source(
+            parse_env(current_source_text, label="source").values
+        )
+        current_text = current_destination.read_text(encoding="utf-8")
         current_content = build_reconciled_content(current_text, selected)
         if current_content == current_text:
             return {**base_result, "status": "already_reconciled", "applied": False}

--- a/scripts/ops/reconcile_public_login_smtp_env.py
+++ b/scripts/ops/reconcile_public_login_smtp_env.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Safely reconcile public-login and SMTP settings into the canonical VPS env.
+
+The command is fail-closed and value-redacting:
+
+* only an explicit allowlist of keys is copied;
+* source values are validated before any write;
+* dry-run is the default;
+* applying requires root, an exclusive lock, and a durable backup;
+* output contains key names and file metadata, never values.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+import stat
+import sys
+import tempfile
+from typing import Mapping, Sequence
+
+
+APPROVED_KEYS: tuple[str, ...] = (
+    "AUTH_PUBLIC_LOGIN",
+    "AUTH_LOG_MAGIC_TOKEN",
+    "SMTP_HOST",
+    "SMTP_PORT",
+    "SMTP_AUTH",
+    "SMTP_USER",
+    "SMTP_PASS",
+    "SMTP_FROM",
+)
+REQUIRED_SOURCE_KEYS: tuple[str, ...] = (
+    "AUTH_PUBLIC_LOGIN",
+    "SMTP_HOST",
+    "SMTP_PORT",
+    "SMTP_AUTH",
+    "SMTP_USER",
+    "SMTP_PASS",
+    "SMTP_FROM",
+)
+FALSE_VALUES = {"0", "false", "no", "off"}
+TRUE_VALUES = {"1", "true", "yes", "on"}
+TLS_PORTS = {465, 587, 2525}
+RECONCILE_MARKER = (
+    "# Reconciled public-login and SMTP keys from the approved legacy runtime source."
+)
+
+
+class ReconcileError(RuntimeError):
+    """Raised for a safe, value-redacted reconciliation failure."""
+
+
+@dataclass(frozen=True)
+class EnvDocument:
+    lines: tuple[str, ...]
+    values: Mapping[str, str]
+
+
+def _key_from_line(raw: str) -> str | None:
+    stripped = raw.strip()
+    if not stripped or stripped.startswith("#") or "=" not in stripped:
+        return None
+    left = stripped.split("=", 1)[0].strip()
+    if left.startswith("export "):
+        left = left[7:].strip()
+    return left or None
+
+
+def parse_env(text: str, *, label: str) -> EnvDocument:
+    lines = tuple(text.splitlines())
+    values: dict[str, str] = {}
+    for raw in lines:
+        key = _key_from_line(raw)
+        if key is None:
+            continue
+        if key in values:
+            raise ReconcileError(f"duplicate key in {label}: {key}")
+        values[key] = raw.strip().split("=", 1)[1].strip()
+    return EnvDocument(lines=lines, values=values)
+
+
+def _normalized(value: str) -> str:
+    return value.strip().strip('"').strip("'").strip().lower()
+
+
+def validate_source(values: Mapping[str, str]) -> dict[str, str]:
+    missing = [key for key in REQUIRED_SOURCE_KEYS if not values.get(key)]
+    if missing:
+        raise ReconcileError(
+            "required approved source keys missing: " + ", ".join(missing)
+        )
+
+    selected = {key: values[key] for key in APPROVED_KEYS if values.get(key)}
+    selected.setdefault("AUTH_LOG_MAGIC_TOKEN", "0")
+
+    if _normalized(selected["AUTH_PUBLIC_LOGIN"]) not in TRUE_VALUES:
+        raise ReconcileError("AUTH_PUBLIC_LOGIN is not enabled in the source")
+    if _normalized(selected["AUTH_LOG_MAGIC_TOKEN"]) not in FALSE_VALUES:
+        raise ReconcileError("AUTH_LOG_MAGIC_TOKEN is not disabled in the source")
+    if _normalized(selected["SMTP_AUTH"]) not in TRUE_VALUES:
+        raise ReconcileError("SMTP_AUTH is not enabled in the source")
+
+    try:
+        smtp_port = int(_normalized(selected["SMTP_PORT"]))
+    except ValueError as exc:
+        raise ReconcileError("SMTP_PORT is not numeric in the source") from exc
+    if smtp_port not in TLS_PORTS:
+        raise ReconcileError("SMTP_PORT is not an approved TLS submission port")
+
+    for key in ("SMTP_HOST", "SMTP_USER", "SMTP_PASS", "SMTP_FROM"):
+        if not _normalized(selected[key]):
+            raise ReconcileError(f"{key} is empty in the source")
+
+    return {key: selected[key] for key in APPROVED_KEYS}
+
+
+def build_reconciled_content(destination_text: str, selected: Mapping[str, str]) -> str:
+    destination = parse_env(destination_text, label="destination")
+    selected_keys = set(selected)
+    kept = [
+        line
+        for line in destination.lines
+        if _key_from_line(line) not in selected_keys
+        and line.strip() != RECONCILE_MARKER
+    ]
+    while kept and kept[-1] == "":
+        kept.pop()
+    kept.extend(
+        (
+            "",
+            RECONCILE_MARKER,
+        )
+    )
+    kept.extend(f"{key}={selected[key]}" for key in APPROVED_KEYS)
+    return "\n".join(kept) + "\n"
+
+
+def _checked_regular_absolute(path: Path, *, label: str) -> Path:
+    if not path.is_absolute():
+        raise ReconcileError(f"{label} path must be absolute")
+    if path.is_symlink():
+        raise ReconcileError(f"{label} must not be a symlink")
+    try:
+        resolved = path.resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise ReconcileError(f"{label} does not exist: {path}") from exc
+    if not resolved.is_file():
+        raise ReconcileError(f"{label} is not a regular file: {path}")
+    return resolved
+
+
+def _write_file_exclusive(path: Path, content: bytes, *, uid: int, gid: int) -> None:
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600)
+    try:
+        with os.fdopen(fd, "wb", closefd=False) as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.fchown(fd, uid, gid)
+        os.fchmod(fd, 0o600)
+    finally:
+        os.close(fd)
+
+
+def reconcile(
+    *,
+    source_path: Path,
+    destination_path: Path,
+    backup_dir: Path,
+    apply: bool,
+    require_root: bool = True,
+) -> dict[str, object]:
+    source = _checked_regular_absolute(source_path, label="source")
+    destination = _checked_regular_absolute(destination_path, label="destination")
+    if os.path.samefile(source, destination):
+        raise ReconcileError("source and destination must be different files")
+    if not backup_dir.is_absolute():
+        raise ReconcileError("backup directory path must be absolute")
+
+    source_text = source.read_text(encoding="utf-8")
+    destination_text = destination.read_text(encoding="utf-8")
+    selected = validate_source(parse_env(source_text, label="source").values)
+    planned_content = build_reconciled_content(destination_text, selected)
+
+    base_result: dict[str, object] = {
+        "destination": str(destination),
+        "updated_keys": list(APPROVED_KEYS),
+        "values_redacted": True,
+    }
+    if planned_content == destination_text:
+        return {**base_result, "status": "already_reconciled", "applied": False}
+    if not apply:
+        return {**base_result, "status": "planned", "applied": False}
+    if require_root and os.geteuid() != 0:
+        raise ReconcileError("--apply requires root")
+
+    if backup_dir.is_symlink():
+        raise ReconcileError("backup directory must not be a symlink")
+    backup_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if backup_dir.is_symlink() or not backup_dir.is_dir():
+        raise ReconcileError("backup directory is not a regular directory")
+    os.chmod(backup_dir, 0o700)
+
+    lock_path = destination.parent / f".{destination.name}.reconcile.lock"
+    lock_fd = os.open(lock_path, os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW, 0o600)
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+
+        # Re-read after acquiring the lock so the write cannot silently erase a
+        # concurrent operator change made after the initial dry validation.
+        current_text = destination.read_text(encoding="utf-8")
+        current_content = build_reconciled_content(current_text, selected)
+        if current_content == current_text:
+            return {**base_result, "status": "already_reconciled", "applied": False}
+
+        destination_stat = destination.stat()
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
+        backup = backup_dir / f"{destination.name}.bak-{timestamp}-{os.getpid()}"
+        _write_file_exclusive(
+            backup,
+            current_text.encode("utf-8"),
+            uid=destination_stat.st_uid,
+            gid=destination_stat.st_gid,
+        )
+        backup_dir_fd = os.open(backup_dir, os.O_DIRECTORY)
+        try:
+            os.fsync(backup_dir_fd)
+        finally:
+            os.close(backup_dir_fd)
+
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{destination.name}.", dir=destination.parent
+        )
+        tmp = Path(tmp_name)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(current_content)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.chown(tmp, destination_stat.st_uid, destination_stat.st_gid)
+            os.chmod(tmp, 0o600)
+            os.replace(tmp, destination)
+            dir_fd = os.open(destination.parent, os.O_DIRECTORY)
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)
+        finally:
+            if tmp.exists():
+                tmp.unlink()
+
+        final_stat = destination.stat()
+        return {
+            **base_result,
+            "status": "reconciled",
+            "applied": True,
+            "backup": str(backup),
+            "mode": f"{stat.S_IMODE(final_stat.st_mode):04o}",
+            "owner_uid": final_stat.st_uid,
+            "owner_gid": final_stat.st_gid,
+        }
+    finally:
+        os.close(lock_fd)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--destination", type=Path, required=True)
+    parser.add_argument("--backup-dir", type=Path, required=True)
+    parser.add_argument(
+        "--apply", action="store_true", help="write after validation; otherwise dry-run"
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="emit a value-redacted JSON receipt"
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        result = reconcile(
+            source_path=args.source,
+            destination_path=args.destination,
+            backup_dir=args.backup_dir,
+            apply=args.apply,
+        )
+    except (OSError, ReconcileError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(result, sort_keys=True))
+    else:
+        print(f"Status: {result['status']}")
+        print(f"Destination: {result['destination']}")
+        print("Updated keys: " + ", ".join(result["updated_keys"]))
+        if result.get("backup"):
+            print(f"Backup: {result['backup']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ops/reconcile_public_login_smtp_env.py
+++ b/scripts/ops/reconcile_public_login_smtp_env.py
@@ -155,6 +155,16 @@ def _checked_regular_absolute(path: Path, *, label: str) -> Path:
     return resolved
 
 
+def _validate_root_owned_runtime_file(path: Path, *, label: str) -> None:
+    path_stat = path.stat()
+    if path_stat.st_uid != 0:
+        raise ReconcileError(f"{label} must be root-owned for --apply")
+    if stat.S_IMODE(path_stat.st_mode) & (stat.S_IWGRP | stat.S_IWOTH):
+        raise ReconcileError(
+            f"{label} must not be writable by group or others for --apply"
+        )
+
+
 def _write_file_exclusive(path: Path, content: bytes, *, uid: int, gid: int) -> None:
     fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600)
     try:
@@ -200,6 +210,9 @@ def reconcile(
         return {**base_result, "status": "planned", "applied": False}
     if require_root and os.geteuid() != 0:
         raise ReconcileError("--apply requires root")
+    if require_root:
+        _validate_root_owned_runtime_file(source, label="source")
+        _validate_root_owned_runtime_file(destination, label="destination")
 
     if backup_dir.is_symlink():
         raise ReconcileError("backup directory must not be a symlink")
@@ -262,9 +275,11 @@ def reconcile(
             with os.fdopen(fd, "w", encoding="utf-8") as handle:
                 handle.write(current_content)
                 handle.flush()
+                os.fchown(
+                    handle.fileno(), destination_stat.st_uid, destination_stat.st_gid
+                )
+                os.fchmod(handle.fileno(), 0o600)
                 os.fsync(handle.fileno())
-            os.chown(tmp, destination_stat.st_uid, destination_stat.st_gid)
-            os.chmod(tmp, 0o600)
             os.replace(tmp, destination)
             dir_fd = os.open(destination.parent, os.O_DIRECTORY)
             try:

--- a/scripts/ops/reconcile_public_login_smtp_env.py
+++ b/scripts/ops/reconcile_public_login_smtp_env.py
@@ -77,7 +77,8 @@ class OpenedEnv:
 
 
 class DigestWriter(Protocol):
-    def update(self, data: bytes) -> None: ...
+    def update(self, data: bytes) -> None:
+        """Add bytes to the digest state."""
 
 
 def _key_from_line(raw: str) -> str | None:
@@ -192,7 +193,9 @@ def _update_plan_field(digest: DigestWriter, label: str, value: bytes) -> None:
     digest.update(value)
 
 
-def _stat_plan_fields(prefix: str, file_stat: os.stat_result) -> tuple[tuple[str, bytes], ...]:
+def _stat_plan_fields(
+    prefix: str, file_stat: os.stat_result
+) -> tuple[tuple[str, bytes], ...]:
     return tuple(
         (f"{prefix}_{name}", str(value).encode("ascii"))
         for name, value in (
@@ -358,6 +361,7 @@ def _write_file_exclusive_at(
             os.unlink(name, dir_fd=directory_fd)
             os.fsync(directory_fd)
         except FileNotFoundError:
+            # The entry was already absent, so no partial secret file remains.
             pass
         raise
     finally:
@@ -405,7 +409,9 @@ def _acquire_exclusive_lock(lock_fd: int) -> None:
         except BlockingIOError as exc:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
-                raise ReconcileError("timed out waiting for reconciliation lock") from exc
+                raise ReconcileError(
+                    "timed out waiting for reconciliation lock"
+                ) from exc
             time.sleep(min(LOCK_RETRY_SECONDS, remaining))
 
 
@@ -587,12 +593,15 @@ def reconcile(
                 or verified_backup.file_stat.st_gid != destination_stat.st_gid
                 or backup_mode != 0o600
             ):
-                raise ReconcileError("backup verification failed before destination replace")
+                raise ReconcileError(
+                    "backup verification failed before destination replace"
+                )
         except BaseException:
             try:
                 os.unlink(backup_name, dir_fd=backup_dir_fd)
                 os.fsync(backup_dir_fd)
             except FileNotFoundError:
+                # The backup is already absent, so rollback cleanup is complete.
                 pass
             raise
 

--- a/scripts/ops/reconcile_public_login_smtp_env.py
+++ b/scripts/ops/reconcile_public_login_smtp_env.py
@@ -155,14 +155,38 @@ def _checked_regular_absolute(path: Path, *, label: str) -> Path:
     return resolved
 
 
-def _validate_root_owned_runtime_file(path: Path, *, label: str) -> None:
-    path_stat = path.stat()
-    if path_stat.st_uid != 0:
+def _validate_root_owned_runtime_stat(file_stat: os.stat_result, *, label: str) -> None:
+    if file_stat.st_uid != 0:
         raise ReconcileError(f"{label} must be root-owned for --apply")
-    if stat.S_IMODE(path_stat.st_mode) & (stat.S_IWGRP | stat.S_IWOTH):
+    if stat.S_IMODE(file_stat.st_mode) & (stat.S_IWGRP | stat.S_IWOTH):
         raise ReconcileError(
             f"{label} must not be writable by group or others for --apply"
         )
+
+
+def _read_regular_no_follow(path: Path, *, label: str) -> tuple[str, os.stat_result]:
+    flags = os.O_RDONLY | os.O_NOFOLLOW
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    try:
+        fd = os.open(path, flags)
+    except OSError as exc:
+        raise ReconcileError(f"unable to open {label} safely: {path}") from exc
+    try:
+        file_stat = os.fstat(fd)
+        if not stat.S_ISREG(file_stat.st_mode):
+            raise ReconcileError(f"{label} is not a regular file: {path}")
+        with os.fdopen(fd, "r", encoding="utf-8", closefd=False) as handle:
+            text = handle.read()
+        return text, file_stat
+    except UnicodeDecodeError as exc:
+        raise ReconcileError(f"{label} is not valid UTF-8: {path}") from exc
+    finally:
+        os.close(fd)
+
+
+def _same_file(left: os.stat_result, right: os.stat_result) -> bool:
+    return left.st_dev == right.st_dev and left.st_ino == right.st_ino
 
 
 def _write_file_exclusive(path: Path, content: bytes, *, uid: int, gid: int) -> None:
@@ -189,13 +213,21 @@ def reconcile(
 ) -> dict[str, object]:
     source = _checked_regular_absolute(source_path, label="source")
     destination = _checked_regular_absolute(destination_path, label="destination")
-    if os.path.samefile(source, destination):
-        raise ReconcileError("source and destination must be different files")
     if not backup_dir.is_absolute():
         raise ReconcileError("backup directory path must be absolute")
+    if apply and require_root and os.geteuid() != 0:
+        raise ReconcileError("--apply requires root")
 
-    source_text = source.read_text(encoding="utf-8")
-    destination_text = destination.read_text(encoding="utf-8")
+    source_text, source_stat = _read_regular_no_follow(source, label="source")
+    destination_text, destination_stat = _read_regular_no_follow(
+        destination, label="destination"
+    )
+    if _same_file(source_stat, destination_stat):
+        raise ReconcileError("source and destination must be different files")
+    if apply and require_root:
+        _validate_root_owned_runtime_stat(source_stat, label="source")
+        _validate_root_owned_runtime_stat(destination_stat, label="destination")
+
     selected = validate_source(parse_env(source_text, label="source").values)
     planned_content = build_reconciled_content(destination_text, selected)
 
@@ -208,12 +240,6 @@ def reconcile(
         return {**base_result, "status": "already_reconciled", "applied": False}
     if not apply:
         return {**base_result, "status": "planned", "applied": False}
-    if require_root and os.geteuid() != 0:
-        raise ReconcileError("--apply requires root")
-    if require_root:
-        _validate_root_owned_runtime_file(source, label="source")
-        _validate_root_owned_runtime_file(destination, label="destination")
-
     if backup_dir.is_symlink():
         raise ReconcileError("backup directory must not be a symlink")
     backup_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
@@ -240,19 +266,34 @@ def reconcile(
             raise ReconcileError("source path changed during reconciliation")
         if current_destination != destination:
             raise ReconcileError("destination path changed during reconciliation")
-        if os.path.samefile(current_source, current_destination):
+        current_source_text, current_source_stat = _read_regular_no_follow(
+            current_source, label="source"
+        )
+        current_text, current_destination_stat = _read_regular_no_follow(
+            current_destination, label="destination"
+        )
+        if not _same_file(source_stat, current_source_stat):
+            raise ReconcileError("source file identity changed during reconciliation")
+        if not _same_file(destination_stat, current_destination_stat):
+            raise ReconcileError(
+                "destination file identity changed during reconciliation"
+            )
+        if _same_file(current_source_stat, current_destination_stat):
             raise ReconcileError("source and destination must be different files")
+        if require_root:
+            _validate_root_owned_runtime_stat(current_source_stat, label="source")
+            _validate_root_owned_runtime_stat(
+                current_destination_stat, label="destination"
+            )
 
-        current_source_text = current_source.read_text(encoding="utf-8")
         selected = validate_source(
             parse_env(current_source_text, label="source").values
         )
-        current_text = current_destination.read_text(encoding="utf-8")
         current_content = build_reconciled_content(current_text, selected)
         if current_content == current_text:
             return {**base_result, "status": "already_reconciled", "applied": False}
 
-        destination_stat = destination.stat()
+        destination_stat = current_destination_stat
         timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
         backup = backup_dir / f"{destination.name}.bak-{timestamp}-{os.getpid()}"
         _write_file_exclusive(

--- a/scripts/ops/reconcile_public_login_smtp_env.py
+++ b/scripts/ops/reconcile_public_login_smtp_env.py
@@ -55,6 +55,7 @@ RECONCILE_MARKER = (
 PLAN_DOMAIN = b"weltgewebe-public-login-smtp-env-plan-v1\0"
 PLAN_SHA256_RE = re.compile(r"[0-9a-f]{64}")
 ASCII_PORT_RE = re.compile(r"[0-9]{1,5}")
+INVALID_LINE_CHARS = frozenset("\r\x0b\x0c\x1c\x1d\x1e\x85\u2028\u2029")
 TEMP_PREFIX_TEMPLATE = ".{name}.reconcile-"
 LOCK_TIMEOUT_SECONDS = 15.0
 LOCK_RETRY_SECONDS = 0.05
@@ -72,6 +73,7 @@ class EnvDocument:
 
 @dataclass(frozen=True)
 class OpenedEnv:
+    raw_bytes: bytes
     text: str
     file_stat: os.stat_result
 
@@ -92,7 +94,9 @@ def _key_from_line(raw: str) -> str | None:
 
 
 def parse_env(text: str, *, label: str) -> EnvDocument:
-    lines = tuple(text.splitlines())
+    if any(character in text for character in INVALID_LINE_CHARS):
+        raise ReconcileError(f"{label} contains an unsupported line separator")
+    lines = tuple(text.split("\n"))
     values: dict[str, str] = {}
     for raw in lines:
         key = _key_from_line(raw)
@@ -323,9 +327,10 @@ def _read_regular_at(
             raise ReconcileError(f"{label} is not a regular file")
         if require_root:
             _validate_root_owned_stat(file_stat, label=label)
-        with os.fdopen(fd, "r", encoding="utf-8", closefd=False) as handle:
-            text = handle.read()
-        return OpenedEnv(text=text, file_stat=file_stat)
+        with os.fdopen(fd, "rb", closefd=False) as handle:
+            raw_bytes = handle.read()
+        text = raw_bytes.decode("utf-8", errors="strict")
+        return OpenedEnv(raw_bytes=raw_bytes, text=text, file_stat=file_stat)
     except UnicodeDecodeError as exc:
         raise ReconcileError(f"{label} is not valid UTF-8") from exc
     finally:
@@ -442,17 +447,19 @@ def reconcile(
     if require_root and os.geteuid() != 0:
         raise ReconcileError("dry-run and apply require root")
 
-    source_dir_fd = _open_trusted_directory(
-        source.parent, label="source parent directory", require_root=require_root
-    )
-    destination_dir_fd = _open_trusted_directory(
-        destination.parent,
-        label="destination parent directory",
-        require_root=require_root,
-    )
+    source_dir_fd: int | None = None
+    destination_dir_fd: int | None = None
     backup_dir_fd: int | None = None
     lock_fd: int | None = None
     try:
+        source_dir_fd = _open_trusted_directory(
+            source.parent, label="source parent directory", require_root=require_root
+        )
+        destination_dir_fd = _open_trusted_directory(
+            destination.parent,
+            label="destination parent directory",
+            require_root=require_root,
+        )
         initial_source = _read_regular_at(
             source_dir_fd, source.name, label="source", require_root=require_root
         )
@@ -574,7 +581,7 @@ def reconcile(
         _write_file_exclusive_at(
             backup_dir_fd,
             backup_name,
-            current_destination.text.encode("utf-8"),
+            current_destination.raw_bytes,
             uid=destination_stat.st_uid,
             gid=destination_stat.st_gid,
         )
@@ -588,7 +595,7 @@ def reconcile(
             )
             backup_mode = stat.S_IMODE(verified_backup.file_stat.st_mode)
             if (
-                verified_backup.text != current_destination.text
+                verified_backup.raw_bytes != current_destination.raw_bytes
                 or verified_backup.file_stat.st_uid != destination_stat.st_uid
                 or verified_backup.file_stat.st_gid != destination_stat.st_gid
                 or backup_mode != 0o600
@@ -661,8 +668,10 @@ def reconcile(
             os.close(lock_fd)
         if backup_dir_fd is not None:
             os.close(backup_dir_fd)
-        os.close(destination_dir_fd)
-        os.close(source_dir_fd)
+        if destination_dir_fd is not None:
+            os.close(destination_dir_fd)
+        if source_dir_fd is not None:
+            os.close(source_dir_fd)
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/scripts/ops/reconcile_public_login_smtp_env.py
+++ b/scripts/ops/reconcile_public_login_smtp_env.py
@@ -4,9 +4,10 @@
 The command is fail-closed and value-redacting:
 
 * only an explicit allowlist of keys is copied;
-* source values are validated before any write;
-* dry-run is the default;
-* applying requires root, an exclusive lock, and a durable backup;
+* source values are canonicalized to the exact runtime vocabulary;
+* dry-run is the default and performs the same trust checks as apply;
+* apply requires the exact plan hash emitted by dry-run;
+* source, destination, lock and backup paths are opened without following symlinks;
 * output contains key names and file metadata, never values.
 """
 
@@ -14,15 +15,18 @@ from __future__ import annotations
 
 import argparse
 import fcntl
+import hashlib
 import json
 import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+import re
+import secrets
 import stat
 import sys
-import tempfile
-from typing import Mapping, Sequence
+import time
+from typing import Mapping, Protocol, Sequence
 
 
 APPROVED_KEYS: tuple[str, ...] = (
@@ -44,12 +48,16 @@ REQUIRED_SOURCE_KEYS: tuple[str, ...] = (
     "SMTP_PASS",
     "SMTP_FROM",
 )
-FALSE_VALUES = {"0", "false", "no", "off"}
-TRUE_VALUES = {"1", "true", "yes", "on"}
 TLS_PORTS = {465, 587, 2525}
 RECONCILE_MARKER = (
     "# Reconciled public-login and SMTP keys from the approved legacy runtime source."
 )
+PLAN_DOMAIN = b"weltgewebe-public-login-smtp-env-plan-v1\0"
+PLAN_SHA256_RE = re.compile(r"[0-9a-f]{64}")
+ASCII_PORT_RE = re.compile(r"[0-9]{1,5}")
+TEMP_PREFIX_TEMPLATE = ".{name}.reconcile-"
+LOCK_TIMEOUT_SECONDS = 15.0
+LOCK_RETRY_SECONDS = 0.05
 
 
 class ReconcileError(RuntimeError):
@@ -60,6 +68,16 @@ class ReconcileError(RuntimeError):
 class EnvDocument:
     lines: tuple[str, ...]
     values: Mapping[str, str]
+
+
+@dataclass(frozen=True)
+class OpenedEnv:
+    text: str
+    file_stat: os.stat_result
+
+
+class DigestWriter(Protocol):
+    def update(self, data: bytes) -> None: ...
 
 
 def _key_from_line(raw: str) -> str | None:
@@ -85,39 +103,69 @@ def parse_env(text: str, *, label: str) -> EnvDocument:
     return EnvDocument(lines=lines, values=values)
 
 
-def _normalized(value: str) -> str:
-    return value.strip().strip('"').strip("'").strip().lower()
+def _logical_scalar(raw: str, *, key: str) -> str:
+    value = raw.strip()
+    if not value:
+        return ""
+    first = value[0]
+    last = value[-1]
+    if first in {"'", '"'}:
+        if len(value) < 2 or last != first:
+            raise ReconcileError(f"malformed quoted value for key: {key}")
+        return value[1:-1].strip()
+    if last in {"'", '"'}:
+        raise ReconcileError(f"malformed quoted value for key: {key}")
+    return value
 
 
 def validate_source(values: Mapping[str, str]) -> dict[str, str]:
-    missing = [key for key in REQUIRED_SOURCE_KEYS if not values.get(key)]
+    missing = [key for key in REQUIRED_SOURCE_KEYS if key not in values]
     if missing:
         raise ReconcileError(
             "required approved source keys missing: " + ", ".join(missing)
         )
 
-    selected = {key: values[key] for key in APPROVED_KEYS if values.get(key)}
-    selected.setdefault("AUTH_LOG_MAGIC_TOKEN", "0")
+    selected: dict[str, str] = {}
 
-    if _normalized(selected["AUTH_PUBLIC_LOGIN"]) not in TRUE_VALUES:
+    public_login = _logical_scalar(values["AUTH_PUBLIC_LOGIN"], key="AUTH_PUBLIC_LOGIN")
+    if public_login == "1" or public_login.lower() == "true":
+        selected["AUTH_PUBLIC_LOGIN"] = "1"
+    else:
         raise ReconcileError("AUTH_PUBLIC_LOGIN is not enabled in the source")
-    if _normalized(selected["AUTH_LOG_MAGIC_TOKEN"]) not in FALSE_VALUES:
-        raise ReconcileError("AUTH_LOG_MAGIC_TOKEN is not disabled in the source")
-    if _normalized(selected["SMTP_AUTH"]) not in TRUE_VALUES:
-        raise ReconcileError("SMTP_AUTH is not enabled in the source")
 
-    try:
-        smtp_port = int(_normalized(selected["SMTP_PORT"]))
-    except ValueError as exc:
-        raise ReconcileError("SMTP_PORT is not numeric in the source") from exc
+    raw_magic_log = values.get("AUTH_LOG_MAGIC_TOKEN", "0")
+    magic_log = _logical_scalar(raw_magic_log, key="AUTH_LOG_MAGIC_TOKEN")
+    if magic_log == "0" or magic_log.lower() == "false":
+        selected["AUTH_LOG_MAGIC_TOKEN"] = "0"
+    else:
+        raise ReconcileError("AUTH_LOG_MAGIC_TOKEN is not disabled in the source")
+
+    smtp_auth = _logical_scalar(values["SMTP_AUTH"], key="SMTP_AUTH")
+    if smtp_auth.lower() != "on":
+        raise ReconcileError("SMTP_AUTH must be exactly 'on' in the source")
+    selected["SMTP_AUTH"] = "on"
+
+    port_text = _logical_scalar(values["SMTP_PORT"], key="SMTP_PORT")
+    if not ASCII_PORT_RE.fullmatch(port_text):
+        raise ReconcileError("SMTP_PORT must contain ASCII digits only")
+    smtp_port = int(port_text)
     if smtp_port not in TLS_PORTS:
         raise ReconcileError("SMTP_PORT is not an approved TLS submission port")
+    selected["SMTP_PORT"] = str(smtp_port)
 
     for key in ("SMTP_HOST", "SMTP_USER", "SMTP_PASS", "SMTP_FROM"):
-        if not _normalized(selected[key]):
+        raw_value = values[key].strip()
+        if not _logical_scalar(raw_value, key=key):
             raise ReconcileError(f"{key} is empty in the source")
+        selected[key] = raw_value
 
     return {key: selected[key] for key in APPROVED_KEYS}
+
+
+def changed_keys(destination: EnvDocument, selected: Mapping[str, str]) -> list[str]:
+    return [
+        key for key in APPROVED_KEYS if destination.values.get(key) != selected[key]
+    ]
 
 
 def build_reconciled_content(destination_text: str, selected: Mapping[str, str]) -> str:
@@ -131,56 +179,152 @@ def build_reconciled_content(destination_text: str, selected: Mapping[str, str])
     ]
     while kept and kept[-1] == "":
         kept.pop()
-    kept.extend(
-        (
-            "",
-            RECONCILE_MARKER,
-        )
-    )
+    kept.extend(("", RECONCILE_MARKER))
     kept.extend(f"{key}={selected[key]}" for key in APPROVED_KEYS)
     return "\n".join(kept) + "\n"
 
 
-def _checked_regular_absolute(path: Path, *, label: str) -> Path:
+def _update_plan_field(digest: DigestWriter, label: str, value: bytes) -> None:
+    label_bytes = label.encode("utf-8")
+    digest.update(len(label_bytes).to_bytes(4, "big"))
+    digest.update(label_bytes)
+    digest.update(len(value).to_bytes(8, "big"))
+    digest.update(value)
+
+
+def _stat_plan_fields(prefix: str, file_stat: os.stat_result) -> tuple[tuple[str, bytes], ...]:
+    return tuple(
+        (f"{prefix}_{name}", str(value).encode("ascii"))
+        for name, value in (
+            ("device", file_stat.st_dev),
+            ("inode", file_stat.st_ino),
+            ("uid", file_stat.st_uid),
+            ("gid", file_stat.st_gid),
+            ("mode", stat.S_IMODE(file_stat.st_mode)),
+        )
+    )
+
+
+def plan_sha256(
+    *,
+    source_path: Path,
+    destination_path: Path,
+    backup_dir: Path,
+    source_stat: os.stat_result,
+    destination_stat: os.stat_result,
+    backup_dir_stat: os.stat_result,
+    source_text: str,
+    destination_text: str,
+    planned_content: str,
+) -> str:
+    digest = hashlib.sha256()
+    digest.update(PLAN_DOMAIN)
+    fields: list[tuple[str, bytes]] = [
+        ("source_path", os.fsencode(source_path)),
+        ("destination_path", os.fsencode(destination_path)),
+        ("backup_dir", os.fsencode(backup_dir)),
+        ("source_text", source_text.encode("utf-8")),
+        ("destination_text", destination_text.encode("utf-8")),
+        ("planned_content", planned_content.encode("utf-8")),
+    ]
+    fields.extend(_stat_plan_fields("source", source_stat))
+    fields.extend(_stat_plan_fields("destination", destination_stat))
+    fields.extend(_stat_plan_fields("backup_dir", backup_dir_stat))
+    for label, value in fields:
+        _update_plan_field(digest, label, value)
+    return digest.hexdigest()
+
+
+def _normalize_absolute_path(path: Path, *, label: str) -> Path:
     if not path.is_absolute():
         raise ReconcileError(f"{label} path must be absolute")
-    if path.is_symlink():
-        raise ReconcileError(f"{label} must not be a symlink")
-    try:
-        resolved = path.resolve(strict=True)
-    except FileNotFoundError as exc:
-        raise ReconcileError(f"{label} does not exist: {path}") from exc
-    if not resolved.is_file():
-        raise ReconcileError(f"{label} is not a regular file: {path}")
-    return resolved
+    if any(part in {".", ".."} for part in path.parts[1:]):
+        raise ReconcileError(f"{label} path must be normalized")
+    return path
 
 
-def _validate_root_owned_runtime_stat(file_stat: os.stat_result, *, label: str) -> None:
-    if file_stat.st_uid != 0:
-        raise ReconcileError(f"{label} must be root-owned for --apply")
-    if stat.S_IMODE(file_stat.st_mode) & (stat.S_IWGRP | stat.S_IWOTH):
-        raise ReconcileError(
-            f"{label} must not be writable by group or others for --apply"
-        )
+def _directory_open_flags() -> int:
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    return flags
 
 
-def _read_regular_no_follow(path: Path, *, label: str) -> tuple[str, os.stat_result]:
+def _file_open_flags() -> int:
     flags = os.O_RDONLY | os.O_NOFOLLOW
     if hasattr(os, "O_CLOEXEC"):
         flags |= os.O_CLOEXEC
+    return flags
+
+
+def _validate_root_owned_stat(file_stat: os.stat_result, *, label: str) -> None:
+    if file_stat.st_uid != 0:
+        raise ReconcileError(f"{label} must be root-owned")
+    if stat.S_IMODE(file_stat.st_mode) & (stat.S_IWGRP | stat.S_IWOTH):
+        raise ReconcileError(f"{label} must not be writable by group or others")
+
+
+def _open_trusted_directory(
+    path: Path,
+    *,
+    label: str,
+    require_root: bool,
+    exact_mode: int | None = None,
+) -> int:
+    normalized = _normalize_absolute_path(path, label=label)
+    current_fd = os.open("/", _directory_open_flags())
     try:
-        fd = os.open(path, flags)
+        root_stat = os.fstat(current_fd)
+        if not stat.S_ISDIR(root_stat.st_mode):
+            raise ReconcileError("filesystem root is not a directory")
+        if require_root:
+            _validate_root_owned_stat(root_stat, label="filesystem root")
+        for part in normalized.parts[1:]:
+            try:
+                next_fd = os.open(part, _directory_open_flags(), dir_fd=current_fd)
+            except OSError as exc:
+                raise ReconcileError(f"unable to open {label} safely: {path}") from exc
+            os.close(current_fd)
+            current_fd = next_fd
+            current_stat = os.fstat(current_fd)
+            if not stat.S_ISDIR(current_stat.st_mode):
+                raise ReconcileError(f"{label} is not a directory: {path}")
+            if require_root:
+                _validate_root_owned_stat(current_stat, label=label)
+
+        final_stat = os.fstat(current_fd)
+        if exact_mode is not None and stat.S_IMODE(final_stat.st_mode) != exact_mode:
+            raise ReconcileError(f"{label} must have mode {exact_mode:04o}")
+        return current_fd
+    except Exception:
+        os.close(current_fd)
+        raise
+
+
+def _read_regular_at(
+    parent_fd: int,
+    name: str,
+    *,
+    label: str,
+    require_root: bool,
+) -> OpenedEnv:
+    if not name or "/" in name or name in {".", ".."}:
+        raise ReconcileError(f"invalid {label} filename")
+    try:
+        fd = os.open(name, _file_open_flags(), dir_fd=parent_fd)
     except OSError as exc:
-        raise ReconcileError(f"unable to open {label} safely: {path}") from exc
+        raise ReconcileError(f"unable to open {label} safely") from exc
     try:
         file_stat = os.fstat(fd)
         if not stat.S_ISREG(file_stat.st_mode):
-            raise ReconcileError(f"{label} is not a regular file: {path}")
+            raise ReconcileError(f"{label} is not a regular file")
+        if require_root:
+            _validate_root_owned_stat(file_stat, label=label)
         with os.fdopen(fd, "r", encoding="utf-8", closefd=False) as handle:
             text = handle.read()
-        return text, file_stat
+        return OpenedEnv(text=text, file_stat=file_stat)
     except UnicodeDecodeError as exc:
-        raise ReconcileError(f"{label} is not valid UTF-8: {path}") from exc
+        raise ReconcileError(f"{label} is not valid UTF-8") from exc
     finally:
         os.close(fd)
 
@@ -189,18 +333,89 @@ def _same_file(left: os.stat_result, right: os.stat_result) -> bool:
     return left.st_dev == right.st_dev and left.st_ino == right.st_ino
 
 
-def _write_file_exclusive(path: Path, content: bytes, *, uid: int, gid: int) -> None:
-    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600)
+def _write_file_exclusive_at(
+    directory_fd: int,
+    name: str,
+    content: bytes,
+    *,
+    uid: int,
+    gid: int,
+) -> os.stat_result:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    fd = os.open(name, flags, 0o600, dir_fd=directory_fd)
     try:
         with os.fdopen(fd, "wb", closefd=False) as handle:
             handle.write(content)
             handle.flush()
-            os.fsync(handle.fileno())
-        os.fchown(fd, uid, gid)
-        os.fchmod(fd, 0o600)
-        os.fsync(fd)
+            os.fchown(fd, uid, gid)
+            os.fchmod(fd, 0o600)
+            os.fsync(fd)
+        return os.fstat(fd)
+    except BaseException:
+        try:
+            os.unlink(name, dir_fd=directory_fd)
+            os.fsync(directory_fd)
+        except FileNotFoundError:
+            pass
+        raise
     finally:
         os.close(fd)
+
+
+def _cleanup_orphan_temps(
+    directory_fd: int,
+    *,
+    prefix: str,
+    expected_uid: int,
+    expected_gid: int,
+) -> None:
+    for name in os.listdir(directory_fd):
+        if not name.startswith(prefix):
+            continue
+        try:
+            fd = os.open(name, _file_open_flags(), dir_fd=directory_fd)
+        except OSError:
+            continue
+        try:
+            file_stat = os.fstat(fd)
+            safe = (
+                stat.S_ISREG(file_stat.st_mode)
+                and file_stat.st_uid == expected_uid
+                and file_stat.st_gid == expected_gid
+                and stat.S_IMODE(file_stat.st_mode) == 0o600
+            )
+        finally:
+            os.close(fd)
+        if safe:
+            # The name can only be swapped by a writer to the already validated
+            # trusted directory; production directories are root-owned and not
+            # writable by group or others, and cleanup runs while holding the lock.
+            os.unlink(name, dir_fd=directory_fd)
+    os.fsync(directory_fd)
+
+
+def _acquire_exclusive_lock(lock_fd: int) -> None:
+    deadline = time.monotonic() + LOCK_TIMEOUT_SECONDS
+    while True:
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return
+        except BlockingIOError as exc:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise ReconcileError("timed out waiting for reconciliation lock") from exc
+            time.sleep(min(LOCK_RETRY_SECONDS, remaining))
+
+
+def _validate_expected_plan(expected_plan_sha256: str | None) -> str:
+    if expected_plan_sha256 is None:
+        raise ReconcileError("--apply requires --expected-plan-sha256 from dry-run")
+    normalized = expected_plan_sha256.strip().lower()
+    if not PLAN_SHA256_RE.fullmatch(normalized):
+        raise ReconcileError("expected plan SHA-256 is invalid")
+    return normalized
 
 
 def reconcile(
@@ -209,140 +424,236 @@ def reconcile(
     destination_path: Path,
     backup_dir: Path,
     apply: bool,
+    expected_plan_sha256: str | None = None,
     require_root: bool = True,
 ) -> dict[str, object]:
-    source = _checked_regular_absolute(source_path, label="source")
-    destination = _checked_regular_absolute(destination_path, label="destination")
-    if not backup_dir.is_absolute():
-        raise ReconcileError("backup directory path must be absolute")
-    if apply and require_root and os.geteuid() != 0:
-        raise ReconcileError("--apply requires root")
+    source = _normalize_absolute_path(source_path, label="source")
+    destination = _normalize_absolute_path(destination_path, label="destination")
+    backup = _normalize_absolute_path(backup_dir, label="backup directory")
 
-    source_text, source_stat = _read_regular_no_follow(source, label="source")
-    destination_text, destination_stat = _read_regular_no_follow(
-        destination, label="destination"
+    if source.name == "" or destination.name == "":
+        raise ReconcileError("source and destination must name regular files")
+    if require_root and os.geteuid() != 0:
+        raise ReconcileError("dry-run and apply require root")
+
+    source_dir_fd = _open_trusted_directory(
+        source.parent, label="source parent directory", require_root=require_root
     )
-    if _same_file(source_stat, destination_stat):
-        raise ReconcileError("source and destination must be different files")
-    if apply and require_root:
-        _validate_root_owned_runtime_stat(source_stat, label="source")
-        _validate_root_owned_runtime_stat(destination_stat, label="destination")
-
-    selected = validate_source(parse_env(source_text, label="source").values)
-    planned_content = build_reconciled_content(destination_text, selected)
-
-    base_result: dict[str, object] = {
-        "destination": str(destination),
-        "updated_keys": list(APPROVED_KEYS),
-        "values_redacted": True,
-    }
-    if planned_content == destination_text:
-        return {**base_result, "status": "already_reconciled", "applied": False}
-    if not apply:
-        return {**base_result, "status": "planned", "applied": False}
-    if backup_dir.is_symlink():
-        raise ReconcileError("backup directory must not be a symlink")
-    backup_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
-    if backup_dir.is_symlink() or not backup_dir.is_dir():
-        raise ReconcileError("backup directory is not a regular directory")
-    backup_dir_stat = backup_dir.stat()
-    if require_root and backup_dir_stat.st_uid != 0:
-        raise ReconcileError("backup directory must be root-owned")
-    os.chmod(backup_dir, 0o700)
-
-    lock_path = destination.parent / f".{destination.name}.reconcile.lock"
-    lock_fd = os.open(lock_path, os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW, 0o600)
+    destination_dir_fd = _open_trusted_directory(
+        destination.parent,
+        label="destination parent directory",
+        require_root=require_root,
+    )
+    backup_dir_fd: int | None = None
+    lock_fd: int | None = None
     try:
-        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        initial_source = _read_regular_at(
+            source_dir_fd, source.name, label="source", require_root=require_root
+        )
+        initial_destination = _read_regular_at(
+            destination_dir_fd,
+            destination.name,
+            label="destination",
+            require_root=require_root,
+        )
+        if _same_file(initial_source.file_stat, initial_destination.file_stat):
+            raise ReconcileError("source and destination must be different files")
 
-        # Re-resolve and re-read both files after acquiring the lock. This keeps
-        # an apply operation from using stale source values or silently replacing
-        # a destination path that another root operator changed after dry-run.
-        current_source = _checked_regular_absolute(source_path, label="source")
-        current_destination = _checked_regular_absolute(
-            destination_path, label="destination"
+        backup_dir_fd = _open_trusted_directory(
+            backup,
+            label="backup directory",
+            require_root=require_root,
+            exact_mode=0o700,
         )
-        if current_source != source:
-            raise ReconcileError("source path changed during reconciliation")
-        if current_destination != destination:
-            raise ReconcileError("destination path changed during reconciliation")
-        current_source_text, current_source_stat = _read_regular_no_follow(
-            current_source, label="source"
+        backup_dir_stat = os.fstat(backup_dir_fd)
+
+        selected = validate_source(
+            parse_env(initial_source.text, label="source").values
         )
-        current_text, current_destination_stat = _read_regular_no_follow(
-            current_destination, label="destination"
+        destination_document = parse_env(initial_destination.text, label="destination")
+        planned_content = build_reconciled_content(initial_destination.text, selected)
+        current_plan_sha256 = plan_sha256(
+            source_path=source,
+            destination_path=destination,
+            backup_dir=backup,
+            source_stat=initial_source.file_stat,
+            destination_stat=initial_destination.file_stat,
+            backup_dir_stat=backup_dir_stat,
+            source_text=initial_source.text,
+            destination_text=initial_destination.text,
+            planned_content=planned_content,
         )
-        if not _same_file(source_stat, current_source_stat):
+        initial_changed_keys = changed_keys(destination_document, selected)
+
+        if apply:
+            expected = _validate_expected_plan(expected_plan_sha256)
+            if expected != current_plan_sha256:
+                raise ReconcileError(
+                    "expected plan SHA-256 does not match current inputs"
+                )
+
+        base_result: dict[str, object] = {
+            "destination": str(destination),
+            "updated_keys": initial_changed_keys,
+            "values_redacted": True,
+            "plan_sha256": current_plan_sha256,
+        }
+        if planned_content == initial_destination.text:
+            return {**base_result, "status": "already_reconciled", "applied": False}
+
+        if not apply:
+            return {**base_result, "status": "planned", "applied": False}
+
+        lock_name = f".{destination.name}.reconcile.lock"
+        lock_flags = os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW
+        if hasattr(os, "O_CLOEXEC"):
+            lock_flags |= os.O_CLOEXEC
+        lock_fd = os.open(lock_name, lock_flags, 0o600, dir_fd=destination_dir_fd)
+        lock_stat = os.fstat(lock_fd)
+        if not stat.S_ISREG(lock_stat.st_mode):
+            raise ReconcileError("reconciliation lock is not a regular file")
+        if require_root:
+            _validate_root_owned_stat(lock_stat, label="reconciliation lock")
+        _acquire_exclusive_lock(lock_fd)
+
+        current_source = _read_regular_at(
+            source_dir_fd, source.name, label="source", require_root=require_root
+        )
+        current_destination = _read_regular_at(
+            destination_dir_fd,
+            destination.name,
+            label="destination",
+            require_root=require_root,
+        )
+        if not _same_file(initial_source.file_stat, current_source.file_stat):
             raise ReconcileError("source file identity changed during reconciliation")
-        if not _same_file(destination_stat, current_destination_stat):
+        if not _same_file(initial_destination.file_stat, current_destination.file_stat):
             raise ReconcileError(
                 "destination file identity changed during reconciliation"
             )
-        if _same_file(current_source_stat, current_destination_stat):
+        if _same_file(current_source.file_stat, current_destination.file_stat):
             raise ReconcileError("source and destination must be different files")
-        if require_root:
-            _validate_root_owned_runtime_stat(current_source_stat, label="source")
-            _validate_root_owned_runtime_stat(
-                current_destination_stat, label="destination"
-            )
+        if initial_source.text != current_source.text:
+            raise ReconcileError("source content changed during reconciliation")
+        if initial_destination.text != current_destination.text:
+            raise ReconcileError("destination content changed during reconciliation")
 
         selected = validate_source(
-            parse_env(current_source_text, label="source").values
+            parse_env(current_source.text, label="source").values
         )
-        current_content = build_reconciled_content(current_text, selected)
-        if current_content == current_text:
-            return {**base_result, "status": "already_reconciled", "applied": False}
+        current_destination_document = parse_env(
+            current_destination.text, label="destination"
+        )
+        current_content = build_reconciled_content(current_destination.text, selected)
+        locked_plan_sha256 = plan_sha256(
+            source_path=source,
+            destination_path=destination,
+            backup_dir=backup,
+            source_stat=current_source.file_stat,
+            destination_stat=current_destination.file_stat,
+            backup_dir_stat=os.fstat(backup_dir_fd),
+            source_text=current_source.text,
+            destination_text=current_destination.text,
+            planned_content=current_content,
+        )
+        if locked_plan_sha256 != current_plan_sha256:
+            raise ReconcileError("reconciliation plan changed after lock")
+        if expected != locked_plan_sha256:
+            raise ReconcileError("expected plan SHA-256 changed after lock")
 
-        destination_stat = current_destination_stat
+        updated_keys = changed_keys(current_destination_document, selected)
+        destination_stat = current_destination.file_stat
         timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
-        backup = backup_dir / f"{destination.name}.bak-{timestamp}-{os.getpid()}"
-        _write_file_exclusive(
-            backup,
-            current_text.encode("utf-8"),
+        backup_name = f"{destination.name}.bak-{timestamp}-{os.getpid()}"
+        _write_file_exclusive_at(
+            backup_dir_fd,
+            backup_name,
+            current_destination.text.encode("utf-8"),
             uid=destination_stat.st_uid,
             gid=destination_stat.st_gid,
         )
-        backup_dir_fd = os.open(backup_dir, os.O_DIRECTORY)
+        os.fsync(backup_dir_fd)
         try:
-            os.fsync(backup_dir_fd)
-        finally:
-            os.close(backup_dir_fd)
-
-        fd, tmp_name = tempfile.mkstemp(
-            prefix=f".{destination.name}.", dir=destination.parent
-        )
-        tmp = Path(tmp_name)
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as handle:
-                handle.write(current_content)
-                handle.flush()
-                os.fchown(
-                    handle.fileno(), destination_stat.st_uid, destination_stat.st_gid
-                )
-                os.fchmod(handle.fileno(), 0o600)
-                os.fsync(handle.fileno())
-            os.replace(tmp, destination)
-            dir_fd = os.open(destination.parent, os.O_DIRECTORY)
+            verified_backup = _read_regular_at(
+                backup_dir_fd,
+                backup_name,
+                label="backup",
+                require_root=require_root,
+            )
+            backup_mode = stat.S_IMODE(verified_backup.file_stat.st_mode)
+            if (
+                verified_backup.text != current_destination.text
+                or verified_backup.file_stat.st_uid != destination_stat.st_uid
+                or verified_backup.file_stat.st_gid != destination_stat.st_gid
+                or backup_mode != 0o600
+            ):
+                raise ReconcileError("backup verification failed before destination replace")
+        except BaseException:
             try:
-                os.fsync(dir_fd)
-            finally:
-                os.close(dir_fd)
-        finally:
-            if tmp.exists():
-                tmp.unlink()
+                os.unlink(backup_name, dir_fd=backup_dir_fd)
+                os.fsync(backup_dir_fd)
+            except FileNotFoundError:
+                pass
+            raise
 
-        final_stat = destination.stat()
+        temp_prefix = TEMP_PREFIX_TEMPLATE.format(name=destination.name)
+        _cleanup_orphan_temps(
+            destination_dir_fd,
+            prefix=temp_prefix,
+            expected_uid=destination_stat.st_uid,
+            expected_gid=destination_stat.st_gid,
+        )
+        temp_name = f"{temp_prefix}{secrets.token_hex(12)}"
+        temp_created = False
+        try:
+            _write_file_exclusive_at(
+                destination_dir_fd,
+                temp_name,
+                current_content.encode("utf-8"),
+                uid=destination_stat.st_uid,
+                gid=destination_stat.st_gid,
+            )
+            temp_created = True
+            os.replace(
+                temp_name,
+                destination.name,
+                src_dir_fd=destination_dir_fd,
+                dst_dir_fd=destination_dir_fd,
+            )
+            temp_created = False
+            os.fsync(destination_dir_fd)
+        finally:
+            if temp_created:
+                os.unlink(temp_name, dir_fd=destination_dir_fd)
+
+        final_destination = _read_regular_at(
+            destination_dir_fd,
+            destination.name,
+            label="destination",
+            require_root=require_root,
+        )
+        if final_destination.text != current_content:
+            raise ReconcileError("destination verification failed after atomic replace")
+        final_stat = final_destination.file_stat
         return {
-            **base_result,
+            "destination": str(destination),
+            "updated_keys": updated_keys,
+            "values_redacted": True,
+            "plan_sha256": locked_plan_sha256,
             "status": "reconciled",
             "applied": True,
-            "backup": str(backup),
+            "backup": str(backup / backup_name),
             "mode": f"{stat.S_IMODE(final_stat.st_mode):04o}",
             "owner_uid": final_stat.st_uid,
             "owner_gid": final_stat.st_gid,
         }
     finally:
-        os.close(lock_fd)
+        if lock_fd is not None:
+            os.close(lock_fd)
+        if backup_dir_fd is not None:
+            os.close(backup_dir_fd)
+        os.close(destination_dir_fd)
+        os.close(source_dir_fd)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -351,7 +662,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--destination", type=Path, required=True)
     parser.add_argument("--backup-dir", type=Path, required=True)
     parser.add_argument(
-        "--apply", action="store_true", help="write after validation; otherwise dry-run"
+        "--apply", action="store_true", help="write after a matching dry-run plan"
+    )
+    parser.add_argument(
+        "--expected-plan-sha256",
+        help="plan_sha256 from the immediately preceding dry-run; required with --apply",
     )
     parser.add_argument(
         "--json", action="store_true", help="emit a value-redacted JSON receipt"
@@ -367,6 +682,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             destination_path=args.destination,
             backup_dir=args.backup_dir,
             apply=args.apply,
+            expected_plan_sha256=args.expected_plan_sha256,
         )
     except (OSError, ReconcileError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
@@ -378,6 +694,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"Status: {result['status']}")
         print(f"Destination: {result['destination']}")
         print("Updated keys: " + ", ".join(result["updated_keys"]))
+        print(f"Plan SHA-256: {result['plan_sha256']}")
         if result.get("backup"):
             print(f"Backup: {result['backup']}")
     return 0


### PR DESCRIPTION
## Summary

- add a dry-run-first, value-redacting reconciler for the canonical VPS env
- copy only the approved public-login and SMTP key allowlist from the legacy runtime source
- validate enabled login, disabled token logging, authenticated SMTP and supported TLS ports before writing
- require root for apply, reject symlinks and identical source/destination files, lock exclusively, create a durable `0600` backup, and replace atomically
- document the one-time reconciliation path

## Why

Issue #1384 requires selective reconciliation of the root-managed canonical env. An ad-hoc shell mutation was correctly blocked by the operator safety filter. This tool makes the operation reviewable, repeatable and value-redacted instead of bypassing that boundary or copying the entire legacy env.

## Validation

- `python3 -m pytest -q scripts/ci/tests` — 178 passed, 38 subtests passed
- `ruff check scripts/ops/reconcile_public_login_smtp_env.py scripts/ci/tests/test_reconcile_public_login_smtp_env.py`
- `ruff format --check scripts/ops/reconcile_public_login_smtp_env.py scripts/ci/tests/test_reconcile_public_login_smtp_env.py`
- `python3 -m py_compile scripts/ops/reconcile_public_login_smtp_env.py scripts/ci/tests/test_reconcile_public_login_smtp_env.py`
- `git diff --check`

Part of #1384. After merge, the operator will run dry-run, apply, readiness validation, deploy, and the two-email live proof.


