### PR TITLE
fix(docs): restore canonical repository truth

### DIFF
--- a/.github/grabowski-required-checks.json
+++ b/.github/grabowski-required-checks.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": 1,
+  "required_checks": [
+    "Detect docs updates",
+    "Core Guard Tests"
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,9 @@ jobs:
         shell: bash
         run: bash scripts/guard/run.sh
 
+      - name: Validate canonical truth contract
+        run: python3 -m unittest scripts.ci.tests.test_canonical_truth_contract -v
+
   ci:
     needs: docs-changes
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-guard.yml
+++ b/.github/workflows/docs-guard.yml
@@ -66,7 +66,7 @@ jobs:
           python-version-file: '.python-version'
 
       - name: Install Python test dependencies
-        run: python -m pip install pytest==8.3.4
+        run: python -m pip install pytest==8.3.4 pyyaml==6.0.2
 
       - name: Report lifecycle global strict
         run: python3 -m scripts.docmeta.validate_report_lifecycle --mode strict

--- a/README.md
+++ b/README.md
@@ -1,54 +1,70 @@
-<!-- "Docs-only" ist ein formaler Gate-Status (ADR-0001). Das Repo ENTHÄLT operativen Code in apps/ und infra/. Diese Runtime-Artefakte sind Teil der Wahrheitsschicht und müssen gemäß dem definierten Truth Model (repo.meta.yaml) berücksichtigt werden. -->
-<!-- Docs-only (ADR-0001 Clean-Slate) • Re-Entry via Gates A–D -->
-
 # Weltgewebe
 
-Mobile-first Webprojekt mit SvelteKit (Web), Rust/Axum (API), Postgres + Outbox, NATS JetStream und Caddy.
+Weltgewebe ist ein aktives, im Aufbau befindliches Karteninterface für
+Kollektivgüter, lokale Beziehungen und gemeinschaftliche Koordination. Das
+Repository enthält die Webanwendung, die Rust-API, Datenverträge,
+Datenbankmigrationen, Compose-Profile, Caddy-Konfiguration und Betriebswerkzeuge.
 
-## Status des Repos
+## Aktueller Zustand
 
-- Weltgewebe ist ein **eigenständiges Projekt**. Repositories wie `heimgewebe/contracts`, `wgx` oder `hauski` sind optionale Quellen und Werkzeuge, keine monolithische Codebasis.
-- Formaler **Docs-only/Clean-Slate**-Status nach ADR-0001. Gleichzeitig enthält das Repo operative Artefakte unter `apps/` und `infra/`, die Teil der Wahrheitsschicht sind.
-- Code-Re-Entry erfolgt über die **Gates A–D**; siehe [`docs/process/fahrplan.md`](docs/process/fahrplan.md).
-- Wahrheit und Konfliktauflösung folgen strikt [`repo.meta.yaml`](repo.meta.yaml) und dem [Agent Reading Protocol](docs/policies/agent-reading-protocol.md). `docs/index.md` ist Navigation, keine Wahrheitsschicht. `docs/_generated/*` ist Diagnose, nicht Ursprung.
+- **Web:** SvelteKit, TypeScript, MapLibre GL und PMTiles.
+- **API:** Rust, Axum und Tokio.
+- **Authentifizierung:** Magic Links, Passkeys und profilweit persistente
+  HTTP-only-Sitzungscookies.
+- **Domänendaten:** JSONL ist weiterhin der Standard-Lese- und Schreibpfad.
+  PostgreSQL-Pfade für Accounts, Knoten und Fäden sind einzeln opt-in und noch
+  kein allgemeiner Produktions-Cutover.
+- **Betrieb:** Docker Compose und Caddy; der öffentliche Produktionspfad ist
+  `wg-prod-1`.
+- **Ausbaulücke:** Der durchgängige Produktweg von der Garnrolle über einen
+  gespeicherten Knoten bis zu einem Faden ist noch nicht vollständig als ein
+  Produktionsfluss abgeschlossen.
 
-## Start Here
+Historische ADRs und Berichte bleiben als Entscheidungs- und
+Entwicklungsgeschichte erhalten. Sie dürfen den aktuellen Code, die Migrationen
+oder die hier verlinkten kanonischen Ist-Dokumente nicht überstimmen.
 
-- **Constitution / Repo Truth Model:** [`repo.meta.yaml`](repo.meta.yaml)
-- **System Map:** [`docs/_generated/system-map.md`](docs/_generated/system-map.md)
-- **Runtime:** [`runtime/README.md`](runtime/README.md)
-- **Operations:** [`runbooks/README.md`](runbooks/README.md)
-- **Architecture Overview:** [`architecture/overview.md`](architecture/overview.md)
+`docs/_generated/*` enthält ausschließlich abgeleitete Diagnose-, Index- und
+Navigationsartefakte. Diese Dateien werden über registrierte Generatoren
+aktualisiert und sind keine eigenständige Wahrheits- oder Entscheidungsschicht.
 
-## Schnellzugriff
+## Start hier
 
-- [Dokumentationsindex](docs/index.md)
-- [Repo-Architektur](docs/architekturstruktur.md)
-- [Agenten-Leitfaden](AGENTS.md)
-- [Beitragen](CONTRIBUTING.md)
-- [Master-Roadmap](docs/roadmap.md)
-- [Optimierungsstatus](docs/reports/optimierungsstatus.md)
-- [Task-Control-Blaupause](docs/blueprints/doc-structure-task-control.md)
-- [Task-Control-Roadmap](docs/blueprints/doc-structure-task-control-roadmap.md)
-- [Deployment-Übersicht](docs/deploy/README.md)
-- [Gate-Fahrplan](docs/process/fahrplan.md)
+| Frage | Wahrheitsort |
+|---|---|
+| Was läuft heute? | [`runtime/README.md`](runtime/README.md) |
+| Wie sind die Komponenten verbunden? | [`architecture/overview.md`](architecture/overview.md) |
+| Welche Sicherheitsgrenzen gelten? | [`architecture/security.md`](architecture/security.md) |
+| Wie wird betrieben oder diagnostiziert? | [`runbooks/README.md`](runbooks/README.md) |
+| Welche Daten liegen wo? | [`docs/datenmodell.md`](docs/datenmodell.md) |
+| Welche Technik ist real, optional oder geplant? | [`docs/techstack.md`](docs/techstack.md) |
+| Welche Dokumente und Wissensbereiche existieren? | [`docs/index.md`](docs/index.md) |
+| Wie wird deployt? | [`docs/deploy/README.md`](docs/deploy/README.md) |
+| Welche Begriffe gelten fachlich? | [`docs/domain/vocabulary.md`](docs/domain/vocabulary.md) |
+| Welche Quellen haben Vorrang? | [`repo.meta.yaml`](repo.meta.yaml) |
 
 ## Für Agents
 
-Verbindliche Leseordnung vor jedem Patch:
+Vor Änderungen gilt diese Leseordnung:
 
 1. [`repo.meta.yaml`](repo.meta.yaml)
 2. [`AGENTS.md`](AGENTS.md)
 3. [`agent-policy.yaml`](agent-policy.yaml)
 4. [`docs/policies/agent-reading-protocol.md`](docs/policies/agent-reading-protocol.md)
-5. [`docs/index.md`](docs/index.md) — nur Navigation
-6. betroffene Blueprint-, Report-, Spec- oder Codepfade
+5. [`docs/index.md`](docs/index.md) als Navigation, nicht als Wahrheitsquelle
+6. die betroffenen Contracts, Migrationen, Runtime-Konfigurationen und Tests
+7. erst danach Planungsdokumente und historische Berichte
 
-Interpolation ist verboten. Bei nicht auflösbaren Widersprüchen oder fehlenden Zielnachweisen MUSS abgebrochen werden.
+Bei einem Widerspruch zwischen Statusdokument und ausführbarem Vertrag wird
+nicht interpoliert. Der Widerspruch wird benannt und aufgelöst.
 
 ## Lokal starten
 
-Voraussetzungen: Docker, Docker Compose und `just` (alternativ `make`).
+Voraussetzungen:
+
+- Docker mit Compose
+- `just`
+- für Webentwicklung Node.js und pnpm gemäß den versionierten Metadaten
 
 ```bash
 cp .env.example .env
@@ -57,8 +73,9 @@ just up
 
 Prüfen:
 
-- Frontend: <http://localhost:8081>
-- API Healthcheck: <http://localhost:8081/api/health/live>
+- Web/Frontdoor: <http://localhost:8081>
+- API-Liveness: <http://localhost:8081/api/health/live>
+- API-Readiness: <http://localhost:8081/api/health/ready>
 
 Stoppen:
 
@@ -66,74 +83,73 @@ Stoppen:
 just down
 ```
 
-> ⚙️ Der vollständig betriebsbereite Dev-Stack ist Teil von **Gate C** (Infra-light). Für Detailschritte siehe [`docs/quickstart-gate-c.md`](docs/quickstart-gate-c.md). Im VS-Code-Devcontainer richtet `.devcontainer/post-create.sh` Tools wie `just`, `uv` und `vale` automatisch ein.
+Die lokale Beispielkonfiguration ist nicht automatisch eine
+Produktionskonfiguration. Öffentlicher Login, SMTP, Proxy-Vertrauen,
+Datenbankmigrationen und Secrets besitzen zusätzliche fail-closed
+Vorprüfungen.
 
 ## Entwicklung und Qualität
 
-- Beitragsregeln und Routing: [`CONTRIBUTING.md`](CONTRIBUTING.md)
-- Schneller lokaler Hygiene-Check: `just check` (Rust/API-Grundchecks, Demo-Daten, Domain-Contracts, `cargo deny`)
-- Breiterer CI-Spiegel bei Web/API-Änderungen: `just ci`
-- Frontend-/Gate-A-Prototyp: [`apps/web/README.md`](apps/web/README.md)
-- Web-E2E (Playwright): siehe Workflow [`.github/workflows/web-e2e.yml`](.github/workflows/web-e2e.yml); lokal in `apps/web/` mit `pnpm test:setup` (einmalig) und `pnpm test`.
-- Performance-Budgets: [`ci/budget.json`](ci/budget.json); Soft-Limits in [`policies/`](policies/).
-- Doku- und Relations-Checks: Skripte unter `scripts/docmeta/` plus CI-Workflow `docs-guard.yml`.
-- Domain-Contracts lokal validieren: `just contracts-domain-check`.
-
-### Build- und Konfigurationsdetails
-
-- Die API liefert `/version` mit Build-Metadaten:
-  - `version` kommt aus `env!("CARGO_PKG_VERSION")` (Cargo-Paketmetadaten; **kein Fallback** auf `"unknown"`).
-  - `GIT_COMMIT_SHA` und `BUILD_TIMESTAMP` sind optional; sie fallen über `option_env!(...).unwrap_or("unknown")` auf `"unknown"` zurück, wenn nicht vom CI gesetzt.
-  - Diese Werte werden **nicht** in `.env` gepflegt.
-- Defaults: [`configs/app.defaults.yml`](configs/app.defaults.yml). Overrides via Env-Variablen `HA_FADE_DAYS`, `HA_RON_DAYS`, `HA_ANONYMIZE_OPT_IN`, `HA_DELEGATION_EXPIRE_DAYS` oder `APP_CONFIG_PATH`.
-- Policies-Pfad-Override: `POLICY_LIMITS_PATH=/pfad/zur/limits.yaml`.
-
-## Deployment und Betrieb
-
-- Übersicht: [`docs/deploy/README.md`](docs/deploy/README.md)
-- Heimserver als Referenz-Integration: [`docs/deploy/heimserver.integration.md`](docs/deploy/heimserver.integration.md)
-- Security: [`docs/deploy/security.md`](docs/deploy/security.md)
-- Drift-Policy: [`docs/deploy/DRIFT_POLICY.md`](docs/deploy/DRIFT_POLICY.md)
-- Runbook: [`docs/runbook.md`](docs/runbook.md); Observability: [`docs/runbook.observability.md`](docs/runbook.observability.md)
-
-> **Hinweis:** Das Heimserver-Deployment ist Referenz-Implementierung des Integration-Contracts. Die langfristige Produktionsumgebung kann abweichen, der Contract bleibt gültig.
-
-## Roadmap und offene Arbeit
-
-- [Master-Roadmap](docs/roadmap.md)
-- [Optimierungsstatus](docs/reports/optimierungsstatus.md)
-- [Task-Control-Roadmap](docs/blueprints/doc-structure-task-control-roadmap.md)
-
-Task-Control Phase 2 ist eingeführt. Die Arbeitssteuerung liegt jetzt unter `docs/tasks/`; der maschinenlesbare Optimierungsstatus liegt unter `docs/reports/optimierungsstatus.json`.
-
-Task-Index-Check-Modus (`generate_task_index.py --check`) und CI-Guard (`.github/workflows/task-index.yml`) sind vorhanden.
-
-Offen bleiben ein echter Schreibgenerator bzw. Bot-PRs (bewusst spätere Entscheidung) und der Implementierungs-Mapping-Ausbau.
-
-GitHub Issue Forms, PR-Template und Release-Konfiguration sind bewusst zurückgestellt. Sie werden erst wieder aufgenommen, wenn ihr Nutzen gegenüber kontextgenauen PR-Bodies belegt ist oder externe Beitragende bzw. ein stabilisierter Release-Prozess sie erforderlich machen.
-
-## Semantik (ausgesetzt)
-
-Die ursprünglich geplante `semantAH`-Integration (ADR-0042) ist ausgesetzt; Contracts und CI-Jobs wurden entfernt. Eine Reaktivierung würde eine neue ADR erfordern.
-
-## Task-Control
-
-Die operative Arbeitssteuerung liegt in `docs/tasks/`:
-
-| Datei | Zweck |
-|---|---|
-| `docs/tasks/board.md` | Menschliche Arbeitskarte (aktive Prioritäten, Blocker) |
-| `docs/tasks/index.json` | Maschinenlesbarer Task-Index (Phase-2-Seed: manuell) |
-| `docs/tasks/schema.json` | Validierungsvertrag |
-| `docs/reports/optimierungsstatus.md` | Maßgebliche Statusmatrix (Wahrheitsquelle für OPT-* Einträge) |
-| `docs/reports/optimierungsstatus.json` | Maschinenlesbarer Zwilling der Statusmatrix |
-
-Nächste Priorität ist der CI-Lauf-Nachweis für `TASK-CTL-003`; Check-Modus und CI-Guard laufen bereits. GitHub Issue Forms und PR-Template bleiben zurückgestellt.
-
 ```bash
-python3 -m scripts.docmeta.validate_task_index docs/tasks/index.json
+just check   # schneller Repository- und Contract-Check
+just ci      # breiter lokaler Spiegel für Web, API und Abhängigkeiten
 ```
 
-## Beiträge & Docs
+Weitere wichtige Prüfpfade:
 
-Stilprüfung via Vale läuft automatisch bei Doku-PRs; lokal `vale docs/` für Hinweise.
+- Domain-Contracts: `just contracts-domain-check`
+- Web-E2E: siehe [`apps/web/README.md`](apps/web/README.md)
+- Datenbankbeweise: `.github/workflows/db-*.yml`
+- Proxy- und Deployvertrag: `.github/workflows/proxy-trust-preflight.yml`
+- Dokumentwahrheit: `.github/workflows/docs-guard.yml`
+
+## Produktbegriffe und technische Namen
+
+| Produktbegriff | Technische Namen im Bestand | Bedeutung |
+|---|---|---|
+| Garnrolle | Account, teilweise historisch Role | persönlicher Ausgangspunkt im Gewebe |
+| Knoten | Node | Ort, Ressource, Vorhaben oder anderer gemeinschaftlicher Bezugspunkt |
+| Faden | Edge | Beziehung zwischen Garnrollen und/oder Knoten |
+| Gespräch | Conversation/Message | geplant und vertraglich beschrieben, aber noch kein vollständiger produktiver Persistenzpfad |
+
+`RoN` ist derzeit noch in Contracts, Daten und Migrationen als Legacy-Modus
+vorhanden. Das steht im Widerspruch zum angestrebten Modell „eine Garnrolle je
+Account; Sichtbarkeit und Verortung als Eigenschaften“ und wird in einem
+eigenen, migrationsgebundenen Cutover bereinigt. Neue Produkttexte sollen RoN
+nicht als zweiten Kontotyp festschreiben.
+
+## Daten- und Datenschutzgrenze
+
+Weltgewebe verwendet notwendige, sichere Sitzungscookies für Anmeldung und
+Sitzungserhalt. Der Datenschutzvertrag erlaubt diese Cookies, schließt aber
+Werbe- und Trackingcookies sowie verdeckte Profilbildung aus. Öffentliche und
+private Accountfelder werden getrennt behandelt; reale Privatpositionen dürfen
+nicht als öffentliche Kartenkoordinaten ausgegeben werden.
+
+## Deployment
+
+Der kanonische öffentliche Pfad ist in
+[`docs/deploy/vps.md`](docs/deploy/vps.md) beschrieben. Das Repository behauptet
+keinen Livezustand allein aufgrund eingecheckter Konfiguration. Runtime- und
+Deploybelege müssen frisch erhoben werden.
+
+Statische Web-Builds werden unter anderem durch Cloudflare- und Vercel-
+Integrationen geprüft. Diese Vorschauen sind zusätzliche Plattformbelege; die
+öffentliche Routingwahrheit liegt im VPS-/Caddy-Vertrag und dessen konfiguriertem
+Web-Upstream.
+
+## Planung und Status
+
+- [`docs/tasks/board.md`](docs/tasks/board.md) ist eine repositoryinterne
+  Arbeitskarte.
+- [`docs/tasks/index.json`](docs/tasks/index.json) ist der maschinenlesbare
+  Quellindex dieser Planung.
+- GitHub-Issues bilden nur ausgewählte öffentliche oder operative Einzelthemen
+  ab.
+- Statusbehauptungen aus Berichten müssen gegen Code, Contracts, Migrationen,
+  CI und Runtimebelege geprüft werden.
+
+## Lizenz
+
+Weltgewebe steht unter der
+[GNU Affero General Public License 3.0 oder später](LICENSE).

--- a/apps/api/Cargo.toml
+++ b/apps/api/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 rust-version = "1.85.0"
 authors = ["Weltgewebe Team"]
-license = "MIT"
+license = "AGPL-3.0-or-later"
 
 [dependencies]
 anyhow = "1"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,7 @@
 {
   "name": "weltgewebe-web",
   "version": "0.0.0",
+  "license": "AGPL-3.0-or-later",
   "packageManager": "pnpm@9.11.0",
   "private": true,
   "type": "module",

--- a/architecture/overview.md
+++ b/architecture/overview.md
@@ -1,14 +1,120 @@
 ---
 id: overview
 title: Architecture Overview
-summary: Überblick über die Systemarchitektur und zentrale Designentscheidungen.
+summary: Aktuelle Komponenten, Datenflüsse, Wahrheitsorte und Ausbaugrenzen des Weltgewebe-Systems.
 role: norm
 organ: governance
 status: canonical
-last_reviewed: 2026-06-09
+last_reviewed: 2026-07-11
 depends_on: []
-relations: []
+relations:
+  - type: relates_to
+    target: architecture/security.md
+  - type: relates_to
+    target: runtime/README.md
+  - type: relates_to
+    target: docs/techstack.md
 verifies_with: []
 ---
 
 # Architecture Overview
+
+## Systemgrenze
+
+Weltgewebe ist ein Karten- und Koordinationssystem. Die heute implementierte
+Kernfläche besteht aus:
+
+1. einer statisch baubaren SvelteKit-Webanwendung,
+2. einer Rust-/Axum-API,
+3. Caddy als öffentlichem beziehungsweise lokalem Frontdoor,
+4. JSONL- und opt-in PostgreSQL-Persistenzpfaden,
+5. PostgreSQL für Sitzungen und ausgewählte Auth-/Domänenpfade,
+6. NATS als im Produktions-Compose vorhandener, optional genutzter Eventkanal.
+
+Gespräche, Nachrichten, föderale Governance und Gewebekonten sind teilweise als
+Contracts oder Konzepte vorhanden, aber nicht als vollständige produktive
+Ende-zu-Ende-Systeme.
+
+## Komponenten
+
+| Komponente | Pfad | heutige Verantwortung |
+|---|---|---|
+| Web | `apps/web` | Karte, Login, Einstellungen, Account- und Knotenansichten, statischer Build |
+| API | `apps/api` | Authentifizierung, Sitzungen, Accounts, Knoten, Fäden, Health und Metriken |
+| Domain-Contracts | `contracts/domain` | JSON-Schema-Verträge für Account, Knoten, Faden sowie noch nicht vollständig implementierte Gesprächsobjekte |
+| Caddy | `infra/caddy` | TLS-/Host-Routing, Proxygrenze, Sicherheitsheader und Web-Upstream |
+| Compose | `infra/compose` | lokale, produktive und zielbezogene Servicezusammenstellung |
+| PostgreSQL | `apps/api/migrations` | Sitzungen, Domain-Tabellen und Passkey-Credentials; Nutzung hängt von expliziten Quellschaltern ab |
+| JSONL | `.gewebe/in` beziehungsweise konfigurierte Datenpfade | Standardquelle für Domänendaten und Standard-Schreibpfad |
+| NATS | Produktions-Compose und `NATS_URL` | Verbindungs- und Readinessfläche; kein vollständig belegter Outbox-/Projektionskern |
+
+## Hauptdatenflüsse
+
+### Lesen von Domänendaten
+
+```text
+Web -> Caddy -> Axum API -> konfigurierte Domain-Lesequelle
+                              |- JSONL (Standard)
+                              `- PostgreSQL (explizites Opt-in)
+```
+
+### Schreiben von Domänendaten
+
+Accounts, Knoten und Fäden besitzen getrennte Quellschalter. PostgreSQL-Schreiben
+ist nur zulässig, wenn auch aus PostgreSQL gelesen wird. Es gibt keinen
+stillschweigenden Fallback und keinen allgemeinen Dual-Write.
+
+### Anmeldung
+
+```text
+Browser -> Magic Link oder Passkey -> API -> Session Store
+Browser <- HttpOnly/SameSite/Secure-Sitzungscookie
+```
+
+Der Browser speichert keinen Bearer-Token in `localStorage` oder
+`sessionStorage`. Normale Tabs und Fenster desselben Browserprofils teilen die
+Cookie-Sitzung; andere Profile und private Kontexte bleiben getrennt.
+
+### Karte
+
+Die Webanwendung lädt eine MapLibre-Karte und PMTiles-basierte Basiskarten. Die
+Komponente besitzt einen expliziten asynchronen Abbauvertrag, damit eine laufende
+Initialisierung nach dem Verlassen der Seite keine Kartenressourcen zurücklässt.
+
+## Wahrheitsmodell
+
+Bei Konflikten gilt die Reihenfolge aus `repo.meta.yaml`:
+
+1. Domain-Contracts,
+2. kanonische Policies,
+3. Runtime-Konfiguration und Code,
+4. normative Spezifikationen,
+5. Berichte und Navigationsartefakte.
+
+Migrationen und ausführbare Konfiguration präzisieren den realen physischen
+Zustand. Eine Roadmap darf einen geplanten Zustand nicht als bereits betrieben
+darstellen.
+
+## Bewusste Ausbaugrenzen
+
+- JSONL ist noch nicht vollständig durch PostgreSQL abgelöst.
+- Das Legacy-Modell `ron` widerspricht dem angestrebten einheitlichen
+  Garnrollenmodell und braucht einen migrationsgebundenen Cutover.
+- Gesprächs- und Nachrichtencontracts bedeuten noch keine produktive
+  Persistenzfläche.
+- NATS im Stack bedeutet noch keinen belegten Transactional-Outbox-Betrieb.
+- Externe Vorschauplattformen sind keine Quelle für die Produktionsrouting-
+  oder Runtimewahrheit.
+
+## Nächster fachlicher Integrationsbeweis
+
+Der wichtigste vertikale Schnitt ist:
+
+1. Account anmelden,
+2. Garnrolle bearbeiten und verorten,
+3. Knoten dauerhaft anlegen,
+4. Knoten nach Neuladen auf Karte und Profil wiederfinden,
+5. Faden anlegen und erneut lesen.
+
+Dieser Schnitt soll ohne Demo-Fallback und mit eindeutigem Persistenzpfad
+belegt werden.

--- a/architecture/security.md
+++ b/architecture/security.md
@@ -1,14 +1,113 @@
 ---
 id: security
 title: Security Architecture
-summary: Sicherheitsarchitektur, Bedrohungsmodell und Schutzmechanismen.
+summary: Aktuelle Vertrauensgrenzen, Schutzmechanismen und offene Sicherheitsannahmen.
 role: norm
 organ: governance
 status: canonical
-last_reviewed: 2026-06-09
+last_reviewed: 2026-07-11
 depends_on: []
-relations: []
+relations:
+  - type: relates_to
+    target: docs/specs/auth-api.md
+  - type: relates_to
+    target: docs/deploy/vps.md
+  - type: relates_to
+    target: runtime/README.md
 verifies_with: []
 ---
 
 # Security Architecture
+
+## Schutzobjekte
+
+- Sitzungen und Login-Tokens
+- Passkey-Credentials und WebAuthn-Identitäten
+- reale Accountpositionen und private Accountfelder
+- SMTP-, Datenbank- und Signatursecrets
+- administrative Mutationen an Accounts, Knoten und Fäden
+- Herkunft der Client-IP für Ratelimits und Auditierung
+- Integrität von Migrationen und Deploymentkonfiguration
+
+## Vertrauensgrenzen
+
+### Browser
+
+Der Browser erhält eine HTTP-only-Sitzung über Cookies. Der Authzustand wird beim
+Laden über `/api/auth/me` wiederhergestellt. Bearer-Tokens werden nicht im
+Webspeicher abgelegt.
+
+Sitzungscookies verwenden einen gemeinsamen Scope und werden bei Logout
+profilweit gelöscht. Mutierende Cookie-Requests unterliegen dem CSRF-Vertrag der
+API. Notwendige Sitzungscookies sind erlaubt; Tracking- oder Werbecookies sind
+nicht Teil des Systems.
+
+### Caddy und API
+
+Im öffentlichen beziehungsweise proxied Betrieb ist Caddy die vertrauenswürdige
+Proxygrenze:
+
+- eingehende fremde `Forwarded`-Header werden entfernt,
+- `X-Forwarded-For` wird aus der tatsächlichen Remote-Adresse neu gesetzt,
+- die API akzeptiert Proxyheader nur aus ausdrücklich konfigurierten Netzen,
+- aktive IP-Ratelimits erfordern eine explizite Proxyentscheidung,
+- direkter Betrieb wird mit `AUTH_TRUSTED_PROXIES=none` erklärt.
+
+Ein alternativer Proxy muss denselben Überschreibungs- und
+Headerbereinigungsvertrag erfüllen.
+
+### API und Persistenz
+
+PostgreSQL-Schreibpfade dürfen nicht mit einer JSONL-Lesequelle kombiniert
+werden. Die Konfiguration verweigert den Start, wenn persistierte Änderungen
+nach einem Neustart unsichtbar würden. Es gibt keinen stillen Fallback von
+PostgreSQL zu JSONL.
+
+Öffentliche Accountprojektionen dürfen private Standortkoordinaten nicht direkt
+ausgeben. Die Trennung zwischen `public_payload`, `private_payload` und
+Standortfeldern ist eine Sicherheitsgrenze, keine bloße Darstellungsfrage.
+
+### Secrets
+
+Secrets gehören weder in Git, PR-Kommentare, Chat noch rohe Diagnoseausgaben.
+Betriebsprüfungen dürfen nur Vorhandensein, Quelle, Berechtigung und redigierte
+Fingerprints belegen. Rotation und Injection sind privilegierte, separat
+auditierte Vorgänge.
+
+## Authentifizierungsflächen
+
+| Fläche | aktueller Schutz |
+|---|---|
+| Magic Link | kurzlebiger Token, neuester Loginversuch maßgeblich, keine Tokenlogs im Produktionsvertrag |
+| Passkey | WebAuthn-Origin/RP-Vertrag, Credential-Duplikatschutz, opt-in Persistenzpfad |
+| Session | Serverzustand, Ablaufzeit, Device-ID, persistenter Cookie mit Sicherheitsabstand |
+| Step-up | eigener kurzlebiger Nachweis für sensible Accountänderungen |
+| Logout | Sessionentfernung und Cookie-Löschung mit identischem Scope |
+| Ratelimit | IP-basiert und nur mit geklärter Proxyvertrauensgrenze startfähig |
+
+## Deployment- und Lieferkettengrenzen
+
+- Images, Actions und Werkzeuge sollen versions- oder digestgebunden sein.
+- Datenbankmigrationen sind kein Nebeneffekt eines beliebigen Smokes.
+- `WELTGEWEBE_API_STARTUP_MIGRATIONS` legt fest, ob angewendet, nur verifiziert
+  oder bewusst übersprungen wird.
+- Der kanonische Deploypfad ist `scripts/weltgewebe-up`; zielbezogene Shims
+  delegieren dorthin.
+- Mergefähigkeit erfordert grünes CI, aktuelle Headbindung und ein
+  risikogewichtetes Selbstreview. Externe Modellreviews sind kein Pflichtbeleg.
+
+## Offene Risiken
+
+- Das Legacy-Identitätsmodell `ron` muss ohne Datenverlust migriert werden.
+- Der vollständige PostgreSQL-Cutover ist nicht abgeschlossen.
+- Branch-/Ruleset-Schutz muss nach Stabilisierung der Pflichtcheckliste aktiv
+  und minimal gehalten werden.
+- Vorschauplattformen können extern scheitern; ihre Rolle muss von der
+  Produktionsroutingwahrheit getrennt bleiben.
+
+## Keine Sicherheitsbehauptung ohne Beleg
+
+Dieses Dokument beschreibt den Vertrag im Repository. Es behauptet nicht, dass
+eine konkrete Runtime aktuell gesund, ein Secret rotiert oder ein Provider
+korrekt konfiguriert ist. Dafür sind frische Runtime-, CI- und Betriebsbelege
+nötig.

--- a/deny.toml
+++ b/deny.toml
@@ -14,6 +14,7 @@ wildcards = "deny"
 [licenses]
 version = 2
 allow = [
+  "AGPL-3.0-or-later",
   "Apache-2.0",
   "BSD-2-Clause",
   "BSD-3-Clause",

--- a/docs/_generated/backlinks.md
+++ b/docs/_generated/backlinks.md
@@ -84,6 +84,12 @@ Generated automatically. Do not edit.
 
 - [relates_to] docs/reports/domain-backfill-proof.md
 
+## architecture/overview.md
+
+- [relates_to] docs/architekturstruktur.md
+- [relates_to] docs/datenmodell.md
+- [relates_to] docs/techstack.md
+
 ## audit/impl-registry.yaml
 
 - [relates_to] docs/blueprints/blueprint-agent-safety-control-layer.md
@@ -181,7 +187,6 @@ Generated automatically. Do not edit.
 ## docs/architekturstruktur.md
 
 - [relates_to] docs/adr/ADR-0001__clean-slate-docs-monorepo.md
-- [relates_to] docs/datenmodell.md
 - [relates_to] docs/techstack.md
 - [relates_to] docs/vision.md
 - [relates_to] docs/zusammenstellung.md
@@ -333,6 +338,7 @@ Generated automatically. Do not edit.
 ## docs/deploy/README.md
 
 - [relates_to] docs/blueprints/weltgewebe.deploy.plan.md
+- [relates_to] docs/datenmodell.md
 - [relates_to] docs/deploy/CHANGELOG.md
 - [relates_to] docs/deploy/DRIFT_POLICY.md
 - [relates_to] docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md
@@ -428,7 +434,6 @@ Generated automatically. Do not edit.
 - [relates_to] docs/deploy/heimserver.integration.md
 - [relates_to] docs/deploy/security.md
 - [relates_to] docs/deployment_governance.md
-- [relates_to] docs/runbook.md
 - [relates_to] docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md
 
 ## docs/deployment_governance.md
@@ -926,7 +931,6 @@ Generated automatically. Do not edit.
 
 ## docs/vision.md
 
-- [relates_to] docs/architekturstruktur.md
 - [relates_to] docs/geist-und-plan.md
 - [relates_to] docs/inhalt.md
 - [relates_to] docs/overview/inhalt.md
@@ -974,6 +978,10 @@ Generated automatically. Do not edit.
 - [relates_to] docs/blueprints/blueprint-agent-safety-control-layer.md
 - [relates_to] docs/policies/agent-reading-protocol.md
 - [relates_to] docs/policies/architecture-critique.md
+
+## runbooks/README.md
+
+- [relates_to] docs/runbook.md
 
 ## scripts/agent/check_non_ideal_task.py
 

--- a/docs/_generated/relates-to-audit.md
+++ b/docs/_generated/relates-to-audit.md
@@ -14,9 +14,9 @@ Generated automatically. Do not edit.
 
 | Metrik | Wert |
 | --- | --- |
-| Relationen gesamt | 547 |
+| Relationen gesamt | 549 |
 | — depends_on | 20 |
-| — relates_to | 523 |
+| — relates_to | 525 |
 | — supersedes | 4 |
 | relates_to Anteil | 96% |
 
@@ -30,7 +30,7 @@ _Keine Lücken erkannt._
 
 > Zusammenhängende Gruppen im relates_to-Graphen.
 
-**Cluster 1** (211 Dokumente):
+**Cluster 1** (213 Dokumente):
 
 - `.github/workflows/api.yml`
 - `.github/workflows/basemap-runtime-proof.yml`
@@ -47,6 +47,7 @@ _Keine Lücken erkannt._
 - `apps/api/src/state.rs`
 - `apps/api/tests/db_domain_account_write_path.rs`
 - `apps/api/tests/db_domain_backfill.rs`
+- `architecture/overview.md`
 - `audit/impl-registry.yaml`
 - `contracts/agent/handoff.schema.json`
 - `contracts/agent/run-result.schema.json`
@@ -214,6 +215,7 @@ _Keine Lücken erkannt._
 - `infra/compose/compose.prod.override.yml`
 - `infra/compose/compose.vps.override.yml`
 - `repo.meta.yaml`
+- `runbooks/README.md`
 - `scripts/agent/check_non_ideal_task.py`
 - `scripts/agent/json_contract.py`
 - `scripts/agent/run_task.py`

--- a/docs/_generated/relations-analysis.md
+++ b/docs/_generated/relations-analysis.md
@@ -17,9 +17,9 @@ Generated automatically. Do not edit.
 | Dokumente gesamt | 159 |
 | Dokumente mit ausgehenden Relationen | 158 |
 | Dokumente als Ziel referenziert | 122 |
-| Relationen gesamt | 547 |
+| Relationen gesamt | 549 |
 | — depends_on | 20 |
-| — relates_to | 523 |
+| — relates_to | 525 |
 | — supersedes | 4 |
 | Isolierte Dokumente | 0 |
 | depends_on Zyklen | 0 |
@@ -34,14 +34,14 @@ Generated automatically. Do not edit.
 - ⚠️ High outbound count (8): `docs/reference/agent-operability-fixture-matrix.md` — possible over-linking
 - ⚠️ High outbound count (8): `docs/reports/domain-edge-write-path-proof.md` — possible over-linking
 - ⚠️ High inbound count (20): `docs/tasks/board.md` — central dependency, review carefully
+- ⚠️ High inbound count (16): `docs/deploy/README.md` — central dependency, review carefully
 - ⚠️ High inbound count (15): `docs/adr/ADR-0006__auth-magic-link-session-passkey.md` — central dependency, review carefully
-- ⚠️ High inbound count (15): `docs/deploy/README.md` — central dependency, review carefully
 - ⚠️ High inbound count (14): `docs/reports/auth-status-matrix.md` — central dependency, review carefully
 - ⚠️ High inbound count (13): `docs/adr/ADR-0007__auth-persistence-production-db-path.md` — central dependency, review carefully
 - ⚠️ High inbound count (13): `docs/reports/optimierungsstatus.md` — central dependency, review carefully
-- ⚠️ High inbound count (12): `docs/deployment.md` — central dependency, review carefully
 - ⚠️ High inbound count (11): `docs/blueprints/auth-roadmap.md` — central dependency, review carefully
 - ⚠️ High inbound count (11): `docs/blueprints/domain-data-postgres-cutover.md` — central dependency, review carefully
+- ⚠️ High inbound count (11): `docs/deployment.md` — central dependency, review carefully
 
 ### Zyklen (depends_on)
 
@@ -60,14 +60,14 @@ _Keine Zyklen gefunden._
 **Eingehend (inbound):**
 
 - `docs/tasks/board.md` — 20 eingehende Relationen
+- `docs/deploy/README.md` — 16 eingehende Relationen
 - `docs/adr/ADR-0006__auth-magic-link-session-passkey.md` — 15 eingehende Relationen
-- `docs/deploy/README.md` — 15 eingehende Relationen
 - `docs/reports/auth-status-matrix.md` — 14 eingehende Relationen
 - `docs/adr/ADR-0007__auth-persistence-production-db-path.md` — 13 eingehende Relationen
 - `docs/reports/optimierungsstatus.md` — 13 eingehende Relationen
-- `docs/deployment.md` — 12 eingehende Relationen
 - `docs/blueprints/auth-roadmap.md` — 11 eingehende Relationen
 - `docs/blueprints/domain-data-postgres-cutover.md` — 11 eingehende Relationen
+- `docs/deployment.md` — 11 eingehende Relationen
 
 ### Isolierte Dokumente
 

--- a/docs/_generated/system-map.md
+++ b/docs/_generated/system-map.md
@@ -17,20 +17,20 @@ Source: scripts/docmeta/generate_system_map.py
 |---|---|---|---|---|---|---|---|---|
 |blueprint.docmeta-engine|architecture/blueprint.docmeta-engine.md|norm|governance|canonical|2026-06-09||||
 |docmeta.schema|architecture/docmeta.schema.md|norm|docmeta|canonical|2026-06-09||scripts/docmeta/check_doc_review_age.py, scripts/docmeta/check_repo_index_consistency.py, scripts/docmeta/generate_system_map.py, scripts/docmeta/validate_relations.py||
-|overview|architecture/overview.md|norm|governance|canonical|2026-06-09||||
-|security|architecture/security.md|norm|governance|canonical|2026-06-09||||
+|overview|architecture/overview.md|norm|governance|canonical|2026-07-11||||
+|security|architecture/security.md|norm|governance|canonical|2026-07-11||||
 
 ## Zone: reality
 
 |id|path|role|organ|status|last_reviewed|depends_on|verifies_with|missing_scripts|
 |---|---|---|---|---|---|---|---|---|
-|runtime.readme|runtime/README.md|reality|runtime|canonical|2026-06-09||||
+|runtime.readme|runtime/README.md|reality|runtime|canonical|2026-07-11||||
 
 ## Zone: runbooks
 
 |id|path|role|organ|status|last_reviewed|depends_on|verifies_with|missing_scripts|
 |---|---|---|---|---|---|---|---|---|
-|runbooks.readme|runbooks/README.md|runbooks|ops|canonical|2026-06-09||||
+|runbooks.readme|runbooks/README.md|runbooks|ops|canonical|2026-07-11||||
 
 ## Automated Checks
 

--- a/docs/architekturstruktur.md
+++ b/docs/architekturstruktur.md
@@ -3,161 +3,111 @@ id: docs.architecture.overview
 title: Architekturüberblick
 doc_type: architecture
 status: active
-summary: >
-  Kurzbeschreibung der Architektur und Struktur.
+summary: Aktuelle Repositorystruktur, Verantwortungsgrenzen und bewusst geplante Erweiterungen.
 relations:
+  - type: relates_to
+    target: architecture/overview.md
   - type: relates_to
     target: docs/techstack.md
   - type: relates_to
     target: docs/datenmodell.md
-  - type: relates_to
-    target: docs/vision.md
 ---
-# Architektur & Struktur
 
-Dieses Dokument beschreibt die Zielstruktur des Weltgewebe-Repositories. Es dient als Referenzrahmen,
-damit sich Contributors schnell orientieren können und klar ist, wo welche Verantwortlichkeiten liegen.
-Wo die Realität aktuell noch abweicht (z.B. fehlender `apps/worker`), ist dies explizit markiert.
+# Architektur und Repositorystruktur
 
-⸻
+Dieses Dokument erklärt, **wo** die heute vorhandenen Systemteile liegen. Die
+Komponenten- und Datenflusswahrheit steht in
+[`architecture/overview.md`](../architecture/overview.md); der tatsächliche
+Technologiestand in [`docs/techstack.md`](techstack.md).
 
-ASCII-Baum
+## Aktuelle Struktur
 
-Damit das Weltgewebe langfristig wartbar bleibt, folgt das Repo einer bewusst
-einfachen, aber erweiterbaren Struktur:
+```text
+weltgewebe/
+├── apps/
+│   ├── api/                 Rust-/Axum-API, Migrationen und API-Tests
+│   └── web/                 SvelteKit-Webanwendung und Browserbeweise
+├── architecture/            kurze kanonische Architektur- und Sicherheitskarten
+├── contracts/domain/        JSON-Schema-Verträge für fachliche Objekte
+├── configs/                 Anwendungsvorgaben
+├── docs/                    Spezifikationen, Entscheidungen, Berichte und Planung
+├── infra/
+│   ├── caddy/               Frontdoor- und Proxyverträge
+│   └── compose/             lokale, produktive und optionale Compose-Profile
+├── policies/                technische Grenzwerte und Sicherheitsvorgaben
+├── runbooks/                operative Einstiegskarten
+├── runtime/                 Laufzeitvertrag ohne ungeprüfte Livebehauptung
+├── scripts/                 Guards, Deploy-, Daten- und Entwicklungswerkzeuge
+├── tests/                   repositoryweite Tests
+├── .github/workflows/       CI-, Proof- und Sicherheitsabläufe
+├── repo.meta.yaml           Wahrheits- und Discoveryvertrag
+└── README.md                Einstieg und aktueller Gesamtzustand
+```
 
-```txt
-weltgewebe/weltgewebe-repo/
-├─ apps/                         # Ausführbare Anwendungen (Web, API, Worker)
-│  ├─ web/                       # SvelteKit-Frontend (PWA, MapLibre)
-│  │  ├─ src/
-│  │  │  ├─ routes/             # Seiten, Endpunkte (+page.svelte/+server.ts)
-│  │  │  ├─ lib/                # UI-Komponenten, Stores, Utilities
-│  │  │  ├─ hooks.client.ts     # RUM-Initialisierung (LongTasks)
-│  │  │  └─ app.d.ts            # App-Typdefinitionen
-│  │  ├─ static/                # Fonts, Icons, manifest.webmanifest
-│  │  ├─ tests/                 # Frontend-Tests (Vitest, Playwright)
-│  │  ├─ svelte.config.js
-│  │  ├─ vite.config.ts
-│  │  └─ README.md
-│  │
-│  ├─ api/                      # Rust (Axum) – REST + SSE
-│  │  ├─ src/
-│  │  │  ├─ main.rs             # Einstiegspunkt, Router
-│  │  │  ├─ routes/             # HTTP- und SSE-Endpunkte
-│  │  │  ├─ domain/             # (geplant) Geschäftslogik, Services
-│  │  │  ├─ repo/               # (geplant) SQLx-Abfragen, Postgres-Anbindung
-│  │  │  ├─ events/             # (geplant) Outbox-Publisher, Eventtypen
-│  │  │  └─ telemetry/          # Prometheus/OTel-Integration
-│  │  ├─ migrations/            # Datenbankschemata, pg_partman
-│  │  ├─ tests/                 # API-Tests (Rust)
-│  │  ├─ Cargo.toml
-│  │  └─ README.md
-│  │
-│  ├─ worker/                   # (geplant) Projector/Indexer/Jobs
-│  │                             # Aktuell noch nicht im Repo angelegt.
-│  └─ search/                   # (optional, geplant) Such-Adapter/SDKs
-│                                # Wird bei Bedarf als eigener Ordner ergänzt.
-│
-├─ contracts/                   # Datenverträge & Schemata (JSON Schema)
-│  ├─ domain/                   # Schemata für Kernentitäten (Node, Edge, ...)
-│  └─ README.md
-│
-├─ packages/                    # (optional) Geteilte Libraries/SDKs
-│  └─ README.md
-│
-├─ infra/                       # Betrieb/Deployment/Observability
-│  ├─ compose/                  # Docker Compose Profile
-│  │  ├─ compose.core.yml       # Basis-Stack: web, api, db, caddy
-│  │  ├─ compose.observ.yml     # Monitoring: Prometheus, Grafana, Loki/Tempo
-│  │  ├─ compose.stream.yml     # (optional) Event-Streaming: NATS/JetStream
-│  │  └─ compose.search.yml     # (optional) Suche: Typesense/Meili, KeyDB
-│  ├─ caddy/
-│  │  └─ Caddyfile              # Proxy, HTTP/3, CSP, TLS
-│  ├─ compose/
-│  │  ├─ sql/
-│  │  │  └─ init/               # SQL-Init-Skripte, Extensions (z.B. uuid-ossp, pgcrypto)
-│  │  └─ monitoring/
-│  │     └─ prometheus.yml      # Prometheus-Konfiguration
-│  │
-│  │  # Hinweis:
-│  │  # Die frühere Unterscheidung `infra/db` und `infra/monitoring`
-│  │  # wurde in der Realität durch `infra/compose/sql` und
-│  │  # `infra/compose/monitoring` ersetzt.
-│  ├─ nomad/                    # (optional, geplant) Orchestrierungsspezifikationen
-│  └─ k8s/                      # (optional, geplant) Kubernetes-Manifeste
-│
-├─ docs/                        # Dokumentation & Entscheidungen
-│  ├─ adr/                      # Architecture Decision Records
-│  │  └─ ADR-0005-auth.md       # Minimales Auth-Konzept
-│  ├─ techstack.md              # Techstack v3.2 (Referenz)
-│  ├─ datenmodell.md            # Datenbank- und Projektionstabellen
-│  └─ runbook.md                # Woche-1/2 Setup, DR/DSGVO-Drills
-│
-├─ .github/
-│  └─ workflows/                # GitHub Actions für Build, Tests, Infra
-│                               # (z.B. ci.yml, web-e2e.yml, infra.yml, metrics.yml, links.yml)
-├─ policies/                    # Governance & Qualitäts-Geländer
-│  ├─ limits.yaml               # Budget-Grenzen (z.B. max. Payload-Größe)
-│  ├─ perf.json                 # Performance-Budgets (Frontend)
-│  ├─ retention.yml             # Aufbewahrungsfristen
-│  ├─ security.yml              # Minimal-Sicherheitsanforderungen
-│  └─ slo.yaml                  # SLO-/SLI-Definitionen
-├─ scripts/                     # Hilfsskripte (Setup, Metriken, Domain-Checks, Dev-Helper)
-│  ├─ dev/
-│  │  └─ gewebe-demo-server.mjs
-│  ├─ tools/
-│  │  ├─ json_escape
-│  │  ├─ uv-pin.sh
-│  │  └─ yq-pin.sh
-│  ├─ contracts-domain-check.sh # Domain-Verträge (JSON Schema) prüfen
-│  ├─ setup.sh                  # Lokales Setup (Rust-Tooling, etc.)
-│  └─ wgx-metrics-snapshot.sh   # Metrik-Snapshot für WGX
-│
-├─ .env.example                 # Beispiel-Umgebungsvariablen
-├─ .editorconfig                # Editor-Standards
-├─ .gitignore                   # Ignorier-Regeln
-├─ LICENSE                      # Lizenztext
-└─ README.md                    # Projektüberblick, Quickstart
+## Verantwortungen
 
-⸻
+### `apps/web`
 
-Erläuterungen zu den Hauptordnern
+- statisch baubare SvelteKit-Anwendung,
+- Karte mit MapLibre und PMTiles,
+- Login-, Einstellungs-, Account- und Knotenansichten,
+- Vitest-/Playwright-Tests und Buildbelege.
 
-- **apps/**
-  Enthält ausführbare Anwendungen: Web-Frontend (SvelteKit) und API (Rust/Axum). Worker (Eventprojektionen, Rebuilds)
-  und optionale Search-Adapter sind im Architekturplan vorgesehen, aber aktuell noch nicht angelegt.
-  Jeder Unterordner ist eine eigenständige App mit eigenem README und Build-Konfig.
-- **packages/**
-  Platz für geteilte Libraries oder SDKs, die von mehreren Apps genutzt werden. Wird erst angelegt, wenn Bedarf an
-  gemeinsamem Code entsteht.
-- **infra/**
-  Infrastruktur- und Deployment-Ebene. Compose-Profile für verschiedene Betriebsmodi (`infra/compose/*.yml`),
-  Caddy-Konfiguration (`infra/caddy`), DB-Init (`infra/compose/sql/init`), Monitoring-Setup
-  (`infra/compose/monitoring`). Optional Nomad- oder Kubernetes-Definitionen für spätere Skalierung können als
-  `infra/nomad` bzw. `infra/k8s` ergänzt werden.
-- **docs/**
-  Dokumentation und Architekturentscheidungen. Enthält ADRs, Techstack-Beschreibung, Diagramme,
-  Datenmodellübersicht und Runbooks.
-- **.github/workflows/**
-  Alle GitHub-Actions-Workflows rund um Continuous Integration/Deployment (Builds, Tests, Link-Checks, Metrics).
-- **scripts/**
-  Hilfsskripte für Setup, Domain-Checks, Dev-Demos und Metriken.
-- **policies/**
-  Zentrale Budgets und Leitplanken (Performance, Limits, Retention, Security, SLOs).
-- **Root**
-  Repository-Metadaten: .env.example (Vorlage), Editor- und Git-Configs, Lizenz und README mit Projektüberblick.
+Ein produktiver Laufzeit-SSR-Server ist nicht der aktuelle Standard.
 
-⸻
+### `apps/api`
 
-Zusammenfassung
+- HTTP-API mit Axum,
+- Magic-Link-, Passkey- und Sitzungslogik,
+- Accounts, Knoten und Fäden,
+- JSONL- und opt-in PostgreSQL-Pfade,
+- Health- und Metrikendpunkte.
 
-Diese Struktur spiegelt den aktuellen Techstack (v3.2) wider:
+Es gibt derzeit keinen produktiven Outbox-Relay, keinen Projector-Worker und
+keine implementierte Gesprächs- oder Nachrichtenpersistenz.
 
-- Mobil-first via PWA (SvelteKit).
-- Rust/Axum API mit Outbox/JetStream-Eventing.
-- Compose-first Infrastruktur mit klar getrennten Profilen.
-- Observability und Compliance fest verankert.
-- Erweiterbar durch optionale packages/, nomad/, k8s/.
+### `contracts/domain`
 
-Dies dient als Referenzrahmen für alle weiteren Arbeiten am Weltgewebe-Repository.
+Die Contracts beschreiben aktuelle und teilweise geplante Fachobjekte. Ein
+vorhandenes Schema beweist nicht automatisch einen API-, Datenbank- oder
+UI-Pfad. Besonders Gespräch, Nachricht und historische Rolle müssen daher als
+Vertragsvorbereitung und nicht als fertiges Subsystem gelesen werden.
+
+### `infra`
+
+Docker Compose und Caddy sind die aktuelle Delivery-Basis. Vorhandene Profile
+werden in [`runtime/README.md`](../runtime/README.md) eingeordnet. Nomad,
+Kubernetes, eigenständige Suchdienste oder weitere Orchestrierungsschichten sind
+keine heutige Standardarchitektur.
+
+### `docs`, `architecture`, `runtime`, `runbooks`
+
+- `architecture/`: knappe kanonische System- und Sicherheitswahrheit,
+- `runtime/`: unterstützte Laufzeitverträge und Beobachtungsgrenzen,
+- `runbooks/`: operative Einstiege,
+- `docs/`: Detailverträge, ADRs, Berichte und Planung.
+
+Historische Berichte und ADRs bleiben erhalten, dürfen aktuellen Code oder die
+kanonischen Einstiegskarten aber nicht überstimmen.
+
+## Noch nicht vorhandene Zielkomponenten
+
+Neue Verzeichnisse oder Dienste werden erst angelegt, wenn ein konkreter Bedarf
+und ein Betriebsvertrag bestehen. Aktuell nicht als Standard vorhanden sind:
+
+- `apps/worker` für Projektionen oder Outbox-Relay,
+- eigenständige Search-Services,
+- `packages/` als gemeinsame SDK-Schicht,
+- Nomad-/Kubernetes-Produktionsorchestrierung,
+- Event-Sourcing als allgemeines Persistenzmodell,
+- vollständige Observability-Plattform mit verbindlichen SLOs.
+
+## Änderungsregel
+
+Eine Strukturänderung ist erst kanonisch, wenn:
+
+1. der ausführbare Pfad im Repository vorhanden ist,
+2. Ownership und Wiederherstellung geklärt sind,
+3. Tests oder Runtimebelege existieren,
+4. diese Datei, `architecture/overview.md` und `docs/techstack.md` konsistent
+   aktualisiert wurden.

--- a/docs/datenmodell.md
+++ b/docs/datenmodell.md
@@ -3,147 +3,152 @@ id: datenmodell
 title: Datenmodell
 doc_type: reference
 status: active
-summary: Dokumentation des PostgreSQL-Datenmodells mit Kernentitäten, Beziehungen und Lese-Modellen.
+summary: Aktuelles physisches Datenmodell, Quellenumschaltung und noch nicht implementiertes Zielmodell.
 relations:
   - type: relates_to
-    target: docs/architekturstruktur.md
+    target: architecture/overview.md
   - type: relates_to
     target: docs/domain/vocabulary.md
   - type: relates_to
     target: docs/techstack.md
+  - type: relates_to
+    target: docs/deploy/README.md
 ---
+
 # Datenmodell
 
-Dieses Dokument beschreibt das Datenmodell der Weltgewebe-Anwendung, das auf PostgreSQL aufbaut.
-Es dient als Referenz für Entwickler, um die Kernentitäten, ihre Beziehungen und die daraus
-abgeleiteten Lese-Modelle zu verstehen.
+## Wichtigste Aussage
 
-## Grundprinzipien
+PostgreSQL ist **nicht** pauschal die alleinige Quelle der Wahrheit. Für
+Domänendaten bleibt JSONL der Standard. PostgreSQL kann als Lesequelle und für
+einzelne Schreibpfade ausdrücklich aktiviert werden. Auth-Sitzungen und
+Passkey-Credentials besitzen eigene Persistenzentscheidungen.
 
-- **Source of Truth:** PostgreSQL ist die alleinige Quelle der Wahrheit.
-- **Transaktionaler Outbox:** Alle Zustandsänderungen werden transaktional in die `outbox`-Tabelle
-  geschrieben, um eine konsistente Event-Verteilung an nachgelagerte Systeme (z.B. via NATS
-  JetStream) zu garantieren.
-- **Normalisierung:** Das Schreib-Modell ist normalisiert, um Datenintegrität zu gewährleisten.
-  Lese-Modelle (Projektionen/Views) sind für spezifische Anwendungsfälle denormalisiert und
-  optimiert.
-- **UUIDs:** Alle Primärschlüssel sind UUIDs (`v4`), um eine verteilte Generierung zu
-  ermöglichen und Abhängigkeiten von sequenziellen IDs zu vermeiden.
+## Quellenmatrix
 
----
+| Domäne | Standard lesen | Standard schreiben | PostgreSQL-Option |
+|---|---|---|---|
+| Accounts/Garnrollen | JSONL | JSONL-Append | `domain_accounts`; Account-Create opt-in |
+| Knoten | JSONL | JSONL-Rewrite | `domain_nodes`; Patch opt-in |
+| Fäden | JSONL | JSONL-Append | `domain_edges`; Create opt-in |
+| Sitzungen | In-Memory ohne DB | gleicher Store | `sessions` bei konfiguriertem DB-Store |
+| Passkeys | In-Memory | In-Memory | `passkey_credentials` opt-in |
+| Gespräche/Nachrichten | kein vollständiger produktiver Pfad | kein vollständiger produktiver Pfad | nur Contracts, keine Tabellen |
 
-## Tabellen (Schreib-Modell)
+PostgreSQL-Schreiben verlangt PostgreSQL-Lesen. Die API verweigert ungültige
+Mischzustände, damit Änderungen nach einem Neustart nicht unsichtbar werden.
+Es gibt keinen allgemeinen Dual-Write.
 
-### `nodes`
+## Physische PostgreSQL-Tabellen
 
-Speichert geografische oder logische Knotenpunkte, die als Anker für Gesprächsräume dienen.
+Die folgende Übersicht wird aus den aktuellen Migrationen abgeleitet.
 
-|Spalte|Typ|Beschreibung|
+### `sessions`
+
+| Spalte | Typ | Bedeutung |
 |---|---|---|
-|`id`|`uuid` (PK)|Eindeutiger Identifikator des Knotens.|
-|`location`|`geography(Point, 4326)`|Geografischer Standort (Längen- und Breitengrad).|
-|`h3_index`|`bigint`|H3-Index für schnelle geografische Abfragen.|
-|`title`|`text`|Anzeigename des Knotens.|
-|`summary`|`text`|Kurze Zusammenfassung. Ein längeres `description`-Feld ist für später reserviert.|
-|`created_at`|`timestamptz`|Zeitstempel der Erstellung.|
-|`updated_at`|`timestamptz`|Zeitstempel der letzten Änderung.|
+| `id` | `TEXT` PK | serverseitige Session-ID |
+| `account_id` | `TEXT` | zugehöriger Account |
+| `device_id` | `TEXT` | Browser-/Gerätebezug |
+| `created_at` | `TIMESTAMPTZ` | Erstellung |
+| `last_active` | `TIMESTAMPTZ` | letzte Aktivität |
+| `expires_at` | `TIMESTAMPTZ` | serverseitiger Ablauf |
 
-### `roles`
+Derzeit besteht kein Foreign Key auf `domain_accounts`, weil Accounts weiterhin
+aus JSONL gelesen werden können.
 
-Verwaltet Benutzer- oder Systemrollen, die Berechtigungen steuern.
+### `domain_accounts`
 
-|Spalte|Typ|Beschreibung|
+| Gruppe | Spalten |
+|---|---|
+| Identität | `id`, `kind`, `title`, `mode` |
+| Sichtbarkeit/Ort | `radius_m`, `location_lat`, `location_lon` |
+| Betrieb/Auth | `disabled`, `role`, `email`, `webauthn_user_id` |
+| Zeit | `created_at`, `updated_at` |
+| Restfelder | `public_payload`, `private_payload` |
+
+E-Mail-Adressen besitzen einen trim-/case-normalisierten partiellen Unique-Index.
+`public_pos` wird nicht gespeichert, sondern aus privater Position, Radius und
+ID deterministisch abgeleitet.
+
+`kind` und `mode` verwenden noch Legacy-Defaults `ron`. Diese Defaults sind kein
+bestätigtes Zielmodell. Ihre Ablösung braucht eine Datenmigration und kann nicht
+nur dokumentarisch erfolgen.
+
+### `domain_nodes`
+
+| Spalte | Typ | Bedeutung |
 |---|---|---|
-|`id`|`uuid` (PK)|Eindeutiger Identifikator der Rolle.|
-|`user_id`|`uuid` (FK)|Referenz zum Benutzer (externes System).|
-|`permissions`|`jsonb`|Berechtigungen der Rolle als JSON-Objekt.|
-|`created_at`|`timestamptz`|Zeitstempel der Erstellung.|
+| `id` | `TEXT` PK | Knoten-ID |
+| `kind` | `TEXT` | Knotentyp |
+| `title` | `TEXT` | Titel |
+| `lat`, `lon` | `DOUBLE PRECISION` | optionale Position |
+| `created_at`, `updated_at` | `TIMESTAMPTZ` | Zeitangaben |
+| `payload` | `JSONB` | übrige JSONL-Felder |
 
-### `edges`
+Es gibt derzeit keine PostGIS-Geometrie. Der Geoindex ist ein einfacher
+B-Tree auf `(lat, lon)`.
 
-Definiert Beziehungen zwischen Knoten und Rollen (z.B. Mitgliedschaften, Zuständigkeiten).
+### `domain_edges`
 
-|Spalte|Typ|Beschreibung|
+| Spalte | Typ | Bedeutung |
 |---|---|---|
-|`id`|`uuid` (PK)|Eindeutiger Identifikator der Kante.|
-|`source_type`|`text`|Typ des Ursprungs (`role`, `node`).|
-|`source_id`|`uuid`|ID des Ursprungsobjekts.|
-|`target_type`|`text`|Typ des Ziels (`role`, `node`).|
-|`target_id`|`uuid`|ID des Zielobjekts.|
-|`edge_kind`|`text`|Art der Beziehung (`delegation`, `membership`, `ownership`, `reference`).|
-|`note`|`text`|Optionale Notiz zur Beziehung.|
-|`created_at`|`timestamptz`|Zeitstempel der Erstellung.|
-|`expires_at`|`timestamptz`|Optionaler Ablaufzeitpunkt.|
+| `id` | `TEXT` PK | Faden-ID |
+| `source_id`, `target_id` | `TEXT` | Endpunkte |
+| `edge_kind` | `TEXT` | Beziehungsart |
+| `created_at` | `TIMESTAMPTZ` | Erstellung |
+| `payload` | `JSONB` | Typinformationen, Notiz und Restfelder |
 
-### `conversations`
+Foreign Keys sind bewusst noch nicht gesetzt. Vor einer FK-Entscheidung ist ein
+Orphan- und Referenzaudit erforderlich; bestehende Fäden dürfen nicht
+stillschweigend verworfen werden.
 
-Repräsentiert die Gesprächsräume ("conversations"), die mit unterschiedlichen Subjekten
-(z.B. Knoten, Gremien) verknüpft sein können.
+### `passkey_credentials`
 
-|Spalte|Typ|Beschreibung|
+| Spalte | Typ | Bedeutung |
 |---|---|---|
-|`id`|`uuid` (PK)|Eindeutiger Identifikator des Gesprächsraums.|
-|`conversation_type`|`text`|Typ des Gesprächsraums (z.B. `node`, `webrat`, `naehstuebchen`, `private`).|
-|`subject_id`|`uuid`|Zugehöriges Subjekt (z.B. `nodes.id`). Kann `NULL` sein.|
-|`author_role_id`|`uuid` (FK, `roles.id`)|Rolle, die den Gesprächsraum eröffnet hat.|
-|`title`|`text`|Titel des Gesprächsraums.|
-|`created_at`|`timestamptz`|Zeitstempel der Erstellung.|
-|`updated_at`|`timestamptz`|Zeitstempel der letzten Änderung.|
+| `credential_id` | `TEXT` PK | hexkodierte WebAuthn-Credential-ID |
+| `account_id` | `TEXT` | zugehöriger Account |
+| `webauthn_user_id` | `UUID` | stabiler WebAuthn-User-Handle |
+| `credential` | `JSONB` | öffentlicher Credential-Datensatz und Counter |
+| Zeitfelder | `TIMESTAMPTZ` | Erstellung, Änderung, letzte Nutzung |
 
-### `messages`
+Die Tabelle speichert keine privaten Passkey-Schlüssel. Ein Foreign Key zu
+`domain_accounts` ist bis zum vollständigen PostgreSQL-Accountcutover bewusst
+ausgesetzt.
 
-Speichert einzelne Beiträge innerhalb eines Gesprächsraums.
+## JSONL-Modell
 
-|Spalte|Typ|Beschreibung|
-|---|---|---|
-|`id`|`uuid` (PK)|Eindeutiger Identifikator der Nachricht.|
-|`conversation_id`|`uuid` (FK, `conversations.id`)|Zugehöriger Gesprächsraum.|
-|`author_role_id`|`uuid` (FK, `roles.id`)|Rolle, die die Nachricht verfasst hat.|
-|`content`|`text`|Inhalt der Nachricht.|
-|`created_at`|`timestamptz`|Zeitstempel der Erstellung.|
+JSONL-Datensätze folgen den JSON-Schemas in `contracts/domain`. Die API lädt sie
+beim Start in begrenzte In-Memory-Stores. Schreibpfade serialisieren
+check-and-write innerhalb eines Prozesses und verwenden `fsync`; sie sind kein
+Ersatz für eine transaktionale Mehrprozessdatenbank.
 
-### `outbox`
+## Contracts ohne produktive Tabellen
 
-Implementiert das Transactional Outbox Pattern für zuverlässige Event-Publikation.
+`conversation.schema.json`, `message.schema.json` und `role.schema.json`
+beschreiben fachliche beziehungsweise geplante Objekte. Die aktuelle
+Migrationshistorie enthält keine `conversations`, `messages`, `roles`, `outbox`
+oder Projektionsviews. Dokumente dürfen diese Objekte daher nicht als bereits
+persistierte PostgreSQL-Fläche darstellen.
 
-|Spalte|Typ|Beschreibung|
-|---|---|---|
-|`id`|`uuid` (PK)|Eindeutiger Identifikator des Events.|
-|`aggregate_type`|`text`|Typ des Aggregats (z.B. "conversation", "message").|
-|`aggregate_id`|`uuid`|ID des betroffenen Aggregats.|
-|`event_type`|`text`|Typ des Events (z.B. "conversation.created", "message.posted").|
-|`payload`|`jsonb`|Event-Daten.|
-|`created_at`|`timestamptz`|Zeitstempel der Erstellung.|
+## Cutover-Regeln
 
----
+Ein vollständiger PostgreSQL-Cutover ist erst belegt, wenn:
 
-## Projektionen (Lese-Modelle)
+1. Backfill und Orphan-Audit grün sind,
+2. die betroffene Lesequelle PostgreSQL ist,
+3. alle benötigten Mutationen PostgreSQL schreiben,
+4. kein restart-unsichtbarer JSONL-Pfad verbleibt,
+5. Rollback und Wiederherstellung definiert sind,
+6. DB- und Browser-Ende-zu-Ende-Beweise grün sind,
+7. die Produktionsruntime die Schalter frisch belegt.
 
-Diese Views sind für die Lese-Performance optimiert und fassen Daten aus mehreren Tabellen zusammen.
-Sie werden von den Workern (Projektoren) asynchron aktualisiert.
+## Logisches Zielmodell
 
-### `public_role_view`
-
-Eine denormalisierte Sicht auf Rollen, die nur öffentlich sichtbare Informationen enthält.
-
-|Spalte|Typ|Beschreibung|
-|---|---|---|
-|`role_id`|`uuid`|Identifikator der Rolle.|
-|`display_name`|`text`|Öffentlich sichtbarer Name (ggf. aus einem externen User-Service).|
-|`avatar_url`|`text`|URL zu einem Avatar-Bild.|
-
-### `conversation_view`
-
-Eine zusammengefasste Ansicht von Gesprächsräumen für die schnelle Darstellung in der
-Benutzeroberfläche.
-
-|Spalte|Typ|Beschreibung|
-|---|---|---|
-|`conversation_id`|`uuid`|Identifikator des Gesprächsraums.|
-|`node_id`|`uuid`|Zugehöriger Knoten.|
-|`node_name`|`text`|Name des zugehörigen Knotens.|
-|`author_display_name`|`text`|Anzeigename des Autors.|
-|`title`|`text`|Titel des Gesprächsraums.|
-|`comment_count`|`integer`|Anzahl der Kommentare (wird vom Projektor berechnet).|
-|`last_activity_at`|`timestamptz`|Zeitstempel der letzten Aktivität.|
-|`created_at`|`timestamptz`|Zeitstempel der Erstellung.|
+Das angestrebte Produktmodell besteht aus einer Garnrolle je Account,
+Eigenschaften für Sichtbarkeit und Verortung, Knoten als Kollektivgüter oder
+Orte sowie Fäden als Beziehungen. Dieses Zielmodell ist noch nicht vollständig
+mit den Legacyfeldern `kind`, `mode`, `role` und `ron` versöhnt. Bis zur
+Migration gelten die physischen Contracts und Datenintegritätsregeln vor einer
+vereinfachenden Produktbeschreibung.

--- a/docs/geist-und-plan.md
+++ b/docs/geist-und-plan.md
@@ -212,14 +212,14 @@ Extraktion: Plan der Weltweberei
 4. Organisation
    - Lokale Ortswebereien mit eigenen Konten.
    - Föderation mehrerer Ortswebereien möglich.
-5. Technik
-   - Frontend: SvelteKit, MapLibre, PWA.
-   - Backend: Rust (Axum), PostgreSQL + PostGIS + h3, Event-Outbox, NATS JetStream.
-   - Suche: Typesense / MeiliSearch.
-   - Infrastruktur: Nomad, Caddy (HTTP/3), PgBouncer.
-   - Observability: Prometheus, Grafana, Loki, Tempo.
-   - Security: SBOM, Signaturen, DSGVO-Forget-Pipeline, Key-Rotation.
-   - Kostenkontrolle: FinOps-KPIs (€/Session, €/GB Traffic).
+5. Technische Zielskizze aus dem historischen Ausgangstext (keine Ist-Architektur)
+   - Frontend-Ziel: SvelteKit, MapLibre, PWA.
+   - Backend-Ziel: Rust (Axum), PostgreSQL/PostGIS, mögliche Event- und NATS-Flächen.
+   - Mögliche spätere Suche: Typesense oder MeiliSearch nur nach Bedarfsbeleg.
+   - Mögliche spätere Infrastruktur: zusätzliche Orchestrierung erst nach Skalierungsbeleg; aktuell Compose und Caddy.
+   - Observability-Ziel: Metriken, Logs und Traces; aktuell nur Teilflächen vorhanden.
+   - Security-Ziele: SBOM, Signaturen, Forget-Pipeline und Rotation jeweils nur mit eigenem Betriebsbeleg.
+   - Kostenkontrolle bleibt ein Zielmodell, nicht ein aktuell gemessener SLO.
 
 ⸻
 
@@ -227,7 +227,7 @@ Essenz-Kristall
 
 👉 Die Weltweberei ist eine kartenbasierte Demokratie-Engine: Jede Handlung wird als Faden sichtbar,
 jeder Knoten ist Raum für Aktionen oder Ressourcen, alle Prozesse laufen transparent, freiwillig,
-temporär und verhandelbar – technisch abgesichert durch Event-Sourcing, föderierbar in Ortsgeweben
+temporär und verhandelbar – mit einer noch auszubauenden, auditierbaren Technik und föderierbaren Ortsgeweben
 und getragen von einem klaren DSGVO-Privacy-by-Design.
 
 ⸻

--- a/docs/inhalt.md
+++ b/docs/inhalt.md
@@ -165,7 +165,7 @@ Aktuell benutze ich WhatsApp und Signal
 **Verantwortlicher:** Alexander Mohr, Huskoppelallee 13, 23795 Klein Rönnau
 
 **Datenschutz:** Das Weltgewebe ist so konzipiert, dass keine Daten erhoben werden, ohne dass du sie selbst
-einträgst. Es gibt kein Tracking, keine versteckten Cookies, keine automatische Profilbildung. Sichtbar
+einträgst. Es gibt kein Werbetracking und keine versteckte Profilbildung. Notwendige HTTP-only-Sitzungscookies werden für Anmeldung und Sitzungserhalt verwendet. Sichtbar
 wird nur das, was du freiwillig sichtbar machst: Name, Wohnort, Verbindungen im Gewebe. Deine persönlichen
 Daten kannst du jederzeit verändern oder zurückziehen. Die Verarbeitung deiner Daten erfolgt auf Grundlage
 von Artikel 6 Absatz 1 lit. a und f der Datenschutzgrundverordnung – also: Einverständnis & legitimes

--- a/docs/overview/inhalt.md
+++ b/docs/overview/inhalt.md
@@ -27,11 +27,12 @@ einen klaren Einstieg in die inhaltliche Stoßrichtung des Projekts.
 - **Transparenz herstellen:** Dokumentation, Policies und öffentlich nachvollziehbare Entscheidungen
   haben Vorrang vor reinem Feature-Output.
 
-## Projektumfang (Docs-only, Gate-Strategie)
+## Projektumfang (aktiver Aufbau)
 
-Das Repository befindet sich in Phase ADR-0001 „Docs-only“. Technische Re-Entry-Pfade sind über
-Gates A–D definiert. So bleiben Experimente nachvollziehbar und können schrittweise in den
-Produktionskontext überführt werden.
+Das Repository enthält aktive Web-, API-, Auth-, Datenbank-, Karten-, CI- und
+Deploymentpfade. Die historischen Gates A–D bleiben als Entwicklungsgeschichte
+nützlich, sind aber kein aktuelles „Docs-only“-Statuslabel. Produktreife wird pro
+vertikalem Nutzerweg und durch aktuelle Code-, CI- und Runtimebelege bewertet.
 
 ## Domänensprache
 
@@ -47,6 +48,6 @@ Die Kernelemente sind in `docs/domain/vocabulary.md` definiert und durch
 - **Fahrplan & Prozesse:** `docs/process/fahrplan.md` beschreibt Freigaben, Gates und
   Quality-Gates.
 
-> _Stand:_ Docs-only, Fokus auf Ethik, UX und transparente Entscheidungsprozesse.
+> _Stand:_ Aktiver Aufbau; Ethik, UX und transparente Entscheidungen bleiben Leitplanken.
 > Mit dem Startpunkt hier und der Systematik im Schwesterdokument erhalten Außenstehende in
 > zwei Klicks den vollständigen Projektkontext.

--- a/docs/policies/orientierung.md
+++ b/docs/policies/orientierung.md
@@ -55,7 +55,7 @@ Es beschreibt:
   - Operative Konsequenz: Ortswebereien mit eigenem Konto + föderalen Hooks.
 - **Privacy by Design**
   - Bedeutung: Sichtbar nur freiwillig Eingetragenes.
-  - Operative Konsequenz: Keine Cookies/Tracking; Sichtbarkeit nur durch bewusst gesetzte Garnrollen-Verortung.
+  - Operative Konsequenz: Keine Werbe- oder Trackingcookies; notwendige sichere Sitzungscookies; Sichtbarkeit nur durch bewusst gesetzte Garnrollen-Verortung.
 
 ---
 
@@ -127,14 +127,14 @@ Es beschreibt:
 
 ---
 
-## 6 · Technische Leitplanken (aus techstack.md)
+## 6 · Technische Leitplanken
 
-- **Architektur:** Rust API (Axum) + SvelteKit Frontend + PostgreSQL / NATS JetStream
-  (Event-Sourcing).
-- **Monitoring:** Prometheus + Grafana + Loki + Tempo.
-- **Security:** SBOM + cosign + Key-Rotation + DSGVO-Forget-Pipeline.
-- **HA & Cost Control:** Nomad Cluster · PgBouncer · Opex-KPIs < €1 / Session.
-- **Garnrollen-Sichtbarkeit (ADR-0009):** Garnrolle auf Karte setzen + Sichtbarkeitsauswahl (ab Phase C).
+- **Aktueller Kern:** Rust/Axum-API, statisches SvelteKit-Web, Docker Compose und Caddy.
+- **Datenwahrheit:** JSONL bleibt Standard; PostgreSQL-Pfade werden einzeln und beweisgebunden umgestellt.
+- **Events und Beobachtung:** NATS sowie Prometheus-/Grafana-/Loki-/Tempo-Konfigurationen sind vorhanden, aber kein vollständiges Event-Sourcing- oder Observability-System ist allgemein produktiv belegt.
+- **Security:** sichere Sitzungen, Proxygrenze, CI-/Contract-Checks und secret-sichere Betriebsabläufe sind reale Leitplanken; SBOM, Signaturen, automatische Rotation und Forget-Pipeline bleiben gesondert nachzuweisende Ziele.
+- **Skalierung:** Compose ist der aktuelle Standard. Nomad, Kubernetes, HA-Cluster und FinOps-Ziele sind keine heutige Betriebswahrheit.
+- **Garnrollen-Sichtbarkeit:** Sichtbarkeit und Verortung sollen Eigenschaften einer Garnrolle sein; der Legacy-Modus `ron` wird separat migriert.
 
 ---
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -3,525 +3,182 @@ id: docs.runbook
 title: Runbook
 doc_type: runbook
 status: active
-summary: >
-  Allgemeines operatives Runbook.
+summary: Aktuelle lokale, diagnostische und wiederherstellungsbezogene Betriebsabläufe.
 relations:
+  - type: relates_to
+    target: runbooks/README.md
   - type: relates_to
     target: docs/runbook.observability.md
   - type: relates_to
-    target: docs/deployment.md
-  - type: relates_to
     target: docs/deploy/README.md
 ---
-## Runbook
 
-Dieses Dokument enthält praxisorientierte Anleitungen für den Betrieb, die
-Wartung und das Onboarding im Weltgewebe-Projekt.
+# Allgemeines Runbook
 
-## 1. Onboarding (Woche 1-2)
+Dieses Dokument enthält nur Abläufe, die mit der aktuellen Repositorystruktur
+vereinbar sind. Für öffentliche Deployments, Migrationen und Mailbetrieb gelten
+die spezialisierten Runbooks unter [`docs/deploy/`](deploy/README.md).
 
-Ziel dieses Runbooks ist es, neuen Teammitgliedern einen strukturierten und
-schnellen Einstieg zu ermöglichen.
+## 1. Lokales Onboarding
 
-### Woche 1: Systemüberblick & lokales Setup
+### Voraussetzungen
 
-- **Tag 1: Willkommen & Einführung**
-  - **Kennenlernen:** Team und Ansprechpartner.
-  - **Projekt-Kontext:** Lektüre von [README.md](../README.md),
-    [docs/overview/inhalt.md](overview/inhalt.md) und
-    [docs/geist-und-plan.md](geist-und-plan.md).
-  - **Architektur:** `docs/architekturstruktur.md` und `docs/techstack.md` durcharbeiten, um die
-    Komponenten und ihre Zusammenspiel zu verstehen.
-  - **Zugänge:** Accounts für GitHub, Docker Hub, etc. beantragen.
+- Git
+- Docker mit Compose
+- `just`
+- Node.js und pnpm gemäß den versionierten Repositorymetadaten
+- Rust nur für direkte API-Entwicklung außerhalb des Containerpfads
 
-- **Tag 2-3: Lokales Setup**
-  - **Voraussetzungen:** Git, Docker, Docker Compose, `just` und Rust (stable) installieren.
-  - **Codespaces (Zero-Install):** GitHub Codespaces öffnen, das Devcontainer-Setup starten und im
-    Terminal `npm run dev -- --host` ausführen. So lassen sich Frontend und API ohne lokale
-    Installation testen – ideal auch auf iPad.
-  - **Repository klonen:** `git clone <repo-url>`
-  - **`.env`-Datei erstellen:** `cp .env.example .env`.
-  - **Core-Stack starten:** `just up` (bevorzugt) oder `make up` als Fallback. Überprüfen, ob alle
-    Container (`web`, `api`, `db`, `caddy`) laufen: `docker ps`.
-  - **Web-Frontend aufrufen:** `http://localhost:5173` (SvelteKit-Devserver) oder – falls der Caddy
-    Reverse-Proxy aktiv ist – `http://localhost:3000` im Browser öffnen.
-  - **API-Healthcheck:** API-Endpunkt `/health` aufrufen, um eine positive Antwort zu sehen.
-
-- **Tag 4-5: Erster kleiner Beitrag**
-  - **Hygiene-Checks:** `just check` ausführen und sicherstellen, dass alle Linter, Formatierer und
-    Tests erfolgreich durchlaufen.
-  - **"Good first issue" suchen:** Ein kleines, abgeschlossenes Ticket (z.B.
-    eine Textänderung in der UI oder eine Doku-Ergänzung) auswählen.
-  - **Workflow üben:** Branch erstellen, Änderung implementieren, Commit mit
-    passendem Präfix (`docs: ...` oder `feat(web): ...`) erstellen und einen Pull
-    Request zur Review stellen.
-
-### Woche 2: Vertiefung & erste produktive Aufgaben
-
-- **Monitoring & Observability:**
-  - **Monitoring-Stack starten:** `docker compose -f infra/compose/compose.observ.yml up -d`.
-  - **Dashboards erkunden:** Grafana (`http://localhost:3001`) öffnen und die Dashboards für
-    Web-Vitals, API-Latenzen und Systemmetriken ansehen.
-- **Datenbank & Events:**
-  - **Event-Streaming-Stack starten:** `docker compose -f infra/compose/compose.stream.yml up -d`.
-  - **Datenbank-Migrationen:** Verzeichnis `apps/api/migrations/` ansehen, um die
-    Schema-Entwicklung nachzuvollziehen.
-- **Produktiv werden:**
-  - **Erstes Feature-Ticket:** Eine überschaubare User-Story oder einen Bug bearbeiten, der alle
-    Schichten (Web, API) betrifft.
-  - **Pair-Programming:** Eine Session mit einem erfahrenen Teammitglied planen, um komplexere Teile
-    der Codebase kennenzulernen.
-
----
-
-## 2. Disaster Recovery Drill
-
-Dieses Runbook beschreibt die Schritte zur Simulation eines Totalausfalls und der Wiederherstellung
-des Systems. Der Drill sollte quartalsweise durchgeführt werden, um die Betriebsbereitschaft
-sicherzustellen.
-
-> **Eigenständige Runbooks:** Dieser Abschnitt ist der **Probelauf**. Der
-> reale Vorfallprozess steht in [Incident Response](runbooks/incident-response.md),
-> der detaillierte Datenwiederherstellungs-Ablauf in
-> [DB Recovery](runbooks/db-recovery.md).
-
-**Szenario:** Das primäre Rechenzentrum ist vollständig ausgefallen. Das System muss aus Backups in
-einer sauberen Umgebung wiederhergestellt werden.
-
-**Ziele (RTO/RPO):**
-
-- **Recovery Time Objective (RTO):** < 4 Stunden
-- **Recovery Point Objective (RPO):** < 5 Minuten
-
-### Vorbereitung
-
-1. **Backup-Verfügbarkeit prüfen:** Sicherstellen, dass die letzten WAL-Archive der
-   PostgreSQL-Datenbank an einem sicheren, externen Ort (z.B. S3-Bucket) verfügbar sind –
-   verschlüsselt (z.B. S3 SSE-KMS) und mittels Object Lock unveränderbar abgelegt.
-2. **Infrastruktur-Code:** Sicherstellen, dass der `infra/`-Ordner den aktuellen Stand der
-   produktiven Infrastruktur abbildet.
-3. **Team informieren:** Alle Beteiligten über den Beginn des Drills in Kenntnis setzen.
-
-### Durchführung
-
-1. **Saubere Umgebung bereitstellen:** Eine neue VM- oder Kubernetes-Umgebung ohne bestehende Daten
-   oder Konfigurationen hochfahren.
-2. **Infrastruktur aufbauen:**
-    - Das Repository auf die neue Umgebung klonen.
-    - Die Basis-Infrastruktur über die Compose-Files oder Nomad-Jobs starten
-      (`infra/compose/compose.core.yml` etc.). Die Container starten, bleiben aber ggf. im
-      Wartezustand, da die Datenbank noch nicht bereit ist.
-3. **Datenbank-Wiederherstellung (Point-in-Time Recovery):**
-    - Eine neue PostgreSQL-Instanz starten.
-    - Das letzte Basis-Backup einspielen.
-    - Die WAL-Archive aus dem Backup-Speicher bis zum letzten verfügbaren Zeitpunkt vor
-      dem "Ausfall" wiederherstellen.
-4. **Systemstart & Event-Replay:**
-    - Die Applikations-Container (API, Worker) neu starten, damit sie sich mit der
-      wiederhergestellten Datenbank verbinden.
-    - Den `outbox`-Relay-Prozess starten. Dieser beginnt, die noch nicht verarbeiteten
-      Events aus der `outbox`-Tabelle an NATS JetStream zu senden.
-    - Die Worker (Projektoren) starten. Sie konsumieren die Events von JetStream
-      und bauen die Lese-Modelle (`faden_view` etc.) neu auf.
-5. **Verifikation & Abschluss:**
-    - **Datenkonsistenz prüfen:** Stichprobenartige Überprüfung der wiederhergestellten Daten in den
-      Lese-Modellen.
-    - **Funktionstests:** Manuelle oder automatisierte Smoke-Tests durchführen (z.B. Login, Gesprächsraum
-      erstellen).
-    - **Zeitmessung:** Die benötigte Zeit für die Wiederherstellung stoppen und mit dem RTO
-      vergleichen.
-    - **Datenverlust bewerten:** Den Zeitpunkt des letzten wiederhergestellten
-      WAL-Segments mit dem Zeitpunkt des "Ausfalls" vergleichen, um den
-      Datenverlust zu ermitteln (sollte RPO nicht überschreiten).
-6. **Drill beenden:** Die Testumgebung herunterfahren und die Ergebnisse
-   dokumentieren.
-
-| Startzeit | Endzeit | RTO erreicht?     | RPO erreicht?     |
-|-----------|---------|-------------------|-------------------|
-|           |         | [ ] Ja / [ ] Nein | [ ] Ja / [ ] Nein |
-
-### Nachbereitung
-
-- **Lessons Learned:** Ein kurzes Meeting abhalten, um Probleme oder
-  Verbesserungspotenziale zu besprechen.
-- **Runbook aktualisieren:** Dieses Runbook bei Bedarf mit den gewonnenen Erkenntnissen anpassen.
-- **Automatisierung nutzen:** `just drill` ausführen, um den Drill reproduzierbar zu starten und
-  Smoke-Tests anzustoßen.
-
----
-
-## 3. Public Login Configuration
-
-The system supports a Magic Link-based public login flow. This feature is
-gated by environment variables and requires specific infrastructure
-configuration for security.
-
-### Enable Public Login
-
-To enable public login, set the following environment variables in your `.env` file (or deployment configuration):
+### Start
 
 ```bash
-# Enable the public login feature
-AUTH_PUBLIC_LOGIN=1
-
-# The base URL of the application (required for generating magic links)
-APP_BASE_URL=https://weltgewebe.net
-
-# Trusted proxies
-# CRITICAL: In production, set this to the actual IP/CIDR of your reverse proxy (e.g. Caddy).
-# See "How to Determine Trusted Proxies CIDR" below.
-AUTH_TRUSTED_PROXIES=127.0.0.1,::1,172.16.0.0/12
-
-# Rate Limiting (Application Level)
-# Keyed by IP and Email. Defaults are infinite if unset.
-AUTH_RL_IP_PER_MIN=5
-AUTH_RL_IP_PER_HOUR=100
-AUTH_RL_EMAIL_PER_MIN=3
-AUTH_RL_EMAIL_PER_HOUR=10
-
-# SMTP Configuration (Required for Magic Links)
-# If unset, magic links are NOT deliverable. They are only logged if AUTH_LOG_MAGIC_TOKEN=1 (Dev).
-SMTP_HOST=smtp.example.com
-SMTP_PORT=587
-SMTP_USER=apikey
-SMTP_PASS=secret
-SMTP_FROM=noreply@weltgewebe.net
-
-# Development / Debugging
-# If true, the magic link token is logged to stdout. DO NOT ENABLE IN PROD.
-AUTH_LOG_MAGIC_TOKEN=0
+git clone <repo-url>
+cd weltgewebe
+cp .env.example .env
+just up
 ```
 
-### How to Determine Trusted Proxies CIDR
-
-Correct configuration of trusted proxies is vital for security (IP rate limiting)
-and audit logs. There are two layers:
-
-1. **Caddy (Edge):** Needs to know the IP of any upstream Load Balancer or Proxy to extract the client IP.
-2. **App (Backend):** Needs to know the IP of Caddy (or the Docker network) to trust the headers sent by Caddy.
-
-#### Step-by-Step: Finding the Docker Network CIDR
-
-If Caddy and the App run in the same Docker Compose stack, the App sees requests coming from the Docker network
-gateway or Caddy's container IP. You must trust the entire Docker subnet. Only do this if your reverse proxy
-container is the direct upstream of the app container in the same Docker network; otherwise trust only the real
-proxy IPs.
-
-1. **Find the Network Subnet:**
-
-   Run this command to inspect the default bridge network (usually `infra_default`) and extract the Subnet:
-
-   ```bash
-   # Replace 'infra_default' if your network is named differently
-   docker network inspect infra_default --format '{{range .IPAM.Config}}{{.Subnet}}{{end}}'
-   # Output example: 172.18.0.0/16
-   ```
-
-2. **Configure `.env`:**
-   Add this CIDR to `AUTH_TRUSTED_PROXIES` alongside localhost.
-
-   ```bash
-   AUTH_TRUSTED_PROXIES=127.0.0.1,::1,172.18.0.0/16
-   ```
-
-### Rate Limiting (Backend Enforcement)
-
-To protect the authentication endpoints from abuse, rate limiting is primarily enforced by the backend API.
-The Edge Proxy (Caddy) passes the client IP to the backend.
-
-> **Warning:** Rate limits rely on accurate client IP resolution. Ensure your Edge Proxy
-> configuration correctly sets headers (e.g., `X-Forwarded-For`) and the API backend
-> trusts the correct proxy IPs (`AUTH_TRUSTED_PROXIES`), especially if behind another proxy.
-> Otherwise, you risk rate-limiting the proxy itself because all requests appear to come from the proxy IP.
-
-#### Check Client IP Visibility
-
-Before enforcing strict limits, verify that the API sees the correct client IP:
-
-1. **Check Access Logs:** Inspect the API logs to confirm the remote IP matches the client, not the Edge proxy.
-
-   ```bash
-   # Check the Weltgewebe stack API logs
-   docker compose -f infra/compose/compose.prod.yml logs -n 200 api
-
-   # Alternatively, check the Heimserver Edge-Caddy logs (outside this repository)
-   # e.g., cd /opt/heimgewebe/edge && docker compose logs -n 200 edge-caddy
-   ```
-
-2. **Verify Proxy Visibility:**
-   > **Critical Warning:** If the API is behind an Edge Proxy or Load Balancer, it will likely
-   > receive the proxy's IP instead of the user's if trust is misconfigured. This causes **all users**
-   > to share the same rate limit bucket.
-
-   **Mitigation:**
-   - **Edge-Caddy:** If running behind a secondary Edge/LB, you **must** configure `trusted_proxies` in your Edge Caddyfile.
-     Ensure you properly pass down the real IP:
-
-     ```caddy
-     {
-         # Uncomment and add your LB/CDN CIDRs here:
-         # servers {
-         #     trusted_proxies static 10.0.0.0/8 172.16.0.0/12 ...
-         # }
-     }
-     ```
-
-   - **App:** Check `AUTH_TRUSTED_PROXIES` in `.env` for application-level IP resolution (rate limits and
-     audit logs). The API must trust the IP of the Edge-Caddy to parse the forwarded headers.
-   - **Do not blindly trust headers** if the API is directly exposed to the internet
-     (which violates the proxy-first contract).
-
-3. **Practical Test (Device Isolation):**
-   - **Step A:** Connect Device A (e.g., WiFi) and trigger 10 requests -> Expect `429 Too Many Requests`.
-   - **Step B:** Connect Device B (e.g., Mobile Data) and trigger 1 request -> Expect `200 OK`.
-   - **Result:**
-     - If Device B gets `200 OK`: Rate limiting is correctly keyed by Client IP.
-     - If Device B gets `429`: The API sees the upstream Proxy IP. **Action required:**
-       Fix `AUTH_TRUSTED_PROXIES` and Edge-Caddy headers.
-
-#### Request Endpoint (`login_limit`)
-
-- **Rate:** 5 requests per minute (per IP)
-- **Window:** 1 minute
-- **Endpoint:** `POST /api/auth/magic-link/request`
-
-#### Consume Endpoint (`login_consume_limit`)
-
-- **Rate:** 30 requests per minute (per IP)
-- **Window:** 1 minute
-- **Endpoint:** `POST /api/auth/magic-link/consume`
-- **Note:** The consume endpoint is typically called once per flow. Frequent
-  429s here indicate abuse or incorrect client IP resolution.
-
-This configuration is defined in `infra/caddy/Caddyfile.prod`.
-
-**Tuning Limits:**
-To adjust the rate limits, modify `infra/caddy/Caddyfile.prod`:
-
-```caddy
-rate_limit {
-    zone login_limit {
-        key {remote_host}
-        events 10   # Increase to 10 requests
-        window 1m
-    }
-}
-```
-
-**Verification:**
-To verify rate limiting is active, use a loop to trigger the limit. Using `curl`
-with output suppression (`-sS`) and write-out (`-w`) makes it easier to spot
-the `429` status code.
-
-> **Note:** The verification loop must send a valid JSON body. A `400 Bad Request` or `422 Unprocessable Entity`
-> response indicates an invalid payload, not a failure of the rate limit.
+Prüfen:
 
 ```bash
-# Expect 5x 200, then 429
-for i in {1..10}; do \
-  curl -sS -o /dev/null -w "%{http_code}\n" \
-    -X POST \
-    -H "Content-Type: application/json" \
-    -d '{"email":"test@example.com"}' \
-    https://weltgewebe.net/api/auth/magic-link/request; \
-done
+curl -fsS http://127.0.0.1:8081/api/health/live
+curl -fsS http://127.0.0.1:8081/api/health/ready
 ```
 
-### Required Env for Caddy
+Die Web-/Caddy-Frontdoor liegt im Standard-Core-Profil auf Port `8081`. Der
+SvelteKit-Devserver kann für direkte Webentwicklung separat gestartet werden;
+er ist nicht mit dem Compose-Frontdoor gleichzusetzen.
 
-The production Caddy configuration (`infra/compose/compose.prod.yml`) enforces the presence of specific environment
-variables to prevent silent failures or misconfiguration loops. If these are missing, `docker compose config` (and
-deployment) will fail fast.
-
-- `WEB_UPSTREAM_URL`: The full URL of the upstream web application (e.g., `https://weltgewebe-web.pages.dev`).
-- `WEB_UPSTREAM_HOST`: The hostname of the upstream web application (e.g., `weltgewebe-web.pages.dev`), used
-  for `Host` header forwarding.
-
-Ensure these are set in your `.env` file or deployment secrets.
-
-## 4. Account Creation v0 (Hauptpfad) & Erst-Admin-Bootstrap
-
-Es gibt zwei klar getrennte Wege, einen Account anzulegen:
-
-- **Account Creation v0 (Hauptpfad):** Ein eingeloggter **Admin** legt Accounts
-  über `POST /api/accounts` an. Der Account wird dauerhaft gespeichert
-  (JSONL-Append + In-Memory-Store) und ist sofort über `GET /api/accounts` und
-  die Karte sichtbar. Keine öffentliche Registrierung, kein Self-Signup.
-- **Bootstrap (Init-/Not-/Dev-Pfad):** legt den **ersten Admin** an (Henne-Ei:
-  der erste Admin kann nicht per API entstehen) bzw. seedet beim Container-Start.
-  Ausdrücklich **nicht** der normale Erstellungsprozess.
-
-Die Datenebene ist JSONL-gespeist (`GEWEBE_IN_DIR`, Standard `.gewebe/in`); der
-In-Memory-Store ist die Lesequelle und wird beim Start aus dem JSONL geladen.
-
-### Account Creation v0: `POST /api/accounts`
-
-- **Authz:** nur **Admin** (eigene `require_admin`-Prüfung, strenger als das
-  generische `require_write` für Weber+Admin). Weber dürfen in v0 **keine**
-  Accounts anlegen.
-- **Typ:** immer verortete Garnrolle (`type=garnrolle`, `mode=verortet`).
-- **Position:** Request nimmt eine interne `location` entgegen; `public_pos` wird
-  daraus abgeleitet. Bei `radius_m=0` ist `public_pos == location` (exakt). Bei
-  `radius_m>0` wird `public_pos` deterministisch auf Basis der Account-ID
-  innerhalb eines ±`radius_m`-Meter-Quadrats verschoben (kein Zufallswert, kein
-  Sprung bei erneutem Laden). Die Verschiebung ist garantiert nicht null.
-- **Rollenvergabe:** Der `role`-Parameter erlaubt `"weber"` (Default) oder
-  `"admin"`. Ein Admin darf in v0 auch Admin-Accounts anlegen — dies ist
-  **bewusste Machtweitergabe** und ermöglicht kontrollierten Auf- und Abbau der
-  Betreiberstruktur. Nur der **erste Admin** muss per Bootstrap erzeugt werden
-  (Henne-Ei: kein API-Zugang vor dem ersten Admin); alle weiteren Admins legt
-  ein bestehender Admin über diesen Endpunkt an.
-
-**Request-Body:**
-
-| Feld | Pflicht | Bedeutung |
-|---|---|---|
-| `title` | ja | Anzeigename (nicht leer) |
-| `location.lat` | ja | Breitengrad, Zahl in `[-90, 90]` |
-| `location.lon` | ja | Längengrad, Zahl in `[-180, 180]` |
-| `radius_m` | nein | Unschärferadius in Metern (Default `0` ⇒ exakte `public_pos`; `>0` ⇒ deterministische ID-basierte Verschiebung) |
-| `summary` | nein | Kurzbeschreibung (leer ⇒ weggelassen) |
-| `role` | nein | `weber` oder `admin` (Allowlist, Default `weber`) |
-| `tags` | nein | Liste von Strings |
-| `id` | nein | UUID (sonst serverseitig generiert) |
-| `email` | nein | operatives Feld (nicht Teil des Domain-Contracts) |
-
-**Antworten:** `201 Created` (Account-JSON) · `400` ungültige Felder/Koordinaten ·
-`401` nicht eingeloggt · `403` eingeloggt, aber nicht Admin · `409` ID/E-Mail-Konflikt.
-
-**Beispiel (lokal, Admin-Session via Dev-Login):**
+### Qualitätsprüfung
 
 ```bash
-# Admin-Session holen (AUTH_DEV_LOGIN=1 vorausgesetzt), Cookie speichern:
-curl -fsS -c cookies.txt -X POST http://127.0.0.1:8081/api/auth/dev/login \
-  -H 'Content-Type: application/json' -H 'Origin: http://127.0.0.1:8081' \
-  -d '{"account_id":"<ADMIN_UUID>"}'
-
-# Account anlegen (Cookie + Origin nötig wegen CSRF):
-curl -fsS -b cookies.txt -X POST http://127.0.0.1:8081/api/accounts \
-  -H 'Content-Type: application/json' -H 'Origin: http://127.0.0.1:8081' \
-  -d '{"title":"Alice","location":{"lat":53.5503,"lon":9.9932},"tags":["real"]}'
+just check
+just ci
 ```
 
-**Smoke (POST → GET, zusätzlich /map bei Web/Caddy-Origin):**
+`just ci` ist der breitere lokale Spiegel. Datenbank-, Browser- und
+Deploybeweise besitzen zusätzliche Workflows und können externe Dienste oder
+Container benötigen.
+
+## 2. Diagnose
+
+### Vor jeder Änderung
+
+1. Git-Head, Branch und Dirty-State prüfen.
+2. laufende Compose-Projekte und Zielprofile prüfen.
+3. effektive Env nur redigiert beziehungsweise als Vorhandenseinsmetadaten
+   lesen.
+4. Datenquellschalter und Migrationsmodus prüfen.
+5. erst danach einen Reparaturpfad wählen.
+
+### Health und Logs
 
 ```bash
-just smoke-account-create   # liest Admin-ID aus bootstrap-first-account.env
+docker compose -f infra/compose/compose.core.yml ps
+curl -fsS http://127.0.0.1:8081/api/health/live
+curl -fsS http://127.0.0.1:8081/api/health/ready
+docker compose -f infra/compose/compose.core.yml logs --tail=200 api caddy
 ```
 
-> **Hinweis:** `smoke-account-create.sh` prüft `/map` nur, wenn gegen die Web/Caddy-Origin geprüft wird.
-> Im Direct-API-Modus (`API_PREFIX=`) wird `/map` bewusst übersprungen, da die Rust-API keine `/map`-Route hat.
->
-> **UI:** Ein Minimalformular „Account erstellen" ist bewusst **nicht** Teil
-> dieses PR und folgt als expliziter Folge-PR. v0 ist API + Smoke + Tests.
+Logs dürfen nicht unredigiert weitergegeben werden, wenn Token-, Mail- oder
+Secretwerte enthalten sein könnten.
 
-### Erst-Admin & Initialisierung: Bootstrap (Not-/Dev-Pfad)
+### Typische Fehlerklassen
 
-Der Bootstrap-Account ist immer eine **verortete Garnrolle** (`type=garnrolle`,
-`mode=verortet`, `radius_m=0`). Für den **ersten Admin** `ACCOUNT_ROLE=admin`
-setzen — danach legt dieser Admin alle weiteren Accounts über die API an.
+| Symptom | zuerst prüfen |
+|---|---|
+| `502` oder leere Frontdoor | Caddy-Upstream, Compose-Netz, TLS-/Hostvertrag |
+| Loginmail fehlt | Public-Login-Schalter, SMTP-Bereitschaft, Absender und redigierte Logs |
+| Login gilt nur scheinbar lokal | Cookie-Scope, Sessionstore, `/auth/me`, Browserprofil |
+| Änderung verschwindet nach Neustart | Domain-Lese- und Schreibquelle |
+| API startet nicht | Konfigurationsvalidierung, Proxyentscheidung, Migrationsmodus |
+| Karte bleibt leer | Web-Build, Basemap-Konfiguration, PMTiles-Range und API-Daten getrennt |
 
-`scripts/dev/bootstrap-first-account.sh` legt genau einen Account an und
-schreibt die Metadaten (Account-ID, Titel, Position) nach
-`.gewebe/in/bootstrap-first-account.env`.
+## 3. Datenquellen und Migrationen
 
-**Pflichtfelder (per Umgebungsvariable):**
+JSONL ist der Standardpfad für Domänendaten. PostgreSQL ist ein explizites
+Opt-in pro Lese- und Schreibfläche. Vor einer Umschaltung:
 
-| Variable | Bedeutung | Validierung |
-|---|---|---|
-| `ACCOUNT_TITLE` | Anzeigename des Accounts | nicht leer |
-| `PUBLIC_LAT` | Breitengrad der öffentlichen Kartenposition | Zahl in `[-90, 90]` |
-| `PUBLIC_LON` | Längengrad der öffentlichen Kartenposition | Zahl in `[-180, 180]` |
+1. Backfill-/Orphan-Belege lesen,
+2. PostgreSQL-Lesequelle aktivieren,
+3. nur kompatible Schreibquellen aktivieren,
+4. Migrationen separat autorisieren,
+5. Restart- und Readback-Verhalten prüfen.
 
-**Optionale Felder:**
+Ein Health-Smoke, Compose-Start oder erfolgreicher Build erteilt keine
+Migrationsfreigabe. Siehe
+[`docs/deploy/vps-db-initialization-boundary.md`](deploy/vps-db-initialization-boundary.md).
 
-| Variable | Bedeutung | Standard |
-|---|---|---|
-| `ACCOUNT_ID` | UUID (sonst automatisch generiert) | auto |
-| `ACCOUNT_SUMMARY` | Kurzbeschreibung (leer ⇒ weggelassen) | leer |
-| `ACCOUNT_ROLE` | `weber` oder `admin` (Allowlist) | `admin` |
-| `ACCOUNT_TAGS` | Kommagetrennte Tags | `real` |
-| `ACCOUNT_EMAIL` | E-Mail-Adresse (operatives Feld) | leer |
+## 4. Wiederherstellung
 
-Der Account-Typ ist fix `garnrolle`/`verortet` und nicht konfigurierbar.
-Werte werden scriptintern JSON-sicher escaped; der Bootstrap-Pfad benötigt kein `jq`. `jq` wird nur für Smoke-/Dev-Auswertung verwendet.
+### Heute belegbarer Rahmen
 
-**Flags:**
+Das Repository enthält PostgreSQL-Migrationen und Compose-Profile, aber keinen
+allgemein belegten WAL-/PITR-, Outbox-Replay- oder Projector-Rebuild-Vertrag.
+RTO/RPO-Werte dürfen deshalb nicht als erfüllt behauptet werden.
 
-- `--round-location` — Koordinaten auf 3 Dezimalstellen runden (~111 m Unschärfe)
-- `--clean-demo` — Bekannte Demo-IDs aus dem Datensatz entfernen
-- `--force` — Neu anlegen, auch wenn Metadatei bereits existiert
+Ein sicherer Wiederherstellungstest muss in einer entbehrlichen Umgebung:
 
-**Idempotenz:** Dieser Pfad ist für die Initialisierung des ersten Admins gedacht.
-Die Idempotenz wird über die Metadatei `.gewebe/in/bootstrap-first-account.env`
-gesteuert: Wenn diese Datei existiert, wird das Skript ohne Fehler beendet und
-gibt die bereits gespeicherte Account-ID aus. Mit `--force` kann ein neuer Account
-angelegt werden, auch wenn die Metadatei bereits existiert.
+1. den exakten Repository-/Image-Stand festhalten,
+2. eine vorhandene, dokumentierte Sicherung nach deren eigenem Vertrag
+   wiederherstellen,
+3. Migrationen im passenden Modus prüfen,
+4. die effektiven Domainquellen dokumentieren,
+5. API-Readiness, Auth-Sitzung und repräsentative Domänenlesevorgänge testen,
+6. Ergebnis, Dauer, Datenstand und Restlücken festhalten.
 
-**Hinweis zur Position:** `PUBLIC_LAT`/`PUBLIC_LON` werden als `public_pos` über
-`/api/accounts` öffentlich sichtbar. Bewusste Entscheidung — die Position ist
-auf der Karte sichtbar. `--round-location` reduziert die Präzision (~111 m).
-`.gewebe/in/` ist git-ignored; keine echten Koordinaten werden ins Repo geschrieben.
+Ohne registrierte Sicherungsquelle wird kein hypothetisches S3-, WAL-, Nomad-,
+Outbox- oder JetStream-Verfahren erfunden.
 
-### Lokal (dev): Erst-Admin bootstrappen, dann per API erstellen
+### Noch nötig für einen belastbaren DR-Vertrag
+
+- kanonische Sicherungsquelle und Retention,
+- automatisierter Restore-Beweis,
+- definierte RTO/RPO-Ziele,
+- Umgang mit JSONL und PostgreSQL während des Cutovers,
+- redigierter Wiederherstellungsbeleg,
+- regelmäßiger, tatsächlich ausgeführter Drill.
+
+## 5. Public Login und SMTP
+
+Der aktuelle Produktionsablauf steht in
+[`docs/deploy/vps.md`](deploy/vps.md) und im Mail-Migrationsrunbook. Mindestregeln:
+
+- `AUTH_PUBLIC_LOGIN` erst nach grünem SMTP-Readiness-Preflight aktivieren,
+- `AUTH_LOG_MAGIC_TOKEN` in Produktion deaktiviert halten,
+- `AUTH_TRUSTED_PROXIES` ausdrücklich setzen,
+- Secretwerte nicht ausgeben,
+- nach Änderung API-Readiness und reale Mailzustellung prüfen.
+
+Die API erzwingt IP- und E-Mail-basierte Ratelimits. Caddy bereinigt fremde
+Forwardingheader und setzt die beobachtete Remote-Adresse neu. Ein alternativer
+Proxy muss denselben Vertrag erfüllen.
+
+## 6. Account- und Produkt-Smokes
+
+Der erste Admin kann über den ausdrücklich aktivierten Bootstrap-Pfad erzeugt
+werden. Weitere Accounts entstehen über den administrativen API-Pfad. Die
+konkreten Befehle und Variablen stehen in den Dev-/Deployskripten; echte Namen,
+Adressen und E-Mail-Adressen gehören nicht in Repositorybeispiele oder Logs.
+
+Der wichtigste noch ausstehende Produkt-Smoke ist eine durchgängige persistente
+Kette:
+
+1. anmelden,
+2. Garnrolle bearbeiten und verorten,
+3. Knoten anlegen,
+4. nach Neuladen wiederfinden,
+5. Faden anlegen und wieder lesen.
+
+Bis dieser Test grün ist, sind einzelne Account-, Knoten- oder Fadenbeweise kein
+Nachweis eines vollständig nutzbaren Produktflusses.
+
+## 7. Stoppen und Aufräumen
 
 ```bash
-# 1. Ersten Admin bootstrappen (ACCOUNT_ROLE=admin!):
-ACCOUNT_ROLE="admin" ACCOUNT_TITLE="Alice" PUBLIC_LAT="53.5503" PUBLIC_LON="9.9932" \
-  just bootstrap-first-account
-
-# 2. Dev-Stack mit Dev-Login starten:
-AUTH_DEV_LOGIN=1 just up
-
-# 3. Smoke: Bootstrap-Account sichtbar?
-just smoke-seed
-
-# 4. Account Creation v0: Admin legt weitere Accounts per API an.
-just smoke-account-create
+just down
 ```
 
-Dev-Login (kein Public-Login nötig): `AUTH_DEV_LOGIN=1` setzen, dann
-`POST /api/auth/dev/login` mit der `account_id` aus der Metadatei.
-Magic-Link/Public-Login bleibt bewusst außerhalb dieses Pfads (siehe Abschnitt 3).
-
-### Produktion / `weltgewebe-up`
-
-Der API-Container-Entrypoint führt den Bootstrap beim Start aus, wenn aktiviert.
-In der `.env` (oder deployment secrets):
-
-```bash
-GEWEBE_SEED_REAL=true
-GEWEBE_SEED_DEMO=false
-
-# Pflichtfelder für GEWEBE_SEED_REAL=true:
-ACCOUNT_TITLE=Alice
-PUBLIC_LAT=53.5503
-PUBLIC_LON=9.9932
-
-# Optional:
-# ACCOUNT_SUMMARY=Gründerin
-# ACCOUNT_ROLE=admin      # first real bootstrap account should be admin; later accounts via API
-# ACCOUNT_TAGS=real
-# ACCOUNT_EMAIL=alice@example.com
-```
-
-`GEWEBE_SEED_REAL=true` und `GEWEBE_SEED_DEMO=true` gleichzeitig sind verboten:
-Der Entrypoint bricht mit Fehler ab (kein Mischbetrieb aus realem Erstaccount
-und Demo-Daten).
-
-Danach deployen und gegen den Caddy-Origin smoken:
-
-```bash
-scripts/weltgewebe-up --with-caddy
-BASE_URL=https://<deine-domain> just smoke-seed
-```
-
-Dieser Pfad ist für die Initialisierung des ersten Admins gedacht; technisch wird
-Idempotenz über `bootstrap-first-account.env` gesteuert (Entrypoint überspringt
-den Lauf, wenn diese Metadatei auf dem Volume `/data` bereits existiert).
-
-Bei realem Bootstrap muss `GEWEBE_SEED_DEMO=false` gesetzt sein. Wenn
-`GEWEBE_SEED_REAL=true` und `GEWEBE_SEED_DEMO=true` gleichzeitig gesetzt sind,
-bricht der Entrypoint bewusst ab; es gibt keinen Mischbetrieb aus Real- und
-Demo-Seeding.
-
+Volumes, Daten, fremde Compose-Projekte oder Runtime-Secrets werden nicht als
+Routine-Aufräumaktion gelöscht. Solche Eingriffe brauchen einen eigenen
+Wiederherstellungs- und Autorisierungsbeleg.

--- a/docs/techstack.md
+++ b/docs/techstack.md
@@ -3,359 +3,117 @@ id: docs.techstack
 title: Techstack
 doc_type: architecture
 status: active
-summary: >
-  Dokumentation des verwendeten Technologie-Stacks.
+summary: Tatsächlich vorhandener Technologie-Stack, getrennt nach Betrieb, Implementierung und Planung.
 relations:
+  - type: relates_to
+    target: architecture/overview.md
   - type: relates_to
     target: docs/architekturstruktur.md
   - type: relates_to
     target: docs/datenmodell.md
 ---
-Weltgewebe Tech Stack
 
-Der Weltgewebe Tech-Stack ist ein vollständig dokumentiertes Systemprofil. Er nutzt eine moderne Web-Architektur mit
-SvelteKit im Frontend, PostgreSQL als Source of Truth, NATS JetStream für Event-Distribution, und umfangreiche
-Überwachung sowie Sicherheits- und Kostenkonzepte. Die folgenden Abschnitte fassen alle Komponenten zusammen –
-verständlich für Entwickler, Auditoren und PMs, mit konkreten Vorgaben und Kennzahlen.
+# Techstack
 
-Frontend (SvelteKit + Qwik-Escape)
-  •  SvelteKit-Only: Das Frontend basiert ausschließlich auf SvelteKit, um mit minimalem Overhead und maximaler
-     Performance native Web-App-Features zu nutzen. Zusätzliche Frameworks werden vermieden.
-  •  Qwik-Escape (A/B- oder Fast-Track): Eine optionale Qwik-Integration („Fast-Track“) erlaubt reines Client-Rendering
-     dort, wo ein messbarer ROI vorliegt (z.B. extrem hohe Traffic-Routen). A/B-Tests evaluieren den Nutzen. Erst bei
-     signifikantem Performance-Gewinn wird die Qwik-Escape-Variante aktiviert.
-  •  UX-Performance: Wir messen Frontend-Performance, insbesondere Long Tasks (>50ms im Browser), da sie über 50 % der
-     Responsiveness-Probleme verursachen. Entsprechende Metriken (z.B. Anzahl Long-Running Tasks pro Seite) fließen in
-     die Überwachung ein, um Code und Third-Party-Assets zu optimieren.
+Dieses Dokument trennt vier Zustände. „Im Repository vorhanden“ bedeutet nicht
+automatisch „produktiv betrieben“.
 
-Backend & Datenhaltung
-  •  PostgreSQL + Outbox: Alle Änderungen werden in PostgreSQL als „Source of Truth“ gespeichert. Zur zuverlässigen
-     Event-Publikation nutzen wir das Transactional Outbox Pattern: Datenänderungen und zu sendende Events werden in
-     derselben DB-Transaktion zusammengefasst. Ein separater Outbox-Relay-Prozess liest aus der Outbox-Tabelle und
-     sendet die Events an NATS. So bleibt Daten- und Event-Zustand konsistent.
-  •  NATS JetStream: Für verteilte Events (Event-Bus) setzen wir NATS JetStream ein. JetStream bietet verteilte,
-     persitente Streams und skalierbare Consumer-Gruppen. Mit dem prometheus-nats-exporter erfassen wir JetStream-
-     Metriken (z.B. Consumer-Lag) in Prometheus. Ein existierendes Grafana-Dashboard visualisiert JetStream-Stats.
-     Dadurch sehen wir Rückstände (Lag) von Event-Streams und können bei Problemen reagieren.
-  •  Transaktionale Sicherheit: Durch Outbox und logische Replikation wird sichergestellt, dass Events nur bei
-     erfolgreichem DB-Commit versendet werden. Dies vermeidet inkonsistente Zustände (siehe Outbox-Pattern). Je nach
-     Umfang kann die Outbox über Debezium/Logical Replication implementiert werden.
+## Heute implementiert und kanonisch
 
-Monitoring & Observability
-  •  Prometheus & Grafana: Infrastruktur und Anwendungen werden mit Prometheus überwacht und in Grafana visualisiert.
-     Kernmetriken umfassen System- und Anwendungskennzahlen (CPU, Speicher, Antwortzeiten, Latenzen). Wir definieren
-     Dashboards für alle relevanten Subsystenelemente (DB, Services, NATS, Edge).
-  •  Long-Task-Attribution: Der Browser gibt uns Informationen zu Long-Running Tasks (Hauptthread-Blocker). Wir sammeln
-     diese durch Real-User Monitoring (z.B. über PerformanceObserver oder Synthetics). Wie Studien zeigen, sind lange
-     Tasks (>50 ms) Hauptursache für wahrgenommenen Lag. Die Metriken fließen in Dashboards und Alerts ein (z.B. „>10
-     Long-Tasks auf Landing-Page“).
-  •  JetStream-Lag: Über den NATS-Exporter werden JetStream-spezifische Werte (z.B. consumer lag, stream depth) erfasst
-     . In Grafana sehen wir, ob Event-Queues anwachsen. Alerts warnen, wenn ein Consumer hinterherhinkt.
-  •  Edge-Kosten: Wir messen Netzwerkmetriken und CDN-Kosten. Key-Metriken sind ausgehende Traffic-Volumina und Kosten
-     pro Gigabyte. Monitoring umfasst außerdem HTTP/3-spezifische Stats (Caddy kann diese liefern). So sehen wir, wo
-     hohe Egress-Kosten entstehen und optimieren ggf. Caching oder Traffic-Shaping.
-  •  Alert-Trigger: Alerts basieren auf SLIs (siehe SLO-Matrix weiter unten). Beispiele: „CPU >90 % länger als 5 min“,
-     „Service-Response 95%-Latency >X ms“ oder „>10% JetStream-Nachrichten-Lag“.
+### Web
 
-Data Lifecycle & DSGVO-Compliance
-  •  Phasenorientierte DLM: Unsere Daten durchlaufen definierte Lebenszyklus-Phasen (Erfassung, Speicherung, Nutzung,
-     Archivierung, Löschung). In der Datenspeicherung schirmen wir personenbezogene Daten mittels Encryption und
-     Pseudonymisierung ab, um DSGVO-Anforderungen zu erfüllen.
-  •  Daten-Pipeline: Automatisierte Pipelines klassifizieren Daten beim Import (z.B. personenbezogen oder anonym),
-     verschlüsseln sie nach Bedarf und taggen sie mit Aufbewahrungsfristen. Die Pipelines sorgen für konsistente
-     Metadaten, damit später entschieden wird, was wann gelöscht wird.
-  •  Forget-Pipeline: Um das „Recht auf Vergessenwerden“ zu erfüllen, haben wir einen Löschworkflow implementiert. Nach
-     Ablauf eines Retentionszeitraums oder auf Nutzernachfrage entfernt die Pipeline alle verbliebenen persönlichen
-     Daten (End-of-Lifecycle). Dabei kann eine Kombination aus Soft-Delete, Datenmaskierung und finaler physischer
-     Löschung zum Einsatz kommen. Jede Löschung wird auditfähig protokolliert.
-  •  Audit & Protokollierung: Zugriffe und Änderungen an sensiblen Daten werden lückenlos geloggt. Retentions- und
-     Lösch-Fälle sind dokumentiert, um DSGVO-Audits zu bestehen.
+- SvelteKit 2 und Svelte 5
+- TypeScript und Vite
+- statischer Adapter
+- MapLibre GL und PMTiles
+- Playwright und Vitest
+- pnpm 9 mit versioniertem Lockfile
 
-Disaster Recovery
-  •  Regelmäßige Drills: Mindestens vierteljährlich führen wir einen DR-Drill durch. Dabei simulieren wir einen
-     Totalausfall des primären Rechenzentrums.
-     In jedem Drill wird unsere Infrastruktur nach definiertem RPO/RTO-Konzept
-     in einer sauberen Umgebung neu aufgebaut.
-  •  Rebuild + Replay: Der Drill umfasst: (1) Neuaufbau aller Cluster (Nomad, DBs, NATS, etc.) mit Infrastruktur-as-
-     Code, (2) Event-Replay: Verarbeitung gespeicherter Events aus der Outbox/Historie, um den Datenstand zu
-     rekonstruieren, (3) Verifikation: Konsistenz-Checks zwischen Quellsystem und Wiederherstellung. Alle Schritte
-     werden dokumentiert und gemessen (Recovery-Time, Datenverlust).
-  •  Continuous Testing: Diese Übung ist Teil eines kontinuierlichen Verbesserungsprozesses.
-     Erkenntnisse fließen in die
-     Systemhärtung ein (z.B. Code-Updates, Automatisierung).
-     TestRail empfiehlt, DR-Prozesse regelmäßig zu validieren, damit das Team eingespielt bleibt.
+### API
 
-Service Level Objectives (SLO) & Alerts
-  •  Routen-granulare SLOs: Für jeden Haupt-Service bzw. Endpunkt definieren wir eigene SLOs (z.B. 99,9 % Verfügbarkeit
-     pro Monat, p95-Latenz ≤ X ms). Kritische Pfade (z.B. Buchung, Checkout) haben höhere Ziele als weniger relevante
-     Routen. So kann z.B. die API-Route /api/checkout ein eigenes SLO „99,95 % bez. Erfolgsrate“ erhalten.
-  •  Fehlerbudget-Alarmierung: Zu jedem SLO wird ein Fehlerbudget und automatische Trigger konfiguriert. Wir überwachen
-     z.B. „gültige vs. fehlerhafte API-Antworten pro Route“ oder „Erfolgsrate von Calls pro Endpoint“. Sinkt die SLI
-     unter das Ziel, wird sofort ein Alert ausgelöst. Tools wie Datadog erlauben es, gruppierte SLOs zu erstellen – zum
-     Beispiel nach Route oder Traffic-Knoten – und Fehlerraten granular einzusehen.
-  •  Routing-Matrix: Eine SLO-Trigger-Matrix zeigt, welcher Alarm bei Überschreitung welcher Schwelle ausgelöst wird
-     (z.B. erste Warnung bei 1 % Fehlerbudget-Auslastung, Eskalation bei 5 %). Diese Matrix wird routenweise gepflegt
-     und bildet die Grundlage für Runbooks.
+- Rust 2021
+- Axum 0.8 und Tokio
+- sqlx für PostgreSQL
+- WebAuthn über `webauthn-rs`
+- SMTP über `lettre`
+- Prometheus-Metriken
 
-Suche (Typesense / MeiliSearch)
-  •  Primäre Suche: Typesense: Als schnellere Suchlösung setzen wir Typesense ein. Typesense bietet ultraschnelle,
-     typos-tolerante Volltextsuche und einfache Konfiguration. Damit können wir Instant-Suchergebnisse und
-     Autovervollständigung gewährleisten.
-  •  Fallback: MeiliSearch: Als sekundäre Engine dient MeiliSearch.
-     Sie überzeugt durch entwicklerfreundliches Setup und extrem schnelle Indexierung.
-     Fällt Typesense aus oder erreicht es Kapazitätsgrenzen, schalten wir automatisch auf
-     MeiliSearch um.
-     Beide Systeme werden laufend via Monitoring auf ihre Ressourcen- und Durchsatz-Zahlen geprüft.
-  •  DX-Metriken: Für Entwickler-Effizienz („Developer Experience“) tracken wir Kennzahlen wie Time-to-Market von
-     Suchfeatures, Code-Review-Durchlaufzeiten und Einrichtungsaufwand. Diese Metriken sorgen dafür, dass wir die
-     Wartbarkeit und Erweiterbarkeit unserer Suche kontinuierlich verbessern können.
+`rust-version = 1.85.0` beschreibt die minimale Cargo-Kompatibilität des
+API-Pakets. Die repositoryweit gepinnte Entwicklungs-/CI-Toolchain kann neuer
+sein. Beide Angaben sind verschiedene Verträge und dürfen nicht gleichgesetzt
+werden.
 
-Kostenmanagement & KPIs
-  •  Lastszenarien (S1–S4): Zur Kostenprojektion definieren wir vier Traffic-Szenarien:
-  •  S1 Normalbetrieb: Standard-Traffic (Basisjahr).
-  •  S2 Wachstum: +50 % Nutzer, saisonale Peak-Zeiten.
-  •  S3 Spitzenlast: z.B. „Black Friday“-ähnlicher Ansturm (2–3× Basis).
-  •  S4 Extremfall: Ungeschätzter Extrem-Traffic (Worst-Case).
-  In einer Kosten-Tabelle modellieren wir für jedes Szenario Sessions/Monat und Bandbreitenbedarf
-  und berechnen die ungefähren Cloud-Kosten (z.B. Instanz-Stunden, Daten-Egress, Speichervolumen).
-  Darin führen wir auch geschätzte KPIs wie € pro Session oder € pro GB auf.
-  Solche Einheitenwerte erlauben es, Kostenentwicklungen zu interpretieren:
-  „Kosten/Nutzer“ ist ein aussagekräftiger FinOps-KPI.
-  •  KPI-Metriken: Basis-KPIs sind u.a. „€ pro Session“, „€ pro App-Request“, „€ pro GB Traffic“. Studien empfehlen,
-     Cloud-Kosten in Relation zum Traffic zu setzen (z.B. Cost per Session). Wir definieren Schwellenwerte (z.B. Ziel:
-     < €1/Session) und überwachen Abweichungen. Die KPI-Berichte werden monatlich aktualisiert.
-  •  Kostenkontrolle: Neben Budget-Alerts nutzen wir Cloud Cost Monitore (z.B. über Grafana/Cloud-Anbieter) zur
-     Echtzeit-Überwachung. So erkennen wir Abweichungen sofort und prüfen, ob sie durch geändertes Nutzungsverhalten
-     gerechtfertigt sind.
+### Datenhaltung
 
-Infrastruktur & Hochverfügbarkeit
-  •  Nomad-Cluster: Für Deployment und Orchestrierung nutzen wir HashiCorp Nomad. Nomad ermöglicht Multi-Region-Cluster
-     für Hochverfügbarkeit und Rolling-Updates. Alle Services (Container, Java-Services, Batch-Jobs) laufen über Nomad-
-     Jobs. Nomad ist leichtgewichtig und ersetzt schwerfällige K8s-Setups.
-  •  PgBouncer: Zwischen App-Servern und PostgreSQL setzen wir einen PgBouncer-Connection-Pool ein, um
-     Datenbankverbindungen effizient zu verwalten. So skalieren wir die Zahl gleichzeitiger Clients, ohne Postgres
-     übermäßig zu belasten.
-  •  Caddy HTTP/3: Als Frontend-Proxy verwenden wir Caddy Server. Mit Caddy 2.6+ ist HTTP/3 (QUIC) standardmäßig
-     verfügbar, was Latenzen an mobilen Clients verringert. Caddy übernimmt TLS, Load-Balancing und kann durch Plugins
-     leicht erweitert werden.
-  •  HA-Pfade: Die Infrastruktur ist redundant ausgelegt: Multi-AZ-Datenbanken, mehrfach vorhandene Nomad-Server,
-     mehrere Netzwerk-Provider. Jede kritische Komponente hat mindestens einen Ausfalls-Backup (Active/Active-
-     Konfiguration). Netzwerkpfade sind redundant (z.B. Multi-Region-Backbone, DNS-Round-Robin).
-  •  Load Shedding: Um Überlastung zu vermeiden, implementieren wir Load Shedding: Bei Erreichen kritischer
-     Auslastungsgrenzen (CPU, Queue-Längen) lehnen Services aktiv neue Anfragen ab (HTTP 503) und schützen so bereits
-     laufende Anfragen vor Timeout. Auf diese Weise bleibt die Verfügbarkeit der angenommenen Anfragen hoch, selbst
-     wenn eingehender Traffic kurzfristig stark ansteigt. Amazon empfiehlt diesen Ansatz, um Latency-Probleme in
-     Availability-Probleme zu wandeln: Beim Hochlastpunkt soll nur der Überhang ausgestoßen werden, nicht alle Anfragen
-     .
+- JSONL als Standardquelle für Domänendaten
+- PostgreSQL-Tabellen für Sitzungen, Accounts, Knoten, Fäden und
+  Passkey-Credentials
+- getrennte opt-in Lese- und Schreibschalter für den PostgreSQL-Cutover
+- kein allgemeiner Transactional-Outbox-Pfad
+- kein vollständig belegtes PostGIS-Modell; Koordinaten liegen derzeit als
+  `DOUBLE PRECISION` vor
 
-Sicherheit und Compliance
-  •  SBOM (Software Bill of Materials):
-    •  Jede neue Anwendungsversion erzeugt automatisch ein SBOM (z.B. via Syft/Trivy).
-    •  Das SBOM beschreibt alle Abhängigkeiten.
-    •  Es wird zusammen mit dem Build-Artefakt archiviert und als Attestation hinterlegt.
-    •  Bei Deployments prüfen wir das SBOM auf bekannte Schwachstellen.
-  •  Artifact Signing & Attestations:
-    Container-Images und Pakete werden signiert (z.B. mit Sigstore Cosign).
-    Neben dem SBOM legen wir erweiterte Attestations (z.B. SLSA-Provenance) als Metadaten ab.
-    So ist Herkunft und Integrität jedes Artefakts überprüfbar.
-  •  CI/CD-Gates:
-    Unsere Pipelines erzwingen strikte Checks: Builds mit kritischen CVEs oder fehlender Signatur werden verworfen.
-    Policy-Gates (Kyverno/OPA) verhindern bei Deployment nicht-konforme Artefakte.
-    Nur signierte Images aus genehmigten Repositories dürfen in den Cluster gelangen.
-    „Latest“-Tags sind verboten, stattdessen verwenden wir digest-gezählte Artefakte.
-  •  Key Rotation:
-    Alle kryptografischen Schlüssel (z.B. Datenbank-Passwörter, TLS-Private Keys, JWT-Keys)
-    werden automatisiert rotiert.
-    Wir folgen bewährten Policies (z.B. Rotation mindestens alle 90 Tage),
-    um das Risiko kompromittierter Keys zu begrenzen.
-    Auch für API-Schlüssel und OAuth-Tokens gelten strenge Lebensdauern.
-    Key-Rotation ist Teil unseres Compliance-Plans (PCI-DSS, ISO 27001 empfehlen dies ausdrücklich).
-  •  Strikte Zugriffsverwaltung:
-    CI/CD-Zugriffe, Secrets und Konfigurations-Änderungen erfordern Multi-Faktor-Authentifizierung und Genehmigungen.
-    Wir setzen auf Infrastructure-as-Code Reviews und manuelle Freigaben für kritische Änderungen.
-  •  Regelmäßige Security-Audits:
-    Quartalsweise führen wir Security- und Compliance-Audits durch (z.B. SAST-Scans, Pentests der Infrastruktur,
-    Review von Konfigurationen). Erkannten Risiken begegnen wir unmittelbar mit Patches oder Architektur-Änderungen.
+### Delivery
 
-Observability & Runbooks
-  •  Umfassendes Monitoring:
-    Logs, Metriken und Traces sind ab Deployment Day 1 aktiv.
-    Aggregierte Logs (z.B. über Loki/Elasticsearch) erlauben schnelle Fehlersuche.
-    Wir benutzen „OpenTelemetry“-Standards, wo sinnvoll, um Metriken und Traces einheitlich zu erfassen.
-    So haben Entwickler und SREs über Dashboards stets Einblick in Systemzustand und Nutzerinteraktionen.
-  •  Runbooks:
-    Für alle kritischen Prozesse und Incident-Typen existieren Runbooks – strukturierte
-    Schritt-für-Schritt-Anleitungen für Wiederherstellung und Fehlerbehebung.
-    Das beginnt bei Onboarding-Checklisten für neue Teammitglieder
-    (Woche 1–2: Systemüberblick, Account-Setup, Dev-Umgebung)
-    und geht bis zu Incident-Runbooks (z.B. „Netzwerkausfall“, „Datenbank-Recovery“).
-    Runbooks minimieren Fehler im Stresstest und sorgen für reproduzierbare Abläufe.
-    •  Onboarding (Woche 1–2):
-      In den ersten zwei Wochen erhält jeder neue Entwickler klare Dokumentation zu Infrastruktur,
-      Tools, Zugangsdaten und Erst-Checks (Smoke-Tests).
-    Themen sind u.a. Code-Repo, CI/CD-Pipeline, Monitoring-Zugriff, evtl. Testumgebung-Einrichtung.
-    Diese „Woche-1“-Dokumente sind versioniert und werden regelmäßig aktualisiert.
-  •  Quartalsweise Audits:
-    Neben Security-Audits gibt es quartalsweise auch Architektur- und Compliance-Reviews.
-    Dabei prüfen wir z.B. Datenflüsse auf DSGVO-Konformität, Updates von Abhängigkeiten auf CVEs,
-    oder Business-Continuity-Übungen.
-    Ergebnisse werden in Handlungsplänen festgehalten und umgesetzt.
+- Docker und Docker Compose
+- Caddy als Frontdoor und Reverse Proxy
+- VPS-Ziel `wg-prod-1`
+- statischer Web-Upstream über eine extern konfigurierte Hostingplattform
+- Cloudflare- und Vercel-Status als zusätzliche Build-/Vorschaubelege
 
-Quellen: Technische Muster und Best Practices stammen u.a. aus aktuellen DevOps- und SRE-Leitfäden.
-Die Zitate verweisen auf etablierte Konzepte (Outbox-Pattern, Disaster-DR-Tests, FinOps-KPIs, CI/CD-Security).
+### Qualität und Sicherheit
 
-⸻
+- GitHub Actions mit Rust-, Web-, Datenbank-, Auth-, Proxy-, Basemap- und
+  CodeQL-Prüfungen
+- `cargo deny`
+- Domain-Contract-Validierung
+- Caddy-Adaptions- und Compose-Vorprüfungen
+- risikogewichtetes, head- und diffgebundenes Selbstreview vor Merge
 
-🌐 Weltgewebe Techstack – Übersicht
+## Im Repository vorhanden, aber nicht allgemein produktiv belegt
 
-Frontend
-  •  SvelteKit + TypeScript → Standard, einheitliche Toolchain
-  •  Qwik-Escape → nur route-granular via A/B/Fast-Track bei messbarem ROI (≥ 10 % LCP, ≥ 20 % TTI, ≤ +25 % Opex)
-  •  MapLibre GL + PMTiles → Karten, Prebakes, Tileset-Versionierung
-  •  PWA → Offline-Shell, feingranulare Caches
-  •  Security → CSP/COOP/COEP, Islands-Pattern
+- NATS im Produktions-Compose und API-Verbindungsfläche
+- PgBouncer im Core-Profil
+- Prometheus-Konfiguration und optionale Observability-Profile
+- PostgreSQL-Domainlese- und einzelne Schreibpfade
+- PostgreSQL-Passkeypersistenz
+- PWA-/Offline-nahe Webbestandteile
+- Gesprächs-, Nachrichten- und Rollencontracts
 
-Backend & Realtime
-  •  Rust (Axum + Tokio), sqlx, OpenAPI (utoipa)
-  •  SSE → Standard für Live-Feeds
-  •  WebSocket → nur für echte Bidir-Flows (Chat/Kollab), Idle >30 s schließen
-  •  Guards → SSE keep-alive, WS Token-Bucket (10/s, Burst 20)
+Für diese Punkte ist jeweils ein eigener Runtime- oder Ende-zu-Ende-Beleg nötig.
 
-Persistenz & Events
-  •  PostgreSQL 16 + PostGIS + h3-pg = Source of Truth
-  •  Transactional Outbox → garantiert konsistente Events
-  •  NATS JetStream = aktiver Distributor
-  •  Policies: max_age=30d, max_bytes=100GiB, dupe_window=72h
-  •  Alarme: RAM >350 MB/Stream, Topics >50, Consumers >200, per-Consumer lag
+## Geplant oder noch unvollständig
 
-Suche & Cache
-  •  Typesense (Default)
-  •  MeiliSearch (Fallback bei DX-Friktion)
-  •  KeyDB → Caches, Rate-Limits, Locks
-  •  DX-KPIs → Index-Zeit ≤2 h, Tuning ≤4 h, No-Hits-Rate, RAM
+- vollständiger JSONL-zu-PostgreSQL-Cutover
+- einheitliches Garnrollenmodell ohne RoN-Kontotyp
+- durchgängiger Garnrolle–Knoten–Faden-Produktfluss
+- Gespräche und Nachrichten
+- föderale Governance und Gewebekonten
+- normalisierte Geoabfragen beziehungsweise PostGIS
+- verlässliche Eventprojektionen und Outbox
+- konsolidierte Observability mit definierten SLOs
+- automatisierte Restore- und Disaster-Recovery-Beweise
 
-Delivery & Edge
-  •  Caddy (HTTP/3) → Proxy, TLS, Brotli/Zstd, immutable Assets
-  •  Caching → SSR-HTML s-maxage=600, Tiles immutable
-  •  Edge-Budget:
-  •  30d Opex-Δ ≤ 10 %
-  •  Boost ≤ 25–30 % nur bei globalem LCP-ROI (≥ 300 ms in ≥ 3 Regionen)
-  •  Auto-Rollback bei > 15 % Mehrkosten ohne ≥ 150 ms Gewinn
+## Nicht aktueller Standard
 
-Observability & Monitoring
-  •  Prometheus + Grafana + Loki + Tempo
-  •  RUM Long-Task Attribution → PerformanceObserver, Budget ≤ 200 ms p75/Route
-  •  JetStream Monitoring → per-Consumer lag, redeliveries, ack_wait_exceeded
-  •  Dashboards → Web-Vitals, API-Latenzen, Search-DX, Edge-Kosten, GIS-Interaktionen
+Folgende Technologien sind keine heutige Betriebswahrheit und dürfen nur nach
+einer neuen Architekturentscheidung als Standard bezeichnet werden:
 
-Infrastruktur & HA
-  •  Nomad → Orchestrierung (primär)
-  •  PgBouncer → Connection-Pooling (transaction mode)
-  •  WAL-Archiv + Repl-Slots → DR-Pfad
-  •  Caddy HTTP/3 → Entry Proxy
-  •  HA-Pfade → Compose → Nomad → Swarm-Mini (Drill) → K8s (nur bei massivem Scale)
-  •  Load Shedding → HTTP 503 bei Überlast statt Timeout
+- Nomad oder Kubernetes als Primärorchestrierung
+- Multi-AZ- oder Multi-Region-Betrieb
+- KeyDB
+- Typesense oder MeiliSearch
+- Debezium
+- Loki/Tempo als vollständig betriebene Plattform
+- automatische Cosign-/SLSA-Attestierung aller Artefakte
+- automatisierte Rotation sämtlicher Schlüssel
 
-Security & Compliance
-  •  SBOM (Syft/Trivy) + cosign Attestations
-  •  Key Rotation → ed25519 halbjährlich, Overlap 14 Tage
-  •  CI-Gates → clippy -D, audit/deny, Semgrep, Trivy, CodeQL
-  •  Access Control → MFA, Secrets via sops/age
-  •  Data Lifecycle (DSGVO) → PII-Klassen, Retention, Forget-Pipeline (Replay+Rebuild), Audit-Logs
+## Entscheidungsregel
 
-Reliability & Governance
-  •  Error-Budgets → 99,0–99,5 %/Monat; Release-Freeze bei Riss
-  •  Disaster-Recovery Drill → vierteljährlich: Replica-Promote + JetStream-Replay + Outbox-Rebuild + Verify
-  •  Runbooks → Woche 1–2 Onboarding + Incident Playbooks; Quartals-Audits
+Eine neue Technologie wird erst Teil des kanonischen Stacks, wenn
 
-Kosten & KPIs
-  •  Traffic-Szenarien S1–S4: 100 → 100k MAU
-  •  Kostenbänder: Hetzner (15–900 €), DO-Hybrid (70–2400 €)
-  •  KPIs: €/1 000 Sessions, €/GB egress, €/Mio Events, Edge-Quote %
-
-⸻
-
-👉 Kurz: mobil-first, audit-ready, rewrite-frei skalierbar.
-Frontend simpel (SvelteKit-only), Events konsistent (PG Outbox + JetStream), Kosten & Latenz
-metrisch kontrolliert, DSGVO & Security vollständig eingebaut, Disaster-Recovery geprobt.
-
-⸻
-
-WELTGEWEBE TECHSTACK
-─────────────────────────
-
-Frontend
-├─ SvelteKit + TypeScript (Standard)
-│   ├─ MapLibre GL + PMTiles (Karten, Prebakes)
-│   ├─ PWA (Offline-Shell, Caches)
-│   └─ CSP/COOP/COEP, Islands-Pattern
-└─ Qwik-Escape (nur bei ROI via A/B/Fast-Track)
-
-Backend & Realtime
-├─ Rust (Axum + Tokio), sqlx, utoipa/OpenAPI
-├─ SSE (Default für Live-Feeds)
-└─ WebSocket (nur Chat/Kollab, Idle >30s Close)
-   └─ Guards: SSE keep-alive, WS Token-Bucket (10/s, Burst 20)
-
-Persistenz & Events
-├─ PostgreSQL 16 + PostGIS + h3-pg (Source of Truth)
-├─ Transactional Outbox (Event-Konsistenz)
-└─ NATS JetStream (aktiver Distributor)
-   ├─ Policies: max_age=30d, max_bytes=100GiB, dupe_window=72h
-   └─ Alarme: RAM >350MB/Stream, Topics >50, Consumers >200, Lag pro Consumer
-
-Suche & Cache
-├─ Typesense (Default)
-├─ MeiliSearch (Fallback bei DX-Reibung)
-└─ KeyDB (Cache, Rate-Limits, Locks)
-
-Delivery & Edge
-├─ Caddy (HTTP/3, Brotli/Zstd, immutable Assets)
-├─ Caching: SSR-HTML s-maxage=600, Tiles immutable
-└─ Edge-Budget:
-   ├─ 30d Opex-Δ ≤ 10 %
-   ├─ Boost ≤ 25–30 % bei globalem LCP-ROI
-   └─ Auto-Rollback bei >15 % Mehrkosten ohne ≥150ms Gewinn
-
-Observability & Monitoring
-├─ Prometheus + Grafana + Loki + Tempo
-├─ RUM Long-Task Attribution (Budget ≤200ms p75/Route)
-├─ JetStream Monitoring (Lag, redeliveries, ack_wait_exceeded)
-└─ Dashboards: Web-Vitals, API-Latenzen, Search-DX, Edge-Kosten, GIS
-
-Infrastruktur & HA
-├─ Nomad (Orchestrierung primär)
-├─ PgBouncer (Connection-Pool, transaction mode)
-├─ WAL-Archiv + Repl-Slots (DR-Pfad)
-├─ Caddy HTTP/3 (Proxy)
-├─ HA-Pfade: Compose → Nomad → Swarm-Mini (Drill) → K8s (bei Mass-Scale)
-└─ Load Shedding: HTTP 503 bei Überlast statt Timeout
-
-Security & Compliance
-├─ SBOM (Syft/Trivy) + cosign Attestations
-├─ Key Rotation (ed25519 halbjährlich, Overlap 14d)
-├─ CI-Gates: clippy -D, audit/deny, Semgrep, Trivy, CodeQL
-├─ Access Control: MFA, Secrets via sops/age
-└─ Data Lifecycle (DSGVO)
-   ├─ PII-Klassen, Retention, Redaction
-   └─ Forget-Pipeline (Replay+Rebuild), Audit-Logs
-
-Reliability & Governance
-├─ Error-Budgets: 99.0–99.5 % / Monat → Release-Freeze bei Riss
-├─ Disaster-Recovery Drill (vierteljährlich)
-│   └─ Replica-Promote + JetStream-Replay + Outbox-Rebuild + Verify
-└─ Runbooks
-    ├─ Woche 1–2 Onboarding & Smoke-Tests
-    ├─ Incident Playbooks (Netz, DB, API)
-    └─ Quartals-Audits (Security & Compliance)
-
-Kosten & KPIs
-├─ Szenarien S1–S4: 100 → 100k MAU
-│   ├─ Requests/Tag: 10k → 10M
-│   ├─ Events/Tag:   20k → 20M
-│   ├─ Tile-Hits:    50k → 15M
-│   └─ Volumen:      3GB → 2TB
-├─ Kostenbänder:
-│   ├─ Hetzner:  €15–900
-│   └─ DO-Hybrid: €70–2400
-└─ KPIs: €/1000 Sessions, €/GB egress, €/Mio Events, Edge-Quote %
+1. ein konkretes Produkt- oder Betriebsproblem belegt ist,
+2. der einfachere vorhandene Stack nicht genügt,
+3. Betriebs- und Wiederherstellungspfad definiert sind,
+4. Tests und Ownership existieren,
+5. die Änderung in Code oder Runtime nachgewiesen ist.

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -32,8 +32,9 @@ Anträge, die innerhalb der Gemeinschaft gestellt werden, sind sieben Tage lang 
 dieser aus, treten sie in Kraft. Jede Handlung ist ein Event, das öffentlich einsehbar und kryptografisch
 unveränderlich gespeichert wird ￼.
 • Freiwilligkeit & Datenschutz:
-Es werden keine Daten gesammelt, außer die, die die Teilnehmenden selbst eintragen. Keine Cookies,
-kein Tracking, keine Profilbildung. Sichtbar ist nur, was bewusst geteilt wird ￼.
+Es werden keine Werbe- oder Trackingprofile aufgebaut. Für Anmeldung und
+Sitzungserhalt verwendet das System notwendige, sichere HTTP-only-Sitzungscookies.
+Sichtbar ist nur, was bewusst geteilt wird ￼.
 • Währung = Engagement:
 Es gibt keine künstliche Währung. Das eigene - sichtbar gemachte - Engagement wirkt sich aber begünstigend
 auf die Durchbringung eigener Anträge aus.

--- a/docs/zusammenstellung.md
+++ b/docs/zusammenstellung.md
@@ -28,8 +28,8 @@ I. Grundprinzipien und Philosophie
 - Radikale Transparenz: Grundsätzlich sind alle Aktionen öffentlich sichtbar. Ausgenommen sind private Informationen
   im Nutzerkonto und private Nachrichten zwischen Nutzern.
 - Freiwilligkeit: Die Teilnahme am Weltgewebe erfolgt ausschließlich nach informierter Zustimmung.
-- Datenschutz (Privacy by Design): Es findet keine verdeckte Datensammlung statt, also keine Cookies, kein
-  Tracking und keine automatische Profilbildung. Sichtbar ist nur, was Nutzer bewusst eintragen, wie Name, Wohnort
+- Datenschutz (Privacy by Design): Es findet keine verdeckte Datensammlung, kein Werbetracking und keine
+  automatische Profilbildung statt. Notwendige HTTP-only-Sitzungscookies dienen ausschließlich Anmeldung und Sitzungserhalt. Sichtbar ist nur, was Nutzer bewusst eintragen, wie Name, Wohnort
   und Verbindungen. Die rechtliche Grundlage für die Datenverarbeitung bilden die
   Datenschutzgrundverordnung-Artikel 6 Abs. 1 lit. a und f.
 - Währungskonzept: Es gibt keine künstlichen Credits oder Alternativwährungen. Die eigentliche "Währung" ist

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "weltgewebe-root",
+  "license": "AGPL-3.0-or-later",
   "private": true,
   "packageManager": "pnpm@9.11.0",
   "engines": {

--- a/repo.meta.yaml
+++ b/repo.meta.yaml
@@ -4,7 +4,7 @@ repo_type: service
 role: weltgewebe-stack
 status: active
 summary: >
-  Mobile-first Webprojekt mit SvelteKit (Web), Rust/Axum (API), Postgres+Outbox, JetStream und Caddy.
+  Aktives Karteninterface mit SvelteKit, Rust/Axum, JSONL-/PostgreSQL-Cutoverpfaden, NATS und Caddy.
 
 owners:
   - heimgewebe

--- a/runbooks/README.md
+++ b/runbooks/README.md
@@ -1,14 +1,82 @@
 ---
 id: runbooks.readme
 title: Runbooks
-summary: Operative Runbooks für Betrieb, Wartung und Fehlerbehebung.
+summary: Einstieg in die operativen Runbooks und die Reihenfolge sicherer Diagnose- und Änderungsschritte.
 role: runbooks
 organ: ops
 status: canonical
-last_reviewed: 2026-06-09
+last_reviewed: 2026-07-11
 depends_on: []
-relations: []
+relations:
+  - type: relates_to
+    target: docs/deploy/README.md
+  - type: relates_to
+    target: docs/runbook.md
+  - type: relates_to
+    target: docs/runbook.observability.md
 verifies_with: []
 ---
 
 # Runbooks
+
+## Grundregel
+
+Erst beobachten, dann entscheiden, dann verändern, danach erneut beobachten.
+Ein grünes Repository oder ein erfolgreiches Deploymentskript ersetzt keinen
+Livebeleg.
+
+## Einstieg nach Situation
+
+| Situation | Einstieg |
+|---|---|
+| öffentlicher VPS deployen oder prüfen | [`docs/deploy/vps.md`](../docs/deploy/vps.md) |
+| Deploymentvertrag und Profile verstehen | [`docs/deploy/README.md`](../docs/deploy/README.md) |
+| Migrationen auf VPS einordnen | [`docs/deploy/vps-db-initialization-boundary.md`](../docs/deploy/vps-db-initialization-boundary.md) |
+| migrationssicheren Runtime-Smoke ausführen | [`docs/deploy/vps-migration-safe-runtime-smoke.md`](../docs/deploy/vps-migration-safe-runtime-smoke.md) |
+| Public Login und SMTP vorbereiten | [`docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md`](../docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md) |
+| Sicherheitsgrenzen prüfen | [`docs/deploy/security.md`](../docs/deploy/security.md) |
+| allgemeine Anwendungsvorfälle | [`docs/runbook.md`](../docs/runbook.md) |
+| Metriken und Diagnose | [`docs/runbook.observability.md`](../docs/runbook.observability.md) |
+| Drift klassifizieren | [`docs/deploy/DRIFT_POLICY.md`](../docs/deploy/DRIFT_POLICY.md) |
+
+## Sichere Reihenfolge für Deployarbeit
+
+1. Zielhost, Repository, Commit und Arbeitsbaum prüfen.
+2. offene PRs, laufende Deploys und Leases prüfen.
+3. Env nur auf Vorhandensein und Quelle prüfen; keine Secretwerte ausgeben.
+4. Compose rendern und Zielprofil verifizieren.
+5. Datenbankhistorie und Migrationsmodus prüfen.
+6. kanonischen Deploypfad ausführen.
+7. Health, Routing, Auth und Logs nach dem Effekt prüfen.
+8. Revision, Ergebnis und Restunsicherheit als Beleg festhalten.
+
+## Diagnose vor Reparatur
+
+- **502/Proxyfehler:** Caddy-Ziel, Upstream, TLS und Headervertrag prüfen.
+- **Loginfehler:** Public-Login-Schalter, SMTP-Bereitschaft, Sessionstore und
+  Cookie-Scope getrennt prüfen.
+- **Daten fehlen nach Neustart:** Lese- und Schreibquelle vergleichen; keine
+  JSONL/PostgreSQL-Mischung zulassen.
+- **Migration schlägt fehl:** nicht wiederholt blind starten; Verlauf und
+  Preflightgrenze lesen.
+- **Karte bleibt leer:** Web-Build, Basemap-Konfiguration, PMTiles-Range und
+  API-Fallback getrennt prüfen.
+
+## Destruktive Grenzen
+
+Die folgenden Schritte brauchen einen eigenen autorisierten Vorgang und einen
+Wiederherstellungsplan:
+
+- Datenbankmigrationen oder Datenbereinigung,
+- Secretrotation,
+- DNS-/Provideränderungen,
+- Volume- oder Datenlöschung,
+- Zwangsentfernung fremder Compose-Projekte,
+- irreversible Identitäts- oder RoN-Migration.
+
+## Veraltete Runbooks
+
+Historische Heimserver- und Übergangsdokumente können weiterhin nützliche
+Verträge enthalten. Sie dürfen nicht als aktueller Produktionspfad behandelt
+werden, wenn ihr Dokumentkopf oder die Deploymentübersicht sie als retired oder
+Referenz ausweist.

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1,14 +1,114 @@
 ---
 id: runtime.readme
 title: Runtime Reality
-summary: Aktueller Laufzeitzustand und beobachtetes Systemverhalten.
+summary: Kanonischer Vertrag für Laufzeitprofile, beobachtbare Wahrheit und Konfigurationsschalter.
 role: reality
 organ: runtime
 status: canonical
-last_reviewed: 2026-06-09
+last_reviewed: 2026-07-11
 depends_on: []
-relations: []
+relations:
+  - type: relates_to
+    target: docs/deploy/vps.md
+  - type: relates_to
+    target: runbooks/README.md
+  - type: relates_to
+    target: docs/datenmodell.md
 verifies_with: []
 ---
 
 # Runtime Reality
+
+## Was dieses Dokument belegt
+
+Dieses Dokument beschreibt die im Repository unterstützten Laufzeitprofile und
+ihre Verträge. Es belegt **nicht**, dass ein konkreter Host im Moment gesund ist.
+Livezustand entsteht erst durch frische Beobachtung von Host, Compose-Render,
+Containern, Health-Endpunkten, Migrationen und Logs.
+
+## Kanonischer Produktionspfad
+
+Der öffentliche Zielpfad ist `wg-prod-1` gemäß
+[`docs/deploy/vps.md`](../docs/deploy/vps.md). Der historische Heimserverpfad ist
+kein Produktionsziel mehr, bleibt aber als Referenzvertrag dokumentiert.
+
+Der Deploy-Einstieg ist:
+
+```text
+scripts/weltgewebe-up
+```
+
+Zielbezogene Hilfsskripte dürfen keinen zweiten Deployvertrag pflegen, sondern
+müssen an diesen Pfad delegieren.
+
+## Laufzeitprofile
+
+| Profil | Dateien | Zweck |
+|---|---|---|
+| lokal/core | `compose.core.yml` | Web, API, Caddy, PostgreSQL und PgBouncer für Entwicklung/Integration |
+| produktiv | `compose.prod.yml` | API, Caddy, PostgreSQL und NATS |
+| VPS | `compose.prod.yml` + `compose.vps.override.yml` | öffentlicher Frontdoor auf `wg-prod-1` |
+| Beobachtung | `compose.observ.yml` | optionale Monitoringkomponenten |
+| SMTP | `compose.smtp.override.yml` | explizite Mailkonfiguration ohne Secretwerte im Repository |
+
+Die exakte Service- und Env-Wahrheit ergibt sich aus dem gerenderten
+Compose-Modell, nicht aus dieser Tabelle allein.
+
+## Webbereitstellung
+
+Die Webanwendung ist ein statischer SvelteKit-Build. Caddy kann zu einem
+konfigurierten HTTPS-Web-Upstream routen. Cloudflare Pages und Vercel liefern
+zusätzliche Build-/Vorschauzustände; keine der beiden Plattformen ist allein die
+kanonische Produktionsruntime. Maßgeblich sind der Caddy-Vertrag und der
+effektive `WEB_UPSTREAM`.
+
+## Domänenquellen
+
+| Schalter | Standard | Bedeutung |
+|---|---|---|
+| `WELTGEWEBE_DOMAIN_READ_SOURCE` | `jsonl` | Quelle für Accounts, Knoten und Fäden |
+| `WELTGEWEBE_DOMAIN_ACCOUNT_WRITE_SOURCE` | `jsonl` | Account-Erzeugung |
+| `WELTGEWEBE_DOMAIN_NODE_WRITE_SOURCE` | `jsonl` | Knotenänderungen |
+| `WELTGEWEBE_DOMAIN_EDGE_WRITE_SOURCE` | `jsonl` | Fadenerzeugung |
+
+`postgres` ist jeweils ein explizites Opt-in. Jeder PostgreSQL-Schreibpfad
+verlangt auch `domain_read_source=postgres` und einen verfügbaren Pool. Ungültige
+Kombinationen führen zu einem Konfigurations- oder Startfehler.
+
+## Auth- und Sessionpersistenz
+
+Sitzungen können in PostgreSQL persistiert werden; ohne Datenbankpfad verwendet
+die API einen In-Memory-Store. Passkey-Credentials besitzen einen opt-in
+PostgreSQL-Pfad. Die effektive Quelle muss aus Konfiguration und Startlogs
+redigiert beobachtet werden.
+
+## Migrationen
+
+`WELTGEWEBE_API_STARTUP_MIGRATIONS` besitzt drei unterschiedliche Bedeutungen:
+
+- `run`: Migrationen anwenden,
+- `verify-applied`: nur nachweisen, dass der erwartete Verlauf bereits vorliegt,
+- `skip`: bewusst keine Migrationsprüfung ausführen.
+
+Ein Route- oder Health-Smoke erteilt keine Migrationsfreigabe.
+
+## Proxyentscheidung
+
+Bei aktivem IP-Ratelimit muss `AUTH_TRUSTED_PROXIES` ausdrücklich gesetzt sein:
+
+- `none` für direkten Betrieb,
+- Netzliste für einen kontrollierten Proxybetrieb.
+
+Die API darf Proxyheader nur von diesen Quellen übernehmen.
+
+## Minimaler Beobachtungssatz
+
+Für eine belastbare Runtimeaussage sind mindestens nötig:
+
+1. erwarteter Git-Commit beziehungsweise Image-Digest,
+2. gerendertes Compose-Modell ohne unerklärte Warnungen,
+3. Containerstatus und Health,
+4. `/health/live` und `/health/ready`,
+5. Migrationsmodus und Datenquellschalter,
+6. redigierte Secret-Quellen beziehungsweise Vorhandenseinsbelege,
+7. Logs ohne Token- oder Secretlecks.

--- a/scripts/ci/tests/test_canonical_truth_contract.py
+++ b/scripts/ci/tests/test_canonical_truth_contract.py
@@ -1,0 +1,106 @@
+"""Regression tests for the repository's canonical truth surfaces."""
+
+from __future__ import annotations
+
+import json
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+class CanonicalTruthContractTests(unittest.TestCase):
+    def test_docs_guard_installs_all_discovered_ci_test_dependencies(self) -> None:
+        workflow = (ROOT / ".github/workflows/docs-guard.yml").read_text(encoding="utf-8")
+        self.assertIn("pytest==8.3.4 pyyaml==6.0.2", workflow)
+
+    def test_required_check_catalog_is_strict_and_matches_universal_jobs(self) -> None:
+        path = ROOT / ".github/grabowski-required-checks.json"
+        data = json.loads(path.read_text(encoding="utf-8"))
+        self.assertEqual(set(data), {"schema_version", "required_checks"})
+        self.assertEqual(data["schema_version"], 1)
+        self.assertEqual(
+            data["required_checks"],
+            ["Detect docs updates", "Core Guard Tests"],
+        )
+        workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+        for name in data["required_checks"]:
+            self.assertIn(f"name: {name}", workflow)
+
+    def test_package_license_metadata_matches_repository_license(self) -> None:
+        cargo = (ROOT / "apps/api/Cargo.toml").read_text(encoding="utf-8")
+        self.assertRegex(cargo, r'(?m)^license = "AGPL-3\.0-or-later"$')
+        for path in (ROOT / "package.json", ROOT / "apps/web/package.json"):
+            data = json.loads(path.read_text(encoding="utf-8"))
+            self.assertEqual(data.get("license"), "AGPL-3.0-or-later", path)
+        license_text = (ROOT / "LICENSE").read_text(encoding="utf-8")
+        self.assertIn("GNU AFFERO GENERAL PUBLIC LICENSE", license_text)
+        deny = (ROOT / "deny.toml").read_text(encoding="utf-8")
+        self.assertRegex(deny, r'(?m)^\s*"AGPL-3\.0-or-later",?$')
+
+    def test_readme_describes_active_implementation_not_docs_only_status(self) -> None:
+        text = (ROOT / "README.md").read_text(encoding="utf-8")
+        self.assertIn("aktives, im Aufbau befindliches Karteninterface", text)
+        self.assertNotRegex(text, r"(?i)formaler\s+\*\*docs-only")
+        self.assertNotIn("<!-- Docs-only", text)
+
+    def test_canonical_entrypoints_are_substantive(self) -> None:
+        required = {
+            "architecture/overview.md": ("## Komponenten", "## Hauptdatenflüsse"),
+            "architecture/security.md": ("## Vertrauensgrenzen", "## Authentifizierungsflächen"),
+            "runtime/README.md": ("## Laufzeitprofile", "## Domänenquellen"),
+            "runbooks/README.md": ("## Einstieg nach Situation", "## Sichere Reihenfolge"),
+        }
+        for relative, headings in required.items():
+            text = (ROOT / relative).read_text(encoding="utf-8")
+            self.assertGreater(len(text.split()), 180, relative)
+            for heading in headings:
+                self.assertIn(heading, text, relative)
+
+    def test_active_architecture_and_runbook_do_not_claim_missing_subsystems(self) -> None:
+        architecture = (ROOT / "docs/architekturstruktur.md").read_text(encoding="utf-8")
+        runbook = (ROOT / "docs/runbook.md").read_text(encoding="utf-8")
+        orientation = (ROOT / "docs/policies/orientierung.md").read_text(encoding="utf-8")
+        self.assertIn("keinen produktiven Outbox-Relay", architecture)
+        self.assertNotIn("Outbox/JetStream-Eventing", architecture)
+        self.assertIn("allgemein belegten WAL-/PITR-", runbook)
+        self.assertNotIn("den `outbox`-Relay-Prozess starten", runbook)
+        self.assertIn("Compose ist der aktuelle Standard", orientation)
+
+    def test_techstack_separates_current_present_planned_and_nonstandard(self) -> None:
+        text = (ROOT / "docs/techstack.md").read_text(encoding="utf-8")
+        for heading in (
+            "## Heute implementiert und kanonisch",
+            "## Im Repository vorhanden, aber nicht allgemein produktiv belegt",
+            "## Geplant oder noch unvollständig",
+            "## Nicht aktueller Standard",
+        ):
+            self.assertIn(heading, text)
+
+    def test_data_model_names_actual_sources_and_absent_tables(self) -> None:
+        text = (ROOT / "docs/datenmodell.md").read_text(encoding="utf-8")
+        self.assertIn("JSONL der Standard", text)
+        for table in ("sessions", "domain_accounts", "domain_nodes", "domain_edges", "passkey_credentials"):
+            self.assertIn(f"`{table}`", text)
+        self.assertIn("keine `conversations`, `messages`, `roles`, `outbox`", text)
+        self.assertNotIn("PostgreSQL ist die alleinige Quelle der Wahrheit", text)
+
+    def test_active_privacy_docs_do_not_promise_zero_cookies(self) -> None:
+        paths = (
+            "README.md",
+            "docs/vision.md",
+            "docs/inhalt.md",
+            "docs/policies/orientierung.md",
+            "docs/zusammenstellung.md",
+        )
+        forbidden = re.compile(r"(?i)(keine cookies|keine cookies/track|also keine cookies)")
+        for relative in paths:
+            text = (ROOT / relative).read_text(encoding="utf-8")
+            self.assertIsNone(forbidden.search(text), relative)
+        combined = "\n".join((ROOT / p).read_text(encoding="utf-8") for p in paths)
+        self.assertIn("Sitzungscookies", combined)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The repository's canonical entrypoints still described a docs-only clean slate, treated PostgreSQL and an Outbox/JetStream stack as current truth, promised zero cookies, and exposed conflicting AGPL/MIT package metadata. Several canonical architecture/runtime/runbook files were effectively empty.

## Change

- rewrite README, architecture, runtime and runbook entrypoints from current code, migrations, Compose and config
- separate current, present-but-unproven, planned and nonstandard technologies
- document JSONL as the default domain source and PostgreSQL as an explicit cutover path
- identify RoN as unresolved legacy semantics rather than a target account type
- replace stale operational recovery instructions with supported boundaries
- correct session-cookie language without weakening the no-tracking contract
- align Cargo and Node package metadata plus cargo-deny policy with AGPL-3.0-or-later
- add a base-bound Grabowski required-check catalog
- add canonical-truth regression tests to the universal Core Guard job
- regenerate all affected derived documentation through registered generators

## Verification

- `just ci`
- `make ci-validate`
- `python3 -m unittest scripts.ci.tests.test_canonical_truth_contract -v`
- `bash scripts/guard/run.sh`
- docmeta schema, relations, link, generated-artifact and index checks
- five-loop factual, governance, integration and adversarial self-review

## Boundaries

- no production deploy
- no database, DNS, provider or secret mutation
- no RoN data migration in this PR; that requires a separate migration-bound change