### PR TITLE
docs(db): bind proof matrix to squash merge

### DIFF
--- a/docs/reports/opt-arc-001-db-proof-matrix.json
+++ b/docs/reports/opt-arc-001-db-proof-matrix.json
@@ -27,9 +27,9 @@
       "test": "apps/api/tests/db_domain_schema_migrations.rs",
       "report": null,
       "ci_evidence": {
-        "run_url": "https://github.com/heimgewebe/weltgewebe/actions/runs/29134467227",
-        "run_id": 29134467227,
-        "commit": "b3878e15e357b89edf06835e859c761d85d63229",
+        "run_url": "https://github.com/heimgewebe/weltgewebe/actions/runs/29135060216",
+        "run_id": 29135060216,
+        "commit": "ace991ceb8e8cab0d035293d7e20b58fc57ef56e",
         "job": "db-domain-schema-migrations-proof"
       },
       "command": "cargo test --locked -p weltgewebe-api --test db_domain_schema_migrations -- --include-ignored --test-threads=1"
@@ -44,9 +44,9 @@
       "test": "apps/api/tests/db_domain_backfill.rs",
       "report": "docs/reports/domain-backfill-proof.md",
       "ci_evidence": {
-        "run_url": "https://github.com/heimgewebe/weltgewebe/actions/runs/29134467227",
-        "run_id": 29134467227,
-        "commit": "b3878e15e357b89edf06835e859c761d85d63229",
+        "run_url": "https://github.com/heimgewebe/weltgewebe/actions/runs/29135060216",
+        "run_id": 29135060216,
+        "commit": "ace991ceb8e8cab0d035293d7e20b58fc57ef56e",
         "job": "db-domain-backfill-proof"
       },
       "command": "cargo test --locked -p weltgewebe-api --test db_domain_backfill -- --include-ignored --test-threads=1"
@@ -73,9 +73,9 @@
       "test": "apps/api/tests/db_domain_account_write_path.rs",
       "report": "docs/reports/domain-account-write-path-proof.md",
       "ci_evidence": {
-        "run_url": "https://github.com/heimgewebe/weltgewebe/actions/runs/29134467227",
-        "run_id": 29134467227,
-        "commit": "b3878e15e357b89edf06835e859c761d85d63229",
+        "run_url": "https://github.com/heimgewebe/weltgewebe/actions/runs/29135060216",
+        "run_id": 29135060216,
+        "commit": "ace991ceb8e8cab0d035293d7e20b58fc57ef56e",
         "job": "db-domain-account-write-path-proof"
       },
       "command": "cargo test --locked -p weltgewebe-api --test db_domain_account_write_path -- --include-ignored --test-threads=1"
@@ -90,9 +90,9 @@
       "test": "apps/api/tests/db_domain_node_write_path.rs",
       "report": "docs/reports/domain-node-write-path-proof.md",
       "ci_evidence": {
-        "run_url": "https://github.com/heimgewebe/weltgewebe/actions/runs/29134467227",
-        "run_id": 29134467227,
-        "commit": "b3878e15e357b89edf06835e859c761d85d63229",
+        "run_url": "https://github.com/heimgewebe/weltgewebe/actions/runs/29135060216",
+        "run_id": 29135060216,
+        "commit": "ace991ceb8e8cab0d035293d7e20b58fc57ef56e",
         "job": "db-domain-node-write-path-proof"
       },
       "command": "cargo test --locked -p weltgewebe-api --test db_domain_node_write_path -- --include-ignored --test-threads=1"
@@ -107,9 +107,9 @@
       "test": "apps/api/tests/db_domain_edge_write_path.rs",
       "report": "docs/reports/domain-edge-write-path-proof.md",
       "ci_evidence": {
-        "run_url": "https://github.com/heimgewebe/weltgewebe/actions/runs/29134467227",
-        "run_id": 29134467227,
-        "commit": "b3878e15e357b89edf06835e859c761d85d63229",
+        "run_url": "https://github.com/heimgewebe/weltgewebe/actions/runs/29135060216",
+        "run_id": 29135060216,
+        "commit": "ace991ceb8e8cab0d035293d7e20b58fc57ef56e",
         "job": "db-domain-edge-write-path-proof"
       },
       "command": "cargo test --locked -p weltgewebe-api --test db_domain_edge_write_path -- --include-ignored --test-threads=1"


### PR DESCRIPTION
## Ursache

PR #1390 wurde korrekt als Squash gemergt. Die fünf PostgreSQL-Belege verwiesen danach jedoch noch auf einen Commit des PR-Branches. Dieser Commit ist bei einem Squash kein Vorfahr von `main`, weshalb der Main-`Docs Guard` zu Recht blockierte.

## Änderung

Bindet die fünf DB-Belege an:

- Main-Commit `ace991ceb8e8cab0d035293d7e20b58fc57ef56e`
- erfolgreichen API-Lauf `29135060216`

Dieser Lauf enthält die grün abgeschlossenen Schema-, Backfill-, Account-, Knoten- und Faden-PostgreSQL-Jobs auf exakt dem gemergten Stand.

## Prüfung

- `python3 -m scripts.docmeta.validate_opt_arc_001_db_proof_matrix`
- 128 Matrixtests
- `make ci-validate`
- `git diff --check`

Keine Produkt-, Schema- oder Runtimeänderung.
