### PR TITLE
fix(compose): pin published PgBouncer image

### DIFF
--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -101,6 +101,12 @@ Der Guard listet alle blockierenden Container mit Name, Projekt-Label und Config
   - `compose.observ.yml` – Observability / Zusatzdienste
   - `compose.ops.override.yml` – Lokale Entwicklungs-/Ops-Umgebung (NATS + API-Port-Mapping für Debugging)
 
+Der nur im `dev`-Profil verwendete PgBouncer-Container ist in
+`compose.core.yml` sowohl auf eine veröffentlichte Version als auch auf den
+OCI-Manifest-Digest gepinnt. Bei Aktualisierungen müssen Registry-Existenz,
+`linux/amd64` und `linux/arm64` sowie der vollständige Compose-Smoke erneut
+belegt werden; `latest` ist dafür nicht zulässig.
+
 ---
 
 ## 3. Services & Netzwerk

--- a/infra/compose/compose.core.yml
+++ b/infra/compose/compose.core.yml
@@ -85,7 +85,7 @@ services:
 
   pgbouncer:
     profiles: ["dev"]
-    image: edoburu/pgbouncer:1.20
+    image: edoburu/pgbouncer:v1.25.2-p0@sha256:7d7a27d9e90985cab5cf42256f5c13a3120baa4b055b69df37beb272b89b2340
     environment:
       DATABASE_URL: postgres://welt:gewebe@db:5432/weltgewebe
       POOL_MODE: transaction


### PR DESCRIPTION
## Ursache

Main-`compose-smoke` konnte `edoburu/pgbouncer:1.20` nicht ziehen, weil dieser Tag in der Registry nicht existiert.

## Änderung

Pinnt PgBouncer auf den veröffentlichten Multi-Arch-Tag `v1.25.2-p0` und zusätzlich auf den unveränderlichen OCI-Manifest-Digest.

## Belege

- Registry-Manifest für linux/amd64 und linux/arm64 aufgelöst
- exaktes Image lokal gezogen
- `docker compose ... config` rendert exakt den gebundenen Tag und Digest
- `make ci-validate`
- `git diff --check`
