### PR TITLE
fix(compose): align PgBouncer and Caddy runtime contracts

### DIFF
--- a/docs/deploy/CHANGELOG.md
+++ b/docs/deploy/CHANGELOG.md
@@ -10,6 +10,32 @@ relations:
 ---
 # Deployment-Änderungsprotokoll
 
+## 2026-07-11 - Dev-Compose-Verträge für PgBouncer und Caddy korrigiert
+
+**Geänderte Dateien:**
+
+- `infra/compose/compose.core.yml`
+- `infra/caddy/Caddyfile`
+- `infra/caddy/Caddyfile.dev`
+- `docs/deploy/README.md`
+
+**Beschreibung:**
+
+Der auf PgBouncer 1.25.2 aktualisierte Dev-Stack verwendet den tatsächlichen
+Container-Listener `5432`, veröffentlicht ihn optional als Hostport `6432` und
+authentifiziert PostgreSQL-16-SCRAM-Passwörter mit `scram-sha-256`. Der alte
+`trust`/MD5-Mischvertrag führte zu `wrong password type` und wird nicht mehr
+verwendet. Gleichzeitig wurden von Caddy 2.7 nicht mehr akzeptierte globale
+`experimental_http3`-Serveroptionen aus den repo-internen Dev-Caddyfiles
+entfernt. Der vollständige isolierte Stack wurde mit gesunder API über
+SQLx → PgBouncer → PostgreSQL sowie laufendem Web- und Caddy-Service geprüft.
+
+**Produktionswirkung:**
+
+Keine direkte. Produktion auf `wg-prod-1` nutzt weiterhin den kanonischen
+direkten PostgreSQL-Pfad und `Caddyfile.vps`; die Änderung repariert den
+Dev-/CI-Compose-Smoke und verhindert falsche Rückschlüsse aus einem roten Main.
+
 ## 2026-05-24 - Account-Erstellung v0: compose.prod.yml reicht Bootstrap-Variablen durch
 
 **Geänderte Dateien:**

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -107,6 +107,19 @@ OCI-Manifest-Digest gepinnt. Bei Aktualisierungen müssen Registry-Existenz,
 `linux/amd64` und `linux/arm64` sowie der vollständige Compose-Smoke erneut
 belegt werden; `latest` ist dafür nicht zulässig.
 
+Der Container lauscht intern auf Port `5432`; deshalb verbindet sich die API im
+Compose-Netz über `pgbouncer:5432`. Nur die optionale Veröffentlichung auf dem
+Entwicklungsrechner bleibt `6432:5432`, damit PgBouncer nicht mit dem direkten
+PostgreSQL-Port verwechselt wird. PostgreSQL 16 verwendet SCRAM-Passwörter;
+der Dev-Pooler muss daher `AUTH_TYPE=scram-sha-256` verwenden. `trust` oder ein
+MD5-generiertes Userlist-Passwort sind mit diesem Pfad nicht zulässig.
+
+Die repo-internen Caddy-Dateien `Caddyfile` und `Caddyfile.dev` müssen direkt
+mit dem in `compose.core.yml` gepinnten Caddy-Image validierbar sein. Veraltete
+globale Optionen wie `experimental_http3` dürfen nicht wieder eingeführt
+werden; HTTP/3 wird von aktuellen Caddy-Versionen ohne diesen historischen
+Schalter verwaltet.
+
 ---
 
 ## 3. Services & Netzwerk

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -1,13 +1,5 @@
 {
   auto_https off
-  servers :8081 {
-    protocol {
-      experimental_http3
-    }
-    logs {
-      level INFO
-    }
-  }
 }
 
 :8081 {

--- a/infra/caddy/Caddyfile.dev
+++ b/infra/caddy/Caddyfile.dev
@@ -1,13 +1,5 @@
 {
   auto_https off
-  servers :8081 {
-    protocol {
-      experimental_http3
-    }
-    logs {
-      level INFO
-    }
-  }
 }
 
 :8081 {

--- a/infra/compose/compose.core.yml
+++ b/infra/compose/compose.core.yml
@@ -1,6 +1,4 @@
 ---
-version: "3.9"
-
 services:
   web:
     profiles: ["dev"]
@@ -39,7 +37,7 @@ services:
     command: ["cargo", "run", "--manifest-path", "apps/api/Cargo.toml", "--bin", "weltgewebe-api"]
     environment:
       API_BIND: ${API_BIND:-0.0.0.0:8080}
-      DATABASE_URL: postgres://welt:gewebe@pgbouncer:6432/weltgewebe
+      DATABASE_URL: postgres://welt:gewebe@pgbouncer:5432/weltgewebe
       RUST_LOG: ${RUST_LOG:-info}
       AUTH_DEV_LOGIN: ${AUTH_DEV_LOGIN:-0}
       AUTH_COOKIE_SECURE: ${AUTH_COOKIE_SECURE:-1}
@@ -91,12 +89,14 @@ services:
       POOL_MODE: transaction
       MAX_CLIENT_CONN: 200
       DEFAULT_POOL_SIZE: 10
-      AUTH_TYPE: trust
+      AUTH_TYPE: scram-sha-256
     depends_on:
       db:
         condition: service_healthy
+    # Containers use PgBouncer's actual listener 5432. The host keeps the
+    # conventional development port 6432 to distinguish it from PostgreSQL.
     ports:
-      - "6432:6432"
+      - "6432:5432"
 
   caddy:
     profiles: ["dev"]


### PR DESCRIPTION
## Ziel

Stellt den vollständigen Dev-/CI-Compose-Smoke nach dem PgBouncer-Imagewechsel wieder her.

## Änderungen

- API verbindet intern zu PgBouncer auf dessen tatsächlichem Listener `5432`
- Hostzugang bleibt über Mapping `6432:5432` unterscheidbar
- PgBouncer nutzt `scram-sha-256` und kann PostgreSQL-16-SCRAM-Passwörter verwenden
- veraltete, von Caddy 2.7 nicht mehr akzeptierte `experimental_http3`-Serverblöcke entfernt
- obsolete Compose-`version`-Angabe entfernt

## Belege

- vollständiger isolierter Stack: PostgreSQL healthy, PgBouncer running, API healthy, Web healthy, Caddy running
- API-Log: Session store backed by PostgreSQL database
- `docker compose ... config`
- Caddy-Validierung beider Dev-Caddyfiles gegen `caddy:2.7`
- `make ci-validate`
