### PR TITLE
fix(settings): persist own Garnrolle profile

### DIFF
--- a/apps/api/src/domain_db.rs
+++ b/apps/api/src/domain_db.rs
@@ -13,7 +13,9 @@ use uuid::Uuid;
 
 use crate::auth::accounts::AccountStore;
 use crate::auth::role::Role;
-use crate::routes::accounts::{map_json_to_public_account, AccountInternal};
+use crate::routes::accounts::{
+    map_json_to_public_account, AccountInternal, Location as AccountLocation,
+};
 use crate::routes::auth::MAX_EMAIL_LEN;
 use crate::routes::edges::Edge;
 use crate::routes::nodes::{Location, Node};
@@ -902,6 +904,14 @@ impl NewDomainAccountRow {
         let public_payload = payload_from_keys(&["summary", "tags"], v);
 
         let mut priv_map = Map::new();
+        if let Some(address) = v
+            .get("address")
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            priv_map.insert("address".to_string(), Value::String(address.to_string()));
+        }
         if let Some(vis) = visibility {
             priv_map.insert("visibility".to_string(), Value::String(vis.to_string()));
             if vis == "private" {
@@ -1037,6 +1047,151 @@ pub async fn insert_account_from_jsonl_record(
 }
 
 /// Name of the check constraint that rejects after-trim empty persisted emails.
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AccountProfileUpdate {
+    pub title: String,
+    pub summary: Option<String>,
+    pub tags: Vec<String>,
+    pub address: Option<String>,
+    pub map_state: String,
+    pub radius_m: i64,
+    pub location: Option<AccountLocation>,
+}
+
+#[derive(Debug, Clone)]
+pub struct StoredAccountProfile {
+    pub account: AccountInternal,
+    pub address: Option<String>,
+    pub location: Option<AccountLocation>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum AccountProfileUpdateError {
+    #[error("account not found")]
+    NotFound,
+    #[error("a map location is required for this visibility")]
+    MissingLocation,
+    #[error("failed to serialise account profile: {0}")]
+    Serialization(#[source] serde_json::Error),
+    #[error("failed to map updated account")]
+    Mapping,
+    #[error("failed to update account profile in domain_accounts: {0}")]
+    Database(#[source] sqlx::Error),
+}
+
+pub async fn load_account_profile_from_postgres(
+    pool: &PgPool,
+    account_id: &str,
+) -> Result<Option<(Option<String>, Option<AccountLocation>)>, sqlx::Error> {
+    let row: Option<(Option<String>, Option<f64>, Option<f64>)> = sqlx::query_as(
+        "SELECT private_payload->>'address', location_lat, location_lon \
+         FROM domain_accounts WHERE id = $1",
+    )
+    .bind(account_id)
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(row.map(|(address, lat, lon)| {
+        let location = match (lat, lon) {
+            (Some(lat), Some(lon)) => Some(AccountLocation { lat, lon }),
+            _ => None,
+        };
+        (address, location)
+    }))
+}
+
+pub async fn update_account_profile_in_postgres(
+    pool: &PgPool,
+    account_id: &str,
+    update: &AccountProfileUpdate,
+) -> Result<StoredAccountProfile, AccountProfileUpdateError> {
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(AccountProfileUpdateError::Database)?;
+    let existing: Option<(Option<f64>, Option<f64>)> = sqlx::query_as(
+        "SELECT location_lat, location_lon FROM domain_accounts WHERE id = $1 FOR UPDATE",
+    )
+    .bind(account_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(AccountProfileUpdateError::Database)?;
+    let Some((existing_lat, existing_lon)) = existing else {
+        return Err(AccountProfileUpdateError::NotFound);
+    };
+
+    let effective_location = update
+        .location
+        .clone()
+        .or(match (existing_lat, existing_lon) {
+            (Some(lat), Some(lon)) => Some(AccountLocation { lat, lon }),
+            _ => None,
+        });
+    if update.map_state != "not_on_map" && effective_location.is_none() {
+        return Err(AccountProfileUpdateError::MissingLocation);
+    }
+
+    let mut public_map = Map::new();
+    if let Some(summary) = &update.summary {
+        public_map.insert("summary".to_string(), Value::String(summary.clone()));
+    }
+    if !update.tags.is_empty() {
+        public_map.insert("tags".to_string(), json!(update.tags));
+    }
+    let public_payload = serde_json::to_string(&Value::Object(public_map))
+        .map_err(AccountProfileUpdateError::Serialization)?;
+
+    let mut private_map = Map::new();
+    if let Some(address) = &update.address {
+        private_map.insert("address".to_string(), Value::String(address.clone()));
+    }
+    let private_payload = serde_json::to_string(&Value::Object(private_map))
+        .map_err(AccountProfileUpdateError::Serialization)?;
+
+    let (new_lat, new_lon) = match &update.location {
+        Some(location) => (Some(location.lat), Some(location.lon)),
+        None => (None, None),
+    };
+
+    let row: AccountRow = sqlx::query_as(
+        "UPDATE domain_accounts SET \
+           title = $2, \
+           map_state = $3, \
+           radius_m = $4, \
+           location_lat = COALESCE($5, location_lat), \
+           location_lon = COALESCE($6, location_lon), \
+           public_payload = (public_payload - 'summary' - 'tags') || $7::jsonb, \
+           private_payload = (private_payload - 'address' - 'visibility' - 'suppress_public_pos' - 'ron_flag') || $8::jsonb, \
+           updated_at = now() \
+         WHERE id = $1 \
+         RETURNING id, kind, title, mode, map_state, radius_m, disabled, \
+           location_lat, location_lon, role, email, webauthn_user_id::text, \
+           public_payload::text, private_payload::text",
+    )
+    .bind(account_id)
+    .bind(&update.title)
+    .bind(&update.map_state)
+    .bind(update.radius_m)
+    .bind(new_lat)
+    .bind(new_lon)
+    .bind(&public_payload)
+    .bind(&private_payload)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(AccountProfileUpdateError::Database)?;
+
+    tx.commit()
+        .await
+        .map_err(AccountProfileUpdateError::Database)?;
+    let account = account_row_to_internal(row).ok_or(AccountProfileUpdateError::Mapping)?;
+    Ok(StoredAccountProfile {
+        account,
+        address: update.address.clone(),
+        location: effective_location,
+    })
+}
+
 pub const ACCOUNT_EMAIL_NOT_EMPTY_CONSTRAINT: &str = "domain_accounts_email_not_empty_after_trim";
 
 /// Error from the account email update write path.

--- a/apps/api/src/routes/accounts.rs
+++ b/apps/api/src/routes/accounts.rs
@@ -7,7 +7,11 @@ use super::{
 };
 use crate::auth::{accounts::AccountStore, role::Role};
 use crate::config::DomainAccountWriteSource;
-use crate::domain_db::{insert_account_from_jsonl_record, AccountWriteError};
+use crate::domain_db::{
+    insert_account_from_jsonl_record, load_account_profile_from_postgres,
+    update_account_profile_in_postgres, AccountProfileUpdate, AccountProfileUpdateError,
+    AccountWriteError,
+};
 use crate::middleware::auth::AuthContext;
 use crate::state::ApiState;
 use axum::{
@@ -37,7 +41,7 @@ fn accounts_path() -> PathBuf {
     in_dir().join("demo.accounts.jsonl")
 }
 
-#[derive(Serialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Location {
     pub lat: f64,
     pub lon: f64,
@@ -75,6 +79,38 @@ pub struct AccountPublic {
     pub disabled: bool,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
+}
+
+#[derive(Serialize, Clone, Debug, PartialEq)]
+pub struct OwnGarnrolleProfile {
+    pub id: String,
+    pub title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    pub tags: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub location: Option<Location>,
+    pub map_state: GarnrolleMapState,
+    pub radius_m: u32,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct UpdateOwnGarnrolleRequest {
+    pub title: String,
+    #[serde(default)]
+    pub summary: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub address: Option<String>,
+    pub map_state: GarnrolleMapState,
+    #[serde(default)]
+    pub radius_m: Option<u32>,
+    #[serde(default)]
+    pub location: Option<Location>,
 }
 
 #[derive(Clone, Debug)]
@@ -399,6 +435,382 @@ pub(crate) async fn append_account_line(record: &Value) -> std::io::Result<()> {
     file.flush().await?;
     file.sync_all().await?;
     Ok(())
+}
+
+const MAX_PROFILE_TITLE_LEN: usize = 160;
+const MAX_PROFILE_SUMMARY_LEN: usize = 2_000;
+const MAX_PROFILE_ADDRESS_LEN: usize = 500;
+const MAX_PROFILE_TAGS: usize = 64;
+const MAX_PROFILE_TAG_LEN: usize = 80;
+
+fn profile_response(
+    account: &AccountInternal,
+    address: Option<String>,
+    location: Option<Location>,
+) -> OwnGarnrolleProfile {
+    OwnGarnrolleProfile {
+        id: account.public.id.clone(),
+        title: account.public.title.clone(),
+        summary: account.public.summary.clone(),
+        tags: account.public.tags.clone(),
+        address,
+        location,
+        map_state: account.public.map_state,
+        radius_m: account.public.radius_m,
+    }
+}
+
+async fn latest_jsonl_account_record(account_id: &str) -> std::io::Result<Option<Value>> {
+    let file = match File::open(accounts_path()).await {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    let mut lines = BufReader::new(file).lines();
+    let mut latest = None;
+    while let Some(line) = lines.next_line().await? {
+        let Ok(value) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+        if value.get("id").and_then(Value::as_str) == Some(account_id) {
+            latest = Some(value);
+        }
+    }
+    Ok(latest)
+}
+
+fn private_profile_from_record(record: &Value) -> (Option<String>, Option<Location>) {
+    let address = record
+        .get("address")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let location = record.get("location").and_then(|location| {
+        let lat = location.get("lat").and_then(json_f64)?;
+        let lon = location.get("lon").and_then(json_f64)?;
+        Some(Location { lat, lon })
+    });
+    (address, location)
+}
+
+fn validate_profile_update(
+    payload: UpdateOwnGarnrolleRequest,
+) -> Result<AccountProfileUpdate, (StatusCode, String)> {
+    let bad = |message: &str| (StatusCode::BAD_REQUEST, message.to_string());
+    let title = payload.title.trim().to_string();
+    if title.is_empty() || title.len() > MAX_PROFILE_TITLE_LEN {
+        return Err(bad("title must be between 1 and 160 bytes"));
+    }
+    let summary = payload
+        .summary
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    if summary
+        .as_ref()
+        .is_some_and(|value| value.len() > MAX_PROFILE_SUMMARY_LEN)
+    {
+        return Err(bad("summary is too long"));
+    }
+    let address = payload
+        .address
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    if address
+        .as_ref()
+        .is_some_and(|value| value.len() > MAX_PROFILE_ADDRESS_LEN)
+    {
+        return Err(bad("address is too long"));
+    }
+
+    let mut tags = Vec::new();
+    for raw in payload.tags {
+        let tag = raw.trim();
+        if tag.is_empty() {
+            continue;
+        }
+        if tag.len() > MAX_PROFILE_TAG_LEN {
+            return Err(bad("a tag is too long"));
+        }
+        if !tags.iter().any(|existing| existing == tag) {
+            tags.push(tag.to_string());
+        }
+    }
+    for required in ["account", "garnrolle"] {
+        if !tags.iter().any(|tag| tag == required) {
+            tags.push(required.to_string());
+        }
+    }
+    if tags.len() > MAX_PROFILE_TAGS {
+        return Err(bad("too many tags"));
+    }
+
+    if let Some(location) = &payload.location {
+        if !location.lat.is_finite()
+            || !location.lon.is_finite()
+            || !(-90.0..=90.0).contains(&location.lat)
+            || !(-180.0..=180.0).contains(&location.lon)
+        {
+            return Err(bad(
+                "location is outside the valid latitude/longitude range",
+            ));
+        }
+    }
+
+    let (radius_m, map_state) = match payload.map_state {
+        GarnrolleMapState::NotOnMap => (0_i64, "not_on_map".to_string()),
+        GarnrolleMapState::Exact => {
+            if address.is_none() {
+                return Err(bad("address is required for a mapped Garnrolle"));
+            }
+            (0_i64, "exact".to_string())
+        }
+        GarnrolleMapState::Radius => {
+            if address.is_none() {
+                return Err(bad("address is required for a mapped Garnrolle"));
+            }
+            let radius = payload.radius_m.unwrap_or(250);
+            if !(50..=5_000).contains(&radius) {
+                return Err(bad("radius_m must be between 50 and 5000"));
+            }
+            (i64::from(radius), "radius".to_string())
+        }
+    };
+
+    Ok(AccountProfileUpdate {
+        title,
+        summary,
+        tags,
+        address,
+        map_state,
+        radius_m,
+        location: payload.location,
+    })
+}
+
+fn update_jsonl_profile_record(
+    mut record: Value,
+    update: &AccountProfileUpdate,
+) -> Result<(Value, Option<Location>), (StatusCode, String)> {
+    let object = record.as_object_mut().ok_or_else(|| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "stored account record is invalid".to_string(),
+        )
+    })?;
+    let existing_location = object.get("location").and_then(|value| {
+        let lat = value.get("lat").and_then(json_f64)?;
+        let lon = value.get("lon").and_then(json_f64)?;
+        Some(Location { lat, lon })
+    });
+    let effective_location = update.location.clone().or(existing_location);
+    if update.map_state != "not_on_map" && effective_location.is_none() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "a map location is required for this visibility".to_string(),
+        ));
+    }
+
+    object.insert("type".to_string(), json!("garnrolle"));
+    object.insert("title".to_string(), json!(update.title));
+    object.insert("map_state".to_string(), json!(update.map_state));
+    object.insert("radius_m".to_string(), json!(update.radius_m));
+    object.remove("mode");
+    object.remove("ron_flag");
+    object.remove("visibility");
+    object.remove("suppress_public_pos");
+    match &update.summary {
+        Some(summary) => {
+            object.insert("summary".to_string(), json!(summary));
+        }
+        None => {
+            object.remove("summary");
+        }
+    }
+    if update.tags.is_empty() {
+        object.remove("tags");
+    } else {
+        object.insert("tags".to_string(), json!(update.tags));
+    }
+    match &update.address {
+        Some(address) => {
+            object.insert("address".to_string(), json!(address));
+        }
+        None => {
+            object.remove("address");
+        }
+    }
+    if let Some(location) = &update.location {
+        object.insert(
+            "location".to_string(),
+            json!({ "lat": location.lat, "lon": location.lon }),
+        );
+    }
+    Ok((record, effective_location))
+}
+
+pub async fn get_own_garnrolle_profile(
+    State(state): State<ApiState>,
+    Extension(ctx): Extension<AuthContext>,
+) -> Result<Json<OwnGarnrolleProfile>, (StatusCode, String)> {
+    let account_id = ctx
+        .account_id
+        .as_deref()
+        .filter(|_| ctx.authenticated)
+        .ok_or((
+            StatusCode::UNAUTHORIZED,
+            "authentication required".to_string(),
+        ))?;
+    let _persist_guard = state.accounts_persist.lock().await;
+    let account = state
+        .accounts
+        .read()
+        .await
+        .get(account_id)
+        .cloned()
+        .ok_or((StatusCode::NOT_FOUND, "account not found".to_string()))?;
+
+    let (address, location) = match state.config.domain_account_write_source {
+        DomainAccountWriteSource::Jsonl => {
+            let record = latest_jsonl_account_record(account_id)
+                .await
+                .map_err(|error| {
+                    tracing::error!(%error, "failed to read own JSONL account profile");
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "failed to load account profile".to_string(),
+                    )
+                })?
+                .ok_or((
+                    StatusCode::NOT_FOUND,
+                    "account profile not found".to_string(),
+                ))?;
+            private_profile_from_record(&record)
+        }
+        DomainAccountWriteSource::Postgres => {
+            let pool = state.db_pool.as_ref().ok_or((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "PostgreSQL pool unavailable for account profile".to_string(),
+            ))?;
+            load_account_profile_from_postgres(pool, account_id)
+                .await
+                .map_err(|error| {
+                    tracing::error!(%error, "failed to read own PostgreSQL account profile");
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "failed to load account profile".to_string(),
+                    )
+                })?
+                .ok_or((
+                    StatusCode::NOT_FOUND,
+                    "account profile not found".to_string(),
+                ))?
+        }
+    };
+
+    Ok(Json(profile_response(&account, address, location)))
+}
+
+pub async fn update_own_garnrolle_profile(
+    State(state): State<ApiState>,
+    Extension(ctx): Extension<AuthContext>,
+    Json(payload): Json<UpdateOwnGarnrolleRequest>,
+) -> Result<Json<OwnGarnrolleProfile>, (StatusCode, String)> {
+    let account_id = ctx
+        .account_id
+        .clone()
+        .filter(|_| ctx.authenticated)
+        .ok_or((
+            StatusCode::UNAUTHORIZED,
+            "authentication required".to_string(),
+        ))?;
+    let update = validate_profile_update(payload)?;
+    let _persist_guard = state.accounts_persist.lock().await;
+    let existing = state
+        .accounts
+        .read()
+        .await
+        .get(&account_id)
+        .cloned()
+        .ok_or((StatusCode::NOT_FOUND, "account not found".to_string()))?;
+
+    let stored = match state.config.domain_account_write_source {
+        DomainAccountWriteSource::Jsonl => {
+            let record = latest_jsonl_account_record(&account_id)
+                .await
+                .map_err(|error| {
+                    tracing::error!(%error, "failed to read JSONL account before profile update");
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "failed to update account profile".to_string(),
+                    )
+                })?
+                .ok_or((
+                    StatusCode::NOT_FOUND,
+                    "account profile not found".to_string(),
+                ))?;
+            let (record, location) = update_jsonl_profile_record(record, &update)?;
+            let public = map_json_to_public_account(&record).ok_or((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "failed to project updated account".to_string(),
+            ))?;
+            append_account_line(&record).await.map_err(|error| {
+                tracing::error!(%error, "failed to append JSONL account profile update");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "failed to persist account profile".to_string(),
+                )
+            })?;
+            let mut account = existing;
+            account.public = public;
+            crate::domain_db::StoredAccountProfile {
+                account,
+                address: update.address.clone(),
+                location,
+            }
+        }
+        DomainAccountWriteSource::Postgres => {
+            let pool = state.db_pool.as_ref().ok_or((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "PostgreSQL pool unavailable for account profile".to_string(),
+            ))?;
+            update_account_profile_in_postgres(pool, &account_id, &update)
+                .await
+                .map_err(|error| match error {
+                    AccountProfileUpdateError::NotFound => {
+                        (StatusCode::NOT_FOUND, "account not found".to_string())
+                    }
+                    AccountProfileUpdateError::MissingLocation => (
+                        StatusCode::BAD_REQUEST,
+                        "a map location is required for this visibility".to_string(),
+                    ),
+                    other => {
+                        tracing::error!(error = %other, "failed to update PostgreSQL account profile");
+                        (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "failed to persist account profile".to_string(),
+                        )
+                    }
+                })?
+        }
+    };
+
+    {
+        let mut accounts = state.accounts.write().await;
+        accounts.insert(stored.account.clone());
+    }
+    tracing::info!(
+        event = "account.profile.updated",
+        account_id = %account_id,
+        map_state = %update.map_state,
+        write_source = ?state.config.domain_account_write_source,
+        "Account updated its own Garnrolle profile"
+    );
+    Ok(Json(profile_response(
+        &stored.account,
+        stored.address,
+        stored.location,
+    )))
 }
 
 /// Create the first/next account as an operator (Admin-only; gated by
@@ -968,5 +1380,137 @@ mod additional_tests {
         let account = map_json_to_public_account(&input).expect("Mapping failed");
         assert_eq!(account.map_state, GarnrolleMapState::NotOnMap);
         assert!(account.public_pos.is_none());
+    }
+}
+
+#[cfg(test)]
+mod profile_update_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn request(
+        map_state: GarnrolleMapState,
+        address: Option<&str>,
+        location: Option<Location>,
+    ) -> UpdateOwnGarnrolleRequest {
+        UpdateOwnGarnrolleRequest {
+            title: "  Meine Garnrolle  ".to_string(),
+            summary: Some("  Gemeinsame Dinge  ".to_string()),
+            tags: vec![
+                "skill:Kochen".to_string(),
+                "skill:Kochen".to_string(),
+                "interest:Commons".to_string(),
+            ],
+            address: address.map(str::to_string),
+            map_state,
+            radius_m: Some(250),
+            location,
+        }
+    }
+
+    #[test]
+    fn exact_profile_requires_address_and_valid_location() {
+        let missing_address = validate_profile_update(request(
+            GarnrolleMapState::Exact,
+            None,
+            Some(Location {
+                lat: 53.5,
+                lon: 10.0,
+            }),
+        ));
+        assert_eq!(missing_address.unwrap_err().0, StatusCode::BAD_REQUEST);
+
+        let invalid_location = validate_profile_update(request(
+            GarnrolleMapState::Exact,
+            Some("Poelsweg 2, Hamburg"),
+            Some(Location {
+                lat: 91.0,
+                lon: 10.0,
+            }),
+        ));
+        assert_eq!(invalid_location.unwrap_err().0, StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn profile_validation_normalises_fields_and_keeps_required_tags() {
+        let update = validate_profile_update(request(
+            GarnrolleMapState::Radius,
+            Some("  Poelsweg 2, Hamburg  "),
+            Some(Location {
+                lat: 53.5,
+                lon: 10.0,
+            }),
+        ))
+        .expect("valid profile");
+
+        assert_eq!(update.title, "Meine Garnrolle");
+        assert_eq!(update.summary.as_deref(), Some("Gemeinsame Dinge"));
+        assert_eq!(update.address.as_deref(), Some("Poelsweg 2, Hamburg"));
+        assert_eq!(update.map_state, "radius");
+        assert_eq!(update.radius_m, 250);
+        assert_eq!(
+            update.tags,
+            vec!["skill:Kochen", "interest:Commons", "account", "garnrolle"]
+        );
+    }
+
+    #[test]
+    fn jsonl_update_preserves_operational_identity_and_existing_location() {
+        let record = json!({
+            "id": "own-account",
+            "type": "garnrolle",
+            "title": "Alt",
+            "role": "weber",
+            "email": "private@example.test",
+            "webauthn_user_id": "79e8d447-c7b3-46ff-bcc9-55a0d843f780",
+            "map_state": "exact",
+            "radius_m": 0,
+            "location": {"lat": 53.5, "lon": 10.0},
+            "address": "Alte Adresse"
+        });
+        let update = validate_profile_update(UpdateOwnGarnrolleRequest {
+            title: "Neu".to_string(),
+            summary: None,
+            tags: vec![],
+            address: Some("Neue Adresse".to_string()),
+            map_state: GarnrolleMapState::Exact,
+            radius_m: None,
+            location: None,
+        })
+        .expect("valid profile");
+
+        let (updated, effective_location) =
+            update_jsonl_profile_record(record, &update).expect("update record");
+        assert_eq!(updated["id"], "own-account");
+        assert_eq!(updated["role"], "weber");
+        assert_eq!(updated["email"], "private@example.test");
+        assert_eq!(
+            updated["webauthn_user_id"],
+            "79e8d447-c7b3-46ff-bcc9-55a0d843f780"
+        );
+        assert_eq!(updated["title"], "Neu");
+        assert_eq!(updated["address"], "Neue Adresse");
+        assert_eq!(effective_location.unwrap().lat, 53.5);
+        assert_eq!(updated["location"]["lat"], 53.5);
+    }
+
+    #[test]
+    fn not_on_map_keeps_internal_location_but_has_no_public_projection() {
+        let record = json!({
+            "id": "own-account",
+            "type": "garnrolle",
+            "title": "Alt",
+            "role": "weber",
+            "map_state": "exact",
+            "radius_m": 0,
+            "location": {"lat": 53.5, "lon": 10.0}
+        });
+        let update = validate_profile_update(request(GarnrolleMapState::NotOnMap, None, None))
+            .expect("not-on-map profile");
+        let (updated, _) = update_jsonl_profile_record(record, &update).expect("update record");
+        let public = map_json_to_public_account(&updated).expect("public account");
+        assert_eq!(public.map_state, GarnrolleMapState::NotOnMap);
+        assert!(public.public_pos.is_none());
+        assert_eq!(updated["location"]["lat"], 53.5);
     }
 }

--- a/apps/api/src/routes/mod.rs
+++ b/apps/api/src/routes/mod.rs
@@ -17,7 +17,10 @@ use crate::middleware::authz::{require_admin, require_write};
 use crate::state::ApiState;
 
 use self::{
-    accounts::{create_account, get_account, list_accounts},
+    accounts::{
+        create_account, get_account, get_own_garnrolle_profile, list_accounts,
+        update_own_garnrolle_profile,
+    },
     auth::{
         consume_login_get, consume_login_post, consume_step_up, dev_login, list_dev_accounts,
         list_devices, logout, logout_all, me, passkey_auth_options, passkey_auth_verify,
@@ -52,6 +55,12 @@ pub fn api_router() -> Router<ApiState> {
             get(list_accounts)
                 .post(create_account)
                 .route_layer(from_fn(require_admin)),
+        )
+        .route(
+            "/accounts/me/profile",
+            get(get_own_garnrolle_profile)
+                .patch(update_own_garnrolle_profile)
+                .route_layer(from_fn(require_write)),
         )
         .route("/accounts/{id}", get(get_account))
         .route("/auth/dev/accounts", get(list_dev_accounts))

--- a/apps/api/tests/api_accounts_create.rs
+++ b/apps/api/tests/api_accounts_create.rs
@@ -631,3 +631,209 @@ async fn radius_m_positive_public_pos_is_deterministic() -> Result<()> {
     );
     Ok(())
 }
+
+fn patch_own_profile(cookie: Option<&str>, json_body: &str) -> Request<body::Body> {
+    let mut builder = Request::patch("/accounts/me/profile")
+        .header("Content-Type", "application/json")
+        .header("Host", "localhost")
+        .header("Origin", "http://localhost");
+    if let Some(cookie) = cookie {
+        builder = builder.header("Cookie", cookie);
+    }
+    builder
+        .body(body::Body::from(json_body.to_string()))
+        .expect("profile request")
+}
+
+#[tokio::test]
+#[serial]
+async fn weber_updates_only_own_jsonl_garnrolle_and_reads_private_profile() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let in_dir = tmp.path().join("in");
+    std::fs::create_dir_all(&in_dir)?;
+    let _env = set_gewebe_in_dir(&in_dir);
+    let own_id = "weber-profile-1";
+    let other_id = "other-profile-1";
+    std::fs::write(
+        in_dir.join("demo.accounts.jsonl"),
+        format!(
+            "{}\n{}\n",
+            serde_json::json!({
+                "id": own_id,
+                "type": "garnrolle",
+                "title": "Eigene Garnrolle",
+                "role": "weber",
+                "map_state": "not_on_map",
+                "radius_m": 0
+            }),
+            serde_json::json!({
+                "id": other_id,
+                "type": "garnrolle",
+                "title": "Fremde Garnrolle",
+                "role": "weber",
+                "map_state": "not_on_map",
+                "radius_m": 0
+            })
+        ),
+    )?;
+
+    let (app, cookie, state) = app_with_operator(&in_dir, own_id, Role::Weber).await?;
+    let response = app
+        .clone()
+        .oneshot(patch_own_profile(
+            Some(&cookie),
+            r#"{
+              "title":"Meine gesetzte Garnrolle",
+              "summary":"Selbst gespeichert",
+              "tags":["skill:Kochen","interest:Commons"],
+              "address":"Poelsweg 2, Hamburg",
+              "map_state":"exact",
+              "location":{"lat":53.5604,"lon":10.0630}
+            }"#,
+        ))
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = body::to_bytes(response.into_body(), usize::MAX).await?;
+    let profile: serde_json::Value = serde_json::from_slice(&bytes)?;
+    assert_eq!(profile["id"], own_id);
+    assert_eq!(profile["title"], "Meine gesetzte Garnrolle");
+    assert_eq!(profile["address"], "Poelsweg 2, Hamburg");
+    assert_eq!(profile["location"]["lat"], 53.5604);
+    assert_eq!(profile["map_state"], "exact");
+    assert!(profile.get("email").is_none());
+    assert!(profile.get("role").is_none());
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::get("/accounts/me/profile")
+                .header("Cookie", &cookie)
+                .body(body::Body::empty())?,
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = body::to_bytes(response.into_body(), usize::MAX).await?;
+    let reloaded: serde_json::Value = serde_json::from_slice(&bytes)?;
+    assert_eq!(reloaded["address"], "Poelsweg 2, Hamburg");
+    assert_eq!(reloaded["location"]["lon"], 10.0630);
+
+    let contents = std::fs::read_to_string(in_dir.join("demo.accounts.jsonl"))?;
+    let records: Vec<serde_json::Value> = contents
+        .lines()
+        .map(serde_json::from_str)
+        .collect::<Result<_, _>>()?;
+    let latest_own = records
+        .iter()
+        .rev()
+        .find(|record| record["id"] == own_id)
+        .context("latest own record")?;
+    assert_eq!(latest_own["title"], "Meine gesetzte Garnrolle");
+    let other_records = records
+        .iter()
+        .filter(|record| record["id"] == other_id)
+        .count();
+    assert_eq!(other_records, 1, "foreign Garnrolle must not be written");
+
+    let cache = state.accounts.read().await;
+    let own = cache.get(own_id).context("own account in cache")?;
+    assert_eq!(own.public.title, "Meine gesetzte Garnrolle");
+    assert_eq!(own.public.map_state, GarnrolleMapState::Exact);
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn gast_reads_own_private_profile_but_cannot_update_it() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let in_dir = tmp.path().join("in");
+    std::fs::create_dir_all(&in_dir)?;
+    let _env = set_gewebe_in_dir(&in_dir);
+    let account_id = "gast-profile-1";
+    std::fs::write(
+        in_dir.join("demo.accounts.jsonl"),
+        serde_json::json!({
+            "id": account_id,
+            "type": "garnrolle",
+            "title": "Gast Garnrolle",
+            "role": "gast",
+            "map_state": "not_on_map",
+            "radius_m": 0,
+            "address": "Private Testadresse"
+        })
+        .to_string()
+            + "
+",
+    )?;
+    let (app, cookie, _state) = app_with_operator(&in_dir, account_id, Role::Gast).await?;
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::get("/accounts/me/profile")
+                .header("Cookie", &cookie)
+                .body(body::Body::empty())?,
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = body::to_bytes(response.into_body(), usize::MAX).await?;
+    let profile: serde_json::Value = serde_json::from_slice(&bytes)?;
+    assert_eq!(profile["id"], account_id);
+    assert_eq!(profile["address"], "Private Testadresse");
+    assert!(profile.get("role").is_none());
+
+    let response = app
+        .oneshot(patch_own_profile(
+            Some(&cookie),
+            r#"{"title":"Nicht erlaubt","tags":[],"map_state":"not_on_map"}"#,
+        ))
+        .await?;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn own_profile_update_requires_authentication_and_rejects_identity_fields() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let in_dir = tmp.path().join("in");
+    std::fs::create_dir_all(&in_dir)?;
+    let _env = set_gewebe_in_dir(&in_dir);
+    std::fs::write(
+        in_dir.join("demo.accounts.jsonl"),
+        serde_json::json!({
+            "id": "weber-profile-2",
+            "type": "garnrolle",
+            "title": "Eigene Garnrolle",
+            "role": "weber",
+            "map_state": "not_on_map",
+            "radius_m": 0
+        })
+        .to_string()
+            + "\n",
+    )?;
+    let (app, cookie, _state) = app_with_operator(&in_dir, "weber-profile-2", Role::Weber).await?;
+
+    let response = app
+        .clone()
+        .oneshot(patch_own_profile(
+            None,
+            r#"{"title":"X","tags":[],"map_state":"not_on_map"}"#,
+        ))
+        .await?;
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    let response = app
+        .oneshot(patch_own_profile(
+            Some(&cookie),
+            r#"{
+              "id":"other-profile",
+              "role":"admin",
+              "title":"X",
+              "tags":[],
+              "map_state":"not_on_map"
+            }"#,
+        ))
+        .await?;
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    Ok(())
+}

--- a/apps/api/tests/auth_security_invariants.rs
+++ b/apps/api/tests/auth_security_invariants.rs
@@ -393,6 +393,7 @@ const CSRF_COVERED_MUTATING_ROUTES: &[(&str, &str)] = &[
     ("POST", "/nodes"),
     ("POST", "/edges"),
     ("POST", "/accounts"),
+    ("PATCH", "/accounts/me/profile"),
 ];
 
 const CSRF_EXEMPT_MUTATING_ROUTES: &[(&str, &str)] = &[

--- a/apps/api/tests/db_domain_account_write_path.rs
+++ b/apps/api/tests/db_domain_account_write_path.rs
@@ -90,6 +90,18 @@ const WEBAUTHN_STABLE_ID: &str = "aaaaaaaa-aaaa-4aaa-8aaa-000000000004";
 const STEP_UP_EMAIL_ID: &str = "aaaaaaaa-aaaa-4aaa-8aaa-000000000030";
 const STEP_UP_EMAIL_DUP_ID: &str = "aaaaaaaa-aaaa-4aaa-8aaa-000000000031";
 
+type PersistedProfileRow = (
+    String,
+    String,
+    i64,
+    Option<f64>,
+    Option<f64>,
+    String,
+    String,
+    Option<String>,
+    Option<String>,
+);
+
 async fn clean(pool: &PgPool) {
     pool.execute("DELETE FROM domain_accounts WHERE id LIKE 'aaaaaaaa-aaaa-4aaa-8aaa-%'")
         .await
@@ -820,6 +832,174 @@ async fn step_up_update_email_persists_to_postgres_and_reloads() -> Result<()> {
         !in_dir.join("demo.accounts.jsonl").exists(),
         "PostgreSQL write mode must not append JSONL"
     );
+
+    clean(&pool).await;
+    Ok(())
+}
+
+fn patch_own_profile(cookie: &str, json_body: &str) -> Request<body::Body> {
+    Request::patch("/accounts/me/profile")
+        .header("Content-Type", "application/json")
+        .header("Host", "localhost")
+        .header("Origin", "http://localhost")
+        .header("Cookie", cookie)
+        .body(body::Body::from(json_body.to_string()))
+        .expect("profile request")
+}
+
+#[tokio::test]
+#[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
+#[serial]
+async fn own_garnrolle_profile_persists_privately_and_reloads_from_postgres() -> Result<()> {
+    const PROFILE_ID: &str = "aaaaaaaa-aaaa-4aaa-8aaa-000000000032";
+    const WEBAUTHN_ID: &str = "139d028d-56dd-4dd2-90b0-f5e6ca285bbb";
+
+    let pool = connect_pool().await;
+    run_migrations(&pool).await;
+    clean(&pool).await;
+    insert_account_from_jsonl_record(
+        &pool,
+        &serde_json::json!({
+            "id": PROFILE_ID,
+            "type": "garnrolle",
+            "title": "Unverortete Garnrolle",
+            "role": "admin",
+            "email": "profile-owner@example.test",
+            "webauthn_user_id": WEBAUTHN_ID,
+            "map_state": "not_on_map",
+            "radius_m": 0
+        }),
+    )
+    .await
+    .expect("insert profile fixture");
+
+    let tmp = tempfile::tempdir()?;
+    let in_dir = tmp.path().join("in");
+    std::fs::create_dir_all(&in_dir)?;
+    let _env = set_gewebe_in_dir(&in_dir);
+    let (app, cookie, state) = postgres_write_app(pool.clone(), PROFILE_ID).await?;
+
+    let response = app
+        .clone()
+        .oneshot(patch_own_profile(
+            &cookie,
+            r#"{
+              "title":"Meine PostgreSQL Garnrolle",
+              "summary":"Dauerhaft gespeichert",
+              "tags":["skill:Kochen","interest:Commons"],
+              "address":"Poelsweg 2, Hamburg",
+              "map_state":"radius",
+              "radius_m":300,
+              "location":{"lat":53.5604,"lon":10.0630}
+            }"#,
+        ))
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let response_body = body::to_bytes(response.into_body(), usize::MAX).await?;
+    let profile: serde_json::Value = serde_json::from_slice(&response_body)?;
+    assert_eq!(profile["id"], PROFILE_ID);
+    assert_eq!(profile["title"], "Meine PostgreSQL Garnrolle");
+    assert_eq!(profile["address"], "Poelsweg 2, Hamburg");
+    assert_eq!(profile["location"]["lat"], 53.5604);
+    assert_eq!(profile["map_state"], "radius");
+    assert_eq!(profile["radius_m"], 300);
+    assert!(profile.get("email").is_none());
+    assert!(profile.get("role").is_none());
+    assert!(profile.get("webauthn_user_id").is_none());
+
+    let row: PersistedProfileRow = sqlx::query_as(
+        "SELECT title, map_state, radius_m, location_lat, location_lon, \
+           public_payload::text, private_payload::text, email, webauthn_user_id::text \
+         FROM domain_accounts WHERE id = $1",
+    )
+    .bind(PROFILE_ID)
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(row.0, "Meine PostgreSQL Garnrolle");
+    assert_eq!(row.1, "radius");
+    assert_eq!(row.2, 300);
+    assert!((row.3.expect("lat") - 53.5604).abs() < 1e-9);
+    assert!((row.4.expect("lon") - 10.0630).abs() < 1e-9);
+    let public_payload: serde_json::Value = serde_json::from_str(&row.5)?;
+    let private_payload: serde_json::Value = serde_json::from_str(&row.6)?;
+    assert_eq!(public_payload["summary"], "Dauerhaft gespeichert");
+    assert_eq!(public_payload["tags"][0], "skill:Kochen");
+    assert_eq!(private_payload["address"], "Poelsweg 2, Hamburg");
+    assert_eq!(row.7.as_deref(), Some("profile-owner@example.test"));
+    assert_eq!(row.8.as_deref(), Some(WEBAUTHN_ID));
+
+    // The durable row, not a parallel JSONL write, is the source of truth.
+    assert!(!in_dir.join("demo.accounts.jsonl").exists());
+    let reloaded = load_accounts_from_postgres(&pool).await?;
+    let reloaded_account = reloaded.get(PROFILE_ID).context("reloaded account")?;
+    assert_eq!(reloaded_account.public.title, "Meine PostgreSQL Garnrolle");
+    assert_eq!(reloaded_account.public.map_state, GarnrolleMapState::Radius);
+    assert_eq!(reloaded_account.public.radius_m, 300);
+    assert_eq!(
+        reloaded_account.email.as_deref(),
+        Some("profile-owner@example.test")
+    );
+    assert_eq!(reloaded_account.webauthn_user_id.to_string(), WEBAUTHN_ID);
+
+    let cached = state.accounts.read().await;
+    let cached_account = cached.get(PROFILE_ID).context("cached account")?;
+    assert_eq!(cached_account.public.title, "Meine PostgreSQL Garnrolle");
+    assert_eq!(
+        cached_account.email.as_deref(),
+        Some("profile-owner@example.test")
+    );
+    drop(cached);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::get("/accounts/me/profile")
+                .header("Cookie", &cookie)
+                .body(body::Body::empty())?,
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let response_body = body::to_bytes(response.into_body(), usize::MAX).await?;
+    let reloaded_profile: serde_json::Value = serde_json::from_slice(&response_body)?;
+    assert_eq!(reloaded_profile["address"], "Poelsweg 2, Hamburg");
+    assert_eq!(reloaded_profile["location"]["lon"], 10.0630);
+
+    // Hiding the Garnrolle removes only the public projection. The internal
+    // coordinate remains available for a later, user-controlled reactivation.
+    let response = app
+        .clone()
+        .oneshot(patch_own_profile(
+            &cookie,
+            r#"{
+              "title":"Meine PostgreSQL Garnrolle",
+              "summary":"Dauerhaft gespeichert",
+              "tags":["skill:Kochen","interest:Commons"],
+              "address":"Poelsweg 2, Hamburg",
+              "map_state":"not_on_map"
+            }"#,
+        ))
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let response_body = body::to_bytes(response.into_body(), usize::MAX).await?;
+    let hidden_profile: serde_json::Value = serde_json::from_slice(&response_body)?;
+    assert_eq!(hidden_profile["map_state"], "not_on_map");
+    assert_eq!(hidden_profile["location"]["lat"], 53.5604);
+
+    let (map_state, radius_m, lat, lon): (String, i64, Option<f64>, Option<f64>) =
+        sqlx::query_as(
+            "SELECT map_state, radius_m, location_lat, location_lon              FROM domain_accounts WHERE id = $1",
+        )
+        .bind(PROFILE_ID)
+        .fetch_one(&pool)
+        .await?;
+    assert_eq!(map_state, "not_on_map");
+    assert_eq!(radius_m, 0);
+    assert!((lat.expect("internal lat") - 53.5604).abs() < 1e-9);
+    assert!((lon.expect("internal lon") - 10.0630).abs() < 1e-9);
+    let hidden_reload = load_accounts_from_postgres(&pool).await?;
+    let hidden_account = hidden_reload.get(PROFILE_ID).context("hidden account")?;
+    assert_eq!(hidden_account.public.map_state, GarnrolleMapState::NotOnMap);
+    assert!(hidden_account.public.public_pos.is_none());
 
     clean(&pool).await;
     Ok(())

--- a/apps/web/src/lib/api/domainWrites.ts
+++ b/apps/web/src/lib/api/domainWrites.ts
@@ -1,8 +1,7 @@
-import type { Edge, Location, Node } from "$lib/map/types";
+import type { Edge, GarnrolleMapState, Location, Node } from "$lib/map/types";
 
 /**
- * Thrown when a domain write (`POST /nodes`, `POST /edges`) is rejected by the
- * API. Carries the HTTP status so callers can map it to an understandable,
+ * Thrown when a domain write is rejected by the API. Carries the HTTP status so callers can map it to an understandable,
  * German, user-facing message without leaking backend/internal detail.
  */
 export class ApiRequestError extends Error {
@@ -25,6 +24,60 @@ async function postJson<T>(path: string, payload: unknown): Promise<T> {
     throw new ApiRequestError(res.status);
   }
   return res.json();
+}
+
+async function patchJson<T>(path: string, payload: unknown): Promise<T> {
+  const res = await fetch(path, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+    credentials: "include",
+  });
+  if (!res.ok) {
+    throw new ApiRequestError(res.status);
+  }
+  return res.json();
+}
+
+async function getJson<T>(path: string): Promise<T> {
+  const res = await fetch(path, { credentials: "include" });
+  if (!res.ok) {
+    throw new ApiRequestError(res.status);
+  }
+  return res.json();
+}
+
+export interface OwnGarnrolleProfile {
+  id: string;
+  title: string;
+  summary?: string | null;
+  tags: string[];
+  address?: string | null;
+  location?: Location | null;
+  map_state: GarnrolleMapState;
+  radius_m: number;
+}
+
+export interface UpdateOwnGarnrollePayload {
+  title: string;
+  summary?: string;
+  tags: string[];
+  address?: string;
+  location?: Location;
+  map_state: GarnrolleMapState;
+  radius_m?: number;
+}
+
+/** GET /api/accounts/me/profile — private profile of the active account only. */
+export function getOwnGarnrolleProfile(): Promise<OwnGarnrolleProfile> {
+  return getJson<OwnGarnrolleProfile>("/api/accounts/me/profile");
+}
+
+/** PATCH /api/accounts/me/profile — update only the active account's Garnrolle. */
+export function updateOwnGarnrolle(
+  payload: UpdateOwnGarnrollePayload,
+): Promise<OwnGarnrolleProfile> {
+  return patchJson<OwnGarnrolleProfile>("/api/accounts/me/profile", payload);
 }
 
 export interface CreateNodePayload {

--- a/apps/web/src/lib/auth/store.ts
+++ b/apps/web/src/lib/auth/store.ts
@@ -15,9 +15,40 @@ const initialUser: AuthStatus = {
   account_id: undefined,
 };
 
+const SENSITIVE_GARNROLLE_SESSION_PREFIXES = [
+  "weltgewebe:garnrolle-draft:",
+  "weltgewebe:garnrolle-return-location:",
+] as const;
+
+function clearSensitiveGarnrolleSessionData(keepAccountId?: string) {
+  if (!browser) return;
+  const keysToRemove: string[] = [];
+  for (let index = 0; index < sessionStorage.length; index += 1) {
+    const key = sessionStorage.key(index);
+    if (!key) continue;
+    const prefix = SENSITIVE_GARNROLLE_SESSION_PREFIXES.find((candidate) =>
+      key.startsWith(candidate),
+    );
+    const keepKey =
+      prefix && keepAccountId ? `${prefix}${keepAccountId}` : null;
+    if (prefix && key !== keepKey) {
+      keysToRemove.push(key);
+    }
+  }
+  for (const key of keysToRemove) {
+    sessionStorage.removeItem(key);
+  }
+}
+
 const createAuthStore = () => {
   const store = writable<AuthStatus>(initialUser);
   const { subscribe, set } = store;
+  function applyAuthState(next: AuthStatus) {
+    clearSensitiveGarnrolleSessionData(
+      next.authenticated ? next.account_id : undefined,
+    );
+    set(next);
+  }
 
   // Helper to fetch current status
   const checkAuth = async () => {
@@ -38,18 +69,18 @@ const createAuthStore = () => {
             account_id:
               typeof data.account_id === "string" ? data.account_id : undefined,
           };
-          set(validated);
+          applyAuthState(validated);
           return validated;
         } else {
           console.warn("Invalid auth payload:", data);
         }
       }
       // Fallback
-      set(initialUser);
+      applyAuthState(initialUser);
       return initialUser;
     } catch (e) {
       console.warn("Auth check failed:", e);
-      set(initialUser);
+      applyAuthState(initialUser);
       return initialUser;
     }
   };
@@ -116,7 +147,7 @@ const createAuthStore = () => {
       } catch (e) {
         console.error("Logout error:", e);
         // Even if network fails, we should clear local state
-        set(initialUser);
+        applyAuthState(initialUser);
       }
     },
   };

--- a/apps/web/src/lib/components/MyGarnrolleSection.svelte
+++ b/apps/web/src/lib/components/MyGarnrolleSection.svelte
@@ -1,6 +1,14 @@
 <script lang="ts">
+  import { browser } from "$app/environment";
+  import { goto, invalidateAll } from "$app/navigation";
   import { authStore } from "$lib/auth/store";
-  import type { Account } from "$lib/map/types";
+  import {
+    ApiRequestError,
+    getOwnGarnrolleProfile,
+    updateOwnGarnrolle,
+    type OwnGarnrolleProfile,
+  } from "$lib/api/domainWrites";
+  import type { Account, GarnrolleMapState, Location } from "$lib/map/types";
   import {
     describeGarnrolleVisibility,
     findOwnGarnrolle,
@@ -9,41 +17,299 @@
   export let accounts: Account[] = [];
   export let accountsLoadError: string | null = null;
 
-  let draftKey = "";
+  type GarnrolleDraft = {
+    displayName: string;
+    summary: string;
+    skills: string;
+    goods: string;
+    interests: string;
+    address: string;
+    visibilityChoice: GarnrolleMapState;
+    radiusM: number;
+    selectedLocation: Location | null;
+  };
+
+  let profileKey = "";
   let displayName = "";
   let summary = "";
   let skills = "";
   let goods = "";
   let interests = "";
   let address = "";
-  let visibilityChoice: "not_on_map" | "exact" | "radius" = "not_on_map";
+  let visibilityChoice: GarnrolleMapState = "not_on_map";
   let radiusM = 250;
+  let selectedLocation: Location | null = null;
+  let isLoadingProfile = false;
+  let isSaving = false;
+  let profileError: string | null = null;
+  let saveMessage: string | null = null;
 
   $: ownGarnrolle = findOwnGarnrolle(accounts, $authStore.account_id);
   $: visibility = describeGarnrolleVisibility(ownGarnrolle);
-  $: currentKey = `${$authStore.account_id ?? "guest"}:${ownGarnrolle?.id ?? "unlisted"}`;
-
-  $: if (currentKey !== draftKey) {
-    draftKey = currentKey;
-    displayName = ownGarnrolle?.title ?? "Meine Garnrolle";
-    summary = ownGarnrolle?.summary ?? "";
-    skills =
-      ownGarnrolle?.tags
-        ?.filter((tag) => tag !== "account" && tag !== "garnrolle")
-        .join(", ") ?? "";
-    goods = "";
-    interests = "";
-    address = "";
-    visibilityChoice = visibility.state;
-    radiusM =
-      ownGarnrolle?.radius_m && ownGarnrolle.radius_m > 0
-        ? ownGarnrolle.radius_m
-        : 250;
-  }
-
+  $: activeAccountId =
+    $authStore.authenticated && $authStore.account_id
+      ? $authStore.account_id
+      : null;
+  $: canEdit = $authStore.role === "weber" || $authStore.role === "admin";
+  $: canSave =
+    canEdit &&
+    !!ownGarnrolle &&
+    !!displayName.trim() &&
+    !isLoadingProfile &&
+    !isSaving &&
+    (visibilityChoice === "not_on_map" ||
+      (!!address.trim() && selectedLocation !== null));
   $: mapHref = ownGarnrolle?.public_pos
     ? `/map?focus=garnrolle:${ownGarnrolle.id}`
     : "/map";
+
+  $: if (activeAccountId && activeAccountId !== profileKey) {
+    profileKey = activeAccountId;
+    void loadPrivateProfile(activeAccountId);
+  }
+  $: if (!activeAccountId && profileKey) {
+    profileKey = "";
+    resetDraft();
+  }
+
+  function splitList(value: string): string[] {
+    return value
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter((entry, index, all) => entry && all.indexOf(entry) === index);
+  }
+
+  function categoryValues(tags: string[], prefix: string): string[] {
+    return tags
+      .filter((tag) => tag.startsWith(prefix))
+      .map((tag) => tag.slice(prefix.length))
+      .filter(Boolean);
+  }
+
+  function profileSkills(tags: string[]): string[] {
+    const prefixed = categoryValues(tags, "skill:");
+    const legacy = tags.filter(
+      (tag) =>
+        tag !== "account" &&
+        tag !== "garnrolle" &&
+        !tag.startsWith("skill:") &&
+        !tag.startsWith("good:") &&
+        !tag.startsWith("interest:"),
+    );
+    return [...prefixed, ...legacy].filter(
+      (entry, index, all) => all.indexOf(entry) === index,
+    );
+  }
+
+  function draftStorageKey(accountId: string): string {
+    return `weltgewebe:garnrolle-draft:${accountId}`;
+  }
+
+  function currentDraft(): GarnrolleDraft {
+    return {
+      displayName,
+      summary,
+      skills,
+      goods,
+      interests,
+      address,
+      visibilityChoice,
+      radiusM,
+      selectedLocation,
+    };
+  }
+
+  function applyDraft(draft: Partial<GarnrolleDraft>) {
+    if (typeof draft.displayName === "string") displayName = draft.displayName;
+    if (typeof draft.summary === "string") summary = draft.summary;
+    if (typeof draft.skills === "string") skills = draft.skills;
+    if (typeof draft.goods === "string") goods = draft.goods;
+    if (typeof draft.interests === "string") interests = draft.interests;
+    if (typeof draft.address === "string") address = draft.address;
+    if (
+      draft.visibilityChoice === "not_on_map" ||
+      draft.visibilityChoice === "exact" ||
+      draft.visibilityChoice === "radius"
+    ) {
+      visibilityChoice = draft.visibilityChoice;
+    }
+    if (typeof draft.radiusM === "number" && Number.isFinite(draft.radiusM)) {
+      radiusM = draft.radiusM;
+    }
+    if (
+      draft.selectedLocation === null ||
+      (typeof draft.selectedLocation?.lat === "number" &&
+        typeof draft.selectedLocation?.lon === "number")
+    ) {
+      selectedLocation = draft.selectedLocation ?? null;
+    }
+  }
+
+  function resetDraft() {
+    displayName = "";
+    summary = "";
+    skills = "";
+    goods = "";
+    interests = "";
+    address = "";
+    visibilityChoice = "not_on_map";
+    radiusM = 250;
+    selectedLocation = null;
+    profileError = null;
+    saveMessage = null;
+  }
+
+  function applyProfile(profile: OwnGarnrolleProfile) {
+    displayName = profile.title;
+    summary = profile.summary ?? "";
+    skills = profileSkills(profile.tags).join(", ");
+    goods = categoryValues(profile.tags, "good:").join(", ");
+    interests = categoryValues(profile.tags, "interest:").join(", ");
+    address = profile.address ?? "";
+    visibilityChoice = profile.map_state;
+    radiusM = profile.radius_m > 0 ? profile.radius_m : 250;
+    selectedLocation = profile.location ?? null;
+  }
+
+  function returnedMapLocation(accountId: string): Location | null {
+    if (!browser) return null;
+    const key = `weltgewebe:garnrolle-return-location:${accountId}`;
+    const stored = sessionStorage.getItem(key);
+    sessionStorage.removeItem(key);
+    if (!stored) return null;
+    try {
+      const value = JSON.parse(stored) as Partial<Location>;
+      const lat = value.lat;
+      const lon = value.lon;
+      if (
+        typeof lat !== "number" ||
+        typeof lon !== "number" ||
+        !Number.isFinite(lat) ||
+        !Number.isFinite(lon) ||
+        lat < -90 ||
+        lat > 90 ||
+        lon < -180 ||
+        lon > 180
+      ) {
+        return null;
+      }
+      return { lat, lon };
+    } catch {
+      return null;
+    }
+  }
+
+  async function loadPrivateProfile(accountId: string) {
+    isLoadingProfile = true;
+    profileError = null;
+    saveMessage = null;
+    try {
+      const profile = await getOwnGarnrolleProfile();
+      if (profile.id !== accountId) {
+        throw new Error("profile-account-mismatch");
+      }
+      applyProfile(profile);
+
+      if (browser) {
+        const stored = sessionStorage.getItem(draftStorageKey(accountId));
+        if (stored) {
+          try {
+            applyDraft(JSON.parse(stored) as Partial<GarnrolleDraft>);
+          } catch {
+            sessionStorage.removeItem(draftStorageKey(accountId));
+          }
+        }
+      }
+      const returned = returnedMapLocation(accountId);
+      if (returned) {
+        selectedLocation = returned;
+        saveMessage =
+          "Kartenpunkt übernommen. Prüfe Adresse und Sichtbarkeit und speichere anschließend.";
+      }
+    } catch (error) {
+      if (error instanceof ApiRequestError && error.status === 401) {
+        profileError =
+          "Deine Sitzung ist abgelaufen. Bitte melde dich erneut an.";
+      } else {
+        profileError =
+          "Deine Garnrolle konnte nicht vollständig geladen werden. Bitte lade die Seite neu.";
+      }
+    } finally {
+      isLoadingProfile = false;
+    }
+  }
+
+  function saveDraftForMap() {
+    if (!browser || !activeAccountId) return;
+    sessionStorage.setItem(
+      draftStorageKey(activeAccountId),
+      JSON.stringify(currentDraft()),
+    );
+  }
+
+  async function chooseMapLocation() {
+    saveMessage = null;
+    profileError = null;
+    saveDraftForMap();
+    await goto("/map?compose=garnrolle");
+  }
+
+  function profileTags(): string[] {
+    return [
+      ...splitList(skills).map((tag) => `skill:${tag}`),
+      ...splitList(goods).map((tag) => `good:${tag}`),
+      ...splitList(interests).map((tag) => `interest:${tag}`),
+    ];
+  }
+
+  function describeSaveError(error: unknown): string {
+    if (error instanceof ApiRequestError) {
+      if (error.status === 401) {
+        return "Deine Sitzung ist abgelaufen. Bitte melde dich erneut an.";
+      }
+      if (error.status === 403) {
+        return "Dein Konto darf die Garnrolle derzeit nicht bearbeiten.";
+      }
+      if (error.status === 400) {
+        return "Bitte prüfe Name, Adresse, Kartenpunkt und Sichtbarkeit.";
+      }
+    }
+    return "Die Garnrolle konnte nicht gespeichert werden. Bitte versuche es erneut.";
+  }
+
+  async function handleSave(event: SubmitEvent) {
+    event.preventDefault();
+    profileError = null;
+    saveMessage = null;
+    if (!canSave || !activeAccountId) return;
+
+    isSaving = true;
+    try {
+      await updateOwnGarnrolle({
+        title: displayName.trim(),
+        summary: summary.trim() || undefined,
+        tags: profileTags(),
+        address: address.trim() || undefined,
+        location: selectedLocation ?? undefined,
+        map_state: visibilityChoice,
+        radius_m: visibilityChoice === "radius" ? radiusM : undefined,
+      });
+      if (browser) {
+        sessionStorage.removeItem(draftStorageKey(activeAccountId));
+      }
+      await invalidateAll();
+      saveMessage = "Deine Garnrolle wurde gespeichert.";
+      await goto("/settings#meine-garnrolle", {
+        replaceState: true,
+        noScroll: true,
+        keepFocus: true,
+      });
+    } catch (error) {
+      profileError = describeSaveError(error);
+    } finally {
+      isSaving = false;
+    }
+  }
 </script>
 
 <section
@@ -78,10 +344,9 @@
             Garnrollen-Daten konnten nicht geladen werden: {accountsLoadError}
           </p>
         {:else if !ownGarnrolle}
-          <p class="muted">
-            Deine Sitzung ist aktiv. Es gibt noch keinen öffentlichen
-            Garnrollen-Datensatz für diesen Account. Produktsprachlich heißt
-            das: Die Garnrolle ist angelegt, aber noch nicht auf der Karte.
+          <p class="warn">
+            Deine Sitzung ist aktiv, aber der zugehörige Garnrollen-Datensatz
+            fehlt. Speichern ist deshalb gesperrt.
           </p>
         {/if}
       </div>
@@ -95,18 +360,28 @@
       </a>
     </div>
 
-    <form class="garnrolle-form" aria-describedby="my-garnrolle-save-note">
-      <fieldset>
+    <form
+      class="garnrolle-form"
+      aria-describedby="my-garnrolle-save-note"
+      on:submit={handleSave}
+    >
+      <fieldset disabled={isLoadingProfile || isSaving}>
         <legend>Garnrolle beschreiben</legend>
         <label>
           Anzeigename
-          <input bind:value={displayName} placeholder="Meine Garnrolle" />
+          <input
+            bind:value={displayName}
+            placeholder="Meine Garnrolle"
+            maxlength="160"
+            required
+          />
         </label>
         <label>
           Kurzbeschreibung
           <textarea
             bind:value={summary}
             rows="3"
+            maxlength="2000"
             placeholder="Was bringst du ins Gewebe ein?"></textarea>
         </label>
         <label>
@@ -132,11 +407,15 @@
         </label>
       </fieldset>
 
-      <fieldset>
+      <fieldset disabled={isLoadingProfile || isSaving}>
         <legend>Garnrolle auf Karte setzen</legend>
         <label>
           Adresse
-          <input bind:value={address} placeholder="Poelsweg 2, Hamburg" />
+          <input
+            bind:value={address}
+            maxlength="500"
+            placeholder="Straße, Hausnummer, Ort"
+          />
         </label>
 
         <div class="radio-group" role="radiogroup" aria-label="Sichtbarkeit">
@@ -155,20 +434,53 @@
             <input type="radio" bind:group={visibilityChoice} value="exact" />
             <span>
               <strong>Exakt sichtbar</strong>
-              <small
-                >Die angegebene Position wird sichtbar. Das ist ein regulärer
-                positiver Fall.</small
-              >
+              <small>Der von dir gewählte Kartenpunkt wird öffentlich.</small>
             </span>
           </label>
           <label class="radio-card">
             <input type="radio" bind:group={visibilityChoice} value="radius" />
             <span>
               <strong>Im Umkreis sichtbar</strong>
-              <small>Die Garnrolle erscheint nur ungefähr.</small>
+              <small>
+                Die öffentliche Position wird innerhalb des gewählten Umkreises
+                versetzt.
+              </small>
             </span>
           </label>
         </div>
+
+        {#if visibilityChoice !== "not_on_map"}
+          <div class="location-card" data-testid="garnrolle-location-state">
+            {#if selectedLocation}
+              <div>
+                <strong>Kartenpunkt gewählt</strong>
+                <small>
+                  {selectedLocation.lat.toFixed(5)},
+                  {selectedLocation.lon.toFixed(5)}
+                </small>
+              </div>
+              <button type="button" class="btn" on:click={chooseMapLocation}>
+                Kartenpunkt ändern
+              </button>
+            {:else}
+              <div>
+                <strong>Noch kein Kartenpunkt gewählt</strong>
+                <small>
+                  Die Adresse wird nicht automatisch in eine Position
+                  umgewandelt. Wähle den passenden Punkt selbst auf der Karte.
+                </small>
+              </div>
+              <button
+                type="button"
+                class="btn btn-primary"
+                on:click={chooseMapLocation}
+                data-testid="choose-garnrolle-location"
+              >
+                Ort auf Karte wählen
+              </button>
+            {/if}
+          </div>
+        {/if}
 
         {#if visibilityChoice === "radius"}
           <label>
@@ -184,14 +496,53 @@
         {/if}
       </fieldset>
 
-      <div class="actions">
-        <button type="button" class="btn btn-primary" disabled>Speichern</button
+      {#if !canEdit}
+        <p
+          class="form-message error"
+          role="alert"
+          data-testid="garnrolle-role-warning"
         >
+          Dein Konto besitzt noch keine Weber-Berechtigung. Die Garnrolle kann
+          deshalb nicht gespeichert werden.
+        </p>
+      {/if}
+
+      {#if profileError}
+        <p
+          class="form-message error"
+          role="alert"
+          data-testid="garnrolle-error"
+        >
+          {profileError}
+        </p>
+      {/if}
+      {#if saveMessage}
+        <p
+          class="form-message success"
+          role="status"
+          data-testid="garnrolle-success"
+        >
+          {saveMessage}
+        </p>
+      {/if}
+
+      <div class="actions">
+        <button
+          type="submit"
+          class="btn btn-primary"
+          disabled={!canSave}
+          data-testid="save-garnrolle"
+        >
+          {isSaving ? "Wird gespeichert…" : "Speichern"}
+        </button>
         <a class="btn" href="/map?compose=node">Ersten Knoten weben</a>
       </div>
       <p id="my-garnrolle-save-note" class="muted">
-        Dieser Schnitt baut die Oberfläche und Semantik. Persistenz für Profil
-        und Verortung folgt im nächsten API-Schnitt.
+        Öffentlich sind Anzeigename, Kurzbeschreibung, Fähigkeiten, Güter und
+        Interessen. Deine Adresse bleibt privat. Bei „Exakt sichtbar“ ist der
+        gewählte Kartenpunkt öffentlich; bei „Im Umkreis sichtbar“ nur eine
+        versetzte Näherung; bei „Noch nicht auf der Karte“ keine Position.
+        Adresse und Kartenpunkt werden nicht automatisch abgeglichen.
       </p>
     </form>
   {/if}
@@ -244,7 +595,8 @@
   }
 
   .status-card,
-  .empty-card {
+  .empty-card,
+  .location-card {
     border: 1px solid var(--panel-border, rgba(255, 255, 255, 0.08));
     border-radius: 12px;
     display: flex;
@@ -256,6 +608,18 @@
   .status-card p,
   .empty-card p {
     margin: 0.35rem 0 0;
+  }
+
+  .location-card {
+    align-items: center;
+  }
+
+  .location-card small {
+    color: var(--muted, #9aa4b2);
+    display: block;
+    font-weight: 400;
+    margin-top: 0.25rem;
+    max-width: 34rem;
   }
 
   .warn {
@@ -324,6 +688,22 @@
     margin-top: 0.25rem;
   }
 
+  .form-message {
+    border-radius: 8px;
+    margin: 0;
+    padding: 0.8rem 1rem;
+  }
+
+  .form-message.error {
+    background: rgba(255, 107, 107, 0.12);
+    border: 1px solid #ff6b6b;
+  }
+
+  .form-message.success {
+    background: rgba(84, 225, 166, 0.12);
+    border: 1px solid rgba(84, 225, 166, 0.7);
+  }
+
   .actions {
     display: flex;
     flex-wrap: wrap;
@@ -359,7 +739,8 @@
   @media (max-width: 640px) {
     .section-head,
     .status-card,
-    .empty-card {
+    .empty-card,
+    .location-card {
       display: grid;
     }
   }

--- a/apps/web/src/lib/components/panels/AccountPanel.svelte
+++ b/apps/web/src/lib/components/panels/AccountPanel.svelte
@@ -34,6 +34,35 @@
 
   $: accountDetails = $accountDetailsStore;
   $: isLoadingDetails = $isLoadingDetailsStore;
+  $: profileTags = (accountDetails?.tags || $selection?.data?.tags || []) as string[];
+  $: skills = categoryValues(profileTags, 'skill:', true);
+  $: goods = categoryValues(profileTags, 'good:');
+  $: interests = categoryValues(profileTags, 'interest:');
+  $: otherTags = profileTags.filter(
+    (tag) =>
+      tag.includes(':') &&
+      !tag.startsWith('skill:') &&
+      !tag.startsWith('good:') &&
+      !tag.startsWith('interest:')
+  );
+
+  function categoryValues(tags: string[], prefix: string, includeLegacy = false): string[] {
+    const values = tags
+      .filter((tag) => tag.startsWith(prefix))
+      .map((tag) => tag.slice(prefix.length))
+      .filter(Boolean);
+    if (includeLegacy) {
+      values.push(
+        ...tags.filter(
+          (tag) =>
+            tag !== 'account' &&
+            tag !== 'garnrolle' &&
+            !tag.includes(':')
+        )
+      );
+    }
+    return values.filter((value, index, all) => all.indexOf(value) === index);
+  }
 
   const tabs = ['profil', 'aktivitaet', 'knoten'];
 
@@ -120,12 +149,18 @@
           <p><strong>Art:</strong> {accountDetails?.type || $selection?.data?.type}</p>
         {/if}
 
-        {#if (accountDetails?.tags || $selection?.data?.tags)?.length > 0}
-          <p><strong>Tags:</strong> {(accountDetails?.tags || $selection?.data?.tags).join(', ')}</p>
+        {#if skills.length > 0}
+          <p><strong>Fähigkeiten:</strong> {skills.join(', ')}</p>
         {/if}
-
-        <p><strong>Kompetenzen:</strong> Noch nicht hinterlegt.</p>
-        <p><strong>Vergemeinschaftete Güter:</strong> Noch nicht hinterlegt.</p>
+        {#if goods.length > 0}
+          <p><strong>Güter:</strong> {goods.join(', ')}</p>
+        {/if}
+        {#if interests.length > 0}
+          <p><strong>Interessen:</strong> {interests.join(', ')}</p>
+        {/if}
+        {#if otherTags.length > 0}
+          <p><strong>Weitere Tags:</strong> {otherTags.join(', ')}</p>
+        {/if}
       </div>
 
     {:else if activeTab === 'aktivitaet'}

--- a/apps/web/src/lib/components/panels/KompositionPanel.svelte
+++ b/apps/web/src/lib/components/panels/KompositionPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { invalidateAll } from '$app/navigation';
+  import { browser } from '$app/environment';
+  import { goto, invalidateAll } from '$app/navigation';
   import { kompositionDraft, lastCreatedNodeId, leaveToNavigation, systemState } from '$lib/stores/uiView';
   import { authStore } from '$lib/auth/store';
   import { createEdge, createNode, ApiRequestError } from '$lib/api/domainWrites';
@@ -22,9 +23,27 @@
   let edgeError: string | null = null;
 
   $: canWrite = $authStore.role === 'weber' || $authStore.role === 'admin';
+  $: placingGarnrolle = $kompositionDraft?.mode === 'place-garnrolle';
   $: canSubmit = !!$kompositionDraft?.lngLat && !!title.trim() && !!address.trim();
 
+  async function returnToGarnrolleSettings(withLocation: boolean) {
+    const location = withLocation ? $kompositionDraft?.lngLat : undefined;
+    const accountId = $authStore.account_id;
+    if (browser && location && accountId) {
+      sessionStorage.setItem(
+        `weltgewebe:garnrolle-return-location:${accountId}`,
+        JSON.stringify({ lat: location[1], lon: location[0] })
+      );
+    }
+    leaveToNavigation();
+    await goto('/settings#meine-garnrolle');
+  }
+
   function handleCancel() {
+    if (placingGarnrolle) {
+      void returnToGarnrolleSettings(false);
+      return;
+    }
     if (createdNodeId) {
       // The node already exists — closing the panel must not hide that.
       void finalizeSuccess(createdNodeId);
@@ -143,6 +162,48 @@
     </div>
     <div class="actions">
       <button type="button" class="btn btn-secondary" on:click={handleCancel}>Schließen</button>
+    </div>
+  {:else if placingGarnrolle}
+    <div data-testid="garnrolle-placement">
+      {#if $kompositionDraft?.lngLat}
+        <div class="state-set">
+          <p><strong>Kartenpunkt gewählt</strong></p>
+          <p>
+            {$kompositionDraft.lngLat[1].toFixed(5)},
+            {$kompositionDraft.lngLat[0].toFixed(5)}
+          </p>
+          <p class="ghost">
+            Prüfe, ob dieser Punkt zu deiner Adresse passt. Erst in den
+            Einstellungen wird die Garnrolle gespeichert.
+          </p>
+        </div>
+      {:else}
+        <div class="state-pending">
+          <p><strong>Kartenpunkt ausstehend</strong></p>
+          <p>
+            Drücke etwa eine Sekunde auf den gewünschten Ort der Karte. Du
+            kannst den Punkt danach bestätigen oder erneut setzen.
+          </p>
+        </div>
+      {/if}
+      <div class="actions">
+        <button
+          type="button"
+          class="btn btn-secondary"
+          on:click={() => returnToGarnrolleSettings(false)}
+        >
+          Abbrechen
+        </button>
+        <button
+          type="button"
+          class="btn btn-primary"
+          disabled={!$kompositionDraft?.lngLat}
+          on:click={() => returnToGarnrolleSettings(true)}
+          data-testid="confirm-garnrolle-location"
+        >
+          Diesen Punkt übernehmen
+        </button>
+      </div>
     </div>
   {:else if createdNodeId && edgeError}
     <div class="state-set">

--- a/apps/web/src/lib/map/overlay/komposition.ts
+++ b/apps/web/src/lib/map/overlay/komposition.ts
@@ -4,7 +4,7 @@ import type {
   MapTouchEvent,
 } from "maplibre-gl";
 import { get } from "svelte/store";
-import { enterKomposition } from "$lib/stores/uiView";
+import { enterKomposition, kompositionDraft } from "$lib/stores/uiView";
 import { authStore } from "$lib/auth/store";
 
 /**
@@ -12,7 +12,7 @@ import { authStore } from "$lib/auth/store";
  * must not open an apparently-functional composition panel — it silently
  * does nothing, exactly like the (hidden) "Neuer Knoten" action-bar button.
  */
-function canCreateNode(): boolean {
+function canComposeOnMap(): boolean {
   const role = get(authStore).role;
   return role === "weber" || role === "admin";
 }
@@ -35,13 +35,16 @@ export function setupKompositionInteraction(map: MapLibreMap) {
       e.originalEvent.target instanceof HTMLElement &&
       e.originalEvent.target.closest(".map-marker");
     if (markerClicked) return;
-    if (!canCreateNode()) return;
+    if (!canComposeOnMap()) return;
 
     longPressStartX = e.point.x;
     longPressStartY = e.point.y;
     longPressTimer = setTimeout(() => {
       enterKomposition({
-        mode: "new-knoten",
+        mode:
+          get(kompositionDraft)?.mode === "place-garnrolle"
+            ? "place-garnrolle"
+            : "new-knoten",
         lngLat: [e.lngLat.lng, e.lngLat.lat],
         source: "map-longpress",
       });
@@ -65,13 +68,16 @@ export function setupKompositionInteraction(map: MapLibreMap) {
       e.originalEvent.target instanceof HTMLElement &&
       e.originalEvent.target.closest(".map-marker");
     if (markerClicked) return;
-    if (!canCreateNode()) return;
+    if (!canComposeOnMap()) return;
 
     longPressStartX = e.point.x;
     longPressStartY = e.point.y;
     longPressTimer = setTimeout(() => {
       enterKomposition({
-        mode: "new-knoten",
+        mode:
+          get(kompositionDraft)?.mode === "place-garnrolle"
+            ? "place-garnrolle"
+            : "new-knoten",
         lngLat: [e.lngLat.lng, e.lngLat.lat],
         source: "map-longpress",
       });

--- a/apps/web/src/lib/map/scene.test.ts
+++ b/apps/web/src/lib/map/scene.test.ts
@@ -70,7 +70,7 @@ describe("buildMapScene", () => {
   it("transforms accounts with public_pos into entities", () => {
     const scene = buildMapScene({
       nodes: [],
-      accounts: [makeAccount()],
+      accounts: [makeAccount({ tags: ["skill:Kochen", "interest:Commons"] })],
       edges: [],
       loadState: "ok",
       resourceStatus: [{ resource: "accounts", status: "ok" }],
@@ -82,6 +82,10 @@ describe("buildMapScene", () => {
     expect(scene.entities[0].type).toBe("garnrolle");
     expect(scene.entities[0].lat).toBe(53.56);
     expect(scene.entities[0].lon).toBe(10.06);
+    expect(scene.entities[0].tags).toEqual([
+      "skill:Kochen",
+      "interest:Commons",
+    ]);
   });
 
   it("excludes Garnrollen without a public position", () => {

--- a/apps/web/src/lib/map/scene.ts
+++ b/apps/web/src/lib/map/scene.ts
@@ -90,6 +90,7 @@ function mapAccountsToEntities(accounts: Account[]): MapEntityGarnrolle[] {
         lat: a.public_pos.lat,
         lon: a.public_pos.lon,
         summary: a.summary,
+        tags: a.tags,
         modules: a.modules,
         created_at: a.created_at,
       });

--- a/apps/web/src/lib/map/urlState.test.ts
+++ b/apps/web/src/lib/map/urlState.test.ts
@@ -142,6 +142,10 @@ describe("parseMapUrlState", () => {
     expect(parse("compose=node").compose).toBe("node");
   });
 
+  it("accepts compose=garnrolle", () => {
+    expect(parse("compose=garnrolle").compose).toBe("garnrolle");
+  });
+
   it("records compose=edge as invalid", () => {
     const result = parse("compose=edge");
     expect(result.compose).toBeNull();

--- a/apps/web/src/lib/map/urlState.ts
+++ b/apps/web/src/lib/map/urlState.ts
@@ -19,6 +19,7 @@
  *  - `focus=account:<id>`     → alias for `garnrolle:<id>`
  *  - `lens=filter|search`     → open a filter/search lens
  *  - `compose=node`           → enter node composition
+ *  - `compose=garnrolle`      → choose the own Garnrolle map point
  *  - `tab=<tab>`              → tolerated parser-side only (not wired to UI tabs)
  */
 
@@ -33,8 +34,8 @@ export type MapUrlFocus = {
 /** Lenses that can be opened from the URL. */
 export type MapUrlLens = "filter" | "search";
 
-/** Composition modes addressable via the URL (first slice: node only). */
-export type MapUrlCompose = "node";
+/** Composition modes addressable via the URL. */
+export type MapUrlCompose = "node" | "garnrolle";
 
 export type ParsedMapUrlState = {
   focus: MapUrlFocus | null;
@@ -93,11 +94,11 @@ export function isSupportedLens(value: string | null): value is MapUrlLens {
   return value === "filter" || value === "search";
 }
 
-/** Type guard: is the value a supported composition mode (`node`)? */
+/** Type guard: is the value a supported composition mode? */
 export function isSupportedCompose(
   value: string | null,
 ): value is MapUrlCompose {
-  return value === "node";
+  return value === "node" || value === "garnrolle";
 }
 
 /** Records a known key as invalid at most once (order of first sighting). */

--- a/apps/web/src/lib/panels/panelDetails.test.ts
+++ b/apps/web/src/lib/panels/panelDetails.test.ts
@@ -57,10 +57,10 @@ async function flushMicrotasks() {
 }
 
 describe("buildPanelEndpoint", () => {
-  it("returns the singular local endpoint when no apiBase is given", () => {
-    expect(buildPanelEndpoint("node", "abc", "")).toBe("/api/node/abc");
-    expect(buildPanelEndpoint("account", "x", "")).toBe("/api/account/x");
-    expect(buildPanelEndpoint("edge", "1", "")).toBe("/api/edge/1");
+  it("returns the plural local endpoint exposed by the API router", () => {
+    expect(buildPanelEndpoint("node", "abc", "")).toBe("/api/nodes/abc");
+    expect(buildPanelEndpoint("account", "x", "")).toBe("/api/accounts/x");
+    expect(buildPanelEndpoint("edge", "1", "")).toBe("/api/edges/1");
   });
 
   it("returns the plural remote endpoint when apiBase is set", () => {

--- a/apps/web/src/lib/panels/panelDetails.ts
+++ b/apps/web/src/lib/panels/panelDetails.ts
@@ -117,8 +117,9 @@ export function buildPanelEndpoint(
   apiBase?: string,
 ): string {
   const base = apiBase ?? import.meta.env.PUBLIC_GEWEBE_API_BASE ?? "";
+  const resourcePath = `${resource}s`;
   if (base) {
-    return `${base}/api/${resource}s/${id}`;
+    return `${base}/api/${resourcePath}/${id}`;
   }
-  return `/api/${resource}/${id}`;
+  return `/api/${resourcePath}/${id}`;
 }

--- a/apps/web/src/lib/stores/uiView.ts
+++ b/apps/web/src/lib/stores/uiView.ts
@@ -64,7 +64,7 @@ export const contextPanelOpen = derived(
 );
 
 export type KompositionDraft = {
-  mode: "new-knoten";
+  mode: "new-knoten" | "place-garnrolle";
   lngLat?: [number, number];
   source: "map-longpress" | "action-bar";
 } | null;

--- a/apps/web/src/routes/map/+page.svelte
+++ b/apps/web/src/routes/map/+page.svelte
@@ -152,10 +152,13 @@
   }
 
   function applyImmediateMapUrlAddressing(parsed: ParsedMapUrlState) {
-    if (parsed.compose === 'node') {
+    if (parsed.compose) {
       closeSearch();
       closeFilter();
-      enterKomposition({ mode: 'new-knoten', source: 'action-bar' });
+      enterKomposition({
+        mode: parsed.compose === 'garnrolle' ? 'place-garnrolle' : 'new-knoten',
+        source: 'action-bar'
+      });
       return;
     }
     // A valid focus takes precedence: leave stale focus/composition and close
@@ -213,7 +216,7 @@
       applyImmediateMapUrlAddressing(parsed);
       // compose is final; without a valid focus there is nothing for the focus
       // pass to do. Either way the focus lock is satisfied for this query.
-      if (parsed.compose === 'node' || !parsed.focus) {
+      if (parsed.compose || !parsed.focus) {
         lastResolvedFocusUrlSearch = search;
       }
     }

--- a/apps/web/tests/fixtures/mockApi.ts
+++ b/apps/web/tests/fixtures/mockApi.ts
@@ -73,6 +73,16 @@ export async function mockApiResponses(
   // mirroring the real API's persist-then-cache-then-readable contract.
   const createdNodes: Record<string, unknown>[] = [];
   const createdEdges: Record<string, unknown>[] = [];
+  const mockAccounts = demoAccounts.map((account) => ({ ...account }));
+  const privateProfiles = new Map(
+    mockAccounts.map((account) => [
+      account.id,
+      {
+        address: "",
+        location: account.location ? { ...account.location } : null,
+      },
+    ]),
+  );
   let nextNodeId = 1;
   let nextEdgeId = 1;
 
@@ -135,11 +145,102 @@ export async function mockApiResponses(
       });
     }
 
+    if (url.endsWith("/api/accounts/me/profile")) {
+      if (!isAuthenticated || !currentAccountId) {
+        return route.fulfill({ status: 401 });
+      }
+      const account = mockAccounts.find((item) => item.id === currentAccountId);
+      if (!account) {
+        return route.fulfill({ status: 404 });
+      }
+      const privateProfile = privateProfiles.get(currentAccountId) ?? {
+        address: "",
+        location: null,
+      };
+      if (method === "PATCH") {
+        const payload = route.request().postDataJSON() as Record<
+          string,
+          unknown
+        >;
+        const mapState = payload.map_state;
+        const location = payload.location as
+          | { lat?: unknown; lon?: unknown }
+          | undefined;
+        if (
+          typeof payload.title !== "string" ||
+          !payload.title.trim() ||
+          (mapState !== "not_on_map" &&
+            mapState !== "exact" &&
+            mapState !== "radius") ||
+          (mapState !== "not_on_map" &&
+            (typeof location?.lat !== "number" ||
+              typeof location?.lon !== "number"))
+        ) {
+          return route.fulfill({ status: 400 });
+        }
+        account.title = payload.title.trim();
+        account.summary =
+          typeof payload.summary === "string" ? payload.summary : "";
+        account.tags = Array.isArray(payload.tags)
+          ? payload.tags.filter((tag): tag is string => typeof tag === "string")
+          : [];
+        account.map_state = mapState;
+        account.radius_m =
+          mapState === "radius" && typeof payload.radius_m === "number"
+            ? payload.radius_m
+            : 0;
+        if (location) {
+          privateProfile.location = {
+            lat: location.lat as number,
+            lon: location.lon as number,
+          };
+        }
+        privateProfile.address =
+          typeof payload.address === "string" ? payload.address : "";
+        if (mapState === "not_on_map") {
+          delete account.public_pos;
+        } else if (privateProfile.location) {
+          account.public_pos = { ...privateProfile.location };
+        }
+        privateProfiles.set(currentAccountId, privateProfile);
+      } else if (method !== "GET") {
+        return route.fulfill({ status: 405 });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: account.id,
+          title: account.title,
+          summary: account.summary,
+          tags: account.tags,
+          address: privateProfile.address || undefined,
+          location: privateProfile.location || undefined,
+          map_state: account.map_state ?? "not_on_map",
+          radius_m: account.radius_m ?? 0,
+        }),
+      });
+    }
+
+    const accountDetailMatch = new URL(url).pathname.match(
+      /^\/api\/accounts\/([^/]+)$/,
+    );
+    if (accountDetailMatch && method === "GET") {
+      const account = mockAccounts.find(
+        (item) => item.id === decodeURIComponent(accountDetailMatch[1]),
+      );
+      return route.fulfill({
+        status: account ? 200 : 404,
+        contentType: "application/json",
+        body: JSON.stringify(account ?? { error: "account not found" }),
+      });
+    }
+
     if (url.endsWith("/api/accounts")) {
       return route.fulfill({
         status: 200,
         contentType: "application/json",
-        body: JSON.stringify(demoAccounts),
+        body: JSON.stringify(mockAccounts),
       });
     }
 

--- a/apps/web/tests/garnrolle-self-service.spec.ts
+++ b/apps/web/tests/garnrolle-self-service.spec.ts
@@ -1,0 +1,263 @@
+import { expect, test, type Page } from "@playwright/test";
+import { mockApiResponses } from "./fixtures/mockApi";
+
+const ACCOUNT_ID = "00000000-0000-0000-0000-000000000003";
+
+async function openSettingsAsWeber(page: Page) {
+  await mockApiResponses(page, {
+    auth: {
+      authenticated: true,
+      account_id: ACCOUNT_ID,
+      role: "weber",
+    },
+  });
+  const profileResponse = page.waitForResponse((response) =>
+    response.url().endsWith("/api/accounts/me/profile"),
+  );
+  await page.goto("/settings#meine-garnrolle");
+  expect((await profileResponse).status()).toBe(200);
+  const section = page.locator('[data-testid="my-garnrolle-section"]');
+  await expect(section).toBeVisible();
+  await expect(section.getByLabel("Anzeigename")).not.toHaveValue("");
+  await expect(section.locator('[data-testid="save-garnrolle"]')).toBeEnabled();
+  return section;
+}
+
+async function longPressMapCenter(page: Page) {
+  const map = page.locator("#map");
+  await expect(map).toBeVisible();
+  await map.hover({ position: { x: 50, y: 50 } });
+  await page.mouse.down();
+  await page.waitForTimeout(950);
+  await page.mouse.up();
+}
+
+test.describe("Eigene Garnrolle speichern", () => {
+  test("clears sensitive Garnrolle drafts on logout", async ({ page }) => {
+    await mockApiResponses(page, {
+      auth: {
+        authenticated: true,
+        account_id: ACCOUNT_ID,
+        role: "weber",
+      },
+    });
+    await page.goto("/settings#meine-garnrolle");
+    await page.evaluate((accountId) => {
+      sessionStorage.setItem(
+        `weltgewebe:garnrolle-draft:${accountId}`,
+        JSON.stringify({ address: "private draft" }),
+      );
+      sessionStorage.setItem(
+        "weltgewebe:garnrolle-draft:previous-account",
+        JSON.stringify({ address: "stale private draft" }),
+      );
+      sessionStorage.setItem("weltgewebe:unrelated-test", "keep");
+    }, ACCOUNT_ID);
+    await page.reload();
+    await expect(
+      page.locator('[data-testid="account-section-status"]'),
+    ).toBeVisible();
+    const afterAuthenticatedReload = await page.evaluate(
+      (accountId) => ({
+        current: sessionStorage.getItem(
+          `weltgewebe:garnrolle-draft:${accountId}`,
+        ),
+        previous: sessionStorage.getItem(
+          "weltgewebe:garnrolle-draft:previous-account",
+        ),
+      }),
+      ACCOUNT_ID,
+    );
+    expect(afterAuthenticatedReload.current).not.toBeNull();
+    expect(afterAuthenticatedReload.previous).toBeNull();
+    await page.evaluate((accountId) => {
+      sessionStorage.setItem(
+        `weltgewebe:garnrolle-return-location:${accountId}`,
+        JSON.stringify({ lat: 53.5, lon: 10.0 }),
+      );
+    }, ACCOUNT_ID);
+
+    await page.locator('[data-testid="account-section-logout"]').click();
+    await expect(
+      page.locator('[data-testid="account-section-anonymous"]'),
+    ).toBeVisible();
+    const remaining = await page.evaluate(
+      (accountId) => ({
+        draft: sessionStorage.getItem(
+          `weltgewebe:garnrolle-draft:${accountId}`,
+        ),
+        location: sessionStorage.getItem(
+          `weltgewebe:garnrolle-return-location:${accountId}`,
+        ),
+        unrelated: sessionStorage.getItem("weltgewebe:unrelated-test"),
+      }),
+      ACCOUNT_ID,
+    );
+    expect(remaining).toEqual({
+      draft: null,
+      location: null,
+      unrelated: "keep",
+    });
+  });
+
+  test("keeps the form read-only for a guest account", async ({ page }) => {
+    await mockApiResponses(page, {
+      auth: {
+        authenticated: true,
+        account_id: ACCOUNT_ID,
+        role: "gast",
+      },
+    });
+    await page.goto("/settings#meine-garnrolle");
+    const section = page.locator('[data-testid="my-garnrolle-section"]');
+    await expect(
+      section.locator('[data-testid="garnrolle-role-warning"]'),
+    ).toContainText("keine Weber-Berechtigung");
+    await expect(
+      section.locator('[data-testid="save-garnrolle"]'),
+    ).toBeDisabled();
+  });
+
+  test("saves a not-on-map profile and reloads the persisted values", async ({
+    page,
+  }) => {
+    const section = await openSettingsAsWeber(page);
+    const save = section.locator('[data-testid="save-garnrolle"]');
+
+    await section.getByLabel("Anzeigename").fill("Alex im Weltgewebe");
+    await section
+      .getByLabel("Kurzbeschreibung")
+      .fill("Ich beginne meine Garnrolle selbst.");
+    await section.getByLabel("Fähigkeiten").fill("Organisation, Kochen");
+    await section.getByLabel("Güter").fill("Werkzeug");
+    await section.getByLabel("Interessen").fill("Commons");
+    await section.getByLabel("Noch nicht auf der Karte").check();
+    await expect(save).toBeEnabled();
+
+    const requestPromise = page.waitForRequest(
+      (request) =>
+        request.url().endsWith("/api/accounts/me/profile") &&
+        request.method() === "PATCH",
+    );
+    await save.click();
+    const request = await requestPromise;
+    expect(request.postDataJSON()).toMatchObject({
+      title: "Alex im Weltgewebe",
+      summary: "Ich beginne meine Garnrolle selbst.",
+      map_state: "not_on_map",
+      tags: [
+        "skill:Organisation",
+        "skill:Kochen",
+        "good:Werkzeug",
+        "interest:Commons",
+      ],
+    });
+    await expect(
+      section.locator('[data-testid="garnrolle-success"]'),
+    ).toContainText("gespeichert");
+
+    await page.reload();
+    await expect(page.getByLabel("Anzeigename")).toHaveValue(
+      "Alex im Weltgewebe",
+    );
+    await expect(page.getByLabel("Fähigkeiten")).toHaveValue(
+      "Organisation, Kochen",
+    );
+  });
+
+  test("requires a self-selected map point and preserves the draft across map navigation", async ({
+    page,
+  }) => {
+    const section = await openSettingsAsWeber(page);
+    await section.getByLabel("Anzeigename").fill("Garnrolle am gewählten Ort");
+    await section.getByLabel("Adresse").fill("Poelsweg 2, Hamburg");
+    await section.getByLabel("Fähigkeiten").fill("Nachbarschaftshilfe");
+    await section.getByLabel("Exakt sichtbar").check();
+
+    const save = section.locator('[data-testid="save-garnrolle"]');
+    // The address is not silently geocoded. A point chosen by the user is required.
+    await expect(save).toBeDisabled();
+    await section.locator('[data-testid="choose-garnrolle-location"]').click();
+
+    await expect(page).toHaveURL(/\/map\?compose=garnrolle/);
+    const placement = page.locator('[data-testid="garnrolle-placement"]');
+    await expect(placement).toContainText("Kartenpunkt ausstehend");
+    await longPressMapCenter(page);
+    await expect(placement).toContainText("Kartenpunkt gewählt");
+    await placement
+      .locator('[data-testid="confirm-garnrolle-location"]')
+      .click();
+
+    await expect(page).toHaveURL(/\/settings#meine-garnrolle$/);
+    const returned = page.locator('[data-testid="my-garnrolle-section"]');
+    await expect(returned.getByLabel("Anzeigename")).toHaveValue(
+      "Garnrolle am gewählten Ort",
+    );
+    await expect(returned.getByLabel("Adresse")).toHaveValue(
+      "Poelsweg 2, Hamburg",
+    );
+    await expect(
+      returned.locator('[data-testid="garnrolle-location-state"]'),
+    ).toContainText("Kartenpunkt gewählt");
+    await expect(
+      returned.locator('[data-testid="save-garnrolle"]'),
+    ).toBeEnabled();
+
+    const requestPromise = page.waitForRequest(
+      (request) =>
+        request.url().endsWith("/api/accounts/me/profile") &&
+        request.method() === "PATCH",
+    );
+    await returned.locator('[data-testid="save-garnrolle"]').click();
+    const payload = (await requestPromise).postDataJSON();
+    expect(payload).toMatchObject({
+      title: "Garnrolle am gewählten Ort",
+      address: "Poelsweg 2, Hamburg",
+      map_state: "exact",
+      tags: ["skill:Nachbarschaftshilfe"],
+    });
+    expect(typeof payload.location?.lat).toBe("number");
+    expect(typeof payload.location?.lon).toBe("number");
+    await expect(
+      returned.locator('[data-testid="garnrolle-success"]'),
+    ).toContainText("gespeichert");
+
+    await page.goto(`/map?focus=garnrolle:${ACCOUNT_ID}`);
+    const panel = page.locator('[data-testid="context-panel"]');
+    await expect(panel).toContainText("Fähigkeiten: Nachbarschaftshilfe");
+    await expect(panel).not.toContainText("skill:Nachbarschaftshilfe");
+  });
+});
+
+test.describe("Garnrollen-Kartenpunkt per Touch", () => {
+  test.use({ hasTouch: true });
+
+  test("accepts an iPad-style touch longpress", async ({ page }) => {
+    await mockApiResponses(page, {
+      auth: {
+        authenticated: true,
+        account_id: ACCOUNT_ID,
+        role: "weber",
+      },
+    });
+    await page.goto("/map?compose=garnrolle");
+    const placement = page.locator('[data-testid="garnrolle-placement"]');
+    await expect(placement).toContainText("Kartenpunkt ausstehend");
+
+    const map = page.locator("#map canvas").first();
+    const box = await map.boundingBox();
+    if (!box) throw new Error("map has no bounding box");
+    const touchPoint = { x: box.x + 50, y: box.y + 50 };
+    const client = await page.context().newCDPSession(page);
+    await client.send("Input.dispatchTouchEvent", {
+      type: "touchStart",
+      touchPoints: [touchPoint],
+    });
+    await page.waitForTimeout(950);
+    await client.send("Input.dispatchTouchEvent", {
+      type: "touchEnd",
+      touchPoints: [],
+    });
+    await expect(placement).toContainText("Kartenpunkt gewählt");
+  });
+});

--- a/docs/deploy/CHANGELOG.md
+++ b/docs/deploy/CHANGELOG.md
@@ -10,6 +10,40 @@ relations:
 ---
 # Deployment-Änderungsprotokoll
 
+## 2026-07-11 - Eigene Garnrolle dauerhaft beschreiben und verorten
+
+**Geänderte Bereiche:**
+
+- privates Eigenprofil `GET/PATCH /accounts/me/profile`
+- PostgreSQL- und JSONL-Account-Schreibpfad
+- Einstellungen „Meine Garnrolle“
+- nutzergesteuerte Kartenpunktwahl über `compose=garnrolle`
+
+**Beschreibung:**
+
+Ein angemeldeter Weber oder Admin kann ausschließlich die eigene Garnrolle
+beschreiben und deren Kartensichtbarkeit speichern. Für `exact` und `radius`
+wird kein Ort aus der Adresse geraten: Der Nutzer wählt den Punkt selbst durch
+einen langen Druck auf die Karte und bestätigt ihn anschließend im
+Einstellungsformular. Der ungespeicherte Entwurf und die einmalig übergebene
+Koordinate bleiben im sitzungsgebundenen Browserspeicher; Koordinaten erscheinen
+nicht in der URL. Abmeldung, Sitzungsverlust oder Kontowechsel entfernen diese
+sensiblen Entwurfsdaten. `not_on_map` entfernt die öffentliche Projektion,
+bewahrt aber die private interne Koordinate. Lokale Fokuspanels verwenden nun
+die tatsächlich angebotenen pluralen Detailrouten (`/nodes`, `/accounts`,
+`/edges`) und zeigen die gespeicherten Kategorien ohne technische Präfixe.
+
+Im PostgreSQL-Modus wird zuerst `domain_accounts` aktualisiert und erst danach
+der In-Memory-Cache. E-Mail, Rolle und WebAuthn-Identität sind nicht Teil des
+PATCH-Schemas und bleiben unverändert. Die öffentliche Account-Antwort enthält
+weiterhin weder Adresse noch interne Koordinate.
+
+**Produktionswirkung:**
+
+Nach Deployment wird der bisher deaktivierte Speicherbutton funktionsfähig.
+Eine Garnrollen- oder Webungsaktion wird dadurch nicht automatisch ausgeführt;
+der Nutzer löst Kartenwahl und Speicherung selbst aus.
+
 ## 2026-07-11 - Dev-Compose-Verträge für PgBouncer und Caddy korrigiert
 
 **Geänderte Dateien:**

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -195,7 +195,8 @@ Das ist **keine Validierung**, sondern eine **sichtbare Beobachtung**.
   PostgreSQL-Domänentabellen.
 - **WELTGEWEBE_DOMAIN_ACCOUNT_WRITE_SOURCE**: Default `jsonl`.
   `postgres` persistiert Account-Erzeugung einschließlich Auth-
-  Autoprovisionierung in `domain_accounts`.
+  Autoprovisionierung sowie `PATCH /accounts/me/profile` für die eigene
+  Garnrolle in `domain_accounts`.
 - **WELTGEWEBE_DOMAIN_NODE_WRITE_SOURCE**: Default `jsonl`.
   `postgres` persistiert `POST /nodes` und `PATCH /nodes/{id}` in
   `domain_nodes`.

--- a/docs/reports/domain-account-write-path-proof.md
+++ b/docs/reports/domain-account-write-path-proof.md
@@ -216,9 +216,10 @@ Testfälle:
 
 DB-Suiten für lokalen PostgreSQL-Proof sind vorbereitet (`db_domain_schema_migrations`,
 `db_domain_backfill`, `db_domain_read_path`, `db_domain_account_write_path`).
-Der neue Eigenprofil-Test wurde lokal gegen PostgreSQL 16 ausgeführt. Der
-frische PR-CI-Beleg für den geänderten vollständigen Harness steht aus
-(Job `db-domain-account-write-path-proof` in `.github/workflows/api.yml`).
+Der neue Eigenprofil-Test wurde lokal gegen PostgreSQL 16 ausgeführt und ist
+zusätzlich durch GitHub Actions Run `29149078893`, Job
+`db-domain-account-write-path-proof` (`86535506561`), auf Commit
+`83eeced1f1235687f3ccc99cf4300a133b8686ef` erfolgreich gebunden.
 
 `suppress_public_pos` wird von `POST /accounts` nicht akzeptiert; Phase E-A
 erhält Datenschutz über `visibility=private` und bestehende Loader-Semantik

--- a/docs/reports/domain-account-write-path-proof.md
+++ b/docs/reports/domain-account-write-path-proof.md
@@ -12,8 +12,9 @@ created: 2026-06-04
 lang: de
 summary: >
   Proof-Bericht für OPT-ARC-001 Phase E-A: optionaler PostgreSQL-Schreibpfad für
-  die Account-Erzeugung (`POST /accounts`) und – über dasselbe enge Write-Gate –
-  die Step-up-E-Mail-Aktualisierung (AUTH-PG-001, `UpdateEmail`-Intent). JSONL
+  Account-Erzeugung (`POST /accounts`), das private Eigenprofil der Garnrolle
+  (`GET/PATCH /accounts/me/profile`) und die Step-up-E-Mail-Aktualisierung
+  (AUTH-PG-001, `UpdateEmail`-Intent). JSONL
   bleibt Default; kein Dual-Write; Knoten-, Kanten- und WebAuthn-Credential-
   Persistenz bleiben unverändert.
 relations:
@@ -36,8 +37,9 @@ relations:
 ## Scope
 
 Dieser Proof dokumentiert OPT-ARC-001 **Phase E-A** als bewusst engen,
-opt-in PostgreSQL-Schreibpfad für die Account-Erzeugung (`POST /accounts`)
-sowie den unter **AUTH-PG-001** ergänzten, über dasselbe Write-Gate laufenden
+opt-in PostgreSQL-Schreibpfad für die Account-Erzeugung (`POST /accounts`),
+das private Eigenprofil (`GET/PATCH /accounts/me/profile`) sowie den unter
+**AUTH-PG-001** ergänzten, über dasselbe Write-Gate laufenden
 Step-up-E-Mail-Aktualisierungspfad (`UpdateEmail`-Intent beim Step-up-Consume).
 
 Geltende Grenzen:
@@ -48,7 +50,8 @@ Geltende Grenzen:
   `domain_account_write_source: postgres` aktiviert.
 - Der Account-Write-Gate ist getrennt vom Read-Gate
   (`WELTGEWEBE_DOMAIN_READ_SOURCE`). Es ist **kein** breiter
-  `WELTGEWEBE_DOMAIN_WRITE_SOURCE`, weil nur Account-Create implementiert ist.
+  `WELTGEWEBE_DOMAIN_WRITE_SOURCE`; alle Account-Mutationen bleiben an den
+  spezifischen Account-Schreibschalter gebunden.
 - PostgreSQL-Account-Write **erfordert** den PostgreSQL-Read-Source und einen
   konfigurierten Pool. Andernfalls bricht Config-Load bzw. Startup hart ab
   (kein stiller JSONL-Fallback).
@@ -86,7 +89,9 @@ Geltende Grenzen:
 | Ungültiger Wert | harter Config-Fehler (kein Fallback) |
 | Harte Kopplung | `postgres` erfordert `domain_read_source=postgres` (Config-Load) **und** einen Pool (Startup) |
 
-## Route-Verhalten (`POST /accounts`)
+## Route-Verhalten
+
+### `POST /accounts`
 
 | Read-Source | Account-Write-Source | Verhalten |
 |---|---|---|
@@ -98,6 +103,24 @@ Geltende Grenzen:
 `PATCH /nodes` bleibt im Postgres-Read-Modus unverändert blockiert
 (`reject_if_postgres_read_source`).
 
+### `GET/PATCH /accounts/me/profile`
+
+- `GET` verlangt eine gültige Sitzung und liefert nur das private Profil des
+  aktiven Accounts: Titel, Beschreibung, Kategorien, Adresse, interne
+  Koordinate, `map_state` und Radius. E-Mail, Rolle und WebAuthn-Identität
+  werden nie serialisiert.
+- `PATCH` akzeptiert keine Account-ID und verwendet ausschließlich die
+  `account_id` der Sitzung. Unbekannte Felder wie `id` oder `role` werden
+  abgewiesen.
+- `PATCH` ist für Weber und Admin erlaubt, für Gäste verboten.
+- `exact` und `radius` verlangen eine Adresse und eine gültige vorhandene oder
+  neu übermittelte Koordinate. `not_on_map` setzt Radius 0 und entfernt jede
+  öffentliche Position, ohne die private Koordinate zu löschen.
+- PostgreSQL-Modus: Transaktion und Zeilensperre, DB-Update vor Cache-Update,
+  kein JSONL-Write. JSONL-Modus: Append eines vollständigen neuen Snapshots,
+  danach Cache-Update. Kein Dual-Write.
+
+
 ## Implementierte Belege
 
 - `apps/api/src/config.rs`: `DomainAccountWriteSource` (Default `Jsonl`),
@@ -106,7 +129,10 @@ Geltende Grenzen:
   Postgres+Postgres-Read-Accept.
 - `apps/api/src/lib.rs`: Startup-Gate — `Postgres` verlangt einen Pool, sonst
   harter Startfehler; klares Logging „account-create write source“.
-- `apps/api/src/domain_db.rs`: `NewDomainAccountRow::from_jsonl_record`
+- `apps/api/src/domain_db.rs`: `NewDomainAccountRow::from_jsonl_record`,
+  `load_account_profile_from_postgres` und
+  `update_account_profile_in_postgres` (Transaktion, Zeilensperre,
+  DB-vor-Cache-Vertrag, Erhalt der operativen Identität);
   (gleiches semantisches Mapping wie der Phase-C-Backfill) und
   `insert_account_from_jsonl_record` (eine Zeile, plain `INSERT` ohne
   `ON CONFLICT`; UUID/JSONB via `::uuid`/`::jsonb`-Casts, weil der sqlx-Build
@@ -116,7 +142,8 @@ Geltende Grenzen:
 - `apps/api/src/routes/domain_write_guard.rs`:
   `reject_account_create_unless_writable` (Account-Create-Gate) neben dem
   unveränderten `reject_if_postgres_read_source` (Node-Writes).
-- `apps/api/src/routes/accounts.rs::create_account`: gemeinsame
+- `apps/api/src/routes/accounts.rs`: `create_account` sowie strikt auf den
+  aktiven Session-Account gebundene Eigenprofil-Handler; gemeinsame
   Validierung/Record-Bau/Public-Projektion/Duplikatprüfung; Verzweigung nur am
   Persistenzschritt; Cache-Update erst nach erfolgreichem Write; DB-Insert-Fehler
   mappt `DuplicateId` → `409 CONFLICT`, sonst `500`.
@@ -170,6 +197,10 @@ DATABASE_URL=postgres://welt:gewebe@localhost:5432/weltgewebe \
 
 Testfälle:
 
+- `own_garnrolle_profile_persists_privately_and_reloads_from_postgres`:
+  PATCH des eigenen Profils, private Adresse/Koordinate, Erhalt von E-Mail,
+  Rolle und WebAuthn-Identität, kein JSONL-Write, Reload aus PostgreSQL sowie
+  Wechsel zu `not_on_map` ohne öffentliche Projektion.
 - `account_create_persists_stable_webauthn_user_id_across_reload`:
   Erfolg (201), korrekte Spalten/Payloads, Cache enthält den Account sofort,
   kein JSONL-Append; DB, Cache und `load_accounts_from_postgres` verwenden
@@ -185,7 +216,8 @@ Testfälle:
 
 DB-Suiten für lokalen PostgreSQL-Proof sind vorbereitet (`db_domain_schema_migrations`,
 `db_domain_backfill`, `db_domain_read_path`, `db_domain_account_write_path`).
-Lokaler PostgreSQL-Proof in dieser Umgebung nicht ausgeführt. PR-CI ist maßgeblich; der PR-CI-Beleg steht aus
+Der neue Eigenprofil-Test wurde lokal gegen PostgreSQL 16 ausgeführt. Der
+frische PR-CI-Beleg für den geänderten vollständigen Harness steht aus
 (Job `db-domain-account-write-path-proof` in `.github/workflows/api.yml`).
 
 `suppress_public_pos` wird von `POST /accounts` nicht akzeptiert; Phase E-A

--- a/docs/reports/opt-arc-001-db-proof-matrix.json
+++ b/docs/reports/opt-arc-001-db-proof-matrix.json
@@ -71,18 +71,13 @@
     {
       "id": "db-domain-account-write-path-proof",
       "phase": "E-A",
-      "claim": "Optional PostgreSQL account write path covers POST /accounts, auth auto-provisioning and step-up email persistence behind explicit write gates.",
-      "state": "ci_proven",
+      "claim": "Optional PostgreSQL account write path covers POST /accounts, own Garnrolle profile updates, auth auto-provisioning and step-up email persistence behind explicit write gates.",
+      "state": "prepared",
       "workflow": ".github/workflows/api.yml",
       "workflow_job": "db-domain-account-write-path-proof",
       "test": "apps/api/tests/db_domain_account_write_path.rs",
       "report": "docs/reports/domain-account-write-path-proof.md",
-      "ci_evidence": {
-        "run_url": "https://github.com/heimgewebe/weltgewebe/actions/runs/29140838304",
-        "run_id": 29140838304,
-        "commit": "b3ce2f130f1a2edaa01f2e239336a96c944d1b16",
-        "job": "db-domain-account-write-path-proof"
-      },
+      "ci_evidence": null,
       "command": "cargo test --locked -p weltgewebe-api --test db_domain_account_write_path -- --include-ignored --test-threads=1"
     },
     {

--- a/docs/reports/opt-arc-001-db-proof-matrix.json
+++ b/docs/reports/opt-arc-001-db-proof-matrix.json
@@ -72,12 +72,17 @@
       "id": "db-domain-account-write-path-proof",
       "phase": "E-A",
       "claim": "Optional PostgreSQL account write path covers POST /accounts, own Garnrolle profile updates, auth auto-provisioning and step-up email persistence behind explicit write gates.",
-      "state": "prepared",
+      "state": "ci_proven",
       "workflow": ".github/workflows/api.yml",
       "workflow_job": "db-domain-account-write-path-proof",
       "test": "apps/api/tests/db_domain_account_write_path.rs",
       "report": "docs/reports/domain-account-write-path-proof.md",
-      "ci_evidence": null,
+      "ci_evidence": {
+        "run_url": "https://github.com/heimgewebe/weltgewebe/actions/runs/29149078893",
+        "run_id": 29149078893,
+        "commit": "83eeced1f1235687f3ccc99cf4300a133b8686ef",
+        "job": "db-domain-account-write-path-proof"
+      },
       "command": "cargo test --locked -p weltgewebe-api --test db_domain_account_write_path -- --include-ignored --test-threads=1"
     },
     {


### PR DESCRIPTION
## Problem

Die Produktionsoberfläche zeigte das Garnrollenformular, ließ `Speichern` aber absichtlich deaktiviert und behauptete, Persistenz folge erst in einem späteren API-Schnitt. Damit konnte Alex seine Garnrolle trotz Login nicht selbst setzen.

## Umsetzung

- privates, sitzungsgebundenes `GET/PATCH /accounts/me/profile`
- Schreibzugriff ausschließlich auf die eigene Garnrolle; Weber/Admin dürfen schreiben, Gast nur lesen
- dauerhafte JSONL- und PostgreSQL-Pfade ohne Dual-Write; Datenbank vor Cache
- Erhalt von E-Mail, Rolle und WebAuthn-Identität
- Adresse und interne Koordinate bleiben privat
- `exact`/`radius` verlangen einen vom Nutzer selbst gewählten Kartenpunkt
- Kartenpunktwahl per langem Maus- oder Touchdruck, ohne externen Geocoder
- Entwurf und Punktübergabe nur über accountgebundenes `sessionStorage`, nie über URL; Löschung bei Logout, Sitzungsverlust oder Kontowechsel
- verständliche Anzeige von Fähigkeiten, Gütern und Interessen
- Korrektur lokaler Detailpanels auf die tatsächlich vorhandenen pluralen API-Routen

## Nutzergrenze

Dieser Patch legt keine Garnrolle, keinen Knoten und keinen Faden automatisch an. Kartenpunkt und Speicherung werden ausschließlich durch den angemeldeten Nutzer ausgelöst.

## Datenschutz

Öffentlich sind Anzeigename, Kurzbeschreibung, Fähigkeiten, Güter und Interessen. Die Adresse bleibt privat. Bei `exact` ist der gewählte Punkt öffentlich, bei `radius` nur die deterministisch versetzte Näherung und bei `not_on_map` keine Position.

## Belege

- `just ci`
- `make ci-validate`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`
- echter PostgreSQL-16-Test: Speichern, Reload, Identitätserhalt, kein JSONL-Dual-Write, Privacy-Wechsel zu `not_on_map`
- Browser-E2E: Gastschutz, Speichern/Reload, Kartenwechsel mit Entwurfserhalt, semantisches Fokuspanel, Logout-/Kontowechsel-Bereinigung
- iPad-artiger Touch-Langdruck direkt auf dem MapLibre-Canvas

Der formale DB-Proof ist bis zum erfolgreichen GitHub-Job bewusst `prepared`; danach wird die Matrix an den tatsächlichen Run und Commit gebunden.