### PR TITLE
fix(map): render Garnrolle marker reliably on WebKit

### DIFF
--- a/apps/web/src/lib/map/overlay/nodes.ts
+++ b/apps/web/src/lib/map/overlay/nodes.ts
@@ -1,6 +1,6 @@
 import type { Map as MapLibreMap, Marker } from "maplibre-gl";
 import type { MapEntityViewModel } from "$lib/map/types";
-import { ICONS, MARKER_SIZES } from "$lib/ui/icons";
+import { ICONS } from "$lib/ui/icons";
 
 function hasRenderablePosition(item: MapEntityViewModel): boolean {
   return (
@@ -121,14 +121,13 @@ export class NodesOverlay {
         element.dataset.testid = `marker-${item.type}-${item.id}`;
 
         if (markerCategory === "account") {
-          element.style.setProperty(
-            "--marker-icon",
-            `url('${ICONS.garnrolle}')`,
-          );
-          element.style.setProperty(
-            "--marker-size",
-            `${MARKER_SIZES.account}px`,
-          );
+          const icon = document.createElement("img");
+          icon.className = "marker-account__icon";
+          icon.src = ICONS.garnrolle;
+          icon.alt = "";
+          icon.setAttribute("aria-hidden", "true");
+          icon.draggable = false;
+          element.append(icon);
         }
 
         element.setAttribute("aria-label", item.title);

--- a/apps/web/src/routes/map/+page.svelte
+++ b/apps/web/src/routes/map/+page.svelte
@@ -480,8 +480,15 @@
   #map :global(canvas){ filter: grayscale(0.2) saturate(0.75) brightness(1.03) contrast(0.95); }
 
   #map :global(.map-marker){
+    appearance:none;
+    -webkit-appearance:none;
     width:24px;
     height:24px;
+    min-width:0;
+    min-height:0;
+    margin:0;
+    padding:0;
+    box-sizing:border-box;
     border-radius:999px;
     border:2px solid var(--panel-border);
     background:var(--accent, #ff8c42);
@@ -494,19 +501,23 @@
   }
 
   #map :global(.marker-account) {
-    background-image: var(--marker-icon);
-    background-size: contain;
-    background-repeat: no-repeat;
-    background-position: center;
+    width:44px;
+    height:44px;
+    background:transparent;
+    border:none;
+    box-shadow:none;
+    transform:none;
+    border-radius:0;
+  }
 
-    background-color: transparent;
-    border: none;
-    box-shadow: none;
-
-    width: var(--marker-size, 34px);
-    height: var(--marker-size, 34px);
-    transform: none;
-    border-radius: 0;
+  #map :global(.marker-account__icon) {
+    display:block;
+    width:100%;
+    height:100%;
+    object-fit:contain;
+    pointer-events:none;
+    user-select:none;
+    -webkit-user-drag:none;
   }
 
   @media (hover: hover) and (pointer: fine) {

--- a/apps/web/tests/garnrolle-marker-rendering.spec.ts
+++ b/apps/web/tests/garnrolle-marker-rendering.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "@playwright/test";
+import { mockApiResponses } from "./fixtures/mockApi";
+
+const GARNROLLE_ID = "7d97a42e-3704-4a33-a61f-0e0a6b4d65d8";
+
+test.describe("Garnrolle marker rendering", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockApiResponses(page);
+    await page.goto(`/map?focus=garnrolle:${GARNROLLE_ID}`);
+  });
+
+  test("uses a reset button and a loaded intrinsic image", async ({ page }) => {
+    const marker = page.getByTestId(`marker-garnrolle-${GARNROLLE_ID}`);
+    await expect(marker).toBeVisible();
+    await expect(marker).toHaveCSS("appearance", "none");
+    await expect(marker).toHaveCSS("padding", "0px");
+    await expect(marker).toHaveCSS("width", "44px");
+    await expect(marker).toHaveCSS("height", "44px");
+    await expect(marker).toHaveCSS("background-image", "none");
+
+    const icon = marker.locator("img.marker-account__icon");
+    await expect(icon).toHaveCount(1);
+    await expect(icon).toHaveAttribute("alt", "");
+    await expect(icon).toHaveAttribute("aria-hidden", "true");
+    await expect(icon).toHaveJSProperty("complete", true);
+    await expect(icon).toHaveJSProperty("naturalWidth", 256);
+    await expect(icon).toHaveJSProperty("naturalHeight", 255);
+    await expect(icon).toHaveCSS("width", "44px");
+    await expect(icon).toHaveCSS("height", "44px");
+    await expect(icon).toHaveCSS("object-fit", "contain");
+  });
+});


### PR DESCRIPTION
## Problem

Auf iPad/WebKit wird der verortete Garnrollen-Marker als schmaler nativer Buttonrest statt als Garnrollensymbol dargestellt. Position, Knoten und Faden sind korrekt; betroffen ist nur die Marker-Darstellung.

## Ursache

Der Marker war ein nativer `<button>` mit `appearance: auto`, Standard-Padding und einem dynamisch gesetzten CSS-Hintergrundbild. Diese Kombination ist browserabhängig und auf WebKit fragil.

## Änderung

- setzt das native Button-Aussehen vollständig zurück
- hält die Marker-Geometrie explizit bei 44×44 Pixeln
- ersetzt das CSS-Hintergrundbild durch ein echtes dekoratives `<img>`
- lässt MapLibre-Anker, Position, Klickziel und zugängliche Beschriftung unverändert
- ergänzt einen Browser-Regressionsbeleg für Bildladung, intrinsische Größe und Button-Reset

## Belege

- `just ci`
- `make ci-validate`
- Web Lint und Svelte-Typprüfung
- 127 Web-Unit-Tests
- 19 relevante Playwright-Tests für Marker, Karte, Fokuspanel und Filter
- neuer Markerbeleg: Bild vollständig geladen, 256×255 intrinsisch, Marker 44×44, `appearance: none`, Padding 0

## Abgrenzung

Keine API-, Datenbank-, Garnrollen-, Knoten-, Faden- oder Koordinatenänderung.