### PR TITLE
fix: harden deployment and backup contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ npm-debug.log*
 build/
 dist/
 .tmp/
+apps/web/releases/
 # Local lint/tool virtual environments
 .tmp-yamllint/
 target/

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -94,6 +94,16 @@ Secretwerte enthalten sein könnten.
 | API startet nicht | Konfigurationsvalidierung, Proxyentscheidung, Migrationsmodus |
 | Karte bleibt leer | Web-Build, Basemap-Konfiguration, PMTiles-Range und API-Daten getrennt |
 
+### Atomarer Webartefakt-Readback
+
+`scripts/ops/install-web-artifact.sh` validiert Archiv, Version und Commit,
+schaltet den Webroot per Symlink um und wartet danach begrenzt auf einen
+konsistenten öffentlichen Readback. Die Prüfung akzeptiert die bei HTTP/2
+üblichen kleingeschriebenen Headernamen, verlangt `Cache-Control: no-store`
+und bindet `X-Weltgewebe-Build`, Version und Commit gemeinsam. Erst nach Ablauf
+aller Versuche wird zurückgerollt. `apps/web/releases/` ist versioniert als
+Laufzeitzustand ignoriert und darf den Produktionscheckout nicht verschmutzen.
+
 ## 3. Datenquellen und Migrationen
 
 Im belegten Produktionspfad `wg-prod-1` ist PostgreSQL die Lese- und

--- a/docs/runbooks/db-recovery.md
+++ b/docs/runbooks/db-recovery.md
@@ -78,6 +78,11 @@ Die Standard-Retention beträgt 14 Tage.
 
 Systemd:
 
+Die Backup-Unit gibt im strikten Dateisystem-Sandboxing nur `/var/backups`
+schreibbar und legt daraus vor dem eigentlichen Dump das engere Zielverzeichnis
+`/var/backups/weltgewebe/postgres` mit Modus `0700` an. Das verhindert einen
+Erststartfehler, wenn der Zielpfad noch nicht existiert.
+
 - `weltgewebe-postgres-backup.service`;
 - `weltgewebe-postgres-backup.timer` – täglich gegen 02:15 Uhr mit begrenzter
   Zufallsverzögerung.
@@ -133,7 +138,22 @@ mitgenommen. Der bestehende Restic-Lauf auf `heim-pc` sichert `~/merges`
 anschließend in das entfernte Restic-Repository und liest einen Sentinel aus
 dem exakten Snapshot zurück.
 
-Systemd auf `heim-pc`:
+Systemd auf `heim-pc` wird nicht direkt aus einem beweglichen Checkout
+kopiert. Stattdessen installiert der folgende Befehl das Pullskript unter einem
+unveränderlichen, vollständigen Git-Commit, erzeugt daraus die User-Unit, legt
+den schreibbaren Zielpfad vor dem Sandboxstart an und aktiviert den Timer:
+
+```bash
+EXPECTED_COMMIT="$(git rev-parse HEAD)" \
+  scripts/ops/install-postgres-offhost-pull-user-units.sh --enable-now
+```
+
+Die Installation schreibt zusätzlich ein SHA256- und commitgebundenes
+`install.receipt`. Die eingecheckte Service-Datei ist eine Vorlage; ihr
+`@WELTGEWEBE_COMMIT@`-Platzhalter darf nicht ungeprüft als aktive Unit kopiert
+werden. `ProtectKernelModules` wird in der User-Unit bewusst nicht verwendet,
+weil diese Kernel-Capability im User-Manager nicht portabel verfügbar ist. Alle
+übrigen Sandboxgrenzen bleiben aktiv.
 
 - `weltgewebe-postgres-offhost-pull.service`;
 - `weltgewebe-postgres-offhost-pull.timer` – täglich gegen 04:15 Uhr.

--- a/scripts/ops/install-postgres-offhost-pull-user-units.sh
+++ b/scripts/ops/install-postgres-offhost-pull-user-units.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+umask 077
+
+fail() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+require_cmd() { command -v "$1" > /dev/null 2>&1 || fail "required command not found: $1"; }
+sha256_file() { sha256sum "$1" | awk '{print $1}'; }
+usage() {
+  cat << 'USAGE'
+Usage: install-postgres-offhost-pull-user-units.sh [--enable-now]
+
+Install the pull program into an immutable commit-named user runtime directory,
+generate the user service from its commit placeholder, reload the user manager,
+and optionally enable the daily timer immediately.
+USAGE
+}
+
+enable_now=0
+case "$#" in
+  0) ;;
+  1)
+    case "$1" in
+      --enable-now) enable_now=1 ;;
+      --help | -h)
+        usage
+        exit 0
+        ;;
+      *)
+        usage >&2
+        exit 2
+        ;;
+    esac
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac
+
+for cmd in git install mktemp cmp grep sed sha256sum awk; do require_cmd "$cmd"; done
+
+REPO_DIR="${REPO_DIR:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." > /dev/null 2>&1 && pwd)}"
+TARGET_HOME="${TARGET_HOME:-${HOME:?HOME must be set}}"
+SYSTEMCTL_BIN="${SYSTEMCTL_BIN:-systemctl}"
+[[ -d "$REPO_DIR/.git" || -f "$REPO_DIR/.git" ]] || fail "REPO_DIR must be a Git checkout"
+[[ -d "$TARGET_HOME" && ! -L "$TARGET_HOME" ]] || fail "TARGET_HOME must be an existing real directory"
+
+repo_commit="$(git -C "$REPO_DIR" rev-parse HEAD)"
+expected_commit="${EXPECTED_COMMIT:-$repo_commit}"
+[[ "$expected_commit" =~ ^[0-9a-f]{40}$ ]] || fail "EXPECTED_COMMIT must be a full 40-character Git commit"
+[[ "$repo_commit" == "$expected_commit" ]] || fail "checkout HEAD does not match EXPECTED_COMMIT"
+
+pull_rel=scripts/ops/pull-production-postgres-backup.sh
+service_rel=scripts/ops/systemd/weltgewebe-postgres-offhost-pull.service
+timer_rel=scripts/ops/systemd/weltgewebe-postgres-offhost-pull.timer
+for relative in "$pull_rel" "$service_rel" "$timer_rel"; do
+  [[ -f "$REPO_DIR/$relative" && ! -L "$REPO_DIR/$relative" ]] || fail "required source file missing or unsafe: $relative"
+  git -C "$REPO_DIR" ls-files --error-unmatch "$relative" > /dev/null 2>&1 || fail "required source file is not bound to Git: $relative"
+done
+git -C "$REPO_DIR" diff --quiet -- "$pull_rel" "$service_rel" "$timer_rel" || fail "off-host install sources contain uncommitted changes"
+git -C "$REPO_DIR" diff --cached --quiet -- "$pull_rel" "$service_rel" "$timer_rel" || fail "off-host install sources contain staged changes"
+
+token_count="$(awk '{ count += gsub(/@WELTGEWEBE_COMMIT@/, "&") } END { print count + 0 }' "$REPO_DIR/$service_rel")"
+[[ "$token_count" == 1 ]] || fail "off-host service template must contain exactly one commit placeholder"
+! grep -q '^ProtectKernelModules=' "$REPO_DIR/$service_rel" || fail "ProtectKernelModules is not portable in a user service"
+
+release_dir="$TARGET_HOME/.local/libexec/weltgewebe/$expected_commit"
+unit_dir="$TARGET_HOME/.config/systemd/user"
+destination_dir="$TARGET_HOME/merges/weltgewebe-production-backups"
+pull_target="$release_dir/pull-production-postgres-backup.sh"
+receipt="$release_dir/install.receipt"
+service_target="$unit_dir/weltgewebe-postgres-offhost-pull.service"
+timer_target="$unit_dir/weltgewebe-postgres-offhost-pull.timer"
+
+install -d -m 0755 "$release_dir" "$unit_dir"
+install -d -m 0700 "$destination_dir"
+if [[ -e "$pull_target" ]]; then
+  cmp -s "$REPO_DIR/$pull_rel" "$pull_target" || fail "commit runtime already exists with different pull program"
+else
+  install -m 0755 "$REPO_DIR/$pull_rel" "$pull_target"
+fi
+
+service_tmp="$(mktemp "$unit_dir/.weltgewebe-postgres-offhost-pull.service.XXXXXX")"
+timer_tmp="$(mktemp "$unit_dir/.weltgewebe-postgres-offhost-pull.timer.XXXXXX")"
+receipt_tmp=""
+cleanup() {
+  [[ -z "$service_tmp" ]] || rm -f "$service_tmp"
+  [[ -z "$timer_tmp" ]] || rm -f "$timer_tmp"
+  [[ -z "$receipt_tmp" ]] || rm -f "$receipt_tmp"
+}
+trap cleanup EXIT
+sed "s/@WELTGEWEBE_COMMIT@/$expected_commit/g" "$REPO_DIR/$service_rel" > "$service_tmp"
+! grep -q '@WELTGEWEBE_COMMIT@' "$service_tmp" || fail "commit placeholder remained in generated service"
+grep -qxF "ExecStart=%h/.local/libexec/weltgewebe/$expected_commit/pull-production-postgres-backup.sh" "$service_tmp" || fail "generated service is not commit-bound"
+chmod 0644 "$service_tmp"
+install -m 0644 "$REPO_DIR/$timer_rel" "$timer_tmp"
+mv -f "$service_tmp" "$service_target"
+service_tmp=""
+mv -f "$timer_tmp" "$timer_target"
+timer_tmp=""
+
+"$SYSTEMCTL_BIN" --user daemon-reload
+if ((enable_now == 1)); then
+  "$SYSTEMCTL_BIN" --user enable --now weltgewebe-postgres-offhost-pull.timer
+fi
+
+receipt_tmp="$(mktemp "$release_dir/.install.receipt.XXXXXX")"
+{
+  printf 'contract=weltgewebe-postgres-offhost-user-install-v1\n'
+  printf 'git_commit=%s\n' "$expected_commit"
+  printf 'pull_sha256=%s\n' "$(sha256_file "$pull_target")"
+  printf 'service_sha256=%s\n' "$(sha256_file "$service_target")"
+  printf 'timer_sha256=%s\n' "$(sha256_file "$timer_target")"
+} > "$receipt_tmp"
+chmod 0600 "$receipt_tmp"
+mv -f "$receipt_tmp" "$receipt"
+receipt_tmp=""
+printf 'Off-host pull runtime installed for commit %s\nService: %s\nReceipt: %s\n' \
+  "$expected_commit" "$service_target" "$receipt"

--- a/scripts/ops/install-web-artifact.sh
+++ b/scripts/ops/install-web-artifact.sh
@@ -22,13 +22,17 @@ WEB_RELEASE_RETENTION="${WEB_RELEASE_RETENTION:-5}"
 PUBLIC_VERSION_URL="${PUBLIC_VERSION_URL:-}"
 CADDY_VALIDATE_CMD="${CADDY_VALIDATE_CMD:-}"
 CADDY_RELOAD_CMD="${CADDY_RELOAD_CMD:-}"
+PUBLIC_READBACK_ATTEMPTS="${PUBLIC_READBACK_ATTEMPTS:-30}"
+PUBLIC_READBACK_INTERVAL_SECONDS="${PUBLIC_READBACK_INTERVAL_SECONDS:-1}"
 
-for cmd in gzip tar awk curl python3; do require_cmd "$cmd"; done
+for cmd in gzip tar awk curl python3 sleep; do require_cmd "$cmd"; done
 [[ -n "$WEB_ARTIFACT_ARCHIVE" && -f "$WEB_ARTIFACT_ARCHIVE" ]] || fail "WEB_ARTIFACT_ARCHIVE must name an existing archive"
 [[ "$WEB_ARTIFACT_SHA256" =~ ^[0-9a-fA-F]{64}$ ]] || fail "WEB_ARTIFACT_SHA256 must be a 64-character digest"
 [[ -n "$WEB_ARTIFACT_VERSION" && -n "$WEB_ARTIFACT_COMMIT" ]] || fail "expected artifact version and commit are required"
 [[ -n "$PUBLIC_VERSION_URL" && -n "$CADDY_VALIDATE_CMD" && -n "$CADDY_RELOAD_CMD" ]] || fail "public readback, Caddy validation, and Caddy recreate commands are required"
 case "$WEB_RELEASE_RETENTION" in '' | *[!0-9]*) fail "WEB_RELEASE_RETENTION must be a non-negative integer" ;; esac
+case "$PUBLIC_READBACK_ATTEMPTS" in '' | *[!0-9]* | 0) fail "PUBLIC_READBACK_ATTEMPTS must be a positive integer" ;; esac
+case "$PUBLIC_READBACK_INTERVAL_SECONDS" in '' | *[!0-9]*) fail "PUBLIC_READBACK_INTERVAL_SECONDS must be a non-negative integer" ;; esac
 
 actual_sha="$(sha256_file "$WEB_ARTIFACT_ARCHIVE")"
 [[ "$actual_sha" == "$WEB_ARTIFACT_SHA256" ]] || fail "artifact sha256 mismatch"
@@ -53,7 +57,13 @@ tmp_link="${WEB_ROOT}.tmp.$$"
 previous_kind=absent
 previous_target=""
 previous_dir=""
-cleanup() { rm -rf "$stage_dir" "$tmp_link"; }
+readback=""
+headers=""
+cleanup() {
+  rm -rf "$stage_dir" "$tmp_link"
+  [[ -z "$readback" ]] || rm -f "$readback"
+  [[ -z "$headers" ]] || rm -f "$headers"
+}
 trap cleanup EXIT
 
 tar -xzf "$WEB_ARTIFACT_ARCHIVE" -C "$stage_dir" --no-same-owner --no-same-permissions
@@ -102,6 +112,8 @@ rollback() {
   esac
   # A bind mount follows the old inode until Caddy is recreated.
   run_cmd "$CADDY_RELOAD_CMD" > /dev/null 2>&1 || true
+  # The failed release was newly created by this run and must not block an exact retry.
+  rm -rf "$release_dir"
 }
 
 ln -s "$release_dir" "$tmp_link"
@@ -113,30 +125,43 @@ fi
 
 readback="$(mktemp)"
 headers="$(mktemp)"
-if ! curl -fsS -D "$headers" -o "$readback" "$PUBLIC_VERSION_URL"; then
+public_readback_matches() {
+  : > "$readback"
+  : > "$headers"
+  curl -fsS -D "$headers" -o "$readback" "$PUBLIC_VERSION_URL" || return 1
+  grep -iq '^Cache-Control:.*no-store' "$headers" || return 1
+  public_build="$(awk '
+    tolower($1) == "x-weltgewebe-build:" {
+      sub(/^[^:]+:[[:space:]]*/, "")
+      sub(/\r$/, "")
+      print
+      exit
+    }
+  ' "$headers")"
+  public_version="$(read_version_field "$readback" 1)" || return 1
+  public_commit="$(read_version_field "$readback" 3)" || return 1
+  [[ "$public_version" == "$WEB_ARTIFACT_VERSION" ]] || return 1
+  [[ "$public_commit" == "$WEB_ARTIFACT_COMMIT" ]] || return 1
+  [[ "$public_build" == "$WEB_ARTIFACT_VERSION" || "$public_build" == "$WEB_ARTIFACT_COMMIT" ]] || return 1
+}
+
+readback_ok=0
+for ((attempt = 1; attempt <= PUBLIC_READBACK_ATTEMPTS; attempt++)); do
+  if public_readback_matches; then
+    readback_ok=1
+    break
+  fi
+  if ((attempt < PUBLIC_READBACK_ATTEMPTS)); then
+    sleep "$PUBLIC_READBACK_INTERVAL_SECONDS"
+  fi
+done
+if ((readback_ok == 0)); then
   rollback
-  fail "public version readback failed; previous web release restored"
+  fail "public version readback did not converge after ${PUBLIC_READBACK_ATTEMPTS} attempts; previous web release restored"
 fi
-if ! grep -iq '^Cache-Control:.*no-store' "$headers"; then
-  rollback
-  fail "public version readback lacks no-store; previous web release restored"
-fi
-public_build="$(awk 'BEGIN{IGNORECASE=1} /^X-Weltgewebe-Build:/ {sub(/^[^:]+:[[:space:]]*/,""); sub(/\r$/,""); print; exit}' "$headers")"
-public_version="$(read_version_field "$readback" 1)"
-public_commit="$(read_version_field "$readback" 3)"
 rm -f "$readback" "$headers"
-[[ "$public_version" == "$WEB_ARTIFACT_VERSION" ]] || {
-  rollback
-  fail "public version mismatch; previous web release restored"
-}
-[[ -z "$public_commit" || "$public_commit" == "$WEB_ARTIFACT_COMMIT" ]] || {
-  rollback
-  fail "public commit mismatch; previous web release restored"
-}
-[[ "$public_build" == "$WEB_ARTIFACT_VERSION" || "$public_build" == "$WEB_ARTIFACT_COMMIT" ]] || {
-  rollback
-  fail "public build header mismatch; previous web release restored"
-}
+readback=""
+headers=""
 
 # Keep the current target and the newest older releases. Never follow or delete the active symlink target.
 if ((WEB_RELEASE_RETENTION > 0)); then

--- a/scripts/ops/systemd/weltgewebe-postgres-backup.service
+++ b/scripts/ops/systemd/weltgewebe-postgres-backup.service
@@ -13,6 +13,7 @@ Environment=POSTGRES_CONTAINER=weltgewebe-db-1
 Environment=BACKUP_DIR=/var/backups/weltgewebe/postgres
 Environment=BACKUP_RETENTION_DAYS=14
 Environment=GIT_REPO_DIR=/opt/weltgewebe
+ExecStartPre=/usr/bin/install -d -o root -g root -m 0700 /var/backups/weltgewebe/postgres
 ExecStart=/opt/weltgewebe/scripts/ops/postgres-backup.sh
 UMask=0077
 NoNewPrivileges=true
@@ -24,7 +25,7 @@ ProtectKernelModules=true
 ProtectControlGroups=true
 RestrictSUIDSGID=true
 LockPersonality=true
-ReadWritePaths=/var/backups/weltgewebe/postgres
+ReadWritePaths=/var/backups
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/ops/systemd/weltgewebe-postgres-offhost-pull.service
+++ b/scripts/ops/systemd/weltgewebe-postgres-offhost-pull.service
@@ -5,7 +5,8 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=%h/repos/weltgewebe/scripts/ops/pull-production-postgres-backup.sh
+# Installed by install-postgres-offhost-pull-user-units.sh, which substitutes the exact commit.
+ExecStart=%h/.local/libexec/weltgewebe/@WELTGEWEBE_COMMIT@/pull-production-postgres-backup.sh
 UMask=0077
 NoNewPrivileges=true
 PrivateTmp=true
@@ -13,7 +14,6 @@ ProtectSystem=strict
 ProtectHome=read-only
 ReadWritePaths=%h/merges/weltgewebe-production-backups
 ProtectKernelTunables=true
-ProtectKernelModules=true
 ProtectControlGroups=true
 RestrictSUIDSGID=true
 LockPersonality=true

--- a/scripts/tests/test_offhost_backup_pull_contract.sh
+++ b/scripts/tests/test_offhost_backup_pull_contract.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." > /dev/null 2>&1 && pwd)"
+INSTALLER="$REPO_ROOT/scripts/ops/install-postgres-offhost-pull-user-units.sh"
+SERVICE_TEMPLATE="$REPO_ROOT/scripts/ops/systemd/weltgewebe-postgres-offhost-pull.service"
 root="$(mktemp -d)"
 trap 'rm -rf "$root"' EXIT
 remote="$root/remote"
@@ -41,4 +44,49 @@ if PATH="$bin:$PATH" ALLOW_TEST_REMOTE_BACKUP_DIR=1 REMOTE_HOST=test-host REMOTE
   echo 'expected sha mismatch to fail' >&2
   exit 1
 fi
+# The user service is generated from a clean commit placeholder and must avoid
+# ProtectKernelModules, which is unsupported by the real user manager on heim-pc.
+grep -q '@WELTGEWEBE_COMMIT@' "$SERVICE_TEMPLATE"
+if grep -q '^ProtectKernelModules=' "$SERVICE_TEMPLATE"; then
+  echo 'user service must not request ProtectKernelModules' >&2
+  exit 1
+fi
+install_home="$root/install-home"
+fixture_repo="$root/install-repo"
+mkdir -p "$install_home" "$fixture_repo/scripts/ops/systemd"
+cp "$REPO_ROOT/scripts/ops/pull-production-postgres-backup.sh" "$fixture_repo/scripts/ops/"
+cp "$SERVICE_TEMPLATE" "$fixture_repo/scripts/ops/systemd/"
+cp "$REPO_ROOT/scripts/ops/systemd/weltgewebe-postgres-offhost-pull.timer" "$fixture_repo/scripts/ops/systemd/"
+git -C "$fixture_repo" init -q
+git -C "$fixture_repo" config user.name contract-test
+git -C "$fixture_repo" config user.email contract-test@example.invalid
+git -C "$fixture_repo" add scripts
+git -C "$fixture_repo" commit -qm 'test: bind off-host installer fixture'
+commit="$(git -C "$fixture_repo" rev-parse HEAD)"
+HOME="$install_home" TARGET_HOME="$install_home" REPO_DIR="$fixture_repo" \
+  EXPECTED_COMMIT="$commit" SYSTEMCTL_BIN=/bin/true \
+  "$INSTALLER" --enable-now > /dev/null
+installed_pull="$install_home/.local/libexec/weltgewebe/$commit/pull-production-postgres-backup.sh"
+installed_service="$install_home/.config/systemd/user/weltgewebe-postgres-offhost-pull.service"
+receipt="$install_home/.local/libexec/weltgewebe/$commit/install.receipt"
+[[ -x "$installed_pull" ]]
+cmp -s "$fixture_repo/scripts/ops/pull-production-postgres-backup.sh" "$installed_pull"
+grep -qxF "ExecStart=%h/.local/libexec/weltgewebe/$commit/pull-production-postgres-backup.sh" "$installed_service"
+if grep -q '@WELTGEWEBE_COMMIT@' "$installed_service"; then
+  echo 'generated service retained the commit placeholder' >&2
+  exit 1
+fi
+if grep -q '^ProtectKernelModules=' "$installed_service"; then
+  echo 'generated user service retained ProtectKernelModules' >&2
+  exit 1
+fi
+grep -qxF 'contract=weltgewebe-postgres-offhost-user-install-v1' "$receipt"
+grep -qxF "git_commit=$commit" "$receipt"
+[[ "$(stat -c %a "$receipt")" == 600 ]]
+[[ "$(stat -c %a "$install_home/merges/weltgewebe-production-backups")" == 700 ]]
+# Reinstalling the same commit is idempotent.
+HOME="$install_home" TARGET_HOME="$install_home" REPO_DIR="$fixture_repo" \
+  EXPECTED_COMMIT="$commit" SYSTEMCTL_BIN=/bin/true \
+  "$INSTALLER" > /dev/null
+
 printf 'test_offhost_backup_pull_contract: OK\n'

--- a/scripts/tests/test_postgres_backup_restore_contract.sh
+++ b/scripts/tests/test_postgres_backup_restore_contract.sh
@@ -5,6 +5,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
 REPO_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
 BACKUP_SCRIPT="$REPO_ROOT/scripts/ops/postgres-backup.sh"
 RESTORE_SCRIPT="$REPO_ROOT/scripts/ops/postgres-restore-proof.sh"
+BACKUP_UNIT="$REPO_ROOT/scripts/ops/systemd/weltgewebe-postgres-backup.service"
+
+grep -qxF 'ExecStartPre=/usr/bin/install -d -o root -g root -m 0700 /var/backups/weltgewebe/postgres' "$BACKUP_UNIT"
+grep -qxF 'ReadWritePaths=/var/backups' "$BACKUP_UNIT"
+if grep -qxF 'ReadWritePaths=/var/backups/weltgewebe/postgres' "$BACKUP_UNIT"; then
+  echo "backup unit must allow first-run creation before narrowing to the target" >&2
+  exit 1
+fi
 
 TEMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TEMP_DIR"' EXIT

--- a/scripts/tests/test_web_artifact_install_contract.sh
+++ b/scripts/tests/test_web_artifact_install_contract.sh
@@ -23,6 +23,7 @@ sha="$(sha256sum "$archive" | awk '{print $1}')"
 
 MOCK_BIN="$TEMP_DIR/bin"
 mkdir -p "$MOCK_BIN"
+curl_counter="$TEMP_DIR/curl-count"
 cat > "$MOCK_BIN/curl" << SH
 #!/usr/bin/env bash
 set -euo pipefail
@@ -46,8 +47,17 @@ while [ "\$#" -gt 0 ]; do
       ;;
   esac
 done
-printf 'HTTP/1.1 200 OK\r\nCache-Control: no-store\r\nX-Weltgewebe-Build: abc1234\r\n\r\n' > "\$headers"
-cat "$artifact_src/_app/version.json" > "\$out"
+count=0
+if [[ -f "$curl_counter" ]]; then read -r count < "$curl_counter"; fi
+count=\$((count + 1))
+printf '%s\n' "\$count" > "$curl_counter"
+if [[ "\$count" -eq 1 ]]; then
+  printf 'HTTP/2 200\r\ncache-control: no-store\r\nx-weltgewebe-build: old-build\r\n\r\n' > "\$headers"
+  printf '{"version":"old-build","commit":"old-build"}\n' > "\$out"
+else
+  printf 'HTTP/2 200\r\ncache-control: no-store\r\nx-weltgewebe-build: abc1234\r\n\r\n' > "\$headers"
+  cat "$artifact_src/_app/version.json" > "\$out"
+fi
 SH
 chmod +x "$MOCK_BIN/curl"
 
@@ -66,11 +76,14 @@ PATH="$MOCK_BIN:$PATH" \
   PUBLIC_VERSION_URL="https://example.invalid/_app/version.json" \
   CADDY_VALIDATE_CMD="true" \
   CADDY_RELOAD_CMD="touch $reload_marker" \
+  PUBLIC_READBACK_ATTEMPTS=3 \
+  PUBLIC_READBACK_INTERVAL_SECONDS=0 \
   bash "$INSTALL_SCRIPT" > /dev/null
 
 test -L "$web_root"
 test -f "$(readlink "$web_root")/index.html"
 test -f "$reload_marker"
+test "$(cat "$curl_counter")" -eq 2
 
 # A pre-existing real build directory must be preserved as the rollback source.
 rollback_root="$TEMP_DIR/rollback-current"
@@ -107,6 +120,8 @@ if PATH="$BAD_BIN:$PATH" \
   PUBLIC_VERSION_URL="https://example.invalid/_app/version.json" \
   CADDY_VALIDATE_CMD="true" \
   CADDY_RELOAD_CMD="true" \
+  PUBLIC_READBACK_ATTEMPTS=2 \
+  PUBLIC_READBACK_INTERVAL_SECONDS=0 \
   bash "$INSTALL_SCRIPT" > /dev/null 2>&1; then
   echo "installer should fail on public readback mismatch" >&2
   exit 1
@@ -114,6 +129,7 @@ fi
 test -d "$rollback_root"
 test ! -L "$rollback_root"
 test -f "$rollback_root/old-sentinel"
+test ! -d "$rollback_releases/abc1234-abc1234-build"
 
 if PATH="$MOCK_BIN:$PATH" \
   REPO_DIR="$REPO_ROOT" \
@@ -130,5 +146,7 @@ if PATH="$MOCK_BIN:$PATH" \
   echo "installer should fail on sha mismatch" >&2
   exit 1
 fi
+
+git -C "$REPO_ROOT" check-ignore -q apps/web/releases/runtime-release
 
 echo "PASS: web artifact install contract"


### PR DESCRIPTION
## Zweck

Härtet die vier im kontrollierten Audit-Release-Rollout beobachteten Betriebsverträge dauerhaft:

- atomarer Webartefakt-Readback wartet begrenzt auf Konvergenz und liest HTTP/2-Header portabel;
- fehlgeschlagene Webreleases werden vollständig zurückgerollt und blockieren keinen exakten Retry;
- die PostgreSQL-Backup-Unit kann ihr geschütztes Zielverzeichnis beim Erststart anlegen;
- die Off-Host-User-Unit wird aus einem sauberen exakten Commit in einen unveränderlichen Laufzeitpfad installiert, ohne das nicht portable `ProtectKernelModules`;
- `apps/web/releases/` gilt ausdrücklich als Laufzeitzustand und verschmutzt Git nicht.

## Sicherheitsgrenzen

- keine Datenbank-, Compose- oder Produktlogikänderung;
- keine Dirty-Source-Ausnahme im Off-Host-Installer;
- Unitdateien werden atomar erzeugt;
- Receipt wird erst nach erfolgreichem systemd-Reload beziehungsweise Aktivierung geschrieben;
- Version, Commit, Buildheader und `no-store` werden gemeinsam geprüft.

## Prüfungen

- `just lint`
- `make ci-validate`
  - 810 Docmeta-Tests
  - 160 Agenttests
  - 49 CI-Tests
- Webartefakt-Vertrag: HTTP/2-Kleinschreibung, verzögerte Readiness, Rollback und Retry
- PostgreSQL-Backup-/Restore-Vertrag
- Off-Host-Pull und commitgebundener User-Unit-Installer
- Repository-Contract-Guards
- realer transienter User-systemd-Lauf mit allen verbleibenden Sandboxregeln
- `git diff --check`

## Bindung

- Basis: `2a4ca64972cf6be0e5ab437ba122dc282a19139e`
- Head: `ea280736bb95fd8913835f6f9126ac887f07b84b`
- Diff-SHA256: `a8562a53396049d4723b620da6089c6345d15304d216379f2309375ed318dd42`