### PR TITLE
fix: harden review-sensitive ops edges

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -94,15 +94,25 @@ Secretwerte enthalten sein könnten.
 | API startet nicht | Konfigurationsvalidierung, Proxyentscheidung, Migrationsmodus |
 | Karte bleibt leer | Web-Build, Basemap-Konfiguration, PMTiles-Range und API-Daten getrennt |
 
-### Atomarer Webartefakt-Readback
+### Webartefakt-Umschaltung und verifizierter Readback
 
-`scripts/ops/install-web-artifact.sh` validiert Archiv, Version und Commit,
-schaltet den Webroot per Symlink um und wartet danach begrenzt auf einen
-konsistenten öffentlichen Readback. Die Prüfung akzeptiert die bei HTTP/2
-üblichen kleingeschriebenen Headernamen, verlangt `Cache-Control: no-store`
-und bindet `X-Weltgewebe-Build`, Version und Commit gemeinsam. Erst nach Ablauf
-aller Versuche wird zurückgerollt. `apps/web/releases/` ist versioniert als
-Laufzeitzustand ignoriert und darf den Produktionscheckout nicht verschmutzen.
+`scripts/ops/install-web-artifact.sh` validiert Archiv, Dateibaum, Version und
+Commit. Eine hostweite `flock`-Sperre serialisiert Umschaltung und Rollback. Ein
+bereits aktiver, bytegleich geprüfter Release kann idempotent erneut verifiziert
+werden, ohne Caddy neu zu erzeugen. Bei einem neuen Release wird der Webroot
+atomar per Symlink umgeschaltet und Caddy danach neu erzeugt. Der laufende alte
+Container hält bis dahin seinen bisherigen Bind-Mount; der öffentliche Readback
+kann deshalb sinnvoll erst nach der Neuerzeugung den neuen Stand prüfen.
+
+Der Readback akzeptiert kleingeschriebene HTTP/2-Headernamen, entfernt
+abschließenden Leerraum, verlangt `Cache-Control: no-store` und bindet
+`X-Weltgewebe-Build`, Version und Commit gemeinsam. Sowohl einzelne
+`curl`-Aufrufe als auch die gesamte Prüfschleife besitzen Zeitgrenzen; Anzahl,
+Dauer und letzter Fehlergrund werden ausgegeben. Ein Rollback löscht einen neuen
+Release nur, wenn derselbe Lauf ihn angelegt hat und seine Dateisystemidentität
+unverändert ist. Dies ist ein verifizierter Umschalt- und Rollbackvertrag, aber
+kein Blue-Green- oder allgemeiner Zero-Downtime-Vertrag. `apps/web/releases/`
+ist Laufzeitzustand und darf den Produktionscheckout nicht verschmutzen.
 
 ## 3. Datenquellen und Migrationen
 

--- a/docs/runbooks/db-recovery.md
+++ b/docs/runbooks/db-recovery.md
@@ -78,11 +78,17 @@ Die Standard-Retention beträgt 14 Tage.
 
 Systemd:
 
-Die Backup-Unit gibt im strikten Dateisystem-Sandboxing nur `/var/backups`
-schreibbar und legt daraus vor dem eigentlichen Dump das engere Zielverzeichnis
-`/var/backups/weltgewebe/postgres` mit Modus `0700` an. Das verhindert einen
-Erststartfehler, wenn der Zielpfad noch nicht existiert.
+Eine getrennte, kurzlebige Vorbereitungs-Unit legt zunächst
+`/var/backups/weltgewebe` mit Modus `0750` und das engere PostgreSQL-Ziel mit
+Modus `0700` an. Sie führt ausschließlich feste `/usr/bin/install`-Befehle aus,
+hat eine begrenzte Capability-Menge und darf unter `/var` nur in
+`/var/backups` schreiben. Der eigentliche Dumpdienst startet erst danach und
+besitzt ausschließlich Schreibzugriff auf
+`/var/backups/weltgewebe/postgres`. Dadurch bleibt die Erststartfähigkeit
+erhalten, ohne den umfassenderen Schreibbereich während des Backupskripts zu
+öffnen.
 
+- `weltgewebe-postgres-backup-prepare.service`;
 - `weltgewebe-postgres-backup.service`;
 - `weltgewebe-postgres-backup.timer` – täglich gegen 02:15 Uhr mit begrenzter
   Zufallsverzögerung.
@@ -148,8 +154,8 @@ EXPECTED_COMMIT="$(git rev-parse HEAD)" \
   scripts/ops/install-postgres-offhost-pull-user-units.sh --enable-now
 ```
 
-Die Installation schreibt zusätzlich ein SHA256- und commitgebundenes
-`install.receipt`. Die eingecheckte Service-Datei ist eine Vorlage; ihr
+Die Installation schreibt zusätzlich ein zeitgestempeltes, SHA256- und
+commitgebundenes `install.receipt`. Die eingecheckte Service-Datei ist eine Vorlage; ihr
 `@WELTGEWEBE_COMMIT@`-Platzhalter darf nicht ungeprüft als aktive Unit kopiert
 werden. `ProtectKernelModules` wird in der User-Unit bewusst nicht verwendet,
 weil diese Kernel-Capability im User-Manager nicht portabel verfügbar ist. Alle

--- a/scripts/ops/install-postgres-offhost-pull-user-units.sh
+++ b/scripts/ops/install-postgres-offhost-pull-user-units.sh
@@ -40,7 +40,7 @@ case "$#" in
     ;;
 esac
 
-for cmd in git install mktemp cmp grep sed sha256sum awk; do require_cmd "$cmd"; done
+for cmd in git install mktemp cmp grep sed sha256sum awk date; do require_cmd "$cmd"; done
 
 REPO_DIR="${REPO_DIR:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." > /dev/null 2>&1 && pwd)}"
 TARGET_HOME="${TARGET_HOME:-${HOME:?HOME must be set}}"
@@ -110,6 +110,7 @@ fi
 receipt_tmp="$(mktemp "$release_dir/.install.receipt.XXXXXX")"
 {
   printf 'contract=weltgewebe-postgres-offhost-user-install-v1\n'
+  printf 'installed_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   printf 'git_commit=%s\n' "$expected_commit"
   printf 'pull_sha256=%s\n' "$(sha256_file "$pull_target")"
   printf 'service_sha256=%s\n' "$(sha256_file "$service_target")"

--- a/scripts/ops/install-web-artifact.sh
+++ b/scripts/ops/install-web-artifact.sh
@@ -6,6 +6,7 @@ fail() {
   printf 'ERROR: %s\n' "$*" >&2
   exit 1
 }
+warn() { printf 'WARNING: %s\n' "$*" >&2; }
 require_cmd() { command -v "$1" > /dev/null 2>&1 || fail "required command not found: $1"; }
 sha256_file() { if command -v sha256sum > /dev/null 2>&1; then sha256sum "$1" | awk '{print $1}'; else shasum -a 256 "$1" | awk '{print $1}'; fi; }
 read_version_field() { python3 "$REPO_DIR/scripts/lib/parse-version-json.py" "$1" | sed -n "${2}p"; }
@@ -19,20 +20,32 @@ WEB_ARTIFACT_COMMIT="${WEB_ARTIFACT_COMMIT:-}"
 WEB_ROOT="${WEB_ROOT:-/opt/weltgewebe/apps/web/build}"
 WEB_RELEASES_DIR="${WEB_RELEASES_DIR:-/opt/weltgewebe/apps/web/releases}"
 WEB_RELEASE_RETENTION="${WEB_RELEASE_RETENTION:-5}"
+WEB_INSTALL_LOCK_WAIT_SECONDS="${WEB_INSTALL_LOCK_WAIT_SECONDS:-0}"
 PUBLIC_VERSION_URL="${PUBLIC_VERSION_URL:-}"
 CADDY_VALIDATE_CMD="${CADDY_VALIDATE_CMD:-}"
 CADDY_RELOAD_CMD="${CADDY_RELOAD_CMD:-}"
 PUBLIC_READBACK_ATTEMPTS="${PUBLIC_READBACK_ATTEMPTS:-30}"
+PUBLIC_READBACK_TOTAL_SECONDS="${PUBLIC_READBACK_TOTAL_SECONDS:-30}"
 PUBLIC_READBACK_INTERVAL_SECONDS="${PUBLIC_READBACK_INTERVAL_SECONDS:-1}"
+PUBLIC_READBACK_CONNECT_TIMEOUT_SECONDS="${PUBLIC_READBACK_CONNECT_TIMEOUT_SECONDS:-2}"
+PUBLIC_READBACK_REQUEST_TIMEOUT_SECONDS="${PUBLIC_READBACK_REQUEST_TIMEOUT_SECONDS:-4}"
 
-for cmd in gzip tar awk curl python3 sleep; do require_cmd "$cmd"; done
+for cmd in gzip tar awk curl python3 sleep flock realpath stat diff find sort sed date grep readlink dirname mv ln rm chmod install mktemp; do require_cmd "$cmd"; done
 [[ -n "$WEB_ARTIFACT_ARCHIVE" && -f "$WEB_ARTIFACT_ARCHIVE" ]] || fail "WEB_ARTIFACT_ARCHIVE must name an existing archive"
 [[ "$WEB_ARTIFACT_SHA256" =~ ^[0-9a-fA-F]{64}$ ]] || fail "WEB_ARTIFACT_SHA256 must be a 64-character digest"
 [[ -n "$WEB_ARTIFACT_VERSION" && -n "$WEB_ARTIFACT_COMMIT" ]] || fail "expected artifact version and commit are required"
 [[ -n "$PUBLIC_VERSION_URL" && -n "$CADDY_VALIDATE_CMD" && -n "$CADDY_RELOAD_CMD" ]] || fail "public readback, Caddy validation, and Caddy recreate commands are required"
 case "$WEB_RELEASE_RETENTION" in '' | *[!0-9]*) fail "WEB_RELEASE_RETENTION must be a non-negative integer" ;; esac
+case "$WEB_INSTALL_LOCK_WAIT_SECONDS" in '' | *[!0-9]*) fail "WEB_INSTALL_LOCK_WAIT_SECONDS must be a non-negative integer" ;; esac
 case "$PUBLIC_READBACK_ATTEMPTS" in '' | *[!0-9]* | 0) fail "PUBLIC_READBACK_ATTEMPTS must be a positive integer" ;; esac
+case "$PUBLIC_READBACK_TOTAL_SECONDS" in '' | *[!0-9]* | 0) fail "PUBLIC_READBACK_TOTAL_SECONDS must be a positive integer" ;; esac
 case "$PUBLIC_READBACK_INTERVAL_SECONDS" in '' | *[!0-9]*) fail "PUBLIC_READBACK_INTERVAL_SECONDS must be a non-negative integer" ;; esac
+case "$PUBLIC_READBACK_CONNECT_TIMEOUT_SECONDS" in '' | *[!0-9]* | 0) fail "PUBLIC_READBACK_CONNECT_TIMEOUT_SECONDS must be a positive integer" ;; esac
+case "$PUBLIC_READBACK_REQUEST_TIMEOUT_SECONDS" in '' | *[!0-9]* | 0) fail "PUBLIC_READBACK_REQUEST_TIMEOUT_SECONDS must be a positive integer" ;; esac
+((PUBLIC_READBACK_CONNECT_TIMEOUT_SECONDS <= PUBLIC_READBACK_REQUEST_TIMEOUT_SECONDS)) || fail "public readback connect timeout must not exceed request timeout"
+case "$WEB_RELEASES_DIR" in /*) ;; *) fail "WEB_RELEASES_DIR must be an absolute path" ;; esac
+case "$WEB_ROOT" in /*) ;; *) fail "WEB_ROOT must be an absolute path" ;; esac
+[[ "$WEB_RELEASES_DIR" != / && "$WEB_ROOT" != / ]] || fail "web release and root paths must not be filesystem root"
 
 actual_sha="$(sha256_file "$WEB_ARTIFACT_ARCHIVE")"
 [[ "$actual_sha" == "$WEB_ARTIFACT_SHA256" ]] || fail "artifact sha256 mismatch"
@@ -51,7 +64,20 @@ with tarfile.open(archive, 'r:gz') as tf:
             raise SystemExit(f"unsupported archive member: {member.name}")
 PY
 
+[[ ! -L "$WEB_RELEASES_DIR" ]] || fail "WEB_RELEASES_DIR must not be a symlink"
 install -d -m 0755 "$WEB_RELEASES_DIR"
+WEB_RELEASES_DIR="$(realpath -e -- "$WEB_RELEASES_DIR")"
+[[ "$WEB_RELEASES_DIR" != / ]] || fail "resolved WEB_RELEASES_DIR must not be filesystem root"
+web_root_normalized="$(realpath -ms -- "$WEB_ROOT")"
+case "$web_root_normalized/" in "$WEB_RELEASES_DIR"/*) fail "WEB_ROOT must remain outside WEB_RELEASES_DIR" ;; esac
+[[ -d "$(dirname -- "$WEB_ROOT")" ]] || fail "WEB_ROOT parent directory must already exist"
+
+lock_path="$WEB_RELEASES_DIR/.install.lock"
+exec {web_install_lock_fd}> "$lock_path"
+if ! flock -w "$WEB_INSTALL_LOCK_WAIT_SECONDS" "$web_install_lock_fd"; then
+  fail "another web artifact installation is active"
+fi
+
 stage_dir="$(mktemp -d "${WEB_RELEASES_DIR}/.stage.XXXXXX")"
 tmp_link="${WEB_ROOT}.tmp.$$"
 previous_kind=absent
@@ -59,10 +85,39 @@ previous_target=""
 previous_dir=""
 readback=""
 headers=""
+release_dir=""
+release_identity=""
+release_created=0
+release_reused=0
+switched=0
+remove_created_release() {
+  ((release_created == 1)) || return 0
+  if [[ ! -d "$release_dir" || -L "$release_dir" ]]; then
+    warn "refusing to remove changed release path during cleanup: $release_dir"
+    return 1
+  fi
+  current_identity="$(stat -Lc '%d:%i' -- "$release_dir" 2> /dev/null || true)"
+  if [[ -z "$current_identity" || "$current_identity" != "$release_identity" ]]; then
+    warn "refusing to remove release whose filesystem identity changed: $release_dir"
+    return 1
+  fi
+  resolved_release="$(realpath -e -- "$release_dir" 2> /dev/null || true)"
+  if [[ -z "$resolved_release" || "$(dirname -- "$resolved_release")" != "$WEB_RELEASES_DIR" ]]; then
+    warn "refusing to remove release outside the canonical release directory: $release_dir"
+    return 1
+  fi
+  rm -rf --one-file-system -- "$release_dir"
+  release_created=0
+}
+
 cleanup() {
-  rm -rf "$stage_dir" "$tmp_link"
-  [[ -z "$readback" ]] || rm -f "$readback"
-  [[ -z "$headers" ]] || rm -f "$headers"
+  [[ -z "$stage_dir" ]] || rm -rf -- "$stage_dir"
+  rm -f -- "$tmp_link"
+  [[ -z "$readback" ]] || rm -f -- "$readback"
+  [[ -z "$headers" ]] || rm -f -- "$headers"
+  if ((release_created == 1 && switched == 0)); then
+    remove_created_release || true
+  fi
 }
 trap cleanup EXIT
 
@@ -77,89 +132,198 @@ artifact_commit="$(read_version_field "$version_json" 3)"
 [[ "$artifact_version" == "$WEB_ARTIFACT_VERSION" ]] || fail "artifact version mismatch"
 if [[ -n "$artifact_commit" ]]; then
   [[ "$artifact_commit" == "$WEB_ARTIFACT_COMMIT" ]] || fail "artifact commit mismatch"
-else [[ "$WEB_ARTIFACT_VERSION" == "$WEB_ARTIFACT_COMMIT" ]] || fail "artifact lacks commit and version does not match expected commit"; fi
+else
+  [[ "$WEB_ARTIFACT_VERSION" == "$WEB_ARTIFACT_COMMIT" ]] || fail "artifact lacks commit and version does not match expected commit"
+fi
 
 release_name="$artifact_version${artifact_build_id:+-$artifact_build_id}"
 case "$release_name" in '' | *[!A-Za-z0-9._-]*) fail "artifact version/build id contains unsupported characters" ;; esac
+case "$release_name" in [A-Za-z0-9]*) ;; *) fail "artifact release name must begin with an alphanumeric character" ;; esac
 release_dir="$WEB_RELEASES_DIR/$release_name"
-[[ ! -e "$release_dir" ]] || fail "release directory already exists: $release_dir"
-mv "$artifact_root" "$release_dir"
-find "$release_dir" -type d -exec chmod 0755 {} +
-find "$release_dir" -type f -exec chmod 0644 {} +
+if [[ -e "$release_dir" || -L "$release_dir" ]]; then
+  [[ -d "$release_dir" && ! -L "$release_dir" ]] || fail "existing release path is not a real directory: $release_dir"
+  if ! diff -qr --no-dereference -- "$artifact_root" "$release_dir" > /dev/null; then
+    fail "existing release directory differs from the supplied artifact: $release_dir"
+  fi
+  release_reused=1
+  rm -rf -- "$stage_dir"
+  stage_dir=""
+else
+  mv -- "$artifact_root" "$release_dir"
+  release_created=1
+  release_identity="$(stat -Lc '%d:%i' -- "$release_dir")"
+  find "$release_dir" -type d -exec chmod 0755 {} +
+  find "$release_dir" -type f -exec chmod 0644 {} +
+fi
 
 # Validate configuration before changing the bind-mount source.
-run_cmd "$CADDY_VALIDATE_CMD" || fail "Caddy validation command failed"
+if ! run_cmd "$CADDY_VALIDATE_CMD"; then
+  if ((release_created == 0)); then
+    fail "Caddy validation command failed; existing release left unchanged"
+  fi
+  if remove_created_release; then
+    fail "Caddy validation command failed; newly staged release removed"
+  fi
+  fail "Caddy validation command failed and staged release cleanup was incomplete"
+fi
 
+current_target=""
 if [[ -L "$WEB_ROOT" ]]; then
   previous_kind=symlink
   previous_target="$(readlink "$WEB_ROOT")"
+  current_target="$(readlink -f "$WEB_ROOT" 2> /dev/null || true)"
 elif [[ -d "$WEB_ROOT" ]]; then
   previous_kind=directory
   previous_dir="$WEB_RELEASES_DIR/pre-artifact-$(date -u +%Y%m%dT%H%M%SZ)-$$"
-  mv "$WEB_ROOT" "$previous_dir"
 elif [[ -e "$WEB_ROOT" ]]; then
   fail "WEB_ROOT is neither a directory nor a symlink: $WEB_ROOT"
 fi
 
 rollback() {
-  rm -f "$WEB_ROOT" "$tmp_link"
-  case "$previous_kind" in
-    symlink)
-      ln -s "$previous_target" "$tmp_link"
-      mv -Tf "$tmp_link" "$WEB_ROOT"
-      ;;
-    directory) [[ -d "$previous_dir" ]] && mv "$previous_dir" "$WEB_ROOT" ;;
-  esac
-  # A bind mount follows the old inode until Caddy is recreated.
-  run_cmd "$CADDY_RELOAD_CMD" > /dev/null 2>&1 || true
-  # The failed release was newly created by this run and must not block an exact retry.
-  rm -rf "$release_dir"
+  rollback_failed=0
+  if ((switched == 1)); then
+    active_now="$(readlink -f "$WEB_ROOT" 2> /dev/null || true)"
+    if [[ "$active_now" != "$release_dir" ]]; then
+      warn "refusing to overwrite WEB_ROOT because its target changed during rollback"
+      rollback_failed=1
+    else
+      rm -f -- "$WEB_ROOT" "$tmp_link"
+      case "$previous_kind" in
+        symlink)
+          ln -s -- "$previous_target" "$tmp_link"
+          mv -Tf -- "$tmp_link" "$WEB_ROOT"
+          ;;
+        directory)
+          if [[ -d "$previous_dir" ]]; then
+            mv -- "$previous_dir" "$WEB_ROOT"
+          else
+            warn "previous web directory is unavailable during rollback"
+            rollback_failed=1
+          fi
+          ;;
+      esac
+      # A bind mount follows the old inode until Caddy is recreated.
+      if ! run_cmd "$CADDY_RELOAD_CMD" > /dev/null 2>&1; then
+        warn "Caddy recreate failed while restoring the previous web release"
+        rollback_failed=1
+      fi
+      switched=0
+    fi
+  fi
+  remove_created_release || rollback_failed=1
+  return "$rollback_failed"
 }
 
-ln -s "$release_dir" "$tmp_link"
-mv -Tf "$tmp_link" "$WEB_ROOT"
-if ! run_cmd "$CADDY_RELOAD_CMD"; then
-  rollback
-  fail "Caddy recreate command failed; previous web release restored"
+if ((release_reused == 1)) && [[ "$current_target" == "$release_dir" ]]; then
+  printf 'Web release already active; validating public readback: %s\n' "$release_dir"
+else
+  [[ ! -e "$tmp_link" && ! -L "$tmp_link" ]] || fail "temporary web-root link already exists: $tmp_link"
+  ln -s -- "$release_dir" "$tmp_link"
+  if [[ "$previous_kind" == directory ]]; then
+    mv -- "$WEB_ROOT" "$previous_dir"
+  fi
+  if ! mv -Tf -- "$tmp_link" "$WEB_ROOT"; then
+    if [[ "$previous_kind" == directory && ! -e "$WEB_ROOT" && -d "$previous_dir" ]]; then
+      mv -- "$previous_dir" "$WEB_ROOT" || warn "failed to restore previous web directory after switch failure"
+    fi
+    fail "atomic web-root switch failed"
+  fi
+  switched=1
+  if ! run_cmd "$CADDY_RELOAD_CMD"; then
+    if rollback; then
+      fail "Caddy recreate command failed; previous web release restored"
+    fi
+    fail "Caddy recreate command failed and rollback was incomplete"
+  fi
 fi
 
 readback="$(mktemp)"
 headers="$(mktemp)"
+readback_reason="not-attempted"
 public_readback_matches() {
+  local request_timeout="$1"
+  readback_reason="unknown"
   : > "$readback"
   : > "$headers"
-  curl -fsS -D "$headers" -o "$readback" "$PUBLIC_VERSION_URL" || return 1
-  grep -iq '^Cache-Control:.*no-store' "$headers" || return 1
+  if ! curl -fsS \
+    --connect-timeout "$PUBLIC_READBACK_CONNECT_TIMEOUT_SECONDS" \
+    --max-time "$request_timeout" \
+    -D "$headers" -o "$readback" "$PUBLIC_VERSION_URL"; then
+    readback_reason="curl-failed"
+    return 1
+  fi
+  if ! grep -iq '^Cache-Control:.*no-store' "$headers"; then
+    readback_reason="cache-control-mismatch"
+    return 1
+  fi
   public_build="$(awk '
     tolower($1) == "x-weltgewebe-build:" {
       sub(/^[^:]+:[[:space:]]*/, "")
-      sub(/\r$/, "")
+      gsub(/[[:space:]]+$/, "")
       print
       exit
     }
   ' "$headers")"
-  public_version="$(read_version_field "$readback" 1)" || return 1
-  public_commit="$(read_version_field "$readback" 3)" || return 1
-  [[ "$public_version" == "$WEB_ARTIFACT_VERSION" ]] || return 1
-  [[ "$public_commit" == "$WEB_ARTIFACT_COMMIT" ]] || return 1
-  [[ "$public_build" == "$WEB_ARTIFACT_VERSION" || "$public_build" == "$WEB_ARTIFACT_COMMIT" ]] || return 1
+  public_version="$(read_version_field "$readback" 1)" || {
+    readback_reason="version-json-invalid"
+    return 1
+  }
+  public_commit="$(read_version_field "$readback" 3)" || {
+    readback_reason="version-json-invalid"
+    return 1
+  }
+  [[ "$public_version" == "$WEB_ARTIFACT_VERSION" ]] || {
+    readback_reason="version-mismatch"
+    return 1
+  }
+  [[ "$public_commit" == "$WEB_ARTIFACT_COMMIT" ]] || {
+    readback_reason="commit-mismatch"
+    return 1
+  }
+  [[ "$public_build" == "$WEB_ARTIFACT_VERSION" || "$public_build" == "$WEB_ARTIFACT_COMMIT" ]] || {
+    readback_reason="build-header-mismatch"
+    return 1
+  }
+  readback_reason="ok"
 }
 
 readback_ok=0
+readback_attempts_made=0
+readback_started=$SECONDS
 for ((attempt = 1; attempt <= PUBLIC_READBACK_ATTEMPTS; attempt++)); do
-  if public_readback_matches; then
+  elapsed=$((SECONDS - readback_started))
+  remaining=$((PUBLIC_READBACK_TOTAL_SECONDS - elapsed))
+  ((remaining > 0)) || break
+  request_timeout=$PUBLIC_READBACK_REQUEST_TIMEOUT_SECONDS
+  ((request_timeout <= remaining)) || request_timeout=$remaining
+  readback_attempts_made=$attempt
+  if public_readback_matches "$request_timeout"; then
     readback_ok=1
     break
   fi
-  if ((attempt < PUBLIC_READBACK_ATTEMPTS)); then
-    sleep "$PUBLIC_READBACK_INTERVAL_SECONDS"
+  elapsed=$((SECONDS - readback_started))
+  printf 'Web artifact readback attempt %d failed after %ss: %s\n' \
+    "$attempt" "$elapsed" "$readback_reason" >&2
+  remaining=$((PUBLIC_READBACK_TOTAL_SECONDS - elapsed))
+  if ((attempt < PUBLIC_READBACK_ATTEMPTS && remaining > 0 && PUBLIC_READBACK_INTERVAL_SECONDS > 0)); then
+    sleep_for=$PUBLIC_READBACK_INTERVAL_SECONDS
+    ((sleep_for <= remaining)) || sleep_for=$remaining
+    ((sleep_for > 0)) && sleep "$sleep_for"
   fi
 done
+readback_elapsed=$((SECONDS - readback_started))
 if ((readback_ok == 0)); then
-  rollback
-  fail "public version readback did not converge after ${PUBLIC_READBACK_ATTEMPTS} attempts; previous web release restored"
+  if ((switched == 0 && release_created == 0)); then
+    fail "active web release failed public verification after ${readback_attempts_made} attempt(s) and ${readback_elapsed}s (${readback_reason}); active files were left unchanged"
+  fi
+  if rollback; then
+    fail "public version readback did not converge after ${readback_attempts_made} attempt(s) and ${readback_elapsed}s (${readback_reason}); previous web release restored"
+  fi
+  fail "public version readback failed and rollback was incomplete after ${readback_attempts_made} attempt(s) and ${readback_elapsed}s (${readback_reason})"
 fi
-rm -f "$readback" "$headers"
+printf 'Web artifact public readback converged after %d attempt(s) in %ss.\n' \
+  "$readback_attempts_made" "$readback_elapsed"
+rm -f -- "$readback" "$headers"
 readback=""
 headers=""
 
@@ -171,7 +335,11 @@ if ((WEB_RELEASE_RETENTION > 0)); then
   for dir in "${old[@]}"; do
     [[ "$(readlink -f "$dir")" == "$active" ]] && continue
     kept=$((kept + 1))
-    ((kept <= WEB_RELEASE_RETENTION)) || rm -rf "$dir"
+    ((kept <= WEB_RELEASE_RETENTION)) || rm -rf --one-file-system -- "$dir"
   done
 fi
-printf 'Web artifact installed: %s\nWeb root now points to: %s\n' "$release_dir" "$(readlink "$WEB_ROOT")"
+if ((release_reused == 1)); then
+  printf 'Web artifact verified idempotently: %s\nWeb root points to: %s\n' "$release_dir" "$(readlink "$WEB_ROOT")"
+else
+  printf 'Web artifact installed: %s\nWeb root now points to: %s\n' "$release_dir" "$(readlink "$WEB_ROOT")"
+fi

--- a/scripts/ops/systemd/weltgewebe-postgres-backup-prepare.service
+++ b/scripts/ops/systemd/weltgewebe-postgres-backup-prepare.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=Prepare the restricted Weltgewebe PostgreSQL backup directory
+Documentation=file:/opt/weltgewebe/docs/runbooks/db-recovery.md
+Before=weltgewebe-postgres-backup.service
+AssertPathIsDirectory=/var/backups
+
+[Service]
+Type=oneshot
+User=root
+Group=root
+ExecStart=/usr/bin/install -d -o root -g root -m 0750 /var/backups/weltgewebe
+ExecStart=/usr/bin/install -d -o root -g root -m 0700 /var/backups/weltgewebe/postgres
+UMask=0077
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+LockPersonality=true
+ReadOnlyPaths=/var
+ReadWritePaths=/var/backups
+CapabilityBoundingSet=CAP_CHOWN CAP_DAC_OVERRIDE CAP_FOWNER

--- a/scripts/ops/systemd/weltgewebe-postgres-backup.service
+++ b/scripts/ops/systemd/weltgewebe-postgres-backup.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Weltgewebe PostgreSQL logical backup
 Documentation=file:/opt/weltgewebe/docs/runbooks/db-recovery.md
-Requires=docker.service
-After=docker.service
+Requires=docker.service weltgewebe-postgres-backup-prepare.service
+After=docker.service weltgewebe-postgres-backup-prepare.service
 
 [Service]
 Type=oneshot
@@ -13,7 +13,6 @@ Environment=POSTGRES_CONTAINER=weltgewebe-db-1
 Environment=BACKUP_DIR=/var/backups/weltgewebe/postgres
 Environment=BACKUP_RETENTION_DAYS=14
 Environment=GIT_REPO_DIR=/opt/weltgewebe
-ExecStartPre=/usr/bin/install -d -o root -g root -m 0700 /var/backups/weltgewebe/postgres
 ExecStart=/opt/weltgewebe/scripts/ops/postgres-backup.sh
 UMask=0077
 NoNewPrivileges=true
@@ -25,7 +24,7 @@ ProtectKernelModules=true
 ProtectControlGroups=true
 RestrictSUIDSGID=true
 LockPersonality=true
-ReadWritePaths=/var/backups
+ReadWritePaths=/var/backups/weltgewebe/postgres
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/tests/test_offhost_backup_pull_contract.sh
+++ b/scripts/tests/test_offhost_backup_pull_contract.sh
@@ -81,6 +81,7 @@ if grep -q '^ProtectKernelModules=' "$installed_service"; then
   exit 1
 fi
 grep -qxF 'contract=weltgewebe-postgres-offhost-user-install-v1' "$receipt"
+grep -Eq '^installed_at=[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$' "$receipt"
 grep -qxF "git_commit=$commit" "$receipt"
 [[ "$(stat -c %a "$receipt")" == 600 ]]
 [[ "$(stat -c %a "$install_home/merges/weltgewebe-production-backups")" == 700 ]]

--- a/scripts/tests/test_postgres_backup_restore_contract.sh
+++ b/scripts/tests/test_postgres_backup_restore_contract.sh
@@ -6,13 +6,23 @@ REPO_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
 BACKUP_SCRIPT="$REPO_ROOT/scripts/ops/postgres-backup.sh"
 RESTORE_SCRIPT="$REPO_ROOT/scripts/ops/postgres-restore-proof.sh"
 BACKUP_UNIT="$REPO_ROOT/scripts/ops/systemd/weltgewebe-postgres-backup.service"
+PREPARE_UNIT="$REPO_ROOT/scripts/ops/systemd/weltgewebe-postgres-backup-prepare.service"
 
-grep -qxF 'ExecStartPre=/usr/bin/install -d -o root -g root -m 0700 /var/backups/weltgewebe/postgres' "$BACKUP_UNIT"
-grep -qxF 'ReadWritePaths=/var/backups' "$BACKUP_UNIT"
-if grep -qxF 'ReadWritePaths=/var/backups/weltgewebe/postgres' "$BACKUP_UNIT"; then
-  echo "backup unit must allow first-run creation before narrowing to the target" >&2
+grep -qxF 'Requires=docker.service weltgewebe-postgres-backup-prepare.service' "$BACKUP_UNIT"
+grep -qxF 'After=docker.service weltgewebe-postgres-backup-prepare.service' "$BACKUP_UNIT"
+grep -qxF 'ReadWritePaths=/var/backups/weltgewebe/postgres' "$BACKUP_UNIT"
+if grep -q '^ExecStartPre=' "$BACKUP_UNIT" || grep -qxF 'ReadWritePaths=/var/backups' "$BACKUP_UNIT"; then
+  echo "backup service must not prepare or write the broad backup parent" >&2
   exit 1
 fi
+grep -qxF 'Before=weltgewebe-postgres-backup.service' "$PREPARE_UNIT"
+grep -qxF 'AssertPathIsDirectory=/var/backups' "$PREPARE_UNIT"
+grep -qxF 'ExecStart=/usr/bin/install -d -o root -g root -m 0750 /var/backups/weltgewebe' "$PREPARE_UNIT"
+grep -qxF 'ExecStart=/usr/bin/install -d -o root -g root -m 0700 /var/backups/weltgewebe/postgres' "$PREPARE_UNIT"
+grep -qxF 'ProtectSystem=full' "$PREPARE_UNIT"
+grep -qxF 'ReadOnlyPaths=/var' "$PREPARE_UNIT"
+grep -qxF 'ReadWritePaths=/var/backups' "$PREPARE_UNIT"
+grep -qxF 'CapabilityBoundingSet=CAP_CHOWN CAP_DAC_OVERRIDE CAP_FOWNER' "$PREPARE_UNIT"
 
 TEMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TEMP_DIR"' EXIT

--- a/scripts/tests/test_web_artifact_install_contract.sh
+++ b/scripts/tests/test_web_artifact_install_contract.sh
@@ -24,9 +24,12 @@ sha="$(sha256sum "$archive" | awk '{print $1}')"
 MOCK_BIN="$TEMP_DIR/bin"
 mkdir -p "$MOCK_BIN"
 curl_counter="$TEMP_DIR/curl-count"
-cat > "$MOCK_BIN/curl" << SH
+curl_args_log="$TEMP_DIR/curl-args"
+cat > "$MOCK_BIN/curl" << CURLMOCK
 #!/usr/bin/env bash
 set -euo pipefail
+printf '%q ' "\$@" >> "$curl_args_log"
+printf '\n' >> "$curl_args_log"
 headers=""
 out=""
 while [ "\$#" -gt 0 ]; do
@@ -37,6 +40,9 @@ while [ "\$#" -gt 0 ]; do
       ;;
     -o)
       out="\$2"
+      shift 2
+      ;;
+    --connect-timeout | --max-time)
       shift 2
       ;;
     -*)
@@ -55,73 +61,116 @@ if [[ "\$count" -eq 1 ]]; then
   printf 'HTTP/2 200\r\ncache-control: no-store\r\nx-weltgewebe-build: old-build\r\n\r\n' > "\$headers"
   printf '{"version":"old-build","commit":"old-build"}\n' > "\$out"
 else
-  printf 'HTTP/2 200\r\ncache-control: no-store\r\nx-weltgewebe-build: abc1234\r\n\r\n' > "\$headers"
+  # Deliberate trailing horizontal whitespace before CR proves robust trimming.
+  printf 'HTTP/2 200\r\ncache-control: no-store\r\nx-weltgewebe-build: abc1234 \t\r\n\r\n' > "\$headers"
   cat "$artifact_src/_app/version.json" > "\$out"
 fi
-SH
+CURLMOCK
 chmod +x "$MOCK_BIN/curl"
+
+reload_counter="$TEMP_DIR/reload-count"
+cat > "$MOCK_BIN/reload" << RELOADMOCK
+#!/usr/bin/env bash
+set -euo pipefail
+count=0
+if [[ -f "$reload_counter" ]]; then read -r count < "$reload_counter"; fi
+printf '%s\n' "\$((count + 1))" > "$reload_counter"
+RELOADMOCK
+chmod +x "$MOCK_BIN/reload"
 
 release_dir="$TEMP_DIR/releases"
 web_root="$TEMP_DIR/current"
-reload_marker="$TEMP_DIR/reloaded"
+common_env=(
+  REPO_DIR="$REPO_ROOT"
+  WEB_ARTIFACT_ARCHIVE="$archive"
+  WEB_ARTIFACT_SHA256="$sha"
+  WEB_ARTIFACT_VERSION=abc1234
+  WEB_ARTIFACT_COMMIT=abc1234
+  WEB_ROOT="$web_root"
+  WEB_RELEASES_DIR="$release_dir"
+  PUBLIC_VERSION_URL=https://example.invalid/_app/version.json
+  CADDY_VALIDATE_CMD=true
+  CADDY_RELOAD_CMD="$MOCK_BIN/reload"
+  PUBLIC_READBACK_ATTEMPTS=3
+  PUBLIC_READBACK_TOTAL_SECONDS=5
+  PUBLIC_READBACK_INTERVAL_SECONDS=0
+  PUBLIC_READBACK_CONNECT_TIMEOUT_SECONDS=2
+  PUBLIC_READBACK_REQUEST_TIMEOUT_SECONDS=3
+)
 
-PATH="$MOCK_BIN:$PATH" \
-  REPO_DIR="$REPO_ROOT" \
-  WEB_ARTIFACT_ARCHIVE="$archive" \
-  WEB_ARTIFACT_SHA256="$sha" \
-  WEB_ARTIFACT_VERSION="abc1234" \
-  WEB_ARTIFACT_COMMIT="abc1234" \
-  WEB_ROOT="$web_root" \
-  WEB_RELEASES_DIR="$release_dir" \
-  PUBLIC_VERSION_URL="https://example.invalid/_app/version.json" \
-  CADDY_VALIDATE_CMD="true" \
-  CADDY_RELOAD_CMD="touch $reload_marker" \
-  PUBLIC_READBACK_ATTEMPTS=3 \
-  PUBLIC_READBACK_INTERVAL_SECONDS=0 \
-  bash "$INSTALL_SCRIPT" > /dev/null
+first_output="$TEMP_DIR/first-output"
+first_error="$TEMP_DIR/first-error"
+env PATH="$MOCK_BIN:$PATH" "${common_env[@]}" bash "$INSTALL_SCRIPT" > "$first_output" 2> "$first_error"
 
 test -L "$web_root"
 test -f "$(readlink "$web_root")/index.html"
-test -f "$reload_marker"
+test "$(cat "$reload_counter")" -eq 1
 test "$(cat "$curl_counter")" -eq 2
+grep -q -- '--connect-timeout 2' "$curl_args_log"
+grep -q -- '--max-time 3' "$curl_args_log"
+grep -q 'version-mismatch' "$first_error"
+grep -q 'converged after 2 attempt(s)' "$first_output"
+
+# Reinstalling the exact active artifact is idempotent and does not recreate Caddy.
+idempotent_output="$TEMP_DIR/idempotent-output"
+env PATH="$MOCK_BIN:$PATH" "${common_env[@]}" bash "$INSTALL_SCRIPT" > "$idempotent_output"
+test "$(cat "$reload_counter")" -eq 1
+grep -q 'verified idempotently' "$idempotent_output"
+
+BAD_BIN="$TEMP_DIR/bad-bin"
+mkdir -p "$BAD_BIN"
+cat > "$BAD_BIN/curl" << 'BADCURL'
+#!/usr/bin/env bash
+set -euo pipefail
+headers=""
+out=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -D) headers="$2"; shift 2 ;;
+    -o) out="$2"; shift 2 ;;
+    --connect-timeout | --max-time) shift 2 ;;
+    -*) shift ;;
+    *) shift ;;
+  esac
+done
+printf 'HTTP/1.1 200 OK\r\nCache-Control: no-store\r\nX-Weltgewebe-Build: wrong\r\n\r\n' > "$headers"
+printf '{"version":"wrong","commit":"wrong"}\n' > "$out"
+BADCURL
+chmod +x "$BAD_BIN/curl"
+
+# A failed verification of an already active, reused release must preserve it.
+if env PATH="$BAD_BIN:$PATH" "${common_env[@]}" \
+  PUBLIC_READBACK_ATTEMPTS=2 PUBLIC_READBACK_TOTAL_SECONDS=2 \
+  PUBLIC_READBACK_CONNECT_TIMEOUT_SECONDS=1 PUBLIC_READBACK_REQUEST_TIMEOUT_SECONDS=1 \
+  bash "$INSTALL_SCRIPT" > /dev/null 2>&1; then
+  echo "active reused release verification should fail on a wrong public readback" >&2
+  exit 1
+fi
+test -L "$web_root"
+test -d "$release_dir/abc1234-abc1234-build"
+test "$(cat "$reload_counter")" -eq 1
 
 # A pre-existing real build directory must be preserved as the rollback source.
 rollback_root="$TEMP_DIR/rollback-current"
 rollback_releases="$TEMP_DIR/rollback-releases"
 mkdir -p "$rollback_root"
 printf 'old production build\n' > "$rollback_root/old-sentinel"
-BAD_BIN="$TEMP_DIR/bad-bin"
-mkdir -p "$BAD_BIN"
-cat > "$BAD_BIN/curl" << SH
-#!/usr/bin/env bash
-set -euo pipefail
-headers=""
-out=""
-while [ "\$#" -gt 0 ]; do
-  case "\$1" in
-    -D) headers="\$2"; shift 2 ;;
-    -o) out="\$2"; shift 2 ;;
-    -*) shift ;;
-    *) shift ;;
-  esac
-done
-printf 'HTTP/1.1 200 OK\r\nCache-Control: no-store\r\nX-Weltgewebe-Build: wrong\r\n\r\n' >"\$headers"
-printf '{"version":"wrong","commit":"wrong"}\n' >"\$out"
-SH
-chmod +x "$BAD_BIN/curl"
-if PATH="$BAD_BIN:$PATH" \
+if env PATH="$BAD_BIN:$PATH" \
   REPO_DIR="$REPO_ROOT" \
   WEB_ARTIFACT_ARCHIVE="$archive" \
   WEB_ARTIFACT_SHA256="$sha" \
-  WEB_ARTIFACT_VERSION="abc1234" \
-  WEB_ARTIFACT_COMMIT="abc1234" \
+  WEB_ARTIFACT_VERSION=abc1234 \
+  WEB_ARTIFACT_COMMIT=abc1234 \
   WEB_ROOT="$rollback_root" \
   WEB_RELEASES_DIR="$rollback_releases" \
-  PUBLIC_VERSION_URL="https://example.invalid/_app/version.json" \
-  CADDY_VALIDATE_CMD="true" \
-  CADDY_RELOAD_CMD="true" \
+  PUBLIC_VERSION_URL=https://example.invalid/_app/version.json \
+  CADDY_VALIDATE_CMD=true \
+  CADDY_RELOAD_CMD=true \
   PUBLIC_READBACK_ATTEMPTS=2 \
+  PUBLIC_READBACK_TOTAL_SECONDS=2 \
   PUBLIC_READBACK_INTERVAL_SECONDS=0 \
+  PUBLIC_READBACK_CONNECT_TIMEOUT_SECONDS=1 \
+  PUBLIC_READBACK_REQUEST_TIMEOUT_SECONDS=1 \
   bash "$INSTALL_SCRIPT" > /dev/null 2>&1; then
   echo "installer should fail on public readback mismatch" >&2
   exit 1
@@ -131,17 +180,96 @@ test ! -L "$rollback_root"
 test -f "$rollback_root/old-sentinel"
 test ! -d "$rollback_releases/abc1234-abc1234-build"
 
-if PATH="$MOCK_BIN:$PATH" \
+# A validation failure occurs before the switch and must remove only the release
+# created by that run so an exact retry remains possible.
+validation_root="$TEMP_DIR/validation-current"
+validation_releases="$TEMP_DIR/validation-releases"
+mkdir -p "$validation_root"
+printf 'old validation build\n' > "$validation_root/old-sentinel"
+if env PATH="$MOCK_BIN:$PATH" \
   REPO_DIR="$REPO_ROOT" \
   WEB_ARTIFACT_ARCHIVE="$archive" \
-  WEB_ARTIFACT_SHA256="bad" \
-  WEB_ARTIFACT_VERSION="abc1234" \
-  WEB_ARTIFACT_COMMIT="abc1234" \
+  WEB_ARTIFACT_SHA256="$sha" \
+  WEB_ARTIFACT_VERSION=abc1234 \
+  WEB_ARTIFACT_COMMIT=abc1234 \
+  WEB_ROOT="$validation_root" \
+  WEB_RELEASES_DIR="$validation_releases" \
+  PUBLIC_VERSION_URL=https://example.invalid/_app/version.json \
+  CADDY_VALIDATE_CMD=false \
+  CADDY_RELOAD_CMD=true \
+  bash "$INSTALL_SCRIPT" > /dev/null 2>&1; then
+  echo "installer should fail when Caddy validation fails" >&2
+  exit 1
+fi
+test -d "$validation_root"
+test -f "$validation_root/old-sentinel"
+test ! -d "$validation_releases/abc1234-abc1234-build"
+
+# A Caddy recreate failure occurs after the switch. It must restore the previous
+# real directory and remove only the newly created release.
+reload_fail_root="$TEMP_DIR/reload-fail-current"
+reload_fail_releases="$TEMP_DIR/reload-fail-releases"
+mkdir -p "$reload_fail_root"
+printf 'old reload build\n' > "$reload_fail_root/old-sentinel"
+if env PATH="$MOCK_BIN:$PATH" \
+  REPO_DIR="$REPO_ROOT" \
+  WEB_ARTIFACT_ARCHIVE="$archive" \
+  WEB_ARTIFACT_SHA256="$sha" \
+  WEB_ARTIFACT_VERSION=abc1234 \
+  WEB_ARTIFACT_COMMIT=abc1234 \
+  WEB_ROOT="$reload_fail_root" \
+  WEB_RELEASES_DIR="$reload_fail_releases" \
+  PUBLIC_VERSION_URL=https://example.invalid/_app/version.json \
+  CADDY_VALIDATE_CMD=true \
+  CADDY_RELOAD_CMD=false \
+  bash "$INSTALL_SCRIPT" > /dev/null 2>&1; then
+  echo "installer should fail when Caddy recreation fails" >&2
+  exit 1
+fi
+test -d "$reload_fail_root"
+test ! -L "$reload_fail_root"
+test -f "$reload_fail_root/old-sentinel"
+test ! -d "$reload_fail_releases/abc1234-abc1234-build"
+
+# A held host-wide lock must reject a concurrent install before staging or switching.
+lock_releases="$TEMP_DIR/lock-releases"
+lock_root="$TEMP_DIR/lock-current"
+mkdir -p "$lock_releases"
+exec 8> "$lock_releases/.install.lock"
+flock -n 8
+if env PATH="$MOCK_BIN:$PATH" \
+  REPO_DIR="$REPO_ROOT" \
+  WEB_ARTIFACT_ARCHIVE="$archive" \
+  WEB_ARTIFACT_SHA256="$sha" \
+  WEB_ARTIFACT_VERSION=abc1234 \
+  WEB_ARTIFACT_COMMIT=abc1234 \
+  WEB_ROOT="$lock_root" \
+  WEB_RELEASES_DIR="$lock_releases" \
+  PUBLIC_VERSION_URL=https://example.invalid/_app/version.json \
+  CADDY_VALIDATE_CMD=true \
+  CADDY_RELOAD_CMD=true \
+  WEB_INSTALL_LOCK_WAIT_SECONDS=0 \
+  bash "$INSTALL_SCRIPT" > /dev/null 2>&1; then
+  echo "concurrent installer should fail while the deployment lock is held" >&2
+  exit 1
+fi
+flock -u 8
+exec 8>&-
+test ! -e "$lock_root"
+test ! -L "$lock_root"
+test -z "$(find "$lock_releases" -maxdepth 1 -type d -name '.stage.*' -print -quit)"
+
+if env PATH="$MOCK_BIN:$PATH" \
+  REPO_DIR="$REPO_ROOT" \
+  WEB_ARTIFACT_ARCHIVE="$archive" \
+  WEB_ARTIFACT_SHA256=bad \
+  WEB_ARTIFACT_VERSION=abc1234 \
+  WEB_ARTIFACT_COMMIT=abc1234 \
   WEB_ROOT="$TEMP_DIR/other-current" \
   WEB_RELEASES_DIR="$TEMP_DIR/other-releases" \
-  PUBLIC_VERSION_URL="https://example.invalid/_app/version.json" \
-  CADDY_VALIDATE_CMD="true" \
-  CADDY_RELOAD_CMD="true" \
+  PUBLIC_VERSION_URL=https://example.invalid/_app/version.json \
+  CADDY_VALIDATE_CMD=true \
+  CADDY_RELOAD_CMD=true \
   bash "$INSTALL_SCRIPT" > /dev/null 2>&1; then
   echo "installer should fail on sha mismatch" >&2
   exit 1


### PR DESCRIPTION
## Anlass

Kritischer Nachlauf zu den widersprüchlichen Reviews von PR #1399. Dieser PR übernimmt nur belegbare Risiken und hält unbelegte Architekturbehauptungen ausdrücklich aus dem Patch heraus.

## Bestätigte Befunde

- Der Webinstaller hatte keine hostweite Parallelitätssperre.
- Die Anzahl der Readback-Versuche begrenzte die Dauer nicht, weil `curl` kein eigenes Zeitlimit hatte.
- Rollback-Löschung sollte an die konkrete, von diesem Lauf erzeugte Dateisystemidentität gebunden sein.
- Ein exakt gleicher aktiver Release sollte idempotent erneut verifizierbar sein.
- Der eigentliche PostgreSQL-Dumpdienst sollte nicht den gesamten Pfad `/var/backups` schreibbar sehen.
- Readback-Dauer, Versuche und Fehlergrund fehlten als Betriebsevidenz.

## Umsetzung

### Webartefakt

- hostweite `flock`-Sperre pro Releasewurzel;
- kanonische Pfad- und Release-Namensprüfung;
- idempotente Wiederverifikation eines bytegleichen bereits aktiven Releases ohne Caddy-Neustart;
- `curl`-Connect-, Request- und Gesamtzeitgrenzen;
- Whitespace-robustes HTTP/2-Headerparsing;
- protokollierte Versuchszahl, Dauer und letzter Fehlergrund;
- Rollback löscht nur einen durch denselben Lauf angelegten Release mit unveränderter Device-/Inode-Identität und kanonischem Elternpfad;
- sichere Wiederherstellung bei Caddy-Validierungs-, Symlink-Umschalt-, Caddy-Neustart- und öffentlichem Readbackfehler;
- Retention löscht nicht über Dateisystemgrenzen hinweg.

### PostgreSQL-Backup

- neue feste Vorbereitungs-Unit mit begrenzter Capability-Menge;
- nur diese kurzlebige Unit darf unter `/var/backups` Verzeichnisse vorbereiten;
- der eigentliche Dumpdienst bleibt auf `/var/backups/weltgewebe/postgres` beschränkt;
- reale Kompatibilitätsprobe der Sandboxeigenschaften auf `wg-prod-1` erfolgreich.

### Off-Host

- Installations-Receipt enthält zusätzlich einen UTC-Zeitstempel.

## Bewusst nicht umgesetzt

- Kein öffentlicher Readback vor Caddy-Neuerzeugung: Der laufende alte Container hält bis dahin seinen bisherigen Bind-Mount; die öffentliche URL würde nur den alten Stand prüfen.
- Kein Blue-Green-Umbau: Das ist ein eigener Architekturball, kein notwendiger Fix für die belegten Fehler.
- Keine pauschale 5–8-Sekunden-Grenze: Standard bleibt eine konfigurierbare, nun tatsächlich harte 30-Sekunden-Obergrenze.
- Kein Gesamt-Repo-Clean-Gate im Off-Host-Installer: Installiert werden drei explizit Git- und hashgebundene Quelldateien; fremde Änderungen außerhalb dieses Scopes beeinflussen das Artefakt nicht.
- Keine Lockerung der realen `$HOME`-Pfadprüfung.

## Prüfungen

- `just lint`
- `make ci-validate`
  - 810 Docmeta-Tests
  - 160 Agenttests
  - 49 CI-Tests
- Webvertrag: Parallelität, Idempotenz, Header-Whitespace, echte Curl-Zeitgrenzen, Caddy-Validierungsfehler, Caddy-Neustartfehler, öffentlicher Mismatch und Rollback
- PostgreSQL-Backup-/Restore-Vertrag
- Off-Host-Pull-/Installervertrag
- Repository-Contract-Guards
- realer transienter systemd-Sandboxlauf auf `wg-prod-1`
- `git diff --check`

## Bindung

- Basis: `e0740690420b249988b5040fc72246df02f9b47b`
- Head: `fcde189d206d233630f8fcd4c10b0f3272b5ca70`
- Diff-SHA256: `f5a8f179f62de5ae725c687621456b8886407a2ac0e4c131e50983ff694517fd`