### PR TITLE
feat: make domain creates idempotent

### DIFF
--- a/apps/api/migrations/20260712000001_domain_create_idempotency.down.sql
+++ b/apps/api/migrations/20260712000001_domain_create_idempotency.down.sql
@@ -1,0 +1,11 @@
+DROP INDEX IF EXISTS domain_edges_create_operation_unique;
+ALTER TABLE domain_edges
+    DROP CONSTRAINT IF EXISTS domain_edges_create_operation_pair,
+    DROP COLUMN IF EXISTS create_operation_id,
+    DROP COLUMN IF EXISTS create_actor_id;
+
+DROP INDEX IF EXISTS domain_nodes_create_operation_unique;
+ALTER TABLE domain_nodes
+    DROP CONSTRAINT IF EXISTS domain_nodes_create_operation_pair,
+    DROP COLUMN IF EXISTS create_operation_id,
+    DROP COLUMN IF EXISTS create_actor_id;

--- a/apps/api/migrations/20260712000001_domain_create_idempotency.up.sql
+++ b/apps/api/migrations/20260712000001_domain_create_idempotency.up.sql
@@ -1,0 +1,45 @@
+-- Durable idempotency keys for user-initiated node and edge creation.
+--
+-- The pair is scoped to the authenticated account and resource table. Existing
+-- rows remain NULL/NULL and preserve their historical semantics. New callers
+-- may omit operation_id; those writes also remain NULL/NULL.
+
+ALTER TABLE domain_nodes
+    ADD COLUMN create_actor_id TEXT,
+    ADD COLUMN create_operation_id TEXT,
+    ADD CONSTRAINT domain_nodes_create_operation_pair
+        CHECK (
+            (create_actor_id IS NULL AND create_operation_id IS NULL)
+            OR
+            (
+                create_actor_id IS NOT NULL
+                AND btrim(create_actor_id) <> ''
+                AND create_operation_id IS NOT NULL
+                AND create_operation_id ~
+                    '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+            )
+        );
+
+CREATE UNIQUE INDEX domain_nodes_create_operation_unique
+    ON domain_nodes (create_actor_id, create_operation_id)
+    WHERE create_operation_id IS NOT NULL;
+
+ALTER TABLE domain_edges
+    ADD COLUMN create_actor_id TEXT,
+    ADD COLUMN create_operation_id TEXT,
+    ADD CONSTRAINT domain_edges_create_operation_pair
+        CHECK (
+            (create_actor_id IS NULL AND create_operation_id IS NULL)
+            OR
+            (
+                create_actor_id IS NOT NULL
+                AND btrim(create_actor_id) <> ''
+                AND create_operation_id IS NOT NULL
+                AND create_operation_id ~
+                    '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+            )
+        );
+
+CREATE UNIQUE INDEX domain_edges_create_operation_unique
+    ON domain_edges (create_actor_id, create_operation_id)
+    WHERE create_operation_id IS NOT NULL;

--- a/apps/api/src/domain_db.rs
+++ b/apps/api/src/domain_db.rs
@@ -23,6 +23,23 @@ use crate::state::OrderedCache;
 
 const DEFAULT_TIMESTAMP: &str = "1970-01-01T00:00:00Z";
 
+/// One client-generated create operation, scoped to the authenticated account.
+/// Resource ids and timestamps remain server-owned; this key only identifies a
+/// retry of the same user action.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreateOperationKey {
+    pub actor_id: String,
+    pub operation_id: String,
+}
+
+/// Durable create result. `Existing` means the operation key was already
+/// committed; the route still verifies that the semantic request is identical.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CreateWriteOutcome<T> {
+    Created,
+    Existing(T),
+}
+
 type NodeRow = (
     String,
     String,
@@ -526,6 +543,21 @@ fn node_from_row(row: NodeRow) -> Result<Node, anyhow::Error> {
     })
 }
 
+fn edge_from_row(row: EdgeRow) -> Result<Edge, anyhow::Error> {
+    let (id, source_id, target_id, edge_kind, created_at, payload_text) = row;
+    let payload = parse_payload(&payload_text);
+    Ok(Edge {
+        id,
+        source_id,
+        source_type: payload_string(&payload, "source_type"),
+        target_id,
+        target_type: payload_string(&payload, "target_type"),
+        edge_kind,
+        note: payload_string(&payload, "note"),
+        created_at: created_at.map(|t| t.to_rfc3339()),
+    })
+}
+
 /// Apply a patch to one `domain_nodes` row inside a transaction.
 ///
 /// Semantics:
@@ -649,6 +681,8 @@ pub async fn patch_node_in_postgres(
 pub enum NodeCreateError {
     #[error("node id already exists")]
     DuplicateId,
+    #[error("failed to map existing node row: {0}")]
+    Mapping(#[source] anyhow::Error),
     #[error("failed to serialize node payload: {0}")]
     Serialization(#[source] serde_json::Error),
     #[error("invalid server-generated node timestamp: {0}")]
@@ -665,7 +699,11 @@ pub enum NodeCreateError {
 /// writers without adding correctness.
 ///
 /// This function performs no in-memory mutation and writes no JSONL.
-pub async fn insert_domain_node(pool: &PgPool, node: &Node) -> Result<(), NodeCreateError> {
+pub async fn insert_domain_node(
+    pool: &PgPool,
+    node: &Node,
+    operation: Option<&CreateOperationKey>,
+) -> Result<CreateWriteOutcome<Node>, NodeCreateError> {
     let mut payload_map = Map::new();
     if let Some(summary) = &node.summary {
         payload_map.insert("summary".to_string(), json!(summary));
@@ -693,9 +731,41 @@ pub async fn insert_domain_node(pool: &PgPool, node: &Node) -> Result<(), NodeCr
 
     let mut tx = pool.begin().await.map_err(NodeCreateError::Database)?;
 
+    if let Some(operation) = operation {
+        sqlx::query(
+            "SELECT pg_advisory_xact_lock(\
+                 hashtextextended($1, hashtextextended($2, 0))\
+             )",
+        )
+        .bind(&operation.actor_id)
+        .bind(&operation.operation_id)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(NodeCreateError::Database)?;
+
+        let existing: Option<NodeRow> = sqlx::query_as(
+            "SELECT id, kind, title, lat, lon, created_at, updated_at, payload::text \
+             FROM domain_nodes \
+             WHERE create_actor_id = $1 AND create_operation_id = $2",
+        )
+        .bind(&operation.actor_id)
+        .bind(&operation.operation_id)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(NodeCreateError::Database)?;
+
+        if let Some(row) = existing {
+            let existing = node_from_row(row).map_err(NodeCreateError::Mapping)?;
+            tx.commit().await.map_err(NodeCreateError::Database)?;
+            return Ok(CreateWriteOutcome::Existing(existing));
+        }
+    }
+
     let result = sqlx::query(
-        "INSERT INTO domain_nodes (id, kind, title, lat, lon, created_at, updated_at, payload) \
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)",
+        "INSERT INTO domain_nodes \
+            (id, kind, title, lat, lon, created_at, updated_at, payload, \
+             create_actor_id, create_operation_id) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10)",
     )
     .bind(&node.id)
     .bind(&node.kind)
@@ -705,16 +775,35 @@ pub async fn insert_domain_node(pool: &PgPool, node: &Node) -> Result<(), NodeCr
     .bind(created_at)
     .bind(updated_at)
     .bind(&payload)
+    .bind(operation.map(|value| value.actor_id.as_str()))
+    .bind(operation.map(|value| value.operation_id.as_str()))
     .execute(&mut *tx)
     .await;
 
     match result {
         Ok(_) => {
             tx.commit().await.map_err(NodeCreateError::Database)?;
-            Ok(())
+            Ok(CreateWriteOutcome::Created)
         }
         Err(sqlx::Error::Database(db_err)) if db_err.is_unique_violation() => {
             tx.rollback().await.ok();
+            if let Some(operation) = operation {
+                let existing: Option<NodeRow> = sqlx::query_as(
+                    "SELECT id, kind, title, lat, lon, created_at, updated_at, payload::text \
+                     FROM domain_nodes \
+                     WHERE create_actor_id = $1 AND create_operation_id = $2",
+                )
+                .bind(&operation.actor_id)
+                .bind(&operation.operation_id)
+                .fetch_optional(pool)
+                .await
+                .map_err(NodeCreateError::Database)?;
+                if let Some(row) = existing {
+                    return node_from_row(row)
+                        .map(CreateWriteOutcome::Existing)
+                        .map_err(NodeCreateError::Mapping);
+                }
+            }
             Err(NodeCreateError::DuplicateId)
         }
         Err(e) => {
@@ -1363,15 +1452,37 @@ pub enum EdgeWriteError {
 pub async fn insert_domain_edge(
     pool: &PgPool,
     edge: &crate::routes::edges::Edge,
-) -> Result<(), EdgeWriteError> {
+    operation: Option<&CreateOperationKey>,
+) -> Result<CreateWriteOutcome<Edge>, EdgeWriteError> {
     let row = NewDomainEdgeRow::from_edge(edge).map_err(EdgeWriteError::Mapping)?;
 
     let mut tx = pool.begin().await.map_err(EdgeWriteError::Database)?;
 
+    // The existing edge path already serializes creates for cache-limit and
+    // duplicate-id semantics. The operation lookup belongs inside the same
+    // transaction so a replay cannot race the first insert.
     sqlx::query("LOCK TABLE domain_edges IN EXCLUSIVE MODE")
         .execute(&mut *tx)
         .await
         .map_err(EdgeWriteError::Database)?;
+
+    if let Some(operation) = operation {
+        let existing: Option<EdgeRow> = sqlx::query_as(
+            "SELECT id, source_id, target_id, edge_kind, created_at, payload::text \
+             FROM domain_edges \
+             WHERE create_actor_id = $1 AND create_operation_id = $2",
+        )
+        .bind(&operation.actor_id)
+        .bind(&operation.operation_id)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(EdgeWriteError::Database)?;
+        if let Some(row) = existing {
+            let existing = edge_from_row(row).map_err(EdgeWriteError::Mapping)?;
+            tx.commit().await.map_err(EdgeWriteError::Database)?;
+            return Ok(CreateWriteOutcome::Existing(existing));
+        }
+    }
 
     let (exists,): (bool,) =
         sqlx::query_as("SELECT EXISTS (SELECT 1 FROM domain_edges WHERE id = $1)")
@@ -1401,9 +1512,10 @@ pub async fn insert_domain_edge(
 
     let result = sqlx::query(
         "INSERT INTO domain_edges \
-            (id, source_id, target_id, edge_kind, created_at, payload) \
+            (id, source_id, target_id, edge_kind, created_at, payload, \
+             create_actor_id, create_operation_id) \
          VALUES \
-            ($1, $2, $3, $4, $5, $6::jsonb)",
+            ($1, $2, $3, $4, $5, $6::jsonb, $7, $8)",
     )
     .bind(&row.id)
     .bind(&row.source_id)
@@ -1411,16 +1523,35 @@ pub async fn insert_domain_edge(
     .bind(&row.edge_kind)
     .bind(row.created_at)
     .bind(&row.payload)
+    .bind(operation.map(|value| value.actor_id.as_str()))
+    .bind(operation.map(|value| value.operation_id.as_str()))
     .execute(&mut *tx)
     .await;
 
     match result {
         Ok(_) => {
             tx.commit().await.map_err(EdgeWriteError::Database)?;
-            Ok(())
+            Ok(CreateWriteOutcome::Created)
         }
         Err(sqlx::Error::Database(db_err)) if db_err.is_unique_violation() => {
             tx.rollback().await.ok();
+            if let Some(operation) = operation {
+                let existing: Option<EdgeRow> = sqlx::query_as(
+                    "SELECT id, source_id, target_id, edge_kind, created_at, payload::text \
+                     FROM domain_edges \
+                     WHERE create_actor_id = $1 AND create_operation_id = $2",
+                )
+                .bind(&operation.actor_id)
+                .bind(&operation.operation_id)
+                .fetch_optional(pool)
+                .await
+                .map_err(EdgeWriteError::Database)?;
+                if let Some(row) = existing {
+                    return edge_from_row(row)
+                        .map(CreateWriteOutcome::Existing)
+                        .map_err(EdgeWriteError::Mapping);
+                }
+            }
             Err(EdgeWriteError::DuplicateId)
         }
         Err(e) => {

--- a/apps/api/src/routes/edges.rs
+++ b/apps/api/src/routes/edges.rs
@@ -5,7 +5,9 @@ use super::query::{
 };
 use crate::auth::role::Role;
 use crate::config::DomainEdgeWriteSource;
-use crate::domain_db::{insert_domain_edge, EdgeWriteError};
+use crate::domain_db::{
+    insert_domain_edge, CreateOperationKey, CreateWriteOutcome, EdgeWriteError,
+};
 use crate::middleware::auth::AuthContext;
 use crate::state::{ApiState, OrderedCache};
 use crate::utils::edges_path;
@@ -295,8 +297,41 @@ async fn append_edge_line(record: &Value) -> std::io::Result<()> {
     Ok(())
 }
 
+const CREATE_ACTOR_KEY: &str = "_create_actor_id";
+const CREATE_OPERATION_KEY: &str = "_create_operation_id";
+
+fn add_create_operation_metadata(record: &mut Value, operation: Option<&CreateOperationKey>) {
+    let Some(operation) = operation else {
+        return;
+    };
+    let object = record
+        .as_object_mut()
+        .expect("canonical edge create record must be an object");
+    object.insert(
+        CREATE_ACTOR_KEY.to_string(),
+        Value::String(operation.actor_id.clone()),
+    );
+    object.insert(
+        CREATE_OPERATION_KEY.to_string(),
+        Value::String(operation.operation_id.clone()),
+    );
+}
+
+fn edge_matches_create(edge: &Edge, expected: &edge_create::ValidatedCreateEdge) -> bool {
+    expected
+        .id
+        .as_ref()
+        .is_none_or(|expected_id| edge.id == *expected_id)
+        && edge.source_id == expected.source_id
+        && edge.source_type.as_deref() == Some(expected.source_type.as_str())
+        && edge.target_id == expected.target_id
+        && edge.target_type.as_deref() == Some(expected.target_type.as_str())
+        && edge.edge_kind == expected.edge_kind
+        && edge.note == expected.note
+}
+
 /// Outcome of inspecting the persisted edges file before a create.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 struct EdgePersistenceStatus {
     /// The file already holds at least `max_edges_cache_limit()` lines, so an
     /// appended record would land on a line index [`load_edges`] never
@@ -307,55 +342,84 @@ struct EdgePersistenceStatus {
     /// it is not in the in-memory cache (e.g. in a suffix the loader
     /// truncated away).
     duplicate_id: bool,
+    /// Durable result of the same account-scoped operation, when present.
+    existing_operation: Option<Edge>,
 }
 
-/// Scan the persisted edges file before an append, mirroring [`load_edges`]
-/// semantics: every line counts toward the cache limit, unparseable lines are
-/// skipped, and a final unterminated line is still read. The whole file is
-/// scanned — also beyond the limit — so a duplicate id in the unmaterialized
-/// suffix is detected. A missing file means an empty persistence source.
-/// Callers MUST hold the `edge_create_persist_lock`.
-async fn inspect_edge_persistence_for_create(id: &str) -> std::io::Result<EdgePersistenceStatus> {
+/// Scan the persisted edges file once before an append, mirroring
+/// [`load_edges`] semantics: every line counts toward the cache limit,
+/// unparseable lines are skipped, and a final unterminated line is still read.
+/// The whole file is scanned — also beyond the limit — so duplicate ids and an
+/// earlier operation result in an unmaterialized suffix remain detectable. A
+/// missing file means an empty persistence source. Callers MUST hold the
+/// `edge_create_persist_lock`.
+async fn inspect_edge_persistence_for_create(
+    id: &str,
+    operation: Option<&CreateOperationKey>,
+) -> std::io::Result<EdgePersistenceStatus> {
     let path = edges_path();
     let max_edges = max_edges_cache_limit();
     let file = match File::open(&path).await {
-        Ok(f) => f,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            // A missing file is only writable when the loader would materialize
-            // at least one appended line after restart.
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             return Ok(EdgePersistenceStatus {
                 cache_limit_reached: max_edges == 0,
                 duplicate_id: false,
+                existing_operation: None,
             });
         }
-        Err(e) => return Err(e),
+        Err(error) => return Err(error),
     };
 
     let mut lines = BufReader::new(file).lines();
-    let mut lines_read: usize = 0;
+    let mut lines_read = 0usize;
+    let mut duplicate_id = false;
+    let mut existing_operation = None;
 
     while let Some(line) = lines.next_line().await? {
         lines_read += 1;
-        let edge: Edge = match serde_json::from_str(&line) {
-            Ok(v) => v,
+        let value: Value = match serde_json::from_str(&line) {
+            Ok(value) => value,
             // The loader skips unparseable lines; mirror that instead of
             // introducing a harder failure mode here.
             Err(_) => continue,
         };
+
+        let operation_matches = operation.is_some_and(|operation| {
+            value.get(CREATE_ACTOR_KEY).and_then(Value::as_str) == Some(operation.actor_id.as_str())
+                && value.get(CREATE_OPERATION_KEY).and_then(Value::as_str)
+                    == Some(operation.operation_id.as_str())
+        });
+        let edge: Edge = match serde_json::from_value(value) {
+            Ok(edge) => edge,
+            Err(error) if operation_matches => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("idempotent edge record cannot be projected: {error}"),
+                ));
+            }
+            // Preserve the loader's historical tolerance for malformed lines.
+            Err(_) => continue,
+        };
+
         if edge.id == id {
-            // Duplicate is terminal: create_edge returns 409 before consulting
-            // the limit, so scanning the remaining file would only extend the
-            // exclusive persist lock.
-            return Ok(EdgePersistenceStatus {
-                cache_limit_reached: false,
-                duplicate_id: true,
-            });
+            duplicate_id = true;
+        }
+        if operation_matches {
+            if existing_operation.is_some() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "duplicate edge create operation metadata",
+                ));
+            }
+            existing_operation = Some(edge);
         }
     }
 
     Ok(EdgePersistenceStatus {
         cache_limit_reached: lines_read >= max_edges,
-        duplicate_id: false,
+        duplicate_id,
+        existing_operation,
     })
 }
 
@@ -414,18 +478,16 @@ fn edge_create_error_message(err: &edge_create::EdgeCreateValidationError) -> St
 ///
 /// Write path: write gate ([`reject_edge_create_unless_writable`]) -> contract
 /// validation (PR-1 semantics) -> server-generated `id` / `created_at` ->
-/// persistence via the configured edge-create write source -> cache insert ->
-/// 201. The cache is only mutated after a successful durable persistence step,
-/// so a failed write never leaves a phantom edge in memory.
+/// persistence via the configured edge-create write source -> cache insert. A
+/// new durable write returns 201; an identical operation replay returns the
+/// existing edge with 200. Failed writes never leave a phantom cache entry.
 ///
-/// JSONL (default): persistence safety checks (file-level duplicate id,
-/// cache-limit materializability) followed by a durable JSONL append (fsync).
+/// JSONL (default): one serialized file scan checks operation replay,
+/// duplicate id and cache-limit materializability before a durable append.
 /// PostgreSQL (opt-in via `WELTGEWEBE_DOMAIN_EDGE_WRITE_SOURCE=postgres`,
-/// requires the PostgreSQL read source): PostgreSQL mode uses `insert_domain_edge`: a serialized transaction with a
-/// table-level lock, duplicate precheck, cache-limit count check, and final
-/// INSERT. Duplicate ids still map to 409; a unique violation remains a
-/// defensive fallback. No dual-write: JSONL mode never touches PostgreSQL,
-/// PostgreSQL mode never appends JSONL and never falls back to JSONL.
+/// requires the PostgreSQL read source): `insert_domain_edge` retains the
+/// serialized table-lock transaction, operation lookup, duplicate precheck,
+/// cache-limit count and final INSERT. No dual-write or fallback exists.
 pub async fn create_edge(
     State(state): State<ApiState>,
     Extension(auth): Extension<AuthContext>,
@@ -433,10 +495,8 @@ pub async fn create_edge(
 ) -> Result<(StatusCode, Json<Edge>), (StatusCode, String)> {
     reject_edge_create_unless_writable(&state)?;
 
-    // Deserialize manually (instead of extracting Json<CreateEdgeRequest>) so
-    // contract violations — unknown fields like `expires_at`, missing required
-    // fields, explicit nulls — map to a deterministic 400 rather than an
-    // extractor-shaped 422.
+    // Manual deserialization keeps unknown fields, missing required fields and
+    // explicit nulls on one deterministic 400 contract.
     let request: edge_create::CreateEdgeRequest = serde_json::from_value(payload).map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
@@ -453,13 +513,13 @@ pub async fn create_edge(
             ),
         )
     })?;
+    let semantic_request = validated.clone();
 
     // Account-originating Fäden represent an action by a concrete Garnrolle.
     // A Weber may therefore only name the authenticated account as source;
     // otherwise a crafted request could make another Garnrolle appear to have
     // woven the Faden. Admins retain the explicit operator path for repairs and
-    // controlled imports. `require_write` already guarantees authentication,
-    // but the missing-account branch stays fail-closed for defense in depth.
+    // controlled imports. The missing-account branch stays fail-closed.
     if validated.source_type == "account" && auth.role != Role::Admin {
         let own_account_id = auth.account_id.as_deref().ok_or_else(|| {
             (
@@ -475,32 +535,44 @@ pub async fn create_edge(
         }
     }
 
+    let operation = match validated.operation_id.as_ref() {
+        Some(operation_id) => {
+            let actor_id = auth.account_id.clone().ok_or_else(|| {
+                (
+                    StatusCode::UNAUTHORIZED,
+                    "authenticated account context missing".to_string(),
+                )
+            })?;
+            Some(CreateOperationKey {
+                actor_id,
+                operation_id: operation_id.clone(),
+            })
+        }
+        None => None,
+    };
+
     // Server-owned values: generate `id` when the client omitted it and stamp
-    // `created_at` (clients can never supply it — see CreateEdgeRequest).
+    // `created_at`. The operation id identifies only a retry and never becomes
+    // the resource id.
     let id = validated
         .id
         .clone()
         .unwrap_or_else(|| Uuid::new_v4().to_string());
     let created_at = chrono::Utc::now().to_rfc3339();
-    let (edge, record) = build_edge_record(validated, id, created_at);
+    let (edge, mut record) = build_edge_record(validated, id, created_at);
+    add_create_operation_metadata(&mut record, operation.as_ref());
 
-    // --- Persist ---
-    // Persist to the configured edge-create write source. Only after a
-    // successful durable write is the cache mutated, and the two write sources
-    // are mutually exclusive (no dual-write): JSONL mode never touches
-    // PostgreSQL, PostgreSQL mode never appends JSONL.
+    // Exactly one configured persistence source is used; there is no
+    // JSONL/PostgreSQL dual-write or fallback.
     match state.config.domain_edge_write_source {
         DomainEdgeWriteSource::Jsonl => {
-            // Serialize JSONL creates so check-then-write is atomic
+            // One lock covers operation lookup, duplicate/limit inspection and
+            // append, so concurrent retries cannot both write.
             let _persist_guard = edge_create_persist_lock().lock().await;
 
-            // Inspect the persistence source itself, not only the cache: when
-            // `max_edges_cache_limit()` truncated the load, the cache holds only a
-            // prefix of the file. A duplicate id hiding in the unmaterialized suffix
-            // and a write that could never be materialized after a restart must both
-            // be rejected here. Duplicate wins over the limit so the client gets the
-            // more precise cause.
-            let persistence = inspect_edge_persistence_for_create(&edge.id)
+            // The existing full-file safety scan now also finds an earlier
+            // operation result, avoiding a second pass over large JSONL files.
+            let persistence = inspect_edge_persistence_for_create(&edge.id, operation.as_ref())
                 .await
                 .map_err(|e| {
                     tracing::error!(error = %e, "failed to inspect edges JSONL before create");
@@ -509,6 +581,17 @@ pub async fn create_edge(
                         "failed to persist edge".to_string(),
                     )
                 })?;
+            if let Some(existing) = persistence.existing_operation {
+                if !edge_matches_create(&existing, &semantic_request) {
+                    return Err((
+                        StatusCode::CONFLICT,
+                        "edge operation id was already used for different data".to_string(),
+                    ));
+                }
+                let mut edges = state.edges.write().await;
+                edges.insert(existing.id.clone(), existing.clone());
+                return Ok((StatusCode::OK, Json(existing)));
+            }
             if persistence.duplicate_id {
                 return Err((StatusCode::CONFLICT, "edge id already exists".to_string()));
             }
@@ -516,9 +599,6 @@ pub async fn create_edge(
                 return Err((StatusCode::CONFLICT, "edge cache limit reached".to_string()));
             }
 
-            // The cache-level duplicate check stays: tests may seed the cache
-            // directly, and it guards the exceptional case of cache/persistence
-            // divergence.
             {
                 let edges = state.edges.read().await;
                 if edges.get(&edge.id).is_some() {
@@ -526,8 +606,8 @@ pub async fn create_edge(
                 }
             }
 
-            // Only after a successful durable append is the cache mutated. A failed
-            // write must never leave a phantom edge in memory.
+            // Cache mutation follows durable append; failed writes never
+            // leave a phantom Faden in memory.
             if let Err(e) = append_edge_line(&record).await {
                 tracing::error!(error = %e, "failed to append edge to JSONL");
                 return Err((
@@ -536,19 +616,12 @@ pub async fn create_edge(
                 ));
             }
 
-            {
-                let mut edges = state.edges.write().await;
-                edges.insert(edge.id.clone(), edge.clone());
-            }
+            let mut edges = state.edges.write().await;
+            edges.insert(edge.id.clone(), edge.clone());
         }
         DomainEdgeWriteSource::Postgres => {
-            // No JSONL inspection and no JSONL append in this mode. `insert_domain_edge`
-            // serializes the DB write with a table-level lock, duplicate precheck,
-            // cache-limit count check, and final INSERT; unique violation remains only a
-            // defensive fallback.
-            //
-            // The cache-level duplicate check stays for parity with the JSONL
-            // arm: tests may seed the cache directly.
+            // PostgreSQL mode never inspects or appends JSONL. The existing
+            // serialized transaction also owns the idempotency lookup.
             {
                 let edges = state.edges.read().await;
                 if edges.get(&edge.id).is_some() {
@@ -556,17 +629,27 @@ pub async fn create_edge(
                 }
             }
 
-            // Startup validation guarantees a pool exists in this mode; treat a
-            // missing pool as an internal error rather than silently degrading
-            // to JSONL.
+            // Missing pool state is an internal error, never permission to
+            // degrade silently to the JSONL write path.
             let pool = state.db_pool.as_ref().ok_or_else(|| {
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "PostgreSQL pool unavailable for edge write".to_string(),
                 )
             })?;
-            match insert_domain_edge(pool, &edge).await {
-                Ok(()) => {}
+            match insert_domain_edge(pool, &edge, operation.as_ref()).await {
+                Ok(CreateWriteOutcome::Created) => {}
+                Ok(CreateWriteOutcome::Existing(existing)) => {
+                    if !edge_matches_create(&existing, &semantic_request) {
+                        return Err((
+                            StatusCode::CONFLICT,
+                            "edge operation id was already used for different data".to_string(),
+                        ));
+                    }
+                    let mut edges = state.edges.write().await;
+                    edges.insert(existing.id.clone(), existing.clone());
+                    return Ok((StatusCode::OK, Json(existing)));
+                }
                 Err(EdgeWriteError::DuplicateId) => {
                     return Err((StatusCode::CONFLICT, "edge id already exists".to_string()));
                 }
@@ -582,10 +665,8 @@ pub async fn create_edge(
                 }
             }
 
-            {
-                let mut edges = state.edges.write().await;
-                edges.insert(edge.id.clone(), edge.clone());
-            }
+            let mut edges = state.edges.write().await;
+            edges.insert(edge.id.clone(), edge.clone());
         }
     }
 
@@ -593,6 +674,7 @@ pub async fn create_edge(
         event = "edge.created",
         edge_id = %edge.id,
         write_source = ?state.config.domain_edge_write_source,
+        operation_bound = operation.is_some(),
         "Edge created"
     );
 
@@ -619,6 +701,8 @@ pub async fn create_edge(
 /// - `source_id` / `target_id` are required, non-blank, and UUID-formatted.
 /// - `id` is optional but, when present, must be non-blank and UUID-formatted.
 /// - `note` is optional but, when present, must be non-blank and ≤ 1000 chars.
+/// - `operation_id` is optional but, when present, must be a non-null UUID and
+///   identifies only one account-scoped create action.
 ///
 /// `deny_unknown_fields` is applied **only** to `CreateEdgeRequest`, never to the
 /// read-side `Edge` model, so existing JSONL/read semantics stay untouched.
@@ -708,6 +792,8 @@ mod edge_create {
         target_type: String,
         #[serde(default, deserialize_with = "deserialize_optional_non_null_string")]
         note: Option<String>,
+        #[serde(default, deserialize_with = "deserialize_optional_non_null_string")]
+        operation_id: Option<String>,
     }
 
     /// Validated form of a `CreateEdgeRequest`.
@@ -725,6 +811,7 @@ mod edge_create {
         pub(super) source_type: String,
         pub(super) target_type: String,
         pub(super) note: Option<String>,
+        pub(super) operation_id: Option<String>,
     }
 
     /// Why a `CreateEdgeRequest` failed validation.
@@ -830,6 +917,20 @@ mod edge_create {
                 }
             }
 
+            let operation_id = match self.operation_id {
+                Some(value) => {
+                    require_non_blank("operation_id", &value)?;
+                    let parsed = Uuid::parse_str(&value).map_err(|_| {
+                        EdgeCreateValidationError::InvalidUuid {
+                            field: "operation_id",
+                            value: value.clone(),
+                        }
+                    })?;
+                    Some(parsed.to_string())
+                }
+                None => None,
+            };
+
             Ok(ValidatedCreateEdge {
                 id: self.id,
                 source_id: self.source_id,
@@ -838,6 +939,7 @@ mod edge_create {
                 source_type: self.source_type,
                 target_type: self.target_type,
                 note: self.note,
+                operation_id,
             })
         }
     }
@@ -861,6 +963,7 @@ mod edge_create {
                 source_type: "node".to_string(),
                 target_type: "account".to_string(),
                 note: None,
+                operation_id: None,
             }
         }
 
@@ -884,6 +987,7 @@ mod edge_create {
                     source_type: "node".to_string(),
                     target_type: "account".to_string(),
                     note: None,
+                    operation_id: None,
                 })
             );
         }
@@ -905,6 +1009,7 @@ mod edge_create {
                     source_type: "node".to_string(),
                     target_type: "account".to_string(),
                     note: Some("a note".to_string()),
+                    operation_id: None,
                 })
             );
         }

--- a/apps/api/src/routes/nodes.rs
+++ b/apps/api/src/routes/nodes.rs
@@ -10,15 +10,17 @@ use super::{
 };
 use crate::config::DomainNodeWriteSource;
 use crate::domain_db::{
-    insert_domain_node, patch_node_in_postgres, NodeCreateError, NodePatchInput, NodeWriteError,
+    insert_domain_node, patch_node_in_postgres, CreateOperationKey, CreateWriteOutcome,
+    NodeCreateError, NodePatchInput, NodeWriteError,
 };
+use crate::middleware::auth::AuthContext;
 use crate::state::{ApiState, OrderedCache};
 use crate::utils::nodes_path;
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
     response::{IntoResponse, Response},
-    Json,
+    Extension, Json,
 };
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{json, Value};
@@ -466,6 +468,77 @@ async fn append_node_line(record: &Value) -> std::io::Result<()> {
     Ok(())
 }
 
+const CREATE_ACTOR_KEY: &str = "_create_actor_id";
+const CREATE_OPERATION_KEY: &str = "_create_operation_id";
+
+fn add_create_operation_metadata(record: &mut Value, operation: Option<&CreateOperationKey>) {
+    let Some(operation) = operation else {
+        return;
+    };
+    let object = record
+        .as_object_mut()
+        .expect("canonical node create record must be an object");
+    object.insert(
+        CREATE_ACTOR_KEY.to_string(),
+        Value::String(operation.actor_id.clone()),
+    );
+    object.insert(
+        CREATE_OPERATION_KEY.to_string(),
+        Value::String(operation.operation_id.clone()),
+    );
+}
+
+/// Find an earlier durable JSONL result for one account-scoped operation.
+/// Unknown metadata remains invisible to the public `Node` projection.
+async fn find_node_by_operation(operation: &CreateOperationKey) -> std::io::Result<Option<Node>> {
+    let path = nodes_path();
+    let file = match File::open(&path).await {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    let mut lines = BufReader::new(file).lines();
+    let mut found = None;
+    while let Some(line) = lines.next_line().await? {
+        let value: Value = match serde_json::from_str(&line) {
+            Ok(value) => value,
+            Err(_) => continue,
+        };
+        let actor_matches = value.get(CREATE_ACTOR_KEY).and_then(Value::as_str)
+            == Some(operation.actor_id.as_str());
+        let operation_matches = value.get(CREATE_OPERATION_KEY).and_then(Value::as_str)
+            == Some(operation.operation_id.as_str());
+        if !actor_matches || !operation_matches {
+            continue;
+        }
+        if found.is_some() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "duplicate node create operation metadata",
+            ));
+        }
+        let node = map_json_to_node(&value).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "idempotent node record cannot be projected",
+            )
+        })?;
+        found = Some(node);
+    }
+    Ok(found)
+}
+
+fn node_matches_create(node: &Node, expected: &node_create::ValidatedCreateNode) -> bool {
+    node.title == expected.title
+        && node.kind == expected.kind
+        && node.address.as_deref() == Some(expected.address.as_str())
+        && node.location.lat == expected.lat
+        && node.location.lon == expected.lon
+        && node.summary == expected.summary
+        && node.info == expected.info
+        && node.tags == expected.tags
+}
+
 /// Build the in-memory `Node` and its canonical JSONL record from a validated
 /// create request plus the server-owned `id` and timestamp.
 fn build_node_record(
@@ -524,6 +597,7 @@ fn node_create_error_message(err: &node_create::NodeCreateValidationError) -> St
         E::InvalidCoordinate { field } => {
             format!("{field} must be a finite number within world bounds")
         }
+        E::InvalidUuid { field, value } => format!("invalid UUID for {field}: {value}"),
         E::TooManyTags { max } => format!("tags exceeds the maximum count of {max}"),
     }
 }
@@ -532,26 +606,27 @@ fn node_create_error_message(err: &node_create::NodeCreateValidationError) -> St
 ///
 /// Write path: write gate ([`reject_node_create_unless_writable`]) -> contract
 /// validation -> server-generated `id` / `created_at` / `updated_at` ->
-/// persistence via the configured node write source -> cache insert -> 201.
-/// The cache is only mutated after a successful durable persistence step, so
-/// a failed write never leaves a phantom node in memory.
+/// persistence via the configured node write source -> cache insert. A new
+/// durable write returns 201; an identical durable operation replay returns the
+/// existing node with 200. Failed writes never leave a phantom cache entry.
 ///
 /// JSONL (default): durable JSONL append (fsync), serialized against
 /// concurrent node persistence via `state.nodes_persist`.
 /// PostgreSQL (opt-in via `WELTGEWEBE_DOMAIN_NODE_WRITE_SOURCE=postgres`,
-/// requires the PostgreSQL read source): a serialized transaction with a
-/// table-level lock, duplicate precheck, and final INSERT. No dual-write:
-/// JSONL mode never touches PostgreSQL, PostgreSQL mode never appends JSONL.
+/// requires the PostgreSQL read source): one transaction, a per-operation
+/// advisory lock when `operation_id` is present, an account-scoped partial
+/// unique index, and the final INSERT. No dual-write: JSONL mode never touches
+/// PostgreSQL, PostgreSQL mode never appends JSONL.
 pub async fn create_node(
     State(state): State<ApiState>,
+    Extension(auth): Extension<AuthContext>,
     Json(payload): Json<Value>,
 ) -> Result<(StatusCode, Json<Node>), (StatusCode, String)> {
     reject_node_create_unless_writable(&state)?;
 
     // Deserialize manually (instead of extracting Json<CreateNodeRequest>) so
-    // contract violations (unknown fields, missing required fields, explicit
-    // nulls on server-owned fields) map to a deterministic 400 rather than an
-    // extractor-shaped 422.
+    // contract violations (unknown fields, missing required fields and explicit
+    // nulls) map to a deterministic 400 rather than an extractor-shaped 422.
     let request: node_create::CreateNodeRequest = serde_json::from_value(payload).map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
@@ -568,19 +643,59 @@ pub async fn create_node(
             ),
         )
     })?;
+    let semantic_request = validated.clone();
+
+    let operation = match validated.operation_id.as_ref() {
+        Some(operation_id) => {
+            let actor_id = auth.account_id.clone().ok_or_else(|| {
+                (
+                    StatusCode::UNAUTHORIZED,
+                    "authenticated account context missing".to_string(),
+                )
+            })?;
+            Some(CreateOperationKey {
+                actor_id,
+                operation_id: operation_id.clone(),
+            })
+        }
+        None => None,
+    };
 
     let id = Uuid::new_v4().to_string();
     let now = chrono::Utc::now().to_rfc3339();
-    let (node, record) = build_node_record(validated, id.clone(), now);
+    let (node, mut record) = build_node_record(validated, id.clone(), now);
+    add_create_operation_metadata(&mut record, operation.as_ref());
 
     match state.config.domain_node_write_source {
         DomainNodeWriteSource::Jsonl => {
-            // Serialize JSONL creates so cache/file mutation cannot interleave.
+            // Serialize operation lookup and append so two retries cannot both
+            // decide that the durable result is absent.
             let _persist_guard = state.nodes_persist.lock().await;
 
-            // id is a freshly generated UUIDv4; a cache collision is
-            // astronomically unlikely but checked defensively, mirroring the
-            // account/edge create paths.
+            if let Some(operation) = operation.as_ref() {
+                let existing = find_node_by_operation(operation).await.map_err(|error| {
+                    tracing::error!(%error, "failed to inspect node create operation");
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "failed to inspect node create operation".to_string(),
+                    )
+                })?;
+                if let Some(existing) = existing {
+                    if !node_matches_create(&existing, &semantic_request) {
+                        return Err((
+                            StatusCode::CONFLICT,
+                            "node operation id was already used for different data".to_string(),
+                        ));
+                    }
+                    let mut nodes = state.nodes.write().await;
+                    nodes.insert(existing.id.clone(), existing.clone());
+                    state.metrics.set_nodes_cache_count(nodes.len() as i64);
+                    return Ok((StatusCode::OK, Json(existing)));
+                }
+            }
+
+            // The id is server-generated, but keep the cache collision check
+            // as a fail-closed invariant and for directly seeded test states.
             {
                 let nodes = state.nodes.read().await;
                 if nodes.get(&id).is_some() {
@@ -588,6 +703,7 @@ pub async fn create_node(
                 }
             }
 
+            // Only a successful durable append may be reflected in cache.
             if let Err(e) = append_node_line(&record).await {
                 tracing::error!(error = %e, "failed to append node to JSONL");
                 return Err((
@@ -601,6 +717,8 @@ pub async fn create_node(
             state.metrics.set_nodes_cache_count(nodes.len() as i64);
         }
         DomainNodeWriteSource::Postgres => {
+            // PostgreSQL mode never appends JSONL. The helper performs the
+            // operation lookup and insert in one transaction.
             {
                 let nodes = state.nodes.read().await;
                 if nodes.get(&id).is_some() {
@@ -608,14 +726,28 @@ pub async fn create_node(
                 }
             }
 
+            // Startup validation normally guarantees this pool; missing
+            // state fails closed rather than falling back to JSONL.
             let pool = state.db_pool.as_ref().ok_or_else(|| {
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "PostgreSQL pool unavailable for node write".to_string(),
                 )
             })?;
-            match insert_domain_node(pool, &node).await {
-                Ok(()) => {}
+            match insert_domain_node(pool, &node, operation.as_ref()).await {
+                Ok(CreateWriteOutcome::Created) => {}
+                Ok(CreateWriteOutcome::Existing(existing)) => {
+                    if !node_matches_create(&existing, &semantic_request) {
+                        return Err((
+                            StatusCode::CONFLICT,
+                            "node operation id was already used for different data".to_string(),
+                        ));
+                    }
+                    let mut nodes = state.nodes.write().await;
+                    nodes.insert(existing.id.clone(), existing.clone());
+                    state.metrics.set_nodes_cache_count(nodes.len() as i64);
+                    return Ok((StatusCode::OK, Json(existing)));
+                }
                 Err(NodeCreateError::DuplicateId) => {
                     return Err((StatusCode::CONFLICT, "node id already exists".to_string()));
                 }
@@ -638,6 +770,7 @@ pub async fn create_node(
         event = "node.created",
         node_id = %node.id,
         write_source = ?state.config.domain_node_write_source,
+        operation_bound = operation.is_some(),
         "Node created"
     );
 
@@ -650,9 +783,22 @@ pub async fn create_node(
 /// request. `id`, `created_at`, `updated_at` are server-owned and therefore
 /// absent from the request type; combined with `deny_unknown_fields` a client
 /// that supplies them gets a deterministic 400 instead of a silently dropped
-/// field.
+/// field. `operation_id` may be omitted, but when present must be a non-null
+/// UUID and identifies only one account-scoped create action.
 mod node_create {
-    use serde::Deserialize;
+    use serde::{de, Deserialize, Deserializer};
+    use uuid::Uuid;
+
+    fn deserialize_optional_non_null_string<'de, D>(
+        deserializer: D,
+    ) -> Result<Option<String>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Option::<String>::deserialize(deserializer)?
+            .map(Some)
+            .ok_or_else(|| de::Error::custom("field must not be null"))
+    }
 
     /// Mirrors `contracts/domain/node.schema.json` (`title.maxLength`).
     const NODE_TITLE_MAX_LEN: usize = 200;
@@ -693,6 +839,8 @@ mod node_create {
         info: Option<String>,
         #[serde(default)]
         tags: Option<Vec<String>>,
+        #[serde(default, deserialize_with = "deserialize_optional_non_null_string")]
+        operation_id: Option<String>,
     }
 
     #[derive(Debug, Clone, PartialEq)]
@@ -705,6 +853,7 @@ mod node_create {
         pub(super) summary: Option<String>,
         pub(super) info: Option<String>,
         pub(super) tags: Vec<String>,
+        pub(super) operation_id: Option<String>,
     }
 
     #[derive(Debug, Clone, PartialEq)]
@@ -712,6 +861,7 @@ mod node_create {
         MissingOrEmptyField(&'static str),
         FieldTooLong { field: &'static str, max: usize },
         InvalidCoordinate { field: &'static str },
+        InvalidUuid { field: &'static str, value: String },
         TooManyTags { max: usize },
     }
 
@@ -802,6 +952,20 @@ mod node_create {
                 validated_tags.push(tag);
             }
 
+            let operation_id = match self.operation_id {
+                Some(value) => {
+                    require_non_blank("operation_id", &value)?;
+                    let parsed = Uuid::parse_str(&value).map_err(|_| {
+                        NodeCreateValidationError::InvalidUuid {
+                            field: "operation_id",
+                            value: value.clone(),
+                        }
+                    })?;
+                    Some(parsed.to_string())
+                }
+                None => None,
+            };
+
             Ok(ValidatedCreateNode {
                 title,
                 kind,
@@ -811,6 +975,7 @@ mod node_create {
                 summary,
                 info,
                 tags: validated_tags,
+                operation_id,
             })
         }
     }
@@ -831,6 +996,7 @@ mod node_create {
                 summary: None,
                 info: None,
                 tags: None,
+                operation_id: None,
             }
         }
 

--- a/apps/api/tests/api_edges.rs
+++ b/apps/api/tests/api_edges.rs
@@ -665,6 +665,84 @@ async fn post_edges_creates_edge_in_jsonl_mode() -> Result<()> {
 
 #[tokio::test]
 #[serial]
+async fn post_edges_replays_same_operation_without_second_write() -> Result<()> {
+    const OPERATION_ID: &str = "20000000-0000-0000-0000-000000000001";
+    let tmp = make_tmp_dir();
+    let in_dir = tmp.path().join("in");
+    fs::create_dir_all(&in_dir)?;
+    let edges_path = in_dir.join("demo.edges.jsonl");
+    let _env = set_gewebe_in_dir(&in_dir);
+
+    let (app, cookie, _initial_state) =
+        app_with_session(Role::Weber, DomainReadSource::Jsonl).await?;
+    let request_body = format!(
+        r#"{{"source_id":"{CREATE_SOURCE_ID}","source_type":"node","target_id":"{CREATE_TARGET_ID}","target_type":"node","edge_kind":"reference","operation_id":"{OPERATION_ID}"}}"#
+    );
+
+    let first_attempt = app
+        .clone()
+        .oneshot(post_edges(Some(&cookie), &request_body));
+    let second_attempt = app
+        .clone()
+        .oneshot(post_edges(Some(&cookie), &request_body));
+    let (first, second) = tokio::join!(first_attempt, second_attempt);
+    let first = first?;
+    let second = second?;
+    let first_status = first.status();
+    let second_status = second.status();
+    assert!(
+        (first_status == StatusCode::CREATED && second_status == StatusCode::OK)
+            || (first_status == StatusCode::OK && second_status == StatusCode::CREATED),
+        "parallel retries must produce one 201 and one 200, got {first_status} and {second_status}"
+    );
+    let first_edge = read_json_body(first).await?;
+    let second_edge = read_json_body(second).await?;
+    assert_eq!(first_edge["id"], second_edge["id"]);
+
+    let (restarted_app, restarted_cookie, restarted_state) =
+        app_with_session(Role::Weber, DomainReadSource::Jsonl).await?;
+    let replay = restarted_app
+        .clone()
+        .oneshot(post_edges(Some(&restarted_cookie), &request_body))
+        .await?;
+    assert_eq!(replay.status(), StatusCode::OK);
+    let replay_edge = read_json_body(replay).await?;
+    assert_eq!(replay_edge["id"], first_edge["id"]);
+    assert!(replay_edge.get("operation_id").is_none());
+    assert!(replay_edge.get("_create_operation_id").is_none());
+
+    let records = jsonl_lines(&edges_path);
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0]["_create_operation_id"], OPERATION_ID);
+    assert_eq!(restarted_state.edges.read().await.len(), 1);
+
+    let changed_body = format!(
+        r#"{{"source_id":"{CREATE_SOURCE_ID}","source_type":"node","target_id":"{CREATE_TARGET_ID}","target_type":"node","edge_kind":"reference","note":"different","operation_id":"{OPERATION_ID}"}}"#
+    );
+    let conflict = restarted_app
+        .oneshot(post_edges(Some(&restarted_cookie), &changed_body))
+        .await?;
+    assert_eq!(conflict.status(), StatusCode::CONFLICT);
+    assert_eq!(jsonl_lines(&edges_path).len(), 1);
+
+    let (other_app, other_cookie, _other_state) = app_with_session_for_account(
+        "writer2",
+        Role::Weber,
+        DomainReadSource::Jsonl,
+        weltgewebe_api::config::DomainEdgeWriteSource::Jsonl,
+    )
+    .await?;
+    let other = other_app
+        .oneshot(post_edges(Some(&other_cookie), &changed_body))
+        .await?;
+    assert_eq!(other.status(), StatusCode::CREATED);
+    assert_eq!(jsonl_lines(&edges_path).len(), 2);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
 async fn post_edges_accepts_client_uuid_id() -> Result<()> {
     let tmp = make_tmp_dir();
     let in_dir = tmp.path().join("in");
@@ -774,6 +852,23 @@ async fn post_edges_rejects_invalid_uuid() -> Result<()> {
     assert!(!edges_path.exists(), "rejected create must not write JSONL");
     assert_eq!(state.edges.read().await.len(), 0);
 
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn post_edges_rejects_invalid_operation_uuid() -> Result<()> {
+    let tmp = make_tmp_dir();
+    let in_dir = tmp.path().join("in");
+    fs::create_dir_all(&in_dir)?;
+    let _env = set_gewebe_in_dir(&in_dir);
+    let (app, cookie, state) = app_with_session(Role::Weber, DomainReadSource::Jsonl).await?;
+    let body_json = format!(
+        r#"{{"source_id":"{CREATE_SOURCE_ID}","source_type":"node","target_id":"{CREATE_TARGET_ID}","target_type":"node","edge_kind":"reference","operation_id":"not-a-uuid"}}"#
+    );
+    let res = app.oneshot(post_edges(Some(&cookie), &body_json)).await?;
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    assert!(state.edges.read().await.is_empty());
     Ok(())
 }
 

--- a/apps/api/tests/api_nodes.rs
+++ b/apps/api/tests/api_nodes.rs
@@ -1001,6 +1001,89 @@ async fn nodes_post_creates_persists_and_reloads() -> anyhow::Result<()> {
 
 #[tokio::test]
 #[serial]
+async fn nodes_post_replays_same_operation_without_second_write() -> anyhow::Result<()> {
+    const OPERATION_ID: &str = "10000000-0000-0000-0000-000000000001";
+    let tmp = make_tmp_dir();
+    let in_dir = tmp.path().join("in");
+    std::fs::create_dir_all(&in_dir)?;
+
+    let (app, cookie, _initial_state, _env) =
+        app_with_account(&in_dir, weber_account("weber1")).await;
+    let request_body = format!(
+        r#"{{"title":"Retry Safe Node","kind":"Werkstatt","address":"Musterstraße 1","location":{{"lat":53.55,"lon":9.99}},"summary":"Same action","operation_id":"{OPERATION_ID}"}}"#
+    );
+
+    let first_attempt = app
+        .clone()
+        .oneshot(post_node_req(Some(&cookie), &request_body));
+    let second_attempt = app
+        .clone()
+        .oneshot(post_node_req(Some(&cookie), &request_body));
+    let (first, second) = tokio::join!(first_attempt, second_attempt);
+    let first = first?;
+    let second = second?;
+    let first_status = first.status();
+    let second_status = second.status();
+    assert!(
+        (first_status == StatusCode::CREATED && second_status == StatusCode::OK)
+            || (first_status == StatusCode::OK && second_status == StatusCode::CREATED),
+        "parallel retries must produce one 201 and one 200, got {first_status} and {second_status}"
+    );
+    let first_body = body::to_bytes(first.into_body(), usize::MAX).await?;
+    let second_body = body::to_bytes(second.into_body(), usize::MAX).await?;
+    let first_node: serde_json::Value = serde_json::from_slice(&first_body)?;
+    let second_node: serde_json::Value = serde_json::from_slice(&second_body)?;
+    assert_eq!(first_node["id"], second_node["id"]);
+
+    // Build a fresh API/cache/session state to simulate a restart after the
+    // server committed but the first response was lost.
+    let (restarted_app, restarted_cookie, restarted_state, _restart_env) =
+        app_with_account(&in_dir, weber_account("weber1")).await;
+    let replay = restarted_app
+        .clone()
+        .oneshot(post_node_req(Some(&restarted_cookie), &request_body))
+        .await?;
+    assert_eq!(replay.status(), StatusCode::OK);
+    let replay_body = body::to_bytes(replay.into_body(), usize::MAX).await?;
+    let replay_node: serde_json::Value = serde_json::from_slice(&replay_body)?;
+    assert_eq!(replay_node["id"], first_node["id"]);
+    assert!(replay_node.get("operation_id").is_none());
+    assert!(replay_node.get("_create_operation_id").is_none());
+
+    let nodes_path = in_dir.join("demo.nodes.jsonl");
+    let contents = fs::read_to_string(&nodes_path)?;
+    assert_eq!(contents.lines().count(), 1);
+    let record: serde_json::Value = serde_json::from_str(contents.lines().next().unwrap())?;
+    assert_eq!(record["_create_actor_id"], "weber1");
+    assert_eq!(record["_create_operation_id"], OPERATION_ID);
+    assert_eq!(restarted_state.nodes.read().await.len(), 1);
+
+    // The key identifies one semantic action. Reusing it for changed data is a
+    // conflict and must still leave exactly one durable node.
+    let changed_body = format!(
+        r#"{{"title":"Different Node","kind":"Werkstatt","address":"Musterstraße 1","location":{{"lat":53.55,"lon":9.99}},"summary":"Same action","operation_id":"{OPERATION_ID}"}}"#
+    );
+    let conflict = restarted_app
+        .oneshot(post_node_req(Some(&restarted_cookie), &changed_body))
+        .await?;
+    assert_eq!(conflict.status(), StatusCode::CONFLICT);
+    assert_eq!(fs::read_to_string(&nodes_path)?.lines().count(), 1);
+
+    // The same UUID belongs to the account/action pair, not globally to all
+    // users. Another account may independently use it for a different node.
+    let (other_app, other_cookie, _other_state, _other_env) =
+        app_with_account(&in_dir, weber_account("weber2")).await;
+    let other = other_app
+        .oneshot(post_node_req(Some(&other_cookie), &changed_body))
+        .await?;
+    assert_eq!(other.status(), StatusCode::CREATED);
+    assert_eq!(fs::read_to_string(nodes_path)?.lines().count(), 2);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
 async fn nodes_post_requires_authentication() -> anyhow::Result<()> {
     let tmp = make_tmp_dir();
     let in_dir = tmp.path().join("in");
@@ -1105,6 +1188,10 @@ async fn nodes_post_rejects_invalid_payloads_with_stable_400() -> anyhow::Result
         r#"{"title":"Extra","kind":"Werkstatt","address":"Somewhere","location":{"lat":10.0,"lon":10.0},"wat":true}"#,
         // Server-owned id supplied by client.
         r#"{"id":"00000000-0000-0000-0000-000000000001","title":"Client Id","kind":"Werkstatt","address":"Somewhere","location":{"lat":10.0,"lon":10.0}}"#,
+        // Client operation id must be a UUID.
+        r#"{"title":"Bad Operation","kind":"Werkstatt","address":"Somewhere","location":{"lat":10.0,"lon":10.0},"operation_id":"not-a-uuid"}"#,
+        // Explicit null is not the same as omitting the optional operation id.
+        r#"{"title":"Null Operation","kind":"Werkstatt","address":"Somewhere","location":{"lat":10.0,"lon":10.0},"operation_id":null}"#,
         // Too many tags.
         &format!(
             r#"{{"title":"Too Many Tags","kind":"Werkstatt","address":"Somewhere","location":{{"lat":10.0,"lon":10.0}},"tags":[{}]}}"#,

--- a/apps/api/tests/db_domain_backfill.rs
+++ b/apps/api/tests/db_domain_backfill.rs
@@ -88,6 +88,28 @@ fn payload_str(keys: &[&str], source: &serde_json::Value) -> String {
     serde_json::to_string(&serde_json::Value::Object(m)).unwrap_or_else(|_| "{}".to_string())
 }
 
+fn create_operation_metadata(
+    source: &serde_json::Value,
+) -> Result<(Option<String>, Option<String>), ()> {
+    let actor = source.get("_create_actor_id");
+    let operation = source.get("_create_operation_id");
+    match (actor, operation) {
+        (None, None) => Ok((None, None)),
+        (Some(actor), Some(operation)) => {
+            let actor = actor
+                .as_str()
+                .filter(|value| !value.trim().is_empty())
+                .ok_or(())?;
+            let operation = operation
+                .as_str()
+                .and_then(|value| uuid::Uuid::parse_str(value).ok())
+                .ok_or(())?;
+            Ok((Some(actor.to_string()), Some(operation.to_string())))
+        }
+        _ => Err(()),
+    }
+}
+
 // ── Import functions ──────────────────────────────────────────────────────────
 
 /// Import JSONL content into domain_nodes.
@@ -145,6 +167,13 @@ async fn import_nodes(pool: &sqlx::PgPool, content: &str) -> BackfillReport {
         let created_at = v.get("created_at").map(parse_ts).unwrap_or(None);
         let updated_at = v.get("updated_at").map(parse_ts).unwrap_or(None);
         let payload = payload_str(&["summary", "info", "tags"], &v);
+        let (create_actor_id, create_operation_id) = match create_operation_metadata(&v) {
+            Ok(metadata) => metadata,
+            Err(()) => {
+                report.skipped_records += 1;
+                continue;
+            }
+        };
 
         let (already_exists,): (bool,) =
             sqlx::query_as("SELECT EXISTS(SELECT 1 FROM domain_nodes WHERE id = $1)")
@@ -155,16 +184,19 @@ async fn import_nodes(pool: &sqlx::PgPool, content: &str) -> BackfillReport {
 
         sqlx::query(
             "INSERT INTO domain_nodes
-                 (id, kind, title, lat, lon, created_at, updated_at, payload)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)
+                 (id, kind, title, lat, lon, created_at, updated_at, payload,
+                  create_actor_id, create_operation_id)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10)
              ON CONFLICT (id) DO UPDATE SET
-                 kind       = EXCLUDED.kind,
-                 title      = EXCLUDED.title,
-                 lat        = EXCLUDED.lat,
-                 lon        = EXCLUDED.lon,
-                 created_at = EXCLUDED.created_at,
-                 updated_at = EXCLUDED.updated_at,
-                 payload    = EXCLUDED.payload",
+                 kind                = EXCLUDED.kind,
+                 title               = EXCLUDED.title,
+                 lat                 = EXCLUDED.lat,
+                 lon                 = EXCLUDED.lon,
+                 created_at          = EXCLUDED.created_at,
+                 updated_at          = EXCLUDED.updated_at,
+                 payload             = EXCLUDED.payload,
+                 create_actor_id     = EXCLUDED.create_actor_id,
+                 create_operation_id = EXCLUDED.create_operation_id",
         )
         .bind(&id)
         .bind(&kind)
@@ -174,6 +206,8 @@ async fn import_nodes(pool: &sqlx::PgPool, content: &str) -> BackfillReport {
         .bind(created_at)
         .bind(updated_at)
         .bind(&payload)
+        .bind(create_actor_id.as_deref())
+        .bind(create_operation_id.as_deref())
         .execute(pool)
         .await
         .unwrap_or_else(|e| panic!("failed to upsert node {id}: {e}"));
@@ -248,6 +282,13 @@ async fn import_edges(pool: &sqlx::PgPool, content: &str) -> BackfillReport {
 
         let created_at = v.get("created_at").map(parse_ts).unwrap_or(None);
         let payload = payload_str(&["source_type", "target_type", "note"], &v);
+        let (create_actor_id, create_operation_id) = match create_operation_metadata(&v) {
+            Ok(metadata) => metadata,
+            Err(()) => {
+                report.skipped_records += 1;
+                continue;
+            }
+        };
 
         let (already_exists,): (bool,) =
             sqlx::query_as("SELECT EXISTS(SELECT 1 FROM domain_edges WHERE id = $1)")
@@ -258,14 +299,17 @@ async fn import_edges(pool: &sqlx::PgPool, content: &str) -> BackfillReport {
 
         sqlx::query(
             "INSERT INTO domain_edges
-                 (id, source_id, target_id, edge_kind, created_at, payload)
-             VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+                 (id, source_id, target_id, edge_kind, created_at, payload,
+                  create_actor_id, create_operation_id)
+             VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8)
              ON CONFLICT (id) DO UPDATE SET
-                 source_id  = EXCLUDED.source_id,
-                 target_id  = EXCLUDED.target_id,
-                 edge_kind  = EXCLUDED.edge_kind,
-                 created_at = EXCLUDED.created_at,
-                 payload    = EXCLUDED.payload",
+                 source_id           = EXCLUDED.source_id,
+                 target_id           = EXCLUDED.target_id,
+                 edge_kind           = EXCLUDED.edge_kind,
+                 created_at          = EXCLUDED.created_at,
+                 payload             = EXCLUDED.payload,
+                 create_actor_id     = EXCLUDED.create_actor_id,
+                 create_operation_id = EXCLUDED.create_operation_id",
         )
         .bind(&id)
         .bind(&source_id)
@@ -273,6 +317,8 @@ async fn import_edges(pool: &sqlx::PgPool, content: &str) -> BackfillReport {
         .bind(&edge_kind)
         .bind(created_at)
         .bind(&payload)
+        .bind(create_actor_id.as_deref())
+        .bind(create_operation_id.as_deref())
         .execute(pool)
         .await
         .unwrap_or_else(|e| panic!("failed to upsert edge {id}: {e}"));
@@ -446,13 +492,13 @@ async fn import_accounts(pool: &sqlx::PgPool, content: &str) -> BackfillReport {
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
 const NODE_FIXTURE: &str = r#"
-{"id":"backfill-proof-node-alpha","kind":"Ort","title":"Alpha Node","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-02T00:00:00Z","location":{"lat":53.5,"lon":10.0},"summary":"Alpha summary","tags":["tag-a"]}
+{"id":"backfill-proof-node-alpha","kind":"Ort","title":"Alpha Node","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-02T00:00:00Z","location":{"lat":53.5,"lon":10.0},"summary":"Alpha summary","tags":["tag-a"],"_create_actor_id":"backfill-actor-node","_create_operation_id":"70000000-0000-0000-0000-000000000001"}
 {"id":"backfill-proof-node-beta","kind":"Person","title":"Beta Node","created_at":"2026-02-01T00:00:00Z","updated_at":"2026-02-02T00:00:00Z","location":{"lat":48.1,"lon":11.6},"info":"Beta info"}
 {"id":"backfill-proof-node-gamma","kind":"Unknown","title":"Gamma Node","location":{"lat":52.5,"lon":13.4}}
 "#;
 
 const EDGE_FIXTURE: &str = r#"
-{"id":"backfill-proof-edge-alpha","source_id":"backfill-proof-node-alpha","target_id":"backfill-proof-node-beta","edge_kind":"knows","created_at":"2026-01-15T00:00:00Z","note":"Test note"}
+{"id":"backfill-proof-edge-alpha","source_id":"backfill-proof-node-alpha","target_id":"backfill-proof-node-beta","edge_kind":"knows","created_at":"2026-01-15T00:00:00Z","note":"Test note","_create_actor_id":"backfill-actor-edge","_create_operation_id":"80000000-0000-0000-0000-000000000001"}
 {"id":"backfill-proof-edge-beta","source_id":"backfill-proof-node-beta","target_id":"backfill-proof-node-gamma","edge_kind":"related"}
 "#;
 
@@ -465,6 +511,7 @@ const MALFORMED_NODE_FIXTURE: &str = r#"
 {"id":"backfill-proof-node-valid-1","kind":"Test","title":"Valid One","location":{"lat":50.0,"lon":9.0}}
 not valid json at all {{{
 {"id":"backfill-proof-node-valid-2","kind":"Test","title":"Valid Two","location":{"lat":51.0,"lon":9.0}}
+{"id":"backfill-proof-node-invalid-operation","kind":"Test","title":"Invalid Operation","location":{"lat":51.5,"lon":9.5},"_create_actor_id":"actor-without-operation"}
 "#;
 
 const DUPLICATE_ID_NODE_FIXTURE: &str = r#"
@@ -519,6 +566,33 @@ async fn domain_backfill_nodes_deterministic_and_idempotent() {
             .expect("node alpha must exist after import");
     assert_eq!(kind, "Ort");
     assert_eq!(title, "Alpha Node");
+
+    let (actor, operation, payload_actor, payload_operation): (
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+    ) = sqlx::query_as(
+        r#"
+        SELECT create_actor_id,
+               create_operation_id,
+               payload->>'_create_actor_id',
+               payload->>'_create_operation_id'
+        FROM domain_nodes
+        WHERE id = $1
+        "#,
+    )
+    .bind("backfill-proof-node-alpha")
+    .fetch_one(&pool)
+    .await
+    .expect("node operation metadata must be readable");
+    assert_eq!(actor.as_deref(), Some("backfill-actor-node"));
+    assert_eq!(
+        operation.as_deref(),
+        Some("70000000-0000-0000-0000-000000000001")
+    );
+    assert!(payload_actor.is_none());
+    assert!(payload_operation.is_none());
 
     let (lat, lon): (Option<f64>, Option<f64>) =
         sqlx::query_as("SELECT lat, lon FROM domain_nodes WHERE id = $1")
@@ -616,6 +690,32 @@ async fn domain_backfill_edges_deterministic_and_idempotent() {
         Some("Test note"),
         "note must be preserved in payload jsonb"
     );
+    let (actor, operation, payload_actor, payload_operation): (
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+    ) = sqlx::query_as(
+        r#"
+        SELECT create_actor_id,
+               create_operation_id,
+               payload->>'_create_actor_id',
+               payload->>'_create_operation_id'
+        FROM domain_edges
+        WHERE id = $1
+        "#,
+    )
+    .bind("backfill-proof-edge-alpha")
+    .fetch_one(&pool)
+    .await
+    .expect("edge operation metadata must be readable");
+    assert_eq!(actor.as_deref(), Some("backfill-actor-edge"));
+    assert_eq!(
+        operation.as_deref(),
+        Some("80000000-0000-0000-0000-000000000001")
+    );
+    assert!(payload_actor.is_none());
+    assert!(payload_operation.is_none());
 
     // Second import (idempotency)
     let r2 = import_edges(&pool, EDGE_FIXTURE).await;
@@ -758,8 +858,14 @@ async fn domain_backfill_malformed_lines_quarantined() {
     run_migrations(&pool).await;
 
     sqlx::query(
-        "DELETE FROM domain_nodes WHERE id IN \
-         ('backfill-proof-node-valid-1', 'backfill-proof-node-valid-2')",
+        r#"
+        DELETE FROM domain_nodes
+        WHERE id IN (
+            'backfill-proof-node-valid-1',
+            'backfill-proof-node-valid-2',
+            'backfill-proof-node-invalid-operation'
+        )
+        "#,
     )
     .execute(&pool)
     .await
@@ -767,18 +873,19 @@ async fn domain_backfill_malformed_lines_quarantined() {
 
     let r = import_nodes(&pool, MALFORMED_NODE_FIXTURE).await;
 
-    // 3 non-empty lines total: 2 valid JSON, 1 malformed
-    assert_eq!(r.records_read, 3, "must count all non-empty lines");
+    // 4 non-empty lines: 2 valid records, 1 malformed JSON line and one
+    // structurally invalid half-populated operation pair.
+    assert_eq!(r.records_read, 4, "must count all non-empty lines");
     assert_eq!(
         r.malformed_json_lines, 1,
         "exactly one malformed line must be quarantined"
     );
     assert_eq!(r.records_inserted, 2, "two valid records must be imported");
-    assert_eq!(r.skipped_records, 0);
+    assert_eq!(r.skipped_records, 1);
 
     let (count,): (i64,) = sqlx::query_as(
         "SELECT COUNT(*) FROM domain_nodes WHERE id IN \
-         ('backfill-proof-node-valid-1', 'backfill-proof-node-valid-2')",
+         ('backfill-proof-node-valid-1', 'backfill-proof-node-valid-2',           'backfill-proof-node-invalid-operation')",
     )
     .fetch_one(&pool)
     .await

--- a/apps/api/tests/db_domain_edge_write_path.rs
+++ b/apps/api/tests/db_domain_edge_write_path.rs
@@ -401,7 +401,94 @@ async fn postgres_edge_create_persists_row_cache_and_loader_roundtrip() -> Resul
     Ok(())
 }
 
-/// B. Absent note stays absent: the payload carries no `note` key (never
+/// B. An account-scoped operation survives a simulated API restart and returns
+/// the same server-owned edge id. Reusing the key for different semantic data
+/// is rejected without a second row.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
+#[serial]
+async fn postgres_edge_create_operation_replays_after_restart() -> Result<()> {
+    const ACTOR_ID: &str = "writepath-edge-idempotency-actor";
+    const OPERATION_ID: &str = "40000000-0000-0000-0000-000000000001";
+
+    let pool = connect_pool().await;
+    run_migrations(&pool).await;
+    clean(&pool).await;
+
+    let tmp = tempfile::tempdir()?;
+    let in_dir = tmp.path().join("in");
+    std::fs::create_dir_all(&in_dir)?;
+    let _env = set_gewebe_in_dir(&in_dir);
+    let request_body = format!(
+        r#"{{"source_id":"{SOURCE_ID}","source_type":"node","target_id":"{TARGET_ID}","target_type":"account","edge_kind":"reference","note":"durable","operation_id":"{OPERATION_ID}"}}"#
+    );
+
+    let (first_app, first_cookie, _) = edge_write_app(
+        pool.clone(),
+        ACTOR_ID,
+        DomainReadSource::Postgres,
+        DomainEdgeWriteSource::Postgres,
+    )
+    .await?;
+    let first_attempt = first_app
+        .clone()
+        .oneshot(post_edges_req(&first_cookie, &request_body));
+    let second_attempt = first_app
+        .clone()
+        .oneshot(post_edges_req(&first_cookie, &request_body));
+    let (first, second) = tokio::join!(first_attempt, second_attempt);
+    let first = first?;
+    let second = second?;
+    let first_status = first.status();
+    let second_status = second.status();
+    assert!(
+        (first_status == StatusCode::CREATED && second_status == StatusCode::OK)
+            || (first_status == StatusCode::OK && second_status == StatusCode::CREATED),
+        "parallel PostgreSQL retries must produce one 201 and one 200, got {first_status} and {second_status}"
+    );
+    let first_edge = read_json_body(first).await?;
+    let second_edge = read_json_body(second).await?;
+    assert_eq!(first_edge["id"], second_edge["id"]);
+    let first_id = first_edge["id"].as_str().context("created edge id")?;
+
+    let (restarted_app, restarted_cookie, restarted_state) = edge_write_app(
+        pool.clone(),
+        ACTOR_ID,
+        DomainReadSource::Postgres,
+        DomainEdgeWriteSource::Postgres,
+    )
+    .await?;
+    let replay = restarted_app
+        .clone()
+        .oneshot(post_edges_req(&restarted_cookie, &request_body))
+        .await?;
+    assert_eq!(replay.status(), StatusCode::OK);
+    let replay_edge = read_json_body(replay).await?;
+    assert_eq!(replay_edge["id"], first_id);
+    assert_eq!(restarted_state.edges.read().await.len(), 1);
+
+    let changed_body = format!(
+        r#"{{"source_id":"{SOURCE_ID}","source_type":"node","target_id":"{TARGET_ID}","target_type":"account","edge_kind":"reference","note":"changed","operation_id":"{OPERATION_ID}"}}"#
+    );
+    let conflict = restarted_app
+        .oneshot(post_edges_req(&restarted_cookie, &changed_body))
+        .await?;
+    assert_eq!(conflict.status(), StatusCode::CONFLICT);
+
+    let (count, actor, operation): (i64, Option<String>, Option<String>) = sqlx::query_as(
+        "SELECT count(*), min(create_actor_id), min(create_operation_id) FROM domain_edges",
+    )
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(count, 1);
+    assert_eq!(actor.as_deref(), Some(ACTOR_ID));
+    assert_eq!(operation.as_deref(), Some(OPERATION_ID));
+
+    clean(&pool).await;
+    Ok(())
+}
+
+/// C. Absent note stays absent: the payload carries no `note` key (never
 /// `note: null`), and the loader reconstructs `note = None`.
 #[tokio::test]
 #[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
@@ -459,7 +546,7 @@ async fn postgres_edge_create_omits_note_key_when_absent() -> Result<()> {
     Ok(())
 }
 
-/// C. Duplicate id from the database surfaces as 409 (plain INSERT, no
+/// D. Duplicate id from the database surfaces as 409 (plain INSERT, no
 /// ON CONFLICT): the second create leaves exactly one row and no extra cache
 /// entry.
 #[tokio::test]
@@ -522,7 +609,7 @@ async fn postgres_edge_create_duplicate_id_returns_409() -> Result<()> {
     Ok(())
 }
 
-/// D. Postgres read + JSONL edge write is blocked with 409 and writes nothing.
+/// E. Postgres read + JSONL edge write is blocked with 409 and writes nothing.
 #[tokio::test]
 #[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
 #[serial]
@@ -566,7 +653,7 @@ async fn postgres_read_jsonl_edge_write_is_blocked() -> Result<()> {
     Ok(())
 }
 
-/// E. Defensive invalid-config state (JSONL read + Postgres edge write, which
+/// F. Defensive invalid-config state (JSONL read + Postgres edge write, which
 /// config load forbids) is rejected with 500 and writes nothing.
 #[tokio::test]
 #[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
@@ -631,7 +718,7 @@ impl Drop for EnvVarGuard {
     }
 }
 
-/// F. PostgreSQL create rejects when domain_edges is already at MAX_EDGES_CACHE.
+/// G. PostgreSQL create rejects when domain_edges is already at MAX_EDGES_CACHE.
 #[tokio::test]
 #[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
 #[serial]

--- a/apps/api/tests/db_domain_node_write_path.rs
+++ b/apps/api/tests/db_domain_node_write_path.rs
@@ -887,7 +887,87 @@ async fn postgres_node_create_persists_and_reload_sees_it() -> Result<()> {
     Ok(())
 }
 
-/// J. Invalid create payloads (missing required fields, out-of-bounds
+/// J. An account-scoped operation survives a simulated API restart. The first
+/// request returns 201; the same semantic request from a newly built app returns
+/// the existing node with 200; changed data under the same key returns 409.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
+#[serial]
+async fn postgres_node_create_operation_replays_after_restart() -> Result<()> {
+    const ACTOR_ID: &str = "writepath-node-idempotency-actor";
+    const OPERATION_ID: &str = "30000000-0000-0000-0000-000000000001";
+
+    let pool = connect_pool().await;
+    run_migrations(&pool).await;
+    clean_all_nodes(&pool).await;
+
+    let tmp = tempfile::tempdir()?;
+    let in_dir = tmp.path().join("in");
+    std::fs::create_dir_all(&in_dir)?;
+    let _env = set_gewebe_in_dir(&in_dir);
+    let request_body = format!(
+        r#"{{"title":"Postgres Retry Node","kind":"Werkstatt","address":"Musterstraße 1","location":{{"lat":53.55,"lon":9.99}},"summary":"durable","operation_id":"{OPERATION_ID}"}}"#
+    );
+
+    let (first_app, first_cookie, _) = postgres_write_app(pool.clone(), ACTOR_ID).await?;
+    let first_attempt = first_app
+        .clone()
+        .oneshot(post_node_req(&first_cookie, &request_body));
+    let second_attempt = first_app
+        .clone()
+        .oneshot(post_node_req(&first_cookie, &request_body));
+    let (first, second) = tokio::join!(first_attempt, second_attempt);
+    let first = first?;
+    let second = second?;
+    let first_status = first.status();
+    let second_status = second.status();
+    assert!(
+        (first_status == StatusCode::CREATED && second_status == StatusCode::OK)
+            || (first_status == StatusCode::OK && second_status == StatusCode::CREATED),
+        "parallel PostgreSQL retries must produce one 201 and one 200, got {first_status} and {second_status}"
+    );
+    let first_bytes = body::to_bytes(first.into_body(), usize::MAX).await?;
+    let second_bytes = body::to_bytes(second.into_body(), usize::MAX).await?;
+    let first_node: serde_json::Value = serde_json::from_slice(&first_bytes)?;
+    let second_node: serde_json::Value = serde_json::from_slice(&second_bytes)?;
+    assert_eq!(first_node["id"], second_node["id"]);
+    let first_id = first_node["id"].as_str().context("created node id")?;
+
+    // New app state and newly loaded PostgreSQL cache simulate an API restart.
+    let (restarted_app, restarted_cookie, restarted_state) =
+        postgres_write_app(pool.clone(), ACTOR_ID).await?;
+    let replay = restarted_app
+        .clone()
+        .oneshot(post_node_req(&restarted_cookie, &request_body))
+        .await?;
+    assert_eq!(replay.status(), StatusCode::OK);
+    let replay_bytes = body::to_bytes(replay.into_body(), usize::MAX).await?;
+    let replay_node: serde_json::Value = serde_json::from_slice(&replay_bytes)?;
+    assert_eq!(replay_node["id"], first_id);
+    assert_eq!(restarted_state.nodes.read().await.len(), 1);
+
+    let changed_body = format!(
+        r#"{{"title":"Changed Retry Node","kind":"Werkstatt","address":"Musterstraße 1","location":{{"lat":53.55,"lon":9.99}},"summary":"durable","operation_id":"{OPERATION_ID}"}}"#
+    );
+    let conflict = restarted_app
+        .oneshot(post_node_req(&restarted_cookie, &changed_body))
+        .await?;
+    assert_eq!(conflict.status(), StatusCode::CONFLICT);
+
+    let (count, actor, operation): (i64, Option<String>, Option<String>) = sqlx::query_as(
+        "SELECT count(*), min(create_actor_id), min(create_operation_id) FROM domain_nodes",
+    )
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(count, 1);
+    assert_eq!(actor.as_deref(), Some(ACTOR_ID));
+    assert_eq!(operation.as_deref(), Some(OPERATION_ID));
+
+    clean_all_nodes(&pool).await;
+    Ok(())
+}
+
+/// K. Invalid create payloads (missing required fields, out-of-bounds
 /// coordinates) return a stable 400 and never touch the database.
 #[tokio::test]
 #[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
@@ -938,7 +1018,7 @@ async fn postgres_node_create_rejects_invalid_payload_without_side_effects() -> 
     Ok(())
 }
 
-/// K. Direct write-path proof: a primary-key collision at the database level
+/// L. Direct write-path proof: a primary-key collision at the database level
 /// is classified as `DuplicateId` and leaves the existing row untouched.
 #[tokio::test]
 #[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
@@ -965,13 +1045,14 @@ async fn insert_domain_node_classifies_duplicate_id() -> Result<()> {
         },
     };
 
-    insert_domain_node(&pool, &make_node("First"))
+    insert_domain_node(&pool, &make_node("First"), None)
         .await
         .expect("first insert must succeed");
 
-    let err = insert_domain_node(&pool, &make_node("Second"))
-        .await
-        .expect_err("duplicate id insert must fail");
+    let err = match insert_domain_node(&pool, &make_node("Second"), None).await {
+        Err(error) => error,
+        Ok(_) => panic!("duplicate id insert must fail"),
+    };
     assert!(
         matches!(err, NodeCreateError::DuplicateId),
         "expected DuplicateId, got {err:?}"

--- a/apps/api/tests/db_domain_schema_migrations.rs
+++ b/apps/api/tests/db_domain_schema_migrations.rs
@@ -89,6 +89,46 @@ async fn index_exists(pool: &sqlx::PgPool, index_name: &str) -> bool {
     row.0
 }
 
+async fn column_exists(pool: &sqlx::PgPool, table_name: &str, column_name: &str) -> bool {
+    let row: (bool,) = sqlx::query_as(
+        r#"
+        SELECT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = $1
+              AND column_name = $2
+        )
+        "#,
+    )
+    .bind(table_name)
+    .bind(column_name)
+    .fetch_one(pool)
+    .await
+    .expect("failed to query information_schema.columns");
+
+    row.0
+}
+
+async fn constraint_exists(pool: &sqlx::PgPool, constraint_name: &str) -> bool {
+    let row: (bool,) = sqlx::query_as(
+        r#"
+        SELECT EXISTS (
+            SELECT 1
+            FROM pg_constraint
+            WHERE connamespace = 'public'::regnamespace
+              AND conname = $1
+        )
+        "#,
+    )
+    .bind(constraint_name)
+    .fetch_one(pool)
+    .await
+    .expect("failed to query pg_constraint");
+
+    row.0
+}
+
 /// Verifies that running all migrations creates the domain tables and
 /// expected indexes for nodes, edges, and accounts.
 ///
@@ -113,6 +153,22 @@ async fn domain_schema_tables_exist_after_migration() {
         index_exists(&pool, "domain_nodes_lat_lon").await,
         "domain_nodes_lat_lon index must exist"
     );
+    assert!(
+        column_exists(&pool, "domain_nodes", "create_actor_id").await,
+        "domain_nodes.create_actor_id must exist"
+    );
+    assert!(
+        column_exists(&pool, "domain_nodes", "create_operation_id").await,
+        "domain_nodes.create_operation_id must exist"
+    );
+    assert!(
+        index_exists(&pool, "domain_nodes_create_operation_unique").await,
+        "domain_nodes create-operation unique index must exist"
+    );
+    assert!(
+        constraint_exists(&pool, "domain_nodes_create_operation_pair").await,
+        "domain_nodes create-operation pair check must exist"
+    );
 
     // --- domain_edges ---
     assert!(
@@ -130,6 +186,22 @@ async fn domain_schema_tables_exist_after_migration() {
     assert!(
         index_exists(&pool, "domain_edges_source_target").await,
         "domain_edges_source_target index must exist"
+    );
+    assert!(
+        column_exists(&pool, "domain_edges", "create_actor_id").await,
+        "domain_edges.create_actor_id must exist"
+    );
+    assert!(
+        column_exists(&pool, "domain_edges", "create_operation_id").await,
+        "domain_edges.create_operation_id must exist"
+    );
+    assert!(
+        index_exists(&pool, "domain_edges_create_operation_unique").await,
+        "domain_edges create-operation unique index must exist"
+    );
+    assert!(
+        constraint_exists(&pool, "domain_edges_create_operation_pair").await,
+        "domain_edges create-operation pair check must exist"
     );
 
     // --- domain_accounts ---
@@ -246,6 +318,204 @@ async fn domain_schema_basic_insert_and_read() {
         .execute(&pool)
         .await
         .expect("failed to clean up domain_accounts probe row");
+
+    pool.close().await;
+}
+
+/// Verifies the create-operation schema contract directly: legacy NULL/NULL
+/// rows remain valid, one account cannot reuse one operation id for a second
+/// row, another account may use the same UUID independently, and half-populated
+/// operation metadata is rejected by the pair check.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
+async fn domain_create_operation_constraints_are_enforced() {
+    let pool = connect_pool().await;
+    run_migrations(&pool).await;
+
+    sqlx::query("DELETE FROM domain_edges WHERE id LIKE 'test-operation-edge-%'")
+        .execute(&pool)
+        .await
+        .expect("failed to clean edge create-operation probe rows");
+    sqlx::query("DELETE FROM domain_nodes WHERE id LIKE 'test-operation-node-%'")
+        .execute(&pool)
+        .await
+        .expect("failed to clean node create-operation probe rows");
+
+    sqlx::query(
+        "INSERT INTO domain_nodes \
+            (id, kind, title, lat, lon, payload, create_actor_id, create_operation_id) \
+         VALUES \
+            ('test-operation-node-a', 'test', 'A', 1, 1, '{}', 'actor-a', \
+             '50000000-0000-0000-0000-000000000001')",
+    )
+    .execute(&pool)
+    .await
+    .expect("first node operation row must insert");
+
+    let node_duplicate = sqlx::query(
+        "INSERT INTO domain_nodes \
+            (id, kind, title, lat, lon, payload, create_actor_id, create_operation_id) \
+         VALUES \
+            ('test-operation-node-b', 'test', 'B', 1, 1, '{}', 'actor-a', \
+             '50000000-0000-0000-0000-000000000001')",
+    )
+    .execute(&pool)
+    .await
+    .expect_err("same actor and node operation must be unique");
+    assert!(node_duplicate
+        .as_database_error()
+        .is_some_and(|error| error.is_unique_violation()));
+
+    sqlx::query(
+        "INSERT INTO domain_nodes \
+            (id, kind, title, lat, lon, payload, create_actor_id, create_operation_id) \
+         VALUES \
+            ('test-operation-node-c', 'test', 'C', 1, 1, '{}', 'actor-b', \
+             '50000000-0000-0000-0000-000000000001')",
+    )
+    .execute(&pool)
+    .await
+    .expect("same node operation UUID must remain independent across accounts");
+
+    let node_half_pair = sqlx::query(
+        "INSERT INTO domain_nodes \
+            (id, kind, title, lat, lon, payload, create_actor_id) \
+         VALUES ('test-operation-node-half', 'test', 'half', 1, 1, '{}', 'actor-a')",
+    )
+    .execute(&pool)
+    .await
+    .expect_err("half-populated node operation metadata must fail");
+    assert_eq!(
+        node_half_pair
+            .as_database_error()
+            .and_then(|error| error.code())
+            .as_deref(),
+        Some("23514")
+    );
+
+    for (id, actor, operation) in [
+        (
+            "test-operation-node-blank-actor",
+            "   ",
+            "50000000-0000-0000-0000-000000000002",
+        ),
+        ("test-operation-node-invalid-uuid", "actor-a", "NOT-A-UUID"),
+    ] {
+        let error = sqlx::query(
+            "INSERT INTO domain_nodes \
+                (id, kind, title, lat, lon, payload, create_actor_id, create_operation_id) \
+             VALUES ($1, 'test', 'invalid metadata', 1, 1, '{}', $2, $3)",
+        )
+        .bind(id)
+        .bind(actor)
+        .bind(operation)
+        .execute(&pool)
+        .await
+        .expect_err("invalid node operation metadata must fail");
+        assert_eq!(
+            error
+                .as_database_error()
+                .and_then(|error| error.code())
+                .as_deref(),
+            Some("23514")
+        );
+    }
+
+    sqlx::query(
+        "INSERT INTO domain_edges \
+            (id, source_id, target_id, edge_kind, payload, create_actor_id, create_operation_id) \
+         VALUES \
+            ('test-operation-edge-a', 'src', 'dst', 'reference', '{}', 'actor-a', \
+             '60000000-0000-0000-0000-000000000001')",
+    )
+    .execute(&pool)
+    .await
+    .expect("first edge operation row must insert");
+
+    let edge_duplicate = sqlx::query(
+        "INSERT INTO domain_edges \
+            (id, source_id, target_id, edge_kind, payload, create_actor_id, create_operation_id) \
+         VALUES \
+            ('test-operation-edge-b', 'src', 'dst', 'reference', '{}', 'actor-a', \
+             '60000000-0000-0000-0000-000000000001')",
+    )
+    .execute(&pool)
+    .await
+    .expect_err("same actor and edge operation must be unique");
+    assert!(edge_duplicate
+        .as_database_error()
+        .is_some_and(|error| error.is_unique_violation()));
+
+    sqlx::query(
+        "INSERT INTO domain_edges \
+            (id, source_id, target_id, edge_kind, payload, create_actor_id, create_operation_id) \
+         VALUES \
+            ('test-operation-edge-c', 'src', 'dst', 'reference', '{}', 'actor-b', \
+             '60000000-0000-0000-0000-000000000001')",
+    )
+    .execute(&pool)
+    .await
+    .expect("same edge operation UUID must remain independent across accounts");
+
+    let edge_half_pair = sqlx::query(
+        "INSERT INTO domain_edges \
+            (id, source_id, target_id, edge_kind, payload, create_operation_id) \
+         VALUES \
+            ('test-operation-edge-half', 'src', 'dst', 'reference', '{}', \
+             '60000000-0000-0000-0000-000000000002')",
+    )
+    .execute(&pool)
+    .await
+    .expect_err("half-populated edge operation metadata must fail");
+    assert_eq!(
+        edge_half_pair
+            .as_database_error()
+            .and_then(|error| error.code())
+            .as_deref(),
+        Some("23514")
+    );
+
+    for (id, actor, operation) in [
+        (
+            "test-operation-edge-blank-actor",
+            "",
+            "60000000-0000-0000-0000-000000000003",
+        ),
+        (
+            "test-operation-edge-invalid-uuid",
+            "actor-a",
+            "60000000-INVALID",
+        ),
+    ] {
+        let error = sqlx::query(
+            "INSERT INTO domain_edges \
+                (id, source_id, target_id, edge_kind, payload, \
+                 create_actor_id, create_operation_id) \
+             VALUES ($1, 'src', 'dst', 'reference', '{}', $2, $3)",
+        )
+        .bind(id)
+        .bind(actor)
+        .bind(operation)
+        .execute(&pool)
+        .await
+        .expect_err("invalid edge operation metadata must fail");
+        assert_eq!(
+            error
+                .as_database_error()
+                .and_then(|error| error.code())
+                .as_deref(),
+            Some("23514")
+        );
+    }
+
+    sqlx::query("DELETE FROM domain_edges WHERE id LIKE 'test-operation-edge-%'")
+        .execute(&pool)
+        .await
+        .expect("failed to clean edge create-operation probe rows");
+    sqlx::query("DELETE FROM domain_nodes WHERE id LIKE 'test-operation-node-%'")
+        .execute(&pool)
+        .await
+        .expect("failed to clean node create-operation probe rows");
 
     pool.close().await;
 }

--- a/apps/web/src/lib/api/domainWrites.ts
+++ b/apps/web/src/lib/api/domainWrites.ts
@@ -86,6 +86,8 @@ export interface CreateNodePayload {
   address: string;
   location: Location;
   summary?: string;
+  /** Stable UUID for retrying one user action after an uncertain response. */
+  operation_id?: string;
 }
 
 /** POST /api/nodes — create a node. Server owns `id`/`created_at`/`updated_at`. */
@@ -99,6 +101,8 @@ export interface CreateEdgePayload {
   target_id: string;
   target_type: string;
   edge_kind: string;
+  /** Stable UUID for retrying one user action after an uncertain response. */
+  operation_id?: string;
 }
 
 /** POST /api/edges — create an edge. Server owns `id`/`created_at`. */

--- a/apps/web/src/lib/components/panels/KompositionPanel.svelte
+++ b/apps/web/src/lib/components/panels/KompositionPanel.svelte
@@ -22,9 +22,36 @@
   let createdNodeId: string | null = null;
   let edgeError: string | null = null;
 
+  // One operation id identifies one semantic user action. A transport failure
+  // may hide a successful server write, so retries reuse the same id while the
+  // payload stays unchanged. Editing the form starts a new semantic action.
+  let nodeOperationId: string | null = null;
+  let nodeOperationSignature: string | null = null;
+  let edgeOperationId: string | null = null;
+
   $: canWrite = $authStore.role === 'weber' || $authStore.role === 'admin';
   $: placingGarnrolle = $kompositionDraft?.mode === 'place-garnrolle';
   $: canSubmit = !!$kompositionDraft?.lngLat && !!title.trim() && !!address.trim();
+
+  function operationIdForNode(payload: {
+    title: string;
+    kind: string;
+    address: string;
+    location: { lat: number; lon: number };
+    summary?: string;
+  }): string {
+    const signature = JSON.stringify(payload);
+    if (!nodeOperationId || nodeOperationSignature !== signature) {
+      nodeOperationId = crypto.randomUUID();
+      nodeOperationSignature = signature;
+    }
+    return nodeOperationId;
+  }
+
+  function operationIdForEdge(): string {
+    edgeOperationId ??= crypto.randomUUID();
+    return edgeOperationId;
+  }
 
   async function returnToGarnrolleSettings(withLocation: boolean) {
     const location = withLocation ? $kompositionDraft?.lngLat : undefined;
@@ -88,6 +115,7 @@
         target_id: nodeId,
         target_type: 'node',
         edge_kind: 'reference',
+        operation_id: operationIdForEdge(),
       });
       await finalizeSuccess(nodeId);
     } catch (e) {
@@ -132,12 +160,16 @@
       const submitDraft = $kompositionDraft;
       const [lon, lat] = submitDraft.lngLat!;
 
-      const node = await createNode({
+      const nodePayload = {
         title: title.trim(),
         kind: nodeType,
         address: address.trim(),
         location: { lat, lon },
         summary: description.trim() || undefined,
+      };
+      const node = await createNode({
+        ...nodePayload,
+        operation_id: operationIdForNode(nodePayload),
       });
 
       // Guard: only proceed if we are still in komposition state and the

--- a/apps/web/tests/komposition.spec.ts
+++ b/apps/web/tests/komposition.spec.ts
@@ -133,6 +133,9 @@ test.describe("Komposition Flow (weber)", () => {
     });
     expect(typeof nodePayload.location?.lat).toBe("number");
     expect(typeof nodePayload.location?.lon).toBe("number");
+    expect(nodePayload.operation_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
 
     // Edge links the current account to the new node.
     const edgeReq = await edgeRequest;
@@ -141,6 +144,9 @@ test.describe("Komposition Flow (weber)", () => {
     expect(edgePayload.source_type).toBe("account");
     expect(edgePayload.target_type).toBe("node");
     expect(edgePayload.edge_kind).toBe("reference");
+    expect(edgePayload.operation_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
 
     // Data reloaded: the debug badge's node count increases by one.
     const debugBadge = page.locator('[data-testid="debug-badge"]');
@@ -151,14 +157,30 @@ test.describe("Komposition Flow (weber)", () => {
     await expect(panel.locator("h2")).toContainText("Knoten");
   });
 
-  test("Edge creation failure shows a partial-success message with retry, not silent failure", async ({
+  test("Edge creation failure shows a partial-success message and reuses the operation id on retry", async ({
     page,
   }) => {
+    const operationIds: string[] = [];
+    let edgeAttempts = 0;
     await page.route("**/api/edges", async (route) => {
-      if (route.request().method() === "POST") {
+      if (route.request().method() !== "POST") {
+        return route.fallback();
+      }
+      const payload = route.request().postDataJSON();
+      operationIds.push(payload.operation_id);
+      edgeAttempts += 1;
+      if (edgeAttempts === 1) {
         return route.fulfill({ status: 500 });
       }
-      return route.continue();
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: "mock-edge-replay",
+          ...payload,
+          created_at: new Date().toISOString(),
+        }),
+      });
     });
 
     await page.locator('button:has-text("Neuer Knoten")').click();
@@ -186,6 +208,54 @@ test.describe("Komposition Flow (weber)", () => {
     // The panel must not silently close — the user stays informed and in
     // control until they explicitly retry or accept the partial result.
     await expect(panel).toBeVisible();
+
+    await panel.locator('button:has-text("Erneut verknüpfen")').click();
+    await expect(panel.locator("h2")).toContainText("Knoten");
+    expect(operationIds).toHaveLength(2);
+    expect(operationIds[1]).toBe(operationIds[0]);
+  });
+
+  test("Node retry reuses its operation id while unchanged form data starts no second action", async ({
+    page,
+  }) => {
+    const operationIds: string[] = [];
+    let attempts = 0;
+    await page.route("**/api/nodes", async (route) => {
+      if (route.request().method() !== "POST") {
+        return route.fallback();
+      }
+      const payload = route.request().postDataJSON();
+      operationIds.push(payload.operation_id);
+      attempts += 1;
+      if (attempts === 1) {
+        return route.fulfill({ status: 500 });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: "mock-node-replay",
+          ...payload,
+          tags: [],
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        }),
+      });
+    });
+
+    await page.locator('button:has-text("Neuer Knoten")').click();
+    const panel = page.locator('[data-testid="context-panel"]');
+    await longPressMapCenter(page);
+    await page.fill("#title", "Retry Node");
+    await page.fill("#address", "Retrystraße 1");
+
+    await panel.locator('button[type="submit"]').click();
+    await expect(panel.locator('[role="alert"]')).toBeVisible();
+    await panel.locator('button[type="submit"]').click();
+
+    await expect(panel.locator("h2")).toContainText("Knoten");
+    expect(operationIds).toHaveLength(2);
+    expect(operationIds[1]).toBe(operationIds[0]);
   });
 });
 

--- a/docs/blueprints/domain-data-postgres-cutover.md
+++ b/docs/blueprints/domain-data-postgres-cutover.md
@@ -59,6 +59,7 @@ Der belegte Repository- und Produktionsvertrag nach der Remediation vom
 - PostgreSQL-Read-Path existiert hinter Domain-Read-Konfiguration.
 - PostgreSQL-Write-Paths existieren für:
   - `POST /accounts`
+  - `POST /nodes`
   - `PATCH /nodes`
   - `POST /edges`
 - `APP_CONFIG_PATH` ist fail-closed: eine explizit gesetzte,
@@ -79,14 +80,14 @@ PostgreSQL-Produktionsvertrag.
 
 | Domain | Lokaler Default | Produktionsvertrag | Status |
 |---|---|---|---|
-| nodes | JSONL read/write | PostgreSQL Read + `PATCH /nodes` | Produktionswahrheit laut Repo-Vertrag; Livebeleg separat |
+| nodes | JSONL read/write | PostgreSQL Read + `POST /nodes` + `PATCH /nodes/{id}` | Produktionswahrheit laut Repo-Vertrag; Livebeleg separat |
 | edges | JSONL read/legacy | PostgreSQL Read + `POST /edges` | Produktionswahrheit laut Repo-Vertrag; Edge-Referenzpolitik offen |
 | accounts | JSONL read/create | PostgreSQL Read + `POST /accounts` | Produktionswahrheit laut Repo-Vertrag; weitere Auth-Mutationen offen |
 
 Zusatzdetails:
 
-- `nodes`: Schema/Backfill/Read-Path proof-geführt; opt-in Node-Patch
-  vorhanden; nicht Default.
+- `nodes`: Schema/Backfill/Read-Path proof-geführt; opt-in Node-Create und
+  Node-Patch vorhanden; nicht Default.
 - `edges`: Schema/Backfill/Read-Path proof-geführt; opt-in Edge-Create
   vorhanden; nicht Default.
 - `accounts`: Schema/Backfill/Read-Path proof-geführt; opt-in Account-Create
@@ -100,7 +101,7 @@ Zusatzbefund:
 - Config-Gates müssen explizit gesetzt werden; fehlerhafte `APP_CONFIG_PATH`-Konfigurationen fail-closed.
 - PostgreSQL-Write-Slices sind getrennt implementiert:
   - E-A Account-Create
-  - E-B Node-Patch
+  - E-B Node-Create und Node-Patch
   - E-C Edge-Create
 - Account-Create, Step-up-E-Mail, normalisierte E-Mail-Eindeutigkeit und der
   PostgreSQL-Passkey-Store sind implementiert und datenbankgetestet.

--- a/docs/datenmodell.md
+++ b/docs/datenmodell.md
@@ -85,9 +85,17 @@ dient nur noch als Rollbackbrücke für den stufenweisen Produktionscutover.
 | `lat`, `lon` | `DOUBLE PRECISION` | optionale Position |
 | `created_at`, `updated_at` | `TIMESTAMPTZ` | Zeitangaben |
 | `payload` | `JSONB` | übrige JSONL-Felder |
+| `create_actor_id`, `create_operation_id` | `TEXT`, nullable | accountgebundene Wiederholungssicherheit für `POST /nodes` |
 
 Es gibt derzeit keine PostGIS-Geometrie. Der Geoindex ist ein einfacher
 B-Tree auf `(lat, lon)`.
+
+`create_actor_id` und `create_operation_id` sind entweder gemeinsam gesetzt
+oder gemeinsam `NULL`. Der Accountwert muss nichtleer und die Vorgangskennung
+eine kanonische UUID sein. Ein partieller Unique-Index erlaubt pro Account nur
+einen Knoten je Vorgangskennung. Die Vorgangskennung ist keine Knoten-ID und
+keine fachliche Duplikaterkennung nach Titel, Adresse oder Koordinaten. Sie
+identifiziert ausschließlich die Wiederholung desselben Speichervorgangs.
 
 ### `domain_edges`
 
@@ -98,10 +106,16 @@ B-Tree auf `(lat, lon)`.
 | `edge_kind` | `TEXT` | Beziehungsart |
 | `created_at` | `TIMESTAMPTZ` | Erstellung |
 | `payload` | `JSONB` | Typinformationen, Notiz und Restfelder |
+| `create_actor_id`, `create_operation_id` | `TEXT`, nullable | accountgebundene Wiederholungssicherheit für `POST /edges` |
 
 Foreign Keys sind bewusst noch nicht gesetzt. Vor einer FK-Entscheidung ist ein
 Orphan- und Referenzaudit erforderlich; bestehende Fäden dürfen nicht
 stillschweigend verworfen werden.
+
+Für Fäden gilt derselbe Vorgangsvertrag wie für Knoten: Account und
+Vorgangskennung sind gemeinsam eindeutig. Ein Wiederholungsversuch mit derselben
+fachlichen Anfrage liefert den bereits gespeicherten Faden; eine Wiederverwendung
+derselben Kennung für andere Daten wird als Konflikt abgewiesen.
 
 ### `passkey_credentials`
 

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -203,6 +203,24 @@ Das ist **keine Validierung**, sondern eine **sichtbare Beobachtung**.
 - **WELTGEWEBE_DOMAIN_EDGE_WRITE_SOURCE**: Default `jsonl`.
   `postgres` persistiert `POST /edges` in `domain_edges`.
 
+`POST /nodes` und `POST /edges` akzeptieren optional eine UUID als
+`operation_id`. Sie wird vom Webclient einmal pro Nutzeraktion erzeugt und bei
+einem ungewissen Antwortausfall wiederverwendet. Der Server bindet sie an den
+authentifizierten Account und die jeweilige Ressourcenart:
+
+- erster erfolgreicher Schreibvorgang: `201 Created`;
+- identische Wiederholung: `200 OK` mit derselben serverseitigen Objekt-ID und
+  ohne zweite persistierte Zeile;
+- dieselbe Kennung mit anderen fachlichen Daten: `409 Conflict`;
+- fehlende `operation_id`: bisheriges Verhalten für ältere Clients.
+
+Der Vertrag gilt in JSONL- und PostgreSQL-Modus und über einen API-Neustart
+hinweg. Der ausführbare JSONL→PostgreSQL-Backfill-Beweis weist nach, dass
+reservierte Vorgangsmetadaten ausschließlich in die internen Spalten übernommen
+werden. Das Repository behauptet damit kein allgemeines Produktionskommando.
+Der Vertrag ersetzt keine fachliche Duplikatprüfung und führt unabhängig
+angelegte reale Knoten oder Fäden niemals automatisch zusammen.
+
 Für einen PostgreSQL-Cutover müssen **Read-Quelle und alle tatsächlich
 verwendeten Schreibquellen gemeinsam** auf `postgres` stehen. PostgreSQL-
 Schreiben bei JSONL-Lesen oder fehlendem Pool ist verboten; die API bricht beim

--- a/docs/reports/domain-backfill-proof.md
+++ b/docs/reports/domain-backfill-proof.md
@@ -70,6 +70,7 @@ These paths are unchanged. JSONL is the active runtime truth until Phase D/E.
 | `created_at` | `created_at` (TIMESTAMPTZ) | Parsed as RFC 3339; NULL if absent or unparseable |
 | `updated_at` | `updated_at` (TIMESTAMPTZ) | Parsed as RFC 3339; NULL if absent or unparseable |
 | `summary`, `info`, `tags` | `payload` (JSONB) | Remaining fields; absent/null keys omitted |
+| `_create_actor_id`, `_create_operation_id` | `create_actor_id`, `create_operation_id` | Optional internal pair; never copied into public payload |
 
 ### domain_edges
 
@@ -81,6 +82,7 @@ These paths are unchanged. JSONL is the active runtime truth until Phase D/E.
 | `edge_kind` / `kind` / `edgeKind` | `edge_kind` | serde aliases preserved; default `""` |
 | `created_at` | `created_at` (TIMESTAMPTZ) | Optional |
 | `source_type`, `target_type`, `note` | `payload` (JSONB) | Participant type hints and free text |
+| `_create_actor_id`, `_create_operation_id` | `create_actor_id`, `create_operation_id` | Optional internal pair; never copied into public payload |
 
 ### domain_accounts
 
@@ -125,6 +127,7 @@ path. The final row contains the last-seen values in file order.
 | Invalid JSON | `malformed_json_lines` incremented; line not imported |
 | Missing `id` | `skipped_records` incremented; line not imported |
 | Missing `source_id` / `target_id` (edges) | `skipped_records` incremented; line not imported |
+| Half-populated or invalid create-operation metadata | `skipped_records` incremented; line not imported |
 | Unparseable timestamp | `NULL` stored in TIMESTAMPTZ column |
 | Invalid `webauthn_user_id` UUID | `NULL` stored; original string discarded |
 


### PR DESCRIPTION
## Problem

Im Kompositionsablauf wird zuerst ein Knoten und danach ein Faden gespeichert. Geht eine HTTP-Antwort nach dem dauerhaften Speichern verloren, konnte ein erneuter Klick bisher einen zweiten Knoten oder Faden erzeugen. Die Oberfläche konnte einen Transportfehler nicht von einer verlorenen Erfolgsantwort unterscheiden.

Closes #1401

## Neuer Vertrag

`POST /nodes` und `POST /edges` akzeptieren optional eine UUID `operation_id`:

- erster erfolgreicher Schreibvorgang: `201 Created`;
- identische Wiederholung desselben Accounts: `200 OK`, dieselbe serverseitige Objekt-ID, keine zweite persistierte Zeile;
- dieselbe Kennung mit geänderten fachlichen Daten: `409 Conflict`;
- dieselbe UUID eines anderen Accounts: unabhängiger Vorgang;
- fehlende Kennung: unverändertes Verhalten für ältere Clients.

## Umsetzung

### PostgreSQL

- nullable `create_actor_id` und `create_operation_id` für Knoten und Fäden;
- CHECK-Constraints für vollständige Paare, nichtleere Accounts und kanonische UUID-Form;
- partielle Unique-Indizes je Account und Ressourcenart;
- Knoten: per-operation Advisory-Lock plus Transaktion;
- Fäden: Idempotenzlookup im bestehenden serialisierten Tabellenlock-Pfad;
- Replaydaten werden aus PostgreSQL rekonstruiert und fachlich mit der Anfrage verglichen.

### JSONL

- reservierte interne Felder `_create_actor_id` und `_create_operation_id`;
- Lookup und Append unter der bestehenden Persistenzsperre;
- Fadenprüfung bleibt ein einzelner vollständiger Dateidurchlauf;
- interne Felder erscheinen nie im öffentlichen API-Modell.

### Web

- die Kompositionsoberfläche erzeugt eine Vorgangskennung pro Nutzeraktion;
- ein ungewisser Retry verwendet dieselbe Kennung;
- eine Änderung des Knotenentwurfs beginnt einen neuen Vorgang;
- Knoten- und Faden-ID sowie Zeitstempel bleiben serverseitig.

### Cutover-Beweis

Der bestehende ausführbare JSONL→PostgreSQL-Backfill-Beweis übernimmt reservierte Vorgangsmetadaten ausschließlich in interne Spalten und quarantänisiert ungültige Halbpaare. Der PR behauptet kein allgemeines Produktions-Backfill-Kommando.

## Gegenbeweise

Belegt sind für JSONL und PostgreSQL:

- zwei parallele Requests ergeben genau ein `201` und ein `200` mit derselben ID;
- ein neu aufgebauter API-Zustand liefert beim Retry weiterhin denselben Datensatz;
- geänderte Daten unter derselben Kennung ergeben `409`;
- ein anderer Account darf dieselbe UUID unabhängig verwenden;
- genau eine dauerhafte Zeile je Accountvorgang;
- ungültige UUIDs, leere Accounts und Halbpaare scheitern bis in PostgreSQL.

## Prüfungen

- vollständiger regulärer API-Testbaum: grün;
- 341 API-Bibliothekstests und alle nicht-datenbankgebundenen Integrationspfade;
- Clippy für alle Targets mit `-D warnings`: grün;
- Kompositions-Browsertests: 6/6 grün;
- Svelte/TypeScript: 0 Fehler, 0 Warnungen;
- Web-Lint: grün;
- vollständiger PostgreSQL-Vertrag vor finalen Proof-Verfeinerungen: 75 Tests grün;
- final erneut ausgeführt: paralleler Knotenpfad, paralleler Fadenpfad, alle 7 Backfilltests und alle 4 Schematests;
- `make ci-validate`: 810 Docmeta-, 160 Agent- und 49 CI-Tests, alle grün;
- Repository- und Ops-Contract-Guards: grün;
- `git diff --check`: grün.

Ein bestehender Ortsauswahl-Browsertest hatte einmalig einen Timing-Ausfall. Er bestand unmittelbar danach fünf Wiederholungen sowie den abschließenden vollständigen 6/6-Lauf; Produktcode und Test wurden deshalb nicht künstlich verändert.

## Grenzen

- keine heuristische Duplikaterkennung nach Titel, Adresse, Koordinaten oder Endpunkten;
- keine automatische Zusammenführung unabhängig angelegter realer Ressourcen;
- keine Änderung der Account-/Profil-Schreibsemantik;
- keine Ausgabe interner Vorgangsmetadaten und keine Protokollierung der rohen UUID.

## Bindung

- Basis: `11b9976cc4b0c174a325e926b8f5229b9ae7c3f1`
- Head: `95e430dd0e20d1c6016fca6f2b55a522b83ad24c`
- Diff-SHA256: `75d6db231fa87bf51448ac2c4efc5527eb013ffcf365e82a760ed5cdfe8e0112`
- Selbstreview-SHA256: `911c35e5522587d05666e9555b6aca3e4eb0de0b1e5eea22229ab03d79375e6c`