### PR TITLE
fix: begrenze API- und Migrationsrollouts auf die API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
           bash -n scripts/tests/test_repo_contract_guards.sh
           bash -n scripts/tests/test_postgres_backup_restore_contract.sh
           bash -n scripts/tests/test_web_artifact_install_contract.sh
+          bash -n scripts/tests/test_weltgewebe_up_deploy_scope.sh
           bash -n scripts/guard/run.sh
 
       - name: Run guard fixture suites
@@ -121,7 +122,8 @@ jobs:
             scripts/tests/test_security_headers_guard.sh \
             scripts/tests/test_repo_contract_guards.sh \
             scripts/tests/test_postgres_backup_restore_contract.sh \
-            scripts/tests/test_web_artifact_install_contract.sh
+            scripts/tests/test_web_artifact_install_contract.sh \
+            scripts/tests/test_weltgewebe_up_deploy_scope.sh
           do
             echo "── $t ──"
             bash "$t"

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ validate-guards: check-system-map-drift
 validate-shell-tests:
 	bash scripts/tests/test_weltgewebe_up_git_branch.sh
 	bash scripts/tests/test_weltgewebe_up_frontend_required.sh
+	bash scripts/tests/test_weltgewebe_up_deploy_scope.sh
 	bash scripts/tests/test_version_guard.sh
 	bash scripts/tests/test_basemap_mode_guard.sh
 	bash scripts/tests/test_security_headers_guard.sh

--- a/docs/_generated/implicit-dependencies.md
+++ b/docs/_generated/implicit-dependencies.md
@@ -34,6 +34,7 @@ Generated automatically. Do not edit.
 | Makefile (validate-guards) | scripts/docmeta/coverage-guard.sh | `bash scripts/docmeta/coverage-guard.sh` | *unclear* |
 | Makefile (validate-shell-tests) | scripts/tests/test_weltgewebe_up_git_branch.sh | `bash scripts/tests/test_weltgewebe_up_git_branch.sh` | *unclear* |
 | Makefile (validate-shell-tests) | scripts/tests/test_weltgewebe_up_frontend_required.sh | `bash scripts/tests/test_weltgewebe_up_frontend_required.sh` | *unclear* |
+| Makefile (validate-shell-tests) | scripts/tests/test_weltgewebe_up_deploy_scope.sh | `bash scripts/tests/test_weltgewebe_up_deploy_scope.sh` | *unclear* |
 | Makefile (validate-shell-tests) | scripts/tests/test_version_guard.sh | `bash scripts/tests/test_version_guard.sh` | *unclear* |
 | Makefile (validate-shell-tests) | scripts/tests/test_basemap_mode_guard.sh | `bash scripts/tests/test_basemap_mode_guard.sh` | *unclear* |
 | Makefile (validate-shell-tests) | scripts/tests/test_security_headers_guard.sh | `bash scripts/tests/test_security_headers_guard.sh` | *unclear* |

--- a/docs/deploy/vps.md
+++ b/docs/deploy/vps.md
@@ -108,6 +108,26 @@ PRUNE_IMAGES=1 ./scripts/deploy_vps.sh
 `scripts/deploy_vps.sh` ist nur noch ein deprecateter Shim, der an
 `weltgewebe-up` delegiert.
 
+Für einen reinen API-Rollout darf nicht der gesamte Stack neu abgeglichen werden:
+
+```bash
+sudo -n ./scripts/weltgewebe-up --deploy-scope api
+```
+
+Für ein kontrolliertes Migrationsfenster gilt:
+
+```bash
+sudo -n ./scripts/weltgewebe-up --deploy-scope migration
+```
+
+Der Migrationsscope startet nur `api` mit `--no-deps`, wendet die eingebetteten
+Migrationen an und setzt den API-Container anschließend automatisch wieder auf
+`WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied`. PostgreSQL, NATS und Caddy
+müssen bereits laufen und ihre Containeridentitäten müssen über den gesamten
+Lauf unverändert bleiben. Vor der Mutation wird ein maschinenlesbarer JSON-Plan
+unter `.ops/deploy-plan-migration.json` geschrieben. Mit `--plan-only` kann der
+Wirkungsplan ohne Containeränderung geprüft werden.
+
 Ein manueller Aufruf **muss** die VPS-Override-Datei mitgeben. Ohne sie fehlen
 `Caddyfile.vps`, `APP_BASE_URL`, `POLICY_LIMITS_PATH`, die IPv6-Bindings sowie
 `AUTH_TRUSTED_PROXIES` und die `AUTH_RL_*`-Rate-Limits — Caddy bliebe an

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,7 +4,7 @@ title: Deployment Contract and Preflight Guard
 doc_type: guide
 status: active
 summary: Anleitung und Dokumentation zum Deployment.
-last_reviewed: "2026-03-05"
+last_reviewed: "2026-07-12"
 relations:
   - type: relates_to
     target: docs/deploy/README.md
@@ -80,6 +80,46 @@ find build/basemap -maxdepth 1 -name "*.pmtiles" -print
 `scripts/weltgewebe-up` runs `scripts/preflight/runtime_contract.sh` before `docker compose up`.
 
 The guard validates required artifacts and aborts the deployment early if mandatory runtime contracts are violated.
+
+## Begrenzte API- und Migrationsrollouts
+
+Der normale Aufruf verwendet weiterhin `--deploy-scope full` und darf den gesamten Compose-Stack abgleichen.
+Für Änderungen, die nur die API betreffen, existieren zwei engere Wirkungsradien:
+
+```bash
+# API neu bauen oder aktualisieren, aber keine Migration anwenden.
+./scripts/weltgewebe-up --deploy-scope api
+
+# Migration ausschließlich durch einen API-Neustart anwenden und danach
+# automatisch wieder auf verify-applied zurückschalten.
+./scripts/weltgewebe-up --deploy-scope migration
+```
+
+Beide begrenzten Pfade:
+
+- setzen `DEPLOY_FRONTEND_MODE=off` und `REQUIRE_FRONTEND=0` voraus;
+- erzeugen vor jeder Containeränderung einen JSON-Plan unter
+  `.ops/deploy-plan-<scope>.json` oder unter dem mit `--deploy-plan-file`
+  gewählten Dateinamen innerhalb desselben Zustandsverzeichnisses;
+- rufen Compose ausschließlich mit `--no-deps ... api` auf;
+- verwenden bewusst kein `--remove-orphans`;
+- werden durch eine hostweite `flock`-Sperre gegen parallele Deployläufe geschützt;
+- behandeln `db`, `nats` und `caddy` als geschützte Dienste und brechen ab,
+  wenn sich deren Containeridentität während des Laufs ändert;
+- verweigern den Start, wenn PostgreSQL oder NATS nicht bereits laufen; auf dem
+  VPS muss zusätzlich Caddy bereits laufen.
+
+Mit `--plan-only` wird der JSON-Plan erzeugt, ohne einen Container zu verändern.
+Der Scope `api` erzwingt `WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied`.
+Der Scope `migration` startet die API einmalig mit `run`, wartet auf einen gesunden
+Zustand und erzeugt anschließend ausschließlich die API erneut mit
+`verify-applied`. Schlägt das Migrationsfenster fehl, versucht der Pfad ebenfalls,
+den sicheren Prüfmodus wiederherzustellen und meldet den Lauf als fehlgeschlagen.
+
+Der JSON-Plan enthält Ziel- und Schutzdienste, die Containeridentitäten vor dem
+Lauf, den Git-Stand, die exakten Compose-Argumente und den erlaubten Wirkungsradius.
+Er ist ein Ausführungsbeleg, ersetzt aber weder Backup noch Restore-Proof vor einer
+produktiven Migration.
 
 ## CSP contract
 

--- a/scripts/ci/tests/test_weltgewebe_up_api_version_contract.py
+++ b/scripts/ci/tests/test_weltgewebe_up_api_version_contract.py
@@ -11,15 +11,25 @@ COMPOSE = REPO / "infra" / "compose" / "compose.prod.yml"
 def test_api_image_tag_is_bound_to_selected_deploy_head_before_compose_config() -> None:
     script = SCRIPT.read_text(encoding="utf-8")
 
-    git_summary = script.index('echo "   Target HEAD after pull: $HEAD_AFTER"')
+    git_summary = script.index('echo "   Target HEAD after pull: $HEAD_AFTER_FULL"')
+    full_commit_guard = script.index(
+        'if [[ ! "$HEAD_AFTER_FULL" =~ ^[0-9a-f]{40}$ || "$HEAD_AFTER" == "unknown" ]]'
+    )
     export_tag = script.index('export API_VERSION="$HEAD_AFTER"')
     export_build = script.index('export WELTGEWEBE_BUILD="$HEAD_AFTER"')
     compose_base_args = script.index('BASE_ARGS=("--env-file" "$ENV_FILE"')
     compose_up = script.index('CMD_BASE=("docker" "compose"')
 
-    assert git_summary < export_tag < export_build < compose_base_args < compose_up
-    assert 'if [[ "$HEAD_AFTER" == "unknown" ]]' in script
-    assert 'refusing to select an API image tag' in script
+    assert (
+        git_summary
+        < full_commit_guard
+        < export_tag
+        < export_build
+        < compose_base_args
+        < compose_up
+    )
+    assert 'HEAD_AFTER_FULL=$(git rev-parse HEAD' in script
+    assert 'refusing deployment' in script
 
 
 def test_prod_compose_uses_api_version_for_api_image_tag() -> None:
@@ -42,8 +52,17 @@ def test_no_pull_path_resolves_current_checkout_head_before_api_tag_guard() -> N
     script = SCRIPT.read_text(encoding="utf-8")
 
     no_pull = script.index('echo ">> Git: Skipped (--no-pull)"')
-    resolve_current_head = script.index('HEAD_AFTER=$(git rev-parse --short HEAD', no_pull)
-    unknown_guard = script.index('if [[ "$HEAD_AFTER" == "unknown" ]]')
+    resolve_short_head = script.index('HEAD_AFTER=$(git rev-parse --short HEAD', no_pull)
+    resolve_full_head = script.index('HEAD_AFTER_FULL=$(git rev-parse HEAD', no_pull)
+    full_commit_guard = script.index(
+        'if [[ ! "$HEAD_AFTER_FULL" =~ ^[0-9a-f]{40}$ || "$HEAD_AFTER" == "unknown" ]]'
+    )
     export_tag = script.index('export API_VERSION="$HEAD_AFTER"')
 
-    assert no_pull < resolve_current_head < unknown_guard < export_tag
+    assert (
+        no_pull
+        < resolve_short_head
+        < resolve_full_head
+        < full_commit_guard
+        < export_tag
+    )

--- a/scripts/tests/test_weltgewebe_up_deploy_scope.sh
+++ b/scripts/tests/test_weltgewebe_up_deploy_scope.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
 REPO_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
 SCRIPT_SOURCE="$REPO_ROOT/scripts/weltgewebe-up"
 WORK_ROOT="$(mktemp -d)"
@@ -14,12 +14,12 @@ fail() {
 
 assert_contains() {
   local haystack="$1" needle="$2"
-  grep -Fq -- "$needle" <<<"$haystack" || fail "expected output to contain: $needle"
+  grep -Fq -- "$needle" <<< "$haystack" || fail "expected output to contain: $needle"
 }
 
 assert_not_contains() {
   local haystack="$1" needle="$2"
-  if grep -Fq -- "$needle" <<<"$haystack"; then
+  if grep -Fq -- "$needle" <<< "$haystack"; then
     fail "expected output not to contain: $needle"
   fi
 }
@@ -36,13 +36,13 @@ new_repo() {
     mkdir -p scripts infra/compose
     cp "$SCRIPT_SOURCE" scripts/weltgewebe-up
     chmod +x scripts/weltgewebe-up
-    cat > .env <<'ENV'
+    cat > .env << 'ENV'
 DATABASE_URL=postgres://example
 POSTGRES_USER=weltgewebe
 POSTGRES_PASSWORD=test
 POSTGRES_DB=weltgewebe
 ENV
-    cat > infra/compose/compose.prod.yml <<'YAML'
+    cat > infra/compose/compose.prod.yml << 'YAML'
 services:
   api:
     image: weltgewebe-api:${API_VERSION}
@@ -64,15 +64,15 @@ setup_mocks() {
   local state="$1"
   local mock_bin="$state/bin"
   mkdir -p "$mock_bin"
-  printf 'api-1\n' >"$state/api.id"
-  printf 'db-1\n' >"$state/db.id"
-  printf 'nats-1\n' >"$state/nats.id"
-  printf 'caddy-1\n' >"$state/caddy.id"
-  : >"$state/compose-up.log"
-  : >"$state/mutation.log"
-  printf 'verify-applied\n' >"$state/api.mode"
+  printf 'api-1\n' > "$state/api.id"
+  printf 'db-1\n' > "$state/db.id"
+  printf 'nats-1\n' > "$state/nats.id"
+  printf 'caddy-1\n' > "$state/caddy.id"
+  : > "$state/compose-up.log"
+  : > "$state/mutation.log"
+  printf 'verify-applied\n' > "$state/api.mode"
 
-  cat >"$mock_bin/docker" <<'MOCK'
+  cat > "$mock_bin/docker" << 'MOCK'
 #!/usr/bin/env bash
 set -euo pipefail
 args=("$@")
@@ -171,11 +171,11 @@ fi
 exit 0
 MOCK
 
-  cat >"$mock_bin/curl" <<'MOCK'
+  cat > "$mock_bin/curl" << 'MOCK'
 #!/usr/bin/env bash
 exit 0
 MOCK
-  cat >"$mock_bin/getent" <<'MOCK'
+  cat > "$mock_bin/getent" << 'MOCK'
 #!/usr/bin/env bash
 printf '127.0.0.1 localhost\n'
 MOCK
@@ -210,7 +210,7 @@ out_plan="$(run_up "$repo_plan" "$state_plan" --deploy-scope api --plan-only 2>&
 plan_path="$repo_plan/.ops/deploy-plan-api.json"
 [[ -f "$plan_path" ]] || fail "plan-only did not create $plan_path"
 [[ ! -s "$state_plan/mutation.log" ]] || fail "plan-only mutated compose"
-python3 - "$plan_path" <<'PY'
+python3 - "$plan_path" << 'PY'
 import json, sys
 p=json.load(open(sys.argv[1], encoding='utf-8'))
 assert p['scope']=='api'
@@ -234,7 +234,7 @@ repo_api="$(new_repo api)"
 state_api="$WORK_ROOT/api-state"
 mkdir -p "$state_api"
 out_api="$(run_up "$repo_api" "$state_api" --deploy-scope api 2>&1)"
-[[ "$(wc -l <"$state_api/compose-up.log")" -eq 1 ]] || fail "API scope should execute one compose up"
+[[ "$(wc -l < "$state_api/compose-up.log")" -eq 1 ]] || fail "API scope should execute one compose up"
 api_call="$(cat "$state_api/compose-up.log")"
 assert_contains "$api_call" "up -d --no-deps api"
 assert_not_contains "$api_call" "--remove-orphans"
@@ -250,13 +250,13 @@ repo_migration="$(new_repo migration)"
 state_migration="$WORK_ROOT/migration-state"
 mkdir -p "$state_migration"
 out_migration="$(run_up "$repo_migration" "$state_migration" --deploy-scope migration 2>&1)"
-[[ "$(wc -l <"$state_migration/compose-up.log")" -eq 2 ]] || fail "migration scope should execute exactly two compose up calls"
+[[ "$(wc -l < "$state_migration/compose-up.log")" -eq 2 ]] || fail "migration scope should execute exactly two compose up calls"
 first_call="$(sed -n '1p' "$state_migration/compose-up.log")"
 second_call="$(sed -n '2p' "$state_migration/compose-up.log")"
 assert_contains "$first_call" "up -d --no-deps api"
 assert_contains "$second_call" "up -d --no-deps --force-recreate api"
 [[ "$(cat "$state_migration/api.mode")" == "verify-applied" ]] || fail "migration scope did not restore verify-applied"
-python3 - "$repo_migration/.ops/deploy-plan-migration.json" <<'PY'
+python3 - "$repo_migration/.ops/deploy-plan-migration.json" << 'PY'
 import json, sys
 p=json.load(open(sys.argv[1], encoding='utf-8'))
 assert p['scope']=='migration'
@@ -281,7 +281,7 @@ out_migration_failure="$( (cd "$repo_migration_failure" && PATH="$mock_bin_migra
 rc_migration_failure=$?
 set -e
 [[ "$rc_migration_failure" -ne 0 ]] || fail "injected migration failure should fail the overall deploy"
-[[ "$(wc -l <"$state_migration_failure/compose-up.log")" -eq 2 ]] || fail "failed migration should trigger exactly one restore call"
+[[ "$(wc -l < "$state_migration_failure/compose-up.log")" -eq 2 ]] || fail "failed migration should trigger exactly one restore call"
 failed_initial_call="$(sed -n '1p' "$state_migration_failure/compose-up.log")"
 failed_restore_call="$(sed -n '2p' "$state_migration_failure/compose-up.log")"
 assert_contains "$failed_initial_call" "up -d --no-deps api"
@@ -337,7 +337,7 @@ repo_lock="$(new_repo lock)"
 state_lock="$WORK_ROOT/lock-state"
 mkdir -p "$state_lock"
 mock_bin_lock="$(setup_mocks "$state_lock")"
-exec {held_lock_fd}>"$state_lock/deploy.lock"
+exec {held_lock_fd}> "$state_lock/deploy.lock"
 flock -n "$held_lock_fd" || fail "could not acquire test deployment lock"
 set +e
 out_lock="$( (cd "$repo_lock" && PATH="$mock_bin_lock:/usr/bin:/bin" MOCK_STATE="$state_lock" WELTGEWEBE_DEPLOY_LOCK_FILE="$state_lock/deploy.lock" REPO_DIR="$repo_lock" ENV_FILE="$repo_lock/.env" DEPLOY_TARGET=vps WELTGEWEBE_STATE_DIR="$repo_lock/.ops" bash scripts/weltgewebe-up --no-pull --no-build --deploy-scope api) 2>&1)"

--- a/scripts/tests/test_weltgewebe_up_deploy_scope.sh
+++ b/scripts/tests/test_weltgewebe_up_deploy_scope.sh
@@ -1,0 +1,367 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+REPO_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
+SCRIPT_SOURCE="$REPO_ROOT/scripts/weltgewebe-up"
+WORK_ROOT="$(mktemp -d)"
+trap 'rm -rf "$WORK_ROOT"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2"
+  grep -Fq -- "$needle" <<<"$haystack" || fail "expected output to contain: $needle"
+}
+
+assert_not_contains() {
+  local haystack="$1" needle="$2"
+  if grep -Fq -- "$needle" <<<"$haystack"; then
+    fail "expected output not to contain: $needle"
+  fi
+}
+
+new_repo() {
+  local name="$1"
+  local repo="$WORK_ROOT/$name/repo"
+  mkdir -p "$repo"
+  (
+    cd "$repo"
+    git init -q
+    git config user.name "Weltgewebe Test"
+    git config user.email "tests@weltgewebe.local"
+    mkdir -p scripts infra/compose
+    cp "$SCRIPT_SOURCE" scripts/weltgewebe-up
+    chmod +x scripts/weltgewebe-up
+    cat > .env <<'ENV'
+DATABASE_URL=postgres://example
+POSTGRES_USER=weltgewebe
+POSTGRES_PASSWORD=test
+POSTGRES_DB=weltgewebe
+ENV
+    cat > infra/compose/compose.prod.yml <<'YAML'
+services:
+  api:
+    image: weltgewebe-api:${API_VERSION}
+  db:
+    image: postgres:16
+  nats:
+    image: nats:2
+  caddy:
+    image: caddy:2
+YAML
+    cp infra/compose/compose.prod.yml infra/compose/compose.vps.override.yml
+    git add .
+    git commit -q -m "test: initial"
+  )
+  echo "$repo"
+}
+
+setup_mocks() {
+  local state="$1"
+  local mock_bin="$state/bin"
+  mkdir -p "$mock_bin"
+  printf 'api-1\n' >"$state/api.id"
+  printf 'db-1\n' >"$state/db.id"
+  printf 'nats-1\n' >"$state/nats.id"
+  printf 'caddy-1\n' >"$state/caddy.id"
+  : >"$state/compose-up.log"
+  : >"$state/mutation.log"
+  printf 'verify-applied\n' >"$state/api.mode"
+
+  cat >"$mock_bin/docker" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+args=("$@")
+joined=" $* "
+state="${MOCK_STATE:?}"
+
+if [[ "${1:-}" == "ps" ]]; then
+  exit 0
+fi
+
+if [[ "${1:-}" == "inspect" ]]; then
+  format=""
+  if [[ "${2:-}" == "--format" ]]; then
+    format="${3:-}"
+  fi
+  case "$format" in
+    *'.State.Health}}{{.State.Health.Status'* ) echo healthy ;;
+    *'.State.Health}}yes'* ) echo yes ;;
+    *'.State.Health.Status'* ) echo healthy ;;
+    *'.NetworkSettings.Networks'* ) echo '[weltgewebe-api api]' ;;
+    *'.Config.Env'* ) echo "WELTGEWEBE_API_STARTUP_MIGRATIONS=$(cat "$state/api.mode")" ;;
+    * ) echo '{}' ;;
+  esac
+  exit 0
+fi
+
+if [[ "${1:-}" != "compose" ]]; then
+  exit 0
+fi
+
+if [[ "$joined" == *" config --services "* ]]; then
+  printf 'api\ndb\nnats\ncaddy\n'
+  exit 0
+fi
+if [[ "$joined" == *" config --format json "* ]]; then
+  printf '%s\n' '{"services":{"api":{},"db":{},"nats":{},"caddy":{}}}'
+  exit 0
+fi
+if [[ "$joined" == *" config "* ]]; then
+  printf '%s\n' 'services: {}'
+  exit 0
+fi
+
+if [[ "$joined" == *" ps -q "* ]]; then
+  service="${args[${#args[@]}-1]}"
+  if [[ "${MOCK_MISSING_SERVICE:-}" == "$service" ]]; then
+    exit 0
+  fi
+  cat "$state/$service.id"
+  exit 0
+fi
+
+if [[ "$joined" == *" up -d "* ]]; then
+  printf '%s\n' "$*" >>"$state/compose-up.log"
+  printf '%s\n' "${WELTGEWEBE_API_STARTUP_MIGRATIONS:-unset}" >"$state/api.mode"
+  printf 'up\n' >>"$state/mutation.log"
+  if [[ "${MOCK_FAIL_INITIAL_MIGRATION:-0}" == "1" && "${WELTGEWEBE_API_STARTUP_MIGRATIONS:-}" == "run" && ! -f "$state/initial-migration-failed" ]]; then
+    : >"$state/initial-migration-failed"
+    echo "injected initial migration failure" >&2
+    exit 94
+  fi
+  if [[ "$joined" != *" --no-deps "* ]]; then
+    echo "bounded command missing --no-deps" >&2
+    exit 91
+  fi
+  if [[ "$joined" == *" --remove-orphans "* ]]; then
+    echo "bounded command contains --remove-orphans" >&2
+    exit 92
+  fi
+  last="${args[${#args[@]}-1]}"
+  [[ "$last" == api ]] || { echo "bounded command target is $last" >&2; exit 93; }
+  if [[ "${MOCK_DRIFT_SERVICE:-}" != "" && ! -f "$state/drift.done" ]]; then
+    printf '%s-2\n' "${MOCK_DRIFT_SERVICE}" >"$state/${MOCK_DRIFT_SERVICE}.id"
+    : >"$state/drift.done"
+  fi
+  exit 0
+fi
+
+if [[ "$joined" == *" ps --format "* ]]; then
+  printf 'weltgewebe-api-1 running healthy\nweltgewebe-db-1 running healthy\nweltgewebe-nats-1 running healthy\nweltgewebe-caddy-1 running healthy\n'
+  exit 0
+fi
+if [[ "$joined" == *" ps "* ]]; then
+  printf 'NAME STATUS\napi healthy\ndb healthy\nnats healthy\ncaddy running\n'
+  exit 0
+fi
+if [[ "$joined" == *" exec -T api "* ]]; then
+  exit 0
+fi
+if [[ "$joined" == *" port api "* ]]; then
+  exit 0
+fi
+if [[ "$joined" == *" logs "* ]]; then
+  exit 0
+fi
+exit 0
+MOCK
+
+  cat >"$mock_bin/curl" <<'MOCK'
+#!/usr/bin/env bash
+exit 0
+MOCK
+  cat >"$mock_bin/getent" <<'MOCK'
+#!/usr/bin/env bash
+printf '127.0.0.1 localhost\n'
+MOCK
+  chmod +x "$mock_bin/docker" "$mock_bin/curl" "$mock_bin/getent"
+  echo "$mock_bin"
+}
+
+run_up() {
+  local repo="$1" state="$2"
+  shift 2
+  local mock_bin
+  mock_bin="$(setup_mocks "$state")"
+  (
+    cd "$repo"
+    PATH="$mock_bin:/usr/bin:/bin" \
+      MOCK_STATE="$state" \
+      REPO_DIR="$repo" \
+      ENV_FILE="$repo/.env" \
+      DEPLOY_TARGET=vps \
+      WELTGEWEBE_STATE_DIR="$repo/.ops" \
+      WELTGEWEBE_DEPLOY_LOCK_FILE="$state/deploy.lock" \
+      WELTGEWEBE_SCOPED_API_HEALTH_TIMEOUT_SECONDS=2 \
+      bash scripts/weltgewebe-up --no-pull --no-build "$@"
+  )
+}
+
+# Plan-only must produce an exact machine-readable plan without any compose mutation.
+repo_plan="$(new_repo plan-only)"
+state_plan="$WORK_ROOT/plan-state"
+mkdir -p "$state_plan"
+out_plan="$(run_up "$repo_plan" "$state_plan" --deploy-scope api --plan-only 2>&1)"
+plan_path="$repo_plan/.ops/deploy-plan-api.json"
+[[ -f "$plan_path" ]] || fail "plan-only did not create $plan_path"
+[[ ! -s "$state_plan/mutation.log" ]] || fail "plan-only mutated compose"
+python3 - "$plan_path" <<'PY'
+import json, sys
+p=json.load(open(sys.argv[1], encoding='utf-8'))
+assert p['scope']=='api'
+assert len(p['git_head'])==40
+assert all(c in '0123456789abcdef' for c in p['git_head'])
+assert p['api_image_tag']
+assert p['target_services']==['api']
+assert p['protected_services']==['db','nats','caddy']
+assert p['startup_migration_mode']=='verify-applied'
+assert p['no_deps'] is True
+assert p['remove_orphans'] is False
+assert p['commands'][0][-1]=='api'
+assert '--no-deps' in p['commands'][0]
+assert '--remove-orphans' not in p['commands'][0]
+PY
+assert_contains "$out_plan" "Plan-only mode: no container mutation performed."
+echo "PASS: plan-only writes an exact bounded API plan without mutation"
+
+# API scope must target only API and preserve all protected service identities.
+repo_api="$(new_repo api)"
+state_api="$WORK_ROOT/api-state"
+mkdir -p "$state_api"
+out_api="$(run_up "$repo_api" "$state_api" --deploy-scope api 2>&1)"
+[[ "$(wc -l <"$state_api/compose-up.log")" -eq 1 ]] || fail "API scope should execute one compose up"
+api_call="$(cat "$state_api/compose-up.log")"
+assert_contains "$api_call" "up -d --no-deps api"
+assert_not_contains "$api_call" "--remove-orphans"
+assert_not_contains "$api_call" " db"
+assert_not_contains "$api_call" " nats"
+assert_not_contains "$api_call" " caddy"
+[[ "$(cat "$state_api/api.mode")" == "verify-applied" ]] || fail "API scope did not force verify-applied"
+assert_contains "$out_api" "Health OK"
+echo "PASS: API scope changes only API and forces verify-applied"
+
+# Migration scope must run API-only, then automatically recreate only API in verify-applied mode.
+repo_migration="$(new_repo migration)"
+state_migration="$WORK_ROOT/migration-state"
+mkdir -p "$state_migration"
+out_migration="$(run_up "$repo_migration" "$state_migration" --deploy-scope migration 2>&1)"
+[[ "$(wc -l <"$state_migration/compose-up.log")" -eq 2 ]] || fail "migration scope should execute exactly two compose up calls"
+first_call="$(sed -n '1p' "$state_migration/compose-up.log")"
+second_call="$(sed -n '2p' "$state_migration/compose-up.log")"
+assert_contains "$first_call" "up -d --no-deps api"
+assert_contains "$second_call" "up -d --no-deps --force-recreate api"
+[[ "$(cat "$state_migration/api.mode")" == "verify-applied" ]] || fail "migration scope did not restore verify-applied"
+python3 - "$repo_migration/.ops/deploy-plan-migration.json" <<'PY'
+import json, sys
+p=json.load(open(sys.argv[1], encoding='utf-8'))
+assert p['scope']=='migration'
+assert p['startup_migration_mode']=='run'
+assert p['automatic_restore_mode']=='verify-applied'
+assert len(p['commands'])==2
+assert p['command_environments']==[
+    {'WELTGEWEBE_API_STARTUP_MIGRATIONS':'run'},
+    {'WELTGEWEBE_API_STARTUP_MIGRATIONS':'verify-applied'},
+]
+PY
+assert_contains "$out_migration" "Running automatic migration-mode restore"
+echo "PASS: migration scope is API-only and automatically restores verify-applied"
+
+# A failed migration-active API start must still attempt an API-only verify-applied restore.
+repo_migration_failure="$(new_repo migration-failure)"
+state_migration_failure="$WORK_ROOT/migration-failure-state"
+mkdir -p "$state_migration_failure"
+mock_bin_migration_failure="$(setup_mocks "$state_migration_failure")"
+set +e
+out_migration_failure="$( (cd "$repo_migration_failure" && PATH="$mock_bin_migration_failure:/usr/bin:/bin" MOCK_STATE="$state_migration_failure" WELTGEWEBE_DEPLOY_LOCK_FILE="$state_migration_failure/deploy.lock" MOCK_FAIL_INITIAL_MIGRATION=1 REPO_DIR="$repo_migration_failure" ENV_FILE="$repo_migration_failure/.env" DEPLOY_TARGET=vps WELTGEWEBE_STATE_DIR="$repo_migration_failure/.ops" WELTGEWEBE_SCOPED_API_HEALTH_TIMEOUT_SECONDS=2 bash scripts/weltgewebe-up --no-pull --no-build --deploy-scope migration) 2>&1)"
+rc_migration_failure=$?
+set -e
+[[ "$rc_migration_failure" -ne 0 ]] || fail "injected migration failure should fail the overall deploy"
+[[ "$(wc -l <"$state_migration_failure/compose-up.log")" -eq 2 ]] || fail "failed migration should trigger exactly one restore call"
+failed_initial_call="$(sed -n '1p' "$state_migration_failure/compose-up.log")"
+failed_restore_call="$(sed -n '2p' "$state_migration_failure/compose-up.log")"
+assert_contains "$failed_initial_call" "up -d --no-deps api"
+assert_contains "$failed_restore_call" "up -d --no-deps --force-recreate api"
+[[ "$(cat "$state_migration_failure/api.mode")" == "verify-applied" ]] || fail "failed migration did not restore verify-applied"
+assert_contains "$out_migration_failure" "Running automatic migration-mode restore"
+assert_contains "$out_migration_failure" "Scoped API container startup failed"
+echo "PASS: failed migration-active start triggers API-only verify-applied restoration"
+
+# Any protected identity drift must fail closed and be diagnosed.
+repo_drift="$(new_repo drift)"
+state_drift="$WORK_ROOT/drift-state"
+mkdir -p "$state_drift"
+mock_bin_drift="$(setup_mocks "$state_drift")"
+set +e
+out_drift="$( (cd "$repo_drift" && PATH="$mock_bin_drift:/usr/bin:/bin" MOCK_STATE="$state_drift" WELTGEWEBE_DEPLOY_LOCK_FILE="$state_drift/deploy.lock" MOCK_DRIFT_SERVICE=db REPO_DIR="$repo_drift" ENV_FILE="$repo_drift/.env" DEPLOY_TARGET=vps WELTGEWEBE_STATE_DIR="$repo_drift/.ops" WELTGEWEBE_SCOPED_API_HEALTH_TIMEOUT_SECONDS=2 bash scripts/weltgewebe-up --no-pull --no-build --deploy-scope api) 2>&1)"
+rc_drift=$?
+set -e
+[[ "$rc_drift" -ne 0 ]] || fail "protected db drift should fail"
+assert_contains "$out_drift" "protected service 'db' changed identity"
+echo "PASS: protected service identity drift fails closed"
+
+# Missing dependencies must stop before compose up.
+repo_missing="$(new_repo missing)"
+state_missing="$WORK_ROOT/missing-state"
+mkdir -p "$state_missing"
+mock_bin_missing="$(setup_mocks "$state_missing")"
+set +e
+out_missing="$( (cd "$repo_missing" && PATH="$mock_bin_missing:/usr/bin:/bin" MOCK_STATE="$state_missing" WELTGEWEBE_DEPLOY_LOCK_FILE="$state_missing/deploy.lock" MOCK_MISSING_SERVICE=db REPO_DIR="$repo_missing" ENV_FILE="$repo_missing/.env" DEPLOY_TARGET=vps WELTGEWEBE_STATE_DIR="$repo_missing/.ops" bash scripts/weltgewebe-up --no-pull --no-build --deploy-scope api) 2>&1)"
+rc_missing=$?
+set -e
+[[ "$rc_missing" -ne 0 ]] || fail "missing db should fail"
+[[ ! -s "$state_missing/mutation.log" ]] || fail "missing protected db still mutated compose"
+assert_contains "$out_missing" "requires running protected service 'db'"
+echo "PASS: missing protected dependencies stop before mutation"
+
+# Plan destinations are restricted to one non-symlink file inside the state directory.
+repo_plan_path="$(new_repo plan-path)"
+state_plan_path="$WORK_ROOT/plan-path-state"
+mkdir -p "$state_plan_path"
+mock_bin_plan_path="$(setup_mocks "$state_plan_path")"
+set +e
+out_plan_path="$( (cd "$repo_plan_path" && PATH="$mock_bin_plan_path:/usr/bin:/bin" MOCK_STATE="$state_plan_path" WELTGEWEBE_DEPLOY_LOCK_FILE="$state_plan_path/deploy.lock" REPO_DIR="$repo_plan_path" ENV_FILE="$repo_plan_path/.env" DEPLOY_TARGET=vps WELTGEWEBE_STATE_DIR="$repo_plan_path/.ops" bash scripts/weltgewebe-up --no-pull --no-build --deploy-scope api --plan-only --deploy-plan-file ../escape.json) 2>&1)"
+rc_plan_path=$?
+set -e
+[[ "$rc_plan_path" -ne 0 ]] || fail "plan path traversal should fail"
+assert_contains "$out_plan_path" "deploy plan name must be one plain file name"
+[[ ! -e "$repo_plan_path/escape.json" ]] || fail "plan path escaped the state directory"
+echo "PASS: deploy plan path is confined to the state directory"
+
+# A second deploy with the same host/project lock must fail before compose mutation.
+repo_lock="$(new_repo lock)"
+state_lock="$WORK_ROOT/lock-state"
+mkdir -p "$state_lock"
+mock_bin_lock="$(setup_mocks "$state_lock")"
+exec {held_lock_fd}>"$state_lock/deploy.lock"
+flock -n "$held_lock_fd" || fail "could not acquire test deployment lock"
+set +e
+out_lock="$( (cd "$repo_lock" && PATH="$mock_bin_lock:/usr/bin:/bin" MOCK_STATE="$state_lock" WELTGEWEBE_DEPLOY_LOCK_FILE="$state_lock/deploy.lock" REPO_DIR="$repo_lock" ENV_FILE="$repo_lock/.env" DEPLOY_TARGET=vps WELTGEWEBE_STATE_DIR="$repo_lock/.ops" bash scripts/weltgewebe-up --no-pull --no-build --deploy-scope api) 2>&1)"
+rc_lock=$?
+set -e
+flock -u "$held_lock_fd"
+exec {held_lock_fd}>&-
+[[ "$rc_lock" -ne 0 ]] || fail "parallel deploy should fail"
+[[ ! -s "$state_lock/mutation.log" ]] || fail "parallel deploy mutated compose"
+assert_contains "$out_lock" "another Weltgewebe deployment is already active"
+echo "PASS: host/project deployment lock rejects parallel effects"
+
+# Incompatible frontend/caddy effects are rejected before runtime inspection.
+repo_incompatible="$(new_repo incompatible)"
+state_incompatible="$WORK_ROOT/incompatible-state"
+mkdir -p "$state_incompatible"
+mock_bin_incompatible="$(setup_mocks "$state_incompatible")"
+set +e
+out_incompatible="$( (cd "$repo_incompatible" && PATH="$mock_bin_incompatible:/usr/bin:/bin" MOCK_STATE="$state_incompatible" WELTGEWEBE_DEPLOY_LOCK_FILE="$state_incompatible/deploy.lock" REPO_DIR="$repo_incompatible" ENV_FILE="$repo_incompatible/.env" DEPLOY_TARGET=vps DEPLOY_FRONTEND_MODE=internal bash scripts/weltgewebe-up --no-pull --no-build --deploy-scope api) 2>&1)"
+rc_incompatible=$?
+set -e
+[[ "$rc_incompatible" -ne 0 ]] || fail "internal frontend mode should be incompatible with API scope"
+assert_contains "$out_incompatible" "requires DEPLOY_FRONTEND_MODE=off"
+[[ ! -s "$state_incompatible/mutation.log" ]] || fail "incompatible frontend mode mutated compose"
+
+echo "PASS: bounded scopes reject frontend and Caddy effects"
+echo "test_weltgewebe_up_deploy_scope: OK"

--- a/scripts/weltgewebe-up
+++ b/scripts/weltgewebe-up
@@ -57,6 +57,10 @@ DO_PULL=1
 BUILD_MODE="auto"
 PURGE_ZOMBIES=0
 BUILD_WEB="auto"
+DEPLOY_SCOPE="${WELTGEWEBE_DEPLOY_SCOPE:-full}"
+PLAN_ONLY=0
+DEPLOY_PLAN_FILE="${WELTGEWEBE_DEPLOY_PLAN_FILE:-}"
+WITH_CADDY_EXPLICIT=0
 DEPLOY_BRANCH="${WELTGEWEBE_DEPLOY_BRANCH:-main}"
 DEPLOY_BRANCH_OVERRIDE=""
 USE_CURRENT_BRANCH=0
@@ -73,6 +77,9 @@ usage() {
   echo "  --build-mode MODE       Set build mode: auto (default), force, no"
   echo "  --no-build              Alias for --build-mode no"
   echo "  --force-build           Alias for --build-mode force"
+  echo "  --deploy-scope SCOPE    Deployment radius: full (default), api, or migration"
+  echo "  --plan-only             Write the scoped JSON plan and stop before container mutation"
+  echo "  --deploy-plan-file NAME Persist the plan as NAME inside the deploy state directory"
   echo
   echo "Safety & Frontend:"
   echo "  --purge-compose-leaks   Automatically remove detected 'zombie' containers (from wrong project)"
@@ -87,7 +94,10 @@ REFRESH_EDGE=0
 
 while [[ "$#" -gt 0 ]]; do
   case $1 in
-    --with-caddy) WITH_CADDY=1 ;;
+    --with-caddy)
+      WITH_CADDY=1
+      WITH_CADDY_EXPLICIT=1
+      ;;
     --no-pull) DO_PULL=0 ;;
     --branch)
       if [[ $# -lt 2 || -z "${2:-}" ]]; then
@@ -114,6 +124,23 @@ while [[ "$#" -gt 0 ]]; do
       ;;
     --no-build) BUILD_MODE="no" ;;
     --force-build) BUILD_MODE="force" ;;
+    --deploy-scope)
+      if [[ $# -lt 2 || -z "${2:-}" ]]; then
+        echo "ERROR: --deploy-scope requires an argument (full|api|migration)."
+        usage
+      fi
+      DEPLOY_SCOPE="$2"
+      shift
+      ;;
+    --plan-only) PLAN_ONLY=1 ;;
+    --deploy-plan-file)
+      if [[ $# -lt 2 || -z "${2:-}" ]]; then
+        echo "ERROR: --deploy-plan-file requires a file name."
+        usage
+      fi
+      DEPLOY_PLAN_FILE="$2"
+      shift
+      ;;
     --purge-compose-leaks) PURGE_ZOMBIES=1 ;;
     --build-web) BUILD_WEB="force" ;;
     --no-build-web) BUILD_WEB="no" ;;
@@ -131,7 +158,46 @@ if [[ -n "$DEPLOY_BRANCH_OVERRIDE" ]]; then
   DEPLOY_BRANCH="$DEPLOY_BRANCH_OVERRIDE"
 fi
 
-if [[ "$DEPLOY_TARGET" == "vps" && "$WITH_CADDY" == "0" ]]; then
+case "$DEPLOY_SCOPE" in
+  full | api | migration) ;;
+  *)
+    echo "ERROR: Invalid deploy scope '$DEPLOY_SCOPE'. Expected: full|api|migration." >&2
+    exit 1
+    ;;
+esac
+
+if [[ "$PLAN_ONLY" == "1" && "$DEPLOY_SCOPE" == "full" ]]; then
+  echo "ERROR: --plan-only is currently supported only for bounded api or migration scopes." >&2
+  exit 1
+fi
+
+if [[ "$DEPLOY_SCOPE" != "full" ]]; then
+  if [[ "$WITH_CADDY_EXPLICIT" == "1" ]]; then
+    echo "ERROR: --with-caddy is incompatible with deploy scope '$DEPLOY_SCOPE'." >&2
+    exit 1
+  fi
+  if [[ "$REFRESH_EDGE" == "1" ]]; then
+    echo "ERROR: --refresh-edge is incompatible with deploy scope '$DEPLOY_SCOPE'." >&2
+    exit 1
+  fi
+  if [[ "$PURGE_ZOMBIES" == "1" ]]; then
+    echo "ERROR: --purge-compose-leaks is incompatible with bounded deploy scopes." >&2
+    exit 1
+  fi
+  if [[ -n "$DEPLOY_FRONTEND_MODE_WAS_SET" && "$DEPLOY_FRONTEND_MODE" != "off" ]]; then
+    echo "ERROR: deploy scope '$DEPLOY_SCOPE' requires DEPLOY_FRONTEND_MODE=off." >&2
+    exit 1
+  fi
+  if [[ -n "${REQUIRE_FRONTEND:-}" && "$REQUIRE_FRONTEND" != "0" ]]; then
+    echo "ERROR: deploy scope '$DEPLOY_SCOPE' requires REQUIRE_FRONTEND=0." >&2
+    exit 1
+  fi
+  DEPLOY_FRONTEND_MODE="off"
+  export REQUIRE_FRONTEND=0
+  WITH_CADDY=0
+fi
+
+if [[ "$DEPLOY_TARGET" == "vps" && "$WITH_CADDY" == "0" && "$DEPLOY_SCOPE" == "full" ]]; then
   WITH_CADDY=1
 fi
 
@@ -253,6 +319,31 @@ if [[ "$COMPOSE_PROJECT" == "compose" ]]; then
 fi
 
 export COMPOSE_PROJECT_NAME="$COMPOSE_PROJECT"
+
+if ! command -v flock > /dev/null 2>&1; then
+  echo "ERROR: flock is required to serialize deployment effects." >&2
+  exit 1
+fi
+if [[ -z "${WELTGEWEBE_DEPLOY_LOCK_FILE:-}" ]]; then
+  if [[ "$(id -u)" == "0" && -d /run/lock && -w /run/lock ]]; then
+    WELTGEWEBE_DEPLOY_LOCK_FILE="/run/lock/weltgewebe-${COMPOSE_PROJECT}.deploy.lock"
+  elif [[ -n "${XDG_RUNTIME_DIR:-}" && -d "$XDG_RUNTIME_DIR" && -w "$XDG_RUNTIME_DIR" ]]; then
+    WELTGEWEBE_DEPLOY_LOCK_FILE="$XDG_RUNTIME_DIR/weltgewebe-${COMPOSE_PROJECT}.deploy.lock"
+  else
+    WELTGEWEBE_DEPLOY_LOCK_FILE="${HOME:?HOME is required}/.local/state/weltgewebe/locks/${COMPOSE_PROJECT}.deploy.lock"
+    install -d -m 0700 "$(dirname "$WELTGEWEBE_DEPLOY_LOCK_FILE")"
+  fi
+fi
+DEPLOY_LOCK_FILE="$WELTGEWEBE_DEPLOY_LOCK_FILE"
+if [[ -L "$DEPLOY_LOCK_FILE" ]]; then
+  echo "ERROR: deployment lock file must not be a symlink: $DEPLOY_LOCK_FILE" >&2
+  exit 1
+fi
+exec {DEPLOY_LOCK_FD}>"$DEPLOY_LOCK_FILE"
+if ! flock -n "$DEPLOY_LOCK_FD"; then
+  echo "ERROR: another Weltgewebe deployment is already active for project $COMPOSE_PROJECT." >&2
+  exit 1
+fi
 
 # 1. Environment Check
 # Normalize ENV_FILE before checking it so relative overrides resolve against
@@ -386,6 +477,7 @@ CURRENT_BRANCH_BEFORE="unknown"
 CURRENT_BRANCH_AFTER="unknown"
 HEAD_BEFORE="unknown"
 HEAD_AFTER="unknown"
+HEAD_AFTER_FULL="unknown"
 REMOTE_DEPLOY_BRANCH_SHA="unknown"
 DETACHED_BEFORE_SWITCH="no"
 BRANCH_SWITCH_ATTEMPTED="no"
@@ -514,6 +606,7 @@ if [[ "$DO_PULL" == "1" ]]; then
   fi
 
   HEAD_AFTER=$(git rev-parse --short HEAD 2> /dev/null || echo "unknown")
+  HEAD_AFTER_FULL=$(git rev-parse HEAD 2> /dev/null || echo "unknown")
   REMOTE_DEPLOY_BRANCH_SHA=$(git rev-parse --short "refs/remotes/${REMOTE}/${DEPLOY_BRANCH_RESOLVED}" 2> /dev/null || echo "$REMOTE_DEPLOY_BRANCH_SHA")
 else
   echo
@@ -523,6 +616,7 @@ else
   BRANCH_SWITCH_RESULT="skipped_no_pull"
   CURRENT_BRANCH_AFTER=$(git symbolic-ref -q --short HEAD 2> /dev/null || echo "DETACHED")
   HEAD_AFTER=$(git rev-parse --short HEAD 2> /dev/null || echo "unknown")
+  HEAD_AFTER_FULL=$(git rev-parse HEAD 2> /dev/null || echo "unknown")
 fi
 
 echo
@@ -536,10 +630,10 @@ if [[ "$DO_PULL" != "1" ]]; then
 fi
 echo "   Branch switch: $([[ "$BRANCH_SWITCH_ATTEMPTED" == "yes" ]] && echo "yes" || echo "no")"
 echo "   Previous HEAD: $HEAD_BEFORE"
-echo "   Target HEAD after pull: $HEAD_AFTER"
+echo "   Target HEAD after pull: $HEAD_AFTER_FULL"
 
-if [[ "$HEAD_AFTER" == "unknown" ]]; then
-  echo "ERROR: Cannot resolve deploy HEAD; refusing to select an API image tag." >&2
+if [[ ! "$HEAD_AFTER_FULL" =~ ^[0-9a-f]{40}$ || "$HEAD_AFTER" == "unknown" ]]; then
+  echo "ERROR: Cannot resolve a full 40-character deploy commit; refusing deployment." >&2
   exit 1
 fi
 
@@ -550,6 +644,15 @@ export API_VERSION="$HEAD_AFTER"
 echo "   API image tag: $API_VERSION"
 export WELTGEWEBE_BUILD="$HEAD_AFTER"
 echo "   Caddy build header: $WELTGEWEBE_BUILD"
+
+case "$DEPLOY_SCOPE" in
+  api)
+    export WELTGEWEBE_API_STARTUP_MIGRATIONS="verify-applied"
+    ;;
+  migration)
+    export WELTGEWEBE_API_STARTUP_MIGRATIONS="run"
+    ;;
+esac
 
 # 3. Preflight: Docker Compose Config (Strict)
 # Run AFTER pull to validate new config
@@ -592,7 +695,7 @@ generate_failure_bundle() {
     echo "current branch before: $CURRENT_BRANCH_BEFORE"
     echo "current branch after: $CURRENT_BRANCH_AFTER"
     echo "head before: $HEAD_BEFORE"
-    echo "head after: $HEAD_AFTER"
+    echo "head after: $HEAD_AFTER_FULL"
     echo "remote deploy branch: $REMOTE_DEPLOY_BRANCH_SHA"
     echo "detached before switch: $DETACHED_BEFORE_SWITCH"
     echo "branch switch attempted: $BRANCH_SWITCH_ATTEMPTED"
@@ -823,22 +926,34 @@ ENABLE_CADDY=0
 
 echo
 echo ">> Service Plan:"
-if [[ "$HAS_CADDY" == "1" ]]; then
-  if [[ "$WITH_CADDY" == "1" ]]; then
-    if [[ "$DEPLOY_TARGET" == "vps" ]]; then
-      echo " - caddy: ENABLED (vps target)"
-    else
-      echo " - caddy: ENABLED (explicit request)"
-    fi
-    ENABLE_CADDY=1
+echo " - deploy scope: $DEPLOY_SCOPE"
+if [[ "$DEPLOY_SCOPE" != "full" ]]; then
+  echo " - api: TARGETED"
+  echo " - db: PROTECTED (identity must not change)"
+  echo " - nats: PROTECTED (identity must not change)"
+  if [[ "$HAS_CADDY" == "1" ]]; then
+    echo " - caddy: PROTECTED (identity must not change)"
   else
-    echo " - caddy: DISABLED (default)"
-    SCALE_ARGS=("--scale" "caddy=0")
+    echo " - caddy: NOT FOUND"
   fi
 else
-  echo " - caddy: NOT FOUND"
-  if [[ "$WITH_CADDY" == "1" ]]; then
-    echo "WARNING: --with-caddy requested but service 'caddy' not found."
+  if [[ "$HAS_CADDY" == "1" ]]; then
+    if [[ "$WITH_CADDY" == "1" ]]; then
+      if [[ "$DEPLOY_TARGET" == "vps" ]]; then
+        echo " - caddy: ENABLED (vps target)"
+      else
+        echo " - caddy: ENABLED (explicit request)"
+      fi
+      ENABLE_CADDY=1
+    else
+      echo " - caddy: DISABLED (default)"
+      SCALE_ARGS=("--scale" "caddy=0")
+    fi
+  else
+    echo " - caddy: NOT FOUND"
+    if [[ "$WITH_CADDY" == "1" ]]; then
+      echo "WARNING: --with-caddy requested but service 'caddy' not found."
+    fi
   fi
 fi
 
@@ -1140,6 +1255,8 @@ if [[ -d "apps/web/build" && "${PUBLIC_BASEMAP_MODE:-}" == "local-sovereign" ]];
   echo "[✓] Sovereign frontend build verified: no remote basemap references; local-basemap present."
 fi
 
+if [[ "$DEPLOY_SCOPE" == "full" ]]; then
+
 # 6c. Basemap Artifact Guard (best effort)
 # Try to ensure the PMTiles artifact exists for Heimserver Caddy to serve
 BASEMAP_DIR="build/basemap"
@@ -1249,6 +1366,12 @@ else
       echo "   [X] WARNING: scripts/basemap/fetch-glyphs.sh not found or not executable. 0 verified glyph set present."
     fi
   fi
+fi
+
+else
+  echo
+  echo ">> Basemap and Glyph Guards:"
+  echo "   Skipped (deploy scope $DEPLOY_SCOPE targets only the API)."
 fi
 
 # 6d. Static UI Runtime Guard & Edge Caddy Recreate
@@ -1417,58 +1540,358 @@ else
 fi
 
 echo ">> Deploying..."
-CMD_BASE=("docker" "compose" "${BASE_ARGS[@]}" "up" "-d" "--remove-orphans")
 
-if [[ "$DO_BUILD" == "1" ]]; then
-  CMD_BASE+=("--build")
-fi
+compose_service_id() {
+  local service="$1"
+  docker compose "${BASE_ARGS[@]}" ps -q "$service" 2> /dev/null || true
+}
 
-if [[ "$ENABLE_CADDY" == "1" ]]; then
-  # Try with Caddy enabled
-  echo "Running: ${CMD_BASE[*]}"
+join_command_for_plan() {
+  local separator=$'\x1f'
+  local joined=""
+  local arg
+  for arg in "$@"; do
+    if [[ "$arg" == *"$separator"* ]]; then
+      echo "ERROR: deployment command argument contains an unsupported control character." >&2
+      return 1
+    fi
+    if [[ -n "$joined" ]]; then
+      joined+="$separator"
+    fi
+    joined+="$arg"
+  done
+  printf '%s' "$joined"
+}
 
-  ERR_FILE=$(mktemp)
-  # Capture all output (stdout and stderr) to prevent log flooding, but retain it for the failure bundle
-  if ! "${CMD_BASE[@]}" > "$ERR_FILE" 2>&1; then
-    ERR_CONTENT=$(cat "$ERR_FILE")
+PROTECTED_SERVICES=(db nats caddy)
+declare -A PROTECTED_IDS_BEFORE=()
 
-    # Check for bind errors (port conflict)
-    if echo "$ERR_CONTENT" | grep -Eq "address already in use|port is already allocated|bind: address already in use"; then
-      echo
-      echo "WARNING: Port conflict detected (Caddy could not bind ports)."
-      echo "Retrying without Caddy (--scale caddy=0)..."
-      CMD_RETRY=("${CMD_BASE[@]}" "--scale" "caddy=0")
-      echo "Running: ${CMD_RETRY[*]}"
+snapshot_protected_services() {
+  local configured_services
+  configured_services="$(docker compose "${BASE_ARGS[@]}" config --services)"
+  local service
+  for service in "${PROTECTED_SERVICES[@]}"; do
+    if grep -qFx "$service" <<< "$configured_services"; then
+      PROTECTED_IDS_BEFORE["$service"]="$(compose_service_id "$service")"
+    else
+      PROTECTED_IDS_BEFORE["$service"]="__not_configured__"
+    fi
+  done
+}
 
-      RETRY_ERR_FILE=$(mktemp)
-      if ! "${CMD_RETRY[@]}" > "$RETRY_ERR_FILE" 2>&1; then
-        generate_failure_bundle "Container startup failed (retry without Caddy)." "$RETRY_ERR_FILE"
+verify_protected_services_unchanged() {
+  local phase="$1"
+  local service before after
+  for service in "${PROTECTED_SERVICES[@]}"; do
+    before="${PROTECTED_IDS_BEFORE[$service]}"
+    if [[ "$before" == "__not_configured__" ]]; then
+      continue
+    fi
+    after="$(compose_service_id "$service")"
+    if [[ "$after" != "$before" ]]; then
+      echo "ERROR: protected service '$service' changed identity during $phase." >&2
+      echo "       before=${before:-<absent>}" >&2
+      echo "       after=${after:-<absent>}" >&2
+      return 1
+    fi
+  done
+}
+
+wait_for_scoped_api_health() {
+  local timeout_seconds="${WELTGEWEBE_SCOPED_API_HEALTH_TIMEOUT_SECONDS:-120}"
+  case "$timeout_seconds" in
+    '' | *[!0-9]*)
+      echo "ERROR: WELTGEWEBE_SCOPED_API_HEALTH_TIMEOUT_SECONDS must be an integer." >&2
+      return 1
+      ;;
+  esac
+  if ((timeout_seconds < 1 || timeout_seconds > 600)); then
+    echo "ERROR: WELTGEWEBE_SCOPED_API_HEALTH_TIMEOUT_SECONDS must be between 1 and 600." >&2
+    return 1
+  fi
+
+  local deadline=$((SECONDS + timeout_seconds))
+  local cid status
+  while ((SECONDS < deadline)); do
+    cid="$(compose_service_id api)"
+    if [[ -n "$cid" ]]; then
+      status="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$cid" 2> /dev/null || true)"
+      case "$status" in
+        healthy | running) return 0 ;;
+        unhealthy | exited | dead) return 1 ;;
+      esac
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+restore_scoped_migration_mode() {
+  export WELTGEWEBE_API_STARTUP_MIGRATIONS="verify-applied"
+  echo "Running automatic migration-mode restore: ${SCOPED_RESTORE_CMD[*]}"
+  local restore_err_file
+  restore_err_file="$(mktemp)"
+  if ! "${SCOPED_RESTORE_CMD[@]}" > "$restore_err_file" 2>&1; then
+    echo "ERROR: failed to restore API startup mode to verify-applied." >&2
+    rm -f "$restore_err_file"
+    return 1
+  fi
+  rm -f "$restore_err_file"
+
+  if ! wait_for_scoped_api_health; then
+    echo "ERROR: API did not become healthy after restoring verify-applied mode." >&2
+    return 1
+  fi
+
+  local api_mode_cid
+  api_mode_cid="$(compose_service_id api)"
+  if [[ -z "$api_mode_cid" ]] || ! docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$api_mode_cid" 2> /dev/null | grep -Fxq 'WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied'; then
+    echo "ERROR: API container is not bound to verify-applied after migration window." >&2
+    return 1
+  fi
+  return 0
+}
+
+write_scoped_deploy_plan() {
+  local initial_command_joined restore_command_joined protected_lines=""
+  initial_command_joined="$(join_command_for_plan "${SCOPED_INITIAL_CMD[@]}")"
+  restore_command_joined=""
+  if ((${#SCOPED_RESTORE_CMD[@]} > 0)); then
+    restore_command_joined="$(join_command_for_plan "${SCOPED_RESTORE_CMD[@]}")"
+  fi
+
+  local service
+  for service in "${PROTECTED_SERVICES[@]}"; do
+    protected_lines+="${service}=${PROTECTED_IDS_BEFORE[$service]}"$'\n'
+  done
+
+  local plan_name
+  if [[ -z "$DEPLOY_PLAN_FILE" ]]; then
+    plan_name="deploy-plan-${DEPLOY_SCOPE}.json"
+  else
+    plan_name="$DEPLOY_PLAN_FILE"
+  fi
+  if [[ "$plan_name" == */* || "$plan_name" == "." || "$plan_name" == ".." || -z "$plan_name" ]]; then
+    echo "ERROR: deploy plan name must be one plain file name inside $WELTGEWEBE_STATE_DIR." >&2
+    return 1
+  fi
+
+  local canonical_state_dir
+  canonical_state_dir="$(realpath -e "$WELTGEWEBE_STATE_DIR")"
+  DEPLOY_PLAN_FILE="$canonical_state_dir/$plan_name"
+  if [[ -L "$DEPLOY_PLAN_FILE" ]]; then
+    echo "ERROR: deploy plan destination must not be a symlink: $DEPLOY_PLAN_FILE" >&2
+    return 1
+  fi
+
+  local plan_tmp
+  plan_tmp="$(mktemp "$canonical_state_dir/.${plan_name}.tmp.XXXXXX")"
+
+  PLAN_INITIAL_COMMAND="$initial_command_joined" \
+    PLAN_RESTORE_COMMAND="$restore_command_joined" \
+    PLAN_PROTECTED_IDS="$protected_lines" \
+    PLAN_PATH="$plan_tmp" \
+    PLAN_SCOPE="$DEPLOY_SCOPE" \
+    PLAN_PROJECT="$COMPOSE_PROJECT" \
+    PLAN_TARGET="$DEPLOY_TARGET" \
+    PLAN_REPO="$REPO_DIR" \
+    PLAN_HEAD="$HEAD_AFTER_FULL" \
+    PLAN_IMAGE_TAG="$API_VERSION" \
+    PLAN_BUILD="$DO_BUILD" \
+    PLAN_ONLY_VALUE="$PLAN_ONLY" \
+    PLAN_MIGRATION_MODE="$WELTGEWEBE_API_STARTUP_MIGRATIONS" \
+    python3 - << 'PY'
+import json
+import os
+from datetime import datetime, timezone
+
+separator = "\x1f"
+initial = os.environ["PLAN_INITIAL_COMMAND"].split(separator)
+restore_raw = os.environ.get("PLAN_RESTORE_COMMAND", "")
+commands = [initial]
+if restore_raw:
+    commands.append(restore_raw.split(separator))
+
+protected = {}
+for line in os.environ.get("PLAN_PROTECTED_IDS", "").splitlines():
+    service, value = line.split("=", 1)
+    protected[service] = None if value in ("", "__not_configured__") else value
+
+scope = os.environ["PLAN_SCOPE"]
+payload = {
+    "schema_version": 1,
+    "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    "scope": scope,
+    "target_services": ["api"],
+    "protected_services": ["db", "nats", "caddy"],
+    "protected_service_ids": protected,
+    "compose_project": os.environ["PLAN_PROJECT"],
+    "deploy_target": os.environ["PLAN_TARGET"],
+    "repository": os.environ["PLAN_REPO"],
+    "git_head": os.environ["PLAN_HEAD"],
+    "api_image_tag": os.environ["PLAN_IMAGE_TAG"],
+    "build_api_image": os.environ["PLAN_BUILD"] == "1",
+    "plan_only": os.environ["PLAN_ONLY_VALUE"] == "1",
+    "startup_migration_mode": os.environ["PLAN_MIGRATION_MODE"],
+    "automatic_restore_mode": "verify-applied" if scope == "migration" else None,
+    "no_deps": True,
+    "remove_orphans": False,
+    "commands": commands,
+    "command_environments": [
+        {"WELTGEWEBE_API_STARTUP_MIGRATIONS": os.environ["PLAN_MIGRATION_MODE"]},
+        *([{"WELTGEWEBE_API_STARTUP_MIGRATIONS": "verify-applied"}] if scope == "migration" else []),
+    ],
+    "authorization": {
+        "allowed_recreated_services": ["api"],
+        "forbidden_recreated_services": ["db", "nats", "caddy"],
+    },
+}
+with open(os.environ["PLAN_PATH"], "w", encoding="utf-8") as handle:
+    json.dump(payload, handle, indent=2, sort_keys=True)
+    handle.write("\n")
+PY
+
+  chmod 0600 "$plan_tmp"
+  mv -fT -- "$plan_tmp" "$DEPLOY_PLAN_FILE"
+  echo ">> Scoped deployment plan: $DEPLOY_PLAN_FILE"
+  cat "$DEPLOY_PLAN_FILE"
+}
+
+if [[ "$DEPLOY_SCOPE" == "full" ]]; then
+  CMD_BASE=("docker" "compose" "${BASE_ARGS[@]}" "up" "-d" "--remove-orphans")
+
+  if [[ "$DO_BUILD" == "1" ]]; then
+    CMD_BASE+=("--build")
+  fi
+
+  if [[ "$ENABLE_CADDY" == "1" ]]; then
+    echo "Running: ${CMD_BASE[*]}"
+
+    ERR_FILE=$(mktemp)
+    if ! "${CMD_BASE[@]}" > "$ERR_FILE" 2>&1; then
+      ERR_CONTENT=$(cat "$ERR_FILE")
+
+      if echo "$ERR_CONTENT" | grep -Eq "address already in use|port is already allocated|bind: address already in use"; then
+        echo
+        echo "WARNING: Port conflict detected (Caddy could not bind ports)."
+        echo "Retrying without Caddy (--scale caddy=0)..."
+        CMD_RETRY=("${CMD_BASE[@]}" "--scale" "caddy=0")
+        echo "Running: ${CMD_RETRY[*]}"
+
+        RETRY_ERR_FILE=$(mktemp)
+        if ! "${CMD_RETRY[@]}" > "$RETRY_ERR_FILE" 2>&1; then
+          generate_failure_bundle "Container startup failed (retry without Caddy)." "$RETRY_ERR_FILE"
+          rm -f "$RETRY_ERR_FILE" "$ERR_FILE"
+          exit 1
+        fi
         rm -f "$RETRY_ERR_FILE" "$ERR_FILE"
+      else
+        generate_failure_bundle "Container startup failed." "$ERR_FILE"
+        rm -f "$ERR_FILE"
         exit 1
       fi
-      rm -f "$RETRY_ERR_FILE" "$ERR_FILE"
     else
-      # We don't want to spam stdout, so we just use the simple message
-      # The full log is safely stored in the bundle via $ERR_FILE
+      rm -f "$ERR_FILE"
+    fi
+  else
+    CMD=("${CMD_BASE[@]}" "${SCALE_ARGS[@]}")
+    echo "Running: ${CMD[*]}"
+
+    ERR_FILE=$(mktemp)
+    if ! "${CMD[@]}" > "$ERR_FILE" 2>&1; then
       generate_failure_bundle "Container startup failed." "$ERR_FILE"
       rm -f "$ERR_FILE"
       exit 1
+    else
+      rm -f "$ERR_FILE"
     fi
-  else
-    rm -f "$ERR_FILE"
   fi
 else
-  # Caddy disabled or not present
-  CMD=("${CMD_BASE[@]}" "${SCALE_ARGS[@]}")
-  echo "Running: ${CMD[*]}"
+  snapshot_protected_services
 
+  if [[ "$PLAN_ONLY" != "1" ]]; then
+    for required_service in db nats; do
+      if [[ -z "${PROTECTED_IDS_BEFORE[$required_service]}" || "${PROTECTED_IDS_BEFORE[$required_service]}" == "__not_configured__" ]]; then
+        echo "ERROR: bounded deploy scope '$DEPLOY_SCOPE' requires running protected service '$required_service'." >&2
+        exit 1
+      fi
+    done
+    if [[ "$DEPLOY_TARGET" == "vps" && ( -z "${PROTECTED_IDS_BEFORE[caddy]}" || "${PROTECTED_IDS_BEFORE[caddy]}" == "__not_configured__" ) ]]; then
+      echo "ERROR: bounded VPS deploy requires the protected caddy service to be running." >&2
+      exit 1
+    fi
+  fi
+
+  SCOPED_INITIAL_CMD=("docker" "compose" "${BASE_ARGS[@]}" "up" "-d" "--no-deps")
+  if [[ "$DO_BUILD" == "1" ]]; then
+    SCOPED_INITIAL_CMD+=("--build")
+  fi
+  SCOPED_INITIAL_CMD+=("api")
+
+  SCOPED_RESTORE_CMD=()
+  if [[ "$DEPLOY_SCOPE" == "migration" ]]; then
+    SCOPED_RESTORE_CMD=("docker" "compose" "${BASE_ARGS[@]}" "up" "-d" "--no-deps" "--force-recreate" "api")
+  fi
+
+  if [[ "${SCOPED_INITIAL_CMD[*]}" == *" --remove-orphans"* ]]; then
+    echo "ERROR: bounded deployment command unexpectedly includes --remove-orphans." >&2
+    exit 1
+  fi
+  for forbidden_target in db nats caddy; do
+    for arg in "${SCOPED_INITIAL_CMD[@]}"; do
+      if [[ "$arg" == "$forbidden_target" ]]; then
+        echo "ERROR: bounded deployment plan unexpectedly targets protected service '$forbidden_target'." >&2
+        exit 1
+      fi
+    done
+  done
+
+  write_scoped_deploy_plan
+  if [[ "$PLAN_ONLY" == "1" ]]; then
+    echo ">> Plan-only mode: no container mutation performed."
+    exit 0
+  fi
+
+  echo "Running scoped command: ${SCOPED_INITIAL_CMD[*]}"
   ERR_FILE=$(mktemp)
-  if ! "${CMD[@]}" > "$ERR_FILE" 2>&1; then
-    generate_failure_bundle "Container startup failed." "$ERR_FILE"
+  if ! "${SCOPED_INITIAL_CMD[@]}" > "$ERR_FILE" 2>&1; then
+    if [[ "$DEPLOY_SCOPE" == "migration" ]]; then
+      restore_scoped_migration_mode || true
+    fi
+    generate_failure_bundle "Scoped API container startup failed." "$ERR_FILE"
     rm -f "$ERR_FILE"
     exit 1
-  else
-    rm -f "$ERR_FILE"
+  fi
+  rm -f "$ERR_FILE"
+
+  if ! verify_protected_services_unchanged "initial scoped API deployment"; then
+    if [[ "$DEPLOY_SCOPE" == "migration" ]]; then
+      restore_scoped_migration_mode || true
+    fi
+    generate_failure_bundle "Protected service identity changed during scoped API deployment."
+    exit 1
+  fi
+
+  if [[ "$DEPLOY_SCOPE" == "migration" ]]; then
+    if ! wait_for_scoped_api_health; then
+      echo "ERROR: migration-mode API did not become healthy; attempting fail-closed restore to verify-applied." >&2
+      restore_scoped_migration_mode || true
+      generate_failure_bundle "Migration-mode API failed before verify-applied restoration."
+      exit 1
+    fi
+
+    if ! restore_scoped_migration_mode; then
+      generate_failure_bundle "Failed to restore API startup mode to verify-applied."
+      exit 1
+    fi
+
+    if ! verify_protected_services_unchanged "automatic verify-applied restoration"; then
+      generate_failure_bundle "Protected service identity changed during migration-mode restoration."
+      exit 1
+    fi
+  elif ! wait_for_scoped_api_health; then
+    generate_failure_bundle "Scoped API did not become healthy."
+    exit 1
   fi
 fi
 

--- a/scripts/weltgewebe-up
+++ b/scripts/weltgewebe-up
@@ -339,7 +339,7 @@ if [[ -L "$DEPLOY_LOCK_FILE" ]]; then
   echo "ERROR: deployment lock file must not be a symlink: $DEPLOY_LOCK_FILE" >&2
   exit 1
 fi
-exec {DEPLOY_LOCK_FD}>"$DEPLOY_LOCK_FILE"
+exec {DEPLOY_LOCK_FD}> "$DEPLOY_LOCK_FILE"
 if ! flock -n "$DEPLOY_LOCK_FD"; then
   echo "ERROR: another Weltgewebe deployment is already active for project $COMPOSE_PROJECT." >&2
   exit 1
@@ -1257,116 +1257,116 @@ fi
 
 if [[ "$DEPLOY_SCOPE" == "full" ]]; then
 
-# 6c. Basemap Artifact Guard (best effort)
-# Try to ensure the PMTiles artifact exists for Heimserver Caddy to serve
-BASEMAP_DIR="build/basemap"
-echo
-echo ">> Basemap Artifact Guard:"
+  # 6c. Basemap Artifact Guard (best effort)
+  # Try to ensure the PMTiles artifact exists for Heimserver Caddy to serve
+  BASEMAP_DIR="build/basemap"
+  echo
+  echo ">> Basemap Artifact Guard:"
 
-evaluate_basemap_state() {
-  local pmtiles_files=()
-  mapfile -t pmtiles_files < <(compgen -G "$BASEMAP_DIR/*.pmtiles" || true)
-  PMTILES_COUNT="${#pmtiles_files[@]}"
-  if ((PMTILES_COUNT > 0)); then
-    FIRST_PMTILES="${pmtiles_files[0]}"
-  else
-    FIRST_PMTILES=""
-  fi
-}
-
-evaluate_basemap_state
-if ((PMTILES_COUNT > 0)); then
-  echo "   [✓] Artifacts already present. Found ${PMTILES_COUNT} PMTiles artifact(s) in ${BASEMAP_DIR}."
-  echo "       -> e.g. ${FIRST_PMTILES}"
-else
-  echo "   [!] Basemap artifact missing. Attempting best-effort PMTiles build..."
-  if [[ -x "scripts/basemap/build-hamburg-pmtiles.sh" ]]; then
-    if bash scripts/basemap/build-hamburg-pmtiles.sh; then
-      evaluate_basemap_state
-      if ((PMTILES_COUNT > 0)); then
-        echo "   [✓] Basemap build succeeded. Generated ${PMTILES_COUNT} PMTiles artifact(s)."
-        echo "       -> e.g. ${FIRST_PMTILES}"
-      else
-        echo "   [X] WARNING: Basemap artifact still missing after build attempt. 0 PMTiles artifacts present in ${BASEMAP_DIR}."
-      fi
-    else
-      evaluate_basemap_state
-      if ((PMTILES_COUNT > 0)); then
-        echo "   [X] WARNING: PMTiles build script failed, but ${PMTILES_COUNT} PMTiles artifact(s) are present. Continuing deployment (best effort)."
-        echo "       -> e.g. ${FIRST_PMTILES}"
-      else
-        echo "   [X] WARNING: PMTiles build script failed. Continuing deployment (best effort). 0 PMTiles artifacts present in ${BASEMAP_DIR}."
-      fi
-    fi
-  else
-    evaluate_basemap_state
+  evaluate_basemap_state() {
+    local pmtiles_files=()
+    mapfile -t pmtiles_files < <(compgen -G "$BASEMAP_DIR/*.pmtiles" || true)
+    PMTILES_COUNT="${#pmtiles_files[@]}"
     if ((PMTILES_COUNT > 0)); then
-      echo "   [X] WARNING: scripts/basemap/build-hamburg-pmtiles.sh not found or not executable, but ${PMTILES_COUNT} PMTiles artifact(s) are present in ${BASEMAP_DIR}."
-      echo "       -> e.g. ${FIRST_PMTILES}"
+      FIRST_PMTILES="${pmtiles_files[0]}"
     else
-      echo "   [X] WARNING: scripts/basemap/build-hamburg-pmtiles.sh not found or not executable. 0 PMTiles artifacts present in ${BASEMAP_DIR}."
+      FIRST_PMTILES=""
     fi
-  fi
-fi
-# 6c2. Basemap Glyphs Guard (best effort)
-# Try to ensure the local glyphs (fonts) exist for offline rendering
-GLYPHS_DIR="map-style/glyphs/Noto Sans Regular"
-EXPECTED_GLYPHS_HASH="d117316544b43a5dde7ee761b36e17701e9f85574e181d76a74814240fdbaf34"
-echo
-echo ">> Basemap Glyphs Guard:"
+  }
 
-evaluate_glyphs_state() {
-  GLYPHS_READY=0
-  GLYPHS_ACTUAL_COUNT=0
-  if [ -f "$GLYPHS_DIR/.complete" ]; then
-    local stored_hash
-    local stored_count
-    stored_hash="$(grep '^HASH=' "$GLYPHS_DIR/.complete" | cut -d= -f2 | tr -d ' \n\r' || true)"
-    stored_count="$(grep '^COUNT=' "$GLYPHS_DIR/.complete" | cut -d= -f2 | tr -d ' \n\r' || true)"
-
-    case "$stored_count" in
-      '' | *[!0-9]*) stored_count=-1 ;;
-    esac
-
-    if [ "$stored_hash" = "$EXPECTED_GLYPHS_HASH" ] && [ "$stored_count" -ge 0 ]; then
-      GLYPHS_ACTUAL_COUNT="$(find "$GLYPHS_DIR" -maxdepth 1 -name '*.pbf' | wc -l | tr -d '[:space:]')"
-      if [ "$GLYPHS_ACTUAL_COUNT" -eq "$stored_count" ]; then
-        GLYPHS_READY=1
-      fi
-    fi
-  fi
-}
-
-evaluate_glyphs_state
-if ((GLYPHS_READY == 1)); then
-  echo "   [✓] Artifacts already present. Found verified glyph set (${GLYPHS_ACTUAL_COUNT} files) in ${GLYPHS_DIR}."
-else
-  echo "   [!] Glyphs missing. Attempting best-effort download..."
-  if [[ -x "scripts/basemap/fetch-glyphs.sh" ]]; then
-    if bash scripts/basemap/fetch-glyphs.sh; then
-      evaluate_glyphs_state
-      if ((GLYPHS_READY == 1)); then
-        echo "   [✓] Glyph fetch succeeded. Found verified glyph set (${GLYPHS_ACTUAL_COUNT} files)."
-      else
-        echo "   [X] WARNING: Glyphs still missing after fetch attempt. 0 verified glyph set present."
-      fi
-    else
-      evaluate_glyphs_state
-      if ((GLYPHS_READY == 1)); then
-        echo "   [X] WARNING: Fetch script failed, but a verified glyph set is present. Continuing (best effort)."
-      else
-        echo "   [X] WARNING: Fetch script failed. Continuing deployment (best effort). 0 verified glyph set present."
-      fi
-    fi
+  evaluate_basemap_state
+  if ((PMTILES_COUNT > 0)); then
+    echo "   [✓] Artifacts already present. Found ${PMTILES_COUNT} PMTiles artifact(s) in ${BASEMAP_DIR}."
+    echo "       -> e.g. ${FIRST_PMTILES}"
   else
-    evaluate_glyphs_state
-    if ((GLYPHS_READY == 1)); then
-      echo "   [X] WARNING: scripts/basemap/fetch-glyphs.sh not found or not executable, but a verified glyph set is present."
+    echo "   [!] Basemap artifact missing. Attempting best-effort PMTiles build..."
+    if [[ -x "scripts/basemap/build-hamburg-pmtiles.sh" ]]; then
+      if bash scripts/basemap/build-hamburg-pmtiles.sh; then
+        evaluate_basemap_state
+        if ((PMTILES_COUNT > 0)); then
+          echo "   [✓] Basemap build succeeded. Generated ${PMTILES_COUNT} PMTiles artifact(s)."
+          echo "       -> e.g. ${FIRST_PMTILES}"
+        else
+          echo "   [X] WARNING: Basemap artifact still missing after build attempt. 0 PMTiles artifacts present in ${BASEMAP_DIR}."
+        fi
+      else
+        evaluate_basemap_state
+        if ((PMTILES_COUNT > 0)); then
+          echo "   [X] WARNING: PMTiles build script failed, but ${PMTILES_COUNT} PMTiles artifact(s) are present. Continuing deployment (best effort)."
+          echo "       -> e.g. ${FIRST_PMTILES}"
+        else
+          echo "   [X] WARNING: PMTiles build script failed. Continuing deployment (best effort). 0 PMTiles artifacts present in ${BASEMAP_DIR}."
+        fi
+      fi
     else
-      echo "   [X] WARNING: scripts/basemap/fetch-glyphs.sh not found or not executable. 0 verified glyph set present."
+      evaluate_basemap_state
+      if ((PMTILES_COUNT > 0)); then
+        echo "   [X] WARNING: scripts/basemap/build-hamburg-pmtiles.sh not found or not executable, but ${PMTILES_COUNT} PMTiles artifact(s) are present in ${BASEMAP_DIR}."
+        echo "       -> e.g. ${FIRST_PMTILES}"
+      else
+        echo "   [X] WARNING: scripts/basemap/build-hamburg-pmtiles.sh not found or not executable. 0 PMTiles artifacts present in ${BASEMAP_DIR}."
+      fi
     fi
   fi
-fi
+  # 6c2. Basemap Glyphs Guard (best effort)
+  # Try to ensure the local glyphs (fonts) exist for offline rendering
+  GLYPHS_DIR="map-style/glyphs/Noto Sans Regular"
+  EXPECTED_GLYPHS_HASH="d117316544b43a5dde7ee761b36e17701e9f85574e181d76a74814240fdbaf34"
+  echo
+  echo ">> Basemap Glyphs Guard:"
+
+  evaluate_glyphs_state() {
+    GLYPHS_READY=0
+    GLYPHS_ACTUAL_COUNT=0
+    if [ -f "$GLYPHS_DIR/.complete" ]; then
+      local stored_hash
+      local stored_count
+      stored_hash="$(grep '^HASH=' "$GLYPHS_DIR/.complete" | cut -d= -f2 | tr -d ' \n\r' || true)"
+      stored_count="$(grep '^COUNT=' "$GLYPHS_DIR/.complete" | cut -d= -f2 | tr -d ' \n\r' || true)"
+
+      case "$stored_count" in
+        '' | *[!0-9]*) stored_count=-1 ;;
+      esac
+
+      if [ "$stored_hash" = "$EXPECTED_GLYPHS_HASH" ] && [ "$stored_count" -ge 0 ]; then
+        GLYPHS_ACTUAL_COUNT="$(find "$GLYPHS_DIR" -maxdepth 1 -name '*.pbf' | wc -l | tr -d '[:space:]')"
+        if [ "$GLYPHS_ACTUAL_COUNT" -eq "$stored_count" ]; then
+          GLYPHS_READY=1
+        fi
+      fi
+    fi
+  }
+
+  evaluate_glyphs_state
+  if ((GLYPHS_READY == 1)); then
+    echo "   [✓] Artifacts already present. Found verified glyph set (${GLYPHS_ACTUAL_COUNT} files) in ${GLYPHS_DIR}."
+  else
+    echo "   [!] Glyphs missing. Attempting best-effort download..."
+    if [[ -x "scripts/basemap/fetch-glyphs.sh" ]]; then
+      if bash scripts/basemap/fetch-glyphs.sh; then
+        evaluate_glyphs_state
+        if ((GLYPHS_READY == 1)); then
+          echo "   [✓] Glyph fetch succeeded. Found verified glyph set (${GLYPHS_ACTUAL_COUNT} files)."
+        else
+          echo "   [X] WARNING: Glyphs still missing after fetch attempt. 0 verified glyph set present."
+        fi
+      else
+        evaluate_glyphs_state
+        if ((GLYPHS_READY == 1)); then
+          echo "   [X] WARNING: Fetch script failed, but a verified glyph set is present. Continuing (best effort)."
+        else
+          echo "   [X] WARNING: Fetch script failed. Continuing deployment (best effort). 0 verified glyph set present."
+        fi
+      fi
+    else
+      evaluate_glyphs_state
+      if ((GLYPHS_READY == 1)); then
+        echo "   [X] WARNING: scripts/basemap/fetch-glyphs.sh not found or not executable, but a verified glyph set is present."
+      else
+        echo "   [X] WARNING: scripts/basemap/fetch-glyphs.sh not found or not executable. 0 verified glyph set present."
+      fi
+    fi
+  fi
 
 else
   echo
@@ -1816,7 +1816,7 @@ else
         exit 1
       fi
     done
-    if [[ "$DEPLOY_TARGET" == "vps" && ( -z "${PROTECTED_IDS_BEFORE[caddy]}" || "${PROTECTED_IDS_BEFORE[caddy]}" == "__not_configured__" ) ]]; then
+    if [[ "$DEPLOY_TARGET" == "vps" && (-z "${PROTECTED_IDS_BEFORE[caddy]}" || "${PROTECTED_IDS_BEFORE[caddy]}" == "__not_configured__") ]]; then
       echo "ERROR: bounded VPS deploy requires the protected caddy service to be running." >&2
       exit 1
     fi


### PR DESCRIPTION
## Ziel
Begrenzt API- und Migrationsrollouts auf den ausdrücklich autorisierten Dienst `api`, statt den gesamten Compose-Stack neu abzugleichen.

## Wirkung
- neue Scopes `full`, `api` und `migration`
- maschinenlesbarer, commitgebundener JSON-Wirkungsplan
- `--no-deps`, kein `--remove-orphans` in begrenzten Scopes
- PostgreSQL, NATS und Caddy durch Containeridentitäten geschützt
- Migrationsfenster setzt die API automatisch auf `verify-applied` zurück
- hostweite `flock`-Sperre gegen parallele Deploys
- Planpfad auf das Zustandsverzeichnis begrenzt

## Belege
- `make ci-validate`
- 810 Docmeta-Tests
- 160 Agenttests
- 49 CI-Tests
- 9 neue Deploy-Scope-Vertragstests
- bestehende Git-, Frontend-, Backup-, Off-Host- und Webinstallerverträge grün

Bureau-Quelle: Ereignis 236.