### PR TITLE
fix(web): Kartenmarker fest an Kartenbewegung koppeln

### DIFF
--- a/apps/web/src/lib/map/overlay/nodes.ts
+++ b/apps/web/src/lib/map/overlay/nodes.ts
@@ -120,6 +120,16 @@ export class NodesOverlay {
         // Robust testing selector based on domain semantics (and unique ID for stability)
         element.dataset.testid = `marker-${item.type}-${item.id}`;
 
+        // MapLibre owns the outer element's transform for geographic positioning.
+        // All Weltgewebe styling and interaction transforms therefore live on
+        // an inner visual element so map movement can never be CSS-interpolated.
+        const visual = document.createElement("span");
+        visual.className =
+          markerCategory === "account"
+            ? "map-marker__visual marker-account__visual"
+            : "map-marker__visual";
+        visual.setAttribute("aria-hidden", "true");
+
         if (markerCategory === "account") {
           const icon = document.createElement("img");
           icon.className = "marker-account__icon";
@@ -127,8 +137,10 @@ export class NodesOverlay {
           icon.alt = "";
           icon.setAttribute("aria-hidden", "true");
           icon.draggable = false;
-          element.append(icon);
+          visual.append(icon);
         }
+
+        element.append(visual);
 
         element.setAttribute("aria-label", item.title);
         element.title = item.title;

--- a/apps/web/src/routes/map/+page.svelte
+++ b/apps/web/src/routes/map/+page.svelte
@@ -479,6 +479,10 @@
   #map{ position:absolute; inset:0; }
   #map :global(canvas){ filter: grayscale(0.2) saturate(0.75) brightness(1.03) contrast(0.95); }
 
+  /*
+   * MapLibre owns the outer marker transform and updates it every render frame.
+   * Weltgewebe effects belong on the inner visual so markers stay map-locked.
+   */
   #map :global(.map-marker){
     appearance:none;
     -webkit-appearance:none;
@@ -489,24 +493,42 @@
     margin:0;
     padding:0;
     box-sizing:border-box;
+    border:0;
+    border-radius:0;
+    background:transparent;
+    display:grid;
+    place-items:center;
+    color:var(--bg);
+    cursor:pointer;
+    box-shadow:none;
+    transition:none;
+  }
+
+  #map :global(.map-marker__visual){
+    width:100%;
+    height:100%;
+    box-sizing:border-box;
     border-radius:999px;
     border:2px solid var(--panel-border);
     background:var(--accent, #ff8c42);
     display:grid;
     place-items:center;
     color:var(--bg);
-    cursor:pointer;
     box-shadow:0 0 0 2px rgba(0,0,0,0.25);
-    transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+    transform-origin:center;
+    transition:transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+    pointer-events:none;
   }
 
   #map :global(.marker-account) {
     width:44px;
     height:44px;
+  }
+
+  #map :global(.marker-account__visual) {
     background:transparent;
     border:none;
     box-shadow:none;
-    transform:none;
     border-radius:0;
   }
 
@@ -521,12 +543,11 @@
   }
 
   @media (hover: hover) and (pointer: fine) {
-    #map :global(.map-marker:hover){
-      transform: scale(1.2);
-      z-index: 10;
+    #map :global(.map-marker:hover .map-marker__visual){
+      transform:scale(1.2);
     }
-    #map :global(.marker-account:hover){
-      transform: scale(1.2);
+    #map :global(.map-marker:hover){
+      z-index:10;
     }
   }
 

--- a/apps/web/tests/garnrolle-marker-rendering.spec.ts
+++ b/apps/web/tests/garnrolle-marker-rendering.spec.ts
@@ -17,6 +17,11 @@ test.describe("Garnrolle marker rendering", () => {
     await expect(marker).toHaveCSS("width", "44px");
     await expect(marker).toHaveCSS("height", "44px");
     await expect(marker).toHaveCSS("background-image", "none");
+    await expect(marker).toHaveCSS("transition-duration", "0s");
+
+    const visual = marker.locator(".map-marker__visual");
+    await expect(visual).toHaveCount(1);
+    await expect(visual).toHaveCSS("transition-property", "transform");
 
     const icon = marker.locator("img.marker-account__icon");
     await expect(icon).toHaveCount(1);
@@ -28,5 +33,65 @@ test.describe("Garnrolle marker rendering", () => {
     await expect(icon).toHaveCSS("width", "44px");
     await expect(icon).toHaveCSS("height", "44px");
     await expect(icon).toHaveCSS("object-fit", "contain");
+  });
+
+  test("stays locked to its projected coordinate during a map jump", async ({
+    page,
+  }) => {
+    const marker = page.getByTestId(`marker-garnrolle-${GARNROLLE_ID}`);
+    await expect(marker).toBeVisible();
+
+    await page.waitForFunction(() => {
+      const map = (
+        window as typeof window & { __TEST_MAP__?: { isMoving(): boolean } }
+      ).__TEST_MAP__;
+      return Boolean(map && !map.isMoving());
+    });
+
+    const errorPx = await page.evaluate(
+      async ({ markerId }) => {
+        const map = (
+          window as typeof window & {
+            __TEST_MAP__?: {
+              getCenter(): { lng: number; lat: number };
+              jumpTo(options: { center: [number, number] }): void;
+              project(lngLat: [number, number]): { x: number; y: number };
+            };
+          }
+        ).__TEST_MAP__;
+        const markerElement = document.querySelector<HTMLElement>(
+          `[data-testid="marker-garnrolle-${markerId}"]`,
+        );
+        if (!map || !markerElement) {
+          throw new Error("test map or marker unavailable");
+        }
+
+        const center = map.getCenter();
+        map.jumpTo({ center: [center.lng + 0.02, center.lat + 0.01] });
+
+        // Two frames allow MapLibre to render the new camera position. A CSS
+        // transition on the outer marker would still be visibly catching up.
+        await new Promise<void>((resolve) =>
+          requestAnimationFrame(() => resolve()),
+        );
+        await new Promise<void>((resolve) =>
+          requestAnimationFrame(() => resolve()),
+        );
+
+        const projected = map.project([10.0629844, 53.5604148]);
+        const rect = markerElement.getBoundingClientRect();
+        const actualAnchor = {
+          x: rect.left + rect.width / 2,
+          y: rect.bottom,
+        };
+        return Math.hypot(
+          actualAnchor.x - projected.x,
+          actualAnchor.y - projected.y,
+        );
+      },
+      { markerId: GARNROLLE_ID },
+    );
+
+    expect(errorPx).toBeLessThanOrEqual(2);
   });
 });


### PR DESCRIPTION
## Problem
MapLibre positioniert HTML-Marker über die CSS-Eigenschaft `transform`. Weltgewebe animierte dieselbe Eigenschaft auf dem äußeren Marker über 150 ms. Knoten und Garnrollen liefen dadurch beim Verschieben oder Zoomen sichtbar hinter der Karte her.

## Lösung
- äußeres Marker-Element bleibt ausschließlich unter MapLibres Positionskontrolle;
- visuelle Form und Hover-Skalierung liegen auf einem inneren Element;
- `transform: none` und die Positions-Transition am äußeren Marker entfallen;
- Bewegungsregression misst Markeranker gegen die von MapLibre projizierte Koordinate.

## Prüfungen
- `svelte-check`: 0 Fehler, 0 Warnungen
- ESLint für alle drei geänderten Dateien: grün
- 22 relevante Playwright-Tests: grün
- neuer Bewegungsnachweis: maximale erlaubte Abweichung 2 px

## Bindung
Implementierter Head: `2c3310b53d039f7d334e18125d067c34c2eeeabd`