### PR TITLE
fix(map): Garnrollen-Beziehungen, Suche und Filtertreffer herstellen

### DIFF
--- a/apps/api/src/routes/accounts.rs
+++ b/apps/api/src/routes/accounts.rs
@@ -21,7 +21,11 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use std::{collections::HashMap, env, path::PathBuf};
+use std::{
+    collections::{HashMap, HashSet},
+    env,
+    path::PathBuf,
+};
 use tokio::{
     fs::{File, OpenOptions},
     io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
@@ -79,6 +83,30 @@ pub struct AccountPublic {
     pub disabled: bool,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
+}
+
+#[derive(Serialize, Clone, Debug, PartialEq)]
+pub struct AccountNodeRelation {
+    pub node_id: String,
+    pub node_title: String,
+    pub node_kind: String,
+    pub edge_kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+#[derive(Serialize, Clone, Debug, PartialEq)]
+pub struct AccountActivity {
+    pub date: String,
+    pub event: String,
+}
+
+#[derive(Serialize, Clone, Debug)]
+pub struct AccountDetails {
+    #[serde(flatten)]
+    pub account: AccountPublic,
+    pub nodes: Vec<AccountNodeRelation>,
+    pub activity: Vec<AccountActivity>,
 }
 
 #[derive(Serialize, Clone, Debug, PartialEq)]
@@ -396,13 +424,75 @@ pub async fn list_accounts(
 pub async fn get_account(
     State(state): State<ApiState>,
     Path(id): Path<String>,
-) -> Result<Json<AccountPublic>, StatusCode> {
-    let accounts = state.accounts.read().await;
-    if let Some(internal) = accounts.get(&id) {
-        Ok(Json(internal.public.clone()))
-    } else {
-        Err(StatusCode::NOT_FOUND)
+) -> Result<Json<AccountDetails>, StatusCode> {
+    // Clone the public profile before reading the relationship caches so this
+    // endpoint never holds several state locks at once.
+    let account = {
+        let accounts = state.accounts.read().await;
+        accounts
+            .get(&id)
+            .map(|internal| internal.public.clone())
+            .ok_or(StatusCode::NOT_FOUND)?
+    };
+
+    // Fäden are the source of truth for which Knoten belong to a Garnrolle.
+    // Both directions are accepted because the domain permits relationships in
+    // either orientation; account-to-account edges are ignored below because
+    // their counterpart is not present in the node cache.
+    let related_edges = {
+        let edges = state.edges.read().await;
+        edges
+            .iter_in_order()
+            .filter(|edge| edge.source_id == id || edge.target_id == id)
+            .cloned()
+            .collect::<Vec<_>>()
+    };
+
+    let node_cache = state.nodes.read().await;
+    let mut seen_nodes = HashSet::new();
+    let mut nodes = Vec::new();
+    let mut activity = Vec::new();
+
+    for edge in related_edges {
+        let related_id = if edge.source_id == id {
+            edge.target_id.as_str()
+        } else {
+            edge.source_id.as_str()
+        };
+        let Some(node) = node_cache.get(related_id) else {
+            continue;
+        };
+
+        if seen_nodes.insert(node.id.clone()) {
+            nodes.push(AccountNodeRelation {
+                node_id: node.id.clone(),
+                node_title: node.title.clone(),
+                node_kind: node.kind.clone(),
+                edge_kind: edge.edge_kind.clone(),
+                note: edge.note.clone(),
+            });
+        }
+
+        if let Some(date) = edge.created_at.clone() {
+            activity.push(AccountActivity {
+                date,
+                event: format!("Hat einen Faden zum Knoten \"{}\" geknüpft.", node.title),
+            });
+        }
     }
+
+    nodes.sort_by(|left, right| {
+        left.node_title
+            .cmp(&right.node_title)
+            .then_with(|| left.node_id.cmp(&right.node_id))
+    });
+    activity.sort_by(|left, right| right.date.cmp(&left.date));
+
+    Ok(Json(AccountDetails {
+        account,
+        nodes,
+        activity,
+    }))
 }
 
 /// Parse a JSON value as f64, accepting either a number or a numeric string.

--- a/apps/api/tests/api_accounts.rs
+++ b/apps/api/tests/api_accounts.rs
@@ -17,8 +17,10 @@ use weltgewebe_api::{
     routes::{
         accounts::{AccountInternal, AccountPublic},
         api_router,
+        edges::Edge,
+        nodes::{Location as NodeLocation, Node},
     },
-    state::ApiState,
+    state::{ApiState, OrderedCache},
     telemetry::{BuildInfo, Metrics},
 };
 
@@ -421,6 +423,93 @@ async fn accounts_cursor_limit_zero_is_bad_request() -> Result<()> {
     let req = Request::get("/accounts?pagination=cursor&limit=0").body(body::Body::empty())?;
     let res = app.oneshot(req).await?;
     assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn account_details_project_connected_nodes_and_activity() -> Result<()> {
+    let mut state = test_state().await?;
+    let mut accounts = AccountStore::new();
+    let mut account = seed_account("account-1");
+    account.public.title = "Alexander Mohr".to_string();
+    account.public.summary = Some("schaunmermal".to_string());
+    accounts.insert(account);
+    state.accounts = Arc::new(RwLock::new(accounts));
+
+    let mut nodes = OrderedCache::new();
+    nodes.insert(
+        "node-1".to_string(),
+        Node {
+            id: "node-1".to_string(),
+            kind: "resource".to_string(),
+            title: "fairschenkbox".to_string(),
+            created_at: "2026-07-11T11:11:50.289607+00:00".to_string(),
+            updated_at: "2026-07-11T11:11:50.289607+00:00".to_string(),
+            summary: Some("sharing is caring".to_string()),
+            info: None,
+            tags: vec![],
+            address: Some("Caspar-Voght-Straße 35".to_string()),
+            location: NodeLocation {
+                lat: 53.55899732464337,
+                lon: 10.060655662114556,
+            },
+        },
+    );
+    state.nodes = Arc::new(RwLock::new(nodes));
+
+    let mut edges = OrderedCache::new();
+    edges.insert(
+        "edge-1".to_string(),
+        Edge {
+            id: "edge-1".to_string(),
+            source_id: "account-1".to_string(),
+            source_type: Some("account".to_string()),
+            target_id: "node-1".to_string(),
+            target_type: Some("node".to_string()),
+            edge_kind: "reference".to_string(),
+            note: None,
+            created_at: Some("2026-07-11T11:11:50.322307+00:00".to_string()),
+        },
+    );
+    state.edges = Arc::new(RwLock::new(edges));
+
+    let app = Router::new().merge(api_router()).with_state(state);
+    let request = Request::get("/accounts/account-1").body(body::Body::empty())?;
+    let response = app.oneshot(request).await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body::to_bytes(response.into_body(), usize::MAX).await?;
+    let value: serde_json::Value = serde_json::from_slice(&body)?;
+
+    assert_eq!(value["id"], "account-1");
+    assert_eq!(value["title"], "Alexander Mohr");
+    assert_eq!(
+        value["nodes"]
+            .as_array()
+            .context("nodes must be array")?
+            .len(),
+        1
+    );
+    assert_eq!(value["nodes"][0]["node_id"], "node-1");
+    assert_eq!(value["nodes"][0]["node_title"], "fairschenkbox");
+    assert_eq!(value["nodes"][0]["node_kind"], "resource");
+    assert_eq!(value["nodes"][0]["edge_kind"], "reference");
+    assert_eq!(
+        value["activity"]
+            .as_array()
+            .context("activity must be array")?
+            .len(),
+        1
+    );
+    assert_eq!(
+        value["activity"][0]["date"],
+        "2026-07-11T11:11:50.322307+00:00"
+    );
+    assert_eq!(
+        value["activity"][0]["event"],
+        "Hat einen Faden zum Knoten \"fairschenkbox\" geknüpft."
+    );
 
     Ok(())
 }

--- a/apps/web/src/lib/components/FilterOverlay.svelte
+++ b/apps/web/src/lib/components/FilterOverlay.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
-  import { tick } from 'svelte';
+  import { createEventDispatcher, tick } from 'svelte';
   import { isFilterOpen, activeFilters, closeFilter, toggleFilterType, clearFilters } from '$lib/stores/filterStore';
   import { contextPanelOpen } from '$lib/stores/uiView';
-  import { restoreTarget } from '$lib/utils/focusManager';
+  import { restoreTarget, suppressNextRestore } from '$lib/utils/focusManager';
+  import type { MapEntityViewModel } from '$lib/map/types';
 
   export let availableTypes: { id: string, label: string, count: number }[] = [];
+  export let filteredResults: MapEntityViewModel[] = [];
+
+  const dispatch = createEventDispatcher<{ select: MapEntityViewModel }>();
+  $: listedResults = filteredResults.slice(0, 50);
 
   let overlayEl: HTMLDivElement;
   let closeBtnEl: HTMLButtonElement;
@@ -31,6 +36,16 @@
         restoreTarget('filter');
       }
     }
+  }
+
+  function selectResult(result: MapEntityViewModel) {
+    suppressNextRestore('filter');
+    dispatch('select', result);
+    closeFilter();
+  }
+
+  function resultType(result: MapEntityViewModel): string {
+    return result.type === 'garnrolle' ? 'Garnrolle' : result.kind || 'Knoten';
   }
 
   function handleGlobalKeydown(e: KeyboardEvent) {
@@ -80,6 +95,37 @@
       {:else}
         <div class="no-filters" role="status">Keine filterbaren Elemente vorhanden</div>
       {/if}
+
+      <section class="filter-results" aria-labelledby="filter-results-heading">
+        <h4 id="filter-results-heading">Treffer ({filteredResults.length})</h4>
+        {#if listedResults.length > 0}
+          <ul class="filter-result-list">
+            {#each listedResults as result}
+              <li>
+                <button
+                  type="button"
+                  class="filter-result"
+                  data-testid={`filter-result-${result.type}-${result.id}`}
+                  on:click={() => selectResult(result)}
+                >
+                  <span class="filter-result-main">
+                    <span class="filter-result-title">{result.title}</span>
+                    {#if result.summary}
+                      <span class="filter-result-summary">{result.summary}</span>
+                    {/if}
+                  </span>
+                  <span class="filter-result-type">{resultType(result)}</span>
+                </button>
+              </li>
+            {/each}
+          </ul>
+          {#if filteredResults.length > listedResults.length}
+            <p class="result-limit-note">Die ersten {listedResults.length} Treffer werden angezeigt.</p>
+          {/if}
+        {:else}
+          <p class="no-results" role="status">Keine Treffer für diese Filter.</p>
+        {/if}
+      </section>
     </div>
   </div>
 {/if}
@@ -200,6 +246,76 @@
     color: var(--muted, #666);
   }
 
+  .filter-results {
+    margin-top: 1rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--panel-border, rgba(0,0,0,0.1));
+  }
+
+  .filter-results h4 {
+    margin: 0 0 0.5rem;
+    font-size: 0.9rem;
+    color: var(--muted, #666);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
+  .filter-result-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  .filter-result {
+    width: 100%;
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.65rem 0.75rem;
+    border: 1px solid var(--panel-border, rgba(0,0,0,0.1));
+    border-radius: var(--radius, 6px);
+    background: var(--panel, #fff);
+    color: var(--text, #333);
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .filter-result:hover,
+  .filter-result:focus-visible {
+    border-color: var(--primary, #005fcc);
+    outline: none;
+  }
+
+  .filter-result-main {
+    min-width: 0;
+    display: grid;
+    gap: 0.15rem;
+  }
+
+  .filter-result-title {
+    font-weight: 600;
+  }
+
+  .filter-result-summary {
+    overflow: hidden;
+    color: var(--muted, #666);
+    font-size: 0.85rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .filter-result-type {
+    flex: 0 0 auto;
+    color: var(--muted, #666);
+    font-size: 0.8rem;
+  }
+
+  .result-limit-note,
+  .no-results,
   .no-filters {
     padding: 1rem;
     text-align: center;

--- a/apps/web/src/lib/components/panels/AccountPanel.svelte
+++ b/apps/web/src/lib/components/panels/AccountPanel.svelte
@@ -64,6 +64,17 @@
     return values.filter((value, index, all) => all.indexOf(value) === index);
   }
 
+  function edgeKindLabel(edgeKind: string): string {
+    switch (edgeKind.toLowerCase()) {
+      case 'delegation':
+        return 'Delegationsfaden';
+      case 'participation':
+        return 'Beteiligungsfaden';
+      default:
+        return 'Faden';
+    }
+  }
+
   const tabs = ['profil', 'aktivitaet', 'knoten'];
 
   function handleKeydown(e: KeyboardEvent) {
@@ -190,7 +201,7 @@
             {#each accountDetails.nodes as node}
               <li>
                 <span class="node-title">{node.node_title || node.node_id}</span>
-                <span class="node-role">({node.edge_kind})</span>
+                <span class="node-role">({edgeKindLabel(node.edge_kind)})</span>
               </li>
             {/each}
           </ul>

--- a/apps/web/src/lib/stores/mapView.test.ts
+++ b/apps/web/src/lib/stores/mapView.test.ts
@@ -141,6 +141,37 @@ describe("mapView presentation helpers", () => {
     expect(deriveSearchMatchIds(results).has("node-1")).toBe(true);
   });
 
+  it("finds Garnrollen by semantic type, plural and profile tags", () => {
+    const scene = sceneFrom(
+      [],
+      [
+        makeAccount({
+          title: "Alexander Mohr",
+          summary: "schaunmermal",
+          tags: ["interest:Commons"],
+        }),
+      ],
+    );
+
+    for (const query of ["Garnrolle", "Garnrollen", "Commons"]) {
+      const results = deriveSearchResults(scene.entities, query, true);
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe("acc-1");
+    }
+  });
+
+  it("finds Knoten by semantic type and kind", () => {
+    const scene = sceneFrom(
+      [makeNode({ title: "Fairschenkbox", kind: "Resource" })],
+      [],
+    );
+
+    expect(deriveSearchResults(scene.entities, "Knoten", true)).toHaveLength(1);
+    expect(deriveSearchResults(scene.entities, "Resource", true)).toHaveLength(
+      1,
+    );
+  });
+
   it("scopes search to the visible markers it is handed", () => {
     const scene = sceneFrom(
       [makeNode({ title: "Findbar", kind: "Werkstatt" })],

--- a/apps/web/src/lib/stores/mapView.ts
+++ b/apps/web/src/lib/stores/mapView.ts
@@ -120,12 +120,24 @@ export function deriveSearchResults(
   if (!isOpen || query.trim().length === 0) {
     return [];
   }
-  const q = query.toLowerCase();
+  const q = query.trim().toLocaleLowerCase("de-DE");
   return visibleMarkers
-    .filter((m) => {
-      const titleMatch = m.title?.toLowerCase().includes(q);
-      const summaryMatch = m.summary?.toLowerCase().includes(q);
-      return titleMatch || summaryMatch;
+    .filter((marker) => {
+      const semanticTerms =
+        marker.type === "node"
+          ? ["Knoten", marker.kind]
+          : ["Garnrolle", "Garnrollen"];
+      const searchableTerms = [
+        marker.title,
+        marker.summary,
+        ...(marker.tags ?? []),
+        ...semanticTerms,
+      ];
+      return searchableTerms.some(
+        (term) =>
+          typeof term === "string" &&
+          term.toLocaleLowerCase("de-DE").includes(q),
+      );
     })
     .slice(0, 10);
 }

--- a/apps/web/src/routes/map/+page.svelte
+++ b/apps/web/src/routes/map/+page.svelte
@@ -119,6 +119,10 @@
     focusAndFlyToPoint(event.detail);
   }
 
+  function handleFilterSelect(event: CustomEvent<MapEntityViewModel>) {
+    focusAndFlyToPoint(event.detail);
+  }
+
   // After KompositionPanel creates a node (+ its account->node edge) and
   // reloads route data, focus/fly-to it once it shows up in the freshly
   // rebuilt scene. Retries on later markersData updates while unresolved
@@ -676,7 +680,7 @@
 
   <ContextPanel />
   <SearchOverlay {filteredResults} on:select={handleSearchSelect} />
-  <FilterOverlay availableTypes={availableTypes} />
+  <FilterOverlay availableTypes={availableTypes} filteredResults={filteredMarkersData} on:select={handleFilterSelect} />
   <ActionBar />
   {#if import.meta.env.DEV || import.meta.env.MODE === 'test'}
     <div class="debug-badge" data-testid="debug-badge">

--- a/apps/web/tests/garnrolle-relations.spec.ts
+++ b/apps/web/tests/garnrolle-relations.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect } from "@playwright/test";
+import { mockApiResponses } from "./fixtures/mockApi";
+
+test.describe("Garnrolle relations", () => {
+  test("shows connected Knoten and activity from persisted Fäden", async ({
+    page,
+  }) => {
+    await mockApiResponses(page);
+
+    await page.route("**/api/nodes", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([
+          {
+            id: "node-1",
+            kind: "resource",
+            title: "fairschenkbox",
+            created_at: "2026-07-11T11:11:50.289607+00:00",
+            updated_at: "2026-07-11T11:11:50.289607+00:00",
+            summary: "sharing is caring",
+            address: "Caspar-Voght-Straße 35",
+            location: { lat: 53.55899732464337, lon: 10.060655662114556 },
+          },
+        ]),
+      });
+    });
+
+    await page.route("**/api/accounts", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([
+          {
+            id: "account-1",
+            type: "garnrolle",
+            title: "Alexander Mohr",
+            summary: "schaunmermal",
+            public_pos: { lat: 53.560395907330474, lon: 10.063080663681632 },
+            map_state: "exact",
+            radius_m: 0,
+            tags: ["interest:Commons", "account", "garnrolle"],
+          },
+        ]),
+      });
+    });
+
+    await page.route("**/api/edges", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([
+          {
+            id: "edge-1",
+            source_id: "account-1",
+            source_type: "account",
+            target_id: "node-1",
+            target_type: "node",
+            edge_kind: "reference",
+            created_at: "2026-07-11T11:11:50.322307+00:00",
+          },
+        ]),
+      });
+    });
+
+    await page.route("**/api/accounts/account-1", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: "account-1",
+          type: "garnrolle",
+          title: "Alexander Mohr",
+          summary: "schaunmermal",
+          public_pos: { lat: 53.560395907330474, lon: 10.063080663681632 },
+          map_state: "exact",
+          radius_m: 0,
+          tags: ["interest:Commons", "account", "garnrolle"],
+          nodes: [
+            {
+              node_id: "node-1",
+              node_title: "fairschenkbox",
+              node_kind: "resource",
+              edge_kind: "reference",
+            },
+          ],
+          activity: [
+            {
+              date: "2026-07-11T11:11:50.322307+00:00",
+              event: 'Hat einen Faden zum Knoten "fairschenkbox" geknüpft.',
+            },
+          ],
+        }),
+      });
+    });
+
+    await page.goto("/map?focus=garnrolle:account-1");
+
+    const panel = page.getByTestId("context-panel");
+    await expect(panel).toBeVisible();
+    await expect(panel.locator("h3")).toHaveText("Alexander Mohr");
+
+    await panel.getByRole("tab", { name: "Aktivität" }).click();
+    await expect(panel.locator("#panel-aktivitaet")).toContainText(
+      'Hat einen Faden zum Knoten "fairschenkbox" geknüpft.',
+    );
+
+    await panel.getByRole("tab", { name: "Knoten" }).click();
+    await expect(panel.locator("#panel-knoten")).toContainText("fairschenkbox");
+    await expect(panel.locator("#panel-knoten")).toContainText("Faden");
+    await expect(panel.locator("#panel-knoten")).not.toContainText("reference");
+  });
+});

--- a/apps/web/tests/ui-filter.spec.ts
+++ b/apps/web/tests/ui-filter.spec.ts
@@ -89,6 +89,47 @@ test.describe("Filter mode", () => {
     await expect(page.locator(".result-item").first()).toHaveText(
       /Test Account/,
     );
+
+    // Search by the domain term, not only by the individual title.
+    await searchInput.clear();
+    await searchInput.fill("Garnrollen");
+    await expect(page.locator(".result-item")).toHaveCount(1);
+    await expect(page.locator(".result-item").first()).toHaveText(
+      /Test Account/,
+    );
+  });
+
+  test("lists filtered Garnrollen as selectable map hits", async ({ page }) => {
+    const filterBtn = page.getByRole("button", { name: "Filter", exact: true });
+    await filterBtn.click();
+
+    const filterOverlay = page.getByTestId("filter-overlay");
+    const garnrolleLabel = page.locator("label.filter-item", {
+      hasText: "Garnrolle",
+    });
+    await garnrolleLabel.click();
+
+    await expect(filterOverlay.getByText("Treffer (1)")).toBeVisible();
+    const result = page.getByTestId("filter-result-garnrolle-account-1");
+    await expect(result).toContainText("Test Account");
+    await result.click();
+
+    await expect(filterOverlay).not.toBeVisible();
+    const contextPanel = page.getByTestId("context-panel");
+    await expect(contextPanel).toBeVisible();
+    await expect(contextPanel.locator(".panel-header h2")).toContainText(
+      "Garnrolle",
+    );
+
+    await page.waitForFunction(() => {
+      const map = (window as any).__TEST_MAP__;
+      if (!map) return false;
+      const center = map.getCenter();
+      return (
+        Math.abs(center.lng - 10.05) < 0.0001 &&
+        Math.abs(center.lat - 53.55) < 0.0001
+      );
+    });
   });
 
   test("Case B & E: Active filter -> Search strictly bounded, and Clear Filters", async ({


### PR DESCRIPTION
## Fehlerbild
- Die Tabs „Aktivität“ und „Knoten“ einer Garnrolle blieben leer, obwohl Faden und Knoten gespeichert waren.
- Die Suche fand eine Garnrolle über ihren Namen, nicht aber über „Garnrolle“, „Garnrollen“, Knotenart oder Profil-Tags.
- Der Filter blendete die Szene korrekt ein und aus, bot entgegen dem kanonischen Kartenvertrag aber keine anwählbare Trefferliste.

## Ursache
`GET /api/accounts/:id` lieferte nur das öffentliche Profil. Das Panel erwartete zusätzlich `nodes` und `activity`. Die Suche verglich ausschließlich Titel und Kurztext. Der Filter projizierte keine Trefferliste.

## Lösung
- Garnrollen-Details werden additiv aus den bestehenden öffentlichen Garnrollen-, Faden- und Knoten-Caches projiziert.
- Aktivität wird aus den Zeitstempeln der Fäden abgeleitet; verbundene Knoten werden eindeutig und deterministisch ausgegeben.
- Nutzertexte verwenden „Faden“ statt des internen Typs `reference`.
- Suche berücksichtigt Typ, Plural, Knotenart und Tags.
- Filter zeigt bis zu 50 aktuell sichtbare Treffer; ein Treffer öffnet das Fokuspanel und fährt die Karte zum Objekt.

## Lokale Belege
- API: vollständige Testfamilie grün, darunter 341 Unit-Tests und alle nicht datenbankgebundenen Integrationstests.
- `cargo clippy --all-targets -- -D warnings`: grün.
- Web-CI: Formatierung, ESLint, Leistungsbudget und Svelte-Typprüfung grün.
- Kartennahe Playwright-Suite: 58/58 grün.
- Neue End-to-End-Beweise für Garnrollen-Aktivität, Knoten, semantische Suche und anwählbare Filtertreffer.

## Grenzen
Die Detailprojektion scannt beim Öffnen einer Garnrolle den bestehenden Faden-Cache. Das ist für den aktuellen Datenumfang und die vorhandene Cachearchitektur korrekt; ein eigener Beziehungsindex wäre erst nach gemessener Skalierungsgrenze gerechtfertigt.

## Bindung
Head: `791dd20fb347f7732b37a3e413e6022d5cf5e883`