### PR TITLE
test(api): Garnrollen-Faden-Lebenszyklus vorwärts belegen

### DIFF
--- a/apps/api/tests/api_edges.rs
+++ b/apps/api/tests/api_edges.rs
@@ -21,6 +21,7 @@ use weltgewebe_api::{
     routes::{
         accounts::{AccountInternal, AccountPublic, GarnrolleMapState},
         api_router,
+        nodes::{Location as NodeLocation, Node},
     },
     state::ApiState,
     telemetry::{BuildInfo, Metrics},
@@ -564,6 +565,122 @@ async fn post_edges_binds_account_source_to_authenticated_weber() -> Result<()> 
     let persisted = jsonl_lines(&edges_path);
     assert_eq!(persisted.len(), 1);
     assert_eq!(persisted[0]["source_id"], OWN_ACCOUNT_ID);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn post_account_edge_projects_garnrolle_relation_and_survives_reload() -> Result<()> {
+    const ACCOUNT_ID: &str = "00000000-0000-0000-0000-000000000021";
+    const NODE_ID: &str = "00000000-0000-0000-0000-000000000022";
+
+    fn relation_node() -> Node {
+        Node {
+            id: NODE_ID.to_string(),
+            kind: "resource".to_string(),
+            title: "Vorwärtsnachweis".to_string(),
+            created_at: "2026-07-13T04:00:00Z".to_string(),
+            updated_at: "2026-07-13T04:00:00Z".to_string(),
+            summary: Some("Neu über den regulären Schreibpfad verknüpft".to_string()),
+            info: None,
+            tags: vec![],
+            address: None,
+            location: NodeLocation {
+                lat: 53.55,
+                lon: 10.0,
+            },
+        }
+    }
+
+    async fn read_account_details(app: &Router) -> Result<serde_json::Value> {
+        let uri = format!("/accounts/{ACCOUNT_ID}");
+        let response = app
+            .clone()
+            .oneshot(
+                Request::get(uri)
+                    .header("Host", "localhost")
+                    .body(body::Body::empty())?,
+            )
+            .await?;
+        assert_eq!(response.status(), StatusCode::OK);
+        read_json_body(response).await
+    }
+
+    fn assert_relation(details: &serde_json::Value, created_at: &str) {
+        assert_eq!(details["id"], ACCOUNT_ID);
+        assert_eq!(details["nodes"].as_array().map(Vec::len), Some(1));
+        assert_eq!(details["nodes"][0]["node_id"], NODE_ID);
+        assert_eq!(details["nodes"][0]["node_title"], "Vorwärtsnachweis");
+        assert_eq!(details["nodes"][0]["edge_kind"], "reference");
+        assert_eq!(details["activity"].as_array().map(Vec::len), Some(1));
+        assert_eq!(details["activity"][0]["date"], created_at);
+        assert_eq!(
+            details["activity"][0]["event"],
+            "Hat einen Faden zum Knoten \"Vorwärtsnachweis\" geknüpft."
+        );
+    }
+
+    let tmp = make_tmp_dir();
+    let in_dir = tmp.path().join("in");
+    fs::create_dir_all(&in_dir)?;
+    let edges_path = in_dir.join("demo.edges.jsonl");
+    let _env = set_gewebe_in_dir(&in_dir);
+
+    let (app, cookie, state) = app_with_session_for_account(
+        ACCOUNT_ID,
+        Role::Weber,
+        DomainReadSource::Jsonl,
+        weltgewebe_api::config::DomainEdgeWriteSource::Jsonl,
+    )
+    .await?;
+    state
+        .nodes
+        .write()
+        .await
+        .insert(NODE_ID.to_string(), relation_node());
+
+    let request_body = format!(
+        r#"{{"source_id":"{ACCOUNT_ID}","source_type":"account","target_id":"{NODE_ID}","target_type":"node","edge_kind":"reference"}}"#
+    );
+    let response = app
+        .clone()
+        .oneshot(post_edges(Some(&cookie), &request_body))
+        .await?;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let created = read_json_body(response).await?;
+    let created_at = created["created_at"]
+        .as_str()
+        .context("created edge must carry created_at")?
+        .to_string();
+    let created_id = created["id"]
+        .as_str()
+        .context("created edge must carry id")?;
+
+    let persisted = jsonl_lines(&edges_path);
+    assert_eq!(persisted.len(), 1);
+    assert_eq!(persisted[0]["id"], created_id);
+    assert_eq!(persisted[0]["source_id"], ACCOUNT_ID);
+    assert_eq!(persisted[0]["target_id"], NODE_ID);
+
+    let immediate_details = read_account_details(&app).await?;
+    assert_relation(&immediate_details, &created_at);
+
+    let (restarted_app, _restarted_cookie, restarted_state) = app_with_session_for_account(
+        ACCOUNT_ID,
+        Role::Weber,
+        DomainReadSource::Jsonl,
+        weltgewebe_api::config::DomainEdgeWriteSource::Jsonl,
+    )
+    .await?;
+    restarted_state
+        .nodes
+        .write()
+        .await
+        .insert(NODE_ID.to_string(), relation_node());
+
+    let restarted_details = read_account_details(&restarted_app).await?;
+    assert_relation(&restarted_details, &created_at);
 
     Ok(())
 }

--- a/apps/api/tests/db_domain_edge_write_path.rs
+++ b/apps/api/tests/db_domain_edge_write_path.rs
@@ -29,7 +29,7 @@ use axum::{
     Router,
 };
 use serial_test::serial;
-use sqlx::{Executor, PgPool};
+use sqlx::PgPool;
 use std::{path::PathBuf, sync::Arc};
 use tokio::sync::RwLock;
 use tower::ServiceExt;
@@ -46,6 +46,7 @@ use weltgewebe_api::{
     routes::{
         accounts::{AccountInternal, AccountPublic, GarnrolleMapState},
         api_router,
+        nodes::{Location as NodeLocation, Node},
     },
     state::ApiState,
     telemetry::{BuildInfo, Metrics},
@@ -86,9 +87,17 @@ const SOURCE_ID: &str = "edec0000-0000-4000-8000-00000000005a";
 const TARGET_ID: &str = "edec0000-0000-4000-8000-00000000005b";
 
 async fn clean(pool: &PgPool) {
-    pool.execute("DELETE FROM domain_edges WHERE id LIKE 'edec0000-%'")
-        .await
-        .expect("clean domain_edges fixtures");
+    sqlx::query(
+        "DELETE FROM domain_edges \
+         WHERE id LIKE 'edec0000-%' \
+            OR source_id IN ($1, $2) \
+            OR target_id IN ($1, $2)",
+    )
+    .bind(SOURCE_ID)
+    .bind(TARGET_ID)
+    .execute(pool)
+    .await
+    .expect("clean domain_edges fixtures");
 }
 
 async fn fixture_row_count(pool: &PgPool) -> i64 {
@@ -248,6 +257,67 @@ async fn read_text_body(res: axum::response::Response) -> Result<String> {
     Ok(String::from_utf8_lossy(&bytes).into_owned())
 }
 
+fn relation_node() -> Node {
+    Node {
+        id: SOURCE_ID.to_string(),
+        kind: "resource".to_string(),
+        title: "PostgreSQL Vorwärtsnachweis".to_string(),
+        created_at: "2026-07-13T04:00:00Z".to_string(),
+        updated_at: "2026-07-13T04:00:00Z".to_string(),
+        summary: Some("Persistente Garnrollen-Knotenbeziehung".to_string()),
+        info: None,
+        tags: vec![],
+        address: None,
+        location: NodeLocation {
+            lat: 53.55,
+            lon: 10.0,
+        },
+    }
+}
+
+async fn read_account_details(app: &Router, account_id: &str) -> Result<serde_json::Value> {
+    let uri = format!("/accounts/{account_id}");
+    let response = app
+        .clone()
+        .oneshot(
+            Request::get(uri)
+                .header("Host", "localhost")
+                .body(body::Body::empty())?,
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    read_json_body(response).await
+}
+
+fn assert_account_relation(details: &serde_json::Value, created_at: &str) {
+    assert_eq!(details["id"], TARGET_ID);
+    assert_eq!(details["nodes"].as_array().map(Vec::len), Some(1));
+    assert_eq!(details["nodes"][0]["node_id"], SOURCE_ID);
+    assert_eq!(
+        details["nodes"][0]["node_title"],
+        "PostgreSQL Vorwärtsnachweis"
+    );
+    assert_eq!(details["nodes"][0]["edge_kind"], "reference");
+    assert_eq!(details["activity"].as_array().map(Vec::len), Some(1));
+    let projected_at = chrono::DateTime::parse_from_rfc3339(
+        details["activity"][0]["date"]
+            .as_str()
+            .expect("projected activity date must be a string"),
+    )
+    .expect("projected activity date must be RFC3339");
+    let expected_at = chrono::DateTime::parse_from_rfc3339(created_at)
+        .expect("created edge date must be RFC3339");
+    assert_eq!(
+        projected_at.timestamp_micros(),
+        expected_at.timestamp_micros(),
+        "PostgreSQL may normalize nanoseconds to microseconds, but the projected activity must preserve the same instant"
+    );
+    assert_eq!(
+        details["activity"][0]["event"],
+        "Hat einen Faden zum Knoten \"PostgreSQL Vorwärtsnachweis\" geknüpft."
+    );
+}
+
 fn create_body(id: &str, note: Option<&str>) -> String {
     match note {
         Some(note) => format!(
@@ -277,11 +347,16 @@ async fn postgres_edge_create_persists_row_cache_and_loader_roundtrip() -> Resul
 
     let (app, cookie, state) = edge_write_app(
         pool.clone(),
-        "writepath-edge-writer-1",
+        TARGET_ID,
         DomainReadSource::Postgres,
         DomainEdgeWriteSource::Postgres,
     )
     .await?;
+    state
+        .nodes
+        .write()
+        .await
+        .insert(SOURCE_ID.to_string(), relation_node());
 
     let res = app
         .clone()
@@ -362,6 +437,7 @@ async fn postgres_edge_create_persists_row_cache_and_loader_roundtrip() -> Resul
     }
     let uri = format!("/edges/{EDGE_ID_A}");
     let res = app
+        .clone()
         .oneshot(
             Request::get(uri.as_str())
                 .header("Host", "localhost")
@@ -372,6 +448,9 @@ async fn postgres_edge_create_persists_row_cache_and_loader_roundtrip() -> Resul
     let fetched = read_json_body(res).await?;
     assert_eq!(fetched["id"], EDGE_ID_A);
     assert_eq!(fetched["created_at"], response_created_at.as_str());
+
+    let immediate_details = read_account_details(&app, TARGET_ID).await?;
+    assert_account_relation(&immediate_details, &response_created_at);
 
     // Level 3: load_edges_from_postgres reconstructs the stored edge.
     let reloaded = load_edges_from_postgres(&pool)
@@ -396,6 +475,21 @@ async fn postgres_edge_create_persists_row_cache_and_loader_roundtrip() -> Resul
         response_created.timestamp_micros(),
         "loader must reconstruct the stored create timestamp"
     );
+
+    let (restarted_app, _restarted_cookie, restarted_state) = edge_write_app(
+        pool.clone(),
+        TARGET_ID,
+        DomainReadSource::Postgres,
+        DomainEdgeWriteSource::Postgres,
+    )
+    .await?;
+    restarted_state
+        .nodes
+        .write()
+        .await
+        .insert(SOURCE_ID.to_string(), relation_node());
+    let restarted_details = read_account_details(&restarted_app, TARGET_ID).await?;
+    assert_account_relation(&restarted_details, &response_created_at);
 
     clean(&pool).await;
     Ok(())


### PR DESCRIPTION
## Anlass

PR #1409 behebt Garnrollen-Beziehungen, Suche und Filter. Der damalige Projektionstest befüllte den Cache jedoch direkt und bewies damit nicht den entscheidenden zukünftigen Lebenszyklus über den regulären Schreibpfad.

## Änderung

- authentifizierter echter `POST /edges` für Garnrolle → Knoten
- Nachweis der persistenten JSONL-Zeile
- unmittelbarer Read-after-write über `GET /accounts/:id`
- erneute API-Initialisierung und identischer Garnrollen-Nachweis
- derselbe gekoppelte Vertrag für den produktiven PostgreSQL-Schreib- und Ladepfad
- Testfixture-Bereinigung gegen zwischen Tests verbleibende, servergenerierte Faden-IDs

## Abgrenzung

- ausschließlich zwei API-Testdateien
- keine Laufzeitlogik, Migration oder Produktionsdatenänderung
- keine Rückfülllogik
- Browserdarstellung bleibt durch `garnrolle-relations.spec.ts` belegt; der UI-Schreibablauf durch `komposition.spec.ts`

## Prüfungen

- `cargo fmt --all -- --check`
- `cargo test --locked -p weltgewebe-api` — grün, einschließlich 341 Kerntests und normaler Integrationsfamilien
- `cargo test --locked -p weltgewebe-api --test api_edges` — 27/27 grün
- `DATABASE_URL=… cargo test --locked -p weltgewebe-api --test db_domain_edge_write_path -- --ignored --test-threads=1` — 7/7 grün gegen isoliertes PostgreSQL 16
- `cargo clippy -p weltgewebe-api --all-targets -- -D warnings` — grün

Dieser PR schließt nur die Nachweislücke. Die produktive Funktion aus #1409 läuft bereits auf Commit `09fe44837783f507ad50c62249e4a3a2488352d9`; der abschließende Produktionsbeweis bleibt an die nach dem Rollout vom Nutzer selbst vorgenommene neue Knotenknüpfung gebunden.