### PR TITLE
fix(web): Knotenhandlung im Garnrollenprofil benennen

### DIFF
--- a/apps/api/src/routes/accounts.rs
+++ b/apps/api/src/routes/accounts.rs
@@ -482,7 +482,7 @@ pub async fn get_account(
 
         if let Some(date) = edge.created_at.clone() {
             let event = if account_is_source {
-                format!("Hat einen Faden zum Knoten \"{}\" geknüpft.", node.title)
+                format!("Hat den Knoten \"{}\" geknüpft.", node.title)
             } else {
                 format!(
                     "Wurde über einen Faden mit dem Knoten \"{}\" verknüpft.",

--- a/apps/api/tests/api_accounts.rs
+++ b/apps/api/tests/api_accounts.rs
@@ -474,7 +474,7 @@ async fn account_details_project_outgoing_relation_without_public_note() -> Resu
         NODE_ID,
         "fairschenkbox",
         "reference",
-        "Hat einen Faden zum Knoten \"fairschenkbox\" geknüpft.",
+        "Hat den Knoten \"fairschenkbox\" geknüpft.",
     );
     assert_eq!(projected_at, CREATED_AT);
 

--- a/apps/api/tests/api_edges.rs
+++ b/apps/api/tests/api_edges.rs
@@ -664,7 +664,7 @@ async fn post_account_edge_projects_garnrolle_relation_and_survives_reload() -> 
         NODE_ID,
         NODE_TITLE,
         "reference",
-        "Hat einen Faden zum Knoten \"Vorwärtsnachweis\" geknüpft.",
+        "Hat den Knoten \"Vorwärtsnachweis\" geknüpft.",
     );
     assert_eq!(immediate_date, created_at);
 
@@ -692,7 +692,7 @@ async fn post_account_edge_projects_garnrolle_relation_and_survives_reload() -> 
         NODE_ID,
         NODE_TITLE,
         "reference",
-        "Hat einen Faden zum Knoten \"Vorwärtsnachweis\" geknüpft.",
+        "Hat den Knoten \"Vorwärtsnachweis\" geknüpft.",
     );
     assert_eq!(restarted_date, created_at);
 

--- a/apps/web/src/lib/components/panels/AccountPanel.svelte
+++ b/apps/web/src/lib/components/panels/AccountPanel.svelte
@@ -64,17 +64,6 @@
     return values.filter((value, index, all) => all.indexOf(value) === index);
   }
 
-  function edgeKindLabel(edgeKind: string): string {
-    switch (edgeKind.toLowerCase()) {
-      case 'delegation':
-        return 'Delegationsfaden';
-      case 'participation':
-        return 'Beteiligungsfaden';
-      default:
-        return 'Faden';
-    }
-  }
-
   const tabs = ['profil', 'aktivitaet', 'knoten'];
 
   function handleKeydown(e: KeyboardEvent) {
@@ -201,7 +190,6 @@
             {#each accountDetails.nodes as node}
               <li>
                 <span class="node-title">{node.node_title || node.node_id}</span>
-                <span class="node-role">({edgeKindLabel(node.edge_kind)})</span>
               </li>
             {/each}
           </ul>
@@ -250,10 +238,5 @@
   .node-title {
     font-weight: 500;
     color: var(--text, #333);
-  }
-
-  .node-role {
-    font-size: 0.85em;
-    color: var(--ghost, #666);
   }
 </style>

--- a/apps/web/src/routes/api/account/[id]/+server.ts
+++ b/apps/web/src/routes/api/account/[id]/+server.ts
@@ -34,7 +34,7 @@ export function GET({ params }: RequestEvent) {
       },
       ...nodes.map((n) => ({
         date: account.created_at, // Mocking date
-        event: `Hat Knoten "${n.node_title}" verknüpft (${n.edge_kind}).`,
+        event: `Hat den Knoten "${n.node_title}" geknüpft.`,
       })),
     ].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()),
   });

--- a/apps/web/tests/garnrolle-relations.spec.ts
+++ b/apps/web/tests/garnrolle-relations.spec.ts
@@ -87,7 +87,7 @@ test.describe("Garnrolle relations", () => {
           activity: [
             {
               date: "2026-07-11T11:11:50.322307+00:00",
-              event: 'Hat einen Faden zum Knoten "fairschenkbox" geknüpft.',
+              event: 'Hat den Knoten "fairschenkbox" geknüpft.',
             },
           ],
         }),
@@ -102,12 +102,12 @@ test.describe("Garnrolle relations", () => {
 
     await panel.getByRole("tab", { name: "Aktivität" }).click();
     await expect(panel.locator("#panel-aktivitaet")).toContainText(
-      'Hat einen Faden zum Knoten "fairschenkbox" geknüpft.',
+      'Hat den Knoten "fairschenkbox" geknüpft.',
     );
 
     await panel.getByRole("tab", { name: "Knoten" }).click();
     await expect(panel.locator("#panel-knoten")).toContainText("fairschenkbox");
-    await expect(panel.locator("#panel-knoten")).toContainText("Faden");
+    await expect(panel.locator("#panel-knoten")).not.toContainText("Faden");
     await expect(panel.locator("#panel-knoten")).not.toContainText("reference");
   });
 });


### PR DESCRIPTION
## Änderung
- Aktivität benennt die bewusste Nutzerhandlung als „Knoten knüpfen“ statt als „Faden knüpfen“.
- Der Reiter „Knoten“ zeigt nur noch den Knotennamen; die technische Fadenart wird dort nicht mehr angehängt.
- API-Projektion und Demo-Fallback verwenden dieselbe Formulierung.
- Das Faden-/Edge-Datenmodell bleibt unverändert.

## Prüfungen
- `cargo fmt --all -- --check`
- API-Test `account_details_project_outgoing_relation_without_public_note`
- API-Test `post_account_edge_projects_garnrolle_relation_and_survives_reload`
- `pnpm --dir apps/web lint`
- `pnpm --dir apps/web check`
- Playwright `tests/garnrolle-relations.spec.ts`