### PR TITLE
fix(web): UI auf produktive Details reduzieren

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -1,11 +1,4 @@
-/* Minimal, utility-light Styles für Click-Dummy */
-:root {
-  --bg: #0b0e12;
-  --fg: #e7ebee;
-  --muted: #9aa3ad;
-  --panel: #141a21;
-  --accent: #7cc4ff;
-}
+/* Gemeinsame Grundstile; Farben und Abstände stammen aus styles/tokens.css. */
 html,
 body,
 #app {
@@ -127,6 +120,8 @@ body {
   background: none;
   border: none;
   padding: 0.5rem 1rem;
+  min-height: 44px;
+  box-sizing: border-box;
   cursor: pointer;
   border-bottom: 2px solid transparent;
   color: var(--ghost, #666);
@@ -148,7 +143,7 @@ body {
   list-style: none;
   padding: 0;
   margin: 0;
-  border-left: 2px solid var(--panel-border, rgba(255, 255, 255, 0.1));
+  border-left: 2px solid var(--panel-border-strong);
   margin-left: 0.5rem;
 }
 .timeline li {

--- a/apps/web/src/lib/components/ActionBar.svelte
+++ b/apps/web/src/lib/components/ActionBar.svelte
@@ -1,43 +1,72 @@
 <script lang="ts">
-  import { contextPanelOpen, systemState, enterKomposition } from '$lib/stores/uiView';
-  import { isSearchOpen, closeSearch } from '$lib/stores/searchStore';
-  import { isFilterOpen, closeFilter } from '$lib/stores/filterStore';
-  import { toggleSearchExclusive, toggleFilterExclusive } from '$lib/stores/overlayManager';
-  import { setRestoreTarget, suppressNextRestore } from '$lib/utils/focusManager';
-  import { authStore } from '$lib/auth/store';
+  import {
+    contextPanelOpen,
+    systemState,
+    enterKomposition,
+  } from "$lib/stores/uiView";
+  import { isSearchOpen, closeSearch } from "$lib/stores/searchStore";
+  import { isFilterOpen, closeFilter } from "$lib/stores/filterStore";
+  import {
+    toggleSearchExclusive,
+    toggleFilterExclusive,
+  } from "$lib/stores/overlayManager";
+  import {
+    setRestoreTarget,
+    suppressNextRestore,
+  } from "$lib/utils/focusManager";
+  import { authStore } from "$lib/auth/store";
 
-  // Only weber/admin can create nodes. Gäste/Anonyme must not see an
-  // apparently-functional write path — the button is hidden, not disabled.
-  $: canCreateNode = $authStore.role === 'weber' || $authStore.role === 'admin';
+  $: canCreateNode = $authStore.role === "weber" || $authStore.role === "admin";
 
   function onNewNode() {
-    if ($isSearchOpen) suppressNextRestore('search');
-    if ($isFilterOpen) suppressNextRestore('filter');
+    if ($isSearchOpen) suppressNextRestore("search");
+    if ($isFilterOpen) suppressNextRestore("filter");
     closeSearch();
     closeFilter();
-    enterKomposition({ mode: 'new-knoten', source: 'action-bar' });
+    enterKomposition({ mode: "new-knoten", source: "action-bar" });
   }
 
   let searchBtnEl: HTMLButtonElement;
   let filterBtnEl: HTMLButtonElement;
 
   function onToggleSearch() {
-    if (searchBtnEl) setRestoreTarget('search', searchBtnEl);
+    if (searchBtnEl) setRestoreTarget("search", searchBtnEl);
     toggleSearchExclusive();
   }
 
   function onToggleFilter() {
-    if (filterBtnEl) setRestoreTarget('filter', filterBtnEl);
+    if (filterBtnEl) setRestoreTarget("filter", filterBtnEl);
     toggleFilterExclusive();
   }
 </script>
 
-<nav class="action-bar" class:panel-open={$contextPanelOpen} aria-label="Aktionsleiste">
+<nav
+  class="action-bar"
+  class:panel-open={$contextPanelOpen}
+  aria-label="Aktionsleiste"
+>
   {#if canCreateNode}
-    <button class="action-btn" class:active={$systemState === 'komposition'} on:click={onNewNode} aria-label="Neuer Knoten">Neuer Knoten</button>
+    <button
+      class="action-btn"
+      class:active={$systemState === "komposition"}
+      on:click={onNewNode}
+      aria-label="Knoten knüpfen">Knoten knüpfen</button
+    >
   {/if}
-  <button bind:this={searchBtnEl} class="action-btn" on:click={onToggleSearch} class:active={$isSearchOpen} aria-label="Suche">Suche</button>
-  <button bind:this={filterBtnEl} class="action-btn" class:active={$isFilterOpen} on:click={onToggleFilter} aria-label="Filter">Filter</button>
+  <button
+    bind:this={searchBtnEl}
+    class="action-btn"
+    on:click={onToggleSearch}
+    class:active={$isSearchOpen}
+    aria-label="Suche">Suche</button
+  >
+  <button
+    bind:this={filterBtnEl}
+    class="action-btn"
+    class:active={$isFilterOpen}
+    on:click={onToggleFilter}
+    aria-label="Filter">Filter</button
+  >
 </nav>
 
 <style>
@@ -46,16 +75,15 @@
     bottom: 0;
     left: 0;
     right: 0;
-    height: var(--actionbar-base-height, 60px);
-    background: var(--panel, #fff);
-    border-top: var(--actionbar-border-width, 1px) solid var(--panel-border, rgba(0,0,0,0.1));
+    height: var(--actionbar-base-height);
+    background: var(--panel);
+    border-top: var(--actionbar-border-width) solid var(--panel-border);
     display: flex;
     justify-content: space-around;
     align-items: center;
     z-index: 40;
-    padding: 0 1rem;
-    padding-bottom: env(safe-area-inset-bottom);
-    box-shadow: var(--shadow, 0 -2px 10px rgba(0,0,0,0.05));
+    padding: 0 1rem env(safe-area-inset-bottom);
+    box-shadow: var(--shadow);
     box-sizing: content-box;
   }
 
@@ -63,7 +91,7 @@
     background: none;
     border: none;
     font-size: 0.9rem;
-    color: var(--text, #333);
+    color: var(--text);
     cursor: pointer;
     padding: 0.5rem 1rem;
     border-radius: 8px;
@@ -72,23 +100,25 @@
   }
 
   .action-btn:hover {
-    background: rgba(0,0,0,0.05);
+    background: var(--accent-soft);
   }
-
   .action-btn:active {
-    background: rgba(255,255,255,0.1);
     transform: scale(0.96);
   }
-
   .action-btn.active {
-    background: var(--accent, #ff8c42);
-    color: var(--bg, #fff);
+    background: var(--accent);
+    color: var(--bg);
   }
 
-  /* Desktop: adjust layout slightly if needed */
+  @media (max-width: 768px) {
+    .action-bar.panel-open {
+      display: none;
+    }
+  }
+
   @media (min-width: 769px) {
     .action-bar.panel-open {
-      right: var(--context-panel-width, 400px); /* leaves room for ContextPanel */
+      right: var(--context-panel-width);
     }
   }
 </style>

--- a/apps/web/src/lib/components/ContextPanel.svelte
+++ b/apps/web/src/lib/components/ContextPanel.svelte
@@ -1,25 +1,58 @@
 <script lang="ts">
-  import { selection, systemState, contextPanelOpen, leaveToNavigation } from '$lib/stores/uiView';
-  import { isSearchOpen } from '$lib/stores/searchStore';
-  import { isFilterOpen } from '$lib/stores/filterStore';
+  import { createEventDispatcher } from "svelte";
+  import {
+    selection,
+    systemState,
+    contextPanelOpen,
+    kompositionDraft,
+    leaveToNavigation,
+  } from "$lib/stores/uiView";
+  import { isSearchOpen } from "$lib/stores/searchStore";
+  import { isFilterOpen } from "$lib/stores/filterStore";
 
-  import NodePanel from './panels/NodePanel.svelte';
-  import AccountPanel from './panels/AccountPanel.svelte';
-  import EdgePanel from './panels/EdgePanel.svelte';
-  import KompositionPanel from './panels/KompositionPanel.svelte';
+  import NodePanel from "./panels/NodePanel.svelte";
+  import AccountPanel from "./panels/AccountPanel.svelte";
+  import EdgePanel from "./panels/EdgePanel.svelte";
+  import KompositionPanel from "./panels/KompositionPanel.svelte";
+
+  type RelatedSelection = { type: "node" | "garnrolle"; id: string };
+  const dispatch = createEventDispatcher<{ selectRelated: RelatedSelection }>();
+  let kompositionPanel: any = null;
+
+  $: panelTitle =
+    $systemState === "komposition"
+      ? $kompositionDraft?.mode === "place-garnrolle"
+        ? "Garnrolle auf die Karte setzen"
+        : "Knoten knüpfen"
+      : $selection?.type === "node"
+        ? "Knoten"
+        : $selection?.type === "account" || $selection?.type === "garnrolle"
+          ? "Garnrolle"
+          : $selection?.type === "edge"
+            ? "Faden"
+            : "Details";
 
   function closePanel() {
+    if ($systemState === "komposition" && kompositionPanel?.requestClose) {
+      kompositionPanel.requestClose();
+      return;
+    }
     leaveToNavigation();
   }
 
-  function handleKeydown(event: KeyboardEvent) {
-    // Prevent repeated Escape from cascading from overlay-close into panel-close
-    if (event.repeat || event.defaultPrevented) return;
+  function handleRelated(event: CustomEvent<RelatedSelection>) {
+    dispatch("selectRelated", event.detail);
+  }
 
-    // Escape closes the panel only when no foreground overlay (search/filter) owns the interaction
-    if (event.key === 'Escape' && $contextPanelOpen && !$isSearchOpen && !$isFilterOpen) {
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.repeat || event.defaultPrevented) return;
+    if (
+      event.key === "Escape" &&
+      $contextPanelOpen &&
+      !$isSearchOpen &&
+      !$isFilterOpen
+    )
       closePanel();
-    }
   }
 </script>
 
@@ -27,38 +60,27 @@
 
 {#if $contextPanelOpen}
   <aside class="context-panel" data-testid="context-panel">
-    <header class="panel-header">
-      {#if $systemState === 'komposition'}
-        <h2>Neuer Knoten</h2>
-      {:else if $selection}
-        {#if $selection.type === 'node'}
-          <h2>Knoten</h2>
-        {:else if $selection.type === 'account' || $selection.type === 'garnrolle'}
-          <h2>Garnrolle</h2>
-        {:else if $selection.type === 'edge'}
-          <h2>Faden</h2>
-        {/if}
-      {:else}
-        <h2>Details</h2>
-      {/if}
-      <button class="close-btn" on:click={closePanel} aria-label="Schließen">✕</button>
+    <header
+      class="panel-header"
+      class:composition={$systemState === "komposition"}
+    >
+      <h2>{panelTitle}</h2>
+      <button class="close-btn" on:click={closePanel} aria-label="Schließen"
+        >✕</button
+      >
     </header>
 
     <div class="panel-content">
-      {#if $systemState === 'komposition'}
-        <KompositionPanel />
+      {#if $systemState === "komposition"}
+        <KompositionPanel bind:this={kompositionPanel} />
       {:else if $selection}
-        {#if $selection.type === 'node'}
-          <NodePanel />
-        {:else if $selection.type === 'account' || $selection.type === 'garnrolle'}
-          <AccountPanel />
-        {:else if $selection.type === 'edge'}
+        {#if $selection.type === "node"}
+          <NodePanel on:selectRelated={handleRelated} />
+        {:else if $selection.type === "account" || $selection.type === "garnrolle"}
+          <AccountPanel on:selectRelated={handleRelated} />
+        {:else if $selection.type === "edge"}
           <EdgePanel />
         {/if}
-      {:else}
-        <div class="empty-state">
-          <p>Bitte ein Objekt auf der Karte auswählen.</p>
-        </div>
       {/if}
     </div>
   </aside>
@@ -68,25 +90,39 @@
   .context-panel {
     position: fixed;
     z-index: 50;
-    background: var(--panel, #fff);
-    color: var(--text, #333);
-    box-shadow: var(--shadow, 0 -4px 16px rgba(0,0,0,0.1));
+    background: var(--panel);
+    color: var(--text);
+    box-shadow: var(--shadow);
     display: flex;
     flex-direction: column;
-    overflow-y: auto;
+    overflow: hidden;
+    box-sizing: border-box;
   }
 
   .panel-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 1rem;
-    border-bottom: 1px solid var(--panel-border, rgba(0,0,0,0.1));
+    min-height: 68px;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--panel-border);
+    flex: 0 0 auto;
   }
 
   .panel-header h2 {
     margin: 0;
-    font-size: 1.2rem;
+    color: var(--muted);
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+  }
+
+  .panel-header.composition h2 {
+    color: var(--text);
+    font-size: 1.1rem;
+    letter-spacing: 0;
+    text-transform: none;
   }
 
   .close-btn {
@@ -103,28 +139,29 @@
 
   .panel-content {
     padding: 1rem;
-    flex: 1;
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
   }
 
-  /* Mobile: Bottom Sheet */
   @media (max-width: 768px) {
     .context-panel {
       bottom: 0;
       left: 0;
       right: 0;
-      max-height: 80vh;
+      max-height: 80dvh;
+      padding-bottom: env(safe-area-inset-bottom);
       border-radius: 16px 16px 0 0;
     }
   }
 
-  /* Desktop: Right Sidebar */
   @media (min-width: 769px) {
     .context-panel {
       top: 0;
       right: 0;
       bottom: 0;
-      width: var(--context-panel-width, 400px);
-      box-shadow: var(--shadow, -4px 0 16px rgba(0,0,0,0.1));
+      width: var(--context-panel-width);
+      box-shadow: -4px 0 16px rgba(0, 0, 0, 0.28);
     }
   }
 </style>

--- a/apps/web/src/lib/components/ContextPanel.svelte
+++ b/apps/web/src/lib/components/ContextPanel.svelte
@@ -9,6 +9,7 @@
   } from "$lib/stores/uiView";
   import { isSearchOpen } from "$lib/stores/searchStore";
   import { isFilterOpen } from "$lib/stores/filterStore";
+  import type { KompositionDraft, Selection, SystemState } from "$lib/stores/uiView";
 
   import NodePanel from "./panels/NodePanel.svelte";
   import AccountPanel from "./panels/AccountPanel.svelte";
@@ -16,25 +17,44 @@
   import KompositionPanel from "./panels/KompositionPanel.svelte";
 
   type RelatedSelection = { type: "node" | "garnrolle"; id: string };
-  const dispatch = createEventDispatcher<{ selectRelated: RelatedSelection }>();
-  let kompositionPanel: any = null;
+  type KompositionPanelHandle = { requestClose: () => void };
 
-  $: panelTitle =
-    $systemState === "komposition"
-      ? $kompositionDraft?.mode === "place-garnrolle"
+  const dispatch = createEventDispatcher<{ selectRelated: RelatedSelection }>();
+  let kompositionPanel: KompositionPanelHandle | null = null;
+
+  function derivePanelTitle(
+    state: SystemState,
+    draft: KompositionDraft,
+    currentSelection: Selection,
+  ): string {
+    if (state === "komposition") {
+      return draft?.mode === "place-garnrolle"
         ? "Garnrolle auf die Karte setzen"
-        : "Knoten knüpfen"
-      : $selection?.type === "node"
-        ? "Knoten"
-        : $selection?.type === "account" || $selection?.type === "garnrolle"
-          ? "Garnrolle"
-          : $selection?.type === "edge"
-            ? "Faden"
-            : "Details";
+        : "Knoten knüpfen";
+    }
+
+    if (currentSelection?.type === "node") return "Knoten";
+    if (
+      currentSelection?.type === "account" ||
+      currentSelection?.type === "garnrolle"
+    ) {
+      return "Garnrolle";
+    }
+    if (currentSelection?.type === "edge") return "Faden";
+    return "Details";
+  }
+
+  $: panelTitle = derivePanelTitle(
+    $systemState,
+    $kompositionDraft,
+    $selection,
+  );
 
   function closePanel() {
-    if ($systemState === "komposition" && kompositionPanel?.requestClose) {
-      kompositionPanel.requestClose();
+    if ($systemState === "komposition") {
+      // Fail closed: while the child handle is not bound yet, never fall back
+      // to discarding a composition draft or a partial-success state.
+      kompositionPanel?.requestClose();
       return;
     }
     leaveToNavigation();

--- a/apps/web/src/lib/components/FilterOverlay.svelte
+++ b/apps/web/src/lib/components/FilterOverlay.svelte
@@ -1,131 +1,161 @@
 <script lang="ts">
-  import { createEventDispatcher, tick } from 'svelte';
-  import { isFilterOpen, activeFilters, closeFilter, toggleFilterType, clearFilters } from '$lib/stores/filterStore';
-  import { contextPanelOpen } from '$lib/stores/uiView';
-  import { restoreTarget, suppressNextRestore } from '$lib/utils/focusManager';
-  import type { MapEntityViewModel } from '$lib/map/types';
+  import { createEventDispatcher, tick } from "svelte";
+  import {
+    isFilterOpen,
+    activeFilters,
+    closeFilter,
+    toggleFilterType,
+    clearFilters,
+  } from "$lib/stores/filterStore";
+  import { contextPanelOpen } from "$lib/stores/uiView";
+  import { restoreTarget, suppressNextRestore } from "$lib/utils/focusManager";
+  import type { MapEntityViewModel } from "$lib/map/types";
+  import { nodeKindLabel } from "$lib/ui/productLanguage";
 
-  export let availableTypes: { id: string, label: string, count: number }[] = [];
+  export let availableTypes: { id: string; label: string; count: number }[] =
+    [];
   export let filteredResults: MapEntityViewModel[] = [];
-
   const dispatch = createEventDispatcher<{ select: MapEntityViewModel }>();
-  $: listedResults = filteredResults.slice(0, 50);
+  $: showResults = $activeFilters.size > 0;
+  $: listedResults = showResults ? filteredResults.slice(0, 50) : [];
 
   let overlayEl: HTMLDivElement;
   let closeBtnEl: HTMLButtonElement;
   let wasOpen = false;
 
-  // Set focus when filter opens
   $: {
     if ($isFilterOpen) {
       wasOpen = true;
       (async () => {
         await tick();
-        if ($isFilterOpen && overlayEl) {
-          const firstCheckboxEl = overlayEl.querySelector('input[type="checkbox"]') as HTMLInputElement;
-          if (firstCheckboxEl) {
-            firstCheckboxEl.focus();
-          } else if (closeBtnEl) {
-            closeBtnEl.focus();
-          }
-        }
+        const first = overlayEl?.querySelector(
+          'input[type="checkbox"]',
+        ) as HTMLInputElement | null;
+        (first || closeBtnEl)?.focus();
       })();
-    } else {
-      if (wasOpen) {
-        wasOpen = false;
-        restoreTarget('filter');
-      }
+    } else if (wasOpen) {
+      wasOpen = false;
+      restoreTarget("filter");
     }
   }
 
   function selectResult(result: MapEntityViewModel) {
-    suppressNextRestore('filter');
-    dispatch('select', result);
+    suppressNextRestore("filter");
+    dispatch("select", result);
     closeFilter();
   }
-
   function resultType(result: MapEntityViewModel): string {
-    return result.type === 'garnrolle' ? 'Garnrolle' : result.kind || 'Knoten';
+    return result.type === "garnrolle"
+      ? "Garnrolle"
+      : nodeKindLabel(result.kind);
   }
-
+  function filterLabel(type: { id: string; label: string }): string {
+    return type.id === "Garnrolle" ? "Garnrolle" : nodeKindLabel(type.id);
+  }
   function handleGlobalKeydown(e: KeyboardEvent) {
-    if (!$isFilterOpen) return;
-    // Respect capture-phase handlers (e.g. Garnrolle menu) that own this Escape
-    if (e.defaultPrevented) return;
-    if (e.key === 'Escape') {
+    if ($isFilterOpen && !e.defaultPrevented && e.key === "Escape")
       closeFilter();
-    }
   }
 </script>
 
 <svelte:window on:keydown={handleGlobalKeydown} />
 
 {#if $isFilterOpen}
-  <div bind:this={overlayEl} class="filter-overlay" class:panel-open={$contextPanelOpen} data-testid="filter-overlay" role="dialog" aria-label="Filter" aria-modal="false">
+  <div
+    bind:this={overlayEl}
+    class="filter-overlay"
+    class:panel-open={$contextPanelOpen}
+    data-testid="filter-overlay"
+    role="dialog"
+    aria-label="Filter"
+    aria-modal="false"
+  >
     <div class="filter-header">
       <h3>Filter</h3>
       <div class="header-actions">
-        {#if $activeFilters.size > 0}
-          <button class="clear-btn" on:click={clearFilters}>Alle löschen</button>
-        {/if}
-        <button class="close-btn" bind:this={closeBtnEl} on:click={closeFilter} aria-label="Filter schließen">✕</button>
+        {#if $activeFilters.size > 0}<button
+            class="clear-btn"
+            on:click={clearFilters}>Auswahl zurücksetzen</button
+          >{/if}
+        <button
+          class="close-btn"
+          bind:this={closeBtnEl}
+          on:click={closeFilter}
+          aria-label="Filter schließen">✕</button
+        >
       </div>
     </div>
 
     <div class="filter-content">
       {#if availableTypes.length > 0}
         <fieldset class="filter-group">
-          <legend>Knotenarten & Garnrollen</legend>
+          <legend>Sichtbare Elemente</legend>
           <ul class="filter-list">
             {#each availableTypes as type}
               <li>
-                <label class="filter-item">
-                  <input
+                <label class="filter-item"
+                  ><input
                     type="checkbox"
                     checked={$activeFilters.has(type.id)}
                     on:change={() => toggleFilterType(type.id)}
-                  />
-                  <span class="filter-label">{type.label}</span>
-                  <span class="filter-count">({type.count})</span>
-                </label>
+                  /><span class="filter-label">{filterLabel(type)}</span><span
+                    class="filter-count">{type.count}</span
+                  ></label
+                >
               </li>
             {/each}
           </ul>
         </fieldset>
       {:else}
-        <div class="no-filters" role="status">Keine filterbaren Elemente vorhanden</div>
+        <div class="no-filters" role="status">
+          Keine filterbaren Elemente vorhanden
+        </div>
       {/if}
 
-      <section class="filter-results" aria-labelledby="filter-results-heading">
-        <h4 id="filter-results-heading">Treffer ({filteredResults.length})</h4>
-        {#if listedResults.length > 0}
-          <ul class="filter-result-list">
-            {#each listedResults as result}
-              <li>
-                <button
-                  type="button"
-                  class="filter-result"
-                  data-testid={`filter-result-${result.type}-${result.id}`}
-                  on:click={() => selectResult(result)}
-                >
-                  <span class="filter-result-main">
-                    <span class="filter-result-title">{result.title}</span>
-                    {#if result.summary}
-                      <span class="filter-result-summary">{result.summary}</span>
-                    {/if}
-                  </span>
-                  <span class="filter-result-type">{resultType(result)}</span>
-                </button>
-              </li>
-            {/each}
-          </ul>
-          {#if filteredResults.length > listedResults.length}
-            <p class="result-limit-note">Die ersten {listedResults.length} Treffer werden angezeigt.</p>
+      {#if showResults}
+        <section
+          class="filter-results"
+          aria-labelledby="filter-results-heading"
+        >
+          <h4 id="filter-results-heading">
+            Treffer ({filteredResults.length})
+          </h4>
+          {#if listedResults.length > 0}
+            <ul class="filter-result-list">
+              {#each listedResults as result}
+                <li>
+                  <button
+                    type="button"
+                    class="filter-result"
+                    data-testid={`filter-result-${result.type}-${result.id}`}
+                    on:click={() => selectResult(result)}
+                    ><span class="filter-result-main"
+                      ><span class="filter-result-title">{result.title}</span
+                      >{#if result.summary}<span class="filter-result-summary"
+                          >{result.summary}</span
+                        >{/if}</span
+                    ><span class="filter-result-type">{resultType(result)}</span
+                    ></button
+                  >
+                </li>
+              {/each}
+            </ul>
+            {#if filteredResults.length > listedResults.length}<p
+                class="result-limit-note"
+              >
+                Die ersten {listedResults.length} Treffer werden angezeigt.
+              </p>{/if}
+          {:else}
+            <p class="no-results" role="status">
+              Keine Treffer für diese Auswahl.
+            </p>
           {/if}
-        {:else}
-          <p class="no-results" role="status">Keine Treffer für diese Filter.</p>
-        {/if}
-      </section>
+        </section>
+      {:else}
+        <p class="filter-hint">
+          Wähle mindestens eine Art aus, um die Karte einzugrenzen.
+        </p>
+      {/if}
     </div>
   </div>
 {/if}
@@ -133,55 +163,44 @@
 <style>
   .filter-overlay {
     position: fixed;
-    bottom: var(--map-bottom-ui-offset, 60px); /* strictly bound to ActionBar + safe-area */
+    bottom: var(--map-bottom-ui-offset);
     left: 0;
     right: 0;
-    background: var(--panel, #fff);
-    border-top: 1px solid var(--panel-border, rgba(0,0,0,0.1));
-    z-index: 39; /* just below ActionBar */
+    background: var(--panel);
+    border-top: 1px solid var(--panel-border);
+    z-index: 39;
     padding: 1rem;
-    box-shadow: 0 -4px 16px rgba(0,0,0,0.1);
+    box-shadow: var(--shadow);
     display: flex;
     flex-direction: column;
-    max-height: 50vh;
+    max-height: 50dvh;
+    box-sizing: border-box;
   }
-
-  /* Desktop: adjust layout to avoid overlapping ContextPanel */
-  @media (min-width: 769px) {
-    .filter-overlay.panel-open {
-      right: var(--context-panel-width, 400px);
-    }
-  }
-
   .filter-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 1rem;
+    margin-bottom: 0.75rem;
+    flex: 0 0 auto;
   }
-
   .filter-header h3 {
     margin: 0;
     font-size: 1.1rem;
-    font-weight: 600;
   }
-
   .header-actions {
     display: flex;
-    gap: 1rem;
+    gap: 0.5rem;
     align-items: center;
   }
-
   .clear-btn {
     background: none;
     border: none;
-    color: var(--primary, #005fcc);
+    color: var(--accent);
     font-size: 0.9rem;
     cursor: pointer;
-    text-decoration: underline;
-    padding: 0;
+    min-height: 44px;
+    padding: 0 0.5rem;
   }
-
   .close-btn {
     background: none;
     border: none;
@@ -193,81 +212,56 @@
     display: grid;
     place-items: center;
   }
-
   .filter-content {
     overflow-y: auto;
+    min-height: 0;
   }
-
   .filter-group {
     border: none;
     padding: 0;
     margin: 0;
   }
-
-  .filter-group legend {
-    margin: 0 0 0.5rem 0;
-    font-size: 0.9rem;
-    color: var(--muted, #666);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-  }
-
-  .filter-list {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-  }
-
-  .filter-item {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    cursor: pointer;
-    padding: 0.25rem 0;
-  }
-
-  .filter-item input[type="checkbox"] {
-    width: 1.1rem;
-    height: 1.1rem;
-    cursor: pointer;
-  }
-
-  .filter-label {
-    flex: 1;
-    font-size: 1rem;
-    color: var(--text, #333);
-  }
-
-  .filter-count {
-    font-size: 0.9rem;
-    color: var(--muted, #666);
-  }
-
-  .filter-results {
-    margin-top: 1rem;
-    padding-top: 1rem;
-    border-top: 1px solid var(--panel-border, rgba(0,0,0,0.1));
-  }
-
+  .filter-group legend,
   .filter-results h4 {
     margin: 0 0 0.5rem;
-    font-size: 0.9rem;
-    color: var(--muted, #666);
+    font-size: 0.78rem;
+    color: var(--muted);
     text-transform: uppercase;
-    letter-spacing: 0.5px;
+    letter-spacing: 0.08em;
   }
-
+  .filter-list,
   .filter-result-list {
     list-style: none;
     padding: 0;
     margin: 0;
     display: grid;
-    gap: 0.5rem;
+    gap: 0.35rem;
   }
-
+  .filter-item {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    cursor: pointer;
+    min-height: 44px;
+    padding: 0 0.25rem;
+  }
+  .filter-item input {
+    width: 1.2rem;
+    height: 1.2rem;
+  }
+  .filter-label {
+    flex: 1;
+    font-size: 1rem;
+  }
+  .filter-count {
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+  }
+  .filter-results {
+    margin-top: 0.75rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--panel-border);
+  }
   .filter-result {
     width: 100%;
     min-height: 44px;
@@ -276,49 +270,58 @@
     justify-content: space-between;
     gap: 1rem;
     padding: 0.65rem 0.75rem;
-    border: 1px solid var(--panel-border, rgba(0,0,0,0.1));
-    border-radius: var(--radius, 6px);
-    background: var(--panel, #fff);
-    color: var(--text, #333);
+    border: 1px solid var(--panel-border-strong);
+    border-radius: 8px;
+    background: var(--panel-solid);
+    color: var(--text);
     text-align: left;
     cursor: pointer;
   }
-
   .filter-result:hover,
   .filter-result:focus-visible {
-    border-color: var(--primary, #005fcc);
-    outline: none;
+    border-color: var(--accent);
   }
-
   .filter-result-main {
     min-width: 0;
     display: grid;
     gap: 0.15rem;
   }
-
   .filter-result-title {
     font-weight: 600;
   }
-
   .filter-result-summary {
     overflow: hidden;
-    color: var(--muted, #666);
+    color: var(--muted);
     font-size: 0.85rem;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
-
   .filter-result-type {
     flex: 0 0 auto;
-    color: var(--muted, #666);
+    color: var(--muted);
     font-size: 0.8rem;
   }
-
+  .filter-hint,
   .result-limit-note,
   .no-results,
   .no-filters {
-    padding: 1rem;
-    text-align: center;
-    color: var(--muted, #666);
+    color: var(--muted);
+    margin: 0.75rem 0 0;
+  }
+
+  @media (min-width: 769px) {
+    .filter-overlay {
+      left: 50%;
+      right: auto;
+      width: min(720px, calc(100vw - 2rem));
+      transform: translateX(-50%);
+      border: 1px solid var(--panel-border);
+      border-bottom: 0;
+      border-radius: 12px 12px 0 0;
+    }
+    .filter-overlay.panel-open {
+      left: calc((100vw - var(--context-panel-width)) / 2);
+      width: min(720px, calc(100vw - var(--context-panel-width) - 2rem));
+    }
   }
 </style>

--- a/apps/web/src/lib/components/Garnrolle.svelte
+++ b/apps/web/src/lib/components/Garnrolle.svelte
@@ -9,15 +9,12 @@
     findOwnGarnrolle,
   } from "$lib/garnrolle/visibility";
 
-  export let label = "Kontoeinstellungen";
+  export let label = "Meine Garnrolle und Konto";
   export let accounts: Account[] = [];
 
   const dispatch = createEventDispatcher<{ requestZoomToOwnGarnrolle: void }>();
   let menuOpen = false;
 
-  // Own Garnrolle must stay discoverable even when it has no public map
-  // position — never invent one, just point at the existing settings surface
-  // instead of silently no-opping the "auf Karte zeigen" action.
   $: ownGarnrolle = findOwnGarnrolle(accounts, $authStore.account_id);
   $: visibility = describeGarnrolleVisibility(ownGarnrolle);
 
@@ -33,15 +30,9 @@
   function closeMenu(event: MouseEvent) {
     if (!menuOpen) return;
     const target = event.target as HTMLElement;
-    if (!target.closest(".garnrolle-container")) {
-      menuOpen = false;
-    }
+    if (!target.closest(".garnrolle-container")) menuOpen = false;
   }
 
-  // Capture phase so this handler fires before bubble-phase Escape listeners
-  // (e.g. ContextPanel, SearchOverlay). preventDefault() signals that the
-  // Garnrolle menu owns this Escape press; ContextPanel checks
-  // event.defaultPrevented and skips its own close logic accordingly.
   function handleKeydown(event: KeyboardEvent) {
     if (!menuOpen) return;
     if (event.key === "Escape") {
@@ -60,29 +51,19 @@
 <svelte:window on:click={closeMenu} on:keydown|capture={handleKeydown} />
 
 <div class="garnrolle-container wrap">
-  <button
-    class="roll wrap-btn"
-    aria-label={label}
-    aria-expanded={menuOpen}
-    on:click={toggleMenu}
-    style="width: {MARKER_SIZES.account}px; height: {MARKER_SIZES.account}px;"
-  >
-    <img src={ICONS.garnrolle} alt={label} />
-  </button>
+  {#if $authStore.authenticated}
+    <button
+      class="roll wrap-btn"
+      aria-label={label}
+      aria-expanded={menuOpen}
+      on:click={toggleMenu}
+      style="width: {MARKER_SIZES.account}px; height: {MARKER_SIZES.account}px;"
+    >
+      <img src={ICONS.garnrolle} alt="" />
+    </button>
 
-  {#if menuOpen}
-    <div class="menu">
-      {#if $authStore.authenticated}
-        <div class="menu-header">
-          <span
-            class="role-badge"
-            class:admin={$authStore.role === "admin"}
-            class:weber={$authStore.role === "weber"}
-            class:gast={$authStore.role === "gast"}
-          >
-            {$authStore.role}
-          </span>
-        </div>
+    {#if menuOpen}
+      <div class="menu" aria-label="Meine Garnrolle und Konto">
         {#if visibility.canZoomToMap}
           <button class="menu-item" on:click={handleZoomToOwnGarnrolle}
             >Meine Garnrolle auf Karte zeigen</button
@@ -92,25 +73,21 @@
           href="/settings#meine-garnrolle"
           class="menu-item"
           on:click={() => (menuOpen = false)}
-          >{visibility.canZoomToMap
-            ? "Meine Garnrolle"
-            : "Meine Garnrolle (noch nicht auf der Karte)"}</a
         >
+          {visibility.canZoomToMap
+            ? "Meine Garnrolle"
+            : "Meine Garnrolle (noch nicht auf der Karte)"}
+        </a>
         <a
           href="/settings"
           class="menu-item"
           on:click={() => (menuOpen = false)}>Konto & Sicherheit</a
         >
-        <button class="menu-item logout-btn" on:click={logout}>Logout</button>
-      {:else}
-        <div class="menu-header">
-          <span class="role-badge gast">gast</span>
-        </div>
-        <a href="/login" class="menu-item" on:click={() => (menuOpen = false)}
-          >Login</a
-        >
-      {/if}
-    </div>
+        <button class="menu-item logout-btn" on:click={logout}>Abmelden</button>
+      </div>
+    {/if}
+  {:else}
+    <a class="login-entry" href="/login">Anmelden</a>
   {/if}
 </div>
 
@@ -124,16 +101,14 @@
     border: none;
     padding: 0;
     margin: 0;
-    text-decoration: none;
     color: inherit;
-    outline: none;
     appearance: none;
   }
-  .wrap-btn:focus-visible {
-    outline: 2px solid var(--primary);
-    border-radius: 4px;
+  .wrap-btn:focus-visible,
+  .login-entry:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
   }
-
   .roll {
     display: block;
     cursor: pointer;
@@ -149,15 +124,28 @@
     transform: scale(0.95);
   }
 
+  .login-entry {
+    display: grid;
+    place-items: center;
+    min-height: 44px;
+    padding: 0 0.9rem;
+    border: 1px solid var(--panel-border-strong);
+    border-radius: 999px;
+    background: var(--panel);
+    color: var(--text);
+    text-decoration: none;
+    font-weight: 600;
+  }
+
   .menu {
     position: absolute;
     top: calc(100% + 8px);
     right: 0;
-    background: var(--panel);
-    border: 1px solid var(--panel-border);
+    background: var(--panel-solid);
+    border: 1px solid var(--panel-border-strong);
     border-radius: 8px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-    min-width: 150px;
+    box-shadow: var(--shadow);
+    min-width: 220px;
     z-index: 50;
     display: flex;
     flex-direction: column;
@@ -165,37 +153,11 @@
     pointer-events: auto;
   }
 
-  .menu-header {
-    padding: 12px 16px 8px;
-    border-bottom: 1px solid var(--panel-border);
-    background: var(--bg);
-  }
-
-  .role-badge {
-    padding: 0.1rem 0.5rem;
-    border-radius: 99px;
-    background: rgba(255, 255, 255, 0.05);
-    text-transform: uppercase;
-    font-weight: bold;
-    font-size: 0.7rem;
-    display: inline-block;
-  }
-  .role-badge.admin {
-    background: var(--accent);
-    color: var(--panel);
-  }
-  .role-badge.weber {
-    background: #54e1a6;
-    color: var(--panel);
-  }
-  .role-badge.gast {
-    background: var(--muted);
-    color: var(--bg);
-  }
-
   .menu-item {
     display: block;
+    min-height: 44px;
     padding: 12px 16px;
+    box-sizing: border-box;
     text-decoration: none;
     color: var(--text);
     font-size: 0.9rem;
@@ -205,18 +167,12 @@
     text-align: left;
     cursor: pointer;
     width: 100%;
-    transition: background 0.1s ease;
   }
   .menu-item:hover {
-    background: rgba(255, 255, 255, 0.05);
+    background: var(--accent-soft);
   }
-
   .logout-btn {
-    color: #ff6b6b;
+    color: var(--danger);
     border-top: 1px solid var(--panel-border);
-  }
-  .logout-btn:hover {
-    background: #ff6b6b;
-    color: white;
   }
 </style>

--- a/apps/web/src/lib/components/MyGarnrolleSection.svelte
+++ b/apps/web/src/lib/components/MyGarnrolleSection.svelte
@@ -224,7 +224,7 @@
       if (returned) {
         selectedLocation = returned;
         saveMessage =
-          "Kartenpunkt übernommen. Prüfe Adresse und Sichtbarkeit und speichere anschließend.";
+          "Ort übernommen. Prüfe Adresse und Sichtbarkeit und speichere anschließend.";
       }
     } catch (error) {
       if (error instanceof ApiRequestError && error.status === 401) {
@@ -271,7 +271,7 @@
         return "Dein Konto darf die Garnrolle derzeit nicht bearbeiten.";
       }
       if (error.status === 400) {
-        return "Bitte prüfe Name, Adresse, Kartenpunkt und Sichtbarkeit.";
+        return "Bitte prüfe Name, Adresse, Ort und Sichtbarkeit.";
       }
     }
     return "Die Garnrolle konnte nicht gespeichert werden. Bitte versuche es erneut.";
@@ -532,14 +532,14 @@
         >
           {isSaving ? "Wird gespeichert…" : "Speichern"}
         </button>
-        <a class="btn" href="/map?compose=node">Ersten Knoten weben</a>
+        <a class="btn" href="/map?compose=node">Ersten Knoten knüpfen</a>
       </div>
       <p id="my-garnrolle-save-note" class="muted">
         Öffentlich sind Anzeigename, Kurzbeschreibung, Fähigkeiten, Güter und
         Interessen. Deine Adresse bleibt privat. Bei „Exakt sichtbar“ ist der
-        gewählte Kartenpunkt öffentlich; bei „Im Umkreis sichtbar“ nur eine
+        gewählte Ort öffentlich; bei „Im Umkreis sichtbar“ nur eine
         versetzte Näherung; bei „Noch nicht auf der Karte“ keine Position.
-        Adresse und Kartenpunkt werden nicht automatisch abgeglichen.
+        Adresse und Ort werden nicht automatisch abgeglichen.
       </p>
     </form>
   {/if}

--- a/apps/web/src/lib/components/MyGarnrolleSection.svelte
+++ b/apps/web/src/lib/components/MyGarnrolleSection.svelte
@@ -434,7 +434,7 @@
             <input type="radio" bind:group={visibilityChoice} value="exact" />
             <span>
               <strong>Exakt sichtbar</strong>
-              <small>Der von dir gewählte Kartenpunkt wird öffentlich.</small>
+              <small>Der von dir gewählte Ort wird öffentlich sichtbar.</small>
             </span>
           </label>
           <label class="radio-card">
@@ -453,18 +453,15 @@
           <div class="location-card" data-testid="garnrolle-location-state">
             {#if selectedLocation}
               <div>
-                <strong>Kartenpunkt gewählt</strong>
-                <small>
-                  {selectedLocation.lat.toFixed(5)},
-                  {selectedLocation.lon.toFixed(5)}
-                </small>
+                <strong>Ort gewählt</strong>
+                <small>Die genaue Position ist auf der Karte gesetzt.</small>
               </div>
               <button type="button" class="btn" on:click={chooseMapLocation}>
-                Kartenpunkt ändern
+                Ort ändern
               </button>
             {:else}
               <div>
-                <strong>Noch kein Kartenpunkt gewählt</strong>
+                <strong>Noch kein Ort gewählt</strong>
                 <small>
                   Die Adresse wird nicht automatisch in eine Position
                   umgewandelt. Wähle den passenden Punkt selbst auf der Karte.

--- a/apps/web/src/lib/components/SearchOverlay.svelte
+++ b/apps/web/src/lib/components/SearchOverlay.svelte
@@ -1,116 +1,110 @@
 <script lang="ts">
-  import { tick, createEventDispatcher } from 'svelte';
-  import { isSearchOpen, searchQuery, closeSearch } from '$lib/stores/searchStore';
-  import { contextPanelOpen } from '$lib/stores/uiView';
-  import type { MapEntityViewModel } from '$lib/map/types';
-  import { restoreTarget } from '$lib/utils/focusManager';
+  import { tick, createEventDispatcher } from "svelte";
+  import {
+    isSearchOpen,
+    searchQuery,
+    closeSearch,
+  } from "$lib/stores/searchStore";
+  import { contextPanelOpen } from "$lib/stores/uiView";
+  import type { MapEntityViewModel } from "$lib/map/types";
+  import { restoreTarget } from "$lib/utils/focusManager";
 
   export let filteredResults: MapEntityViewModel[] = [];
-
-  const dispatch = createEventDispatcher<{
-    select: MapEntityViewModel;
-  }>();
-
+  const dispatch = createEventDispatcher<{ select: MapEntityViewModel }>();
   let inputEl: HTMLInputElement;
   let listEl: HTMLUListElement;
   let activeIndex = -1;
   let wasOpen = false;
 
-  // focus on input when search opens and reset active index
   $: {
     if ($isSearchOpen) {
       wasOpen = true;
       (async () => {
         await tick();
-        if ($isSearchOpen && inputEl) {
-          inputEl.focus();
-        }
+        if ($isSearchOpen && inputEl) inputEl.focus();
       })();
     } else {
       activeIndex = -1;
       if (wasOpen) {
         wasOpen = false;
-        restoreTarget('search');
+        restoreTarget("search");
       }
     }
   }
-
-  // Reset activeIndex when results change
-  $: if (filteredResults || $searchQuery) {
-    activeIndex = -1;
-  }
+  $: if (filteredResults || $searchQuery) activeIndex = -1;
 
   function onSelect(item: MapEntityViewModel) {
-    dispatch('select', item);
+    dispatch("select", item);
     closeSearch();
   }
-
   function handleGlobalKeydown(e: KeyboardEvent) {
-    if (!$isSearchOpen) return;
-    // Respect capture-phase handlers (e.g. Garnrolle menu) that own this Escape
-    if (e.defaultPrevented) return;
-    if (e.key === 'Escape') {
-      closeSearch();
-    }
+    if (!$isSearchOpen || e.defaultPrevented) return;
+    if (e.key === "Escape") closeSearch();
   }
-
   function handleInputKeydown(e: KeyboardEvent) {
     if (!$isSearchOpen || filteredResults.length === 0) return;
-
-    if (e.key === 'ArrowDown') {
+    if (e.key === "ArrowDown") {
       e.preventDefault();
       activeIndex = (activeIndex + 1) % filteredResults.length;
       scrollToActive();
-    } else if (e.key === 'ArrowUp') {
+    } else if (e.key === "ArrowUp") {
       e.preventDefault();
-      activeIndex = activeIndex <= 0 ? filteredResults.length - 1 : activeIndex - 1;
+      activeIndex =
+        activeIndex <= 0 ? filteredResults.length - 1 : activeIndex - 1;
       scrollToActive();
-    } else if (e.key === 'Enter') {
+    } else if (e.key === "Enter") {
       e.preventDefault();
-      if (activeIndex >= 0 && activeIndex < filteredResults.length) {
-        onSelect(filteredResults[activeIndex]);
-      } else if (filteredResults.length > 0) {
-        onSelect(filteredResults[0]);
-      }
-    } else if (e.key === 'Home') {
+      onSelect(filteredResults[activeIndex >= 0 ? activeIndex : 0]);
+    } else if (e.key === "Home") {
       e.preventDefault();
       activeIndex = 0;
       scrollToActive();
-    } else if (e.key === 'End') {
+    } else if (e.key === "End") {
       e.preventDefault();
       activeIndex = filteredResults.length - 1;
       scrollToActive();
     }
   }
-
   async function scrollToActive() {
     await tick();
-    if (listEl && activeIndex >= 0) {
-      const activeEl = listEl.children[activeIndex] as HTMLElement;
-      if (activeEl) {
-        activeEl.scrollIntoView({ block: 'nearest' });
-      }
-    }
+    const activeEl = listEl?.children[activeIndex] as HTMLElement | undefined;
+    activeEl?.scrollIntoView({ block: "nearest" });
   }
 </script>
 
 <svelte:window on:keydown={handleGlobalKeydown} />
 
 {#if $isSearchOpen}
-  <div class="search-overlay" class:panel-open={$contextPanelOpen} data-testid="search-overlay" role="dialog" aria-label="Suche" aria-modal="false">
+  <div
+    class="search-overlay"
+    class:panel-open={$contextPanelOpen}
+    data-testid="search-overlay"
+    role="dialog"
+    aria-label="Suche"
+    aria-modal="false"
+  >
     <div class="search-box">
       <input
         bind:this={inputEl}
         bind:value={$searchQuery}
         type="text"
-        placeholder="Gewebe durchsuchen..."
+        placeholder="Gewebe durchsuchen…"
         aria-label="Suchbegriff"
         aria-autocomplete="list"
-        aria-controls={$searchQuery.trim().length > 0 && filteredResults.length > 0 ? "search-results-listbox" : undefined}
-        aria-activedescendant={activeIndex >= 0 && filteredResults.length > 0 ? `search-result-${filteredResults[activeIndex]?.id}` : undefined}
+        aria-controls={$searchQuery.trim().length > 0 &&
+        filteredResults.length > 0
+          ? "search-results-listbox"
+          : undefined}
+        aria-activedescendant={activeIndex >= 0 && filteredResults.length > 0
+          ? `search-result-${filteredResults[activeIndex]?.id}`
+          : undefined}
         on:keydown={handleInputKeydown}
       />
-      <button class="close-btn" on:click={closeSearch} aria-label="Suche schließen">✕</button>
+      <button
+        class="close-btn"
+        on:click={closeSearch}
+        aria-label="Suche schließen">✕</button
+      >
     </div>
 
     {#if $searchQuery.trim().length > 0}
@@ -130,21 +124,29 @@
               aria-selected={activeIndex === index}
               class:active={activeIndex === index}
               on:click={() => onSelect(result)}
-              on:keydown={(e) => { if (e.key === 'Enter') onSelect(result); }}
+              on:keydown={(e) => {
+                if (e.key === "Enter") onSelect(result);
+              }}
               on:mouseenter={() => (activeIndex = index)}
             >
               <div class="result-content">
                 <span class="result-title">{result.title}</span>
-                {#if result.summary}
-                  <span class="result-summary">{result.summary.length > 60 ? result.summary.slice(0, 60) + '...' : result.summary}</span>
-                {/if}
+                {#if result.summary}<span class="result-summary"
+                    >{result.summary.length > 80
+                      ? result.summary.slice(0, 80) + "…"
+                      : result.summary}</span
+                  >{/if}
               </div>
-              <span class="result-type">{result.type === 'node' ? 'Knoten' : 'Garnrolle'}</span>
+              <span class="result-type"
+                >{result.type === "node" ? "Knoten" : "Garnrolle"}</span
+              >
             </li>
           {/each}
         </ul>
       {:else}
-        <div class="no-results" role="status">Keine Treffer für "{$searchQuery}"</div>
+        <div class="no-results" role="status">
+          Keine Treffer für „{$searchQuery}“
+        </div>
       {/if}
     {/if}
   </div>
@@ -153,42 +155,35 @@
 <style>
   .search-overlay {
     position: fixed;
-    bottom: var(--map-bottom-ui-offset, 60px); /* strictly bound to ActionBar + safe-area */
+    bottom: var(--map-bottom-ui-offset);
     left: 0;
     right: 0;
-    background: var(--panel, #fff);
-    border-top: 1px solid var(--panel-border, rgba(0,0,0,0.1));
-    z-index: 39; /* just below ActionBar */
+    background: var(--panel);
+    border-top: 1px solid var(--panel-border);
+    z-index: 39;
     padding: 1rem;
-    box-shadow: 0 -4px 16px rgba(0,0,0,0.1);
+    box-shadow: var(--shadow);
     display: flex;
     flex-direction: column;
-    max-height: 50vh;
+    max-height: 50dvh;
+    box-sizing: border-box;
   }
-
-  /* Desktop: adjust layout to avoid overlapping ContextPanel */
-  @media (min-width: 769px) {
-    .search-overlay.panel-open {
-      right: var(--context-panel-width, 400px);
-    }
-  }
-
   .search-box {
     display: flex;
     gap: 0.5rem;
-    margin-bottom: 1rem;
   }
-
   .search-box input {
     flex: 1;
+    min-width: 0;
+    min-height: 44px;
     padding: 0.75rem;
-    border: 1px solid var(--panel-border, #ccc);
+    border: 1px solid var(--panel-border-strong);
     border-radius: 8px;
     font-size: 1rem;
-    background: var(--bg, #f9f9f9);
-    color: var(--text, #333);
+    background: var(--bg);
+    color: var(--text);
+    box-sizing: border-box;
   }
-
   .close-btn {
     background: none;
     border: none;
@@ -200,73 +195,74 @@
     display: grid;
     place-items: center;
   }
-
   .results {
     list-style: none;
     padding: 0;
-    margin: 0;
+    margin: 1rem 0 0;
     overflow-y: auto;
   }
-
-  .results li {
-    border-bottom: 1px solid var(--panel-border, rgba(0,0,0,0.05));
-  }
-
-  .results li:last-child {
-    border-bottom: none;
-  }
-
   .result-item {
     width: 100%;
+    box-sizing: border-box;
     text-align: left;
-    padding: 0.75rem 0.5rem;
+    padding: 0.75rem;
     cursor: pointer;
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: 1rem;
     color: var(--text);
+    border-bottom: 1px solid var(--panel-border);
   }
-
-  .result-item:hover, .result-item.active {
-    background: var(--hover, rgba(0,0,0,0.05));
-  }
-
+  .result-item:hover,
   .result-item.active {
-    outline: 2px solid var(--primary, #005fcc);
+    background: var(--accent-soft);
+  }
+  .result-item.active {
+    outline: 2px solid var(--accent);
     outline-offset: -2px;
   }
-
   .result-content {
     display: flex;
     flex-direction: column;
     gap: 0.25rem;
     overflow: hidden;
-    padding-right: 1rem;
+    min-width: 0;
   }
-
   .result-title {
-    font-weight: 500;
+    font-weight: 600;
   }
-
   .result-summary {
-    font-size: 0.8rem;
-    color: var(--muted, #666);
+    font-size: 0.85rem;
+    color: var(--muted);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }
-
   .result-type {
+    flex: 0 0 auto;
     font-size: 0.8rem;
-    color: var(--muted, #666);
-    background: rgba(0,0,0,0.05);
-    padding: 2px 6px;
-    border-radius: 4px;
+    color: var(--muted);
   }
-
   .no-results {
     padding: 1rem;
     text-align: center;
-    color: var(--muted, #666);
+    color: var(--muted);
+  }
+
+  @media (min-width: 769px) {
+    .search-overlay {
+      left: 50%;
+      right: auto;
+      width: min(720px, calc(100vw - 2rem));
+      transform: translateX(-50%);
+      border: 1px solid var(--panel-border);
+      border-bottom: 0;
+      border-radius: 12px 12px 0 0;
+    }
+    .search-overlay.panel-open {
+      left: calc((100vw - var(--context-panel-width)) / 2);
+      width: min(720px, calc(100vw - var(--context-panel-width) - 2rem));
+    }
   }
 </style>

--- a/apps/web/src/lib/components/panels/AccountPanel.svelte
+++ b/apps/web/src/lib/components/panels/AccountPanel.svelte
@@ -1,32 +1,38 @@
 <script lang="ts">
-  import { onDestroy } from 'svelte';
-  import { selection } from '$lib/stores/uiView';
-  import { buildPanelEndpoint, createPanelDetailsLoader } from '$lib/panels/panelDetails';
-  import { formatDate } from '$lib/utils/formatDate';
+  import { createEventDispatcher, onDestroy } from "svelte";
+  import { selection } from "$lib/stores/uiView";
+  import {
+    buildPanelEndpoint,
+    createPanelDetailsLoader,
+  } from "$lib/panels/panelDetails";
+  import { formatDate } from "$lib/utils/formatDate";
 
-  let activeTab = 'profil';
+  const dispatch = createEventDispatcher<{
+    selectRelated: { type: "node"; id: string };
+  }>();
+  let activeTab = "profil";
 
   interface AccountDetails {
     id: string;
     title: string;
     summary?: string;
     tags?: string[];
-    type?: string;
     created_at?: string;
-    nodes?: { node_id: string; node_title: string; node_kind: string; edge_kind: string; note?: string }[];
+    nodes?: {
+      node_id: string;
+      node_title: string;
+      node_kind: string;
+      edge_kind: string;
+    }[];
     activity?: { date: string; event: string }[];
   }
 
-  function setTab(tab: string) {
-    activeTab = tab;
-  }
-
   const detailsLoader = createPanelDetailsLoader<AccountDetails>(selection, {
-    buildEndpoint: (id) => buildPanelEndpoint('account', id),
+    buildEndpoint: (id) => buildPanelEndpoint("account", id),
     onSelectionChange: () => {
-      activeTab = 'profil';
+      activeTab = "profil";
     },
-    resourceLabel: 'account details',
+    resourceLabel: "account details",
   });
   const accountDetailsStore = detailsLoader.details;
   const isLoadingDetailsStore = detailsLoader.isLoading;
@@ -34,209 +40,197 @@
 
   $: accountDetails = $accountDetailsStore;
   $: isLoadingDetails = $isLoadingDetailsStore;
-  $: profileTags = (accountDetails?.tags || $selection?.data?.tags || []) as string[];
-  $: skills = categoryValues(profileTags, 'skill:', true);
-  $: goods = categoryValues(profileTags, 'good:');
-  $: interests = categoryValues(profileTags, 'interest:');
-  $: otherTags = profileTags.filter(
-    (tag) =>
-      tag.includes(':') &&
-      !tag.startsWith('skill:') &&
-      !tag.startsWith('good:') &&
-      !tag.startsWith('interest:')
-  );
+  $: summary = accountDetails?.summary || $selection?.data?.summary;
+  $: profileTags = (accountDetails?.tags ||
+    $selection?.data?.tags ||
+    []) as string[];
+  $: skills = categoryValues(profileTags, "skill:", true);
+  $: goods = categoryValues(profileTags, "good:");
+  $: interests = categoryValues(profileTags, "interest:");
 
-  function categoryValues(tags: string[], prefix: string, includeLegacy = false): string[] {
+  function categoryValues(
+    tags: string[],
+    prefix: string,
+    includeLegacy = false,
+  ): string[] {
     const values = tags
       .filter((tag) => tag.startsWith(prefix))
       .map((tag) => tag.slice(prefix.length))
       .filter(Boolean);
-    if (includeLegacy) {
+    if (includeLegacy)
       values.push(
         ...tags.filter(
           (tag) =>
-            tag !== 'account' &&
-            tag !== 'garnrolle' &&
-            !tag.includes(':')
-        )
+            tag !== "account" && tag !== "garnrolle" && !tag.includes(":"),
+        ),
       );
-    }
     return values.filter((value, index, all) => all.indexOf(value) === index);
   }
 
-  const tabs = ['profil', 'aktivitaet', 'knoten'];
-
+  const tabs = ["profil", "aktivitaet", "knoten"];
+  function setTab(tab: string) {
+    activeTab = tab;
+  }
   function handleKeydown(e: KeyboardEvent) {
     const currentIndex = tabs.indexOf(activeTab);
-    if (currentIndex === -1) return;
-
     let nextIndex = currentIndex;
-    if (e.key === 'ArrowRight') {
-      nextIndex = (currentIndex + 1) % tabs.length;
-      e.preventDefault();
-    } else if (e.key === 'ArrowLeft') {
+    if (e.key === "ArrowRight") nextIndex = (currentIndex + 1) % tabs.length;
+    else if (e.key === "ArrowLeft")
       nextIndex = (currentIndex - 1 + tabs.length) % tabs.length;
-      e.preventDefault();
-    } else if (e.key === 'Home') {
-      nextIndex = 0;
-      e.preventDefault();
-    } else if (e.key === 'End') {
-      nextIndex = tabs.length - 1;
-      e.preventDefault();
-    }
-
-    if (nextIndex !== currentIndex) {
-      setTab(tabs[nextIndex]);
-      const currentButton = e.currentTarget as HTMLElement | null;
-      const tabList = currentButton?.closest('.tabs') as HTMLElement | null;
-      if (tabList) {
-        const buttons = tabList.querySelectorAll('button[role="tab"]');
-        if (buttons[nextIndex]) {
-          (buttons[nextIndex] as HTMLElement).focus();
-        }
-      }
-    }
+    else if (e.key === "Home") nextIndex = 0;
+    else if (e.key === "End") nextIndex = tabs.length - 1;
+    else return;
+    e.preventDefault();
+    setTab(tabs[nextIndex]);
+    const buttons = (e.currentTarget as HTMLElement)
+      ?.closest(".tabs")
+      ?.querySelectorAll('button[role="tab"]');
+    (buttons?.[nextIndex] as HTMLElement | undefined)?.focus();
   }
 </script>
 
 <div class="account-mode">
   <h3>{accountDetails?.title || $selection?.data?.title || $selection?.id}</h3>
-  <p class="summary">{accountDetails?.summary || $selection?.data?.summary || 'Handelnder Akteur im Gewebe.'}</p>
+  {#if summary}<p class="summary">{summary}</p>{/if}
 
-  <div class="tabs" role="tablist" aria-label="Garnrollen Tabs">
+  <div class="tabs" role="tablist" aria-label="Garnrollen-Tabs">
     <button
-      class:active={activeTab === 'profil'}
-      on:click={() => setTab('profil')}
+      class:active={activeTab === "profil"}
+      on:click={() => setTab("profil")}
       on:keydown={handleKeydown}
       role="tab"
-      aria-selected={activeTab === 'profil'}
+      aria-selected={activeTab === "profil"}
       aria-controls="panel-profil"
       id="tab-profil"
-      tabindex={activeTab === 'profil' ? 0 : -1}
-    >Profil</button>
+      tabindex={activeTab === "profil" ? 0 : -1}>Profil</button
+    >
     <button
-      class:active={activeTab === 'aktivitaet'}
-      on:click={() => setTab('aktivitaet')}
+      class:active={activeTab === "aktivitaet"}
+      on:click={() => setTab("aktivitaet")}
       on:keydown={handleKeydown}
       role="tab"
-      aria-selected={activeTab === 'aktivitaet'}
+      aria-selected={activeTab === "aktivitaet"}
       aria-controls="panel-aktivitaet"
       id="tab-aktivitaet"
-      tabindex={activeTab === 'aktivitaet' ? 0 : -1}
-    >Aktivität</button>
+      tabindex={activeTab === "aktivitaet" ? 0 : -1}>Aktivität</button
+    >
     <button
-      class:active={activeTab === 'knoten'}
-      on:click={() => setTab('knoten')}
+      class:active={activeTab === "knoten"}
+      on:click={() => setTab("knoten")}
       on:keydown={handleKeydown}
       role="tab"
-      aria-selected={activeTab === 'knoten'}
+      aria-selected={activeTab === "knoten"}
       aria-controls="panel-knoten"
       id="tab-knoten"
-      tabindex={activeTab === 'knoten' ? 0 : -1}
-    >Knoten</button>
+      tabindex={activeTab === "knoten" ? 0 : -1}>Knoten</button
+    >
   </div>
 
   <div class="tab-content">
     {#if isLoadingDetails && !accountDetails}
-      <p class="ghost">Lade Details...</p>
-    {:else if activeTab === 'profil'}
-      <div class="overview" id="panel-profil" role="tabpanel" aria-labelledby="tab-profil">
-        {#if (accountDetails?.created_at || $selection?.data?.created_at)}
-          <p><strong>Dabei seit:</strong> {formatDate(accountDetails?.created_at || $selection?.data?.created_at)}</p>
-        {/if}
-
-        {#if (accountDetails?.type || $selection?.data?.type)}
-          <p><strong>Art:</strong> {accountDetails?.type || $selection?.data?.type}</p>
-        {/if}
-
-        {#if skills.length > 0}
-          <p><strong>Fähigkeiten:</strong> {skills.join(', ')}</p>
-        {/if}
-        {#if goods.length > 0}
-          <p><strong>Güter:</strong> {goods.join(', ')}</p>
-        {/if}
-        {#if interests.length > 0}
-          <p><strong>Interessen:</strong> {interests.join(', ')}</p>
-        {/if}
-        {#if otherTags.length > 0}
-          <p><strong>Weitere Tags:</strong> {otherTags.join(', ')}</p>
-        {/if}
+      <p class="ghost">Lade Details…</p>
+    {:else if activeTab === "profil"}
+      <div
+        class="overview"
+        id="panel-profil"
+        role="tabpanel"
+        aria-labelledby="tab-profil"
+      >
+        {#if accountDetails?.created_at || $selection?.data?.created_at}<p>
+            <strong>Dabei seit:</strong>
+            {formatDate(
+              accountDetails?.created_at || $selection?.data?.created_at,
+            )}
+          </p>{/if}
+        {#if skills.length > 0}<p>
+            <strong>Fähigkeiten:</strong>
+            {skills.join(", ")}
+          </p>{/if}
+        {#if goods.length > 0}<p>
+            <strong>Güter:</strong>
+            {goods.join(", ")}
+          </p>{/if}
+        {#if interests.length > 0}<p>
+            <strong>Interessen:</strong>
+            {interests.join(", ")}
+          </p>{/if}
       </div>
-
-    {:else if activeTab === 'aktivitaet'}
-      <div class="timeline-placeholder" id="panel-aktivitaet" role="tabpanel" aria-labelledby="tab-aktivitaet">
-        {#if isLoadingDetails}
-          <p class="ghost">Lade Verlauf...</p>
-        {:else if accountDetails?.activity && accountDetails.activity.length > 0}
-          <ul class="timeline">
-            {#each accountDetails.activity as event}
-              <li>
-                <span class="date">{formatDate(event.date)}</span>
-                <span class="event">{event.event}</span>
-              </li>
-            {/each}
+    {:else if activeTab === "aktivitaet"}
+      <div
+        id="panel-aktivitaet"
+        role="tabpanel"
+        aria-labelledby="tab-aktivitaet"
+      >
+        {#if isLoadingDetails}<p class="ghost">Lade Verlauf…</p>
+        {:else if accountDetails?.activity?.length}<ul class="timeline">
+            {#each accountDetails.activity as event}<li>
+                <span class="date">{formatDate(event.date)}</span><span
+                  class="event">{event.event}</span
+                >
+              </li>{/each}
           </ul>
-        {:else}
-          <p class="ghost">Keine Aktivität gefunden.</p>
-        {/if}
+        {:else}<p class="ghost">Noch keine Aktivität.</p>{/if}
       </div>
-
-    {:else if activeTab === 'knoten'}
-      <div class="nodes-placeholder" id="panel-knoten" role="tabpanel" aria-labelledby="tab-knoten">
-        {#if isLoadingDetails}
-          <p class="ghost">Lade Knoten...</p>
-        {:else if accountDetails?.nodes && accountDetails.nodes.length > 0}
-          <ul class="node-list">
-            {#each accountDetails.nodes as node}
-              <li>
-                <span class="node-title">{node.node_title || node.node_id}</span>
-              </li>
-            {/each}
+    {:else}
+      <div id="panel-knoten" role="tabpanel" aria-labelledby="tab-knoten">
+        {#if isLoadingDetails}<p class="ghost">Lade Knoten…</p>
+        {:else if accountDetails?.nodes?.length}<ul class="node-list">
+            {#each accountDetails.nodes as node}<li>
+                <button
+                  type="button"
+                  on:click={() =>
+                    dispatch("selectRelated", {
+                      type: "node",
+                      id: node.node_id,
+                    })}>{node.node_title || node.node_id}</button
+                >
+              </li>{/each}
           </ul>
-        {:else}
-          <p class="ghost">Keine verknüpften Knoten gefunden.</p>
-        {/if}
+        {:else}<p class="ghost">Noch keine geknüpften Knoten.</p>{/if}
       </div>
     {/if}
   </div>
 </div>
 
 <style>
-  .summary {
-    color: var(--ghost, #666);
-    margin-bottom: 1.5rem;
+  h3 {
+    margin: 0;
+    font-size: 1.5rem;
+    line-height: 1.2;
   }
-
+  .summary {
+    color: var(--muted);
+    margin: 0.5rem 0 1.25rem;
+  }
   .ghost {
-    color: var(--muted, #9aa4b2);
+    color: var(--muted);
     font-size: 0.9rem;
   }
-
-  /* Overview Styles */
   .overview p {
-    margin-bottom: 0.5rem;
+    margin: 0 0 0.65rem;
     font-size: 0.95rem;
   }
-
-  /* Nodes Styles */
   .node-list {
     list-style: none;
     padding: 0;
     margin: 0;
-  }
-
-  .node-list li {
-    margin-bottom: 0.5rem;
-    display: flex;
+    display: grid;
     gap: 0.5rem;
-    align-items: baseline;
-    padding: 0.5rem;
-    background: var(--panel-border, rgba(255, 255, 255, 0.03));
-    border-radius: var(--radius, 4px);
   }
-
-  .node-title {
-    font-weight: 500;
-    color: var(--text, #333);
+  .node-list button {
+    width: 100%;
+    min-height: 44px;
+    padding: 0.65rem 0.75rem;
+    border: 1px solid var(--panel-border-strong);
+    border-radius: 8px;
+    background: var(--panel-solid);
+    color: var(--text);
+    text-align: left;
+    font-weight: 600;
+    cursor: pointer;
+  }
+  .node-list button:hover,
+  .node-list button:focus-visible {
+    border-color: var(--accent);
   }
 </style>

--- a/apps/web/src/lib/components/panels/AccountPanel.svelte
+++ b/apps/web/src/lib/components/panels/AccountPanel.svelte
@@ -84,8 +84,8 @@
     setTab(tabs[nextIndex]);
     const buttons = (e.currentTarget as HTMLElement)
       ?.closest(".tabs")
-      ?.querySelectorAll('button[role="tab"]');
-    (buttons?.[nextIndex] as HTMLElement | undefined)?.focus();
+      ?.querySelectorAll<HTMLButtonElement>('button[role="tab"]');
+    buttons?.item(nextIndex)?.focus();
   }
 </script>
 

--- a/apps/web/src/lib/components/panels/KompositionPanel.svelte
+++ b/apps/web/src/lib/components/panels/KompositionPanel.svelte
@@ -1,14 +1,23 @@
 <script lang="ts">
-  import { browser } from '$app/environment';
-  import { goto, invalidateAll } from '$app/navigation';
-  import { kompositionDraft, lastCreatedNodeId, leaveToNavigation, systemState } from '$lib/stores/uiView';
-  import { authStore } from '$lib/auth/store';
-  import { createEdge, createNode, ApiRequestError } from '$lib/api/domainWrites';
+  import { browser } from "$app/environment";
+  import { goto, invalidateAll } from "$app/navigation";
+  import {
+    kompositionDraft,
+    lastCreatedNodeId,
+    leaveToNavigation,
+    systemState,
+  } from "$lib/stores/uiView";
+  import { authStore } from "$lib/auth/store";
+  import {
+    createEdge,
+    createNode,
+    ApiRequestError,
+  } from "$lib/api/domainWrites";
 
-  let title = '';
-  let description = '';
-  let address = '';
-  let nodeType = 'standard';
+  let title = "";
+  let description = "";
+  let address = "";
+  let nodeType = "standard";
   let isSubmitting = false;
 
   let titleError = false;
@@ -21,6 +30,7 @@
   // does not yet, and the UI must say so rather than imply one atomic step.
   let createdNodeId: string | null = null;
   let edgeError: string | null = null;
+  let closeBlocked = false;
 
   // One operation id identifies one semantic user action. A transport failure
   // may hide a successful server write, so retries reuse the same id while the
@@ -29,9 +39,10 @@
   let nodeOperationSignature: string | null = null;
   let edgeOperationId: string | null = null;
 
-  $: canWrite = $authStore.role === 'weber' || $authStore.role === 'admin';
-  $: placingGarnrolle = $kompositionDraft?.mode === 'place-garnrolle';
-  $: canSubmit = !!$kompositionDraft?.lngLat && !!title.trim() && !!address.trim();
+  $: canWrite = $authStore.role === "weber" || $authStore.role === "admin";
+  $: placingGarnrolle = $kompositionDraft?.mode === "place-garnrolle";
+  $: canSubmit =
+    !!$kompositionDraft?.lngLat && !!title.trim() && !!address.trim();
 
   function operationIdForNode(payload: {
     title: string;
@@ -59,21 +70,24 @@
     if (browser && location && accountId) {
       sessionStorage.setItem(
         `weltgewebe:garnrolle-return-location:${accountId}`,
-        JSON.stringify({ lat: location[1], lon: location[0] })
+        JSON.stringify({ lat: location[1], lon: location[0] }),
       );
     }
     leaveToNavigation();
-    await goto('/settings#meine-garnrolle');
+    await goto("/settings#meine-garnrolle");
+  }
+
+  export function requestClose() {
+    handleCancel();
   }
 
   function handleCancel() {
-    if (placingGarnrolle) {
-      void returnToGarnrolleSettings(false);
+    if (createdNodeId && edgeError) {
+      closeBlocked = true;
       return;
     }
-    if (createdNodeId) {
-      // The node already exists — closing the panel must not hide that.
-      void finalizeSuccess(createdNodeId);
+    if (placingGarnrolle) {
+      void returnToGarnrolleSettings(false);
       return;
     }
     leaveToNavigation();
@@ -82,16 +96,16 @@
   function describeCreateNodeError(err: unknown): string {
     if (err instanceof ApiRequestError) {
       if (err.status === 401 || err.status === 403) {
-        return 'Du hast keine Berechtigung, einen Knoten anzulegen.';
+        return "Du hast keine Berechtigung, einen Knoten anzulegen.";
       }
       if (err.status === 400) {
-        return 'Bitte prüfe deine Eingaben: Name, Art, Adresse und Ort müssen ausgefüllt sein.';
+        return "Bitte prüfe deine Eingaben: Name, Knotenart, Adresse und Ort müssen ausgefüllt sein.";
       }
       if (err.status === 409) {
-        return 'Dieser Knoten existiert bereits.';
+        return "Dieser Knoten existiert bereits.";
       }
     }
-    return 'Der Knoten konnte nicht gespeichert werden. Bitte versuche es später erneut.';
+    return "Der Knoten konnte nicht gespeichert werden. Bitte versuche es später erneut.";
   }
 
   async function finalizeSuccess(nodeId: string) {
@@ -102,25 +116,26 @@
 
   async function attemptCreateEdge(nodeId: string) {
     edgeError = null;
+    closeBlocked = false;
     const accountId = $authStore.account_id;
     if (!accountId) {
       edgeError =
-        'Der Knoten wurde gespeichert, aber die Verknüpfung zu deiner Garnrolle konnte nicht hergestellt werden (keine aktive Sitzung). Du kannst es erneut versuchen.';
+        "Der Knoten wurde gespeichert, aber der Faden zu deiner Garnrolle konnte nicht geknüpft werden (keine aktive Sitzung). Du kannst es erneut versuchen.";
       return;
     }
     try {
       await createEdge({
         source_id: accountId,
-        source_type: 'account',
+        source_type: "account",
         target_id: nodeId,
-        target_type: 'node',
-        edge_kind: 'reference',
+        target_type: "node",
+        edge_kind: "reference",
         operation_id: operationIdForEdge(),
       });
       await finalizeSuccess(nodeId);
     } catch (e) {
       edgeError =
-        'Der Knoten wurde gespeichert, aber die Verknüpfung zu deiner Garnrolle konnte nicht hergestellt werden. Du kannst es erneut versuchen oder ohne Verknüpfung fortfahren.';
+        "Der Knoten wurde gespeichert, aber der Faden zu deiner Garnrolle konnte nicht geknüpft werden. Du kannst es erneut versuchen oder bewusst ohne Faden fortfahren.";
     }
   }
 
@@ -174,7 +189,7 @@
 
       // Guard: only proceed if we are still in komposition state and the
       // draft hasn't been replaced in the meantime.
-      if ($systemState === 'komposition' && $kompositionDraft === submitDraft) {
+      if ($systemState === "komposition" && $kompositionDraft === submitDraft) {
         createdNodeId = node.id;
         await attemptCreateEdge(node.id);
       }
@@ -193,17 +208,15 @@
       <p>Nur Weber und Admins können neue Knoten anlegen.</p>
     </div>
     <div class="actions">
-      <button type="button" class="btn btn-secondary" on:click={handleCancel}>Schließen</button>
+      <button type="button" class="btn btn-secondary" on:click={handleCancel}
+        >Schließen</button
+      >
     </div>
   {:else if placingGarnrolle}
     <div data-testid="garnrolle-placement">
       {#if $kompositionDraft?.lngLat}
         <div class="state-set">
-          <p><strong>Kartenpunkt gewählt</strong></p>
-          <p>
-            {$kompositionDraft.lngLat[1].toFixed(5)},
-            {$kompositionDraft.lngLat[0].toFixed(5)}
-          </p>
+          <p><strong>Ort gewählt</strong></p>
           <p class="ghost">
             Prüfe, ob dieser Punkt zu deiner Adresse passt. Erst in den
             Einstellungen wird die Garnrolle gespeichert.
@@ -213,8 +226,8 @@
         <div class="state-pending">
           <p><strong>Kartenpunkt ausstehend</strong></p>
           <p>
-            Drücke etwa eine Sekunde auf den gewünschten Ort der Karte. Du
-            kannst den Punkt danach bestätigen oder erneut setzen.
+            Halte den gewünschten Ort auf der Karte etwa eine Sekunde gedrückt.
+            Du kannst den Punkt danach bestätigen oder erneut setzen.
           </p>
         </div>
       {/if}
@@ -238,29 +251,48 @@
       </div>
     </div>
   {:else if createdNodeId && edgeError}
+    {#if closeBlocked}<div class="form-error" role="alert">
+        Der Knoten ist bereits gespeichert. Entscheide, ob der Faden erneut
+        geknüpft oder bewusst ausgelassen werden soll.
+      </div>{/if}
     <div class="state-set">
       <p><strong>Knoten gespeichert</strong></p>
       <p>{edgeError}</p>
     </div>
     <div class="actions">
-      <button type="button" class="btn btn-secondary" on:click={continueWithoutEdge} disabled={isSubmitting}>
-        Ohne Verknüpfung fortfahren
+      <button
+        type="button"
+        class="btn btn-secondary"
+        on:click={continueWithoutEdge}
+        disabled={isSubmitting}
+      >
+        Ohne Faden fortfahren
       </button>
-      <button type="button" class="btn btn-primary" on:click={retryEdge} disabled={isSubmitting}>
-        {isSubmitting ? 'Versuche erneut…' : 'Erneut verknüpfen'}
+      <button
+        type="button"
+        class="btn btn-primary"
+        on:click={retryEdge}
+        disabled={isSubmitting}
+      >
+        {isSubmitting ? "Versuche erneut…" : "Faden erneut knüpfen"}
       </button>
     </div>
   {:else}
     <form on:submit={handleSubmit} class="komposition-form">
       {#if $kompositionDraft?.lngLat}
         <div class="state-set">
-          <p><strong>Ort gesetzt:</strong> {$kompositionDraft.lngLat[1].toFixed(5)}, {$kompositionDraft.lngLat[0].toFixed(5)}</p>
-          <p class="ghost">Du kannst den Ort ändern, indem du einen anderen Punkt auf der Karte lange drückst.</p>
+          <p><strong>Ort gewählt</strong></p>
+          <p class="ghost">
+            Du kannst den Ort ändern, indem du einen anderen Punkt auf der Karte
+            etwa eine Sekunde gedrückt hältst.
+          </p>
         </div>
       {:else}
         <div class="state-pending">
           <p><strong>Ort ausstehend</strong></p>
-          <p>Bitte wähle den Startpunkt für den neuen Knoten, indem du lange auf die Karte tippst (Longpress).</p>
+          <p>
+            Halte den gewünschten Ort auf der Karte etwa eine Sekunde gedrückt.
+          </p>
         </div>
       {/if}
 
@@ -269,10 +301,15 @@
       {/if}
 
       <div class="form-group">
-        <label for="nodeType">Art</label>
-        <select id="nodeType" bind:value={nodeType} class="input" disabled={isSubmitting}>
-          <option value="standard">Standard</option>
-          <option value="event">Event</option>
+        <label for="nodeType">Knotenart</label>
+        <select
+          id="nodeType"
+          bind:value={nodeType}
+          class="input"
+          disabled={isSubmitting}
+        >
+          <option value="standard">Allgemeiner Knoten</option>
+          <option value="event">Ereignis</option>
           <option value="resource">Ressource</option>
         </select>
       </div>
@@ -289,7 +326,7 @@
           disabled={isSubmitting}
           required
           aria-invalid={titleError}
-          aria-describedby={titleError ? 'title-error' : undefined}
+          aria-describedby={titleError ? "title-error" : undefined}
         />
         {#if titleError}
           <span id="title-error" class="error-msg">Name ist erforderlich</span>
@@ -308,10 +345,12 @@
           disabled={isSubmitting}
           required
           aria-invalid={addressError}
-          aria-describedby={addressError ? 'address-error' : undefined}
+          aria-describedby={addressError ? "address-error" : undefined}
         />
         {#if addressError}
-          <span id="address-error" class="error-msg">Adresse ist erforderlich</span>
+          <span id="address-error" class="error-msg"
+            >Adresse ist erforderlich</span
+          >
         {/if}
       </div>
 
@@ -323,12 +362,16 @@
           class="input"
           placeholder="Worum geht es hier?"
           rows="4"
-          disabled={isSubmitting}
-        ></textarea>
+          disabled={isSubmitting}></textarea>
       </div>
 
       <div class="actions">
-        <button type="button" class="btn btn-secondary" on:click={handleCancel} disabled={isSubmitting}>
+        <button
+          type="button"
+          class="btn btn-secondary"
+          on:click={handleCancel}
+          disabled={isSubmitting}
+        >
           Abbrechen
         </button>
         <button
@@ -336,7 +379,7 @@
           class="btn btn-primary"
           disabled={isSubmitting || !canSubmit}
         >
-          {isSubmitting ? 'Wird erstellt...' : 'Erstellen'}
+          {isSubmitting ? "Wird geknüpft…" : "Knoten knüpfen"}
         </button>
       </div>
     </form>
@@ -345,12 +388,11 @@
 
 <style>
   .komposition-mode {
-    padding: 1rem;
-    height: 100%;
-    overflow-y: auto;
+    min-height: 0;
   }
 
-  .state-set, .state-pending {
+  .state-set,
+  .state-pending {
     background: var(--panel-border, rgba(255, 255, 255, 0.06));
     padding: 1rem;
     border-radius: var(--radius, 8px);

--- a/apps/web/src/lib/components/panels/KompositionPanel.svelte
+++ b/apps/web/src/lib/components/panels/KompositionPanel.svelte
@@ -224,7 +224,7 @@
         </div>
       {:else}
         <div class="state-pending">
-          <p><strong>Kartenpunkt ausstehend</strong></p>
+          <p><strong>Ort ausstehend</strong></p>
           <p>
             Halte den gewünschten Ort auf der Karte etwa eine Sekunde gedrückt.
             Du kannst den Punkt danach bestätigen oder erneut setzen.

--- a/apps/web/src/lib/components/panels/NodePanel.svelte
+++ b/apps/web/src/lib/components/panels/NodePanel.svelte
@@ -61,8 +61,8 @@
     setTab(tabs[nextIndex]);
     const buttons = (e.currentTarget as HTMLElement)
       ?.closest(".tabs")
-      ?.querySelectorAll('button[role="tab"]');
-    (buttons?.[nextIndex] as HTMLElement | undefined)?.focus();
+      ?.querySelectorAll<HTMLButtonElement>('button[role="tab"]');
+    buttons?.item(nextIndex)?.focus();
   }
 </script>
 

--- a/apps/web/src/lib/components/panels/NodePanel.svelte
+++ b/apps/web/src/lib/components/panels/NodePanel.svelte
@@ -1,10 +1,17 @@
 <script lang="ts">
-  import { onDestroy } from 'svelte';
-  import { selection } from '$lib/stores/uiView';
-  import { buildPanelEndpoint, createPanelDetailsLoader } from '$lib/panels/panelDetails';
-  import { formatDate } from '$lib/utils/formatDate';
+  import { createEventDispatcher, onDestroy } from "svelte";
+  import { selection } from "$lib/stores/uiView";
+  import {
+    buildPanelEndpoint,
+    createPanelDetailsLoader,
+  } from "$lib/panels/panelDetails";
+  import { formatDate } from "$lib/utils/formatDate";
+  import { nodeKindLabel } from "$lib/ui/productLanguage";
 
-  let activeTab = 'uebersicht';
+  const dispatch = createEventDispatcher<{
+    selectRelated: { type: "garnrolle"; id: string };
+  }>();
+  let activeTab = "uebersicht";
 
   interface NodeDetails {
     id: string;
@@ -13,22 +20,20 @@
     created_at?: string;
     updated_at?: string;
     kind?: string;
-    tags?: string[];
-    location?: { lat: number; lon: number };
-    participants?: { account_title?: string; account_id: string; edge_kind?: string }[];
+    participants?: {
+      account_title?: string;
+      account_id: string;
+      edge_kind?: string;
+    }[];
     history?: { date: string; event: string }[];
   }
 
-  function setTab(tab: string) {
-    activeTab = tab;
-  }
-
   const detailsLoader = createPanelDetailsLoader<NodeDetails>(selection, {
-    buildEndpoint: (id) => buildPanelEndpoint('node', id),
+    buildEndpoint: (id) => buildPanelEndpoint("node", id),
     onSelectionChange: () => {
-      activeTab = 'uebersicht';
+      activeTab = "uebersicht";
     },
-    resourceLabel: 'node details',
+    resourceLabel: "node details",
   });
   const nodeDetailsStore = detailsLoader.details;
   const isLoadingDetailsStore = detailsLoader.isLoading;
@@ -36,304 +41,170 @@
 
   $: nodeDetails = $nodeDetailsStore;
   $: isLoadingDetails = $isLoadingDetailsStore;
+  $: summary = nodeDetails?.summary || $selection?.data?.summary;
+  $: kind = nodeKindLabel(nodeDetails?.kind || $selection?.data?.kind);
 
-  let displayLat: number | undefined;
-  let displayLon: number | undefined;
-
-  // Typecast or fallback carefully since $selection type doesn't formally export .lat/.lng at the root
-  // even though MapPoint might contain them at runtime
-  $: {
-    const selectionData = nodeDetails || ($selection?.data as any);
-    displayLat = selectionData?.location?.lat ?? selectionData?.lat;
-    displayLon = selectionData?.location?.lon ?? selectionData?.lon;
+  const tabs = ["uebersicht", "verlauf"];
+  function setTab(tab: string) {
+    activeTab = tab;
   }
-
-  const tabs = ['uebersicht', 'gespraech', 'antraege', 'verlauf'];
-
   function handleKeydown(e: KeyboardEvent) {
     const currentIndex = tabs.indexOf(activeTab);
-    if (currentIndex === -1) return;
-
     let nextIndex = currentIndex;
-    if (e.key === 'ArrowRight') {
-      nextIndex = (currentIndex + 1) % tabs.length;
-      e.preventDefault();
-    } else if (e.key === 'ArrowLeft') {
+    if (e.key === "ArrowRight") nextIndex = (currentIndex + 1) % tabs.length;
+    else if (e.key === "ArrowLeft")
       nextIndex = (currentIndex - 1 + tabs.length) % tabs.length;
-      e.preventDefault();
-    } else if (e.key === 'Home') {
-      nextIndex = 0;
-      e.preventDefault();
-    } else if (e.key === 'End') {
-      nextIndex = tabs.length - 1;
-      e.preventDefault();
-    }
-
-    if (nextIndex !== currentIndex) {
-      setTab(tabs[nextIndex]);
-      const currentButton = e.currentTarget as HTMLElement | null;
-      const tabList = currentButton?.closest('.tabs') as HTMLElement | null;
-      if (tabList) {
-        const buttons = tabList.querySelectorAll('button[role="tab"]');
-        if (buttons[nextIndex]) {
-          (buttons[nextIndex] as HTMLElement).focus();
-        }
-      }
-    }
+    else if (e.key === "Home") nextIndex = 0;
+    else if (e.key === "End") nextIndex = tabs.length - 1;
+    else return;
+    e.preventDefault();
+    setTab(tabs[nextIndex]);
+    const buttons = (e.currentTarget as HTMLElement)
+      ?.closest(".tabs")
+      ?.querySelectorAll('button[role="tab"]');
+    (buttons?.[nextIndex] as HTMLElement | undefined)?.focus();
   }
 </script>
 
 <div class="node-mode">
   <h3>{nodeDetails?.title || $selection?.data?.title || $selection?.id}</h3>
-  <p class="summary">{nodeDetails?.summary || $selection?.data?.summary || 'Keine Beschreibung verfügbar.'}</p>
+  {#if summary}<p class="summary">{summary}</p>{/if}
 
-  <div class="tabs" role="tablist" aria-label="Knoten Tabs">
+  <div class="tabs" role="tablist" aria-label="Knoten-Tabs">
     <button
-      class:active={activeTab === 'uebersicht'}
-      on:click={() => setTab('uebersicht')}
+      class:active={activeTab === "uebersicht"}
+      on:click={() => setTab("uebersicht")}
       on:keydown={handleKeydown}
       role="tab"
-      aria-selected={activeTab === 'uebersicht'}
+      aria-selected={activeTab === "uebersicht"}
       aria-controls="panel-uebersicht"
       id="tab-uebersicht"
-      tabindex={activeTab === 'uebersicht' ? 0 : -1}
-    >Übersicht</button>
+      tabindex={activeTab === "uebersicht" ? 0 : -1}>Übersicht</button
+    >
     <button
-      class:active={activeTab === 'gespraech'}
-      on:click={() => setTab('gespraech')}
+      class:active={activeTab === "verlauf"}
+      on:click={() => setTab("verlauf")}
       on:keydown={handleKeydown}
       role="tab"
-      aria-selected={activeTab === 'gespraech'}
-      aria-controls="panel-gespraech"
-      id="tab-gespraech"
-      tabindex={activeTab === 'gespraech' ? 0 : -1}
-    >Gespräch</button>
-    <button
-      class:active={activeTab === 'antraege'}
-      on:click={() => setTab('antraege')}
-      on:keydown={handleKeydown}
-      role="tab"
-      aria-selected={activeTab === 'antraege'}
-      aria-controls="panel-antraege"
-      id="tab-antraege"
-      tabindex={activeTab === 'antraege' ? 0 : -1}
-    >Anträge</button>
-    <button
-      class:active={activeTab === 'verlauf'}
-      on:click={() => setTab('verlauf')}
-      on:keydown={handleKeydown}
-      role="tab"
-      aria-selected={activeTab === 'verlauf'}
+      aria-selected={activeTab === "verlauf"}
       aria-controls="panel-verlauf"
       id="tab-verlauf"
-      tabindex={activeTab === 'verlauf' ? 0 : -1}
-    >Verlauf</button>
+      tabindex={activeTab === "verlauf" ? 0 : -1}>Verlauf</button
+    >
   </div>
 
   <div class="tab-content">
-    {#if activeTab === 'uebersicht'}
-      <div class="overview" id="panel-uebersicht" role="tabpanel" aria-labelledby="tab-uebersicht">
-        {#if isLoadingDetails}
-          <p class="ghost">Lade Details...</p>
+    {#if activeTab === "uebersicht"}
+      <div
+        class="overview"
+        id="panel-uebersicht"
+        role="tabpanel"
+        aria-labelledby="tab-uebersicht"
+      >
+        {#if isLoadingDetails}<p class="ghost">Lade Details…</p>
         {:else}
-          {#if (nodeDetails?.created_at || $selection?.data?.created_at)}
-            <p><strong>Erstellt am:</strong> {formatDate(nodeDetails?.created_at || $selection?.data?.created_at)}</p>
-          {/if}
-
-          {#if (nodeDetails?.kind || $selection?.data?.kind)}
-            <p><strong>Art:</strong> {nodeDetails?.kind || $selection?.data?.kind}</p>
-          {/if}
-
-          {#if (nodeDetails?.tags || $selection?.data?.tags)?.length > 0}
-            <p><strong>Tags:</strong> {(nodeDetails?.tags || $selection?.data?.tags).join(', ')}</p>
-          {/if}
-
-          {#if typeof displayLat === 'number' && typeof displayLon === 'number'}
-            <p><strong>Koordinaten:</strong> {displayLat.toFixed(5)}, {displayLon.toFixed(5)}</p>
-          {/if}
-
-          {#if nodeDetails?.participants && nodeDetails.participants.length > 0}
+          {#if nodeDetails?.created_at || $selection?.data?.created_at}<p>
+              <strong>Geknüpft am:</strong>
+              {formatDate(
+                nodeDetails?.created_at || $selection?.data?.created_at,
+              )}
+            </p>{/if}
+          <p><strong>Knotenart:</strong> {kind}</p>
+          {#if nodeDetails?.participants?.length}
             <div class="participants">
-              <p><strong>Beteiligte:</strong></p>
+              <p><strong>Beteiligte Garnrollen</strong></p>
               <ul>
-                {#each nodeDetails.participants as participant}
-                  <li>
-                    <span class="participant-name">{participant.account_title || participant.account_id}</span>
-                    {#if participant.edge_kind}
-                      <span class="participant-role">({participant.edge_kind})</span>
-                    {/if}
-                  </li>
-                {/each}
+                {#each nodeDetails.participants as participant}<li>
+                    <button
+                      type="button"
+                      on:click={() =>
+                        dispatch("selectRelated", {
+                          type: "garnrolle",
+                          id: participant.account_id,
+                        })}
+                      >{participant.account_title ||
+                        participant.account_id}</button
+                    >
+                  </li>{/each}
               </ul>
             </div>
           {/if}
         {/if}
       </div>
-
-    {:else if activeTab === 'gespraech'}
-      <div class="chat-placeholder" id="panel-gespraech" role="tabpanel" aria-labelledby="tab-gespraech">
-        <div class="messages">
-          <div class="message">
-            <span class="author">System:</span>
-            <span>Willkommen im Gesprächsraum für diesen Knoten.</span>
-          </div>
-        </div>
-        <div class="chat-input">
-          <input type="text" placeholder="Nachricht schreiben..." disabled />
-          <button disabled>Senden</button>
-        </div>
-      </div>
-
-    {:else if activeTab === 'antraege'}
-      <div class="proposals-placeholder" id="panel-antraege" role="tabpanel" aria-labelledby="tab-antraege">
-        <div class="empty-state">
-          <p class="ghost">Keine aktiven Anträge.</p>
-          <button class="btn-secondary" disabled>Neuen Antrag stellen</button>
-        </div>
-      </div>
-
-    {:else if activeTab === 'verlauf'}
-      <div class="timeline-placeholder" id="panel-verlauf" role="tabpanel" aria-labelledby="tab-verlauf">
-        {#if isLoadingDetails}
-          <p class="ghost">Lade Verlauf...</p>
-        {:else if nodeDetails?.history && nodeDetails.history.length > 0}
-          <ul class="timeline">
-            {#each nodeDetails.history as event}
-              <li>
-                <span class="date">{formatDate(event.date)}</span>
-                <span class="event">{event.event}</span>
-              </li>
-            {/each}
+    {:else}
+      <div id="panel-verlauf" role="tabpanel" aria-labelledby="tab-verlauf">
+        {#if isLoadingDetails}<p class="ghost">Lade Verlauf…</p>
+        {:else if nodeDetails?.history?.length}<ul class="timeline">
+            {#each nodeDetails.history as event}<li>
+                <span class="date">{formatDate(event.date)}</span><span
+                  class="event">{event.event}</span
+                >
+              </li>{/each}
           </ul>
-        {:else}
-          <ul class="timeline">
-            {#if $selection?.data?.updated_at && $selection?.data?.updated_at !== $selection?.data?.created_at}
+        {:else if nodeDetails?.created_at || $selection?.data?.created_at}<ul
+            class="timeline"
+          >
             <li>
-              <span class="date">{formatDate($selection?.data?.updated_at)}</span>
-              <span class="event">Knoten aktualisiert.</span>
-            </li>
-            {/if}
-            <li>
-              <span class="date">{$selection?.data?.created_at ? formatDate($selection?.data?.created_at) : 'Kürzlich'}</span>
-              <span class="event">Knoten wurde im Gewebe verankert.</span>
+              <span class="date"
+                >{formatDate(
+                  nodeDetails?.created_at || $selection?.data?.created_at,
+                )}</span
+              ><span class="event">Knoten wurde geknüpft.</span>
             </li>
           </ul>
-        {/if}
+        {:else}<p class="ghost">Noch kein Verlauf.</p>{/if}
       </div>
     {/if}
   </div>
 </div>
 
 <style>
+  h3 {
+    margin: 0;
+    font-size: 1.5rem;
+    line-height: 1.2;
+  }
+  .summary {
+    color: var(--muted);
+    margin: 0.5rem 0 1.25rem;
+  }
+  .ghost {
+    color: var(--muted);
+    font-size: 0.9rem;
+  }
+  .overview > p {
+    margin: 0 0 0.65rem;
+    font-size: 0.95rem;
+  }
   .participants {
     margin-top: 1rem;
     padding-top: 1rem;
-    border-top: 1px solid var(--panel-border, rgba(0,0,0,0.1));
+    border-top: 1px solid var(--panel-border);
   }
-
+  .participants p {
+    margin: 0 0 0.5rem;
+  }
   .participants ul {
     list-style: none;
     padding: 0;
-    margin: 0.5rem 0 0 0;
-  }
-
-  .participants li {
-    margin-bottom: 0.25rem;
-    display: flex;
-    gap: 0.5rem;
-    align-items: baseline;
-  }
-
-  .participant-name {
-    font-weight: 500;
-    color: var(--text, #333);
-  }
-
-  .participant-role {
-    font-size: 0.85em;
-    color: var(--ghost, #666);
-  }
-
-  .summary {
-    color: var(--ghost, #666);
-    margin-bottom: 1.5rem;
-  }
-
-  .ghost {
-    color: var(--muted, #9aa4b2);
-    font-size: 0.9rem;
-  }
-
-  /* Overview Styles */
-  .overview p {
-    margin-bottom: 0.5rem;
-    font-size: 0.95rem;
-  }
-
-  /* Chat Styles */
-  .chat-placeholder {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    height: 300px;
-  }
-
-  .messages {
-    flex: 1;
-    background: var(--panel-border, rgba(255, 255, 255, 0.03));
-    border-radius: var(--radius, 6px);
-    padding: 1rem;
-    overflow-y: auto;
-  }
-
-  .message {
-    margin-bottom: 0.5rem;
-    font-size: 0.95rem;
-  }
-
-  .message .author {
-    font-weight: bold;
-    color: var(--accent, #6aa6ff);
-    margin-right: 0.5rem;
-  }
-
-  .chat-input {
-    display: flex;
+    margin: 0;
+    display: grid;
     gap: 0.5rem;
   }
-
-  .chat-input input {
-    flex: 1;
-    padding: 0.5rem;
-    border: 1px solid var(--panel-border, rgba(255, 255, 255, 0.1));
-    border-radius: var(--radius, 4px);
-    background: transparent;
-    color: var(--text, #e9eef5);
+  .participants button {
+    width: 100%;
+    min-height: 44px;
+    padding: 0.65rem 0.75rem;
+    border: 1px solid var(--panel-border-strong);
+    border-radius: 8px;
+    background: var(--panel-solid);
+    color: var(--text);
+    text-align: left;
+    font-weight: 600;
+    cursor: pointer;
   }
-
-  .chat-input button {
-    padding: 0.5rem 1rem;
-    background: var(--panel-border, rgba(255, 255, 255, 0.1));
-    border: none;
-    border-radius: var(--radius, 4px);
-    color: var(--muted, #9aa4b2);
-    cursor: not-allowed;
+  .participants button:hover,
+  .participants button:focus-visible {
+    border-color: var(--accent);
   }
-
-  /* Proposals Styles */
-  .proposals-placeholder .empty-state {
-    text-align: center;
-    padding: 2rem 0;
-  }
-
-  .btn-secondary {
-    margin-top: 1rem;
-    padding: 0.5rem 1rem;
-    background: transparent;
-    border: 1px solid var(--panel-border, rgba(255, 255, 255, 0.1));
-    color: var(--muted, #9aa4b2);
-    border-radius: var(--radius, 4px);
-    cursor: not-allowed;
-  }
-
 </style>

--- a/apps/web/src/lib/styles/tokens.css
+++ b/apps/web/src/lib/styles/tokens.css
@@ -1,11 +1,17 @@
 :root {
   --bg: #0f1115;
-  --panel: rgba(20, 22, 28, 0.92);
-  --panel-border: rgba(255, 255, 255, 0.06);
+  --panel: rgba(20, 22, 28, 0.96);
+  --panel-solid: #14161c;
+  --panel-border: rgba(255, 255, 255, 0.1);
+  --panel-border-strong: rgba(255, 255, 255, 0.2);
   --text: #e9eef5;
   --muted: #9aa4b2;
   --accent: #6aa6ff;
   --accent-soft: rgba(106, 166, 255, 0.18);
+  --primary: var(--accent);
+  --fg: var(--text);
+  --ghost: var(--muted);
+  --danger: #ff8585;
   --radius: 12px;
   --shadow: 0 6px 24px rgba(0, 0, 0, 0.35);
   /* Layout-Defaults */

--- a/apps/web/src/lib/ui/productLanguage.test.ts
+++ b/apps/web/src/lib/ui/productLanguage.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { nodeKindLabel } from "./productLanguage";
+
+describe("nodeKindLabel", () => {
+  it.each([
+    ["standard", "Allgemeiner Knoten"],
+    ["event", "Ereignis"],
+    ["resource", "Ressource"],
+    [undefined, "Knoten"],
+    ["internal-value", "Knoten"],
+  ])("maps %s to a public product label", (kind, expected) => {
+    expect(nodeKindLabel(kind)).toBe(expected);
+  });
+});

--- a/apps/web/src/lib/ui/productLanguage.ts
+++ b/apps/web/src/lib/ui/productLanguage.ts
@@ -1,0 +1,10 @@
+const NODE_KIND_LABELS: Record<string, string> = {
+  standard: "Allgemeiner Knoten",
+  event: "Ereignis",
+  resource: "Ressource",
+};
+
+export function nodeKindLabel(kind?: string | null): string {
+  if (!kind) return "Knoten";
+  return NODE_KIND_LABELS[kind.toLowerCase()] ?? "Knoten";
+}

--- a/apps/web/src/routes/map/+page.svelte
+++ b/apps/web/src/routes/map/+page.svelte
@@ -679,6 +679,8 @@
     place-items: center;
     color: var(--bg);
     box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.25);
+    align-self: end;
+    justify-self: center;
     transform-origin: center;
     transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
     pointer-events: none;

--- a/apps/web/src/routes/map/+page.svelte
+++ b/apps/web/src/routes/map/+page.svelte
@@ -1,24 +1,47 @@
 <script lang="ts">
-  import { onMount, tick } from 'svelte';
-  import type { PageData } from './$types';
-  import '$lib/styles/tokens.css';
-  import 'maplibre-gl/dist/maplibre-gl.css';
-  import type { Map as MapLibreMap } from 'maplibre-gl';
+  import { onMount, tick } from "svelte";
+  import type { PageData } from "./$types";
+  import "$lib/styles/tokens.css";
+  import "maplibre-gl/dist/maplibre-gl.css";
+  import type { Map as MapLibreMap } from "maplibre-gl";
 
-  import TopBar from '$lib/components/TopBar.svelte';
-  import ContextPanel from '$lib/components/ContextPanel.svelte';
-  import ActionBar from '$lib/components/ActionBar.svelte';
-  import SearchOverlay from '$lib/components/SearchOverlay.svelte';
-  import FilterOverlay from '$lib/components/FilterOverlay.svelte';
-  import type { MapEntityViewModel } from '$lib/map/types';
+  import TopBar from "$lib/components/TopBar.svelte";
+  import ContextPanel from "$lib/components/ContextPanel.svelte";
+  import ActionBar from "$lib/components/ActionBar.svelte";
+  import SearchOverlay from "$lib/components/SearchOverlay.svelte";
+  import FilterOverlay from "$lib/components/FilterOverlay.svelte";
+  import type { MapEntityViewModel } from "$lib/map/types";
 
-  import { page } from '$app/stores';
+  import { page } from "$app/stores";
 
-  import { view, selection, systemState, enterKomposition, leaveToNavigation, lastCreatedNodeId } from '$lib/stores/uiView';
-  import { activeFilters, closeFilter } from '$lib/stores/filterStore';
-  import { isSearchOpen, searchQuery, closeSearch } from '$lib/stores/searchStore';
-  import { openSearchExclusive, openFilterExclusive } from '$lib/stores/overlayManager';
-  import { parseMapUrlState, type MapUrlFocus, type ParsedMapUrlState } from '$lib/map/urlState';
+  import {
+    view,
+    selection,
+    systemState,
+    contextPanelOpen,
+    enterKomposition,
+    leaveToNavigation,
+    lastCreatedNodeId,
+  } from "$lib/stores/uiView";
+  import {
+    activeFilters,
+    isFilterOpen,
+    closeFilter,
+  } from "$lib/stores/filterStore";
+  import {
+    isSearchOpen,
+    searchQuery,
+    closeSearch,
+  } from "$lib/stores/searchStore";
+  import {
+    openSearchExclusive,
+    openFilterExclusive,
+  } from "$lib/stores/overlayManager";
+  import {
+    parseMapUrlState,
+    type MapUrlFocus,
+    type ParsedMapUrlState,
+  } from "$lib/map/urlState";
   import {
     deriveFailedResourceLabels,
     deriveMarkerCounts,
@@ -29,19 +52,22 @@
     deriveVisibleEdges,
     getFilterTypeKey,
     selectMapEntity,
-  } from '$lib/stores/mapView';
-  import { authStore } from '$lib/auth/store';
+  } from "$lib/stores/mapView";
+  import { authStore } from "$lib/auth/store";
 
-  import { get } from 'svelte/store';
+  import { get } from "svelte/store";
 
-  import { currentBasemap, HAMMER_PARK_CENTER } from '$lib/map/config/basemap.current';
-  import { resolveBasemapStyle, rewritePmtilesUrl } from '$lib/map/basemap';
-  import { buildMapScene } from '$lib/map/scene';
+  import {
+    currentBasemap,
+    HAMMER_PARK_CENTER,
+  } from "$lib/map/config/basemap.current";
+  import { resolveBasemapStyle, rewritePmtilesUrl } from "$lib/map/basemap";
+  import { buildMapScene } from "$lib/map/scene";
 
-  import { NodesOverlay } from '$lib/map/overlay/nodes';
-  import { updateEdges } from '$lib/map/overlay/edges';
-  import { setupKompositionInteraction } from '$lib/map/overlay/komposition';
-  import { setupFocusInteraction } from '$lib/map/overlay/focus';
+  import { NodesOverlay } from "$lib/map/overlay/nodes";
+  import { updateEdges } from "$lib/map/overlay/edges";
+  import { setupKompositionInteraction } from "$lib/map/overlay/komposition";
+  import { setupFocusInteraction } from "$lib/map/overlay/focus";
 
   export let data: PageData;
 
@@ -54,7 +80,7 @@
     nodes: data.nodes || [],
     accounts: data.accounts || [],
     edges: data.edges || [],
-    loadState: data.loadState ?? 'ok',
+    loadState: data.loadState ?? "ok",
     resourceStatus: data.resourceStatus ?? [],
     apiBase: import.meta.env.PUBLIC_GEWEBE_API_BASE,
     basemapMode: currentBasemap.mode,
@@ -70,8 +96,13 @@
   $: filteredMarkersData = deriveFilteredMarkers(markersData, $activeFilters);
   // Search is scoped to the currently visible markers (filtered set when a
   // filter is active, otherwise the full set) so it never reaches hidden ones.
-  $: searchBaseMarkers = $activeFilters.size === 0 ? markersData : filteredMarkersData;
-  $: filteredResults = deriveSearchResults(searchBaseMarkers, $searchQuery, $isSearchOpen);
+  $: searchBaseMarkers =
+    $activeFilters.size === 0 ? markersData : filteredMarkersData;
+  $: filteredResults = deriveSearchResults(
+    searchBaseMarkers,
+    $searchQuery,
+    $isSearchOpen,
+  );
   $: searchMatchIds = deriveSearchMatchIds(filteredResults);
   $: edgesData = deriveVisibleEdges(scene.edges, filteredMarkersData);
 
@@ -88,13 +119,17 @@
   // Reactive update for markers and search highlight strictly handled in overlay update
   $: if (nodesOverlay && filteredMarkersData && $view) {
     (async () => {
-      await nodesOverlay.update(filteredMarkersData, $view.showNodes, searchMatchIds);
+      await nodesOverlay.update(
+        filteredMarkersData,
+        $view.showNodes,
+        searchMatchIds,
+      );
     })();
   }
 
   // Reactive update for edges – only after map style is fully loaded
   $: if (map && mapStyleReady && edgesData && $view) {
-     updateEdges(map, edgesData, filteredMarkersData, $view.showEdges);
+    updateEdges(map, edgesData, filteredMarkersData, $view.showEdges);
   }
 
   function focusAndFlyToPoint(item: MapEntityViewModel) {
@@ -104,13 +139,19 @@
 
     const lat = item.lat;
     const lon = item.lon;
-    if (map && typeof lat === 'number' && typeof lon === 'number' && Number.isFinite(lat) && Number.isFinite(lon)) {
+    if (
+      map &&
+      typeof lat === "number" &&
+      typeof lon === "number" &&
+      Number.isFinite(lat) &&
+      Number.isFinite(lon)
+    ) {
       const currentZoom = map.getZoom();
       map.flyTo({
         center: [lon, lat],
         zoom: Math.max(currentZoom, 14),
         speed: 0.8,
-        curve: 1
+        curve: 1,
       });
     }
   }
@@ -123,12 +164,23 @@
     focusAndFlyToPoint(event.detail);
   }
 
+  function handleRelatedSelect(
+    event: CustomEvent<{ type: "node" | "garnrolle"; id: string }>,
+  ) {
+    const related = markersData.find(
+      (item) => item.id === event.detail.id && item.type === event.detail.type,
+    );
+    if (related) focusAndFlyToPoint(related);
+  }
+
   // After KompositionPanel creates a node (+ its account->node edge) and
   // reloads route data, focus/fly-to it once it shows up in the freshly
   // rebuilt scene. Retries on later markersData updates while unresolved
   // (e.g. the reload is still in flight when this first runs).
   $: if ($lastCreatedNodeId) {
-    const created = markersData.find((m) => m.id === $lastCreatedNodeId && m.type === 'node');
+    const created = markersData.find(
+      (m) => m.id === $lastCreatedNodeId && m.type === "node",
+    );
     if (created) {
       focusAndFlyToPoint(created);
       lastCreatedNodeId.set(null);
@@ -152,7 +204,10 @@
     focus: MapUrlFocus,
     items: MapEntityViewModel[],
   ): MapEntityViewModel | null {
-    return items.find((item) => item.type === focus.type && item.id === focus.id) ?? null;
+    return (
+      items.find((item) => item.type === focus.type && item.id === focus.id) ??
+      null
+    );
   }
 
   function applyImmediateMapUrlAddressing(parsed: ParsedMapUrlState) {
@@ -160,8 +215,8 @@
       closeSearch();
       closeFilter();
       enterKomposition({
-        mode: parsed.compose === 'garnrolle' ? 'place-garnrolle' : 'new-knoten',
-        source: 'action-bar'
+        mode: parsed.compose === "garnrolle" ? "place-garnrolle" : "new-knoten",
+        source: "action-bar",
       });
       return;
     }
@@ -181,11 +236,11 @@
     // close stale lens overlays — this matters for same-route/popstate
     // transitions (e.g. /map?lens=filter -> /map) where stores are not reset.
     leaveToNavigation();
-    if (parsed.lens === 'filter') {
+    if (parsed.lens === "filter") {
       openFilterExclusive();
       return;
     }
-    if (parsed.lens === 'search') {
+    if (parsed.lens === "search") {
       openSearchExclusive();
       return;
     }
@@ -242,11 +297,14 @@
     if (!$authStore.authenticated || !$authStore.account_id) return;
     const accountId = $authStore.account_id;
     // Find the marker corresponding to the user's account
-    const userMarker = markersData.find(m => m.id === accountId && m.type === 'garnrolle');
+    const userMarker = markersData.find(
+      (m) => m.id === accountId && m.type === "garnrolle",
+    );
 
     if (userMarker) {
       const typeKey = getFilterTypeKey(userMarker);
-      const isFilteredOut = $activeFilters.size > 0 && !$activeFilters.has(typeKey);
+      const isFilteredOut =
+        $activeFilters.size > 0 && !$activeFilters.has(typeKey);
 
       // Do not override filters: if the user's marker is filtered out, inform the user instead of mutating filter state.
       if (isFilteredOut) {
@@ -270,7 +328,7 @@
   }
 
   // Restore focus when selection is closed or state becomes navigation
-  $: if (($systemState === 'navigation' || !$selection) && lastFocusedElement) {
+  $: if (($systemState === "navigation" || !$selection) && lastFocusedElement) {
     const elToFocus = lastFocusedElement;
     lastFocusedElement = null; // Clear immediately to prevent loop
 
@@ -292,7 +350,7 @@
       await authStore.logout();
     } else {
       try {
-        await authStore.devLogin('7d97a42e-3704-4a33-a61f-0e0a6b4d65d8');
+        await authStore.devLogin("7d97a42e-3704-4a33-a61f-0e0a6b4d65d8");
       } catch (e: any) {
         // Simple UI feedback for dev login issues
         window.alert(`Login failed: ${e.message}\nCheck console for details.`);
@@ -304,7 +362,9 @@
   let cleanupFocus: (() => void) | undefined = undefined;
   let unsubscribeSysState: (() => void) | undefined = undefined;
 
-  const shouldExposeTestMap = import.meta.env.DEV || import.meta.env.VITE_PUBLIC_ENABLE_TEST_MAP === 'true';
+  const shouldExposeTestMap =
+    import.meta.env.DEV ||
+    import.meta.env.VITE_PUBLIC_ENABLE_TEST_MAP === "true";
 
   onMount(() => {
     let maplibreModule: any = null;
@@ -320,7 +380,9 @@
     let loadingTimeout: ReturnType<typeof setTimeout> | undefined = undefined;
     const handleMarkerClick = (e: Event) => {
       const target = e.target as HTMLElement;
-      const markerBtn = target.closest('.map-marker') as HTMLButtonElement | null;
+      const markerBtn = target.closest(
+        ".map-marker",
+      ) as HTMLButtonElement | null;
       if (!markerBtn || !nodesOverlay) return;
 
       const id = markerBtn.dataset.id;
@@ -334,27 +396,29 @@
     };
 
     (async () => {
-      const maplibregl = await import('maplibre-gl');
+      const maplibregl = await import("maplibre-gl");
       if (destroyed) return;
       const container = mapContainer;
       if (!container) {
         return;
       }
 
-      let transformRequestFn: ((url: string, resourceType?: any) => { url: string }) | undefined = undefined;
+      let transformRequestFn:
+        | ((url: string, resourceType?: any) => { url: string })
+        | undefined = undefined;
 
       // PMTiles dev infrastructure is intentionally prepared now, including the runtime
       // dependency 'pmtiles'. The current runtime stays strictly on 'remote-style', since
       // real local artifact proof is still missing. This setup exists solely to reduce later
       // activation cost and does NOT claim that 'local-sovereign' is already working end-to-end.
-      if (currentBasemap.mode === 'local-sovereign') {
-        const pmtiles = await import('pmtiles');
+      if (currentBasemap.mode === "local-sovereign") {
+        const pmtiles = await import("pmtiles");
         if (destroyed) return;
         try {
-          maplibregl.addProtocol('pmtiles', new pmtiles.Protocol().tile);
+          maplibregl.addProtocol("pmtiles", new pmtiles.Protocol().tile);
         } catch (e: any) {
-          if (!e.message?.includes('already registered')) {
-            console.warn('Unexpected error registering PMTiles protocol:', e);
+          if (!e.message?.includes("already registered")) {
+            console.warn("Unexpected error registering PMTiles protocol:", e);
           }
         }
 
@@ -368,7 +432,7 @@
       // pmtiles protocol removal, so it must not be published before the
       // protocol is actually registered.
       maplibreModule = maplibregl;
-      container.addEventListener('click', handleMarkerClick);
+      container.addEventListener("click", handleMarkerClick);
 
       map = new maplibregl.Map({
         container,
@@ -382,14 +446,26 @@
         attributionControl: false,
         transformRequest: transformRequestFn,
       });
-      map.addControl(new maplibregl.NavigationControl({ showZoom: true }), 'bottom-right');
-      map.addControl(new maplibregl.AttributionControl({ compact: false, customAttribution: '© <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener noreferrer">OpenStreetMap</a> contributors' }), 'bottom-right');
+      map.addControl(
+        new maplibregl.NavigationControl({ showZoom: true }),
+        "bottom-right",
+      );
+      map.addControl(
+        new maplibregl.AttributionControl({
+          compact: false,
+          customAttribution:
+            '© <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener noreferrer">OpenStreetMap</a> contributors',
+        }),
+        "bottom-right",
+      );
 
       // Architecture Note: Basemap provides orientation. Overlays (nodes, edges, etc.) carry domain meaning.
       nodesOverlay = new NodesOverlay(map);
       cleanupKomposition = setupKompositionInteraction(map);
-      let sysStateStr = '';
-      unsubscribeSysState = systemState.subscribe(val => { sysStateStr = val; });
+      let sysStateStr = "";
+      unsubscribeSysState = systemState.subscribe((val) => {
+        sysStateStr = val;
+      });
       cleanupFocus = setupFocusInteraction(map, () => sysStateStr);
 
       loadingTimeout = setTimeout(() => {
@@ -411,19 +487,23 @@
         const pendingFocus =
           parseMapUrlState(get(page).url.searchParams).focus !== null;
 
-        if (!pendingFocus && !currentSelection && currentSystemState === 'navigation') {
+        if (
+          !pendingFocus &&
+          !currentSelection &&
+          currentSystemState === "navigation"
+        ) {
           const currentZoom = map?.getZoom() ?? 14;
           map?.flyTo({
             center: [HAMMER_PARK_CENTER.lon, HAMMER_PARK_CENTER.lat],
             zoom: Math.max(currentZoom, 14),
             speed: 0.8,
-            curve: 1
+            curve: 1,
           });
         }
       };
 
-      map.once('load', finishLoading);
-      map.on('error', () => {
+      map.once("load", finishLoading);
+      map.on("error", () => {
         clearTimeout(loadingTimeout);
         isLoading = false;
       });
@@ -453,14 +533,14 @@
       cleanupFocus?.();
       unsubscribeSysState?.();
       nodesOverlay?.destroy();
-      if (map && typeof map.remove === 'function') map.remove();
-      mapContainer?.removeEventListener('click', handleMarkerClick);
-      if (currentBasemap.mode === 'local-sovereign' && maplibreModule) {
+      if (map && typeof map.remove === "function") map.remove();
+      mapContainer?.removeEventListener("click", handleMarkerClick);
+      if (currentBasemap.mode === "local-sovereign" && maplibreModule) {
         try {
-          maplibreModule.removeProtocol('pmtiles');
+          maplibreModule.removeProtocol("pmtiles");
         } catch (e: any) {
-          if (!e.message?.includes('not registered')) {
-            console.warn('Unexpected error removing PMTiles protocol:', e);
+          if (!e.message?.includes("not registered")) {
+            console.warn("Unexpected error removing PMTiles protocol:", e);
           }
         }
       }
@@ -468,115 +548,226 @@
   });
 </script>
 
+<main
+  class="shell"
+  class:panel-open={$contextPanelOpen}
+  class:search-open={$isSearchOpen}
+  class:filter-open={$isFilterOpen}
+>
+  {#if showFilterTooltip}
+    <div class="filter-tooltip" role="status" aria-live="polite">
+      Du hast Garnrollen per Filter ausgeblendet – auch deine eigene.
+    </div>
+  {/if}
+
+  {#if loadState === "partial"}
+    <div class="degraded-banner" role="alert" data-testid="load-state-partial">
+      Einige Kartendaten konnten nicht geladen werden ({failedLabels.join(
+        ", ",
+      )}).
+    </div>
+  {/if}
+  {#if loadState === "failed"}
+    <div
+      class="degraded-banner degraded-banner--failed"
+      role="alert"
+      data-testid="load-state-failed"
+    >
+      Kartendaten konnten nicht geladen werden.
+    </div>
+  {/if}
+
+  <ContextPanel on:selectRelated={handleRelatedSelect} />
+  <SearchOverlay {filteredResults} on:select={handleSearchSelect} />
+  <FilterOverlay
+    {availableTypes}
+    filteredResults={filteredMarkersData}
+    on:select={handleFilterSelect}
+  />
+  <ActionBar />
+  {#if import.meta.env.DEV || import.meta.env.MODE === "test"}
+    <div class="debug-badge" data-testid="debug-badge">
+      Nodes: {markerCounts.nodes} / Accounts: {markerCounts.accounts} / Edges: {edgesData.length}
+      <br />
+      API: {diagnostics.apiMode} / Basemap: {diagnostics.basemapMode}
+      {#if diagnostics.degraded}
+        <br />⚠ Load: {loadState}
+      {/if}
+      <br />
+      <button
+        on:click={toggleLogin}
+        style="pointer-events: auto; margin-top: 4px; font-size: 10px; cursor: pointer;"
+        data-testid="debug-logout"
+      >
+        {$authStore.authenticated ? "Logout" : "Login Demo"}
+      </button>
+    </div>
+  {/if}
+  <TopBar
+    accounts={data.accounts || []}
+    on:zoomToOwnGarnrolle={handleZoomToOwnGarnrolle}
+  />
+  <div
+    id="map"
+    class:panel-open={$contextPanelOpen}
+    class:search-open={$isSearchOpen}
+    class:filter-open={$isFilterOpen}
+    bind:this={mapContainer}
+  ></div>
+  {#if isLoading}
+    <div class="loading-overlay">
+      <div class="spinner"></div>
+    </div>
+  {/if}
+</main>
+
 <style>
-  .shell{
-    position:relative;
-    height:100dvh;
-    height:calc(100dvh - env(safe-area-inset-top) - env(safe-area-inset-bottom));
-    width:100vw;
-    overflow:hidden;
-    background:var(--bg);
-    color:var(--text);
+  .shell {
+    position: relative;
+    height: 100dvh;
+    height: calc(
+      100dvh - env(safe-area-inset-top) - env(safe-area-inset-bottom)
+    );
+    width: 100vw;
+    overflow: hidden;
+    background: var(--bg);
+    color: var(--text);
     padding-top: env(safe-area-inset-top);
     padding-bottom: env(safe-area-inset-bottom);
   }
-  #map{ position:absolute; inset:0; }
-  #map :global(canvas){ filter: grayscale(0.2) saturate(0.75) brightness(1.03) contrast(0.95); }
+  #map {
+    position: absolute;
+    inset: 0;
+  }
+  #map :global(canvas) {
+    filter: grayscale(0.2) saturate(0.75) brightness(1.03) contrast(0.95);
+  }
 
   /*
    * MapLibre owns the outer marker transform and updates it every render frame.
    * Weltgewebe effects belong on the inner visual so markers stay map-locked.
    */
-  #map :global(.map-marker){
-    appearance:none;
-    -webkit-appearance:none;
-    width:24px;
-    height:24px;
-    min-width:0;
-    min-height:0;
-    margin:0;
-    padding:0;
-    box-sizing:border-box;
-    border:0;
-    border-radius:0;
-    background:transparent;
-    display:grid;
-    place-items:center;
-    color:var(--bg);
-    cursor:pointer;
-    box-shadow:none;
-    transition:none;
+  #map :global(.map-marker) {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 44px;
+    height: 44px;
+    min-width: 0;
+    min-height: 0;
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    display: grid;
+    place-items: center;
+    color: var(--bg);
+    cursor: pointer;
+    box-shadow: none;
+    transition: none;
   }
 
-  #map :global(.map-marker__visual){
-    width:100%;
-    height:100%;
-    box-sizing:border-box;
-    border-radius:999px;
-    border:2px solid var(--panel-border);
-    background:var(--accent, #ff8c42);
-    display:grid;
-    place-items:center;
-    color:var(--bg);
-    box-shadow:0 0 0 2px rgba(0,0,0,0.25);
-    transform-origin:center;
-    transition:transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
-    pointer-events:none;
+  #map :global(.map-marker__visual) {
+    width: 24px;
+    height: 24px;
+    box-sizing: border-box;
+    border-radius: 999px;
+    border: 2px solid var(--panel-border);
+    background: var(--accent, #ff8c42);
+    display: grid;
+    place-items: center;
+    color: var(--bg);
+    box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.25);
+    transform-origin: center;
+    transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+    pointer-events: none;
   }
 
   #map :global(.marker-account) {
-    width:44px;
-    height:44px;
+    width: 44px;
+    height: 44px;
   }
 
   #map :global(.marker-account__visual) {
-    background:transparent;
-    border:none;
-    box-shadow:none;
-    border-radius:0;
+    width: 44px;
+    height: 44px;
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    border-radius: 0;
   }
 
   #map :global(.marker-account__icon) {
-    display:block;
-    width:100%;
-    height:100%;
-    object-fit:contain;
-    pointer-events:none;
-    user-select:none;
-    -webkit-user-drag:none;
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    pointer-events: none;
+    user-select: none;
+    -webkit-user-drag: none;
   }
 
   @media (hover: hover) and (pointer: fine) {
-    #map :global(.map-marker:hover .map-marker__visual){
-      transform:scale(1.2);
+    #map :global(.map-marker:hover .map-marker__visual) {
+      transform: scale(1.2);
     }
-    #map :global(.map-marker:hover){
-      z-index:10;
+    #map :global(.map-marker:hover) {
+      z-index: 10;
     }
   }
 
-  #map :global(.map-marker:focus-visible){
-    outline:2px solid var(--fg);
-    outline-offset:2px;
+  #map :global(.map-marker:focus-visible) {
+    outline: 2px solid var(--fg);
+    outline-offset: 2px;
     z-index: 10;
   }
 
   #map :global(.map-marker.search-highlight) {
     outline: 2px solid var(--primary, #005fcc);
     outline-offset: 2px;
-    box-shadow: 0 0 8px 2px var(--primary, rgba(0,95,204,0.6));
+    box-shadow: 0 0 8px 2px var(--primary, rgba(0, 95, 204, 0.6));
     z-index: 5;
   }
 
   #map :global(.marker-account.search-highlight) {
     outline: 2px solid var(--primary, #005fcc);
     outline-offset: 2px;
-    box-shadow: 0 0 8px 2px var(--primary, rgba(0,95,204,0.6));
+    box-shadow: 0 0 8px 2px var(--primary, rgba(0, 95, 204, 0.6));
   }
 
   #map :global(.marker-account:focus-visible) {
     outline: 2px solid var(--primary);
     outline-offset: 2px;
+  }
+
+  #map :global(.maplibregl-ctrl-bottom-right) {
+    right: 12px !important;
+    bottom: calc(var(--map-bottom-ui-offset) + 12px) !important;
+  }
+
+  #map :global(.maplibregl-ctrl-group button) {
+    width: 44px;
+    height: 44px;
+  }
+
+  #map.search-open :global(.maplibregl-ctrl-bottom-right),
+  #map.filter-open :global(.maplibregl-ctrl-bottom-right) {
+    bottom: calc(50dvh + var(--map-bottom-ui-offset) + 12px) !important;
+  }
+
+  @media (min-width: 769px) {
+    #map.panel-open :global(.maplibregl-ctrl-bottom-right) {
+      right: calc(var(--context-panel-width) + 12px) !important;
+    }
+  }
+
+  @media (max-width: 768px) {
+    #map.panel-open :global(.maplibregl-ctrl-bottom-right) {
+      top: calc(env(safe-area-inset-top) + 60px);
+      right: 10px !important;
+      bottom: auto !important;
+    }
   }
 
   .loading-overlay {
@@ -591,12 +782,16 @@
   .spinner {
     width: 40px;
     height: 40px;
-    border: 3px solid rgba(255,255,255,0.1);
+    border: 3px solid rgba(255, 255, 255, 0.1);
     border-top-color: var(--accent);
     border-radius: 50%;
     animation: spin 1s linear infinite;
   }
-  @keyframes spin { to { transform: rotate(360deg); } }
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
 
   .debug-badge {
     position: absolute;
@@ -622,7 +817,7 @@
     padding: 12px 16px;
     border-radius: 8px;
     border: 1px solid var(--panel-border);
-    box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
     z-index: 1000;
     font-size: 0.9rem;
     font-weight: 500;
@@ -632,10 +827,22 @@
   }
 
   @keyframes fadeInOut {
-    0% { opacity: 0; transform: translate(-50%, -10px); }
-    10% { opacity: 1; transform: translate(-50%, 0); }
-    90% { opacity: 1; transform: translate(-50%, 0); }
-    100% { opacity: 0; transform: translate(-50%, -10px); }
+    0% {
+      opacity: 0;
+      transform: translate(-50%, -10px);
+    }
+    10% {
+      opacity: 1;
+      transform: translate(-50%, 0);
+    }
+    90% {
+      opacity: 1;
+      transform: translate(-50%, 0);
+    }
+    100% {
+      opacity: 0;
+      transform: translate(-50%, -10px);
+    }
   }
 
   .degraded-banner {
@@ -659,48 +866,3 @@
     background: rgba(180, 40, 40, 0.9);
   }
 </style>
-
-<main class="shell">
-  {#if showFilterTooltip}
-    <div class="filter-tooltip" role="status" aria-live="polite">
-      Du hast Garnrollen per Filter ausgeblendet – auch deine eigene.
-    </div>
-  {/if}
-
-  {#if loadState === 'partial'}
-    <div class="degraded-banner" role="alert" data-testid="load-state-partial">
-      Einige Kartendaten konnten nicht geladen werden ({failedLabels.join(', ')}).
-    </div>
-  {/if}
-  {#if loadState === 'failed'}
-    <div class="degraded-banner degraded-banner--failed" role="alert" data-testid="load-state-failed">
-      Kartendaten konnten nicht geladen werden.
-    </div>
-  {/if}
-
-  <ContextPanel />
-  <SearchOverlay {filteredResults} on:select={handleSearchSelect} />
-  <FilterOverlay availableTypes={availableTypes} filteredResults={filteredMarkersData} on:select={handleFilterSelect} />
-  <ActionBar />
-  {#if import.meta.env.DEV || import.meta.env.MODE === 'test'}
-    <div class="debug-badge" data-testid="debug-badge">
-      Nodes: {markerCounts.nodes} / Accounts: {markerCounts.accounts} / Edges: {edgesData.length}
-      <br>
-      API: {diagnostics.apiMode} / Basemap: {diagnostics.basemapMode}
-      {#if diagnostics.degraded}
-        <br>⚠ Load: {loadState}
-      {/if}
-      <br>
-      <button on:click={toggleLogin} style="pointer-events: auto; margin-top: 4px; font-size: 10px; cursor: pointer;" data-testid="debug-logout">
-        {$authStore.authenticated ? 'Logout' : 'Login Demo'}
-      </button>
-    </div>
-  {/if}
-  <TopBar accounts={data.accounts || []} on:zoomToOwnGarnrolle={handleZoomToOwnGarnrolle} />
-  <div id="map" bind:this={mapContainer}></div>
-  {#if isLoading}
-    <div class="loading-overlay">
-      <div class="spinner"></div>
-    </div>
-  {/if}
-</main>

--- a/apps/web/tests/actionbar-layout.spec.ts
+++ b/apps/web/tests/actionbar-layout.spec.ts
@@ -10,10 +10,15 @@ test.describe("ActionBar Layout", () => {
     await page.waitForSelector(".action-bar", { timeout: 10000 });
   });
 
-  test("buttons are ordered: Neuer Knoten, Suche, Filter", async ({ page }) => {
+  test("buttons are ordered: Knoten knüpfen, Suche, Filter", async ({
+    page,
+  }) => {
     const buttons = page.locator(".action-bar .action-btn");
     await expect(buttons).toHaveCount(3);
-    await expect(buttons.nth(0)).toHaveAttribute("aria-label", "Neuer Knoten");
+    await expect(buttons.nth(0)).toHaveAttribute(
+      "aria-label",
+      "Knoten knüpfen",
+    );
     await expect(buttons.nth(1)).toHaveAttribute("aria-label", "Suche");
     await expect(buttons.nth(2)).toHaveAttribute("aria-label", "Filter");
   });

--- a/apps/web/tests/garnrolle-not-on-map.spec.ts
+++ b/apps/web/tests/garnrolle-not-on-map.spec.ts
@@ -35,7 +35,7 @@ test.describe("Own Garnrolle discoverability when not_on_map", () => {
     await gotoMapAsAccount(page, NOT_ON_MAP_ACCOUNT_ID);
 
     await page.click(
-      '.garnrolle-container button[aria-label="Kontoeinstellungen"]',
+      '.garnrolle-container button[aria-label="Meine Garnrolle und Konto"]',
     );
     const menu = page.locator(".garnrolle-container .menu");
     await expect(menu).toBeVisible();
@@ -65,7 +65,7 @@ test.describe("Own Garnrolle discoverability when not_on_map", () => {
     await gotoMapAsAccount(page, EXACT_ACCOUNT_ID);
 
     await page.click(
-      '.garnrolle-container button[aria-label="Kontoeinstellungen"]',
+      '.garnrolle-container button[aria-label="Meine Garnrolle und Konto"]',
     );
     const menu = page.locator(".garnrolle-container .menu");
     await expect(menu).toBeVisible();

--- a/apps/web/tests/garnrolle-self-service.spec.ts
+++ b/apps/web/tests/garnrolle-self-service.spec.ts
@@ -186,7 +186,7 @@ test.describe("Eigene Garnrolle speichern", () => {
     const placement = page.locator('[data-testid="garnrolle-placement"]');
     await expect(placement).toContainText("Kartenpunkt ausstehend");
     await longPressMapCenter(page);
-    await expect(placement).toContainText("Kartenpunkt gewählt");
+    await expect(placement).toContainText("Ort gewählt");
     await placement
       .locator('[data-testid="confirm-garnrolle-location"]')
       .click();
@@ -201,7 +201,7 @@ test.describe("Eigene Garnrolle speichern", () => {
     );
     await expect(
       returned.locator('[data-testid="garnrolle-location-state"]'),
-    ).toContainText("Kartenpunkt gewählt");
+    ).toContainText("Ort gewählt");
     await expect(
       returned.locator('[data-testid="save-garnrolle"]'),
     ).toBeEnabled();
@@ -261,6 +261,6 @@ test.describe("Garnrollen-Kartenpunkt per Touch", () => {
       type: "touchEnd",
       touchPoints: [],
     });
-    await expect(placement).toContainText("Kartenpunkt gewählt");
+    await expect(placement).toContainText("Ort gewählt");
   });
 });

--- a/apps/web/tests/garnrolle-self-service.spec.ts
+++ b/apps/web/tests/garnrolle-self-service.spec.ts
@@ -184,7 +184,7 @@ test.describe("Eigene Garnrolle speichern", () => {
 
     await expect(page).toHaveURL(/\/map\?compose=garnrolle/);
     const placement = page.locator('[data-testid="garnrolle-placement"]');
-    await expect(placement).toContainText("Kartenpunkt ausstehend");
+    await expect(placement).toContainText("Ort ausstehend");
     await longPressMapCenter(page);
     await expect(placement).toContainText("Ort gewählt");
     await placement
@@ -245,7 +245,7 @@ test.describe("Garnrollen-Kartenpunkt per Touch", () => {
     });
     await page.goto("/map?compose=garnrolle");
     const placement = page.locator('[data-testid="garnrolle-placement"]');
-    await expect(placement).toContainText("Kartenpunkt ausstehend");
+    await expect(placement).toContainText("Ort ausstehend");
 
     const map = page.locator("#map canvas").first();
     const box = await map.boundingBox();

--- a/apps/web/tests/komposition.spec.ts
+++ b/apps/web/tests/komposition.spec.ts
@@ -205,8 +205,12 @@ test.describe("Komposition Flow (weber)", () => {
       panel.locator('button:has-text("Ohne Faden fortfahren")'),
     ).toBeVisible();
 
-    // The global close control must not discard this partial-success state.
-    await panel.getByRole("button", { name: "Schließen" }).click();
+    // Repeated header and Escape close attempts must not discard this
+    // partial-success state. The user must make an explicit decision.
+    const closeButton = panel.getByRole("button", { name: "Schließen" });
+    await closeButton.click();
+    await closeButton.click();
+    await page.keyboard.press("Escape");
     await expect(panel).toBeVisible();
     await expect(panel).toContainText("Der Knoten ist bereits gespeichert");
 

--- a/apps/web/tests/komposition.spec.ts
+++ b/apps/web/tests/komposition.spec.ts
@@ -57,7 +57,7 @@ test.describe("Komposition Flow (weber)", () => {
   test("Komposition form requires location, name, and address to submit", async ({
     page,
   }) => {
-    await page.locator('button:has-text("Neuer Knoten")').click();
+    await page.locator('button:has-text("Knoten knüpfen")').click();
     const panel = page.locator('[data-testid="context-panel"]');
     await expect(panel).toBeVisible();
 
@@ -75,7 +75,7 @@ test.describe("Komposition Flow (weber)", () => {
     await expect(submitBtn).toBeDisabled(); // still no location
 
     await longPressMapCenter(page);
-    await expect(panel.locator(".state-set")).toContainText("Ort gesetzt");
+    await expect(panel.locator(".state-set")).toContainText("Ort gewählt");
     await expect(submitBtn).toBeEnabled();
 
     await page.fill("#address", "");
@@ -88,7 +88,7 @@ test.describe("Komposition Flow (weber)", () => {
   });
 
   test("Cancel flow cleans up state and closes panel", async ({ page }) => {
-    await page.locator('button:has-text("Neuer Knoten")').click();
+    await page.locator('button:has-text("Knoten knüpfen")').click();
     const panel = page.locator('[data-testid="context-panel"]');
     await expect(panel).toBeVisible();
 
@@ -107,11 +107,11 @@ test.describe("Komposition Flow (weber)", () => {
       (req) => req.url().endsWith("/api/edges") && req.method() === "POST",
     );
 
-    await page.locator('button:has-text("Neuer Knoten")').click();
+    await page.locator('button:has-text("Knoten knüpfen")').click();
     const panel = page.locator('[data-testid="context-panel"]');
 
     await longPressMapCenter(page);
-    await expect(panel.locator(".state-set")).toContainText("Ort gesetzt");
+    await expect(panel.locator(".state-set")).toContainText("Ort gewählt");
 
     await page.fill("#title", "My Awesome Node");
     await page.fill("#address", "Musterstraße 1, 12345 Musterstadt");
@@ -183,11 +183,11 @@ test.describe("Komposition Flow (weber)", () => {
       });
     });
 
-    await page.locator('button:has-text("Neuer Knoten")').click();
+    await page.locator('button:has-text("Knoten knüpfen")').click();
     const panel = page.locator('[data-testid="context-panel"]');
 
     await longPressMapCenter(page);
-    await expect(panel.locator(".state-set")).toContainText("Ort gesetzt");
+    await expect(panel.locator(".state-set")).toContainText("Ort gewählt");
 
     await page.fill("#title", "Partial Node");
     await page.fill("#address", "Somewhere 1");
@@ -197,19 +197,20 @@ test.describe("Komposition Flow (weber)", () => {
     // Clear, honest partial-success messaging — never a silent failure and
     // never a false claim that node+edge were created atomically.
     await expect(panel).toContainText("Knoten gespeichert");
-    await expect(panel).toContainText("Verknüpfung");
+    await expect(panel).toContainText("Faden");
     await expect(
-      panel.locator('button:has-text("Erneut verknüpfen")'),
+      panel.locator('button:has-text("Faden erneut knüpfen")'),
     ).toBeVisible();
     await expect(
-      panel.locator('button:has-text("Ohne Verknüpfung fortfahren")'),
+      panel.locator('button:has-text("Ohne Faden fortfahren")'),
     ).toBeVisible();
 
-    // The panel must not silently close — the user stays informed and in
-    // control until they explicitly retry or accept the partial result.
+    // The global close control must not discard this partial-success state.
+    await panel.getByRole("button", { name: "Schließen" }).click();
     await expect(panel).toBeVisible();
+    await expect(panel).toContainText("Der Knoten ist bereits gespeichert");
 
-    await panel.locator('button:has-text("Erneut verknüpfen")').click();
+    await panel.locator('button:has-text("Faden erneut knüpfen")').click();
     await expect(panel.locator("h2")).toContainText("Knoten");
     expect(operationIds).toHaveLength(2);
     expect(operationIds[1]).toBe(operationIds[0]);
@@ -243,7 +244,7 @@ test.describe("Komposition Flow (weber)", () => {
       });
     });
 
-    await page.locator('button:has-text("Neuer Knoten")').click();
+    await page.locator('button:has-text("Knoten knüpfen")').click();
     const panel = page.locator('[data-testid="context-panel"]');
     await longPressMapCenter(page);
     await page.fill("#title", "Retry Node");
@@ -265,7 +266,7 @@ test.describe("Komposition Flow (gast/anonymous)", () => {
   }) => {
     await gotoMapAs(page, { authenticated: false, role: "gast" });
 
-    await expect(page.locator('button:has-text("Neuer Knoten")')).toHaveCount(
+    await expect(page.locator('button:has-text("Knoten knüpfen")')).toHaveCount(
       0,
     );
 

--- a/apps/web/tests/map-interaction.spec.ts
+++ b/apps/web/tests/map-interaction.spec.ts
@@ -75,7 +75,7 @@ test.describe("Map Interaction & Context Panel", () => {
     await page.waitForSelector(".action-bar", { timeout: 10000 });
 
     // Enter komposition mode via action bar
-    await page.locator('button:has-text("Neuer Knoten")').click();
+    await page.locator('button:has-text("Knoten knüpfen")').click();
 
     const panel = page.locator('[data-testid="context-panel"]');
     await expect(panel).toBeVisible();
@@ -93,7 +93,7 @@ test.describe("Map Interaction & Context Panel", () => {
     await page.waitForSelector(".action-bar", { timeout: 10000 });
 
     // Enter komposition mode to open panel
-    await page.locator('button:has-text("Neuer Knoten")').click();
+    await page.locator('button:has-text("Knoten knüpfen")').click();
     const panel = page.locator('[data-testid="context-panel"]');
     await expect(panel).toBeVisible();
 
@@ -116,7 +116,7 @@ test.describe("Map Interaction & Context Panel", () => {
     page,
   }) => {
     await page.waitForSelector(".action-bar", { timeout: 10000 });
-    await page.locator('button:has-text("Neuer Knoten")').click();
+    await page.locator('button:has-text("Knoten knüpfen")').click();
     const panel = page.locator('[data-testid="context-panel"]');
     await expect(panel).toBeVisible();
     await page.locator('.action-bar button[aria-label="Filter"]').click();
@@ -167,11 +167,11 @@ test.describe("Map Interaction & Context Panel", () => {
     const panel = page.locator('[data-testid="context-panel"]');
     await expect(panel).toBeVisible();
 
-    // Switch to a non-default tab if possible (assuming node default is 'uebersicht', switch to 'gespraech')
-    const gespraechTab = panel.locator('button:has-text("Gespräch")');
-    if (await gespraechTab.isVisible()) {
-      await gespraechTab.click();
-      await expect(gespraechTab).toHaveClass(/active/, { timeout: 5000 });
+    // Switch to the only productive secondary tab.
+    const verlaufTab = panel.locator('button:has-text("Verlauf")');
+    if (await verlaufTab.isVisible()) {
+      await verlaufTab.click();
+      await expect(verlaufTab).toHaveClass(/active/, { timeout: 5000 });
 
       // Click a different marker
       // using page.evaluate because map markers overlap with other invisible MapLibre overlay elements
@@ -196,7 +196,7 @@ test.describe("Map Interaction & Context Panel", () => {
     await page.waitForSelector(".action-bar", { timeout: 10000 });
 
     // Click new node in action bar
-    await page.locator('button:has-text("Neuer Knoten")').click();
+    await page.locator('button:has-text("Knoten knüpfen")').click();
 
     // Context panel should open
     const panel = page.locator('[data-testid="context-panel"]');
@@ -223,7 +223,7 @@ test.describe("Map Interaction & Context Panel", () => {
 
     const panel = page.locator('[data-testid="context-panel"]');
     await panel.waitFor({ state: "visible", timeout: 5000 });
-    await expect(panel.locator(".state-set")).toContainText("Ort gesetzt");
+    await expect(panel.locator(".state-set")).toContainText("Ort gewählt");
   });
 
   test("Empty map click does not close context panel in komposition mode", async ({
@@ -232,7 +232,7 @@ test.describe("Map Interaction & Context Panel", () => {
     await page.waitForSelector(".action-bar", { timeout: 10000 });
 
     // Enter komposition mode via action bar
-    await page.locator('button:has-text("Neuer Knoten")').click();
+    await page.locator('button:has-text("Knoten knüpfen")').click();
     const panel = page.locator('[data-testid="context-panel"]');
     await expect(panel).toBeVisible();
 
@@ -277,23 +277,18 @@ test.describe("Map Interaction & Context Panel", () => {
     await expect(uebersichtTab).toBeFocused();
     await expect(uebersichtTab).toHaveAttribute("aria-selected", "true");
 
-    // Press ArrowRight -> Should move to "Gespräch"
+    // Press ArrowRight -> Should move to "Verlauf"
     await page.keyboard.press("ArrowRight");
-    const gespraechTab = panel.locator('button[role="tab"]', {
-      hasText: "Gespräch",
-    });
-    await expect(gespraechTab).toBeFocused();
-    await expect(gespraechTab).toHaveAttribute("aria-selected", "true");
-    await expect(panel.locator("#panel-gespraech")).toBeVisible();
-
-    // Press End -> Should move to "Verlauf"
-    await page.keyboard.press("End");
     const verlaufTab = panel.locator('button[role="tab"]', {
       hasText: "Verlauf",
     });
     await expect(verlaufTab).toBeFocused();
     await expect(verlaufTab).toHaveAttribute("aria-selected", "true");
     await expect(panel.locator("#panel-verlauf")).toBeVisible();
+
+    // End remains on the last productive tab.
+    await page.keyboard.press("End");
+    await expect(verlaufTab).toBeFocused();
 
     // Press Home -> Should move back to "Übersicht"
     await page.keyboard.press("Home");

--- a/apps/web/tests/ui-detail-remediation.spec.ts
+++ b/apps/web/tests/ui-detail-remediation.spec.ts
@@ -67,6 +67,22 @@ test.describe("UI detail remediation", () => {
     expect(tab?.height).toBeGreaterThanOrEqual(44);
   });
 
+  test("keeps the visible node marker on the original bottom anchor", async ({
+    page,
+  }) => {
+    const marker = page.locator(".map-marker:not(.marker-account)").first();
+    const visual = marker.locator(".map-marker__visual");
+    const [markerBox, visualBox] = await Promise.all([
+      marker.boundingBox(),
+      visual.boundingBox(),
+    ]);
+    expect(markerBox).not.toBeNull();
+    expect(visualBox).not.toBeNull();
+    expect(Math.round((visualBox?.y ?? 0) + (visualBox?.height ?? 0))).toBe(
+      Math.round((markerBox?.y ?? 0) + (markerBox?.height ?? 0)),
+    );
+  });
+
   test("does not expose unfinished node tabs or raw coordinates", async ({
     page,
   }) => {

--- a/apps/web/tests/ui-detail-remediation.spec.ts
+++ b/apps/web/tests/ui-detail-remediation.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from "@playwright/test";
+import { mockApiResponses } from "./fixtures/mockApi";
+
+test.describe("UI detail remediation", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockApiResponses(page, {
+      auth: { authenticated: true, account_id: "e2e-weber", role: "weber" },
+    });
+    await page.goto("/map");
+    await page.waitForSelector(".map-marker");
+  });
+
+  test("keeps map controls and attribution outside desktop focus panel", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.evaluate(() =>
+      (document.querySelector(".map-marker") as HTMLElement)?.click(),
+    );
+    const panel = page.getByTestId("context-panel");
+    const navigation = page.locator(".maplibregl-ctrl-group").first();
+    const attribution = page.locator(".maplibregl-ctrl-attrib");
+    await expect(panel).toBeVisible();
+    await expect(navigation).toBeVisible();
+    await expect(attribution).toBeVisible();
+    const [panelBox, navigationBox, attributionBox] = await Promise.all([
+      panel.boundingBox(),
+      navigation.boundingBox(),
+      attribution.boundingBox(),
+    ]);
+    expect(panelBox).not.toBeNull();
+    for (const box of [navigationBox, attributionBox]) {
+      expect(box).not.toBeNull();
+      expect((box?.x ?? 0) + (box?.width ?? 0)).toBeLessThanOrEqual(
+        panelBox?.x ?? 0,
+      );
+    }
+  });
+
+  test("hides the action bar while a mobile focus sheet is open", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.evaluate(() =>
+      (document.querySelector(".map-marker") as HTMLElement)?.click(),
+    );
+    await expect(page.getByTestId("context-panel")).toBeVisible();
+    await expect(page.locator(".action-bar")).toBeHidden();
+  });
+
+  test("uses 44 pixel interaction targets for markers, map controls and tabs", async ({
+    page,
+  }) => {
+    const marker = await page.locator(".map-marker").first().boundingBox();
+    const control = await page
+      .locator(".maplibregl-ctrl-group button")
+      .first()
+      .boundingBox();
+    await page.evaluate(() =>
+      (document.querySelector(".map-marker") as HTMLElement)?.click(),
+    );
+    const tab = await page.getByRole("tab").first().boundingBox();
+    expect(marker?.width).toBeGreaterThanOrEqual(44);
+    expect(marker?.height).toBeGreaterThanOrEqual(44);
+    expect(control?.width).toBeGreaterThanOrEqual(44);
+    expect(control?.height).toBeGreaterThanOrEqual(44);
+    expect(tab?.height).toBeGreaterThanOrEqual(44);
+  });
+
+  test("does not expose unfinished node tabs or raw coordinates", async ({
+    page,
+  }) => {
+    const node = page.locator(".map-marker:not(.marker-account)").first();
+    await node.click({ force: true });
+    const panel = page.getByTestId("context-panel");
+    await expect(panel.getByRole("tab", { name: "Gespräch" })).toHaveCount(0);
+    await expect(panel.getByRole("tab", { name: "Anträge" })).toHaveCount(0);
+    await expect(panel).not.toContainText("Koordinaten:");
+    await expect(panel).not.toContainText("Art: event");
+  });
+
+  test("keeps filter results hidden until a filter is selected", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Filter" }).click();
+    await expect(page.getByText(/Wähle mindestens eine Art/)).toBeVisible();
+    await expect(page.locator(".filter-result")).toHaveCount(0);
+  });
+});

--- a/apps/web/tests/ui-filter.spec.ts
+++ b/apps/web/tests/ui-filter.spec.ts
@@ -99,7 +99,7 @@ test.describe("Filter mode", () => {
     );
   });
 
-  test("lists filtered Garnrollen as selectable map hits", async ({ page }) => {
+  test("lists selected Garnrollen as selectable map hits", async ({ page }) => {
     const filterBtn = page.getByRole("button", { name: "Filter", exact: true });
     await filterBtn.click();
 
@@ -147,8 +147,10 @@ test.describe("Filter mode", () => {
     const filterOverlay = page.getByTestId("filter-overlay");
     await expect(filterOverlay).toBeVisible();
 
-    // Filter to ONLY show "Event"
-    const eventLabel = page.locator("label.filter-item", { hasText: "Event" });
+    // Filter to ONLY show "Ereignis"
+    const eventLabel = page.locator("label.filter-item", {
+      hasText: "Ereignis",
+    });
     await eventLabel.click();
 
     // Marker count drops strictly to 1
@@ -166,14 +168,14 @@ test.describe("Filter mode", () => {
     await searchInput.fill("Test Node 2");
     await expect(page.locator(".result-item")).toHaveCount(0);
     await expect(page.getByRole("status")).toHaveText(
-      `Keine Treffer für "Test Node 2"`,
+      `Keine Treffer für „Test Node 2“`,
     );
 
     await searchInput.clear();
     await searchInput.fill("Test Account");
     await expect(page.locator(".result-item")).toHaveCount(0);
     await expect(page.getByRole("status")).toHaveText(
-      `Keine Treffer für "Test Account"`,
+      `Keine Treffer für „Test Account“`,
     );
 
     // Search for included item
@@ -186,7 +188,7 @@ test.describe("Filter mode", () => {
 
     // Case E: Clear Filters resets marker count
     await filterBtn.click();
-    const clearBtn = page.getByRole("button", { name: "Alle löschen" });
+    const clearBtn = page.getByRole("button", { name: "Auswahl zurücksetzen" });
     await clearBtn.click();
     await expect(clearBtn).not.toBeVisible();
     await expect(page.locator(markerSelector)).toHaveCount(3);

--- a/apps/web/tests/ui-interaction-clarity.spec.ts
+++ b/apps/web/tests/ui-interaction-clarity.spec.ts
@@ -16,8 +16,10 @@ test.describe("Interaction Clarity & State Feedback", () => {
     const searchOverlay = page.locator('[data-testid="search-overlay"]');
     await expect(searchOverlay).toBeVisible();
 
-    // Click "Neuer Knoten" while search is open
-    await page.locator('button:has-text("Neuer Knoten")').click();
+    // Click "Knoten knüpfen" while search is open
+    await page
+      .locator('.action-bar button[aria-label="Knoten knüpfen"]')
+      .click();
 
     // Search overlay must be closed
     await expect(searchOverlay).toHaveCount(0);
@@ -25,7 +27,9 @@ test.describe("Interaction Clarity & State Feedback", () => {
     // Context panel must be open in komposition mode
     const panel = page.locator('[data-testid="context-panel"]');
     await expect(panel).toBeVisible();
-    await expect(panel.locator(".panel-header h2")).toHaveText("Neuer Knoten");
+    await expect(panel.locator(".panel-header h2")).toHaveText(
+      "Knoten knüpfen",
+    );
   });
 
   test("entering komposition closes open filter overlay", async ({ page }) => {
@@ -34,8 +38,10 @@ test.describe("Interaction Clarity & State Feedback", () => {
     const filterOverlay = page.locator('[data-testid="filter-overlay"]');
     await expect(filterOverlay).toBeVisible();
 
-    // Click "Neuer Knoten" while filter is open
-    await page.locator('button:has-text("Neuer Knoten")').click();
+    // Click "Knoten knüpfen" while filter is open
+    await page
+      .locator('.action-bar button[aria-label="Knoten knüpfen"]')
+      .click();
 
     // Filter overlay must be closed
     await expect(filterOverlay).toHaveCount(0);
@@ -45,10 +51,12 @@ test.describe("Interaction Clarity & State Feedback", () => {
     await expect(panel).toBeVisible();
   });
 
-  test("'Neuer Knoten' button shows active state in komposition mode", async ({
+  test("'Knoten knüpfen' button shows active state in komposition mode", async ({
     page,
   }) => {
-    const newNodeBtn = page.locator('button:has-text("Neuer Knoten")');
+    const newNodeBtn = page.locator(
+      '.action-bar button[aria-label="Knoten knüpfen"]',
+    );
 
     // Initially, button should NOT have active class
     await expect(newNodeBtn).not.toHaveClass(/active/);
@@ -68,7 +76,7 @@ test.describe("Interaction Clarity & State Feedback", () => {
   test("Garnrolle menu closes on Escape", async ({ page }) => {
     // The Garnrolle button is in the TopBar
     const garnrolleBtn = page.locator(
-      '.garnrolle-container button[aria-label="Kontoeinstellungen"]',
+      '.garnrolle-container button[aria-label="Meine Garnrolle und Konto"]',
     );
     await expect(garnrolleBtn).toBeVisible();
 
@@ -92,13 +100,15 @@ test.describe("Interaction Clarity & State Feedback", () => {
     page,
   }) => {
     // Open context panel first (komposition mode)
-    await page.locator('button:has-text("Neuer Knoten")').click();
+    await page
+      .locator('.action-bar button[aria-label="Knoten knüpfen"]')
+      .click();
     const panel = page.locator('[data-testid="context-panel"]');
     await expect(panel).toBeVisible();
 
     // Open Garnrolle menu
     const garnrolleBtn = page.locator(
-      '.garnrolle-container button[aria-label="Kontoeinstellungen"]',
+      '.garnrolle-container button[aria-label="Meine Garnrolle und Konto"]',
     );
     await garnrolleBtn.click();
     const menu = page.locator(".garnrolle-container .menu");
@@ -120,7 +130,7 @@ test.describe("Interaction Clarity & State Feedback", () => {
 
     // Open Garnrolle menu while search is open
     const garnrolleBtn = page.locator(
-      '.garnrolle-container button[aria-label="Kontoeinstellungen"]',
+      '.garnrolle-container button[aria-label="Meine Garnrolle und Konto"]',
     );
     await garnrolleBtn.click();
     const menu = page.locator(".garnrolle-container .menu");
@@ -142,7 +152,7 @@ test.describe("Interaction Clarity & State Feedback", () => {
 
     // Open Garnrolle menu while filter is open
     const garnrolleBtn = page.locator(
-      '.garnrolle-container button[aria-label="Kontoeinstellungen"]',
+      '.garnrolle-container button[aria-label="Meine Garnrolle und Konto"]',
     );
     await garnrolleBtn.click();
     const menu = page.locator(".garnrolle-container .menu");
@@ -164,8 +174,10 @@ test.describe("Interaction Clarity & State Feedback", () => {
     const searchOverlay = page.locator('[data-testid="search-overlay"]');
     await expect(searchOverlay).toBeVisible();
 
-    // Click "Neuer Knoten" — suppressNextRestore should prevent focus restore
-    await page.locator('button:has-text("Neuer Knoten")').click();
+    // Click "Knoten knüpfen" — suppressNextRestore should prevent focus restore
+    await page
+      .locator('.action-bar button[aria-label="Knoten knüpfen"]')
+      .click();
     await expect(searchOverlay).toHaveCount(0);
 
     // Focus must NOT be on the Search button
@@ -182,8 +194,10 @@ test.describe("Interaction Clarity & State Feedback", () => {
     const filterOverlay = page.locator('[data-testid="filter-overlay"]');
     await expect(filterOverlay).toBeVisible();
 
-    // Click "Neuer Knoten" — suppressNextRestore should prevent focus restore
-    await page.locator('button:has-text("Neuer Knoten")').click();
+    // Click "Knoten knüpfen" — suppressNextRestore should prevent focus restore
+    await page
+      .locator('.action-bar button[aria-label="Knoten knüpfen"]')
+      .click();
     await expect(filterOverlay).toHaveCount(0);
 
     // Focus must NOT be on the Filter button

--- a/docs/adr/ADR-0009__garnrolle-verortung-sichtbarkeit.md
+++ b/docs/adr/ADR-0009__garnrolle-verortung-sichtbarkeit.md
@@ -30,7 +30,7 @@ Weltgewebe verwendet künftig ein einziges Accountmodell:
 > Jeder Account hat genau eine Garnrolle.
 
 Die Garnrolle ist die sichtbare und handelnde Rolle eines Menschen oder Akteurs
-im Gewebe. Sie ist der Ursprung von Fäden und kann Knoten weben.
+im Gewebe. Sie ist der Ursprung von Fäden und kann Knoten knüpfen.
 
 Verortung und öffentliche Sichtbarkeit sind Eigenschaften dieser Garnrolle. Sie
 sind kein Identitätsmodus und keine zweite Art von Account.
@@ -81,12 +81,12 @@ eine bewusste Option, nicht der normative Default.
 
 ## Knoten und Fäden
 
-Eine Garnrolle webt Knoten.
+Eine Garnrolle knüpft Knoten.
 
 Ein Knoten ist ein verortetes oder thematisch fassbares Bündel im Gewebe: Ort,
 Projekt, Bedarf, Angebot, Werkzeug, Ereignis, Gruppe oder Commons.
 
-Beim Weben eines Knotens entsteht mindestens ein Faden. Ein Faden beschreibt,
+Beim Knüpfen eines Knotens entsteht mindestens ein Faden. Ein Faden beschreibt,
 was zwischen Garnrolle und Knoten gilt, zum Beispiel:
 
 - gebaut von
@@ -107,7 +107,7 @@ Dokumentationssprache konsistent bleibt.
 2. Seine Garnrolle entsteht.
 3. Er ergänzt Profilinformationen.
 4. Er setzt seine Garnrolle exakt sichtbar auf den Poelsweg 2.
-5. Er webt den Knoten "Fairschenkbox Caspar-Voght-Straße" an der exakten
+5. Er knüpft den Knoten "Fairschenkbox Caspar-Voght-Straße" an der exakten
    Position der Box.
 6. Das System erzeugt einen Gestaltungsfaden:
    "Alexander hat die Fairschenkbox gebaut / betreut sie".

--- a/docs/specs/garnrolle-knoten-faden.md
+++ b/docs/specs/garnrolle-knoten-faden.md
@@ -52,7 +52,7 @@ Die Garnrolle kann enthalten:
 - Fähigkeiten, Güter, Interessen und Tags;
 - optional eine interne reale Position;
 - optional eine öffentliche Kartenprojektion;
-- gewobene Knoten und ausgehende Fäden.
+- geknüpfte Knoten und ausgehende Fäden.
 
 Eine Berechtigungsrolle wie `gast`, `weber` oder `admin` regelt technische Rechte. Sie ist nicht die Identität der Person.
 
@@ -89,7 +89,7 @@ Ein Knoten ist ein fachlich fassbares Bündel. Er kann verortet oder ortsunabhä
 - Veranstaltung;
 - Idee, Frage oder Beschlussgegenstand.
 
-Knoten werden aus einer angemeldeten Garnrolle heraus gewoben. Seed- oder Demo-Inhalte dürfen den organischen Produktpfad nicht ersetzen.
+Knoten werden aus einer angemeldeten Garnrolle heraus geknüpft. Seed- oder Demo-Inhalte dürfen den organischen Produktpfad nicht ersetzen.
 
 ## Fäden
 
@@ -126,7 +126,7 @@ Ein Faden ist nicht automatisch ein Gespräch. Gespräche besitzen eigene Entit�
 2. Eigene Garnrolle sehen.
 3. Garnrolle beschreiben.
 4. Garnrolle optional auf die Karte setzen.
-5. Ersten Knoten weben.
+5. Ersten Knoten knüpfen.
 6. Beim Speichern einen passenden Faden erzeugen.
 7. Knoten und Faden nach Neuladen wiederfinden.
 
@@ -134,7 +134,7 @@ Dieser vertikale Schnitt ist der wichtigste Integrationsbeweis. Er muss ohne Dem
 
 ## Produktsprache
 
-Nutzertexte verwenden Garnrolle, Knoten, Faden, weben, Sichtbarkeit und Gesprächsraum. Interne Begriffe wie Account, Node, Edge, Credential, Token oder WebAuthn erscheinen nicht in der Hauptführung.
+Nutzertexte verwenden Garnrolle, Knoten, Faden, knüpfen, weben, Sichtbarkeit und Gesprächsraum. Interne Begriffe wie Account, Node, Edge, Credential, Token oder WebAuthn erscheinen nicht in der Hauptführung.
 
 ## Nicht-Ziele
 

--- a/docs/specs/ui-interaction.md
+++ b/docs/specs/ui-interaction.md
@@ -79,7 +79,7 @@ Die Aktionsleiste formuliert Absichten und bleibt knapp. Kernhandlungen:
 
 - Suche;
 - Filter;
-- etwas weben;
+- einen Knoten knüpfen;
 - Zugang zur eigenen Garnrolle und zu Kontoeinstellungen.
 
 Seltene oder noch nicht produktive Module gehören nicht als dauerhafte Hauptschaltflächen in die erste Ebene.
@@ -107,7 +107,7 @@ Komposition bedeutet, etwas ins Gewebe zu setzen. Sie läuft im Fokuspanel und b
 Primäre Kompositionen:
 
 - eigene Garnrolle auf die Karte setzen;
-- Knoten weben;
+- Knoten knüpfen;
 - passenden Faden erzeugen.
 
 ## URL-Adressierung


### PR DESCRIPTION
## Zweck

Setzt das Live-UI-Detailaudit auf Build `4541df15` um: kollisionsfreie Kartenbedienung, konsistente mobile Zustände, fachliche Sprache und ein auf produktive Inhalte reduziertes Fokuspanel.

## Änderungen

- MapLibre-Steuerung und OpenStreetMap-Angabe erhalten dynamische Freizonen
- mobile Aktionsleiste verschwindet im Fokus-/Kompositionszustand
- Marker, Kartenknöpfe und Tabs besitzen mindestens 44 px große Trefferflächen
- Suche und Filter werden räumlich verdichtet
- technische Rohbegriffe, Rohkoordinaten und unfertige Knoten-Tabs werden entfernt
- Garnrollen- und Knotenbeziehungen werden direkt anwählbar
- Knotenhandlung heißt durchgängig „Knoten knüpfen“
- partieller Erfolg Knoten gespeichert / Faden fehlgeschlagen kann nicht stillschweigend geschlossen werden

## Prüfung

- `pnpm check`: 0 Fehler, 0 Warnungen
- `pnpm lint`: grün
- `pnpm test:unit`: 135/135
- vollständige Playwright-Matrix: 112/112, Retries 0
- `pnpm build`: grün
- `make validate`: grün
- visueller Readback: 18 Zustände auf Desktop, Tablet und Mobil, alle 9 Messachsen grün

## Abgrenzung

Keine API-, Datenbank-, Migrations- oder Produktionsdatenänderung. Der bekannte allgemeine Vite-Hinweis auf einen großen Chunk bleibt ein getrenntes Optimierungsthema.