### PR TITLE
feat(web): Karte auf eigene Garnrolle und Suchtreffer ausrichten

### DIFF
--- a/apps/web/src/lib/components/SearchDirectionIndicators.svelte
+++ b/apps/web/src/lib/components/SearchDirectionIndicators.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+  import type { MapEntityViewModel } from "$lib/map/types";
+  import type { SearchDirectionIndicator } from "$lib/map/searchNavigation";
+
+  export let indicators: SearchDirectionIndicator[] = [];
+
+  const dispatch = createEventDispatcher<{ select: MapEntityViewModel }>();
+
+  function labelFor(indicator: SearchDirectionIndicator): string {
+    const kind = indicator.item.type === "garnrolle" ? "Garnrolle" : "Knoten";
+    return `${kind} „${indicator.item.title}“ außerhalb des Kartenausschnitts anzeigen`;
+  }
+</script>
+
+{#if indicators.length > 0}
+  <nav
+    class="search-directions"
+    aria-label="Suchtreffer außerhalb des Kartenausschnitts"
+    data-testid="search-direction-indicators"
+  >
+    {#each indicators as indicator (`${indicator.item.type}:${indicator.item.id}`)}
+      <button
+        type="button"
+        class="search-direction"
+        data-testid={`search-direction-${indicator.item.type}-${indicator.item.id}`}
+        data-side={indicator.side}
+        style={`--search-direction-x: ${indicator.x}px; --search-direction-y: ${indicator.y}px; --search-direction-angle: ${indicator.angle}deg;`}
+        aria-label={labelFor(indicator)}
+        title={indicator.item.title}
+        on:click={() => dispatch("select", indicator.item)}
+      >
+        <span class="search-direction__arrow" aria-hidden="true">➜</span>
+      </button>
+    {/each}
+  </nav>
+{/if}
+
+<style>
+  .search-directions {
+    position: absolute;
+    inset: 0;
+    z-index: 38;
+    pointer-events: none;
+  }
+
+  .search-direction {
+    position: absolute;
+    left: var(--search-direction-x);
+    top: var(--search-direction-y);
+    width: 44px;
+    height: 44px;
+    min-width: 44px;
+    min-height: 44px;
+    padding: 0;
+    border: 2px solid var(--panel-border-strong);
+    border-radius: 999px;
+    background: var(--panel);
+    color: var(--primary);
+    box-shadow: var(--shadow);
+    display: grid;
+    place-items: center;
+    transform: translate(-50%, -50%);
+    pointer-events: auto;
+    cursor: pointer;
+  }
+
+  .search-direction:hover {
+    background: var(--accent-soft);
+  }
+
+  .search-direction:focus-visible {
+    outline: 3px solid var(--fg);
+    outline-offset: 2px;
+  }
+
+  .search-direction__arrow {
+    display: block;
+    font-size: 1.35rem;
+    line-height: 1;
+    transform: rotate(var(--search-direction-angle));
+    transform-origin: center;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .search-direction {
+      animation: search-direction-arrive 160ms ease-out;
+    }
+  }
+
+  @keyframes search-direction-arrive {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+</style>

--- a/apps/web/src/lib/map/searchNavigation.test.ts
+++ b/apps/web/src/lib/map/searchNavigation.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import type { AuthStatus } from "$lib/auth/store";
+import type { MapEntityViewModel } from "$lib/map/types";
+import {
+  deriveSearchDirectionIndicators,
+  resolveInitialMapCamera,
+} from "./searchNavigation";
+
+const markers: MapEntityViewModel[] = [
+  {
+    type: "garnrolle",
+    id: "own",
+    title: "Eigene Garnrolle",
+    lat: 53.56,
+    lon: 10.06,
+    created_at: "2026-01-01T00:00:00Z",
+    tags: [],
+  },
+  {
+    type: "node",
+    id: "focus-node",
+    title: "Fokus-Knoten",
+    kind: "Ort",
+    lat: 54,
+    lon: 11,
+    created_at: "2026-01-01T00:00:00Z",
+    tags: [],
+  },
+];
+
+const authenticated: AuthStatus = {
+  authenticated: true,
+  account_id: "own",
+  role: "weber",
+};
+
+const guest: AuthStatus = {
+  authenticated: false,
+  role: "gast",
+};
+
+describe("resolveInitialMapCamera", () => {
+  it("centers on the own positioned Garnrolle", () => {
+    expect(
+      resolveInitialMapCamera(markers, authenticated, null, [10, 53], 12),
+    ).toEqual({
+      center: [10.06, 53.56],
+      zoom: 14,
+      source: "own-garnrolle",
+    });
+  });
+
+  it("lets an explicit focus override the own Garnrolle", () => {
+    expect(
+      resolveInitialMapCamera(
+        markers,
+        authenticated,
+        { type: "node", id: "focus-node" },
+        [10, 53],
+        12,
+      ),
+    ).toEqual({
+      center: [11, 54],
+      zoom: 14,
+      source: "focus",
+    });
+  });
+
+  it("keeps the established fallback for guests or unplaced Garnrollen", () => {
+    expect(resolveInitialMapCamera(markers, guest, null, [10, 53], 12)).toEqual(
+      {
+        center: [10, 53],
+        zoom: 12,
+        source: "fallback",
+      },
+    );
+  });
+});
+
+describe("deriveSearchDirectionIndicators", () => {
+  const bounds = { left: 30, top: 30, right: 370, bottom: 270 };
+
+  it("omits visible matches and places outer matches on the correct edges", () => {
+    const indicators = deriveSearchDirectionIndicators(
+      [
+        { item: markers[0], point: { x: 200, y: 150 } },
+        { item: markers[1], point: { x: 900, y: 150 } },
+      ],
+      bounds,
+    );
+
+    expect(indicators).toHaveLength(1);
+    expect(indicators[0].item.id).toBe("focus-node");
+    expect(indicators[0].side).toBe("right");
+    expect(indicators[0].x).toBeCloseTo(370);
+    expect(indicators[0].y).toBeCloseTo(150);
+    expect(indicators[0].angle).toBeCloseTo(0);
+  });
+
+  it("spreads multiple indicators on the same edge", () => {
+    const indicators = deriveSearchDirectionIndicators(
+      [
+        { item: markers[0], point: { x: 900, y: 145 } },
+        { item: markers[1], point: { x: 900, y: 150 } },
+      ],
+      bounds,
+    );
+
+    expect(indicators).toHaveLength(2);
+    expect(indicators.every((indicator) => indicator.side === "right")).toBe(
+      true,
+    );
+    const positions = indicators
+      .map((indicator) => indicator.y)
+      .sort((a, b) => a - b);
+    expect(positions[1] - positions[0]).toBeGreaterThan(0);
+  });
+
+  it("fails closed for unusable viewport bounds", () => {
+    expect(
+      deriveSearchDirectionIndicators(
+        [{ item: markers[0], point: { x: 900, y: 150 } }],
+        { left: 100, top: 100, right: 50, bottom: 50 },
+      ),
+    ).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/map/searchNavigation.ts
+++ b/apps/web/src/lib/map/searchNavigation.ts
@@ -1,0 +1,241 @@
+import type { AuthStatus } from "$lib/auth/store";
+import type { MapEntityViewModel } from "$lib/map/types";
+import type { MapUrlFocus } from "$lib/map/urlState";
+
+export type MapCameraTargetSource = "focus" | "own-garnrolle" | "fallback";
+
+export interface MapCameraTarget {
+  center: [number, number];
+  zoom: number;
+  source: MapCameraTargetSource;
+}
+
+export interface ViewportBounds {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}
+
+export interface ProjectedSearchMatch {
+  item: MapEntityViewModel;
+  point: { x: number; y: number };
+}
+
+export type IndicatorSide = "top" | "right" | "bottom" | "left";
+
+export interface SearchDirectionIndicator {
+  item: MapEntityViewModel;
+  x: number;
+  y: number;
+  angle: number;
+  side: IndicatorSide;
+}
+
+function hasRenderablePosition(item: MapEntityViewModel | undefined): boolean {
+  return Boolean(
+    item &&
+    Number.isFinite(item.lat) &&
+    Number.isFinite(item.lon) &&
+    item.lat >= -90 &&
+    item.lat <= 90 &&
+    item.lon >= -180 &&
+    item.lon <= 180,
+  );
+}
+
+function findFocusTarget(
+  markers: MapEntityViewModel[],
+  focus: MapUrlFocus | null,
+): MapEntityViewModel | undefined {
+  if (!focus) return undefined;
+  return markers.find(
+    (marker) => marker.type === focus.type && marker.id === focus.id,
+  );
+}
+
+function findOwnGarnrolle(
+  markers: MapEntityViewModel[],
+  auth: AuthStatus,
+): MapEntityViewModel | undefined {
+  if (!auth.authenticated || !auth.account_id) return undefined;
+  return markers.find(
+    (marker) => marker.type === "garnrolle" && marker.id === auth.account_id,
+  );
+}
+
+/**
+ * Resolves the first camera position before MapLibre creates its first frame.
+ * Explicit focus addressing wins, followed by the signed-in person's public
+ * Garnrolle position. The established basemap fallback remains the last resort.
+ */
+export function resolveInitialMapCamera(
+  markers: MapEntityViewModel[],
+  auth: AuthStatus,
+  focus: MapUrlFocus | null,
+  fallbackCenter: [number, number],
+  fallbackZoom: number,
+  focusedZoom = 14,
+): MapCameraTarget {
+  const focusTarget = findFocusTarget(markers, focus);
+  if (hasRenderablePosition(focusTarget)) {
+    return {
+      center: [focusTarget!.lon, focusTarget!.lat],
+      zoom: Math.max(fallbackZoom, focusedZoom),
+      source: "focus",
+    };
+  }
+
+  const ownGarnrolle = findOwnGarnrolle(markers, auth);
+  if (hasRenderablePosition(ownGarnrolle)) {
+    return {
+      center: [ownGarnrolle!.lon, ownGarnrolle!.lat],
+      zoom: Math.max(fallbackZoom, focusedZoom),
+      source: "own-garnrolle",
+    };
+  }
+
+  return {
+    center: fallbackCenter,
+    zoom: fallbackZoom,
+    source: "fallback",
+  };
+}
+
+function isInsideBounds(
+  point: { x: number; y: number },
+  bounds: ViewportBounds,
+): boolean {
+  return (
+    point.x >= bounds.left &&
+    point.x <= bounds.right &&
+    point.y >= bounds.top &&
+    point.y <= bounds.bottom
+  );
+}
+
+function intersectRayWithBounds(
+  point: { x: number; y: number },
+  bounds: ViewportBounds,
+): Omit<SearchDirectionIndicator, "item"> | null {
+  if (isInsideBounds(point, bounds)) return null;
+
+  const centerX = (bounds.left + bounds.right) / 2;
+  const centerY = (bounds.top + bounds.bottom) / 2;
+  const dx = point.x - centerX;
+  const dy = point.y - centerY;
+
+  if (!Number.isFinite(dx) || !Number.isFinite(dy) || (dx === 0 && dy === 0)) {
+    return null;
+  }
+
+  const candidates: Array<{ scale: number; side: IndicatorSide }> = [];
+  if (dx > 0) {
+    candidates.push({ scale: (bounds.right - centerX) / dx, side: "right" });
+  } else if (dx < 0) {
+    candidates.push({ scale: (bounds.left - centerX) / dx, side: "left" });
+  }
+  if (dy > 0) {
+    candidates.push({ scale: (bounds.bottom - centerY) / dy, side: "bottom" });
+  } else if (dy < 0) {
+    candidates.push({ scale: (bounds.top - centerY) / dy, side: "top" });
+  }
+
+  const hit = candidates
+    .filter((candidate) => candidate.scale >= 0)
+    .sort((a, b) => a.scale - b.scale)[0];
+  if (!hit) return null;
+
+  return {
+    x: centerX + dx * hit.scale,
+    y: centerY + dy * hit.scale,
+    angle: (Math.atan2(dy, dx) * 180) / Math.PI,
+    side: hit.side,
+  };
+}
+
+function spreadSideIndicators(
+  indicators: SearchDirectionIndicator[],
+  bounds: ViewportBounds,
+): SearchDirectionIndicator[] {
+  const grouped = new Map<IndicatorSide, SearchDirectionIndicator[]>();
+  for (const indicator of indicators) {
+    const group = grouped.get(indicator.side) ?? [];
+    group.push(indicator);
+    grouped.set(indicator.side, group);
+  }
+
+  const result: SearchDirectionIndicator[] = [];
+  for (const [side, group] of grouped) {
+    const horizontal = side === "top" || side === "bottom";
+    const minimum = horizontal ? bounds.left : bounds.top;
+    const maximum = horizontal ? bounds.right : bounds.bottom;
+    const axis = (indicator: SearchDirectionIndicator) =>
+      horizontal ? indicator.x : indicator.y;
+
+    group.sort((a, b) => axis(a) - axis(b));
+    const available = Math.max(0, maximum - minimum);
+    const spacing = Math.min(52, available / Math.max(group.length + 1, 2));
+    const placed: number[] = [];
+
+    group.forEach((indicator, index) => {
+      const desired = axis(indicator);
+      const lowerBound = index === 0 ? minimum : placed[index - 1] + spacing;
+      placed.push(Math.max(desired, lowerBound));
+    });
+
+    if (placed.length > 0 && placed[placed.length - 1] > maximum) {
+      const overflow = placed[placed.length - 1] - maximum;
+      for (let index = 0; index < placed.length; index += 1) {
+        placed[index] -= overflow;
+      }
+      if (placed[0] < minimum) {
+        const step = available / Math.max(placed.length - 1, 1);
+        for (let index = 0; index < placed.length; index += 1) {
+          placed[index] =
+            placed.length === 1
+              ? (minimum + maximum) / 2
+              : minimum + step * index;
+        }
+      }
+    }
+
+    group.forEach((indicator, index) => {
+      result.push({
+        ...indicator,
+        x: horizontal ? placed[index] : indicator.x,
+        y: horizontal ? indicator.y : placed[index],
+      });
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Converts projected offscreen search results into collision-reduced buttons on
+ * the usable viewport edge. Results already visible inside the usable map area
+ * are omitted because their actual marker is highlighted directly.
+ */
+export function deriveSearchDirectionIndicators(
+  matches: ProjectedSearchMatch[],
+  bounds: ViewportBounds,
+): SearchDirectionIndicator[] {
+  if (
+    !Number.isFinite(bounds.left) ||
+    !Number.isFinite(bounds.top) ||
+    !Number.isFinite(bounds.right) ||
+    !Number.isFinite(bounds.bottom) ||
+    bounds.right <= bounds.left ||
+    bounds.bottom <= bounds.top
+  ) {
+    return [];
+  }
+
+  const indicators = matches.flatMap(({ item, point }) => {
+    const intersection = intersectRayWithBounds(point, bounds);
+    return intersection ? [{ item, ...intersection }] : [];
+  });
+
+  return spreadSideIndicators(indicators, bounds);
+}

--- a/apps/web/src/routes/map/+page.svelte
+++ b/apps/web/src/routes/map/+page.svelte
@@ -9,8 +9,15 @@
   import ContextPanel from "$lib/components/ContextPanel.svelte";
   import ActionBar from "$lib/components/ActionBar.svelte";
   import SearchOverlay from "$lib/components/SearchOverlay.svelte";
+  import SearchDirectionIndicators from "$lib/components/SearchDirectionIndicators.svelte";
   import FilterOverlay from "$lib/components/FilterOverlay.svelte";
   import type { MapEntityViewModel } from "$lib/map/types";
+  import {
+    deriveSearchDirectionIndicators,
+    resolveInitialMapCamera,
+    type SearchDirectionIndicator,
+    type ViewportBounds,
+  } from "$lib/map/searchNavigation";
 
   import { page } from "$app/stores";
 
@@ -53,14 +60,10 @@
     getFilterTypeKey,
     selectMapEntity,
   } from "$lib/stores/mapView";
-  import { authStore } from "$lib/auth/store";
-
+  import { authStore, type AuthStatus } from "$lib/auth/store";
   import { get } from "svelte/store";
 
-  import {
-    currentBasemap,
-    HAMMER_PARK_CENTER,
-  } from "$lib/map/config/basemap.current";
+  import { currentBasemap } from "$lib/map/config/basemap.current";
   import { resolveBasemapStyle, rewritePmtilesUrl } from "$lib/map/basemap";
   import { buildMapScene } from "$lib/map/scene";
 
@@ -115,6 +118,102 @@
   let filterTooltipTimeout: number | null = null;
 
   let nodesOverlay: NodesOverlay | null = null;
+  let searchDirectionIndicators: SearchDirectionIndicator[] = [];
+  let searchDirectionFrame: number | null = null;
+
+  async function resolveInitialAuthStatus(
+    timeoutMs = 2500,
+  ): Promise<AuthStatus> {
+    const known = get(authStore);
+    if (known.authenticated) return known;
+
+    return new Promise((resolve) => {
+      let settled = false;
+      const finish = (status: AuthStatus) => {
+        if (settled) return;
+        settled = true;
+        window.clearTimeout(timeout);
+        resolve(status);
+      };
+      const timeout = window.setTimeout(() => {
+        finish(get(authStore));
+      }, timeoutMs);
+
+      authStore.checkAuth().then(finish, () => finish(get(authStore)));
+    });
+  }
+
+  function getUsableSearchViewport(): ViewportBounds | null {
+    if (!mapContainer) return null;
+    const mapRect = mapContainer.getBoundingClientRect();
+    const edgeInset = 28;
+    let left = edgeInset;
+    let top = edgeInset;
+    let right = mapRect.width - edgeInset;
+    let bottom = mapRect.height - edgeInset;
+
+    const topBarRect = document
+      .querySelector<HTMLElement>(".topbar")
+      ?.getBoundingClientRect();
+    if (topBarRect)
+      top = Math.max(top, topBarRect.bottom - mapRect.top + edgeInset);
+
+    const actionBarRect = document
+      .querySelector<HTMLElement>(".action-bar")
+      ?.getBoundingClientRect();
+    if (actionBarRect && actionBarRect.height > 0) {
+      bottom = Math.min(bottom, actionBarRect.top - mapRect.top - edgeInset);
+    }
+
+    const searchRect = document
+      .querySelector<HTMLElement>('[data-testid="search-overlay"]')
+      ?.getBoundingClientRect();
+    if (searchRect) {
+      bottom = Math.min(bottom, searchRect.top - mapRect.top - edgeInset);
+    }
+
+    const panelRect = document
+      .querySelector<HTMLElement>('[data-testid="context-panel"]')
+      ?.getBoundingClientRect();
+    if (panelRect && panelRect.left > mapRect.left) {
+      right = Math.min(right, panelRect.left - mapRect.left - edgeInset);
+    }
+
+    return right > left && bottom > top ? { left, top, right, bottom } : null;
+  }
+
+  function updateSearchDirectionIndicators() {
+    if (
+      !map ||
+      !$isSearchOpen ||
+      !$searchQuery.trim() ||
+      filteredResults.length === 0
+    ) {
+      searchDirectionIndicators = [];
+      return;
+    }
+    const bounds = getUsableSearchViewport();
+    if (!bounds) {
+      searchDirectionIndicators = [];
+      return;
+    }
+    const projected = filteredResults.map((item) => ({
+      item,
+      point: map!.project([item.lon, item.lat]),
+    }));
+    searchDirectionIndicators = deriveSearchDirectionIndicators(
+      projected,
+      bounds,
+    );
+  }
+
+  function scheduleSearchDirectionIndicators() {
+    if (searchDirectionFrame !== null) return;
+    searchDirectionFrame = window.requestAnimationFrame(() => {
+      searchDirectionFrame = null;
+      updateSearchDirectionIndicators();
+    });
+  }
 
   // Reactive update for markers and search highlight strictly handled in overlay update
   $: if (nodesOverlay && filteredMarkersData && $view) {
@@ -125,6 +224,14 @@
         searchMatchIds,
       );
     })();
+  }
+
+  $: {
+    filteredResults;
+    $isSearchOpen;
+    $searchQuery;
+    $contextPanelOpen;
+    if (map) tick().then(scheduleSearchDirectionIndicators);
   }
 
   // Reactive update for edges – only after map style is fully loaded
@@ -161,6 +268,11 @@
   }
 
   function handleFilterSelect(event: CustomEvent<MapEntityViewModel>) {
+    focusAndFlyToPoint(event.detail);
+  }
+
+  function handleSearchDirectionSelect(event: CustomEvent<MapEntityViewModel>) {
+    closeSearch();
     focusAndFlyToPoint(event.detail);
   }
 
@@ -378,6 +490,9 @@
     // Hoisted so the cleanup can clear it; otherwise a component destroyed
     // before the style loads leaves a 10s timer pointing at dead state.
     let loadingTimeout: ReturnType<typeof setTimeout> | undefined = undefined;
+    const handleSearchViewportChange = () => {
+      scheduleSearchDirectionIndicators();
+    };
     const handleMarkerClick = (e: Event) => {
       const target = e.target as HTMLElement;
       const markerBtn = target.closest(
@@ -396,7 +511,10 @@
     };
 
     (async () => {
-      const maplibregl = await import("maplibre-gl");
+      const [maplibregl, initialAuth] = await Promise.all([
+        import("maplibre-gl"),
+        resolveInitialAuthStatus(),
+      ]);
       if (destroyed) return;
       const container = mapContainer;
       if (!container) {
@@ -434,11 +552,20 @@
       maplibreModule = maplibregl;
       container.addEventListener("click", handleMarkerClick);
 
+      const initialUrlState = parseMapUrlState(get(page).url.searchParams);
+      const initialCamera = resolveInitialMapCamera(
+        markersData,
+        initialAuth,
+        initialUrlState.focus,
+        [currentBasemap.center[0], currentBasemap.center[1]],
+        currentBasemap.zoom,
+      );
+
       map = new maplibregl.Map({
         container,
         style: resolveBasemapStyle(currentBasemap),
-        center: currentBasemap.center,
-        zoom: currentBasemap.zoom,
+        center: initialCamera.center,
+        zoom: initialCamera.zoom,
         minZoom: currentBasemap.minZoom ?? 10,
         maxZoom: currentBasemap.maxZoom ?? 18,
         pitch: currentBasemap.pitch ?? 0,
@@ -467,6 +594,8 @@
         sysStateStr = val;
       });
       cleanupFocus = setupFocusInteraction(map, () => sysStateStr);
+      map.on("move", handleSearchViewportChange);
+      map.on("resize", handleSearchViewportChange);
 
       loadingTimeout = setTimeout(() => {
         isLoading = false;
@@ -476,30 +605,7 @@
         clearTimeout(loadingTimeout);
         isLoading = false;
         mapStyleReady = true;
-
-        const currentSelection = get(selection);
-        const currentSystemState = get(systemState);
-        // A valid focus deep link addresses a specific entity. Suppress the
-        // default fly-to so the map does not first center on the default
-        // location while the focus target is still being resolved (which would
-        // cause a double fly / flicker). Invalid or duplicate focus params are
-        // not valid focus and therefore do not block the default behaviour.
-        const pendingFocus =
-          parseMapUrlState(get(page).url.searchParams).focus !== null;
-
-        if (
-          !pendingFocus &&
-          !currentSelection &&
-          currentSystemState === "navigation"
-        ) {
-          const currentZoom = map?.getZoom() ?? 14;
-          map?.flyTo({
-            center: [HAMMER_PARK_CENTER.lon, HAMMER_PARK_CENTER.lat],
-            zoom: Math.max(currentZoom, 14),
-            speed: 0.8,
-            curve: 1,
-          });
-        }
+        scheduleSearchDirectionIndicators();
       };
 
       map.once("load", finishLoading);
@@ -532,8 +638,17 @@
       cleanupKomposition?.();
       cleanupFocus?.();
       unsubscribeSysState?.();
+      if (searchDirectionFrame !== null) {
+        window.cancelAnimationFrame(searchDirectionFrame);
+        searchDirectionFrame = null;
+      }
+      searchDirectionIndicators = [];
       nodesOverlay?.destroy();
-      if (map && typeof map.remove === "function") map.remove();
+      if (map) {
+        map.off("move", handleSearchViewportChange);
+        map.off("resize", handleSearchViewportChange);
+        if (typeof map.remove === "function") map.remove();
+      }
       mapContainer?.removeEventListener("click", handleMarkerClick);
       if (currentBasemap.mode === "local-sovereign" && maplibreModule) {
         try {
@@ -579,6 +694,10 @@
 
   <ContextPanel on:selectRelated={handleRelatedSelect} />
   <SearchOverlay {filteredResults} on:select={handleSearchSelect} />
+  <SearchDirectionIndicators
+    indicators={searchDirectionIndicators}
+    on:select={handleSearchDirectionSelect}
+  />
   <FilterOverlay
     {availableTypes}
     filteredResults={filteredMarkersData}

--- a/apps/web/tests/map-default-view.spec.ts
+++ b/apps/web/tests/map-default-view.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "@playwright/test";
 import { mockApiResponses } from "./fixtures/mockApi";
 
-test("map centers on hammer park by default", async ({ page }) => {
+test("guest map keeps the Hammer Park fallback", async ({ page }) => {
   await mockApiResponses(page);
 
   // 1. `/map` öffnen
@@ -15,7 +15,7 @@ test("map centers on hammer park by default", async ({ page }) => {
     { timeout: 15000 },
   );
 
-  // Let map do the initial flyTo transition
+  // The fallback is now selected before MapLibre draws its first frame.
   await page.waitForFunction(
     () => {
       const map = (window as any).__TEST_MAP__;
@@ -44,4 +44,40 @@ test("map centers on hammer park by default", async ({ page }) => {
   // HAMMER_PARK_CENTER: lat: 53.5585, lon: 10.0580
   expect(center.lng).toBeCloseTo(10.058, 2);
   expect(center.lat).toBeCloseTo(53.5585, 2);
+});
+
+test("signed-in map starts on the own positioned Garnrolle", async ({
+  page,
+}) => {
+  const ownAccountId = "7d97a42e-3704-4a33-a61f-0e0a6b4d65d8";
+  await mockApiResponses(page, {
+    auth: { authenticated: true, account_id: ownAccountId, role: "weber" },
+  });
+
+  await page.goto("/map");
+  await page.waitForFunction(
+    () => (window as any).__TEST_MAP__ !== undefined,
+    undefined,
+    { timeout: 15000 },
+  );
+
+  await page.waitForFunction(
+    () => {
+      const map = (window as any).__TEST_MAP__;
+      if (!map) return false;
+      const center = map.getCenter();
+      return (
+        Math.abs(center.lng - 10.0629844) < 0.0005 &&
+        Math.abs(center.lat - 53.5604148) < 0.0005 &&
+        map.getZoom() >= 14
+      );
+    },
+    undefined,
+    { timeout: 15000 },
+  );
+
+  await expect(
+    page.getByTestId(`marker-garnrolle-${ownAccountId}`),
+  ).toBeVisible();
+  await expect(page.getByTestId("context-panel")).toHaveCount(0);
 });

--- a/apps/web/tests/map-url-state.spec.ts
+++ b/apps/web/tests/map-url-state.spec.ts
@@ -103,6 +103,20 @@ test.describe("Map URL addressing", () => {
     const panel = page.getByTestId("context-panel");
     await expect(panel).toBeVisible();
     await expect(panel.locator(".panel-header h2")).toContainText("Knoten");
+    await page.waitForFunction(
+      () => {
+        const map = (window as any).__TEST_MAP__;
+        if (!map) return false;
+        const center = map.getCenter();
+        return (
+          Math.abs(center.lng - 10) < 0.0005 &&
+          Math.abs(center.lat - 53.5) < 0.0005 &&
+          map.getZoom() >= 14
+        );
+      },
+      undefined,
+      { timeout: 15000 },
+    );
   });
 
   test("opens the context panel for a garnrolle focus deep link", async ({

--- a/apps/web/tests/ui-search.spec.ts
+++ b/apps/web/tests/ui-search.spec.ts
@@ -80,11 +80,25 @@ test.describe("Search mode", () => {
     await expect(highlightedMarker).toBeVisible();
     await expect(highlightedMarker).toHaveAttribute("data-id", "mock-node-1");
 
-    // Clear search and verify highlight is removed
+    const direction = page.getByTestId("search-direction-node-mock-node-1");
+    await expect(direction).toBeVisible();
+    await expect(direction).toHaveAttribute("data-side", "bottom");
+    const directionBox = await direction.boundingBox();
+    const searchBox = await searchOverlay.boundingBox();
+    expect(directionBox).not.toBeNull();
+    expect(searchBox).not.toBeNull();
+    expect(directionBox!.width).toBeGreaterThanOrEqual(44);
+    expect(directionBox!.height).toBeGreaterThanOrEqual(44);
+    expect(directionBox!.y + directionBox!.height).toBeLessThanOrEqual(
+      searchBox!.y + 1,
+    );
+
+    // Clear search and verify highlight and direction marker are removed
     await searchInput.fill("");
     await expect(
       page.locator('.map-marker[data-search-match="true"]'),
     ).toHaveCount(0);
+    await expect(direction).toHaveCount(0);
 
     // Refill and proceed to test keyboard navigation
     await searchInput.fill("Strick");
@@ -133,6 +147,44 @@ test.describe("Search mode", () => {
     // Also verify search field was cleared
     await searchBtn.click();
     await expect(searchInput).toHaveValue("");
+  });
+
+  test("offscreen direction marker opens and centers its search result", async ({
+    page,
+  }) => {
+    await page.goto("/map");
+    await page.waitForFunction(
+      () => (window as any).__TEST_MAP__ !== undefined,
+      undefined,
+      { timeout: 15000 },
+    );
+
+    await page.getByRole("button", { name: "Suche", exact: true }).click();
+    await page.getByRole("textbox", { name: "Suchbegriff" }).fill("Strick");
+
+    const direction = page.getByTestId("search-direction-node-mock-node-1");
+    await expect(direction).toBeVisible();
+    await direction.click();
+
+    await expect(page.getByTestId("search-overlay")).toHaveCount(0);
+    await expect(page.getByTestId("context-panel")).toBeVisible();
+    await expect(page.getByTestId("search-direction-indicators")).toHaveCount(
+      0,
+    );
+    await page.waitForFunction(
+      () => {
+        const map = (window as any).__TEST_MAP__;
+        if (!map) return false;
+        const center = map.getCenter();
+        return (
+          Math.abs(center.lng - 10) < 0.0001 &&
+          Math.abs(center.lat - 51) < 0.0001 &&
+          map.getZoom() >= 14
+        );
+      },
+      undefined,
+      { timeout: 10000 },
+    );
   });
 
   test("focus restores to search button on Escape", async ({ page }) => {

--- a/docs/specs/ui-interaction.md
+++ b/docs/specs/ui-interaction.md
@@ -27,6 +27,7 @@ verifies_with:
   - apps/web/tests/map-interaction.spec.ts
   - apps/web/tests/ui-filter.spec.ts
 ---
+
 # UI-Interaktionsvertrag
 
 ## Leitidee
@@ -35,11 +36,11 @@ Weltgewebe ist ein kartenbasiertes Koordinationsinterface. Die Karte ist der öf
 
 ## Drei Hauptflächen
 
-| Fläche | Verantwortung |
-|---|---|
-| Karte | räumlicher Überblick, Auswahl und sichtbares Gewebe |
-| Fokuspanel | Details, Gespräche, Entscheidungen und Handlungen |
-| Aktionsleiste | Suche, Filter, Komposition und weitere Absichten |
+| Fläche        | Verantwortung                                       |
+| ------------- | --------------------------------------------------- |
+| Karte         | räumlicher Überblick, Auswahl und sichtbares Gewebe |
+| Fokuspanel    | Details, Gespräche, Entscheidungen und Handlungen   |
+| Aktionsleiste | Suche, Filter, Komposition und weitere Absichten    |
 
 Es gibt keinen zweiten Detail-Drawer, kein dauerhaftes Seitenmenü für Objektinhalte und keine frei schwebenden Hauptformulare über der Karte.
 
@@ -53,6 +54,14 @@ Interaktionen:
 - leere Kartenfläche wählen → Fokus schließen, sofern kein lokaler Dialog Vorrang hat;
 - Karte bewegen → kein neuer globaler Zustand;
 - neue Webung beginnen → Komposition im Fokuspanel.
+
+Der erste Kartenausschnitt folgt einer eindeutigen Priorität:
+
+1. Ein ausdrücklich per URL adressierter Knoten oder eine Garnrolle wird gezeigt.
+2. Sonst startet eine angemeldete Person auf ihrer öffentlich verorteten Garnrolle.
+3. Fehlt eine verortete eigene Garnrolle oder eine Anmeldung, gilt der kanonische Fallback-Ausschnitt.
+
+Die Kamera wird möglichst vor dem ersten sichtbaren Kartenbild bestimmt. Ein unnötiger Zwischensprung vom Fallback zur eigenen Garnrolle ist zu vermeiden.
 
 ## Fokuspanel
 
@@ -91,7 +100,10 @@ Suche und Filter sind lokale Kartenlinsen:
 - sie verändern die sichtbare Szene;
 - sie erzeugen keinen neuen globalen Zustand;
 - sie schließen sich gegenseitig;
-- ein Treffer kann die Karte fokussieren und das Fokuspanel öffnen;
+- passende Knoten und Garnrollen werden auf der Karte hervorgehoben;
+- liegt ein Treffer außerhalb des nutzbaren Kartenausschnitts, zeigt ein Richtungsmarker am Bildschirmrand zu ihm;
+- Richtungsmarker bleiben außerhalb von Topbar, Aktionsleiste, Suchfläche und Fokuspanel und besitzen mindestens 44 × 44 Pixel;
+- ein Treffer oder Richtungsmarker kann die Karte fokussieren und das Fokuspanel öffnen;
 - ein API-Fehler darf nicht wie eine normale leere Ergebnismenge aussehen.
 
 ## Komposition


### PR DESCRIPTION
## Zweck

Die Kartenansicht beginnt für angemeldete Konten auf der eigenen öffentlich verorteten Garnrolle. Suchtreffer bleiben räumlich auffindbar: sichtbare Knoten und Garnrollen werden hervorgehoben, Außentreffer erhalten zugängliche Richtungsmarker am nutzbaren Bildschirmrand.

## Verhalten

- expliziter URL-Fokus hat Vorrang vor der eigenen Garnrolle;
- eigene verortete Garnrolle hat Vorrang vor dem öffentlichen Fallback;
- ohne Anmeldung, ohne verortete Garnrolle oder bei nicht erreichbarer Sitzungsprüfung bleibt der kanonische Fallback erhalten;
- Richtungsmarker meiden Topbar, Aktionsleiste, Suchfläche und breites Fokuspanel;
- Richtungsmarker besitzen mindestens 44 × 44 Pixel;
- Klick auf einen Richtungsmarker schließt die Suche, zentriert die Karte und öffnet das Fokuspanel;
- die bestehende Marker-Hervorhebung bleibt die Darstellung für sichtbare Treffer.

## Prüfung

- Svelte-Check: 0 Fehler, 0 Warnungen
- Unit: 141/141
- gezielte Browsermatrix: 19/19 ohne Retries
- vollständige Browsermatrix: 115/115 ohne Retries
- Produktionsbuild: grün
- `make validate`: grün
- `git diff --check`: grün

Keine API-, Datenbank-, Migrations-, Authentifizierungs- oder Deploydatei wurde verändert.