### PR TITLE
feat(basemap): Schleswig-Holstein als PMTiles-Region ergänzen

### DIFF
--- a/.github/workflows/basemap-runtime-proof.yml
+++ b/.github/workflows/basemap-runtime-proof.yml
@@ -1,7 +1,7 @@
 ---
 name: Basemap Runtime Proof
 
-# This workflow runs four jobs:
+# This workflow runs five jobs:
 #
 #   1. basemap-runtime-proof  (Pfad 1 — epistemischer Dry-Run, nicht blockierend)
 #      Runs the guard in skip mode with no Caddy and no artefact. Reports
@@ -19,7 +19,10 @@ name: Basemap Runtime Proof
 #      The guard verifies endpoint/range delivery (HTTP 206), the PMTiles magic
 #      bytes "PMTiles" and an optional SHA256 match from the generated metadata.
 #
-#   4. basemap-visual-proof  (Pfad 4 — visueller End-to-End-Proof, blockierend)
+#   4. basemap-schleswig-holstein-content-proof
+#      Builds and verifies the pinned Schleswig-Holstein PMTiles artifact independently.
+#
+#   5. basemap-visual-proof  (Pfad 5 — visueller End-to-End-Proof, blockierend)
 #      Reuses the real Hamburg PMTiles artefact from Pfad 3, publishes the
 #      stable alias (basemap-hamburg.pmtiles), starts the Vite preview server
 #      with the local-basemap-serve middleware, and runs the Playwright visual proof
@@ -46,6 +49,7 @@ name: Basemap Runtime Proof
     paths:
       - "infra/caddy/**"
       - "scripts/basemap/build-hamburg-pmtiles.sh"
+      - "scripts/basemap/build-schleswig-holstein-pmtiles.sh"
       - "scripts/basemap/publish-basemap.sh"
       - "scripts/guard/basemap-runtime-proof.sh"
       - "apps/web/tests/proofs/**"
@@ -59,6 +63,7 @@ name: Basemap Runtime Proof
     paths:
       - "infra/caddy/**"
       - "scripts/basemap/build-hamburg-pmtiles.sh"
+      - "scripts/basemap/build-schleswig-holstein-pmtiles.sh"
       - "scripts/basemap/publish-basemap.sh"
       - "scripts/guard/basemap-runtime-proof.sh"
       - "apps/web/tests/proofs/**"
@@ -494,6 +499,83 @@ jobs:
           fi
           printf '```\n\n</details>\n' >> "${GITHUB_STEP_SUMMARY}"
 
+  basemap-schleswig-holstein-content-proof:
+    name: basemap-schleswig-holstein-content-proof
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      BASEMAP_PROOF_MODE: require
+      BASEMAP_PROOF_SCOPE: pmtiles-content
+      BASEMAP_CADDY_URL: http://localhost:8081
+      SOURCE_DATE_EPOCH: "1704067200"
+      ARTEFACT_NAME: basemap-schleswig-holstein-v0.1.0.pmtiles
+      META_NAME: basemap-schleswig-holstein-v0.1.0.meta.json
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # tag: v7.0.0
+
+      - name: Verify Docker availability
+        run: |
+          set -euo pipefail
+          docker --version
+          docker info >/dev/null
+
+      - name: Build real PMTiles artefact (Schleswig-Holstein)
+        run: |
+          set -euo pipefail
+          bash scripts/basemap/build-schleswig-holstein-pmtiles.sh
+          test -s "build/basemap/${ARTEFACT_NAME}"
+          test -s "build/basemap/${META_NAME}"
+          EXPECTED_SHA256="$(python3 -c 'import json,os; print(json.load(open("build/basemap/" + os.environ["META_NAME"], encoding="utf-8"))["sha256"])')"
+          printf 'EXPECTED_SHA256=%s\n' "${EXPECTED_SHA256}" >> "${GITHUB_ENV}"
+
+      - name: Start Caddy serving Schleswig-Holstein PMTiles
+        run: |
+          set -euo pipefail
+          docker run -d --name caddy-proof-schleswig-holstein \
+            -p 8081:8081 \
+            -v "${PWD}/infra/caddy/Caddyfile.proof:/etc/caddy/Caddyfile:ro" \
+            -v "${PWD}/build/basemap:/srv/weltgewebe-basemap:ro" \
+            caddy:2.7 caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
+          for i in $(seq 1 30); do
+            if curl -sf -o /dev/null --max-time 2 "${BASEMAP_CADDY_URL}/"; then
+              exit 0
+            fi
+            sleep 1
+          done
+          docker logs caddy-proof-schleswig-holstein || true
+          exit 1
+
+      - name: Prove Schleswig-Holstein PMTiles content and Range delivery
+        run: |
+          set -euo pipefail
+          BASEMAP_ENDPOINT_PATH="/local-basemap/${ARTEFACT_NAME}" \
+          BASEMAP_PMTILES_PATH="${PWD}/build/basemap/${ARTEFACT_NAME}" \
+          BASEMAP_EXPECTED_SHA256="${EXPECTED_SHA256}" \
+            scripts/guard/basemap-runtime-proof.sh 2>&1 | tee /tmp/schleswig-holstein-proof.txt
+
+      - name: Collect proof evidence
+        if: always()
+        run: |
+          docker logs caddy-proof-schleswig-holstein > /tmp/schleswig-holstein-caddy.log 2>&1 || true
+          xxd -l 16 -g 1 "build/basemap/${ARTEFACT_NAME}" > /tmp/schleswig-holstein-magic.txt 2>/dev/null || true
+
+      - name: Tear down Caddy container
+        if: always()
+        run: docker rm -f caddy-proof-schleswig-holstein || true
+
+      - name: Upload Schleswig-Holstein proof evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        with:
+          name: basemap-schleswig-holstein-content-proof-evidence
+          path: |
+            /tmp/schleswig-holstein-proof.txt
+            /tmp/schleswig-holstein-caddy.log
+            /tmp/schleswig-holstein-magic.txt
+            build/basemap/basemap-schleswig-holstein-v0.1.0.meta.json
+          if-no-files-found: warn
+          retention-days: 14
+
   basemap-visual-proof:
     name: basemap-visual-proof
     needs: [basemap-pmtiles-content-proof]
@@ -516,8 +598,8 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
-          node-version-file: '.node-version'
-          cache: 'pnpm'
+          node-version-file: ".node-version"
+          cache: "pnpm"
           cache-dependency-path: apps/web/pnpm-lock.yaml
 
       - name: Install web dependencies

--- a/.github/workflows/basemap-runtime-proof.yml
+++ b/.github/workflows/basemap-runtime-proof.yml
@@ -577,13 +577,16 @@ jobs:
             /tmp/schleswig-holstein-proof.txt
             /tmp/schleswig-holstein-caddy.log
             /tmp/schleswig-holstein-magic.txt
+            build/basemap/basemap-schleswig-holstein-v0.1.0.pmtiles
             build/basemap/basemap-schleswig-holstein-v0.1.0.meta.json
           if-no-files-found: warn
           retention-days: 14
 
   basemap-visual-proof:
     name: basemap-visual-proof
-    needs: [basemap-pmtiles-content-proof]
+    needs:
+      - basemap-pmtiles-content-proof
+      - basemap-schleswig-holstein-content-proof
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -615,36 +618,48 @@ jobs:
         run: pnpm exec playwright install --with-deps chromium
         working-directory: apps/web
 
-      - name: Download reusable PMTiles artefact from content proof
+      - name: Download Hamburg PMTiles artefact from content proof
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # tag: v8
         with:
           name: basemap-visual-proof-input
-          path: /tmp/basemap-visual-proof-input
+          path: /tmp/basemap-visual-proof-input/hamburg
 
-      - name: Materialize PMTiles artefact for visual proof
+      - name: Download Schleswig-Holstein PMTiles artefact from content proof
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # tag: v8
+        with:
+          name: basemap-schleswig-holstein-content-proof-evidence
+          path: /tmp/basemap-visual-proof-input/schleswig-holstein
+
+      - name: Materialize regional PMTiles artefacts for visual proof
         run: |
           set -euo pipefail
           mkdir -p build/basemap
-          ARTEFACT_SRC="$(find /tmp/basemap-visual-proof-input -type f \
-            -name 'basemap-hamburg-v0.1.0.pmtiles' | head -n 1)"
-          META_SRC="$(find /tmp/basemap-visual-proof-input -type f \
-            -name 'basemap-hamburg-v0.1.0.meta.json' | head -n 1)"
-          test -n "${ARTEFACT_SRC}"
-          test -n "${META_SRC}"
-          cp "${ARTEFACT_SRC}" build/basemap/basemap-hamburg-v0.1.0.pmtiles
-          cp "${META_SRC}" build/basemap/basemap-hamburg-v0.1.0.meta.json
-          test -s build/basemap/basemap-hamburg-v0.1.0.pmtiles
-          test -s build/basemap/basemap-hamburg-v0.1.0.meta.json
+          for region in hamburg schleswig-holstein; do
+            artefact="basemap-${region}-v0.1.0.pmtiles"
+            metadata="basemap-${region}-v0.1.0.meta.json"
+            artefact_src="$(find /tmp/basemap-visual-proof-input -type f \
+              -name "${artefact}" | head -n 1)"
+            metadata_src="$(find /tmp/basemap-visual-proof-input -type f \
+              -name "${metadata}" | head -n 1)"
+            test -n "${artefact_src}"
+            test -n "${metadata_src}"
+            cp "${artefact_src}" "build/basemap/${artefact}"
+            cp "${metadata_src}" "build/basemap/${metadata}"
+            test -s "build/basemap/${artefact}"
+            test -s "build/basemap/${metadata}"
+          done
 
-      - name: Publish basemap (create stable alias basemap-hamburg.pmtiles)
+      - name: Publish regional basemaps with stable aliases
         run: |
           set -euo pipefail
-          bash scripts/basemap/publish-basemap.sh \
-            build/basemap/basemap-hamburg-v0.1.0.pmtiles \
-            build/basemap/basemap-hamburg-v0.1.0.meta.json \
-            build/basemap/
-          test -e build/basemap/basemap-hamburg.pmtiles
-          printf 'Alias verified: build/basemap/basemap-hamburg.pmtiles\n'
+          for region in hamburg schleswig-holstein; do
+            bash scripts/basemap/publish-basemap.sh \
+              "build/basemap/basemap-${region}-v0.1.0.pmtiles" \
+              "build/basemap/basemap-${region}-v0.1.0.meta.json" \
+              build/basemap/
+            test -e "build/basemap/basemap-${region}.pmtiles"
+            printf 'Alias verified: build/basemap/basemap-%s.pmtiles\n' "${region}"
+          done
           ls -la build/basemap/
 
       - name: Run Playwright visual basemap proof
@@ -700,7 +715,7 @@ jobs:
               _msg="${_msg} HTTP 206 Range delivery confirmed, zero remote violations"
               printf '%s\n\n' "${_msg}" >> "${GITHUB_STEP_SUMMARY}"
               printf '%s\n\n' \
-                'Chain: Browser → Vite middleware → basemap-hamburg.pmtiles → HTTP 206 → MapLibre rendered' \
+                'Chain: Browser → Vite → regional PMTiles → HTTP 206 → MapLibre rendered' \
                 >> "${GITHUB_STEP_SUMMARY}"
             else
               printf '%s\n\n' \

--- a/.github/workflows/basemap-runtime-proof.yml
+++ b/.github/workflows/basemap-runtime-proof.yml
@@ -525,11 +525,11 @@ jobs:
           bash scripts/basemap/build-schleswig-holstein-pmtiles.sh
           test -s "build/basemap/${ARTEFACT_NAME}"
           test -s "build/basemap/${META_NAME}"
-          META_PATH="build/basemap/"
+          META_PATH="build/basemap/${META_NAME}"
           EXPECTED_SHA256="$(
             python3 -c \
               'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["sha256"])' \
-              ""
+              "${META_PATH}"
           )"
           printf 'EXPECTED_SHA256=%s\n' "${EXPECTED_SHA256}" >> "${GITHUB_ENV}"
 

--- a/.github/workflows/basemap-runtime-proof.yml
+++ b/.github/workflows/basemap-runtime-proof.yml
@@ -662,6 +662,12 @@ jobs:
           done
           ls -la build/basemap/
 
+      - name: Materialize verified local glyphs
+        run: |
+          set -euo pipefail
+          bash scripts/basemap/fetch-glyphs.sh
+          test -s "map-style/glyphs/Noto Sans Regular/0-255.pbf"
+
       - name: Run Playwright visual basemap proof
         id: visual-proof
         run: pnpm test:proof:basemap-real
@@ -673,8 +679,8 @@ jobs:
         with:
           name: basemap-visual-proof-screenshot
           path: |
-            build/proofs/basemap-visual/screenshot.png
-            build/proofs/basemap-visual/proof-summary.json
+            build/proofs/basemap-visual/*.png
+            build/proofs/basemap-visual/*.json
           if-no-files-found: warn
           retention-days: 14
 
@@ -702,32 +708,58 @@ jobs:
         if: always()
         run: |
           set -euo pipefail
-          SUMMARY_FILE="build/proofs/basemap-visual/proof-summary.json"
+          SUMMARY_DIR="build/proofs/basemap-visual"
           printf '## Basemap Visual Proof\n\n' >> "${GITHUB_STEP_SUMMARY}"
-          if [[ -f "${SUMMARY_FILE}" ]]; then
-            VERDICT="$(
-              python3 -c \
-                'import json, sys; print(json.load(open(sys.argv[1], encoding="utf-8")).get("verdict", "UNKNOWN"))' \
-                "${SUMMARY_FILE}" 2>/dev/null || echo 'UNKNOWN'
-            )"
-            if [[ "${VERDICT}" == "PROVEN" ]]; then
-              _msg='✅ **PROVEN** — MapLibre canvas visible, isStyleLoaded() true,'
-              _msg="${_msg} HTTP 206 Range delivery confirmed, zero remote violations"
-              printf '%s\n\n' "${_msg}" >> "${GITHUB_STEP_SUMMARY}"
-              printf '%s\n\n' \
-                'Chain: Browser → Vite → regional PMTiles → HTTP 206 → MapLibre rendered' \
-                >> "${GITHUB_STEP_SUMMARY}"
-            else
-              printf '%s\n\n' \
-                '❌ **NOT PROVEN** — see test results for details' \
-                >> "${GITHUB_STEP_SUMMARY}"
-            fi
-            printf '<details><summary>Proof summary</summary>\n\n```json\n' >> "${GITHUB_STEP_SUMMARY}"
-            cat "${SUMMARY_FILE}" >> "${GITHUB_STEP_SUMMARY}"
-            printf '\n```\n\n</details>\n' >> "${GITHUB_STEP_SUMMARY}"
-          else
-            printf '%s\n\n' \
-              '❌ **FAILED** — no proof summary found (Playwright test may not have run to completion)' \
-              >> "${GITHUB_STEP_SUMMARY}"
-            exit 1
-          fi
+          python3 - "${SUMMARY_DIR}" "${GITHUB_STEP_SUMMARY}" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          summary_dir = pathlib.Path(sys.argv[1])
+          output_path = pathlib.Path(sys.argv[2])
+          expected = [
+              summary_dir / "proof-summary.json",
+              summary_dir / "schleswig-holstein-proof-summary.json",
+          ]
+          all_proven = True
+          with output_path.open("a", encoding="utf-8") as output:
+              for summary_path in expected:
+                  if not summary_path.is_file():
+                      output.write(f"❌ **FAILED** — missing `{summary_path}`\n\n")
+                      all_proven = False
+                      continue
+                  try:
+                      payload = json.loads(summary_path.read_text(encoding="utf-8"))
+                  except (OSError, json.JSONDecodeError) as exc:
+                      output.write(
+                          f"❌ **FAILED** — invalid `{summary_path}`: {exc}\n\n"
+                      )
+                      all_proven = False
+                      continue
+                  region = payload.get("region", summary_path.stem)
+                  verdict = payload.get("verdict", "UNKNOWN")
+                  rendered = payload.get(
+                      "rendered_from_expected_source",
+                      payload.get("rendered_feature_count", "n/a"),
+                  )
+                  responses = payload.get("pmtiles_206_responses_observed", "n/a")
+                  marker = "✅" if verdict == "PROVEN" else "❌"
+                  output.write(
+                      f"{marker} **{region}: {verdict}** — rendered features: "
+                      f"{rendered}; HTTP 206 responses: {responses}\n\n"
+                  )
+                  output.write(
+                      f"<details><summary>{region} proof summary</summary>\n\n"
+                      "```json\n"
+                      f"{json.dumps(payload, indent=2, ensure_ascii=False)}\n"
+                      "```\n\n</details>\n\n"
+                  )
+                  all_proven = all_proven and verdict == "PROVEN"
+              if all_proven:
+                  output.write(
+                      "Chain: Browser → Vite → glyphs + regional PMTiles → "
+                      "HTTP 206 → MapLibre decoded and rendered\n"
+                  )
+          if not all_proven:
+              raise SystemExit(1)
+          PY

--- a/.github/workflows/basemap-runtime-proof.yml
+++ b/.github/workflows/basemap-runtime-proof.yml
@@ -525,7 +525,12 @@ jobs:
           bash scripts/basemap/build-schleswig-holstein-pmtiles.sh
           test -s "build/basemap/${ARTEFACT_NAME}"
           test -s "build/basemap/${META_NAME}"
-          EXPECTED_SHA256="$(python3 -c 'import json,os; print(json.load(open("build/basemap/" + os.environ["META_NAME"], encoding="utf-8"))["sha256"])')"
+          META_PATH="build/basemap/"
+          EXPECTED_SHA256="$(
+            python3 -c \
+              'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["sha256"])' \
+              ""
+          )"
           printf 'EXPECTED_SHA256=%s\n' "${EXPECTED_SHA256}" >> "${GITHUB_ENV}"
 
       - name: Start Caddy serving Schleswig-Holstein PMTiles

--- a/apps/web/playwright.proof.config.ts
+++ b/apps/web/playwright.proof.config.ts
@@ -4,5 +4,5 @@ import baseConfig from "./playwright.config";
 export default defineConfig({
   ...baseConfig,
   testDir: "tests/proofs",
-  testMatch: "**/basemap-real-hamburg-visual.proof.ts",
+  testMatch: "**/basemap-real-*-visual.proof.ts",
 });

--- a/apps/web/tests/basemap-client-integration.spec.ts
+++ b/apps/web/tests/basemap-client-integration.spec.ts
@@ -22,8 +22,25 @@ test.describe("Basemap Client Integration (local-sovereign)", () => {
               type: "vector",
               url: "pmtiles://basemap-hamburg.pmtiles",
             },
+            "basemap-schleswig-holstein": {
+              type: "vector",
+              url: "pmtiles://basemap-schleswig-holstein.pmtiles",
+            },
           },
-          layers: [],
+          layers: [
+            {
+              id: "hamburg-water",
+              type: "fill",
+              source: "basemap",
+              "source-layer": "water",
+            },
+            {
+              id: "schleswig-holstein-water",
+              type: "fill",
+              source: "basemap-schleswig-holstein",
+              "source-layer": "water",
+            },
+          ],
         }),
       });
     });
@@ -63,17 +80,21 @@ test.describe("Basemap Client Integration (local-sovereign)", () => {
     // Track network requests to confirm what MapLibre actually requests
     // and whether PMTiles correctly issues Range headers.
     const requestedUrls: string[] = [];
-    let sawPmtilesRangeRequest = false;
+    const pmtilesRangeRegions = new Set<string>();
 
     page.on("request", (req) => {
       const url = req.url();
       requestedUrls.push(url);
 
-      if (url.includes("/local-basemap/basemap-hamburg.pmtiles")) {
+      const regionalArtifact = [
+        "basemap-hamburg.pmtiles",
+        "basemap-schleswig-holstein.pmtiles",
+      ].find((artifact) => url.includes(`/local-basemap/${artifact}`));
+      if (regionalArtifact) {
         // PMTiles must request partial content via HTTP Range header
         const reqHeaders = req.headers();
-        if (reqHeaders["range"] && reqHeaders["range"].startsWith("bytes=")) {
-          sawPmtilesRangeRequest = true;
+        if (reqHeaders["range"]?.startsWith("bytes=")) {
+          pmtilesRangeRegions.add(regionalArtifact);
         }
       }
     });
@@ -101,30 +122,32 @@ test.describe("Basemap Client Integration (local-sovereign)", () => {
       )
       .toBeTruthy();
 
-    // PMTiles protocol fetch check. If MapLibre + pmtiles protocol is correctly linked,
-    // the source URL pmtiles://basemap-hamburg.pmtiles should be transformed to a real
-    // fetch against /local-basemap/basemap-hamburg.pmtiles, and it MUST include a Range header.
-    await expect
-      .poll(
-        () =>
-          requestedUrls.some((url) =>
-            url.includes("/local-basemap/basemap-hamburg.pmtiles"),
-          ),
-        {
-          message:
-            "Client should transform pmtiles:// protocol and request local .pmtiles artifact",
-          timeout: 5000,
-        },
-      )
-      .toBeTruthy();
+    // Both regional PMTiles sources must be resolved to local HTTP requests.
+    for (const artifact of [
+      "basemap-hamburg.pmtiles",
+      "basemap-schleswig-holstein.pmtiles",
+    ]) {
+      await expect
+        .poll(
+          () =>
+            requestedUrls.some((url) =>
+              url.includes(`/local-basemap/${artifact}`),
+            ),
+          {
+            message: `Client should request local regional artifact ${artifact}`,
+            timeout: 5000,
+          },
+        )
+        .toBeTruthy();
+    }
 
-    // Final semantic validation: Prove that it actually behaves like a PMTiles client
-    // requesting a byte slice, not just fetching a random file.
+    // Final semantic validation: both sources behave like PMTiles clients and
+    // request byte slices rather than fetching opaque whole files.
     await expect
-      .poll(() => sawPmtilesRangeRequest, {
-        message: "PMTiles client must issue a Range header",
+      .poll(() => pmtilesRangeRegions.size, {
+        message: "Both regional PMTiles clients must issue Range headers",
         timeout: 5000,
       })
-      .toBeTruthy();
+      .toBe(2);
   });
 });

--- a/apps/web/tests/proofs/basemap-real-hamburg-visual.proof.ts
+++ b/apps/web/tests/proofs/basemap-real-hamburg-visual.proof.ts
@@ -34,6 +34,21 @@ import path from "node:path";
  */
 
 const REAL_PMTILES_FILENAME = "basemap-hamburg.pmtiles";
+const SOURCE_ID = "basemap";
+const REGION_LAYER_IDS = ["water", "roads", "buildings", "place-labels"];
+const SOURCE_LAYER_IDS = ["transportation", "water", "place"];
+
+type TestMap = {
+  isStyleLoaded?: () => boolean;
+  isSourceLoaded?: (sourceId: string) => boolean;
+  queryRenderedFeatures?: (options?: {
+    layers?: string[];
+  }) => Array<{ source?: string; layer?: { id?: string } }>;
+  querySourceFeatures?: (
+    sourceId: string,
+    options?: { sourceLayer?: string },
+  ) => Array<unknown>;
+};
 
 const FORBIDDEN_REMOTE_PROVIDERS = [
   "api.maptiler.com",
@@ -74,17 +89,19 @@ test.describe("Basemap Real Hamburg Visual Runtime Proof", () => {
       }> = [];
       const remoteViolations: string[] = [];
       const unexpectedApiRequests: string[] = [];
+      const failedResponses: Array<{ url: string; status: number }> = [];
+      const consoleErrors: string[] = [];
 
       page.on("console", (msg) => {
         if (msg.type() === "error") {
-          console.warn(`[browser-console-error] ${msg.text()}`);
+          consoleErrors.push(msg.text());
         }
       });
 
       // Record PMTiles network events
       page.on("request", (req) => {
         const url = req.url();
-        if (url.includes("/local-basemap/") && url.endsWith(".pmtiles")) {
+        if (url.includes(`/local-basemap/${REAL_PMTILES_FILENAME}`)) {
           pmtilesRequests.push({
             url,
             method: req.method(),
@@ -100,7 +117,10 @@ test.describe("Basemap Real Hamburg Visual Runtime Proof", () => {
 
       page.on("response", (res) => {
         const url = res.url();
-        if (url.includes("/local-basemap/") && url.endsWith(".pmtiles")) {
+        if (res.status() >= 400) {
+          failedResponses.push({ url, status: res.status() });
+        }
+        if (url.includes(`/local-basemap/${REAL_PMTILES_FILENAME}`)) {
           pmtilesResponses.push({
             url,
             status: res.status(),
@@ -109,6 +129,10 @@ test.describe("Basemap Real Hamburg Visual Runtime Proof", () => {
           });
         }
       });
+
+      await page.route("**/favicon.ico", (route) =>
+        route.fulfill({ status: 204, body: "" }),
+      );
 
       // Mock /_app/version.json to suppress UpdateBanner overlay
       await page.route("**/_app/version.json", (route) => {
@@ -326,6 +350,86 @@ test.describe("Basemap Real Hamburg Visual Runtime Proof", () => {
         true,
       );
 
+      const readFeatureEvidence = () =>
+        page.evaluate(
+          ({ sourceId, layerIds, sourceLayerIds }) => {
+            const map = (window as unknown as Record<string, unknown>)
+              .__TEST_MAP__ as TestMap | undefined;
+            const renderedFeatures =
+              map?.queryRenderedFeatures?.({ layers: layerIds }) ?? [];
+            const sourceFeatureCounts = Object.fromEntries(
+              sourceLayerIds.map((sourceLayer) => [
+                sourceLayer,
+                map?.querySourceFeatures?.(sourceId, { sourceLayer })?.length ??
+                  0,
+              ]),
+            );
+            return {
+              sourceLoaded: map?.isSourceLoaded?.(sourceId) ?? false,
+              renderedFeatureCount: renderedFeatures.length,
+              renderedFromExpectedSource: renderedFeatures.filter(
+                (feature) => feature.source === sourceId,
+              ).length,
+              renderedLayerIds: Array.from(
+                new Set(
+                  renderedFeatures
+                    .map((feature) => feature.layer?.id)
+                    .filter((layerId): layerId is string => Boolean(layerId)),
+                ),
+              ),
+              sourceFeatureCounts,
+              sourceFeatureCount: Object.values(sourceFeatureCounts).reduce(
+                (sum, count) => sum + count,
+                0,
+              ),
+            };
+          },
+          {
+            sourceId: SOURCE_ID,
+            layerIds: REGION_LAYER_IDS,
+            sourceLayerIds: SOURCE_LAYER_IDS,
+          },
+        );
+
+      await expect
+        .poll(
+          async () => (await readFeatureEvidence()).renderedFromExpectedSource,
+          {
+            message: "Expected rendered features from the Hamburg source",
+            timeout: 30_000,
+          },
+        )
+        .toBeGreaterThan(0);
+      await expect
+        .poll(async () => (await readFeatureEvidence()).sourceFeatureCount, {
+          message:
+            "Expected decoded vector features from Hamburg source-layers",
+          timeout: 30_000,
+        })
+        .toBeGreaterThan(0);
+      const featureEvidence = await readFeatureEvidence();
+
+      await expect
+        .poll(
+          () =>
+            pmtilesResponses.filter((response) => response.status === 206)
+              .length,
+          {
+            message: "Expected observed HTTP 206 responses for Hamburg PMTiles",
+            timeout: 30_000,
+          },
+        )
+        .toBeGreaterThan(0);
+
+      expect(featureEvidence.sourceLoaded).toBe(true);
+      expect(
+        featureEvidence.sourceFeatureCounts.transportation,
+      ).toBeGreaterThan(0);
+      expect(featureEvidence.sourceFeatureCounts.water).toBeGreaterThan(0);
+      expect(featureEvidence.sourceFeatureCounts.place).toBeGreaterThan(0);
+      expect(failedResponses).toHaveLength(0);
+      expect(consoleErrors).toHaveLength(0);
+
       // Screenshot as visual artifact
       await page.screenshot({
         path: testInfo.outputPath("screenshot.png"),
@@ -336,6 +440,8 @@ test.describe("Basemap Real Hamburg Visual Runtime Proof", () => {
       const proofSummary = {
         timestamp: new Date().toISOString(),
         verdict: "PROVEN",
+        region: "hamburg",
+        source_id: SOURCE_ID,
         pmtiles_filename: REAL_PMTILES_FILENAME,
 
         // SERVER RANGE CONTRACT
@@ -355,6 +461,16 @@ test.describe("Basemap Real Hamburg Visual Runtime Proof", () => {
         ).length,
         canvas_dimensions: canvasDimensions,
         style_loaded: styleLoaded,
+        source_loaded: featureEvidence.sourceLoaded,
+        rendered_feature_count: featureEvidence.renderedFeatureCount,
+        rendered_from_expected_source:
+          featureEvidence.renderedFromExpectedSource,
+        rendered_layer_ids: featureEvidence.renderedLayerIds,
+        decoded_source_feature_count: featureEvidence.sourceFeatureCount,
+        decoded_source_feature_counts_by_layer:
+          featureEvidence.sourceFeatureCounts,
+        failed_responses: failedResponses,
+        console_errors: consoleErrors,
         remote_violations: remoteViolations,
         unexpected_api_requests: unexpectedApiRequests,
 
@@ -427,6 +543,16 @@ test.describe("Basemap Real Hamburg Visual Runtime Proof", () => {
         proofSummary.style_loaded,
         "Proof requires MapLibre style to be loaded",
       ).toBe(true);
+
+      expect(
+        proofSummary.rendered_from_expected_source,
+        "Proof requires visibly rendered features from the Hamburg source",
+      ).toBeGreaterThan(0);
+
+      expect(
+        proofSummary.decoded_source_feature_count,
+        "Proof requires decoded vector features from Hamburg source-layers",
+      ).toBeGreaterThan(0);
 
       // Hard assertion: No external providers
       expect(

--- a/apps/web/tests/proofs/basemap-real-schleswig-holstein-visual.proof.ts
+++ b/apps/web/tests/proofs/basemap-real-schleswig-holstein-visual.proof.ts
@@ -1,0 +1,481 @@
+import { expect, test } from "@playwright/test";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Visual Runtime Proof: real Schleswig-Holstein PMTiles via MapLibre.
+ *
+ * The proof moves the real MapLibre instance to Kiel and requires decoded as
+ * well as visibly rendered features from the Schleswig-Holstein source. The
+ * regional style, glyphs and PMTiles archive are served by the local-basemap
+ * middleware; only application API calls are isolated with explicit mocks.
+ */
+
+const REGION = "schleswig-holstein";
+const SOURCE_ID = "basemap-schleswig-holstein";
+const PMTILES_FILENAME = "basemap-schleswig-holstein.pmtiles";
+const KIEL_CENTER: [number, number] = [10.1228, 54.3233];
+const REGION_LAYER_IDS = [
+  "water-schleswig-holstein",
+  "roads-schleswig-holstein",
+  "buildings-schleswig-holstein",
+  "place-labels-schleswig-holstein",
+];
+const SOURCE_LAYER_IDS = ["transportation", "water", "place"];
+
+const FORBIDDEN_REMOTE_PROVIDERS = [
+  "api.maptiler.com",
+  "tiles.mapbox.com",
+  "api.mapbox.com",
+  "basemaps.cartocdn.com",
+  "tile.openstreetmap.org",
+  "stamen-tiles",
+  "services.arcgisonline.com",
+  "maps.googleapis.com",
+];
+
+type TestMap = {
+  isStyleLoaded?: () => boolean;
+  jumpTo?: (options: { center: [number, number]; zoom: number }) => void;
+  resize?: () => void;
+  triggerRepaint?: () => void;
+  once?: (event: string, handler: () => void) => void;
+  on?: (event: string, handler: (event: unknown) => void) => void;
+  queryRenderedFeatures?: (options?: {
+    layers?: string[];
+  }) => Array<{ source?: string; layer?: { id?: string } }>;
+  querySourceFeatures?: (
+    sourceId: string,
+    options?: { sourceLayer?: string },
+  ) => Array<unknown>;
+  isSourceLoaded?: (sourceId: string) => boolean;
+  getCenter?: () => { lng: number; lat: number };
+  getZoom?: () => number;
+  getStyle?: () => {
+    sources?: Record<string, unknown>;
+    layers?: Array<{ id: string; source?: string }>;
+  };
+};
+
+test.describe("Basemap Real Schleswig-Holstein Visual Runtime Proof", () => {
+  test(
+    "renders real Schleswig-Holstein PMTiles around Kiel with HTTP 206 Range delivery",
+    { tag: "@proof" },
+    async ({ page }, testInfo) => {
+      const buildBasemapDir = path.resolve(
+        process.cwd(),
+        "../../build/basemap",
+      );
+      const aliasPath = path.join(buildBasemapDir, PMTILES_FILENAME);
+      expect(
+        fs.existsSync(aliasPath),
+        `NOT_PROVEN: missing required published PMTiles alias ${aliasPath}`,
+      ).toBe(true);
+
+      const targetRequests: Array<{
+        url: string;
+        rangeHeader: string | null;
+      }> = [];
+      const targetResponses: Array<{
+        url: string;
+        status: number;
+        contentRange: string | null;
+      }> = [];
+      const failedResponses: Array<{ url: string; status: number }> = [];
+      const remoteViolations: string[] = [];
+      const consoleErrors: string[] = [];
+      const unexpectedApiRequests: string[] = [];
+
+      page.on("console", (message) => {
+        if (message.type() === "error") {
+          consoleErrors.push(message.text());
+        }
+      });
+
+      page.on("request", (request) => {
+        const url = request.url();
+        if (url.includes(`/local-basemap/${PMTILES_FILENAME}`)) {
+          targetRequests.push({
+            url,
+            rangeHeader: request.headers()["range"] ?? null,
+          });
+        }
+        for (const provider of FORBIDDEN_REMOTE_PROVIDERS) {
+          if (url.includes(provider)) {
+            remoteViolations.push(url);
+          }
+        }
+      });
+
+      page.on("response", (response) => {
+        const url = response.url();
+        const status = response.status();
+        if (status >= 400) {
+          failedResponses.push({ url, status });
+        }
+        if (url.includes(`/local-basemap/${PMTILES_FILENAME}`)) {
+          targetResponses.push({
+            url,
+            status,
+            contentRange: response.headers()["content-range"] ?? null,
+          });
+        }
+      });
+
+      await page.route("**/favicon.ico", (route) =>
+        route.fulfill({ status: 204, body: "" }),
+      );
+      await page.route("**/_app/version.json", (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ version: "proof" }),
+        }),
+      );
+      await page.route("**/api/**", async (route) => {
+        const url = new URL(route.request().url());
+        const pathname = url.pathname;
+        if (
+          pathname === "/api/nodes" ||
+          pathname.startsWith("/api/nodes/") ||
+          pathname === "/api/accounts" ||
+          pathname.startsWith("/api/accounts/") ||
+          pathname === "/api/edges" ||
+          pathname.startsWith("/api/edges/")
+        ) {
+          return route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify([]),
+          });
+        }
+        if (pathname === "/api/health" || pathname.startsWith("/api/health/")) {
+          return route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({ status: "Ready" }),
+          });
+        }
+        if (pathname === "/api/auth/me" || pathname === "/api/me") {
+          return route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({ authenticated: false, role: "gast" }),
+          });
+        }
+        const requestPathWithQuery = `${url.pathname}${url.search}`;
+        unexpectedApiRequests.push(requestPathWithQuery);
+        return route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ error: requestPathWithQuery }),
+        });
+      });
+
+      await page.goto(`/map?proof=1&region=${REGION}&t=${Date.now()}`);
+
+      const styleResponse = await page.request.get("/local-basemap/style.json");
+      expect(styleResponse.status()).toBe(200);
+      expect(styleResponse.headers()["content-type"] ?? "").toContain(
+        "application/json",
+      );
+      const styleJson = (await styleResponse.json()) as {
+        sources?: Record<string, { url?: string }>;
+      };
+      expect(styleJson.sources?.[SOURCE_ID]?.url).toBe(
+        `pmtiles://${PMTILES_FILENAME}`,
+      );
+
+      const directRangeResponse = await page.request.get(
+        `/local-basemap/${PMTILES_FILENAME}`,
+        { headers: { Range: "bytes=0-511" } },
+      );
+      expect(directRangeResponse.status()).toBe(206);
+      expect(directRangeResponse.headers()["accept-ranges"] ?? "").toContain(
+        "bytes",
+      );
+      expect(directRangeResponse.headers()["content-range"] ?? "").toContain(
+        "bytes 0-511/",
+      );
+      expect(
+        Buffer.from(await directRangeResponse.body())
+          .subarray(0, 7)
+          .toString(),
+      ).toBe("PMTiles");
+
+      await expect(page.locator("#map")).toBeVisible({ timeout: 20_000 });
+      await expect(page.locator("#map canvas")).toBeVisible({
+        timeout: 25_000,
+      });
+      await expect
+        .poll(
+          () =>
+            page.evaluate(() => {
+              const map = (window as unknown as Record<string, unknown>)
+                .__TEST_MAP__ as TestMap | undefined;
+              return map?.isStyleLoaded?.() ?? false;
+            }),
+          {
+            message: "MapLibre style must load before moving to Kiel",
+            timeout: 20_000,
+          },
+        )
+        .toBeTruthy();
+
+      await page.evaluate(() => {
+        const map = (window as unknown as Record<string, unknown>)
+          .__TEST_MAP__ as TestMap | undefined;
+        const errors: string[] = [];
+        (window as unknown as Record<string, unknown>).__SH_MAP_ERRORS__ =
+          errors;
+        map?.on?.("error", (event: unknown) => {
+          const candidate = event as {
+            error?: { message?: string };
+            message?: string;
+          };
+          errors.push(
+            candidate.error?.message ??
+              candidate.message ??
+              JSON.stringify(event),
+          );
+        });
+      });
+
+      await page.evaluate(
+        async ({ center }) => {
+          const map = (window as unknown as Record<string, unknown>)
+            .__TEST_MAP__ as TestMap | undefined;
+          if (!map?.jumpTo || !map.once) {
+            throw new Error(
+              "MapLibre test hook does not expose jumpTo() and once()",
+            );
+          }
+          await new Promise<void>((resolve, reject) => {
+            const timer = window.setTimeout(
+              () =>
+                reject(new Error("MapLibre did not become idle around Kiel")),
+              30_000,
+            );
+            map.once?.("idle", () => {
+              window.clearTimeout(timer);
+              resolve();
+            });
+            map.resize?.();
+            map.jumpTo?.({ center, zoom: 12 });
+            map.triggerRepaint?.();
+          });
+        },
+        { center: KIEL_CENTER },
+      );
+
+      await expect
+        .poll(
+          () =>
+            targetRequests.filter((request) =>
+              request.rangeHeader?.startsWith("bytes="),
+            ).length,
+          {
+            message: `Expected Range requests for ${PMTILES_FILENAME}`,
+            timeout: 30_000,
+          },
+        )
+        .toBeGreaterThan(0);
+
+      await expect
+        .poll(
+          () =>
+            targetResponses.filter((response) => response.status === 206)
+              .length,
+          {
+            message: `Expected HTTP 206 responses for ${PMTILES_FILENAME}`,
+            timeout: 30_000,
+          },
+        )
+        .toBeGreaterThan(0);
+
+      await expect
+        .poll(
+          () =>
+            page.evaluate((sourceId) => {
+              const map = (window as unknown as Record<string, unknown>)
+                .__TEST_MAP__ as TestMap | undefined;
+              return map?.isSourceLoaded?.(sourceId) ?? false;
+            }, SOURCE_ID),
+          {
+            message: "Schleswig-Holstein vector source must finish loading",
+            timeout: 30_000,
+          },
+        )
+        .toBeTruthy();
+
+      const readFeatureEvidence = () =>
+        page.evaluate(
+          ({ sourceId, layerIds, sourceLayerIds }) => {
+            const map = (window as unknown as Record<string, unknown>)
+              .__TEST_MAP__ as TestMap | undefined;
+            const renderedFeatures =
+              map?.queryRenderedFeatures?.({ layers: layerIds }) ?? [];
+            const sourceFeatureCounts = Object.fromEntries(
+              sourceLayerIds.map((sourceLayer) => [
+                sourceLayer,
+                map?.querySourceFeatures?.(sourceId, { sourceLayer })?.length ??
+                  0,
+              ]),
+            );
+            return {
+              renderedFeatureCount: renderedFeatures.length,
+              renderedFromExpectedSource: renderedFeatures.filter(
+                (feature) => feature.source === sourceId,
+              ).length,
+              renderedLayerIds: Array.from(
+                new Set(
+                  renderedFeatures
+                    .map((feature) => feature.layer?.id)
+                    .filter((layerId): layerId is string => Boolean(layerId)),
+                ),
+              ),
+              sourceFeatureCounts,
+              sourceFeatureCount: Object.values(sourceFeatureCounts).reduce(
+                (sum, count) => sum + count,
+                0,
+              ),
+            };
+          },
+          {
+            sourceId: SOURCE_ID,
+            layerIds: REGION_LAYER_IDS,
+            sourceLayerIds: SOURCE_LAYER_IDS,
+          },
+        );
+
+      await expect
+        .poll(
+          async () => (await readFeatureEvidence()).renderedFromExpectedSource,
+          {
+            message:
+              "Expected rendered features from the Schleswig-Holstein source around Kiel",
+            timeout: 30_000,
+          },
+        )
+        .toBeGreaterThan(0);
+
+      await expect
+        .poll(async () => (await readFeatureEvidence()).sourceFeatureCount, {
+          message:
+            "Expected decoded vector features from Schleswig-Holstein source-layers around Kiel",
+          timeout: 30_000,
+        })
+        .toBeGreaterThan(0);
+
+      const featureEvidence = await readFeatureEvidence();
+      const mapDiagnostics = await page.evaluate(
+        ({ sourceId }) => {
+          const map = (window as unknown as Record<string, unknown>)
+            .__TEST_MAP__ as TestMap | undefined;
+          const style = map?.getStyle?.();
+          return {
+            center: map?.getCenter?.() ?? null,
+            zoom: map?.getZoom?.() ?? null,
+            sourceLoaded: map?.isSourceLoaded?.(sourceId) ?? false,
+            styleHasSource: Boolean(style?.sources?.[sourceId]),
+            mapErrors:
+              ((window as unknown as Record<string, unknown>)
+                .__SH_MAP_ERRORS__ as string[] | undefined) ?? [],
+            styleRegionLayers:
+              style?.layers
+                ?.filter((layer) => layer.source === sourceId)
+                .map((layer) => layer.id) ?? [],
+          };
+        },
+        { sourceId: SOURCE_ID },
+      );
+
+      expect(mapDiagnostics.center?.lng).toBeCloseTo(KIEL_CENTER[0], 3);
+      expect(mapDiagnostics.center?.lat).toBeCloseTo(KIEL_CENTER[1], 3);
+      expect(mapDiagnostics.zoom).toBeCloseTo(12, 1);
+      expect(mapDiagnostics.sourceLoaded).toBe(true);
+      expect(mapDiagnostics.styleHasSource).toBe(true);
+      expect(mapDiagnostics.styleRegionLayers).toEqual(
+        expect.arrayContaining(REGION_LAYER_IDS),
+      );
+      expect(featureEvidence.renderedFromExpectedSource).toBeGreaterThan(0);
+      expect(
+        featureEvidence.sourceFeatureCounts.transportation,
+      ).toBeGreaterThan(0);
+      expect(featureEvidence.sourceFeatureCounts.water).toBeGreaterThan(0);
+      expect(featureEvidence.sourceFeatureCounts.place).toBeGreaterThan(0);
+      expect(mapDiagnostics.mapErrors).toHaveLength(0);
+      expect(remoteViolations).toHaveLength(0);
+      expect(unexpectedApiRequests).toHaveLength(0);
+      expect(failedResponses).toHaveLength(0);
+      expect(consoleErrors).toHaveLength(0);
+
+      const screenshotPath = testInfo.outputPath("screenshot.png");
+      await page.screenshot({ path: screenshotPath, fullPage: false });
+
+      const proofSummary = {
+        timestamp: new Date().toISOString(),
+        verdict: "PROVEN",
+        region: REGION,
+        center: mapDiagnostics.center,
+        zoom: mapDiagnostics.zoom,
+        source_id: SOURCE_ID,
+        source_loaded: mapDiagnostics.sourceLoaded,
+        style_region_layers: mapDiagnostics.styleRegionLayers,
+        pmtiles_filename: PMTILES_FILENAME,
+        direct_range_status: directRangeResponse.status(),
+        direct_range_content_range:
+          directRangeResponse.headers()["content-range"] ?? null,
+        pmtiles_range_requests_observed: targetRequests.filter((request) =>
+          request.rangeHeader?.startsWith("bytes="),
+        ).length,
+        pmtiles_206_responses_observed: targetResponses.filter(
+          (response) => response.status === 206,
+        ).length,
+        rendered_feature_count: featureEvidence.renderedFeatureCount,
+        rendered_from_expected_source:
+          featureEvidence.renderedFromExpectedSource,
+        rendered_layer_ids: featureEvidence.renderedLayerIds,
+        decoded_source_feature_count: featureEvidence.sourceFeatureCount,
+        decoded_source_feature_counts_by_layer:
+          featureEvidence.sourceFeatureCounts,
+        map_errors: mapDiagnostics.mapErrors,
+        failed_responses: failedResponses,
+        remote_violations: remoteViolations,
+        unexpected_api_requests: unexpectedApiRequests,
+        console_errors: consoleErrors,
+      };
+      const proofSummaryJson = JSON.stringify(proofSummary, null, 2);
+      const testSummaryPath = testInfo.outputPath("proof-summary.json");
+      fs.writeFileSync(testSummaryPath, proofSummaryJson);
+
+      await testInfo.attach("schleswig-holstein-proof-summary", {
+        body: Buffer.from(proofSummaryJson),
+        contentType: "application/json",
+      });
+      await testInfo.attach("schleswig-holstein-screenshot", {
+        path: screenshotPath,
+        contentType: "image/png",
+      });
+
+      const buildProofDir = path.resolve(
+        process.cwd(),
+        "../../build/proofs/basemap-visual",
+      );
+      fs.mkdirSync(buildProofDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(buildProofDir, "schleswig-holstein-proof-summary.json"),
+        proofSummaryJson,
+      );
+      fs.copyFileSync(
+        screenshotPath,
+        path.join(buildProofDir, "schleswig-holstein-screenshot.png"),
+      );
+
+      console.log(
+        "BASEMAP_SCHLESWIG_HOLSTEIN_PROOF_SUMMARY:",
+        proofSummaryJson,
+      );
+    },
+  );
+});

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -37,7 +37,7 @@ Weltgewebe UI deployment fundamentally operates on three coupled layers:
 2. **Container mount layer**: A bind mount structurally exposes these artifacts to the `edge-caddy` container (`/srv/weltgewebe-web`).
 3. **Edge serving layer**: Caddy reads and serves these static files to the client.
 
-A successful frontend build does *not* automatically guarantee a successful deployment unless the container mount layer correctly reflects the newly built files. The complete chain (Build + Container-Mount + Edge-Serving) is necessary for server-side deployment correctness. It is a known issue with Docker bind mounts that they can drift from the host directory state (meaning the container sees an empty or outdated directory despite the host having the latest files).
+A successful frontend build does _not_ automatically guarantee a successful deployment unless the container mount layer correctly reflects the newly built files. The complete chain (Build + Container-Mount + Edge-Serving) is necessary for server-side deployment correctness. It is a known issue with Docker bind mounts that they can drift from the host directory state (meaning the container sees an empty or outdated directory despite the host having the latest files).
 
 To enforce correct runtime state, the deploy pipeline includes an active guard. After building the UI, `weltgewebe-up` verifies that the `edge-caddy` container can genuinely read the critical build artifacts (`test -s /srv/weltgewebe-web/index.html && test -d /srv/weltgewebe-web/_app`). If this check fails, the pipeline forces a refresh of the edge deployment stack to restore the `edge-caddy` mount coupling, provided frontend delivery is required for the current deploy run.
 
@@ -53,11 +53,11 @@ Server-side correctness does not intrinsically prevent browsers from rendering s
    - **Client-visible diagnostics**: The technical build identifier is also shown directly in the Settings UI.
    - **Primary use**: Enables immediate comparison of delivered versions across clients (for example, Browser A vs. Browser B).
 
-*Note (Phase C Preparation): Future Evaluation: The current bind-mount model could theoretically be replaced by a dedicated Web-Container architecture to eliminate host-mount drift entirely.*
+_Note (Phase C Preparation): Future Evaluation: The current bind-mount model could theoretically be replaced by a dedicated Web-Container architecture to eliminate host-mount drift entirely._
 
 ### Basemap Artifact Deployment (Best Effort)
 
-The deployment script (`weltgewebe-up`) attempts to provide the sovereign PMTiles basemap artifact in the `build/basemap/` directory as a best-effort guard before stack initialization. The deploy/serve path can mount and serve it, but this does not imply the frontend is configured to consume it in production.
+The deployment script (`weltgewebe-up`) attempts to provide every regional PMTiles source required by `map-style/style.json` in the `build/basemap/` directory before stack initialization. Hamburg and Schleswig-Holstein are built and published independently. Each region has a versioned artifact plus stable `.pmtiles` and `.meta.json` aliases. The guard remains best effort, but it reports missing regions separately so one existing region cannot hide another missing one.
 
 #### `PUBLIC_BASEMAP_MODE` Contract
 
@@ -67,12 +67,13 @@ To instruct the production frontend to actually consume the locally hosted sover
 - **Allowed Values:** `local-sovereign` | `remote-style`
 - **Default Behavior:** If unset or invalid, the application falls back to `local-sovereign` in local development/testing contexts, and `remote-style` in production builds.
 - **Purpose:** This flag acts as a deployment-time enablement switch. It allows target environments (like a Heimserver) to actively opt into the fully sovereign map architecture without requiring code changes.
-- **Note:** Setting this flag enables the *frontend capability*. A fully operational rollout still strictly requires the underlying infrastructure (e.g., Caddy routing for `/local-basemap/` and the physical PMTiles artifact) to be proven and present at runtime.
+- **Note:** Setting this flag enables the _frontend capability_. A fully operational rollout still strictly requires the underlying infrastructure (e.g., Caddy routing for `/local-basemap/` and the physical PMTiles artifact) to be proven and present at runtime.
 
 To locally verify the artifact state:
 
 ```bash
-find build/basemap -maxdepth 1 -name "*.pmtiles" -print
+find build/basemap -maxdepth 1 \
+  \( -name "basemap-hamburg*.pmtiles" -o -name "basemap-schleswig-holstein*.pmtiles" \) -print
 ```
 
 ## Preflight guard

--- a/map-style/README.md
+++ b/map-style/README.md
@@ -11,6 +11,7 @@ To ensure total visual sovereignty and compliance (no silent vendor dependencies
 * glyphs are referenced via the stable `/local-basemap/glyphs/{fontstack}/{range}.pbf` runtime path and must be served by the same local-basemap route as `style.json`
 * `pmtiles://` URLs require a protocol handler in the MapLibre runtime (not part of this configuration)
 * The current configuration is wired for the local-sovereign runtime route `/local-basemap/`
+* The style composes two independent regional PMTiles sources: `basemap-hamburg.pmtiles` and `basemap-schleswig-holstein.pmtiles`. Each source carries the same OpenMapTiles layer schema; the style repeats the visual layers for both regions.
 
 ## Structure
 
@@ -20,6 +21,6 @@ To ensure total visual sovereignty and compliance (no silent vendor dependencies
 
 > **Note on Sprites:** To maintain a visually calmed infrastructure basemap, sprites (icons/patterns) are intentionally omitted from this map style MVP. Visual semantics belong in the Weltgewebe overlay.
 
-## Next Steps
+## Regional coverage
 
-1. Load this `style.json` natively in the MapLibre client once the PMTiles protocol is registered.
+The sovereign basemap currently covers Hamburg and Schleswig-Holstein. Additions must provide all four parts together: a pinned build script, a stable PMTiles alias, matching style layers, and an independent runtime/content proof. A style-only source is not considered deployed.

--- a/map-style/style.json
+++ b/map-style/style.json
@@ -2,13 +2,17 @@
   "version": 8,
   "name": "Weltgewebe Sovereign Basemap",
   "metadata": {
-    "weltgewebe:version": "0.1.0",
+    "weltgewebe:version": "0.2.0",
     "weltgewebe:note": "PMTiles URL is a placeholder; actual resolution depends on runtime protocol handler"
   },
   "sources": {
     "basemap": {
       "type": "vector",
       "url": "pmtiles://basemap-hamburg.pmtiles"
+    },
+    "basemap-schleswig-holstein": {
+      "type": "vector",
+      "url": "pmtiles://basemap-schleswig-holstein.pmtiles"
     }
   },
   "glyphs": "/local-basemap/glyphs/{fontstack}/{range}.pbf",
@@ -30,9 +34,28 @@
       }
     },
     {
+      "id": "water-schleswig-holstein",
+      "type": "fill",
+      "source": "basemap-schleswig-holstein",
+      "source-layer": "water",
+      "paint": {
+        "fill-color": "#a0c8f0"
+      }
+    },
+    {
       "id": "roads",
       "type": "line",
       "source": "basemap",
+      "source-layer": "transportation",
+      "paint": {
+        "line-color": "#ffffff",
+        "line-width": 1.5
+      }
+    },
+    {
+      "id": "roads-schleswig-holstein",
+      "type": "line",
+      "source": "basemap-schleswig-holstein",
       "source-layer": "transportation",
       "paint": {
         "line-color": "#ffffff",
@@ -50,9 +73,35 @@
       }
     },
     {
+      "id": "buildings-schleswig-holstein",
+      "type": "fill",
+      "source": "basemap-schleswig-holstein",
+      "source-layer": "building",
+      "paint": {
+        "fill-color": "#d0d0d0",
+        "fill-opacity": 0.5
+      }
+    },
+    {
       "id": "place-labels",
       "type": "symbol",
       "source": "basemap",
+      "source-layer": "place",
+      "layout": {
+        "text-field": "{name}",
+        "text-font": ["Noto Sans Regular"],
+        "text-size": 14
+      },
+      "paint": {
+        "text-color": "#333333",
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "place-labels-schleswig-holstein",
+      "type": "symbol",
+      "source": "basemap-schleswig-holstein",
       "source-layer": "place",
       "layout": {
         "text-field": "{name}",

--- a/scripts/basemap/build-schleswig-holstein-pmtiles.sh
+++ b/scripts/basemap/build-schleswig-holstein-pmtiles.sh
@@ -80,18 +80,51 @@ if [ "$ACTUAL_SHA256" != "$OSM_SHA256" ]; then
 fi
 echo "   [✓] Input integrity verified."
 
-echo "=> Running Planetiler via Docker to generate $OUTPUT_PMTILES..."
-if ! docker run --rm \
-  --platform linux/amd64 \
-  --user "$(id -u):$(id -g)" \
-  -v "$BASEMAP_DIR":/data \
-  "$PLANETILER_IMAGE" \
-  --osm-path="/data/$OSM_FILE" \
-  --output="/data/$OUTPUT_PMTILES" \
-  --download=true; then
-  echo "Error: Docker execution failed." >&2
+PLANETILER_MAX_ATTEMPTS="${PLANETILER_MAX_ATTEMPTS:-3}"
+PLANETILER_RETRY_DELAY_SECONDS="${PLANETILER_RETRY_DELAY_SECONDS:-5}"
+if ! [[ "$PLANETILER_MAX_ATTEMPTS" =~ ^[1-5]$ ]]; then
+  echo "Error: PLANETILER_MAX_ATTEMPTS must be an integer from 1 to 5." >&2
   exit 1
 fi
+if ! [[ "$PLANETILER_RETRY_DELAY_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "Error: PLANETILER_RETRY_DELAY_SECONDS must be a non-negative integer." >&2
+  exit 1
+fi
+
+run_planetiler() {
+  docker run --rm \
+    --platform linux/amd64 \
+    --user "$(id -u):$(id -g)" \
+    -v "$BASEMAP_DIR":/data \
+    "$PLANETILER_IMAGE" \
+    --osm-path="/data/$OSM_FILE" \
+    --output="/data/$OUTPUT_PMTILES" \
+    --download=true
+}
+
+echo "=> Running Planetiler via Docker to generate $OUTPUT_PMTILES..."
+PLANETILER_ATTEMPT=1
+while true; do
+  # Keep fully downloaded auxiliary sources across attempts, but never reuse
+  # partial output or temporary feature stores from a failed build.
+  rm -f \
+    "$BASEMAP_DIR/$OUTPUT_PMTILES" \
+    "$BASEMAP_DIR/$OUTPUT_PMTILES.layerstats.tsv.gz"
+  rm -rf "$BASEMAP_DIR/tmp"
+
+  if run_planetiler; then
+    break
+  fi
+
+  if [ "$PLANETILER_ATTEMPT" -ge "$PLANETILER_MAX_ATTEMPTS" ]; then
+    echo "Error: Planetiler failed after $PLANETILER_ATTEMPT attempt(s)." >&2
+    exit 1
+  fi
+
+  echo "Warning: Planetiler attempt $PLANETILER_ATTEMPT failed; retrying after ${PLANETILER_RETRY_DELAY_SECONDS}s." >&2
+  sleep "$PLANETILER_RETRY_DELAY_SECONDS"
+  PLANETILER_ATTEMPT=$((PLANETILER_ATTEMPT + 1))
+done
 
 if [ ! -f "$BASEMAP_DIR/$OUTPUT_PMTILES" ]; then
   echo "Error: Artifact $OUTPUT_PMTILES not found." >&2

--- a/scripts/basemap/build-schleswig-holstein-pmtiles.sh
+++ b/scripts/basemap/build-schleswig-holstein-pmtiles.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Operational bootstrap for the sovereign Schleswig-Holstein PMTiles basemap.
+# The OSM input and Planetiler image are pinned and hash-verified.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." > /dev/null 2>&1 && pwd)"
+BASEMAP_DIR="$REPO_ROOT/build/basemap"
+
+OSM_FILE="schleswig-holstein-260101.osm.pbf"
+OSM_URL="https://download.geofabrik.de/europe/germany/schleswig-holstein-260101.osm.pbf"
+OSM_SHA256="3e5efb30488daa87a098d61bf1f60155f89cdcf900aeadee5a1cd27910bfd450"
+
+BASEMAP_VERSION="0.1.0"
+BASEMAP_TAG="v${BASEMAP_VERSION}"
+OUTPUT_PMTILES="basemap-schleswig-holstein-${BASEMAP_TAG}.pmtiles"
+OUTPUT_META="basemap-schleswig-holstein-${BASEMAP_TAG}.meta.json"
+
+PLANETILER_IMAGE="ghcr.io/onthegomap/planetiler@sha256:10e4d6850664bd2ad7a223623383c48281e7d87fb427360838b13342cac012bb"
+
+echo "=== Weltgewebe Basemap Builder ==="
+echo "Target:  Schleswig-Holstein"
+echo "Version: ${BASEMAP_VERSION} (Tag: ${BASEMAP_TAG})"
+echo "Tool:    Planetiler (Pinned: 0.8.2 @ sha256:10e4...)"
+echo "Input:   $OSM_FILE (Pinned & Hash-Verified)"
+echo "Format:  PMTiles"
+echo "=================================="
+
+if ! command -v docker > /dev/null 2>&1; then
+  echo "Error: 'docker' is required but not installed or not in PATH." >&2
+  exit 1
+fi
+
+DOWNLOADER=""
+if command -v wget > /dev/null 2>&1; then
+  DOWNLOADER="wget"
+elif command -v curl > /dev/null 2>&1; then
+  DOWNLOADER="curl"
+else
+  echo "Error: Neither 'wget' nor 'curl' is available for downloading the OSM data." >&2
+  exit 1
+fi
+
+mkdir -p "$BASEMAP_DIR"
+cd "$BASEMAP_DIR"
+
+if [ ! -f "$OSM_FILE" ]; then
+  echo "=> Downloading OSM data for Schleswig-Holstein ($OSM_FILE)..."
+  if [ "$DOWNLOADER" = "wget" ]; then
+    wget --tries=5 --waitretry=3 --retry-connrefused --timeout=30 -O "$OSM_FILE" "$OSM_URL" || {
+      rm -f "$OSM_FILE"
+      exit 1
+    }
+  else
+    curl -fL --retry 5 --retry-delay 3 -o "$OSM_FILE" "$OSM_URL" || {
+      rm -f "$OSM_FILE"
+      exit 1
+    }
+  fi
+else
+  echo "=> OSM data '$OSM_FILE' already exists locally, skipping download."
+fi
+
+if command -v sha256sum > /dev/null 2>&1; then
+  SHA256_CMD=(sha256sum)
+elif command -v shasum > /dev/null 2>&1; then
+  SHA256_CMD=(shasum -a 256)
+else
+  echo "Error: 'sha256sum' or 'shasum' is required for artifact verification." >&2
+  exit 1
+fi
+
+ACTUAL_SHA256="$("${SHA256_CMD[@]}" "$OSM_FILE" | awk '{print $1}')"
+if [ "$ACTUAL_SHA256" != "$OSM_SHA256" ]; then
+  echo "Error: Checksum mismatch for $OSM_FILE!" >&2
+  echo "Expected: $OSM_SHA256" >&2
+  echo "Actual:   $ACTUAL_SHA256" >&2
+  exit 1
+fi
+echo "   [✓] Input integrity verified."
+
+echo "=> Running Planetiler via Docker to generate $OUTPUT_PMTILES..."
+if ! docker run --rm \
+  --platform linux/amd64 \
+  --user "$(id -u):$(id -g)" \
+  -v "$BASEMAP_DIR":/data \
+  "$PLANETILER_IMAGE" \
+  --osm-path="/data/$OSM_FILE" \
+  --output="/data/$OUTPUT_PMTILES" \
+  --download=true; then
+  echo "Error: Docker execution failed." >&2
+  exit 1
+fi
+
+if [ ! -f "$BASEMAP_DIR/$OUTPUT_PMTILES" ]; then
+  echo "Error: Artifact $OUTPUT_PMTILES not found." >&2
+  exit 1
+fi
+
+PMTILES_SIZE=$(wc -c < "$BASEMAP_DIR/$OUTPUT_PMTILES" | tr -d '[:space:]')
+PMTILES_SHA256="$("${SHA256_CMD[@]}" "$BASEMAP_DIR/$OUTPUT_PMTILES" | awk '{print $1}')"
+if [ -z "$PMTILES_SHA256" ] || [ "$PMTILES_SIZE" -eq 0 ]; then
+  echo "Error: Failed to determine valid size or hash for $OUTPUT_PMTILES." >&2
+  exit 1
+fi
+
+BUILD_TIMESTAMP_VALUE=""
+if [ "${NON_REPRODUCIBLE_BUILD_TIMESTAMP:-}" = "1" ]; then
+  BUILD_TIMESTAMP_VALUE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+elif [ -n "${SOURCE_DATE_EPOCH:-}" ]; then
+  BUILD_TIMESTAMP_VALUE="$(date -u -d "@${SOURCE_DATE_EPOCH}" +"%Y-%m-%dT%H:%M:%SZ")" || BUILD_TIMESTAMP_VALUE=""
+fi
+
+if [ -n "$BUILD_TIMESTAMP_VALUE" ]; then
+  BUILD_TIMESTAMP_JSON="  \"build_timestamp\": \"${BUILD_TIMESTAMP_VALUE}\","
+else
+  BUILD_TIMESTAMP_JSON=""
+fi
+
+cat << MANIFEST > "$BASEMAP_DIR/$OUTPUT_META"
+{
+  "version": "${BASEMAP_VERSION}",
+  "region": "schleswig-holstein",
+${BUILD_TIMESTAMP_JSON}
+  "toolchain": {
+    "generator": "planetiler",
+    "image": "${PLANETILER_IMAGE}"
+  },
+  "input": {
+    "url": "${OSM_URL}",
+    "sha256": "${OSM_SHA256}",
+    "note": "Pinned historical snapshot with verified SHA256 integrity"
+  },
+  "artifact_name": "${OUTPUT_PMTILES}",
+  "sha256": "${PMTILES_SHA256}",
+  "size_bytes": ${PMTILES_SIZE},
+  "status": "ready"
+}
+MANIFEST
+
+echo "=> Basemap generation complete!"
+echo "Artifact: $BASEMAP_DIR/$OUTPUT_PMTILES"
+echo "Metadata: $BASEMAP_DIR/$OUTPUT_META"

--- a/scripts/ci/tests/test_public_live_readiness.py
+++ b/scripts/ci/tests/test_public_live_readiness.py
@@ -56,7 +56,10 @@ class FakeWorld:
             return FetchResult(url, 200, {"Content-Type": "application/json"}, json.dumps(body).encode())
         if url == "https://weltgewebe.net/local-basemap/glyphs/Noto%20Sans%20Regular/0-255.pbf":
             return FetchResult(url, 200, {}, b"glyph-bytes")
-        if url == "https://weltgewebe.net/local-basemap/basemap-hamburg-v0.1.0.pmtiles":
+        if url in {
+            "https://weltgewebe.net/local-basemap/basemap-hamburg-v0.1.0.pmtiles",
+            "https://weltgewebe.net/local-basemap/basemap-schleswig-holstein-v0.1.0.pmtiles",
+        }:
             return FetchResult(url, 206, {"Content-Range": "bytes 0-15/100"}, b"PMTiles\x03fake")
         return FetchResult(url, 404, {}, b"")
 
@@ -90,11 +93,15 @@ class PublicLiveReadinessTest(unittest.TestCase):
                 "version-json",
                 "basemap-style",
                 "glyph-range",
-                "pmtiles-header",
+                "pmtiles-header:hamburg",
+                "pmtiles-header:schleswig-holstein",
             },
         )
         pmtiles_requests = [headers for url, headers in fake.requests if url.endswith(".pmtiles")]
-        self.assertEqual(pmtiles_requests, [{"Range": "bytes=0-15"}])
+        self.assertEqual(
+            pmtiles_requests,
+            [{"Range": "bytes=0-15"}, {"Range": "bytes=0-15"}],
+        )
 
     def test_wrong_dns_ip_fails(self) -> None:
         fake = FakeWorld(ip="213.21.44.105")
@@ -142,10 +149,13 @@ class PublicLiveReadinessTest(unittest.TestCase):
             return fake.fetcher(url, headers, timeout)
 
         checker = fake.module.PublicLiveChecker(resolver=fake.resolver, fetcher=bad_fetcher)
-        pmtiles_result = [result for result in checker.run() if result.name == "pmtiles-header"][0]
+        pmtiles_results = [
+            result for result in checker.run() if result.name.startswith("pmtiles-header:")
+        ]
 
-        self.assertFalse(pmtiles_result.ok)
-        self.assertIn("missing", pmtiles_result.detail)
+        self.assertEqual(len(pmtiles_results), 2)
+        self.assertTrue(all(not result.ok for result in pmtiles_results))
+        self.assertTrue(all("missing" in result.detail for result in pmtiles_results))
 
 
 class PublicLiveReadinessIPv6Test(unittest.TestCase):

--- a/scripts/ci/tests/test_regional_basemap_style.py
+++ b/scripts/ci/tests/test_regional_basemap_style.py
@@ -76,6 +76,31 @@ class RegionalBasemapStyleTest(unittest.TestCase):
         self.assertIn('"${META_PATH}"', workflow)
         self.assertNotIn('META_PATH="build/basemap/"', workflow)
 
+    def test_visual_proof_materializes_both_regional_sources(self) -> None:
+        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        visual_job = workflow[workflow.index("  basemap-visual-proof:") :]
+
+        self.assertIn(
+            "      - basemap-schleswig-holstein-content-proof",
+            visual_job,
+        )
+        self.assertIn(
+            "name: basemap-schleswig-holstein-content-proof-evidence",
+            visual_job,
+        )
+        self.assertIn(
+            "for region in hamburg schleswig-holstein; do",
+            visual_job,
+        )
+        self.assertIn(
+            '"build/basemap/basemap-${region}-v0.1.0.pmtiles"',
+            visual_job,
+        )
+        self.assertIn(
+            "build/basemap/basemap-schleswig-holstein-v0.1.0.pmtiles",
+            workflow[: workflow.index("  basemap-visual-proof:")],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/ci/tests/test_regional_basemap_style.py
+++ b/scripts/ci/tests/test_regional_basemap_style.py
@@ -101,6 +101,37 @@ class RegionalBasemapStyleTest(unittest.TestCase):
             workflow[: workflow.index("  basemap-visual-proof:")],
         )
 
+    def test_visual_proof_materializes_glyphs_and_publishes_both_evidence_sets(
+        self,
+    ) -> None:
+        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        visual_job = workflow[workflow.index("  basemap-visual-proof:") :]
+
+        self.assertIn(
+            "bash scripts/basemap/fetch-glyphs.sh",
+            visual_job,
+        )
+        self.assertIn(
+            'test -s "map-style/glyphs/Noto Sans Regular/0-255.pbf"',
+            visual_job,
+        )
+        self.assertIn(
+            "build/proofs/basemap-visual/*.png",
+            visual_job,
+        )
+        self.assertIn(
+            "build/proofs/basemap-visual/*.json",
+            visual_job,
+        )
+        self.assertIn(
+            'summary_dir / "proof-summary.json"',
+            visual_job,
+        )
+        self.assertIn(
+            'summary_dir / "schleswig-holstein-proof-summary.json"',
+            visual_job,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/ci/tests/test_regional_basemap_style.py
+++ b/scripts/ci/tests/test_regional_basemap_style.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[3]
+STYLE_PATH = REPO / "map-style" / "style.json"
+
+
+class RegionalBasemapStyleTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.style = json.loads(STYLE_PATH.read_text(encoding="utf-8"))
+
+    def test_style_declares_all_regional_pmtiles_sources(self) -> None:
+        sources = self.style["sources"]
+        self.assertEqual(
+            sources["basemap"]["url"],
+            "pmtiles://basemap-hamburg.pmtiles",
+        )
+        self.assertEqual(
+            sources["basemap-schleswig-holstein"]["url"],
+            "pmtiles://basemap-schleswig-holstein.pmtiles",
+        )
+
+    def test_each_regional_source_has_the_same_visual_layer_set(self) -> None:
+        layers = self.style["layers"]
+        hamburg = {
+            layer["id"]
+            for layer in layers
+            if layer.get("source") == "basemap"
+        }
+        schleswig_holstein = {
+            layer["id"].removesuffix("-schleswig-holstein")
+            for layer in layers
+            if layer.get("source") == "basemap-schleswig-holstein"
+        }
+
+        self.assertEqual(
+            hamburg,
+            {"water", "roads", "buildings", "place-labels"},
+        )
+        self.assertEqual(schleswig_holstein, hamburg)
+
+    def test_layer_ids_are_unique_and_sources_exist(self) -> None:
+        sources = self.style["sources"]
+        layer_ids = [layer["id"] for layer in self.style["layers"]]
+        self.assertEqual(len(layer_ids), len(set(layer_ids)))
+        for layer in self.style["layers"]:
+            if "source" in layer:
+                self.assertIn(layer["source"], sources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/tests/test_regional_basemap_style.py
+++ b/scripts/ci/tests/test_regional_basemap_style.py
@@ -8,6 +8,7 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[3]
 STYLE_PATH = REPO / "map-style" / "style.json"
 UP_SCRIPT_PATH = REPO / "scripts" / "weltgewebe-up"
+WORKFLOW_PATH = REPO / ".github" / "workflows" / "basemap-runtime-proof.yml"
 
 
 class RegionalBasemapStyleTest(unittest.TestCase):
@@ -65,6 +66,15 @@ class RegionalBasemapStyleTest(unittest.TestCase):
             + '{regional_meta}"'
         )
         self.assertIn(expected_url, script)
+
+    def test_content_proof_preserves_metadata_hash_variables(self) -> None:
+        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        self.assertIn(
+            'META_PATH="build/basemap/${META_NAME}"',
+            workflow,
+        )
+        self.assertIn('"${META_PATH}"', workflow)
+        self.assertNotIn('META_PATH="build/basemap/"', workflow)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/tests/test_regional_basemap_style.py
+++ b/scripts/ci/tests/test_regional_basemap_style.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[3]
 STYLE_PATH = REPO / "map-style" / "style.json"
+UP_SCRIPT_PATH = REPO / "scripts" / "weltgewebe-up"
 
 
 class RegionalBasemapStyleTest(unittest.TestCase):
@@ -50,6 +51,20 @@ class RegionalBasemapStyleTest(unittest.TestCase):
         for layer in self.style["layers"]:
             if "source" in layer:
                 self.assertIn(layer["source"], sources)
+
+    def test_deploy_readiness_checks_each_regional_metadata_alias(self) -> None:
+        script = UP_SCRIPT_PATH.read_text(encoding="utf-8")
+        self.assertIn(
+            "for regional_meta in basemap-hamburg.meta.json "
+            "basemap-schleswig-holstein.meta.json; do",
+            script,
+        )
+        expected_url = (
+            '"https://weltgewebe.home.arpa/local-basemap/'
+            + chr(36)
+            + '{regional_meta}"'
+        )
+        self.assertIn(expected_url, script)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/tests/test_schleswig_holstein_basemap_builder.py
+++ b/scripts/ci/tests/test_schleswig_holstein_basemap_builder.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[3]
+BUILDER = REPO / "scripts" / "basemap" / "build-schleswig-holstein-pmtiles.sh"
+INPUT_SHA256 = "3e5efb30488daa87a098d61bf1f60155f89cdcf900aeadee5a1cd27910bfd450"
+
+
+class SchleswigHolsteinBasemapBuilderTest(unittest.TestCase):
+    def test_transient_planetiler_failures_retry_without_reusing_partial_output(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            script = root / "scripts" / "basemap" / BUILDER.name
+            script.parent.mkdir(parents=True)
+            shutil.copy2(BUILDER, script)
+
+            basemap_dir = root / "build" / "basemap"
+            basemap_dir.mkdir(parents=True)
+            (basemap_dir / "schleswig-holstein-260101.osm.pbf").write_bytes(b"fixture")
+
+            fake_bin = root / "fake-bin"
+            fake_bin.mkdir()
+            count_path = root / "docker-count"
+            reuse_path = root / "partial-output-reused"
+            output_path = basemap_dir / "basemap-schleswig-holstein-v0.1.0.pmtiles"
+
+            self._write_executable(
+                fake_bin / "sha256sum",
+                f'''#!/usr/bin/env bash
+printf '%s  %s\\n' "{INPUT_SHA256}" "$1"
+''',
+            )
+            self._write_executable(
+                fake_bin / "sleep",
+                "#!/usr/bin/env bash\nexit 0\n",
+            )
+            self._write_executable(
+                fake_bin / "docker",
+                '''#!/usr/bin/env bash
+set -euo pipefail
+count=0
+if [[ -f "$MOCK_DOCKER_COUNT" ]]; then
+  count="$(cat "$MOCK_DOCKER_COUNT")"
+fi
+count=$((count + 1))
+printf '%s\\n' "$count" > "$MOCK_DOCKER_COUNT"
+if [[ -e "$MOCK_OUTPUT" ]]; then
+  printf 'partial output was reused on attempt %s\\n' "$count" > "$MOCK_REUSE_MARKER"
+  exit 91
+fi
+printf 'partial-%s' "$count" > "$MOCK_OUTPUT"
+if [[ "$count" -lt 3 ]]; then
+  exit 1
+fi
+printf 'PMTiles\\003fixture' > "$MOCK_OUTPUT"
+''',
+            )
+
+            environment = os.environ.copy()
+            environment.update(
+                {
+                    "PATH": f"{fake_bin}:{environment['PATH']}",
+                    "PLANETILER_MAX_ATTEMPTS": "3",
+                    "PLANETILER_RETRY_DELAY_SECONDS": "0",
+                    "MOCK_DOCKER_COUNT": str(count_path),
+                    "MOCK_OUTPUT": str(output_path),
+                    "MOCK_REUSE_MARKER": str(reuse_path),
+                }
+            )
+
+            completed = subprocess.run(
+                ["bash", str(script)],
+                cwd=root,
+                env=environment,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertEqual(count_path.read_text(encoding="utf-8").strip(), "3")
+            self.assertFalse(reuse_path.exists())
+            self.assertTrue(output_path.read_bytes().startswith(b"PMTiles"))
+
+            metadata = json.loads(
+                (basemap_dir / "basemap-schleswig-holstein-v0.1.0.meta.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            self.assertEqual(metadata["region"], "schleswig-holstein")
+            self.assertEqual(metadata["status"], "ready")
+            self.assertIn("retrying", completed.stderr)
+
+    @staticmethod
+    def _write_executable(path: Path, content: str) -> None:
+        path.write_text(textwrap.dedent(content), encoding="utf-8")
+        path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ops/check_public_live_readiness.py
+++ b/scripts/ops/check_public_live_readiness.py
@@ -23,7 +23,10 @@ DEFAULT_WWW_DOMAIN = "www.weltgewebe.net"
 DEFAULT_API_DOMAIN = "api.weltgewebe.net"
 DEFAULT_EXPECTED_IP = "94.16.121.119"
 DEFAULT_GLYPH_PATH = "/local-basemap/glyphs/Noto%20Sans%20Regular/0-255.pbf"
-DEFAULT_PMTILES_PATH = "/local-basemap/basemap-hamburg-v0.1.0.pmtiles"
+DEFAULT_PMTILES_PATHS = (
+    ("hamburg", "/local-basemap/basemap-hamburg-v0.1.0.pmtiles"),
+    ("schleswig-holstein", "/local-basemap/basemap-schleswig-holstein-v0.1.0.pmtiles"),
+)
 API_REQUIRED_CHECKS = ("database", "nats", "policy")
 
 
@@ -164,7 +167,7 @@ class PublicLiveChecker:
     resolver: Resolver = socket_resolve_ipv4
     fetcher: Fetcher = fetch_url
     glyph_path: str = DEFAULT_GLYPH_PATH
-    pmtiles_path: str = DEFAULT_PMTILES_PATH
+    pmtiles_paths: Sequence[tuple[str, str]] = DEFAULT_PMTILES_PATHS
 
     def run(self) -> list[CheckResult]:
         checks = [
@@ -178,7 +181,7 @@ class PublicLiveChecker:
             self.check_version_json(),
             self.check_basemap_style(),
             self.check_glyph_range(),
-            self.check_pmtiles_header(),
+            *self.check_pmtiles_headers(),
         ]
         return checks
 
@@ -318,15 +321,30 @@ class PublicLiveChecker:
             return pass_result("glyph-range", "Glyph range PBF is publicly reachable", bytes=len(result.body))
         return fail_result("glyph-range", "Glyph range PBF is not reachable", status=result.status, bytes=len(result.body))
 
-    def check_pmtiles_header(self) -> CheckResult:
-        url = f"https://{self.domain}{self.pmtiles_path}"
+    def check_pmtiles_headers(self) -> list[CheckResult]:
+        return [self.check_pmtiles_header(region, path) for region, path in self.pmtiles_paths]
+
+    def check_pmtiles_header(self, region: str, path: str) -> CheckResult:
+        name = f"pmtiles-header:{region}"
+        url = f"https://{self.domain}{path}"
         try:
             result = self.fetcher(url, {"Range": "bytes=0-15"}, self.timeout)
         except Exception as exc:
-            return fail_result("pmtiles-header", str(exc), url=url)
+            return fail_result(name, str(exc), url=url)
         if result.status in {200, 206} and result.body.startswith(b"PMTiles"):
-            return pass_result("pmtiles-header", "PMTiles artifact header is publicly reachable", status=result.status)
-        return fail_result("pmtiles-header", "PMTiles artifact header missing", status=result.status, prefix=result.body[:16].hex())
+            return pass_result(
+                name,
+                "Regional PMTiles artifact header is publicly reachable",
+                region=region,
+                status=result.status,
+            )
+        return fail_result(
+            name,
+            "Regional PMTiles artifact header missing",
+            region=region,
+            status=result.status,
+            prefix=result.body[:16].hex(),
+        )
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/scripts/weltgewebe-up
+++ b/scripts/weltgewebe-up
@@ -1257,56 +1257,63 @@ fi
 
 if [[ "$DEPLOY_SCOPE" == "full" ]]; then
 
-  # 6c. Basemap Artifact Guard (best effort)
-  # Try to ensure the PMTiles artifact exists for Heimserver Caddy to serve
+  # 6c. Regional Basemap Artifact Guard (best effort)
+  # Each source referenced by map-style/style.json must exist independently.
   BASEMAP_DIR="build/basemap"
+  BASEMAP_VERSION="0.1.0"
   echo
-  echo ">> Basemap Artifact Guard:"
+  echo ">> Regional Basemap Artifact Guard:"
 
-  evaluate_basemap_state() {
-    local pmtiles_files=()
-    mapfile -t pmtiles_files < <(compgen -G "$BASEMAP_DIR/*.pmtiles" || true)
-    PMTILES_COUNT="${#pmtiles_files[@]}"
-    if ((PMTILES_COUNT > 0)); then
-      FIRST_PMTILES="${pmtiles_files[0]}"
-    else
-      FIRST_PMTILES=""
+  ensure_regional_basemap() {
+    local region="$1"
+    local build_script="$2"
+    local versioned_pmtiles="$BASEMAP_DIR/basemap-${region}-v${BASEMAP_VERSION}.pmtiles"
+    local versioned_meta="$BASEMAP_DIR/basemap-${region}-v${BASEMAP_VERSION}.meta.json"
+    local alias_pmtiles="$BASEMAP_DIR/basemap-${region}.pmtiles"
+    local alias_meta="$BASEMAP_DIR/basemap-${region}.meta.json"
+
+    if [[ ! -s "$versioned_pmtiles" || ! -s "$versioned_meta" ]]; then
+      echo "   [!] ${region}: versioned artifact missing; attempting best-effort build."
+      if [[ ! -x "$build_script" ]]; then
+        echo "   [X] WARNING: ${region}: build script missing or not executable: ${build_script}"
+        return 1
+      fi
+      if ! bash "$build_script"; then
+        echo "   [X] WARNING: ${region}: PMTiles build failed."
+        return 1
+      fi
     fi
+
+    if [[ ! -s "$versioned_pmtiles" || ! -s "$versioned_meta" ]]; then
+      echo "   [X] WARNING: ${region}: build completed without both versioned files."
+      return 1
+    fi
+
+    if ! bash scripts/basemap/publish-basemap.sh \
+      "$versioned_pmtiles" "$versioned_meta" "$BASEMAP_DIR"; then
+      echo "   [X] WARNING: ${region}: atomic alias publication failed."
+      return 1
+    fi
+
+    if [[ ! -e "$alias_pmtiles" || ! -e "$alias_meta" ]]; then
+      echo "   [X] WARNING: ${region}: stable PMTiles/meta aliases are missing after publication."
+      return 1
+    fi
+
+    echo "   [✓] ${region}: versioned artifact and stable aliases ready."
   }
 
-  evaluate_basemap_state
-  if ((PMTILES_COUNT > 0)); then
-    echo "   [✓] Artifacts already present. Found ${PMTILES_COUNT} PMTiles artifact(s) in ${BASEMAP_DIR}."
-    echo "       -> e.g. ${FIRST_PMTILES}"
+  REGIONAL_BASEMAP_FAILURES=0
+  ensure_regional_basemap "hamburg" \
+    "scripts/basemap/build-hamburg-pmtiles.sh" || REGIONAL_BASEMAP_FAILURES=$((REGIONAL_BASEMAP_FAILURES + 1))
+  ensure_regional_basemap "schleswig-holstein" \
+    "scripts/basemap/build-schleswig-holstein-pmtiles.sh" || REGIONAL_BASEMAP_FAILURES=$((REGIONAL_BASEMAP_FAILURES + 1))
+
+  if ((REGIONAL_BASEMAP_FAILURES > 0)); then
+    echo "   [X] WARNING: ${REGIONAL_BASEMAP_FAILURES} regional basemap artifact set(s) are incomplete."
+    echo "       Continuing because this guard remains best effort; local-sovereign mode may show gaps."
   else
-    echo "   [!] Basemap artifact missing. Attempting best-effort PMTiles build..."
-    if [[ -x "scripts/basemap/build-hamburg-pmtiles.sh" ]]; then
-      if bash scripts/basemap/build-hamburg-pmtiles.sh; then
-        evaluate_basemap_state
-        if ((PMTILES_COUNT > 0)); then
-          echo "   [✓] Basemap build succeeded. Generated ${PMTILES_COUNT} PMTiles artifact(s)."
-          echo "       -> e.g. ${FIRST_PMTILES}"
-        else
-          echo "   [X] WARNING: Basemap artifact still missing after build attempt. 0 PMTiles artifacts present in ${BASEMAP_DIR}."
-        fi
-      else
-        evaluate_basemap_state
-        if ((PMTILES_COUNT > 0)); then
-          echo "   [X] WARNING: PMTiles build script failed, but ${PMTILES_COUNT} PMTiles artifact(s) are present. Continuing deployment (best effort)."
-          echo "       -> e.g. ${FIRST_PMTILES}"
-        else
-          echo "   [X] WARNING: PMTiles build script failed. Continuing deployment (best effort). 0 PMTiles artifacts present in ${BASEMAP_DIR}."
-        fi
-      fi
-    else
-      evaluate_basemap_state
-      if ((PMTILES_COUNT > 0)); then
-        echo "   [X] WARNING: scripts/basemap/build-hamburg-pmtiles.sh not found or not executable, but ${PMTILES_COUNT} PMTiles artifact(s) are present in ${BASEMAP_DIR}."
-        echo "       -> e.g. ${FIRST_PMTILES}"
-      else
-        echo "   [X] WARNING: scripts/basemap/build-hamburg-pmtiles.sh not found or not executable. 0 PMTiles artifacts present in ${BASEMAP_DIR}."
-      fi
-    fi
+    echo "   [✓] All regional PMTiles sources required by the sovereign style are ready."
   fi
   # 6c2. Basemap Glyphs Guard (best effort)
   # Try to ensure the local glyphs (fonts) exist for offline rendering
@@ -2160,13 +2167,16 @@ if [[ "$DEPLOY_TARGET" != "vps" ]]; then
       echo "OK (sovereign style.json reachable)"
     fi
 
-    if ! curl -fsS --connect-timeout 2 --max-time 5 --cacert "$EDGE_CA" https://weltgewebe.home.arpa/local-basemap/basemap-hamburg.meta.json > /dev/null 2>&1; then
-      msg="Sovereign Basemap Check skipped/failed: Could not fetch basemap-hamburg.meta.json via Edge Route (/local-basemap/basemap-hamburg.meta.json). PMTiles artifact volume or route is missing."
-      echo "   [!] WARNING: $msg"
-      echo "       This is completely OK if PUBLIC_BASEMAP_MODE=remote-style is intended. It only breaks local-sovereign mode."
-    else
-      echo "OK (sovereign basemap-hamburg.meta.json reachable)"
-    fi
+    for regional_meta in basemap-hamburg.meta.json basemap-schleswig-holstein.meta.json; do
+      if ! curl -fsS --connect-timeout 2 --max-time 5 --cacert "$EDGE_CA" \
+        "https://weltgewebe.home.arpa/local-basemap/" > /dev/null 2>&1; then
+        msg="Sovereign Basemap Check skipped/failed: Could not fetch ${regional_meta} via Edge Route (/local-basemap/${regional_meta}). PMTiles artifact volume or route is missing."
+        echo "   [!] WARNING: $msg"
+        echo "       This is completely OK if PUBLIC_BASEMAP_MODE=remote-style is intended. It only breaks local-sovereign mode."
+      else
+        echo "OK (sovereign ${regional_meta} reachable)"
+      fi
+    done
     echo "   (Note: This proves edge routing readiness, not E2E client usage)"
   fi
   echo

--- a/scripts/weltgewebe-up
+++ b/scripts/weltgewebe-up
@@ -2169,7 +2169,7 @@ if [[ "$DEPLOY_TARGET" != "vps" ]]; then
 
     for regional_meta in basemap-hamburg.meta.json basemap-schleswig-holstein.meta.json; do
       if ! curl -fsS --connect-timeout 2 --max-time 5 --cacert "$EDGE_CA" \
-        "https://weltgewebe.home.arpa/local-basemap/" > /dev/null 2>&1; then
+        "https://weltgewebe.home.arpa/local-basemap/${regional_meta}" > /dev/null 2>&1; then
         msg="Sovereign Basemap Check skipped/failed: Could not fetch ${regional_meta} via Edge Route (/local-basemap/${regional_meta}). PMTiles artifact volume or route is missing."
         echo "   [!] WARNING: $msg"
         echo "       This is completely OK if PUBLIC_BASEMAP_MODE=remote-style is intended. It only breaks local-sovereign mode."


### PR DESCRIPTION
## Ziel

Erweitert die souveräne Weltgewebe-Basiskarte von Hamburg auf Hamburg plus Schleswig-Holstein.

## Umsetzung

- gepinnter Geofabrik-Extrakt `schleswig-holstein-260101.osm.pbf` mit SHA-256-Prüfung
- eigener Planetiler-Build und atomare stabile PMTiles-Aliasse
- zweite regionale Quelle und identische visuelle Ebenen im MapLibre-Stil
- explizite Bereitschaftsprüfungen für Hamburg und Schleswig-Holstein
- reale CI-Inhaltsprüfung mit PMTiles-Signatur, SHA-256 und HTTP-Range-Auslieferung
- Browserintegration prüft Range-Anfragen für beide Regionen
- Deploy-Guard meldet fehlende Regionen getrennt

## Belege

- `make prepare-commit`: grün
- Svelte-Check: 0 Fehler, 0 Warnungen
- Playwright-Basemap-Integration: grün
- reales Schleswig-Holstein-Artefakt: 127636977 Bytes
- SHA-256: `3b58f77dd26e5a773b7ac5b5cda7cb1a7dae0379699bc59cc5304f9c0c2fa70a`
- lokale Caddy-Prüfung: HTTP 206, `Accept-Ranges: bytes`, PMTiles-Signatur korrekt

## Grenze

Die bestehende Inhaltsprüfung beweist Header, Größe, Hash und Range-Auslieferung, aber noch keine tiefe Validierung des internen PMTiles-Verzeichnisses und Kachelindex. Das wird als Folgetask registriert.