### PR TITLE
refactor(web): Garnrollenmenü auf direkten Einstieg reduzieren

### DIFF
--- a/apps/web/src/lib/components/Garnrolle.svelte
+++ b/apps/web/src/lib/components/Garnrolle.svelte
@@ -1,91 +1,20 @@
 <script lang="ts">
-  import { createEventDispatcher } from "svelte";
   import { ICONS, MARKER_SIZES } from "$lib/ui/icons";
   import { authStore } from "$lib/auth/store";
-  import { browser } from "$app/environment";
-  import type { Account } from "$lib/map/types";
-  import {
-    describeGarnrolleVisibility,
-    findOwnGarnrolle,
-  } from "$lib/garnrolle/visibility";
-
-  export let label = "Meine Garnrolle und Konto";
-  export let accounts: Account[] = [];
-
-  const dispatch = createEventDispatcher<{ requestZoomToOwnGarnrolle: void }>();
-  let menuOpen = false;
-
-  $: ownGarnrolle = findOwnGarnrolle(accounts, $authStore.account_id);
-  $: visibility = describeGarnrolleVisibility(ownGarnrolle);
-
-  function handleZoomToOwnGarnrolle() {
-    menuOpen = false;
-    dispatch("requestZoomToOwnGarnrolle");
-  }
-
-  function toggleMenu() {
-    menuOpen = !menuOpen;
-  }
-
-  function closeMenu(event: MouseEvent) {
-    if (!menuOpen) return;
-    const target = event.target as HTMLElement;
-    if (!target.closest(".garnrolle-container")) menuOpen = false;
-  }
-
-  function handleKeydown(event: KeyboardEvent) {
-    if (!menuOpen) return;
-    if (event.key === "Escape") {
-      event.preventDefault();
-      menuOpen = false;
-    }
-  }
-
-  async function logout() {
-    if (!browser) return;
-    await authStore.logout();
-    menuOpen = false;
-  }
+  export let label = "Meine Garnrolle einstellen";
 </script>
-
-<svelte:window on:click={closeMenu} on:keydown|capture={handleKeydown} />
 
 <div class="garnrolle-container wrap">
   {#if $authStore.authenticated}
-    <button
+    <a
       class="roll wrap-btn"
+      href="/settings#meine-garnrolle"
       aria-label={label}
-      aria-expanded={menuOpen}
-      on:click={toggleMenu}
+      title={label}
       style="width: {MARKER_SIZES.account}px; height: {MARKER_SIZES.account}px;"
     >
       <img src={ICONS.garnrolle} alt="" />
-    </button>
-
-    {#if menuOpen}
-      <div class="menu" aria-label="Meine Garnrolle und Konto">
-        {#if visibility.canZoomToMap}
-          <button class="menu-item" on:click={handleZoomToOwnGarnrolle}
-            >Meine Garnrolle auf Karte zeigen</button
-          >
-        {/if}
-        <a
-          href="/settings#meine-garnrolle"
-          class="menu-item"
-          on:click={() => (menuOpen = false)}
-        >
-          {visibility.canZoomToMap
-            ? "Meine Garnrolle"
-            : "Meine Garnrolle (noch nicht auf der Karte)"}
-        </a>
-        <a
-          href="/settings"
-          class="menu-item"
-          on:click={() => (menuOpen = false)}>Konto & Sicherheit</a
-        >
-        <button class="menu-item logout-btn" on:click={logout}>Abmelden</button>
-      </div>
-    {/if}
+    </a>
   {:else}
     <a class="login-entry" href="/login">Anmelden</a>
   {/if}
@@ -96,32 +25,33 @@
     position: relative;
     display: inline-block;
   }
+
   .wrap-btn {
-    background: none;
-    border: none;
-    padding: 0;
     margin: 0;
     color: inherit;
-    appearance: none;
   }
-  .wrap-btn:focus-visible,
-  .login-entry:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: 3px;
-  }
+
   .roll {
     display: block;
     cursor: pointer;
     transition: transform 0.1s ease;
   }
+
   .roll img {
     width: 100%;
     height: 100%;
     object-fit: contain;
     display: block;
   }
+
   .roll:active {
     transform: scale(0.95);
+  }
+
+  .roll:focus-visible,
+  .login-entry:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
   }
 
   .login-entry {
@@ -135,44 +65,5 @@
     color: var(--text);
     text-decoration: none;
     font-weight: 600;
-  }
-
-  .menu {
-    position: absolute;
-    top: calc(100% + 8px);
-    right: 0;
-    background: var(--panel-solid);
-    border: 1px solid var(--panel-border-strong);
-    border-radius: 8px;
-    box-shadow: var(--shadow);
-    min-width: 220px;
-    z-index: 50;
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-    pointer-events: auto;
-  }
-
-  .menu-item {
-    display: block;
-    min-height: 44px;
-    padding: 12px 16px;
-    box-sizing: border-box;
-    text-decoration: none;
-    color: var(--text);
-    font-size: 0.9rem;
-    font-weight: 500;
-    background: none;
-    border: none;
-    text-align: left;
-    cursor: pointer;
-    width: 100%;
-  }
-  .menu-item:hover {
-    background: var(--accent-soft);
-  }
-  .logout-btn {
-    color: var(--danger);
-    border-top: 1px solid var(--panel-border);
   }
 </style>

--- a/apps/web/src/lib/components/TopBar.svelte
+++ b/apps/web/src/lib/components/TopBar.svelte
@@ -1,26 +1,40 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
-  import Garnrolle from './Garnrolle.svelte';
-  import { contextPanelOpen } from '$lib/stores/uiView';
-  import type { Account } from '$lib/map/types';
-
-  export let accounts: Account[] = [];
-
-  const dispatch = createEventDispatcher<{ zoomToOwnGarnrolle: void }>();
+  import Garnrolle from "./Garnrolle.svelte";
+  import { contextPanelOpen } from "$lib/stores/uiView";
 </script>
 
+<div
+  class="topbar"
+  class:panel-open={$contextPanelOpen}
+  role="toolbar"
+  aria-label="Navigation"
+>
+  <div class="spacer"></div>
+  <div class="actions">
+    <Garnrolle />
+  </div>
+</div>
+
 <style>
-  .topbar{
-    position:absolute; inset:0 0 auto 0; min-height:52px; z-index:41;
-    display:flex; align-items:center; gap:8px; padding:0 12px;
-    padding:env(safe-area-inset-top) 12px 0 12px;
-    background: linear-gradient(180deg, rgba(0,0,0,0.55), rgba(0,0,0,0));
-    color:var(--text);
+  .topbar {
+    position: absolute;
+    inset: 0 0 auto 0;
+    min-height: 52px;
+    z-index: 41;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: env(safe-area-inset-top) 12px 0 12px;
+    background: linear-gradient(180deg, rgba(0, 0, 0, 0.55), rgba(0, 0, 0, 0));
+    color: var(--text);
     pointer-events: none;
     transition: right 0.3s ease-in-out;
   }
 
-  .spacer{ flex:1; pointer-events: none; }
+  .spacer {
+    flex: 1;
+    pointer-events: none;
+  }
 
   .actions {
     display: flex;
@@ -29,17 +43,9 @@
     pointer-events: auto;
   }
 
-  /* Desktop: adjust layout slightly to avoid overlapping ContextPanel */
   @media (min-width: 769px) {
     .topbar.panel-open {
-      right: var(--context-panel-width, 400px); /* leaves room for ContextPanel */
+      right: var(--context-panel-width, 400px);
     }
   }
 </style>
-
-<div class="topbar" class:panel-open={$contextPanelOpen} role="toolbar" aria-label="Navigation">
-  <div class="spacer"></div>
-  <div class="actions">
-    <Garnrolle {accounts} on:requestZoomToOwnGarnrolle={() => dispatch('zoomToOwnGarnrolle')} />
-  </div>
-</div>

--- a/apps/web/src/routes/map/+page.svelte
+++ b/apps/web/src/routes/map/+page.svelte
@@ -57,7 +57,6 @@
     deriveSearchResults,
     deriveSearchMatchIds,
     deriveVisibleEdges,
-    getFilterTypeKey,
     selectMapEntity,
   } from "$lib/stores/mapView";
   import { authStore, type AuthStatus } from "$lib/auth/store";
@@ -114,8 +113,6 @@
   let mapStyleReady = false;
   let isLoading = true;
   let lastFocusedElement: HTMLElement | null = null;
-  let showFilterTooltip = false;
-  let filterTooltipTimeout: number | null = null;
 
   let nodesOverlay: NodesOverlay | null = null;
   let searchDirectionIndicators: SearchDirectionIndicator[] = [];
@@ -405,40 +402,6 @@
     }
   }
 
-  function handleZoomToOwnGarnrolle() {
-    if (!$authStore.authenticated || !$authStore.account_id) return;
-    const accountId = $authStore.account_id;
-    // Find the marker corresponding to the user's account
-    const userMarker = markersData.find(
-      (m) => m.id === accountId && m.type === "garnrolle",
-    );
-
-    if (userMarker) {
-      const typeKey = getFilterTypeKey(userMarker);
-      const isFilteredOut =
-        $activeFilters.size > 0 && !$activeFilters.has(typeKey);
-
-      // Do not override filters: if the user's marker is filtered out, inform the user instead of mutating filter state.
-      if (isFilteredOut) {
-        if (filterTooltipTimeout !== null) {
-          window.clearTimeout(filterTooltipTimeout);
-        }
-        showFilterTooltip = false; // brief reset for animation restart
-
-        tick().then(() => {
-          showFilterTooltip = true;
-          filterTooltipTimeout = window.setTimeout(() => {
-            showFilterTooltip = false;
-            filterTooltipTimeout = null;
-          }, 4000);
-        });
-      } else {
-        focusAndFlyToPoint(userMarker);
-      }
-    }
-    // Note: If no marker is found (e.g. not public/placed), this deliberately silently no-ops
-  }
-
   // Restore focus when selection is closed or state becomes navigation
   $: if (($systemState === "navigation" || !$selection) && lastFocusedElement) {
     const elToFocus = lastFocusedElement;
@@ -628,10 +591,6 @@
         clearTimeout(loadingTimeout);
         loadingTimeout = undefined;
       }
-      if (filterTooltipTimeout !== null) {
-        window.clearTimeout(filterTooltipTimeout);
-        filterTooltipTimeout = null;
-      }
       if (shouldExposeTestMap) {
         delete (window as any).__TEST_MAP__;
       }
@@ -669,12 +628,6 @@
   class:search-open={$isSearchOpen}
   class:filter-open={$isFilterOpen}
 >
-  {#if showFilterTooltip}
-    <div class="filter-tooltip" role="status" aria-live="polite">
-      Du hast Garnrollen per Filter ausgeblendet – auch deine eigene.
-    </div>
-  {/if}
-
   {#if loadState === "partial"}
     <div class="degraded-banner" role="alert" data-testid="load-state-partial">
       Einige Kartendaten konnten nicht geladen werden ({failedLabels.join(
@@ -722,10 +675,7 @@
       </button>
     </div>
   {/if}
-  <TopBar
-    accounts={data.accounts || []}
-    on:zoomToOwnGarnrolle={handleZoomToOwnGarnrolle}
-  />
+  <TopBar />
   <div
     id="map"
     class:panel-open={$contextPanelOpen}
@@ -928,60 +878,9 @@
     font-family: monospace;
   }
 
-  .filter-tooltip {
-    position: fixed;
-    top: 80px;
-    left: 50%;
-    transform: translateX(-50%);
-    background: var(--bg);
-    color: var(--text);
-    padding: 12px 16px;
-    border-radius: 8px;
-    border: 1px solid var(--panel-border);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
-    z-index: 1000;
-    font-size: 0.9rem;
-    font-weight: 500;
-    pointer-events: none;
-    text-align: center;
-    animation: fadeInOut 4s ease forwards;
-  }
 
-  @keyframes fadeInOut {
-    0% {
-      opacity: 0;
-      transform: translate(-50%, -10px);
-    }
-    10% {
-      opacity: 1;
-      transform: translate(-50%, 0);
-    }
-    90% {
-      opacity: 1;
-      transform: translate(-50%, 0);
-    }
-    100% {
-      opacity: 0;
-      transform: translate(-50%, -10px);
-    }
-  }
 
-  .degraded-banner {
-    position: absolute;
-    top: 60px;
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: 30;
-    padding: 8px 16px;
-    background: rgba(180, 130, 0, 0.9);
-    color: #fff;
-    font-size: 0.85rem;
-    font-weight: 500;
-    border-radius: 6px;
-    pointer-events: none;
-    text-align: center;
-    white-space: nowrap;
-  }
+
 
   .degraded-banner--failed {
     background: rgba(180, 40, 40, 0.9);

--- a/apps/web/tests/garnrolle-not-on-map.spec.ts
+++ b/apps/web/tests/garnrolle-not-on-map.spec.ts
@@ -28,51 +28,27 @@ async function gotoMapAsAccount(page: Page, accountId: string) {
   await page.waitForSelector(".action-bar", { timeout: 10000 });
 }
 
-test.describe("Own Garnrolle discoverability when not_on_map", () => {
-  test("TopBar surfaces a settings link instead of a dead 'auf Karte zeigen' action", async ({
+async function expectDirectSettingsEntry(page: Page) {
+  const link = page.locator(
+    '.garnrolle-container a[aria-label="Meine Garnrolle einstellen"]',
+  );
+  await expect(link).toBeVisible();
+  await expect(link).toHaveAttribute("href", "/settings#meine-garnrolle");
+  await expect(page.locator(".garnrolle-container .menu")).toHaveCount(0);
+}
+
+test.describe("Own Garnrolle settings entry", () => {
+  test("uses the same direct settings entry when the Garnrolle is not on the map", async ({
     page,
   }) => {
     await gotoMapAsAccount(page, NOT_ON_MAP_ACCOUNT_ID);
-
-    await page.click(
-      '.garnrolle-container button[aria-label="Meine Garnrolle und Konto"]',
-    );
-    const menu = page.locator(".garnrolle-container .menu");
-    await expect(menu).toBeVisible();
-
-    // No dead-click "auf Karte zeigen" action when there is no public position —
-    // inventing a map position is not an option, so the control simply isn't
-    // offered.
-    await expect(
-      menu.locator('button:has-text("Meine Garnrolle auf Karte zeigen")'),
-    ).toHaveCount(0);
-
-    // The Garnrolle stays discoverable via the existing settings surface,
-    // with wording that honestly reflects the not-on-map state.
-    const settingsLink = menu.locator(
-      'a:has-text("Meine Garnrolle (noch nicht auf der Karte)")',
-    );
-    await expect(settingsLink).toBeVisible();
-    await expect(settingsLink).toHaveAttribute(
-      "href",
-      "/settings#meine-garnrolle",
-    );
+    await expectDirectSettingsEntry(page);
   });
 
-  test("TopBar keeps the zoom action for an account with a public position", async ({
+  test("does not add a redundant map action when the Garnrolle has a public position", async ({
     page,
   }) => {
     await gotoMapAsAccount(page, EXACT_ACCOUNT_ID);
-
-    await page.click(
-      '.garnrolle-container button[aria-label="Meine Garnrolle und Konto"]',
-    );
-    const menu = page.locator(".garnrolle-container .menu");
-    await expect(menu).toBeVisible();
-
-    await expect(
-      menu.locator('button:has-text("Meine Garnrolle auf Karte zeigen")'),
-    ).toBeVisible();
-    await expect(menu.locator('a:has-text("Meine Garnrolle")')).toBeVisible();
+    await expectDirectSettingsEntry(page);
   });
 });

--- a/apps/web/tests/ui-interaction-clarity.spec.ts
+++ b/apps/web/tests/ui-interaction-clarity.spec.ts
@@ -73,95 +73,19 @@ test.describe("Interaction Clarity & State Feedback", () => {
     await expect(newNodeBtn).not.toHaveClass(/active/);
   });
 
-  test("Garnrolle menu closes on Escape", async ({ page }) => {
-    // The Garnrolle button is in the TopBar
-    const garnrolleBtn = page.locator(
-      '.garnrolle-container button[aria-label="Meine Garnrolle und Konto"]',
-    );
-    await expect(garnrolleBtn).toBeVisible();
-
-    // Open menu
-    await garnrolleBtn.click();
-    await expect(garnrolleBtn).toHaveAttribute("aria-expanded", "true");
-
-    // Verify menu is visible
-    const menu = page.locator(".garnrolle-container .menu");
-    await expect(menu).toBeVisible();
-
-    // Press Escape
-    await page.keyboard.press("Escape");
-
-    // Menu must be closed
-    await expect(menu).toHaveCount(0);
-    await expect(garnrolleBtn).toHaveAttribute("aria-expanded", "false");
-  });
-
-  test("Escape on Garnrolle menu does NOT close ContextPanel", async ({
+  test("Garnrolle führt ohne Zwischenmenü direkt zu ihren Einstellungen", async ({
     page,
   }) => {
-    // Open context panel first (komposition mode)
-    await page
-      .locator('.action-bar button[aria-label="Knoten knüpfen"]')
-      .click();
-    const panel = page.locator('[data-testid="context-panel"]');
-    await expect(panel).toBeVisible();
-
-    // Open Garnrolle menu
-    const garnrolleBtn = page.locator(
-      '.garnrolle-container button[aria-label="Meine Garnrolle und Konto"]',
+    const garnrolleLink = page.locator(
+      '.garnrolle-container a[aria-label="Meine Garnrolle einstellen"]',
     );
-    await garnrolleBtn.click();
-    const menu = page.locator(".garnrolle-container .menu");
-    await expect(menu).toBeVisible();
 
-    // Press Escape should close menu only, not the panel
-    await page.keyboard.press("Escape");
-    await expect(menu).toHaveCount(0);
-    await expect(panel).toBeVisible(); // panel must remain open
-  });
-
-  test("Escape on Garnrolle menu does NOT close SearchOverlay", async ({
-    page,
-  }) => {
-    // Open search overlay
-    await page.locator('.action-bar button[aria-label="Suche"]').click();
-    const searchOverlay = page.locator('[data-testid="search-overlay"]');
-    await expect(searchOverlay).toBeVisible();
-
-    // Open Garnrolle menu while search is open
-    const garnrolleBtn = page.locator(
-      '.garnrolle-container button[aria-label="Meine Garnrolle und Konto"]',
+    await expect(garnrolleLink).toBeVisible();
+    await expect(garnrolleLink).toHaveAttribute(
+      "href",
+      "/settings#meine-garnrolle",
     );
-    await garnrolleBtn.click();
-    const menu = page.locator(".garnrolle-container .menu");
-    await expect(menu).toBeVisible();
-
-    // Press Escape: Garnrolle menu closes, search stays open
-    await page.keyboard.press("Escape");
-    await expect(menu).toHaveCount(0);
-    await expect(searchOverlay).toBeVisible();
-  });
-
-  test("Escape on Garnrolle menu does NOT close FilterOverlay", async ({
-    page,
-  }) => {
-    // Open filter overlay
-    await page.locator('.action-bar button[aria-label="Filter"]').click();
-    const filterOverlay = page.locator('[data-testid="filter-overlay"]');
-    await expect(filterOverlay).toBeVisible();
-
-    // Open Garnrolle menu while filter is open
-    const garnrolleBtn = page.locator(
-      '.garnrolle-container button[aria-label="Meine Garnrolle und Konto"]',
-    );
-    await garnrolleBtn.click();
-    const menu = page.locator(".garnrolle-container .menu");
-    await expect(menu).toBeVisible();
-
-    // Press Escape: Garnrolle menu closes, filter stays open
-    await page.keyboard.press("Escape");
-    await expect(menu).toHaveCount(0);
-    await expect(filterOverlay).toBeVisible();
+    await expect(page.locator(".garnrolle-container .menu")).toHaveCount(0);
   });
 
   test("focus does not return to Search button when entering komposition", async ({


### PR DESCRIPTION
## Ziel
Das Garnrollen-Menü war vollständig redundant: Kartenfokus geschieht bereits automatisch, Garnrollen- und Kontoaktionen liegen gemeinsam in den Einstellungen.

## Änderung
- Garnrollen-Symbol führt direkt zu `/settings#meine-garnrolle`
- redundantes Zwischenmenü samt Kartenfokus- und Logout-Doppelwegen entfernt
- obsolete TopBar-Ereignisse, Tooltip-Logik und CSS entfernt
- Browserverträge auf den eindeutigen Einstieg umgestellt

## Prüfung
- `pnpm --dir apps/web check`: 0 Fehler, 0 Warnungen
- `pnpm --dir apps/web lint`: bestanden
- gezielte Playwright-Prüfung: 8/8 bestanden
- vollständige Web-Testsuite: erfolgreich abgeschlossen