### PR TITLE
Basemap: PMTiles-Strukturprüfung und HTTP-Vertrag härten

### DIFF
--- a/.github/workflows/basemap-runtime-proof.yml
+++ b/.github/workflows/basemap-runtime-proof.yml
@@ -13,31 +13,29 @@ name: Basemap Runtime Proof
 #      scope=range-delivery. The guard issues a Range request via curl and
 #      asserts HTTP 206 plus Accept-Ranges/Content-Range. Failure fails the job.
 #
-#   3. basemap-pmtiles-content-proof (Pfad 3 — echter Content-Proof, blockierend)
-#      Builds a real PMTiles artefact via scripts/basemap/build-hamburg-pmtiles.sh,
-#      serves it through Caddy, and runs the guard with scope=pmtiles-content.
-#      The guard verifies endpoint/range delivery (HTTP 206), the PMTiles magic
-#      bytes "PMTiles" and an optional SHA256 match from the generated metadata.
+#   3. basemap-pmtiles-content-proof (Pfad 3 — Hamburg Content-Proof, blockierend)
+#      Builds the pinned Hamburg PMTiles artifact, validates every reachable
+#      directory plus bounded deterministic real MVT samples, serves it through
+#      Caddy, and proves HTTP 200/206, Content-Type, Range headers, magic, and SHA.
 #
 #   4. basemap-schleswig-holstein-content-proof
-#      Builds and verifies the pinned Schleswig-Holstein PMTiles artifact independently.
+#      Applies the same independent structure, MVT, HTTP, and hash proof to the
+#      pinned Schleswig-Holstein artifact.
 #
 #   5. basemap-visual-proof  (Pfad 5 — visueller End-to-End-Proof, blockierend)
-#      Reuses the real Hamburg PMTiles artefact from Pfad 3, publishes the
-#      stable alias (basemap-hamburg.pmtiles), starts the Vite preview server
-#      with the local-basemap-serve middleware, and runs the Playwright visual proof
-#      (apps/web/tests/proofs/basemap-real-hamburg-visual.proof.ts) against it.
-#      Proves: Browser → Vite middleware → PMTiles alias → HTTP 206 Range delivery
-#      → MapLibre canvas visible + isStyleLoaded() → zero remote tile violations.
-#      Failure fails the job. Uploads screenshot, trace, and proof summary.
+#      Reuses both validated regional artifacts, publishes stable aliases, starts
+#      the Vite preview server, and runs the Hamburg and Schleswig-Holstein
+#      Playwright proofs. It proves explicit Content-Type and HTTP 206 delivery,
+#      decoded and rendered regional features, MapLibre readiness, and zero remote
+#      tile-provider violations. Failure fails the job.
 #
 # Scope distinction:
-#   Pfad 2 proves Caddy HTTP Range delivery against a .pmtiles file. It does
-#   NOT validate PMTiles content beyond the delivery chain. The pmtiles-content
-#   scope (when used against a real artefact) adds a 7-byte magic-byte prefix
-#   check only; tile-directory and structural PMTiles validation remain future work.
-#   Pfad 4 proves the browser-side visual pipeline using the Vite middleware (not
-#   Caddy); it is a different proof path from Pfad 2/3, not a substitute.
+#   Pfad 2 proves the Caddy representation contract against a synthetic file.
+#   Pfade 3/4 add real archive header/hash checks, complete reachable-directory
+#   traversal, metadata/style reconciliation, and a bounded payload sample. They
+#   do not scan every tile or establish cartographic completeness or source freshness.
+#   Pfad 5 proves the browser-side rendering path using the Vite middleware (not
+#   production Caddy); it complements rather than replaces Pfade 2-4.
 #
 # What is NOT a substitute for either proof:
 #   - basemap-client-integration.spec.ts (mocked MapLibre protocol handler)
@@ -54,6 +52,9 @@ name: Basemap Runtime Proof
       - "scripts/guard/basemap-runtime-proof.sh"
       - "apps/web/tests/proofs/**"
       - "apps/web/package.json"
+      - "apps/web/pnpm-lock.yaml"
+      - "apps/web/scripts/validate-pmtiles.mjs"
+      - "apps/web/scripts/validate-pmtiles.test.mjs"
       - "apps/web/playwright.proof.config.ts"
       - "apps/web/vite.config.ts"
       - "map-style/**"
@@ -68,6 +69,9 @@ name: Basemap Runtime Proof
       - "scripts/guard/basemap-runtime-proof.sh"
       - "apps/web/tests/proofs/**"
       - "apps/web/package.json"
+      - "apps/web/pnpm-lock.yaml"
+      - "apps/web/scripts/validate-pmtiles.mjs"
+      - "apps/web/scripts/validate-pmtiles.test.mjs"
       - "apps/web/playwright.proof.config.ts"
       - "apps/web/vite.config.ts"
       - "map-style/**"
@@ -333,6 +337,22 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # tag: v7.0.0
 
+      - name: Install pnpm for PMTiles validator
+        uses: pnpm/action-setup@b0f76dfb45f55f8421693e4803ac7bb65143bd34 # tag: v6
+        with:
+          version: 9.11.0
+
+      - name: Setup Node for PMTiles validator
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: ".node-version"
+          cache: "pnpm"
+          cache-dependency-path: apps/web/pnpm-lock.yaml
+
+      - name: Install PMTiles validator dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: apps/web
+
       - name: Verify Docker availability
         run: |
           set -euo pipefail
@@ -369,6 +389,19 @@ jobs:
           printf 'META_PATH=%s\n' "${META_PATH}" >> "${GITHUB_ENV}"
           printf 'EXPECTED_SHA256=%s\n' "${EXPECTED_SHA256}" >> "${GITHUB_ENV}"
           printf 'ARTEFACT_SIZE=%s\n' "${FILE_SIZE}" >> "${GITHUB_ENV}"
+
+      - name: Run PMTiles validator corruption tests
+        run: pnpm test:pmtiles-validator
+        working-directory: apps/web
+
+      - name: Deep-validate Hamburg PMTiles structure and MVT samples
+        run: |
+          set -euo pipefail
+          pnpm validate:pmtiles -- \
+            --archive hamburg=../../build/basemap/basemap-hamburg-v0.1.0.pmtiles \
+            --style ../../map-style/style.json \
+            --output /tmp/hamburg-pmtiles-deep-validation.json
+        working-directory: apps/web
 
       - name: Start Caddy serving /local-basemap/ from artefact directory
         run: |
@@ -434,6 +467,7 @@ jobs:
             /tmp/proof-output.txt
             /tmp/magic-bytes.txt
             /tmp/response-headers.txt
+            /tmp/hamburg-pmtiles-deep-validation.json
             /tmp/caddy.log
             build/basemap/basemap-hamburg-v0.1.0.pmtiles
             build/basemap/basemap-hamburg-v0.1.0.meta.json
@@ -513,6 +547,22 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # tag: v7.0.0
 
+      - name: Install pnpm for PMTiles validator
+        uses: pnpm/action-setup@b0f76dfb45f55f8421693e4803ac7bb65143bd34 # tag: v6
+        with:
+          version: 9.11.0
+
+      - name: Setup Node for PMTiles validator
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: ".node-version"
+          cache: "pnpm"
+          cache-dependency-path: apps/web/pnpm-lock.yaml
+
+      - name: Install PMTiles validator dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: apps/web
+
       - name: Verify Docker availability
         run: |
           set -euo pipefail
@@ -532,6 +582,15 @@ jobs:
               "${META_PATH}"
           )"
           printf 'EXPECTED_SHA256=%s\n' "${EXPECTED_SHA256}" >> "${GITHUB_ENV}"
+
+      - name: Deep-validate Schleswig-Holstein PMTiles structure and MVT samples
+        run: |
+          set -euo pipefail
+          pnpm validate:pmtiles -- \
+            --archive schleswig-holstein=../../build/basemap/basemap-schleswig-holstein-v0.1.0.pmtiles \
+            --style ../../map-style/style.json \
+            --output /tmp/schleswig-holstein-pmtiles-deep-validation.json
+        working-directory: apps/web
 
       - name: Start Caddy serving Schleswig-Holstein PMTiles
         run: |
@@ -577,6 +636,7 @@ jobs:
             /tmp/schleswig-holstein-proof.txt
             /tmp/schleswig-holstein-caddy.log
             /tmp/schleswig-holstein-magic.txt
+            /tmp/schleswig-holstein-pmtiles-deep-validation.json
             build/basemap/basemap-schleswig-holstein-v0.1.0.pmtiles
             build/basemap/basemap-schleswig-holstein-v0.1.0.meta.json
           if-no-files-found: warn

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ validate-shell-tests:
 	bash scripts/tests/test_weltgewebe_up_deploy_scope.sh
 	bash scripts/tests/test_version_guard.sh
 	bash scripts/tests/test_basemap_mode_guard.sh
+	bash scripts/tests/test_basemap_runtime_proof_contract.sh
 	bash scripts/tests/test_security_headers_guard.sh
 	bash scripts/tests/test_repo_contract_guards.sh
 	bash scripts/tests/test_postgres_backup_restore_contract.sh

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -46,6 +46,8 @@
     "pretest:proof:basemap-real": "pnpm run generate:basemap-config",
     "pretest:unit": "pnpm run generate:basemap-config",
     "test:unit": "vitest run",
+    "test:pmtiles-validator": "node --test scripts/validate-pmtiles.test.mjs",
+    "validate:pmtiles": "node scripts/validate-pmtiles.mjs",
     "test": "playwright test",
     "test:proof:auth-passkey-register": "playwright test --config=playwright.auth.proof.config.ts --reporter=dot,html,junit",
     "test:proof:auth-session-persistence": "playwright test --config=playwright.auth-session.proof.config.ts",
@@ -61,6 +63,7 @@
     "preview:cs": "vite preview --host 0.0.0.0 --port 4173"
   },
   "devDependencies": {
+    "@mapbox/vector-tile": "1.3.1",
     "@opentelemetry/api": "^1.9.1",
     "@playwright/test": "1.61.0",
     "@sveltejs/adapter-static": "^3.0.10",
@@ -73,6 +76,7 @@
     "eslint": "9.11.1",
     "eslint-plugin-svelte": "2.45.1",
     "globals": "15.9.0",
+    "pbf": "3.3.0",
     "prettier": "3.8.4",
     "prettier-plugin-svelte": "4.1.1",
     "rimraf": "5",

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -31,6 +31,9 @@ importers:
         specifier: ^4.4.1
         version: 4.4.1
     devDependencies:
+      '@mapbox/vector-tile':
+        specifier: 1.3.1
+        version: 1.3.1
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -67,6 +70,9 @@ importers:
       globals:
         specifier: 15.9.0
         version: 15.9.0
+      pbf:
+        specifier: 3.3.0
+        version: 3.3.0
       prettier:
         specifier: 3.8.4
         version: 3.8.4

--- a/apps/web/scripts/validate-pmtiles.mjs
+++ b/apps/web/scripts/validate-pmtiles.mjs
@@ -1,0 +1,662 @@
+import fs from "node:fs";
+import { open, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import { VectorTile } from "@mapbox/vector-tile";
+import Pbf from "pbf";
+import { PMTiles, ResolvedValueCache, TileType, tileIdToZxy } from "pmtiles";
+
+const HEADER_SIZE = 127;
+const DEFAULT_MAX_SAMPLES = 96;
+const MAX_DIRECTORIES = 100_000;
+const MAX_DIRECTORY_ENTRIES = 2_000_000;
+
+class NodeFileSource {
+  constructor(filePath) {
+    this.filePath = path.resolve(filePath);
+    this.handle = null;
+    this.size = 0;
+  }
+
+  getKey() {
+    return this.filePath;
+  }
+
+  async init() {
+    this.handle = await open(this.filePath, "r");
+    this.size = (await this.handle.stat()).size;
+    if (this.size < HEADER_SIZE) {
+      throw new Error(
+        `ARCHIVE_TRUNCATED: ${this.filePath} is ${this.size} bytes; ` +
+          `expected at least ${HEADER_SIZE}`,
+      );
+    }
+    return this;
+  }
+
+  async getBytes(offset, length) {
+    if (!Number.isSafeInteger(offset) || !Number.isSafeInteger(length)) {
+      throw new Error("RANGE_INVALID: offset and length must be safe integers");
+    }
+    if (offset < 0 || length <= 0 || offset >= this.size) {
+      throw new Error(
+        `RANGE_OUT_OF_BOUNDS: ${offset} + ${length} for ${this.size} bytes`,
+      );
+    }
+
+    const bytesToRead = Math.min(length, this.size - offset);
+    const buffer = Buffer.alloc(bytesToRead);
+    const { bytesRead } = await this.handle.read(
+      buffer,
+      0,
+      bytesToRead,
+      offset,
+    );
+    if (bytesRead !== bytesToRead) {
+      throw new Error(
+        `RANGE_READ_SHORT: requested ${bytesToRead} but read ${bytesRead}`,
+      );
+    }
+
+    return {
+      data: buffer.buffer.slice(
+        buffer.byteOffset,
+        buffer.byteOffset + buffer.byteLength,
+      ),
+    };
+  }
+
+  async close() {
+    if (this.handle) {
+      await this.handle.close();
+      this.handle = null;
+    }
+  }
+}
+
+function invariant(condition, code, message) {
+  if (!condition) {
+    throw new Error(`${code}: ${message}`);
+  }
+}
+
+function validateSection(
+  name,
+  offset,
+  length,
+  fileSize,
+  requiredNonEmpty = false,
+) {
+  invariant(
+    Number.isSafeInteger(offset),
+    "HEADER_OFFSET_INVALID",
+    `${name} offset ${offset}`,
+  );
+  invariant(
+    Number.isSafeInteger(length),
+    "HEADER_LENGTH_INVALID",
+    `${name} length ${length}`,
+  );
+  invariant(
+    offset >= HEADER_SIZE,
+    "HEADER_OFFSET_BEFORE_DATA",
+    `${name} offset ${offset}`,
+  );
+  invariant(length >= 0, "HEADER_LENGTH_NEGATIVE", `${name} length ${length}`);
+  if (requiredNonEmpty) {
+    invariant(length > 0, "HEADER_SECTION_EMPTY", `${name} must not be empty`);
+  }
+  invariant(
+    offset + length <= fileSize,
+    "HEADER_SECTION_OUT_OF_BOUNDS",
+    `${name} ${offset}+${length} exceeds ${fileSize}`,
+  );
+  return { name, offset, length, end: offset + length };
+}
+
+function validateHeader(header, fileSize) {
+  invariant(
+    header.specVersion === 3,
+    "SPEC_VERSION_UNSUPPORTED",
+    `expected 3 but found ${header.specVersion}`,
+  );
+  invariant(
+    header.tileType === TileType.Mvt,
+    "TILE_TYPE_UNSUPPORTED",
+    `expected MVT tile type but found ${header.tileType}`,
+  );
+  invariant(
+    header.minZoom <= header.maxZoom,
+    "ZOOM_RANGE_INVALID",
+    `${header.minZoom}..${header.maxZoom}`,
+  );
+  invariant(
+    header.minLon >= -180 &&
+      header.maxLon <= 180 &&
+      header.minLon <= header.maxLon,
+    "BOUNDS_LONGITUDE_INVALID",
+    `${header.minLon}..${header.maxLon}`,
+  );
+  invariant(
+    header.minLat >= -90 &&
+      header.maxLat <= 90 &&
+      header.minLat <= header.maxLat,
+    "BOUNDS_LATITUDE_INVALID",
+    `${header.minLat}..${header.maxLat}`,
+  );
+
+  const sections = [
+    validateSection(
+      "root-directory",
+      header.rootDirectoryOffset,
+      header.rootDirectoryLength,
+      fileSize,
+      true,
+    ),
+    validateSection(
+      "json-metadata",
+      header.jsonMetadataOffset,
+      header.jsonMetadataLength,
+      fileSize,
+      true,
+    ),
+    validateSection(
+      "leaf-directories",
+      header.leafDirectoryOffset,
+      header.leafDirectoryLength ?? 0,
+      fileSize,
+    ),
+    validateSection(
+      "tile-data",
+      header.tileDataOffset,
+      header.tileDataLength ?? 0,
+      fileSize,
+      true,
+    ),
+  ]
+    .filter((section) => section.length > 0)
+    .sort((left, right) => left.offset - right.offset);
+
+  for (let index = 1; index < sections.length; index += 1) {
+    const previous = sections[index - 1];
+    const current = sections[index];
+    invariant(
+      previous.end <= current.offset,
+      "HEADER_SECTION_OVERLAP",
+      `${previous.name} ends at ${previous.end}, ` +
+        `${current.name} starts at ${current.offset}`,
+    );
+  }
+}
+
+function validateDirectoryEntries(entries, context) {
+  invariant(
+    Array.isArray(entries) && entries.length > 0,
+    "DIRECTORY_EMPTY",
+    context,
+  );
+  for (let index = 0; index < entries.length; index += 1) {
+    const entry = entries[index];
+    invariant(
+      Number.isSafeInteger(entry.tileId) && entry.tileId >= 0,
+      "DIRECTORY_TILE_ID_INVALID",
+      `${context} index ${index}`,
+    );
+    invariant(
+      Number.isSafeInteger(entry.offset) && entry.offset >= 0,
+      "DIRECTORY_OFFSET_INVALID",
+      `${context} index ${index}`,
+    );
+    invariant(
+      Number.isSafeInteger(entry.length) && entry.length > 0,
+      "DIRECTORY_LENGTH_INVALID",
+      `${context} index ${index}`,
+    );
+    invariant(
+      Number.isSafeInteger(entry.runLength) && entry.runLength >= 0,
+      "DIRECTORY_RUN_LENGTH_INVALID",
+      `${context} index ${index}`,
+    );
+    if (index > 0) {
+      invariant(
+        entries[index - 1].tileId < entry.tileId,
+        "DIRECTORY_TILE_ID_ORDER",
+        `${context} index ${index}`,
+      );
+    }
+  }
+}
+
+async function walkDirectories(source, cache, header) {
+  const seenDirectories = new Set();
+  const tileEntries = [];
+  let directoryCount = 0;
+  let directoryEntryCount = 0;
+
+  async function visit(offset, length, depth, parentTileId = null) {
+    invariant(depth <= 3, "DIRECTORY_DEPTH_EXCEEDED", `depth ${depth}`);
+    const key = `${offset}:${length}`;
+    invariant(!seenDirectories.has(key), "DIRECTORY_CYCLE_OR_DUPLICATE", key);
+    seenDirectories.add(key);
+    directoryCount += 1;
+    invariant(
+      directoryCount <= MAX_DIRECTORIES,
+      "DIRECTORY_LIMIT_EXCEEDED",
+      String(directoryCount),
+    );
+
+    const entries = await cache.getDirectory(source, offset, length, header);
+    validateDirectoryEntries(entries, key);
+    directoryEntryCount += entries.length;
+    invariant(
+      directoryEntryCount <= MAX_DIRECTORY_ENTRIES,
+      "DIRECTORY_ENTRY_LIMIT_EXCEEDED",
+      String(directoryEntryCount),
+    );
+
+    if (parentTileId !== null) {
+      invariant(
+        entries[0].tileId >= parentTileId,
+        "LEAF_TILE_RANGE_INVALID",
+        `${entries[0].tileId} < ${parentTileId}`,
+      );
+    }
+
+    for (const entry of entries) {
+      if (entry.runLength === 0) {
+        const leafLength = header.leafDirectoryLength ?? 0;
+        invariant(leafLength > 0, "LEAF_DIRECTORY_SECTION_MISSING", key);
+        invariant(
+          entry.offset + entry.length <= leafLength,
+          "LEAF_DIRECTORY_RANGE_OUT_OF_BOUNDS",
+          `${entry.offset}+${entry.length} exceeds ${leafLength}`,
+        );
+        await visit(
+          header.leafDirectoryOffset + entry.offset,
+          entry.length,
+          depth + 1,
+          entry.tileId,
+        );
+      } else {
+        const tileDataLength = header.tileDataLength ?? 0;
+        invariant(
+          entry.offset + entry.length <= tileDataLength,
+          "TILE_DATA_RANGE_OUT_OF_BOUNDS",
+          `${entry.offset}+${entry.length} exceeds ${tileDataLength}`,
+        );
+        tileEntries.push(entry);
+      }
+    }
+  }
+
+  await visit(header.rootDirectoryOffset, header.rootDirectoryLength, 0);
+
+  const sorted = [...tileEntries].sort(
+    (left, right) => left.tileId - right.tileId,
+  );
+  let addressedTiles = 0;
+  let previousEnd = -1;
+  const contentKeys = new Set();
+
+  for (const entry of sorted) {
+    invariant(
+      entry.tileId > previousEnd,
+      "TILE_ID_RANGE_OVERLAP",
+      `${entry.tileId} <= ${previousEnd}`,
+    );
+    previousEnd = entry.tileId + entry.runLength - 1;
+    addressedTiles += entry.runLength;
+    contentKeys.add(`${entry.offset}:${entry.length}`);
+    tileIdToZxy(entry.tileId);
+    tileIdToZxy(previousEnd);
+  }
+
+  invariant(
+    sorted.length === header.numTileEntries,
+    "TILE_ENTRY_COUNT_MISMATCH",
+    `${sorted.length} != ${header.numTileEntries}`,
+  );
+  invariant(
+    addressedTiles === header.numAddressedTiles,
+    "ADDRESSED_TILE_COUNT_MISMATCH",
+    `${addressedTiles} != ${header.numAddressedTiles}`,
+  );
+  invariant(
+    contentKeys.size === header.numTileContents,
+    "TILE_CONTENT_COUNT_MISMATCH",
+    `${contentKeys.size} != ${header.numTileContents}`,
+  );
+
+  return {
+    directoryCount,
+    directoryEntryCount,
+    tileEntries: sorted,
+  };
+}
+
+function normalizeVectorLayers(metadata) {
+  let value = metadata?.vector_layers;
+  if (typeof value === "string") {
+    try {
+      value = JSON.parse(value);
+    } catch {
+      throw new Error(
+        "METADATA_VECTOR_LAYERS_INVALID: string is not valid JSON",
+      );
+    }
+  }
+  invariant(
+    Array.isArray(value),
+    "METADATA_VECTOR_LAYERS_MISSING",
+    "vector_layers must be an array",
+  );
+  const ids = value.map((entry) => entry?.id);
+  invariant(
+    ids.every((id) => typeof id === "string" && id.length > 0),
+    "METADATA_VECTOR_LAYER_ID_INVALID",
+    "every vector layer needs a non-empty id",
+  );
+  return new Set(ids);
+}
+
+function decodeMvt(data) {
+  let tile;
+  try {
+    tile = new VectorTile(new Pbf(new Uint8Array(data)));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`MVT_DECODE_FAILED: ${message}`);
+  }
+  const layers = Object.keys(tile.layers);
+  invariant(
+    layers.length > 0,
+    "MVT_LAYERS_EMPTY",
+    "decoded tile has no layers",
+  );
+  return layers;
+}
+
+function candidateTileIds(tileEntries, maxSamples) {
+  const byZoom = new Map();
+  for (const entry of tileEntries) {
+    const candidates = [
+      entry.tileId,
+      entry.tileId + Math.floor((entry.runLength - 1) / 2),
+      entry.tileId + entry.runLength - 1,
+    ];
+    for (const tileId of candidates) {
+      const [zoom] = tileIdToZxy(tileId);
+      if (!byZoom.has(zoom)) {
+        byZoom.set(zoom, new Set());
+      }
+      byZoom.get(zoom).add(tileId);
+    }
+  }
+
+  const zooms = [...byZoom.keys()].sort((left, right) => left - right);
+  const ordered = [];
+  const seen = new Set();
+  const append = (tileId) => {
+    if (!seen.has(tileId) && ordered.length < maxSamples) {
+      seen.add(tileId);
+      ordered.push(tileId);
+    }
+  };
+
+  // First establish stable cross-zoom coverage with first, middle, and last
+  // candidates for every zoom. Duplicate positions collapse deterministically.
+  for (const zoom of zooms) {
+    const ids = [...byZoom.get(zoom)].sort((left, right) => left - right);
+    for (const position of [
+      0,
+      Math.floor((ids.length - 1) / 2),
+      ids.length - 1,
+    ]) {
+      append(ids[position]);
+    }
+  }
+
+  // Then spend the remaining budget on spatially distributed high-zoom tiles.
+  // Those tiles contain the densest style contract (for example buildings),
+  // while the first pass already preserves cross-zoom representation.
+  for (const zoom of [...zooms].reverse()) {
+    const ids = [...byZoom.get(zoom)].sort((left, right) => left - right);
+    const remaining = maxSamples - ordered.length;
+    if (remaining <= 0) {
+      break;
+    }
+    const take = Math.min(ids.length, remaining);
+    for (let index = 0; index < take; index += 1) {
+      const position =
+        take === 1
+          ? Math.floor((ids.length - 1) / 2)
+          : Math.round((index * (ids.length - 1)) / (take - 1));
+      append(ids[position]);
+    }
+  }
+
+  return ordered;
+}
+
+function loadStyleContract(stylePath, region) {
+  const style = JSON.parse(fs.readFileSync(stylePath, "utf8"));
+  const alias = `basemap-${region}.pmtiles`;
+  const sourceId = Object.entries(style.sources ?? {}).find(
+    ([, source]) => source?.url === `pmtiles://${alias}`,
+  )?.[0];
+  invariant(sourceId, "STYLE_SOURCE_MISSING", `${alias} is not declared`);
+
+  const layers = new Set(
+    (style.layers ?? [])
+      .filter(
+        (entry) =>
+          entry.source === sourceId &&
+          typeof entry["source-layer"] === "string",
+      )
+      .map((entry) => entry["source-layer"]),
+  );
+  invariant(layers.size > 0, "STYLE_SOURCE_LAYERS_MISSING", sourceId);
+  return { sourceId, layers };
+}
+
+export async function validateArchive({
+  region,
+  archivePath,
+  stylePath,
+  maxSamples = DEFAULT_MAX_SAMPLES,
+}) {
+  invariant(
+    typeof region === "string" && region.length > 0,
+    "REGION_INVALID",
+    String(region),
+  );
+  invariant(
+    Number.isInteger(maxSamples) && maxSamples > 0 && maxSamples <= 256,
+    "SAMPLE_LIMIT_INVALID",
+    String(maxSamples),
+  );
+
+  const source = await new NodeFileSource(archivePath).init();
+  try {
+    const cache = new ResolvedValueCache(10_000);
+    const archive = new PMTiles(source, cache);
+    const header = await archive.getHeader();
+    validateHeader(header, source.size);
+
+    const metadata = await archive.getMetadata();
+    const metadataLayers = normalizeVectorLayers(metadata);
+    const styleContract = loadStyleContract(stylePath, region);
+    for (const layer of styleContract.layers) {
+      invariant(
+        metadataLayers.has(layer),
+        "STYLE_LAYER_NOT_IN_METADATA",
+        `${region}:${layer}`,
+      );
+    }
+
+    const directory = await walkDirectories(source, cache, header);
+    invariant(directory.tileEntries.length > 0, "TILE_ENTRIES_EMPTY", region);
+
+    const candidateIds = candidateTileIds(directory.tileEntries, maxSamples);
+    const observedLayers = new Set();
+    const samples = [];
+    let candidatesRead = 0;
+
+    for (const tileId of candidateIds) {
+      if (candidatesRead >= maxSamples) {
+        break;
+      }
+      const [z, x, y] = tileIdToZxy(tileId);
+      const response = await archive.getZxy(z, x, y);
+      invariant(response?.data, "SAMPLE_TILE_MISSING", `${z}/${x}/${y}`);
+      const layers = decodeMvt(response.data);
+      for (const layer of layers) {
+        invariant(
+          metadataLayers.has(layer),
+          "SAMPLE_LAYER_NOT_IN_METADATA",
+          `${region}:${layer} at ${z}/${x}/${y}`,
+        );
+        observedLayers.add(layer);
+      }
+      samples.push({
+        tile_id: tileId,
+        z,
+        x,
+        y,
+        bytes: response.data.byteLength,
+        layers,
+      });
+      candidatesRead += 1;
+
+      if (
+        [...styleContract.layers].every((layer) => observedLayers.has(layer))
+      ) {
+        break;
+      }
+    }
+
+    for (const layer of styleContract.layers) {
+      invariant(
+        observedLayers.has(layer),
+        "STYLE_LAYER_NOT_OBSERVED_IN_SAMPLE",
+        `${region}:${layer}; read ${samples.length} tiles`,
+      );
+    }
+
+    return {
+      region,
+      archive_path: source.filePath,
+      file_size: source.size,
+      header: {
+        spec_version: header.specVersion,
+        tile_type: header.tileType,
+        min_zoom: header.minZoom,
+        max_zoom: header.maxZoom,
+        bounds: [header.minLon, header.minLat, header.maxLon, header.maxLat],
+        num_addressed_tiles: header.numAddressedTiles,
+        num_tile_entries: header.numTileEntries,
+        num_tile_contents: header.numTileContents,
+      },
+      directory: {
+        directory_count: directory.directoryCount,
+        directory_entry_count: directory.directoryEntryCount,
+        tile_entry_count: directory.tileEntries.length,
+      },
+      metadata_layers: [...metadataLayers].sort(),
+      style_source_id: styleContract.sourceId,
+      style_layers: [...styleContract.layers].sort(),
+      observed_sample_layers: [...observedLayers].sort(),
+      samples,
+    };
+  } finally {
+    await source.close();
+  }
+}
+
+function parseArguments(argv) {
+  const result = {
+    archives: [],
+    stylePath: null,
+    outputPath: null,
+    maxSamples: DEFAULT_MAX_SAMPLES,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--archive") {
+      const value = argv[++index];
+      const separator = value?.indexOf("=");
+      invariant(
+        separator > 0,
+        "ARGUMENT_INVALID",
+        "--archive expects region=path",
+      );
+      result.archives.push({
+        region: value.slice(0, separator),
+        archivePath: value.slice(separator + 1),
+      });
+    } else if (argument === "--style") {
+      result.stylePath = argv[++index];
+    } else if (argument === "--output") {
+      result.outputPath = argv[++index];
+    } else if (argument === "--max-samples") {
+      result.maxSamples = Number(argv[++index]);
+    } else {
+      throw new Error(`ARGUMENT_UNKNOWN: ${argument}`);
+    }
+  }
+
+  invariant(
+    result.archives.length > 0,
+    "ARGUMENT_ARCHIVES_MISSING",
+    "at least one --archive region=path is required",
+  );
+  invariant(result.stylePath, "ARGUMENT_STYLE_MISSING", "--style is required");
+  return result;
+}
+
+async function main() {
+  const args = parseArguments(process.argv.slice(2));
+  const reports = [];
+  for (const archive of args.archives) {
+    reports.push(
+      await validateArchive({
+        ...archive,
+        stylePath: args.stylePath,
+        maxSamples: args.maxSamples,
+      }),
+    );
+  }
+
+  const output = {
+    schema_version: 1,
+    verdict: "PROVEN",
+    validator: "bounded-pmtiles-deep-validation-v1",
+    max_samples_per_archive: args.maxSamples,
+    archives: reports,
+    does_not_establish: [
+      "full_tile_by_tile_scan",
+      "cartographic_completeness",
+      "osm_semantic_correctness",
+      "source_data_freshness",
+    ],
+  };
+  const json = `${JSON.stringify(output, null, 2)}\n`;
+  if (args.outputPath) {
+    await writeFile(args.outputPath, json, "utf8");
+  }
+  process.stdout.write(json);
+}
+
+const isEntryPoint =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isEntryPoint) {
+  main().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`NOT_PROVEN: ${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/apps/web/scripts/validate-pmtiles.mjs
+++ b/apps/web/scripts/validate-pmtiles.mjs
@@ -585,6 +585,9 @@ function parseArguments(argv) {
 
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index];
+    if (argument === "--") {
+      continue;
+    }
     if (argument === "--archive") {
       const value = argv[++index];
       const separator = value?.indexOf("=");

--- a/apps/web/scripts/validate-pmtiles.test.mjs
+++ b/apps/web/scripts/validate-pmtiles.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -183,4 +184,29 @@ test("rejects malformed MVT tile payloads", async (t) => {
     validateArchive({ region: "fixture", archivePath, stylePath }),
     /MVT_DECODE_FAILED|MVT_LAYERS_EMPTY/,
   );
+});
+
+test("CLI accepts the conventional standalone argument separator", async (t) => {
+  const { directory, stylePath } = await fixtureContext(t);
+  const archivePath = path.join(directory, "cli.pmtiles");
+  const outputPath = path.join(directory, "receipt.json");
+  await writeFile(archivePath, makeArchive());
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      path.resolve("scripts/validate-pmtiles.mjs"),
+      "--",
+      "--archive",
+      `fixture=${archivePath}`,
+      "--style",
+      stylePath,
+      "--output",
+      outputPath,
+    ],
+    { encoding: "utf8" },
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /"verdict": "PROVEN"/);
 });

--- a/apps/web/scripts/validate-pmtiles.test.mjs
+++ b/apps/web/scripts/validate-pmtiles.test.mjs
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { validateArchive } from "./validate-pmtiles.mjs";
+
+function encodeVarint(value) {
+  const bytes = [];
+  let remaining = value;
+  do {
+    let byte = remaining & 0x7f;
+    remaining = Math.floor(remaining / 128);
+    if (remaining > 0) {
+      byte |= 0x80;
+    }
+    bytes.push(byte);
+  } while (remaining > 0);
+  return Buffer.from(bytes);
+}
+
+function writeUint64(buffer, offset, value) {
+  buffer.writeUInt32LE(value >>> 0, offset);
+  buffer.writeUInt32LE(Math.floor(value / 2 ** 32), offset + 4);
+}
+
+function writeCoordinate(buffer, offset, value) {
+  buffer.writeInt32LE(Math.round(value * 10_000_000), offset);
+}
+
+function minimalMvt() {
+  const feature = Buffer.from([0x18, 0x01, 0x22, 0x03, 0x09, 0x00, 0x00]);
+  const layer = Buffer.concat([
+    Buffer.from([0x0a, 0x05]),
+    Buffer.from("water", "utf8"),
+    Buffer.from([0x12, feature.length]),
+    feature,
+    Buffer.from([0x28, 0x80, 0x20]),
+    Buffer.from([0x78, 0x02]),
+  ]);
+  return Buffer.concat([Buffer.from([0x1a, layer.length]), layer]);
+}
+
+function makeArchive({ corruptDirectory = false, corruptMvt = false } = {}) {
+  const tile = corruptMvt
+    ? Buffer.alloc(minimalMvt().length, 0xff)
+    : minimalMvt();
+  const metadata = Buffer.from(
+    JSON.stringify({
+      vector_layers: [
+        {
+          id: "water",
+          fields: {},
+          minzoom: 0,
+          maxzoom: 0,
+        },
+      ],
+    }),
+    "utf8",
+  );
+  const directory = Buffer.concat([
+    encodeVarint(corruptDirectory ? 0 : 1),
+    ...(corruptDirectory
+      ? []
+      : [
+          encodeVarint(0),
+          encodeVarint(1),
+          encodeVarint(tile.length),
+          encodeVarint(1),
+        ]),
+  ]);
+
+  const rootOffset = 127;
+  const metadataOffset = rootOffset + directory.length;
+  const leafOffset = metadataOffset + metadata.length;
+  const tileOffset = leafOffset;
+  const header = Buffer.alloc(127);
+  header.write("PMTiles", 0, "ascii");
+  header[7] = 3;
+  writeUint64(header, 8, rootOffset);
+  writeUint64(header, 16, directory.length);
+  writeUint64(header, 24, metadataOffset);
+  writeUint64(header, 32, metadata.length);
+  writeUint64(header, 40, leafOffset);
+  writeUint64(header, 48, 0);
+  writeUint64(header, 56, tileOffset);
+  writeUint64(header, 64, tile.length);
+  writeUint64(header, 72, corruptDirectory ? 0 : 1);
+  writeUint64(header, 80, corruptDirectory ? 0 : 1);
+  writeUint64(header, 88, corruptDirectory ? 0 : 1);
+  header[96] = 1;
+  header[97] = 1;
+  header[98] = 1;
+  header[99] = 1;
+  header[100] = 0;
+  header[101] = 0;
+  writeCoordinate(header, 102, -180);
+  writeCoordinate(header, 106, -85);
+  writeCoordinate(header, 110, 180);
+  writeCoordinate(header, 114, 85);
+  header[118] = 0;
+  writeCoordinate(header, 119, 0);
+  writeCoordinate(header, 123, 0);
+
+  return Buffer.concat([header, directory, metadata, tile]);
+}
+
+async function fixtureContext(t) {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "pmtiles-validator-"));
+  t.after(async () => rm(directory, { recursive: true, force: true }));
+  const stylePath = path.join(directory, "style.json");
+  await writeFile(
+    stylePath,
+    JSON.stringify({
+      version: 8,
+      sources: {
+        fixture: {
+          type: "vector",
+          url: "pmtiles://basemap-fixture.pmtiles",
+        },
+      },
+      layers: [
+        {
+          id: "water",
+          type: "fill",
+          source: "fixture",
+          "source-layer": "water",
+        },
+      ],
+    }),
+  );
+  return { directory, stylePath };
+}
+
+test("accepts a structurally valid PMTiles v3 archive and decodes MVT", async (t) => {
+  const { directory, stylePath } = await fixtureContext(t);
+  const archivePath = path.join(directory, "valid.pmtiles");
+  await writeFile(archivePath, makeArchive());
+
+  const report = await validateArchive({
+    region: "fixture",
+    archivePath,
+    stylePath,
+    maxSamples: 4,
+  });
+
+  assert.equal(report.header.spec_version, 3);
+  assert.equal(report.directory.directory_count, 1);
+  assert.equal(report.directory.tile_entry_count, 1);
+  assert.deepEqual(report.observed_sample_layers, ["water"]);
+  assert.equal(report.samples.length, 1);
+});
+
+test("rejects a truncated archive before publication", async (t) => {
+  const { directory, stylePath } = await fixtureContext(t);
+  const archivePath = path.join(directory, "truncated.pmtiles");
+  await writeFile(archivePath, makeArchive().subarray(0, 100));
+
+  await assert.rejects(
+    validateArchive({ region: "fixture", archivePath, stylePath }),
+    /ARCHIVE_TRUNCATED/,
+  );
+});
+
+test("rejects an empty or corrupt root directory", async (t) => {
+  const { directory, stylePath } = await fixtureContext(t);
+  const archivePath = path.join(directory, "directory-corrupt.pmtiles");
+  await writeFile(archivePath, makeArchive({ corruptDirectory: true }));
+
+  await assert.rejects(
+    validateArchive({ region: "fixture", archivePath, stylePath }),
+    /DIRECTORY_EMPTY|TILE_ENTRIES_EMPTY/,
+  );
+});
+
+test("rejects malformed MVT tile payloads", async (t) => {
+  const { directory, stylePath } = await fixtureContext(t);
+  const archivePath = path.join(directory, "mvt-corrupt.pmtiles");
+  await writeFile(archivePath, makeArchive({ corruptMvt: true }));
+
+  await assert.rejects(
+    validateArchive({ region: "fixture", archivePath, stylePath }),
+    /MVT_DECODE_FAILED|MVT_LAYERS_EMPTY/,
+  );
+});

--- a/apps/web/tests/proofs/basemap-real-hamburg-visual.proof.ts
+++ b/apps/web/tests/proofs/basemap-real-hamburg-visual.proof.ts
@@ -250,6 +250,11 @@ test.describe("Basemap Real Hamburg Visual Runtime Proof", () => {
         "Expected Content-Range header for PMTiles delivery",
       ).toContain("bytes 0-511/");
 
+      expect(
+        directRangeResponse.headers()["content-type"] ?? "",
+        "Expected explicit PMTiles Content-Type",
+      ).toContain("application/octet-stream");
+
       // === BROWSER/MAPLIBRE VISUAL CONTRACT ===
       // Map container must be visible
       await expect(page.locator("#map")).toBeVisible({ timeout: 20000 });
@@ -450,6 +455,8 @@ test.describe("Basemap Real Hamburg Visual Runtime Proof", () => {
           directRangeResponse.headers()["accept-ranges"] ?? null,
         direct_range_content_range:
           directRangeResponse.headers()["content-range"] ?? null,
+        direct_range_content_type:
+          directRangeResponse.headers()["content-type"] ?? null,
 
         // BROWSER/MAPLIBRE VISUAL CONTRACT - OBSERVED
         pmtiles_requests_total: pmtilesRequests.length,
@@ -525,6 +532,11 @@ test.describe("Basemap Real Hamburg Visual Runtime Proof", () => {
         proofSummary.direct_range_accept_ranges,
         "Proof requires Accept-Ranges header",
       ).toContain("bytes");
+
+      expect(
+        proofSummary.direct_range_content_type,
+        "Proof requires explicit PMTiles Content-Type",
+      ).toContain("application/octet-stream");
 
       // Hard assertion: MapLibre must have requested at least one local PMTiles file
       expect(

--- a/apps/web/tests/proofs/basemap-real-schleswig-holstein-visual.proof.ts
+++ b/apps/web/tests/proofs/basemap-real-schleswig-holstein-visual.proof.ts
@@ -197,6 +197,9 @@ test.describe("Basemap Real Schleswig-Holstein Visual Runtime Proof", () => {
       expect(directRangeResponse.headers()["content-range"] ?? "").toContain(
         "bytes 0-511/",
       );
+      expect(directRangeResponse.headers()["content-type"] ?? "").toContain(
+        "application/octet-stream",
+      );
       expect(
         Buffer.from(await directRangeResponse.body())
           .subarray(0, 7)
@@ -426,6 +429,8 @@ test.describe("Basemap Real Schleswig-Holstein Visual Runtime Proof", () => {
         direct_range_status: directRangeResponse.status(),
         direct_range_content_range:
           directRangeResponse.headers()["content-range"] ?? null,
+        direct_range_content_type:
+          directRangeResponse.headers()["content-type"] ?? null,
         pmtiles_range_requests_observed: targetRequests.filter((request) =>
           request.rangeHeader?.startsWith("bytes="),
         ).length,

--- a/audit/impl-registry.yaml
+++ b/audit/impl-registry.yaml
@@ -144,10 +144,13 @@ implementations:
     evidence_level: guard
     documented_by:
       - docs/blueprints/map-blaupause.md
+      - docs/deployment.md
     verified_by:
       - scripts/guard/caddy-basemap-route-guard.sh
       - scripts/guard/domain-single-instance-guard.sh
       - scripts/tests/test_domain_single_instance_guard.sh
+      - scripts/ci/tests/test_regional_basemap_style.py
+      - scripts/ci/tests/test_public_live_readiness.py
 
   - id: impl.guard.basemap-runtime-proof
     path: scripts/guard/basemap-runtime-proof.sh
@@ -158,7 +161,23 @@ implementations:
     documented_by:
       - docs/specs/map-experience.md
       - docs/reports/map-status.md
+      - docs/deployment.md
     verified_by:
+      - .github/workflows/basemap-runtime-proof.yml
+      - scripts/ci/tests/test_regional_basemap_style.py
+      - scripts/ci/tests/test_public_live_readiness.py
+
+  - id: impl.guard.pmtiles-deep-validator
+    path: apps/web/scripts/validate-pmtiles.mjs
+    impl_type: guard
+    status: active
+    criticality: medium
+    evidence_level: ci
+    documented_by:
+      - docs/deployment.md
+      - docs/reports/map-basemap-proof-gap-reconciliation.md
+    verified_by:
+      - apps/web/scripts/validate-pmtiles.test.mjs
       - .github/workflows/basemap-runtime-proof.yml
 
   - id: impl.auth.db-session-store

--- a/docs/_generated/doc-coverage.md
+++ b/docs/_generated/doc-coverage.md
@@ -15,7 +15,7 @@ Generated automatically. Do not edit.
 | Component Type | Coverage | Total | Documented |
 | --- | --- | --- | --- |
 | Config | 100% | 3 | 3 |
-| Guard | 100% | 5 | 5 |
+| Guard | 100% | 6 | 6 |
 | Schema | 100% | 1 | 1 |
 | Service | 100% | 3 | 3 |
 | Workflow | 100% | 4 | 4 |

--- a/docs/_generated/implicit-dependencies.md
+++ b/docs/_generated/implicit-dependencies.md
@@ -37,6 +37,7 @@ Generated automatically. Do not edit.
 | Makefile (validate-shell-tests) | scripts/tests/test_weltgewebe_up_deploy_scope.sh | `bash scripts/tests/test_weltgewebe_up_deploy_scope.sh` | *unclear* |
 | Makefile (validate-shell-tests) | scripts/tests/test_version_guard.sh | `bash scripts/tests/test_version_guard.sh` | *unclear* |
 | Makefile (validate-shell-tests) | scripts/tests/test_basemap_mode_guard.sh | `bash scripts/tests/test_basemap_mode_guard.sh` | *unclear* |
+| Makefile (validate-shell-tests) | scripts/tests/test_basemap_runtime_proof_contract.sh | `bash scripts/tests/test_basemap_runtime_proof_contract.sh` | *unclear* |
 | Makefile (validate-shell-tests) | scripts/tests/test_security_headers_guard.sh | `bash scripts/tests/test_security_headers_guard.sh` | *unclear* |
 | Makefile (validate-shell-tests) | scripts/tests/test_repo_contract_guards.sh | `bash scripts/tests/test_repo_contract_guards.sh` | *unclear* |
 | Makefile (validate-shell-tests) | scripts/tests/test_postgres_backup_restore_contract.sh | `bash scripts/tests/test_postgres_backup_restore_contract.sh` | *unclear* |

--- a/docs/deploy/CHANGELOG.md
+++ b/docs/deploy/CHANGELOG.md
@@ -10,6 +10,39 @@ relations:
 ---
 # Deployment-Änderungsprotokoll
 
+## 2026-07-13 - PMTiles-Repräsentationsvertrag und tiefe Archivprüfung
+
+**Geänderte Bereiche:**
+
+- `infra/caddy/Caddyfile`, `Caddyfile.heim`, `Caddyfile.vps` und `Caddyfile.proof`;
+- Basemap-Runtime-Guard und Public-Live-Readiness;
+- regionale PMTiles-Content-Proofs für Hamburg und Schleswig-Holstein.
+
+**Beschreibung:**
+
+Alle `.pmtiles`-Antworten unter `/local-basemap/` erhalten ausdrücklich den
+Medientyp `application/octet-stream`. Voll-/HEAD- und Range-Pfade müssen
+zusätzlich HTTP 200 beziehungsweise 206, `Accept-Ranges: bytes`, ein passendes
+`Content-Range` und die PMTiles-Signatur belegen. Der Vertrag gilt für stabile
+Aliasse und versionierte Dateien beider Regionen.
+
+Vor Veröffentlichung traversiert ein begrenzter Validator alle erreichbaren
+PMTiles-Root- und Leaf-Verzeichnisse, gleicht die Header-Zählwerte ab und
+decodiert bis zu 96 deterministisch über Zoomstufen und Raum verteilte reale
+MVT-Payloads. Die beobachteten Layer müssen zu Metadaten und Kartenstil passen.
+Ein Vollscan jeder Kachel, kartografische Vollständigkeit und Datenfrische
+werden weiterhin nicht behauptet.
+
+**Produktionswirkung:**
+
+Beim Rollout wird ausschließlich die geprüfte `Caddyfile.vps` installiert und
+Caddy nach erfolgreicher Konfigurationsvalidierung neu geladen. Die PMTiles-
+Artefaktbytes und Aliasse werden nicht verändert. Danach müssen die vier
+öffentlichen stabilen/versionierten Pfade für Hamburg und Schleswig-Holstein
+den 200-/206-Headervertrag erfüllen; die bestehenden SHA-256-Werte und der
+Browser-Renderingpfad werden erneut gelesen. Bei Fehlern wird die vorherige
+Caddy-Konfiguration wiederhergestellt.
+
 ## 2026-07-12 - Audit-Remediation für reproduzierbare und wiederherstellbare Deployments
 
 **Geänderte Bereiche:**

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,7 +4,7 @@ title: Deployment Contract and Preflight Guard
 doc_type: guide
 status: active
 summary: Anleitung und Dokumentation zum Deployment.
-last_reviewed: "2026-07-12"
+last_reviewed: "2026-07-13"
 relations:
   - type: relates_to
     target: docs/deploy/README.md
@@ -58,6 +58,32 @@ _Note (Phase C Preparation): Future Evaluation: The current bind-mount model cou
 ### Basemap Artifact Deployment (Best Effort)
 
 The deployment script (`weltgewebe-up`) attempts to provide every regional PMTiles source required by `map-style/style.json` in the `build/basemap/` directory before stack initialization. Hamburg and Schleswig-Holstein are built and published independently. Each region has a versioned artifact plus stable `.pmtiles` and `.meta.json` aliases. The guard remains best effort, but it reports missing regions separately so one existing region cannot hide another missing one.
+
+#### PMTiles HTTP representation contract
+
+Every `.pmtiles` response under `/local-basemap/` uses the explicit media type `application/octet-stream`. The contract applies to versioned files and stable aliases and is identical for the development Caddyfile, the Heim reference, the VPS Caddyfile, and the isolated Caddy proof. A valid public representation must satisfy all of the following:
+
+- a full or HEAD representation returns HTTP 200, `Content-Type: application/octet-stream`, and `Accept-Ranges: bytes`;
+- `Range: bytes=0-15` returns HTTP 206 with the same `Content-Type` and a matching `Content-Range`;
+- the full GET and Range response bodies begin with the PMTiles signature; HEAD is used only for the 200/header contract.
+
+`scripts/ops/check_public_live_readiness.py` checks this contract for the stable and versioned Hamburg and Schleswig-Holstein paths after deployment.
+
+#### Bounded deep PMTiles validation
+
+`apps/web/scripts/validate-pmtiles.mjs` is the publication gate for regional archives. It uses the repository's pinned `pmtiles` reader to validate the v3 header and section boundaries, traverse every reachable root and leaf directory, reconcile directory counts with the header, read metadata, and decode a deterministic bounded sample of real MVT payloads. The sampled layers must agree with metadata and cover every source layer used by `map-style/style.json`.
+
+The two regional content-proof jobs run the validator on the exact artifacts they build and upload its JSON receipt. Unit tests also prove fail-closed behavior for a truncated archive, a corrupt root directory, and malformed MVT bytes. The gate is deliberately bounded: it does not scan every tile and does not establish cartographic completeness, OSM semantic correctness, or source freshness.
+
+Example for a locally available artifact:
+
+```bash
+cd apps/web
+pnpm validate:pmtiles -- \
+  --archive hamburg=../../build/basemap/basemap-hamburg-v0.1.0.pmtiles \
+  --style ../../map-style/style.json \
+  --output /tmp/hamburg-pmtiles-deep-validation.json
+```
 
 #### `PUBLIC_BASEMAP_MODE` Contract
 

--- a/docs/reports/map-status.md
+++ b/docs/reports/map-status.md
@@ -9,7 +9,7 @@ lifecycle_state: active
 lifecycle: audit
 owner: product-map
 owner_task: DOCMETA-REPORT-LIFECYCLE-001
-last_reviewed: 2026-07-12
+last_reviewed: 2026-07-13
 review_after: 2026-08-12
 evidence_required_for_live_claims:
   - exact Git commit and image tag on wg-prod-1
@@ -27,7 +27,7 @@ relations:
 ---
 # Kartenstatus
 
-Stand: 12.07.2026. Dieses Dokument ist ein zeitgebundener Diagnosebericht. Der
+Stand: 13.07.2026. Dieses Dokument ist ein zeitgebundener Diagnosebericht. Der
 dauerhafte Produktvertrag steht in
 [`docs/specs/map-experience.md`](../specs/map-experience.md).
 
@@ -44,6 +44,8 @@ dauerhafte Produktvertrag steht in
 | Garnrolle | `not_on_map`, `exact` und `radius` sind im Browserpfad vorhanden | `garnrolle-self-service.spec.ts` |
 | Knoten und Faden | Komposition erzeugt Knoten und den zugehörigen Faden | `KompositionPanel.svelte`, `komposition.spec.ts` |
 | Produktionsvertrag | PostgreSQL ist für Accounts/Garnrollen, Knoten und Fäden die Produktionswahrheit | `.env.prod.example`, `runtime/README.md`, Compose- und API-Verträge |
+| Regionale Basemap-Integrität | Hamburg und Schleswig-Holstein werden vor Veröffentlichung durch alle erreichbaren PMTiles-Verzeichnisse traversiert; bis zu 96 reale MVT-Kacheln werden deterministisch über Zoomstufen und Raum verteilt decodiert und gegen Metadaten sowie Style-Layer geprüft | `apps/web/scripts/validate-pmtiles.mjs`, `validate-pmtiles.test.mjs`, `basemap-runtime-proof.yml` |
+| PMTiles-HTTP-Vertrag | Stabile und versionierte Regionalpfade müssen bei HTTP 200 und 206 `application/octet-stream`, `Accept-Ranges: bytes`, korrektes `Content-Range` und die PMTiles-Signatur liefern | `infra/caddy/Caddyfile.vps`, `scripts/guard/basemap-runtime-proof.sh`, `scripts/ops/check_public_live_readiness.py` |
 
 ## Datierter Livebeleg
 
@@ -70,6 +72,7 @@ relevanten Runtimewechsel muss er neu erhoben werden.
 - visuelle Korrektheit über repräsentative Zoomstufen, Browser und Geräte;
 - URL-Bindung lokaler Panel-Tabs;
 - dauerhaft gemessene Kartenleistung;
+- ein Vollscan jeder einzelnen PMTiles-Kachel; der Validator prüft alle Verzeichnisse, aber bewusst nur eine begrenzte, deterministische Payload-Stichprobe;
 - ein aktueller Backup-/Restore- und Off-Host-Beleg nach jeder Änderung.
 
 ## Nächste Beweise

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -11,9 +11,11 @@
   # Route matches the public edge contract: /local-basemap/ (frontend, blueprint, Vite middleware)
   handle_path /local-basemap/* {
     root * /srv/weltgewebe-basemap
+    @pmtiles path_regexp \.pmtiles$
+    header @pmtiles Content-Type "application/octet-stream"
     header Access-Control-Allow-Origin "*"
     header Access-Control-Allow-Methods "GET, HEAD, OPTIONS"
-    header Access-Control-Expose-Headers "Content-Range, Accept-Ranges, Content-Length"
+    header Access-Control-Expose-Headers "Content-Type, Content-Range, Accept-Ranges, Content-Length"
     header Access-Control-Allow-Headers "Range, If-None-Match"
     # defensive CORS hardening for clients/browsers that do send preflight requests
     @options {

--- a/infra/caddy/Caddyfile.heim
+++ b/infra/caddy/Caddyfile.heim
@@ -9,9 +9,10 @@ weltgewebe.home.arpa {
     @pmtiles path_regexp \.pmtiles$
     handle @pmtiles {
       root * /srv/weltgewebe-basemap
+      header Content-Type "application/octet-stream"
       header Access-Control-Allow-Origin "*"
       header Access-Control-Allow-Methods "GET, HEAD, OPTIONS"
-      header Access-Control-Expose-Headers "Content-Range, Accept-Ranges, Content-Length"
+      header Access-Control-Expose-Headers "Content-Type, Content-Range, Accept-Ranges, Content-Length"
       header Access-Control-Allow-Headers "Range, If-None-Match"
       @options {
         method OPTIONS

--- a/infra/caddy/Caddyfile.proof
+++ b/infra/caddy/Caddyfile.proof
@@ -2,15 +2,16 @@
 # CI job. It mirrors the public /local-basemap/* route from infra/caddy/Caddyfile
 # down to a stand-alone configuration so that a real Caddy process can serve a
 # .pmtiles file via HTTP Range requests, and the guard
-# scripts/guard/basemap-runtime-proof.sh can verify HTTP 206 + Content-Range
-# against it.
+# scripts/guard/basemap-runtime-proof.sh can verify the explicit PMTiles
+# Content-Type plus HTTP 200/206, Accept-Ranges, and Content-Range against it.
 #
 # Intentionally NOT used in dev/heim/prod. The production Caddyfiles add
 # additional concerns (TLS, CSP, reverse proxies, encoding, CORS) which are
 # outside the scope of the Range-delivery proof.
 #
-# Scope: this configuration proves Caddy HTTP Range delivery on /local-basemap/.
-#        It does not prove production CSP, CORS, or reverse-proxy behaviour.
+# Scope: this configuration proves Caddy's PMTiles representation contract on
+#        /local-basemap/. It does not prove production CSP, CORS, or
+#        reverse-proxy behaviour.
 
 {
 	auto_https off
@@ -20,6 +21,7 @@
 :8081 {
 	handle_path /local-basemap/* {
 		root * /srv/weltgewebe-basemap
+		header Content-Type "application/octet-stream"
 		file_server
 	}
 

--- a/infra/caddy/Caddyfile.vps
+++ b/infra/caddy/Caddyfile.vps
@@ -27,9 +27,10 @@
 		@pmtiles path_regexp \.pmtiles$
 		handle @pmtiles {
 			root * /srv/weltgewebe-basemap
+			header Content-Type "application/octet-stream"
 			header Access-Control-Allow-Origin "*"
 			header Access-Control-Allow-Methods "GET, HEAD, OPTIONS"
-			header Access-Control-Expose-Headers "Content-Range, Accept-Ranges, Content-Length"
+			header Access-Control-Expose-Headers "Content-Type, Content-Range, Accept-Ranges, Content-Length"
 			header Access-Control-Allow-Headers "Range, If-None-Match"
 			@options {
 				method OPTIONS

--- a/scripts/ci/tests/test_public_live_readiness.py
+++ b/scripts/ci/tests/test_public_live_readiness.py
@@ -57,10 +57,30 @@ class FakeWorld:
         if url == "https://weltgewebe.net/local-basemap/glyphs/Noto%20Sans%20Regular/0-255.pbf":
             return FetchResult(url, 200, {}, b"glyph-bytes")
         if url in {
+            "https://weltgewebe.net/local-basemap/basemap-hamburg.pmtiles",
             "https://weltgewebe.net/local-basemap/basemap-hamburg-v0.1.0.pmtiles",
+            "https://weltgewebe.net/local-basemap/basemap-schleswig-holstein.pmtiles",
             "https://weltgewebe.net/local-basemap/basemap-schleswig-holstein-v0.1.0.pmtiles",
         }:
-            return FetchResult(url, 206, {"Content-Range": "bytes 0-15/100"}, b"PMTiles\x03fake")
+            if headers and headers.get("Range") == "bytes=0-15":
+                return FetchResult(
+                    url,
+                    206,
+                    {
+                        "Content-Type": "application/octet-stream",
+                        "Content-Range": "bytes 0-15/100",
+                    },
+                    b"PMTiles\x03fake",
+                )
+            return FetchResult(
+                url,
+                200,
+                {
+                    "Content-Type": "application/octet-stream",
+                    "Accept-Ranges": "bytes",
+                },
+                b"PMTiles\x03fake",
+            )
         return FetchResult(url, 404, {}, b"")
 
     def checker(self):
@@ -93,14 +113,25 @@ class PublicLiveReadinessTest(unittest.TestCase):
                 "version-json",
                 "basemap-style",
                 "glyph-range",
-                "pmtiles-header:hamburg",
-                "pmtiles-header:schleswig-holstein",
+                "pmtiles-header:hamburg-stable",
+                "pmtiles-header:hamburg-versioned",
+                "pmtiles-header:schleswig-holstein-stable",
+                "pmtiles-header:schleswig-holstein-versioned",
             },
         )
         pmtiles_requests = [headers for url, headers in fake.requests if url.endswith(".pmtiles")]
         self.assertEqual(
             pmtiles_requests,
-            [{"Range": "bytes=0-15"}, {"Range": "bytes=0-15"}],
+            [
+                None,
+                {"Range": "bytes=0-15"},
+                None,
+                {"Range": "bytes=0-15"},
+                None,
+                {"Range": "bytes=0-15"},
+                None,
+                {"Range": "bytes=0-15"},
+            ],
         )
 
     def test_wrong_dns_ip_fails(self) -> None:
@@ -145,7 +176,16 @@ class PublicLiveReadinessTest(unittest.TestCase):
 
         def bad_fetcher(url: str, headers: Mapping[str, str] | None, timeout: float):
             if url.endswith(".pmtiles"):
-                return fake.module.FetchResult(url, 200, {}, b"not-pmtiles")
+                status = 206 if headers and headers.get("Range") else 200
+                response_headers = {
+                    "Content-Type": "application/octet-stream",
+                    "Accept-Ranges": "bytes",
+                }
+                if status == 206:
+                    response_headers["Content-Range"] = "bytes 0-15/100"
+                return fake.module.FetchResult(
+                    url, status, response_headers, b"not-pmtiles"
+                )
             return fake.fetcher(url, headers, timeout)
 
         checker = fake.module.PublicLiveChecker(resolver=fake.resolver, fetcher=bad_fetcher)
@@ -153,9 +193,46 @@ class PublicLiveReadinessTest(unittest.TestCase):
             result for result in checker.run() if result.name.startswith("pmtiles-header:")
         ]
 
-        self.assertEqual(len(pmtiles_results), 2)
+        self.assertEqual(len(pmtiles_results), 4)
         self.assertTrue(all(not result.ok for result in pmtiles_results))
-        self.assertTrue(all("missing" in result.detail for result in pmtiles_results))
+        self.assertTrue(
+            all("signature" in result.detail for result in pmtiles_results)
+        )
+
+    def test_pmtiles_contract_requires_explicit_content_type(self) -> None:
+        fake = FakeWorld()
+
+        def bad_fetcher(
+            url: str, headers: Mapping[str, str] | None, timeout: float
+        ):
+            result = fake.fetcher(url, headers, timeout)
+            if url.endswith(".pmtiles"):
+                return fake.module.FetchResult(
+                    result.url,
+                    result.status,
+                    {
+                        key: value
+                        for key, value in result.headers.items()
+                        if key.lower() != "content-type"
+                    },
+                    result.body,
+                )
+            return result
+
+        checker = fake.module.PublicLiveChecker(
+            resolver=fake.resolver, fetcher=bad_fetcher
+        )
+        pmtiles_results = [
+            result
+            for result in checker.run()
+            if result.name.startswith("pmtiles-header:")
+        ]
+
+        self.assertEqual(len(pmtiles_results), 4)
+        self.assertTrue(all(not result.ok for result in pmtiles_results))
+        self.assertTrue(
+            all("content-type" in result.detail for result in pmtiles_results)
+        )
 
 
 class PublicLiveReadinessIPv6Test(unittest.TestCase):

--- a/scripts/ci/tests/test_regional_basemap_style.py
+++ b/scripts/ci/tests/test_regional_basemap_style.py
@@ -9,6 +9,12 @@ REPO = Path(__file__).resolve().parents[3]
 STYLE_PATH = REPO / "map-style" / "style.json"
 UP_SCRIPT_PATH = REPO / "scripts" / "weltgewebe-up"
 WORKFLOW_PATH = REPO / ".github" / "workflows" / "basemap-runtime-proof.yml"
+CADDY_PATHS = (
+    REPO / "infra" / "caddy" / "Caddyfile",
+    REPO / "infra" / "caddy" / "Caddyfile.heim",
+    REPO / "infra" / "caddy" / "Caddyfile.vps",
+    REPO / "infra" / "caddy" / "Caddyfile.proof",
+)
 
 
 class RegionalBasemapStyleTest(unittest.TestCase):
@@ -75,6 +81,41 @@ class RegionalBasemapStyleTest(unittest.TestCase):
         )
         self.assertIn('"${META_PATH}"', workflow)
         self.assertNotIn('META_PATH="build/basemap/"', workflow)
+
+    def test_content_jobs_run_bounded_deep_validation(self) -> None:
+        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        content_jobs = workflow[
+            workflow.index("  basemap-pmtiles-content-proof:") :
+            workflow.index("  basemap-visual-proof:")
+        ]
+
+        self.assertIn("pnpm test:pmtiles-validator", content_jobs)
+        self.assertIn(
+            "--archive hamburg=../../build/basemap/"
+            "basemap-hamburg-v0.1.0.pmtiles",
+            content_jobs,
+        )
+        self.assertIn(
+            "--archive schleswig-holstein=../../build/basemap/"
+            "basemap-schleswig-holstein-v0.1.0.pmtiles",
+            content_jobs,
+        )
+        self.assertIn(
+            "/tmp/hamburg-pmtiles-deep-validation.json", content_jobs
+        )
+        self.assertIn(
+            "/tmp/schleswig-holstein-pmtiles-deep-validation.json",
+            content_jobs,
+        )
+
+    def test_all_caddy_surfaces_declare_pmtiles_content_type(self) -> None:
+        for caddy_path in CADDY_PATHS:
+            with self.subTest(caddyfile=caddy_path.name):
+                text = caddy_path.read_text(encoding="utf-8")
+                self.assertIn(
+                    'Content-Type "application/octet-stream"', text
+                )
+
 
     def test_visual_proof_materializes_both_regional_sources(self) -> None:
         workflow = WORKFLOW_PATH.read_text(encoding="utf-8")

--- a/scripts/guard/basemap-runtime-proof.sh
+++ b/scripts/guard/basemap-runtime-proof.sh
@@ -7,15 +7,16 @@ set -euo pipefail
 #
 #   range-delivery   (default)
 #     Proves that a live Caddy instance delivers a PMTiles artefact via HTTP
-#     Range requests (HTTP 206 Partial Content), with Accept-Ranges/Content-Range
-#     headers present.  Does NOT validate the artefact content itself.
+#     full (HTTP 200) and Range (HTTP 206) representation contract with
+#     application/octet-stream, Accept-Ranges and Content-Range. Does NOT
+#     validate the artefact content itself.
 #
 #   pmtiles-content
 #     Proves that the local artefact exists, is non-empty, carries the exact
 #     PMTiles magic header at byte offset 0 ("PMTiles", 7 bytes), and that
 #     Caddy delivers the same magic bytes 0-6 via HTTP Range request.
 #     Optionally verifies SHA256 when BASEMAP_EXPECTED_SHA256 is set.
-#     Explicitly NOT a deep PMTiles structure validation.
+#     Deep structure is verified by apps/web/scripts/validate-pmtiles.mjs.
 #
 # This is DISTINCT from:
 #   - apps/web/tests/basemap-client-integration.spec.ts  (mocked client test;
@@ -59,74 +60,112 @@ REPO_ROOT="${REPO_ROOT:-$(cd -- "${SCRIPT_DIR}/../.." > /dev/null 2>&1 && pwd)}"
 BASEMAP_PROOF_SCOPE="${BASEMAP_PROOF_SCOPE:-range-delivery}"
 BASEMAP_PROOF_MODE="${BASEMAP_PROOF_MODE:-require}"
 
+read_header_value() {
+  local header_name="${1,,}"
+  local header_file="$2"
+
+  awk -v target="${header_name}:" '
+    tolower($1) == target {
+      sub(/^[^:]*:[[:space:]]*/, "")
+      sub(/\r$/, "")
+      print
+      exit
+    }
+  ' "${header_file}"
+}
+
 require_http_range_proof() {
   local full_url="$1"
-  local header_tmp=""
-  local http_status=""
-  local has_accept_ranges=0
-  local has_content_range=0
+  local expected_type="${BASEMAP_EXPECTED_CONTENT_TYPE:-application/octet-stream}"
+  local full_headers=""
+  local range_headers=""
+  local full_status=""
+  local range_status=""
+  local full_type=""
+  local range_type=""
+  local accept_ranges=""
+  local content_range=""
 
-  header_tmp="$(mktemp)"
+  full_headers="$(mktemp)"
+  range_headers="$(mktemp)"
 
-  http_status="$({
+  full_status="$({
+    curl --silent \
+      --head \
+      --max-time 10 \
+      --output /dev/null \
+      --dump-header "${full_headers}" \
+      --write-out '%{http_code}' \
+      "${full_url}" 2> /dev/null
+  })" || {
+    rm -f "${full_headers}" "${range_headers}"
+    printf 'ERROR: HEAD request to %s failed\n' "${full_url}" >&2
+    return 1
+  }
+
+  if [[ "${full_status}" != "200" ]]; then
+    rm -f "${full_headers}" "${range_headers}"
+    printf 'ERROR: Expected HTTP 200 for PMTiles HEAD, got %s\n' "${full_status}" >&2
+    return 1
+  fi
+
+  full_type="$(read_header_value content-type "${full_headers}" | cut -d';' -f1)"
+  accept_ranges="$(read_header_value accept-ranges "${full_headers}")"
+  if [[ "${full_type}" != "${expected_type}" ]]; then
+    rm -f "${full_headers}" "${range_headers}"
+    printf 'ERROR: PMTiles HEAD Content-Type is %s, expected %s\n' \
+      "${full_type:-<missing>}" "${expected_type}" >&2
+    return 1
+  fi
+  if [[ "${accept_ranges}" != "bytes" ]]; then
+    rm -f "${full_headers}" "${range_headers}"
+    printf 'ERROR: Accept-Ranges is %s, expected bytes\n' \
+      "${accept_ranges:-<missing>}" >&2
+    return 1
+  fi
+
+  range_status="$({
     curl --silent \
       --max-time 10 \
       --header 'Range: bytes=0-511' \
       --output /dev/null \
-      --dump-header "${header_tmp}" \
+      --dump-header "${range_headers}" \
       --write-out '%{http_code}' \
       "${full_url}" 2> /dev/null
   })" || {
-    rm -f "${header_tmp}"
-    printf 'ERROR: curl request to %s failed\n' "${full_url}" >&2
+    rm -f "${full_headers}" "${range_headers}"
+    printf 'ERROR: Range request to %s failed\n' "${full_url}" >&2
     return 1
   }
 
-  if [[ "${http_status}" == "200" ]]; then
-    rm -f "${header_tmp}"
-    printf 'ERROR: Caddy returned HTTP 200 for a Range request — Range delivery is inactive\n' >&2
-    printf '  URL:    %s\n' "${full_url}" >&2
-    printf '  Status: 200 OK (expected 206 Partial Content)\n' >&2
-    printf '  A 200 response to a Range request means the server ignores Range headers.\n' >&2
+  if [[ "${range_status}" != "206" ]]; then
+    rm -f "${full_headers}" "${range_headers}"
+    printf 'ERROR: Expected HTTP 206 for PMTiles Range request, got %s\n' \
+      "${range_status}" >&2
     return 1
   fi
 
-  if [[ "${http_status}" != "206" ]]; then
-    rm -f "${header_tmp}"
-    printf 'ERROR: Unexpected HTTP status %s for Range request\n' "${http_status}" >&2
-    printf '  URL:      %s\n' "${full_url}" >&2
-    printf '  Expected: 206 Partial Content\n' >&2
+  range_type="$(read_header_value content-type "${range_headers}" | cut -d';' -f1)"
+  content_range="$(read_header_value content-range "${range_headers}")"
+  if [[ "${range_type}" != "${expected_type}" ]]; then
+    rm -f "${full_headers}" "${range_headers}"
+    printf 'ERROR: PMTiles Range Content-Type is %s, expected %s\n' \
+      "${range_type:-<missing>}" "${expected_type}" >&2
+    return 1
+  fi
+  if [[ "${content_range}" != bytes\ 0-511/* ]]; then
+    rm -f "${full_headers}" "${range_headers}"
+    printf 'ERROR: Content-Range is %s, expected bytes 0-511/<size>\n' \
+      "${content_range:-<missing>}" >&2
     return 1
   fi
 
-  if grep -qi '^accept-ranges:' "${header_tmp}"; then
-    has_accept_ranges=1
-  fi
-  if grep -qi '^content-range:' "${header_tmp}"; then
-    has_content_range=1
-  fi
-
-  if [[ "${has_accept_ranges}" -eq 0 && "${has_content_range}" -eq 0 ]]; then
-    rm -f "${header_tmp}"
-    printf 'ERROR: Neither Accept-Ranges nor Content-Range header present in response\n' >&2
-    printf '  URL: %s\n' "${full_url}" >&2
-    return 1
-  fi
-
-  printf 'HTTP status: %s (206 Partial Content confirmed)\n' "${http_status}"
-
-  if [[ "${has_accept_ranges}" -eq 1 ]]; then
-    local accept_ranges_val=""
-    accept_ranges_val="$(grep -i '^accept-ranges:' "${header_tmp}" | head -1 | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r')"
-    printf 'Accept-Ranges: %s (confirmed)\n' "${accept_ranges_val}"
-  fi
-  if [[ "${has_content_range}" -eq 1 ]]; then
-    local content_range_val=""
-    content_range_val="$(grep -i '^content-range:' "${header_tmp}" | head -1 | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r')"
-    printf 'Content-Range: %s (confirmed)\n' "${content_range_val}"
-  fi
-
-  rm -f "${header_tmp}"
+  printf 'HTTP full status: 200 (confirmed)\n'
+  printf 'HTTP range status: 206 (confirmed)\n'
+  printf 'Content-Type: %s (full and Range confirmed)\n' "${expected_type}"
+  printf 'Accept-Ranges: bytes (confirmed)\n'
+  printf 'Content-Range: %s (confirmed)\n' "${content_range}"
+  rm -f "${full_headers}" "${range_headers}"
 }
 
 # Validate BASEMAP_PROOF_SCOPE
@@ -146,7 +185,7 @@ fi
 # Proves: local file exists, non-empty, PMTiles magic header at offset 0,
 #         optional SHA256 checksum, and Caddy delivers the same magic bytes
 #         via HTTP Range request (bytes 0-6).
-# Explicitly NOT: deep PMTiles structure validation.
+# Deep structure is proved by the separate bounded validator in the content jobs.
 # ---------------------------------------------------------------------------
 
 if [[ "${BASEMAP_PROOF_SCOPE}" == "pmtiles-content" ]]; then
@@ -285,8 +324,7 @@ if [[ "${BASEMAP_PROOF_SCOPE}" == "pmtiles-content" ]]; then
   printf '  HTTP status:    206 Partial Content\n'
   printf '  SHA256 check:   %s\n' "${SHA256_STATUS}"
   printf '\n'
-  printf 'NOT_PROVEN: Deep PMTiles structure validation (tile index, directory, metadata integrity)\n'
-  printf '  This scope validates magic/header/hash only — full structure proof not implemented.\n'
+  printf 'SCOPE_LIMIT: Deep structure is verified by the separate bounded validator step.\n'
   exit 0
 fi
 

--- a/scripts/ops/check_public_live_readiness.py
+++ b/scripts/ops/check_public_live_readiness.py
@@ -23,9 +23,18 @@ DEFAULT_WWW_DOMAIN = "www.weltgewebe.net"
 DEFAULT_API_DOMAIN = "api.weltgewebe.net"
 DEFAULT_EXPECTED_IP = "94.16.121.119"
 DEFAULT_GLYPH_PATH = "/local-basemap/glyphs/Noto%20Sans%20Regular/0-255.pbf"
+PMTILES_CONTENT_TYPE = "application/octet-stream"
 DEFAULT_PMTILES_PATHS = (
-    ("hamburg", "/local-basemap/basemap-hamburg-v0.1.0.pmtiles"),
-    ("schleswig-holstein", "/local-basemap/basemap-schleswig-holstein-v0.1.0.pmtiles"),
+    ("hamburg-stable", "/local-basemap/basemap-hamburg.pmtiles"),
+    ("hamburg-versioned", "/local-basemap/basemap-hamburg-v0.1.0.pmtiles"),
+    (
+        "schleswig-holstein-stable",
+        "/local-basemap/basemap-schleswig-holstein.pmtiles",
+    ),
+    (
+        "schleswig-holstein-versioned",
+        "/local-basemap/basemap-schleswig-holstein-v0.1.0.pmtiles",
+    ),
 )
 API_REQUIRED_CHECKS = ("database", "nats", "policy")
 
@@ -328,22 +337,70 @@ class PublicLiveChecker:
         name = f"pmtiles-header:{region}"
         url = f"https://{self.domain}{path}"
         try:
-            result = self.fetcher(url, {"Range": "bytes=0-15"}, self.timeout)
+            full = self.fetcher(url, None, self.timeout)
+            partial = self.fetcher(
+                url,
+                {"Range": "bytes=0-15"},
+                self.timeout,
+            )
         except Exception as exc:
             return fail_result(name, str(exc), url=url)
-        if result.status in {200, 206} and result.body.startswith(b"PMTiles"):
-            return pass_result(
-                name,
-                "Regional PMTiles artifact header is publicly reachable",
-                region=region,
-                status=result.status,
+
+        full_headers = _lower_headers(full.headers)
+        partial_headers = _lower_headers(partial.headers)
+        full_type = full_headers.get("content-type", "").split(";", 1)[0].strip().lower()
+        partial_type = (
+            partial_headers.get("content-type", "").split(";", 1)[0].strip().lower()
+        )
+        accept_ranges = full_headers.get("accept-ranges", "").lower()
+        content_range = partial_headers.get("content-range", "")
+
+        failures: list[str] = []
+        if full.status != 200:
+            failures.append(f"full status {full.status} != 200")
+        if not full.body.startswith(b"PMTiles"):
+            failures.append("full response is missing PMTiles signature")
+        if full_type != PMTILES_CONTENT_TYPE:
+            failures.append(
+                f"full content-type {full_type or '<missing>'} != {PMTILES_CONTENT_TYPE}"
             )
-        return fail_result(
+        if accept_ranges != "bytes":
+            failures.append(f"accept-ranges {accept_ranges or '<missing>'} != bytes")
+        if partial.status != 206:
+            failures.append(f"range status {partial.status} != 206")
+        if not partial.body.startswith(b"PMTiles"):
+            failures.append("range response is missing PMTiles signature")
+        if partial_type != PMTILES_CONTENT_TYPE:
+            failures.append(
+                f"range content-type {partial_type or '<missing>'} != {PMTILES_CONTENT_TYPE}"
+            )
+        if not content_range.startswith("bytes 0-15/"):
+            failures.append(
+                f"content-range {content_range or '<missing>'} does not start with bytes 0-15/"
+            )
+
+        if failures:
+            return fail_result(
+                name,
+                "; ".join(failures),
+                region=region,
+                full_status=full.status,
+                range_status=partial.status,
+                full_content_type=full_type,
+                range_content_type=partial_type,
+                accept_ranges=accept_ranges,
+                content_range=content_range,
+            )
+
+        return pass_result(
             name,
-            "Regional PMTiles artifact header missing",
+            "Regional PMTiles full and Range representation contract is public",
             region=region,
-            status=result.status,
-            prefix=result.body[:16].hex(),
+            full_status=full.status,
+            range_status=partial.status,
+            content_type=full_type,
+            accept_ranges=accept_ranges,
+            content_range=content_range,
         )
 
 

--- a/scripts/tests/test_basemap_runtime_proof_contract.sh
+++ b/scripts/tests/test_basemap_runtime_proof_contract.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." > /dev/null 2>&1 && pwd)"
+GUARD="${REPO_ROOT}/scripts/guard/basemap-runtime-proof.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+mkdir -p "${TMP_DIR}/bin"
+printf 'PMTiles' > "${TMP_DIR}/fixture.pmtiles"
+EXPECTED_SHA256="$(sha256sum "${TMP_DIR}/fixture.pmtiles" | awk '{print $1}')"
+
+cat > "${TMP_DIR}/bin/curl" <<'PY'
+#!/usr/bin/python3
+import os
+import pathlib
+import sys
+
+args = sys.argv[1:]
+
+def value_after(flag: str) -> str | None:
+    try:
+        return args[args.index(flag) + 1]
+    except (ValueError, IndexError):
+        return None
+
+output = value_after("--output")
+dump_header = value_after("--dump-header")
+is_head = "--head" in args
+range_value = value_after("--range")
+header_value = value_after("--header")
+omit_content_type = os.environ.get("FAKE_CURL_OMIT_CONTENT_TYPE") == "1"
+
+if range_value == "0-6":
+    if output:
+        pathlib.Path(output).write_bytes(b"PMTiles")
+    sys.stdout.write("206")
+    raise SystemExit(0)
+
+if is_head:
+    lines = ["HTTP/1.1 200 OK"]
+    if not omit_content_type:
+        lines.append("Content-Type: application/octet-stream")
+    lines.extend(["Accept-Ranges: bytes", "Content-Length: 7", ""])
+    if dump_header:
+        pathlib.Path(dump_header).write_text("\r\n".join(lines) + "\r\n")
+    sys.stdout.write("200")
+    raise SystemExit(0)
+
+if header_value == "Range: bytes=0-511":
+    lines = ["HTTP/1.1 206 Partial Content"]
+    if not omit_content_type:
+        lines.append("Content-Type: application/octet-stream")
+    lines.extend(
+        [
+            "Accept-Ranges: bytes",
+            "Content-Range: bytes 0-511/1024",
+            "Content-Length: 512",
+            "",
+        ]
+    )
+    if dump_header:
+        pathlib.Path(dump_header).write_text("\r\n".join(lines) + "\r\n")
+    if output and output != "/dev/null":
+        pathlib.Path(output).write_bytes(b"\0" * 512)
+    sys.stdout.write("206")
+    raise SystemExit(0)
+
+raise SystemExit("unexpected fake curl arguments: " + repr(args))
+PY
+chmod +x "${TMP_DIR}/bin/curl"
+
+COMMON_ENV=(
+  "PATH=${TMP_DIR}/bin:${PATH}"
+  "BASEMAP_PROOF_MODE=require"
+  "BASEMAP_PROOF_SCOPE=pmtiles-content"
+  "BASEMAP_CADDY_URL=http://proof.invalid"
+  "BASEMAP_ENDPOINT_PATH=/local-basemap/fixture.pmtiles"
+  "BASEMAP_PMTILES_PATH=${TMP_DIR}/fixture.pmtiles"
+  "BASEMAP_EXPECTED_SHA256=${EXPECTED_SHA256}"
+)
+
+env "${COMMON_ENV[@]}" "${GUARD}" > "${TMP_DIR}/success.out" 2>&1
+grep -Fq "Content-Type: application/octet-stream (full and Range confirmed)" "${TMP_DIR}/success.out"
+grep -Fq "PROVEN: Caddy PMTiles content verified" "${TMP_DIR}/success.out"
+
+if env "${COMMON_ENV[@]}" FAKE_CURL_OMIT_CONTENT_TYPE=1 "${GUARD}" \
+  > "${TMP_DIR}/missing.out" 2>&1; then
+  printf 'expected missing Content-Type to fail\n' >&2
+  exit 1
+fi
+grep -Fq "PMTiles HEAD Content-Type is <missing>" "${TMP_DIR}/missing.out"
+
+printf 'basemap runtime proof representation contract tests passed\n'

--- a/scripts/tests/test_basemap_runtime_proof_contract.sh
+++ b/scripts/tests/test_basemap_runtime_proof_contract.sh
@@ -10,7 +10,7 @@ mkdir -p "${TMP_DIR}/bin"
 printf 'PMTiles' > "${TMP_DIR}/fixture.pmtiles"
 EXPECTED_SHA256="$(sha256sum "${TMP_DIR}/fixture.pmtiles" | awk '{print $1}')"
 
-cat > "${TMP_DIR}/bin/curl" <<'PY'
+cat > "${TMP_DIR}/bin/curl" << 'PY'
 #!/usr/bin/python3
 import os
 import pathlib


### PR DESCRIPTION
Bureau-Tasks: `WELTGEWEBE-BASEMAP-COVERAGE-V1-T001`, `WELTGEWEBE-BASEMAP-COVERAGE-V1-T003`

Ersetzt PR #1419 ohne Force-Push. Der Ersatz ergänzt die vom Deploy Drift Guard verlangte kanonische Nachführung unter `docs/deploy/CHANGELOG.md`.

## Zweck

Schließt die zwei verbliebenen Basemap-Härtungslücken nach PR #1417:

1. alle erreichbaren PMTiles-Root-/Leaf-Verzeichnisse strukturell prüfen und begrenzte reale MVT-Payloads deterministisch decodieren;
2. den öffentlichen PMTiles-Repräsentationsvertrag für HTTP 200/206 ausdrücklich auf `application/octet-stream` festlegen und live prüfbar machen.

## Umsetzung

- begrenzter PMTiles-v3-Validator auf Basis der gepinnten `pmtiles`-Bibliothek;
- Header-/Abschnittsgrenzen, Verzeichnisgraph, Zählwerte, Metadaten und Style-Layer fail-closed;
- höchstens 96 reale Tile-Payloads je Archiv, über Zoomstufen und Raum verteilt, als MVT decodiert;
- Negativtests für Trunkierung, kaputtes Directory und malformed MVT;
- eigene JSON-Receipts in beiden regionalen Content-Proof-Jobs;
- `Content-Type: application/octet-stream` in allen relevanten Caddy-Verträgen;
- Guard, Browserproof und Public-Live-Readiness prüfen 200/206, Content-Type, Accept-Ranges, Content-Range und Signatur für stabile sowie versionierte Pfade;
- Deploy-Changelog dokumentiert atomaren Caddy-Rollout, Live-Readback und unveränderte PMTiles-Bytes.

## Belege

- `make validate`: grün
- `pnpm lint`, `pnpm check:ci`, `pnpm test:unit`: grün
- Validator-Negativtests: 4/4 grün
- realer Browserproof Hamburg und Schleswig-Holstein: grün
- isolierter Caddy-Proof aller vier stabilen/versionierten Pfade: grün
- Hamburg: 1 Directory, 2622 Tile-Einträge, 3178 adressierte Kacheln, 2451 Inhalte, 71 MVT-Stichproben
- Schleswig-Holstein: 7 Directory-Blöcke, 21492 Tile-Einträge, 28684 adressierte Kacheln, 19751 Inhalte, 29 MVT-Stichproben

## Restgrenzen

Kein Vollscan jeder Kachel; keine Aussage über kartografische Vollständigkeit, OSM-Semantik oder künftige Datenfrische.