### PR TITLE
Karte: Schleswig-Holstein sichtbar kartografieren

### DIFF
--- a/apps/web/src/lib/map/basemap.test.ts
+++ b/apps/web/src/lib/map/basemap.test.ts
@@ -50,6 +50,6 @@ describe("resolveBasemapStyle", () => {
 
   it("returns local path for local-sovereign mode", () => {
     const result = resolveBasemapStyle({ mode: "local-sovereign" } as any);
-    expect(result).toBe("/local-basemap/style.json");
+    expect(result).toBe("/local-basemap/style.json?v=0.3.0");
   });
 });

--- a/apps/web/src/lib/map/basemap.ts
+++ b/apps/web/src/lib/map/basemap.ts
@@ -1,5 +1,8 @@
 import type { BasemapConfig } from "./config/basemap.current";
 
+export const LOCAL_BASEMAP_STYLE_VERSION = "0.3.0";
+export const LOCAL_BASEMAP_STYLE_URL = `/local-basemap/style.json?v=${LOCAL_BASEMAP_STYLE_VERSION}`;
+
 function assertNever(x: never): never {
   throw new Error(`Unsupported basemap mode: ${JSON.stringify(x)}`);
 }
@@ -29,7 +32,7 @@ export function resolveBasemapStyle(config: BasemapConfig): string {
         throw new Error("styleUrl required for remote-style");
       return config.styleUrl;
     case "local-sovereign":
-      return "/local-basemap/style.json";
+      return LOCAL_BASEMAP_STYLE_URL;
     default:
       return assertNever(config);
   }

--- a/apps/web/src/lib/map/config/basemap.current.test.ts
+++ b/apps/web/src/lib/map/config/basemap.current.test.ts
@@ -35,7 +35,7 @@ describe("resolveBasemapMode", () => {
 describe("resolveBasemapStyle", () => {
   it("maps local-sovereign to the local route, never CARTO", () => {
     const style = resolveBasemapStyle({ mode: "local-sovereign" } as any);
-    expect(style).toBe("/local-basemap/style.json");
+    expect(style).toBe("/local-basemap/style.json?v=0.3.0");
     expect(style).not.toContain(CARTO_HOST);
     expect(style).not.toContain("voyager-gl-style");
   });
@@ -56,7 +56,7 @@ describe("currentBasemap (build-time generated config)", () => {
     if (currentBasemap.mode === "local-sovereign") {
       expect(currentBasemap).not.toHaveProperty("styleUrl");
       expect(resolveBasemapStyle(currentBasemap)).toBe(
-        "/local-basemap/style.json",
+        "/local-basemap/style.json?v=0.3.0",
       );
     } else {
       // remote-style is only reachable via an explicit PUBLIC_BASEMAP_MODE.

--- a/apps/web/tests/basemap-client-integration.spec.ts
+++ b/apps/web/tests/basemap-client-integration.spec.ts
@@ -11,7 +11,7 @@ test.describe("Basemap Client Integration (local-sovereign)", () => {
     // Override local-basemap/style.json for this specific test
     // NOTE: This intentionally mocks the network path to verify client-side behavior
     // (MapLibre config and PMTiles protocol loading), not real Edge-routing delivery.
-    await page.route("**/local-basemap/style.json", (route) => {
+    await page.route("**/local-basemap/style.json*", (route) => {
       route.fulfill({
         status: 200,
         contentType: "application/json",

--- a/apps/web/tests/basemap-sovereignty-testbuild.spec.ts
+++ b/apps/web/tests/basemap-sovereignty-testbuild.spec.ts
@@ -63,7 +63,7 @@ test.describe("Basemap Sovereignty Verification (E2E-Test-Build Environment)", (
 
     // 2. ADD SPECIFIC MOCK LAST (evaluated first by Playwright)
     // Provide a valid empty local style mock to simulate the Caddy router serving the artifact
-    await page.route("**/local-basemap/style.json", (route) => {
+    await page.route("**/local-basemap/style.json*", (route) => {
       route.fulfill({
         status: 200,
         contentType: "application/json",

--- a/apps/web/tests/basemap.spec.ts
+++ b/apps/web/tests/basemap.spec.ts
@@ -78,6 +78,8 @@ test.describe("resolveBasemapStyle", () => {
       zoom: 1,
     };
 
-    expect(resolveBasemapStyle(config)).toBe("/local-basemap/style.json");
+    expect(resolveBasemapStyle(config)).toBe(
+      "/local-basemap/style.json?v=0.3.0",
+    );
   });
 });

--- a/apps/web/tests/fixtures/mockApi.ts
+++ b/apps/web/tests/fixtures/mockApi.ts
@@ -55,7 +55,7 @@ export async function mockApiResponses(
   });
 
   // Intercept local map style fetching to provide a deterministic base payload during tests.
-  await page.route("**/local-basemap/style.json", (route) => {
+  await page.route("**/local-basemap/style.json*", (route) => {
     route.fulfill({
       status: 200,
       contentType: "application/json",

--- a/apps/web/tests/proofs/basemap-real-hamburg-visual.proof.ts
+++ b/apps/web/tests/proofs/basemap-real-hamburg-visual.proof.ts
@@ -35,8 +35,21 @@ import path from "node:path";
 
 const REAL_PMTILES_FILENAME = "basemap-hamburg.pmtiles";
 const SOURCE_ID = "basemap";
-const REGION_LAYER_IDS = ["water", "roads", "buildings", "place-labels"];
-const SOURCE_LAYER_IDS = ["transportation", "water", "place"];
+const REGION_LAYER_IDS = [
+  "landcover",
+  "landuse",
+  "water",
+  "roads",
+  "buildings",
+  "place-labels",
+];
+const SOURCE_LAYER_IDS = [
+  "landcover",
+  "landuse",
+  "transportation",
+  "water",
+  "place",
+];
 
 type TestMap = {
   isStyleLoaded?: () => boolean;
@@ -200,7 +213,9 @@ test.describe("Basemap Real Hamburg Visual Runtime Proof", () => {
       await page.goto("/map?proof=1&t=" + Date.now());
 
       // Preflight: style endpoint must exist and point to the local Hamburg PMTiles alias
-      const styleResponse = await page.request.get("/local-basemap/style.json");
+      const styleResponse = await page.request.get(
+        "/local-basemap/style.json?v=0.3.0",
+      );
       expect(
         styleResponse.status(),
         "Expected /local-basemap/style.json to return HTTP 200",
@@ -427,9 +442,14 @@ test.describe("Basemap Real Hamburg Visual Runtime Proof", () => {
         .toBeGreaterThan(0);
 
       expect(featureEvidence.sourceLoaded).toBe(true);
+      expect(featureEvidence.renderedLayerIds).toEqual(
+        expect.arrayContaining(["landcover", "landuse"]),
+      );
       expect(
         featureEvidence.sourceFeatureCounts.transportation,
       ).toBeGreaterThan(0);
+      expect(featureEvidence.sourceFeatureCounts.landcover).toBeGreaterThan(0);
+      expect(featureEvidence.sourceFeatureCounts.landuse).toBeGreaterThan(0);
       expect(featureEvidence.sourceFeatureCounts.water).toBeGreaterThan(0);
       expect(featureEvidence.sourceFeatureCounts.place).toBeGreaterThan(0);
       expect(failedResponses).toHaveLength(0);

--- a/apps/web/tests/proofs/basemap-real-schleswig-holstein-visual.proof.ts
+++ b/apps/web/tests/proofs/basemap-real-schleswig-holstein-visual.proof.ts
@@ -16,12 +16,20 @@ const SOURCE_ID = "basemap-schleswig-holstein";
 const PMTILES_FILENAME = "basemap-schleswig-holstein.pmtiles";
 const KIEL_CENTER: [number, number] = [10.1228, 54.3233];
 const REGION_LAYER_IDS = [
+  "landcover-schleswig-holstein",
+  "landuse-schleswig-holstein",
   "water-schleswig-holstein",
   "roads-schleswig-holstein",
   "buildings-schleswig-holstein",
   "place-labels-schleswig-holstein",
 ];
-const SOURCE_LAYER_IDS = ["transportation", "water", "place"];
+const SOURCE_LAYER_IDS = [
+  "landcover",
+  "landuse",
+  "transportation",
+  "water",
+  "place",
+];
 
 const FORBIDDEN_REMOTE_PROVIDERS = [
   "api.maptiler.com",
@@ -174,14 +182,18 @@ test.describe("Basemap Real Schleswig-Holstein Visual Runtime Proof", () => {
 
       await page.goto(`/map?proof=1&region=${REGION}&t=${Date.now()}`);
 
-      const styleResponse = await page.request.get("/local-basemap/style.json");
+      const styleResponse = await page.request.get(
+        "/local-basemap/style.json?v=0.3.0",
+      );
       expect(styleResponse.status()).toBe(200);
       expect(styleResponse.headers()["content-type"] ?? "").toContain(
         "application/json",
       );
       const styleJson = (await styleResponse.json()) as {
+        metadata?: Record<string, string>;
         sources?: Record<string, { url?: string }>;
       };
+      expect(styleJson.metadata?.["weltgewebe:version"]).toBe("0.3.0");
       expect(styleJson.sources?.[SOURCE_ID]?.url).toBe(
         `pmtiles://${PMTILES_FILENAME}`,
       );
@@ -402,9 +414,17 @@ test.describe("Basemap Real Schleswig-Holstein Visual Runtime Proof", () => {
         expect.arrayContaining(REGION_LAYER_IDS),
       );
       expect(featureEvidence.renderedFromExpectedSource).toBeGreaterThan(0);
+      expect(featureEvidence.renderedLayerIds).toEqual(
+        expect.arrayContaining([
+          "landcover-schleswig-holstein",
+          "landuse-schleswig-holstein",
+        ]),
+      );
       expect(
         featureEvidence.sourceFeatureCounts.transportation,
       ).toBeGreaterThan(0);
+      expect(featureEvidence.sourceFeatureCounts.landcover).toBeGreaterThan(0);
+      expect(featureEvidence.sourceFeatureCounts.landuse).toBeGreaterThan(0);
       expect(featureEvidence.sourceFeatureCounts.water).toBeGreaterThan(0);
       expect(featureEvidence.sourceFeatureCounts.place).toBeGreaterThan(0);
       expect(mapDiagnostics.mapErrors).toHaveLength(0);

--- a/docs/deploy/CHANGELOG.md
+++ b/docs/deploy/CHANGELOG.md
@@ -10,6 +10,34 @@ relations:
 ---
 # Deployment-Änderungsprotokoll
 
+## 2026-07-14 - Schleswig-Holstein sichtbar kartografieren
+
+**Geänderte Bereiche:**
+
+- `map-style/style.json`;
+- Web-Basemap-Auflösung und regionale Browserproofs.
+
+**Beschreibung:**
+
+Der bisherige Regionalstil lud Schleswig-Holstein technisch, zeichnete jedoch nur
+Wasser, Straßen, Gebäude und Ortsnamen. Große ländliche Flächen blieben deshalb
+identisch zum grauen Hintergrund und wirkten wie fehlende Tiles. Style `0.3.0`
+zeichnet nun die vorhandenen `landcover`- und `landuse`-Layer beider regionaler
+PMTiles-Quellen. Der Browserproof verlangt diese Layer künftig ausdrücklich als
+decodierte und sichtbar gerenderte Evidenz.
+
+Der Web-Build lädt den Stil über `/local-basemap/style.json?v=0.3.0`. Der
+Versionsparameter verhindert, dass ein Browser nach einem Stylewechsel weiterhin
+den früheren Hamburg-only beziehungsweise flächenarmen Stil verwendet.
+
+**Produktionswirkung:**
+
+Style und Web-Artefakt müssen gemeinsam veröffentlicht werden. Danach werden die
+öffentliche Buildkennung, der angeforderte Style-URL, echte Schleswig-Holstein-
+Range-Antworten sowie sichtbar gerenderte Landbedeckung und Landnutzung erneut
+über den normalen Kartenpfad geprüft. Die PMTiles-Archive selbst bleiben
+unverändert.
+
 ## 2026-07-13 - PMTiles-Repräsentationsvertrag und tiefe Archivprüfung
 
 **Geänderte Bereiche:**

--- a/map-style/README.md
+++ b/map-style/README.md
@@ -12,6 +12,8 @@ To ensure total visual sovereignty and compliance (no silent vendor dependencies
 * `pmtiles://` URLs require a protocol handler in the MapLibre runtime (not part of this configuration)
 * The current configuration is wired for the local-sovereign runtime route `/local-basemap/`
 * The style composes two independent regional PMTiles sources: `basemap-hamburg.pmtiles` and `basemap-schleswig-holstein.pmtiles`. Each source carries the same OpenMapTiles layer schema; the style repeats the visual layers for both regions.
+* Style version `0.3.0` renders `landcover` and `landuse` before water, roads, buildings and labels. Rural areas therefore remain recognizable instead of collapsing into the uniform background.
+* The web runtime requests the mutable style with its declared version as a query parameter. A style change must bump both `weltgewebe:version` and `LOCAL_BASEMAP_STYLE_VERSION`; CI rejects drift between them.
 
 ## Structure
 
@@ -23,4 +25,4 @@ To ensure total visual sovereignty and compliance (no silent vendor dependencies
 
 ## Regional coverage
 
-The sovereign basemap currently covers Hamburg and Schleswig-Holstein. Additions must provide all four parts together: a pinned build script, a stable PMTiles alias, matching style layers, and an independent runtime/content proof. A style-only source is not considered deployed.
+The sovereign basemap currently covers Hamburg and Schleswig-Holstein. Additions must provide all four parts together: a pinned build script, a stable PMTiles alias, matching style layers, and an independent runtime/content proof. A style-only source is not considered deployed. Runtime proof must establish not only successful tile decoding but also visibly rendered landcover and landuse for rural regional coverage.

--- a/map-style/colors.json
+++ b/map-style/colors.json
@@ -5,6 +5,28 @@
     "roads": "#ffffff",
     "buildings": "#d0d0d0",
     "text": "#333333",
-    "text-halo": "#ffffff"
+    "text-halo": "#ffffff",
+    "landcover": {
+      "farmland": "#e7e0cf",
+      "grass": "#d9e5d3",
+      "wood": "#c9d9c4",
+      "wetland": "#d6e4de",
+      "sand": "#eee2c8",
+      "default": "#dedfd8"
+    },
+    "landuse": {
+      "residential": "#ddd9d2",
+      "industrial": "#d6d0cc",
+      "commercial": "#e1d5d0",
+      "retail": "#e4d7d2",
+      "cemetery": "#d3dfd0",
+      "school": "#dedbd0",
+      "university": "#dedbd0",
+      "hospital": "#e2d6d4",
+      "military": "#d8d1c7",
+      "quarry": "#d2cec5",
+      "pitch": "#d2e0ce",
+      "default": "#dedbd4"
+    }
   }
 }

--- a/map-style/style.json
+++ b/map-style/style.json
@@ -2,8 +2,8 @@
   "version": 8,
   "name": "Weltgewebe Sovereign Basemap",
   "metadata": {
-    "weltgewebe:version": "0.2.0",
-    "weltgewebe:note": "PMTiles URL is a placeholder; actual resolution depends on runtime protocol handler"
+    "weltgewebe:version": "0.3.0",
+    "weltgewebe:note": "Regional PMTiles sources with visible landcover and landuse; bare aliases are resolved by the runtime protocol handler"
   },
   "sources": {
     "basemap": {
@@ -22,6 +22,142 @@
       "type": "background",
       "paint": {
         "background-color": "#e0e0e0"
+      }
+    },
+    {
+      "id": "landcover",
+      "type": "fill",
+      "source": "basemap",
+      "source-layer": "landcover",
+      "minzoom": 7,
+      "paint": {
+        "fill-color": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          "farmland",
+          "#e7e0cf",
+          "grass",
+          "#d9e5d3",
+          "wood",
+          "#c9d9c4",
+          "wetland",
+          "#d6e4de",
+          "sand",
+          "#eee2c8",
+          "#dedfd8"
+        ],
+        "fill-opacity": 0.92
+      }
+    },
+    {
+      "id": "landcover-schleswig-holstein",
+      "type": "fill",
+      "source": "basemap-schleswig-holstein",
+      "source-layer": "landcover",
+      "minzoom": 7,
+      "paint": {
+        "fill-color": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          "farmland",
+          "#e7e0cf",
+          "grass",
+          "#d9e5d3",
+          "wood",
+          "#c9d9c4",
+          "wetland",
+          "#d6e4de",
+          "sand",
+          "#eee2c8",
+          "#dedfd8"
+        ],
+        "fill-opacity": 0.92
+      }
+    },
+    {
+      "id": "landuse",
+      "type": "fill",
+      "source": "basemap",
+      "source-layer": "landuse",
+      "minzoom": 8,
+      "paint": {
+        "fill-color": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          "residential",
+          "#ddd9d2",
+          "industrial",
+          "#d6d0cc",
+          "commercial",
+          "#e1d5d0",
+          "retail",
+          "#e4d7d2",
+          "cemetery",
+          "#d3dfd0",
+          "school",
+          "#dedbd0",
+          "university",
+          "#dedbd0",
+          "hospital",
+          "#e2d6d4",
+          "military",
+          "#d8d1c7",
+          "quarry",
+          "#d2cec5",
+          "pitch",
+          "#d2e0ce",
+          "#dedbd4"
+        ],
+        "fill-opacity": 0.72
+      }
+    },
+    {
+      "id": "landuse-schleswig-holstein",
+      "type": "fill",
+      "source": "basemap-schleswig-holstein",
+      "source-layer": "landuse",
+      "minzoom": 8,
+      "paint": {
+        "fill-color": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          "residential",
+          "#ddd9d2",
+          "industrial",
+          "#d6d0cc",
+          "commercial",
+          "#e1d5d0",
+          "retail",
+          "#e4d7d2",
+          "cemetery",
+          "#d3dfd0",
+          "school",
+          "#dedbd0",
+          "university",
+          "#dedbd0",
+          "hospital",
+          "#e2d6d4",
+          "military",
+          "#d8d1c7",
+          "quarry",
+          "#d2cec5",
+          "pitch",
+          "#d2e0ce",
+          "#dedbd4"
+        ],
+        "fill-opacity": 0.72
       }
     },
     {
@@ -89,7 +225,9 @@
       "source-layer": "place",
       "layout": {
         "text-field": "{name}",
-        "text-font": ["Noto Sans Regular"],
+        "text-font": [
+          "Noto Sans Regular"
+        ],
         "text-size": 14
       },
       "paint": {
@@ -105,7 +243,9 @@
       "source-layer": "place",
       "layout": {
         "text-field": "{name}",
-        "text-font": ["Noto Sans Regular"],
+        "text-font": [
+          "Noto Sans Regular"
+        ],
         "text-size": 14
       },
       "paint": {

--- a/scripts/ci/tests/test_regional_basemap_style.py
+++ b/scripts/ci/tests/test_regional_basemap_style.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[3]
 STYLE_PATH = REPO / "map-style" / "style.json"
+COLORS_PATH = REPO / "map-style" / "colors.json"
 UP_SCRIPT_PATH = REPO / "scripts" / "weltgewebe-up"
 WORKFLOW_PATH = REPO / ".github" / "workflows" / "basemap-runtime-proof.yml"
 CADDY_PATHS = (
@@ -20,6 +21,7 @@ CADDY_PATHS = (
 class RegionalBasemapStyleTest(unittest.TestCase):
     def setUp(self) -> None:
         self.style = json.loads(STYLE_PATH.read_text(encoding="utf-8"))
+        self.colors = json.loads(COLORS_PATH.read_text(encoding="utf-8"))
 
     def test_style_declares_all_regional_pmtiles_sources(self) -> None:
         sources = self.style["sources"]
@@ -47,9 +49,55 @@ class RegionalBasemapStyleTest(unittest.TestCase):
 
         self.assertEqual(
             hamburg,
-            {"water", "roads", "buildings", "place-labels"},
+            {
+                "landcover",
+                "landuse",
+                "water",
+                "roads",
+                "buildings",
+                "place-labels",
+            },
         )
         self.assertEqual(schleswig_holstein, hamburg)
+
+    def test_style_version_matches_cache_busting_web_contract(self) -> None:
+        basemap_module = (
+            REPO / "apps" / "web" / "src" / "lib" / "map" / "basemap.ts"
+        ).read_text(encoding="utf-8")
+        version = self.style["metadata"]["weltgewebe:version"]
+        self.assertEqual(version, "0.3.0")
+        self.assertIn(
+            f'LOCAL_BASEMAP_STYLE_VERSION = "{version}"', basemap_module
+        )
+        self.assertIn(
+            "`/local-basemap/style.json?v=${LOCAL_BASEMAP_STYLE_VERSION}`",
+            basemap_module,
+        )
+
+    def test_regional_land_layers_are_visible_and_class_driven(self) -> None:
+        layers = {layer["id"]: layer for layer in self.style["layers"]}
+        for layer_id in (
+            "landcover",
+            "landcover-schleswig-holstein",
+            "landuse",
+            "landuse-schleswig-holstein",
+        ):
+            with self.subTest(layer=layer_id):
+                layer = layers[layer_id]
+                self.assertEqual(layer["type"], "fill")
+                self.assertGreater(layer["paint"]["fill-opacity"], 0.5)
+                expression = layer["paint"]["fill-color"]
+                self.assertEqual(expression[:2], ["match", ["get", "class"]])
+                self.assertGreaterEqual(len(expression), 8)
+
+    def test_land_layer_colors_match_the_canonical_palette(self) -> None:
+        layers = {layer["id"]: layer for layer in self.style["layers"]}
+        for category in ("landcover", "landuse"):
+            expression = layers[category]["paint"]["fill-color"]
+            pairs = dict(zip(expression[2:-1:2], expression[3:-1:2]))
+            palette = self.colors["theme"][category]
+            self.assertEqual(pairs, {k: v for k, v in palette.items() if k != "default"})
+            self.assertEqual(expression[-1], palette["default"])
 
     def test_layer_ids_are_unique_and_sources_exist(self) -> None:
         sources = self.style["sources"]


### PR DESCRIPTION
## Nutzerbefund

Schleswig-Holstein-PMTiles wurden technisch geladen, wirkten in der öffentlichen Karte jedoch wie nicht vorhanden. Die Reproduktion zeigte 68 erfolgreiche Schleswig-Holstein-Range-Antworten ohne MapLibre-Fehler, aber rund 74 % einheitliches Grau: Der Stil zeichnete nur Wasser, Straßen, Gebäude und Ortsnamen und ignorierte die vorhandenen Landflächen.

## Ursache

- `landcover` und `landuse` waren in beiden PMTiles-Archiven enthalten, aber nicht im Style eingebunden.
- Der Web-Build lud den veränderlichen Style über einen unversionierten Pfad, sodass ein älterer Stil weiterverwendet werden konnte.
- Der bisherige Browserproof akzeptierte geladene/decodierte Features, ohne ländliche Flächen als sichtbar gerenderte Layer zu verlangen.

## Änderung

- Style `0.3.0` zeichnet für Hamburg und Schleswig-Holstein:
  - Landbedeckung: Acker, Gras, Wald, Feuchtgebiet, Sand;
  - Landnutzung: Wohn-, Gewerbe-, Industrie-, Bildungs-, Krankenhaus-, Friedhofs-, Sport- und weitere Flächen.
- Layerreihenfolge: Hintergrund → Landflächen → Wasser → Straßen → Gebäude → Namen.
- Web fordert `/local-basemap/style.json?v=0.3.0` an.
- CI bindet Style-Metadatum und Web-Konstante aneinander.
- Hamburg- und Schleswig-Holstein-Browserproof verlangen nun decodiertes und sichtbar gerendertes `landcover` und `landuse`.

## Belege

- Realer Tiefenvalidator auf beiden unveränderten Produktionsarchiven: grün.
- Schleswig-Holstein um Kiel:
  - 899 decodierte `landcover`-Features;
  - 360 decodierte `landuse`-Features;
  - beide Layer sichtbar gerendert;
  - 3.615 gerenderte Features aus der Schleswig-Holstein-Quelle;
  - 11 beobachtete HTTP-206-Antworten.
- Hamburg-Regressionsproof:
  - 174 `landcover`- und 126 `landuse`-Features;
  - beide Layer sichtbar gerendert.
- Bildmessung:
  - vorher 74,0 % dominante graue Fläche;
  - neuer Kiel-Beweis 5,83 % dominante Einzelfarbe, 16,98 % grün getönte und 7,8 % warme Landflächen.
- `make validate`, `pnpm lint`, `pnpm check:ci`, vollständige Unit-Suite und realer Doppel-Browserproof: grün.

## Produktionswirkung

Style und Web-Artefakt müssen gemeinsam veröffentlicht werden. Die Hamburg- und Schleswig-Holstein-PMTiles-Dateien selbst bleiben bytegleich.