### PR TITLE
Karte weiter herauszoomen und Garnrollen skalieren

### DIFF
--- a/apps/web/src/lib/map/config/basemap.current.ts
+++ b/apps/web/src/lib/map/config/basemap.current.ts
@@ -11,6 +11,7 @@ import {
   BASEMAP_MODE_POLICY,
   type BasemapMode,
 } from "../../generated/basemapModePolicy";
+import { MAP_MIN_ZOOM } from "../markerScale";
 
 export type { BasemapMode };
 
@@ -69,7 +70,7 @@ export function resolveBasemapMode(
 const baseConfig: BaseBasemapConfig = {
   center: [HAMMER_PARK_CENTER.lon, HAMMER_PARK_CENTER.lat], // Hammer Park, Hamm
   zoom: 15,
-  minZoom: 10,
+  minZoom: MAP_MIN_ZOOM,
   maxZoom: 18,
 };
 

--- a/apps/web/src/lib/map/markerScale.test.ts
+++ b/apps/web/src/lib/map/markerScale.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  GARNROLLE_FULL_SIZE_ZOOM,
+  GARNROLLE_MIN_SCALE,
+  MAP_MIN_ZOOM,
+  getGarnrolleMarkerScale,
+} from "./markerScale";
+
+describe("getGarnrolleMarkerScale", () => {
+  it("uses the compact size at and below the broadest map view", () => {
+    expect(getGarnrolleMarkerScale(MAP_MIN_ZOOM)).toBe(GARNROLLE_MIN_SCALE);
+    expect(getGarnrolleMarkerScale(MAP_MIN_ZOOM - 5)).toBe(GARNROLLE_MIN_SCALE);
+  });
+
+  it("restores the full size at local zoom levels", () => {
+    expect(getGarnrolleMarkerScale(GARNROLLE_FULL_SIZE_ZOOM)).toBe(1);
+    expect(getGarnrolleMarkerScale(GARNROLLE_FULL_SIZE_ZOOM + 5)).toBe(1);
+  });
+
+  it("scales smoothly and monotonically between both limits", () => {
+    const low = getGarnrolleMarkerScale(8);
+    const middle = getGarnrolleMarkerScale(10);
+    const high = getGarnrolleMarkerScale(12);
+
+    expect(low).toBeGreaterThan(GARNROLLE_MIN_SCALE);
+    expect(middle).toBeCloseTo(0.82, 5);
+    expect(high).toBeGreaterThan(middle);
+    expect(low).toBeLessThan(middle);
+    expect(high).toBeLessThan(1);
+  });
+
+  it("fails safe to the normal size for a non-finite zoom", () => {
+    expect(getGarnrolleMarkerScale(Number.NaN)).toBe(1);
+    expect(getGarnrolleMarkerScale(Number.POSITIVE_INFINITY)).toBe(1);
+  });
+});

--- a/apps/web/src/lib/map/markerScale.ts
+++ b/apps/web/src/lib/map/markerScale.ts
@@ -1,0 +1,20 @@
+export const MAP_MIN_ZOOM = 7;
+export const GARNROLLE_FULL_SIZE_ZOOM = 13;
+export const GARNROLLE_MIN_SCALE = 0.64;
+
+/**
+ * Keeps Garnrollen legible without letting them dominate a broad map view.
+ * The smoothstep curve avoids visible size jumps while zooming.
+ */
+export function getGarnrolleMarkerScale(zoom: number): number {
+  if (!Number.isFinite(zoom)) return 1;
+  if (zoom <= MAP_MIN_ZOOM) return GARNROLLE_MIN_SCALE;
+  if (zoom >= GARNROLLE_FULL_SIZE_ZOOM) return 1;
+
+  const linearProgress =
+    (zoom - MAP_MIN_ZOOM) / (GARNROLLE_FULL_SIZE_ZOOM - MAP_MIN_ZOOM);
+  const smoothProgress =
+    linearProgress * linearProgress * (3 - 2 * linearProgress);
+
+  return GARNROLLE_MIN_SCALE + (1 - GARNROLLE_MIN_SCALE) * smoothProgress;
+}

--- a/apps/web/src/routes/map/+page.svelte
+++ b/apps/web/src/routes/map/+page.svelte
@@ -64,6 +64,7 @@
 
   import { currentBasemap } from "$lib/map/config/basemap.current";
   import { resolveBasemapStyle, rewritePmtilesUrl } from "$lib/map/basemap";
+  import { getGarnrolleMarkerScale } from "$lib/map/markerScale";
   import { buildMapScene } from "$lib/map/scene";
 
   import { NodesOverlay } from "$lib/map/overlay/nodes";
@@ -210,6 +211,15 @@
       searchDirectionFrame = null;
       updateSearchDirectionIndicators();
     });
+  }
+
+  function updateGarnrolleMarkerScale() {
+    if (!map || !mapContainer) return;
+
+    mapContainer.style.setProperty(
+      "--garnrolle-marker-scale",
+      getGarnrolleMarkerScale(map.getZoom()).toFixed(3),
+    );
   }
 
   // Reactive update for markers and search highlight strictly handled in overlay update
@@ -536,6 +546,8 @@
         attributionControl: false,
         transformRequest: transformRequestFn,
       });
+      updateGarnrolleMarkerScale();
+      map.on("zoom", updateGarnrolleMarkerScale);
       map.addControl(
         new maplibregl.NavigationControl({ showZoom: true }),
         "bottom-right",
@@ -604,6 +616,7 @@
       searchDirectionIndicators = [];
       nodesOverlay?.destroy();
       if (map) {
+        map.off("zoom", updateGarnrolleMarkerScale);
         map.off("move", handleSearchViewportChange);
         map.off("resize", handleSearchViewportChange);
         if (typeof map.remove === "function") map.remove();
@@ -767,6 +780,8 @@
     border: none;
     box-shadow: none;
     border-radius: 0;
+    transform: scale(var(--garnrolle-marker-scale, 1));
+    transform-origin: center bottom;
   }
 
   #map :global(.marker-account__icon) {
@@ -782,6 +797,9 @@
   @media (hover: hover) and (pointer: fine) {
     #map :global(.map-marker:hover .map-marker__visual) {
       transform: scale(1.2);
+    }
+    #map :global(.map-marker.marker-account:hover .marker-account__visual) {
+      transform: scale(var(--garnrolle-marker-scale, 1)) scale(1.2);
     }
     #map :global(.map-marker:hover) {
       z-index: 10;
@@ -877,10 +895,6 @@
     pointer-events: none;
     font-family: monospace;
   }
-
-
-
-
 
   .degraded-banner--failed {
     background: rgba(180, 40, 40, 0.9);

--- a/apps/web/src/routes/map/+page.svelte
+++ b/apps/web/src/routes/map/+page.svelte
@@ -780,7 +780,6 @@
     border: none;
     box-shadow: none;
     border-radius: 0;
-    transform: scale(var(--garnrolle-marker-scale, 1));
     transform-origin: center bottom;
   }
 
@@ -789,6 +788,8 @@
     width: 100%;
     height: 100%;
     object-fit: contain;
+    transform: scale(var(--garnrolle-marker-scale, 1));
+    transform-origin: center bottom;
     pointer-events: none;
     user-select: none;
     -webkit-user-drag: none;
@@ -797,9 +798,6 @@
   @media (hover: hover) and (pointer: fine) {
     #map :global(.map-marker:hover .map-marker__visual) {
       transform: scale(1.2);
-    }
-    #map :global(.map-marker.marker-account:hover .marker-account__visual) {
-      transform: scale(var(--garnrolle-marker-scale, 1)) scale(1.2);
     }
     #map :global(.map-marker:hover) {
       z-index: 10;

--- a/apps/web/tests/garnrolle-marker-rendering.spec.ts
+++ b/apps/web/tests/garnrolle-marker-rendering.spec.ts
@@ -94,4 +94,78 @@ test.describe("Garnrolle marker rendering", () => {
 
     expect(errorPx).toBeLessThanOrEqual(2);
   });
+
+  test("allows regional zoom-out while keeping the touch target stable", async ({
+    page,
+  }) => {
+    const marker = page.getByTestId(`marker-garnrolle-${GARNROLLE_ID}`);
+    await expect(marker).toBeVisible();
+
+    const metrics = await page.evaluate(
+      async ({ markerId }) => {
+        type TestMap = {
+          getMinZoom(): number;
+          getZoom(): number;
+          jumpTo(options: { zoom: number }): void;
+        };
+        const map = (window as typeof window & { __TEST_MAP__?: TestMap })
+          .__TEST_MAP__;
+        const markerElement = document.querySelector<HTMLElement>(
+          `[data-testid="marker-garnrolle-${markerId}"]`,
+        );
+        const visual = markerElement?.querySelector<HTMLElement>(
+          ".marker-account__visual",
+        );
+        if (!map || !markerElement || !visual) {
+          throw new Error("test map or Garnrolle marker unavailable");
+        }
+
+        const settle = async () => {
+          await new Promise((resolve) => setTimeout(resolve, 220));
+          await new Promise<void>((resolve) =>
+            requestAnimationFrame(() => resolve()),
+          );
+        };
+        const measure = () => {
+          const outer = markerElement.getBoundingClientRect();
+          const inner = visual.getBoundingClientRect();
+          return {
+            zoom: map.getZoom(),
+            outerWidth: outer.width,
+            outerHeight: outer.height,
+            visualWidth: inner.width,
+            visualHeight: inner.height,
+            bottomDelta: Math.abs(outer.bottom - inner.bottom),
+          };
+        };
+
+        map.jumpTo({ zoom: 13 });
+        await settle();
+        const local = measure();
+
+        map.jumpTo({ zoom: 7 });
+        await settle();
+        const regional = measure();
+
+        return { minZoom: map.getMinZoom(), local, regional };
+      },
+      { markerId: GARNROLLE_ID },
+    );
+
+    expect(metrics.minZoom).toBe(7);
+    expect(metrics.local.zoom).toBeCloseTo(13, 5);
+    expect(metrics.regional.zoom).toBeCloseTo(7, 5);
+    expect(metrics.local.outerWidth).toBeCloseTo(44, 1);
+    expect(metrics.regional.outerWidth).toBeCloseTo(44, 1);
+    expect(metrics.local.outerHeight).toBeCloseTo(44, 1);
+    expect(metrics.regional.outerHeight).toBeCloseTo(44, 1);
+    expect(metrics.local.visualWidth).toBeCloseTo(44, 1);
+    expect(metrics.regional.visualWidth).toBeCloseTo(28.16, 1);
+    expect(metrics.regional.visualHeight).toBeCloseTo(28.16, 1);
+    expect(metrics.regional.visualWidth).toBeLessThan(
+      metrics.local.visualWidth,
+    );
+    expect(metrics.local.bottomDelta).toBeLessThanOrEqual(0.5);
+    expect(metrics.regional.bottomDelta).toBeLessThanOrEqual(0.5);
+  });
 });

--- a/apps/web/tests/garnrolle-marker-rendering.spec.ts
+++ b/apps/web/tests/garnrolle-marker-rendering.spec.ts
@@ -113,10 +113,10 @@ test.describe("Garnrolle marker rendering", () => {
         const markerElement = document.querySelector<HTMLElement>(
           `[data-testid="marker-garnrolle-${markerId}"]`,
         );
-        const visual = markerElement?.querySelector<HTMLElement>(
-          ".marker-account__visual",
+        const icon = markerElement?.querySelector<HTMLElement>(
+          ".marker-account__icon",
         );
-        if (!map || !markerElement || !visual) {
+        if (!map || !markerElement || !icon) {
           throw new Error("test map or Garnrolle marker unavailable");
         }
 
@@ -128,14 +128,14 @@ test.describe("Garnrolle marker rendering", () => {
         };
         const measure = () => {
           const outer = markerElement.getBoundingClientRect();
-          const inner = visual.getBoundingClientRect();
+          const visibleIcon = icon.getBoundingClientRect();
           return {
             zoom: map.getZoom(),
             outerWidth: outer.width,
             outerHeight: outer.height,
-            visualWidth: inner.width,
-            visualHeight: inner.height,
-            bottomDelta: Math.abs(outer.bottom - inner.bottom),
+            visualWidth: visibleIcon.width,
+            visualHeight: visibleIcon.height,
+            bottomDelta: Math.abs(outer.bottom - visibleIcon.bottom),
           };
         };
 


### PR DESCRIPTION
## Zweck

- regionalen Zoom-out bis Stufe 7 ermöglichen
- Garnrollen bei weitem Kartenausschnitt weich verkleinern
- die 44-px-Touchfläche und den geografischen Kartenanker unverändert lassen

## Umsetzung

- gemeinsame Zoomgrenze `MAP_MIN_ZOOM = 7`
- weiche Garnrollen-Skalierung von 100 % bei Zoom 13 auf 64 % bei Zoom 7
- Skalierung ausschließlich auf dem inneren Bild; MapLibre behält den äußeren Marker-Transform
- Hover-Effekt berücksichtigt die aktuelle Zoomskalierung

## Prüfung

- `make validate`
- `pnpm run check:ci`
- `pnpm run lint`
- `pnpm run test:unit`
- `pnpm run test -- tests/garnrolle-marker-rendering.spec.ts --reporter=line`
- Browservertrag: Zoom 7, sichtbare Garnrolle ca. 28 px, Touchfläche 44 px, unterer Anker stabil