### PR TITLE
fix(web): öffentliche Pfade wahrheitsgemäß ausliefern

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -1,8 +1,9 @@
 <!doctype html>
-<html lang="en">
+<html lang="de">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#f5f1e8" />
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -15,17 +15,19 @@
 
   onMount(() => {
     setUAClasses();
-    // Toggle: ?noinert=1 schaltet Polyfill ab (Debug/Kompat)
     const q = new URLSearchParams(get(page).url.search);
     const disable = q.get('noinert') === '1' || (window as any).__NO_INERT__ === true;
     if (!disable) ensureInertPolyfill();
-
-    // Initialize update polling for controlled self-updating
     updateStore.init();
   });
 </script>
 
 <svelte:head>
+  <title>Weltgewebe – Commons gemeinsam verwalten</title>
+  <meta name="description" content="Das Weltgewebe macht Commons, Knoten, Garnrollen und ihre Beziehungen auf einer gemeinsamen Karte sichtbar und verwaltbar." />
+  <meta name="application-name" content="Weltgewebe" />
+  <link rel="manifest" href="/manifest.webmanifest" />
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
   {#if data?.canonical}
     <link rel="canonical" href={data.canonical} />
   {/if}

--- a/apps/web/src/routes/datenschutz/+page.svelte
+++ b/apps/web/src/routes/datenschutz/+page.svelte
@@ -1,0 +1,35 @@
+<svelte:head>
+  <title>Datenschutz – Weltgewebe</title>
+  <meta name="description" content="Datenschutzhinweise für die Nutzung des Weltgewebes." />
+</svelte:head>
+
+<main class="legal-page">
+  <h1>Datenschutzerklärung</h1>
+  <p><strong>Verantwortlicher:</strong> Alexander Mohr, Huskoppelallee 13, 23795 Klein Rönnau, <a href="mailto:kontakt@weltweberei.org">kontakt@weltweberei.org</a>.</p>
+
+  <h2>Grundsatz</h2>
+  <p>Das Weltgewebe erhebt keine Daten für Werbung, Tracking oder verdeckte Profilbildung. Sichtbar wird nur, was Nutzer selbst eintragen und ausdrücklich als öffentlich kennzeichnen.</p>
+
+  <h2>Anmeldung und Sitzung</h2>
+  <p>Für Anmeldung und Sitzungserhalt werden technisch notwendige, vor JavaScript geschützte HTTP-only-Cookies verwendet. Sie dienen ausschließlich der sicheren Authentifizierung und Sitzungsverwaltung.</p>
+
+  <h2>Veröffentlichte Angaben</h2>
+  <p>Je nach eigener Auswahl können Name, Ortsangabe, Knoten, Garnrollen und Beziehungen öffentlich sichtbar sein. Eine als exakt freigegebene Position wird entsprechend präzise veröffentlicht. Sichtbarkeit und Inhalte können geändert oder zurückgezogen werden.</p>
+
+  <h2>Serverprotokolle</h2>
+  <p>Beim Aufruf können technisch notwendige Verbindungsdaten kurzfristig verarbeitet werden, um Betrieb, Sicherheit und Fehlerdiagnose zu ermöglichen. Eine Nutzung zu Werbezwecken findet nicht statt.</p>
+
+  <h2>Rechtsgrundlagen und Rechte</h2>
+  <p>Die Verarbeitung erfolgt insbesondere auf Grundlage von Einwilligung und berechtigten Interessen an einem sicheren Gemeinschaftssystem. Betroffene können Auskunft, Berichtigung, Löschung, Einschränkung, Datenübertragbarkeit und Widerspruch verlangen sowie eine erteilte Einwilligung widerrufen.</p>
+
+  <h2>Kontakt</h2>
+  <p>Datenschutzanfragen können an <a href="mailto:kontakt@weltweberei.org">kontakt@weltweberei.org</a> gerichtet werden.</p>
+
+  <p><a href="/impressum">Impressum</a> · <a href="/map">Zur Karte</a></p>
+</main>
+
+<style>
+  .legal-page { max-width: 48rem; margin: 0 auto; padding: 2rem 1.25rem 4rem; font: 1rem/1.6 system-ui, sans-serif; }
+  h1, h2 { line-height: 1.2; }
+  a { color: inherit; text-decoration-thickness: .1em; text-underline-offset: .15em; }
+</style>

--- a/apps/web/src/routes/impressum/+page.svelte
+++ b/apps/web/src/routes/impressum/+page.svelte
@@ -1,0 +1,30 @@
+<svelte:head>
+  <title>Impressum – Weltgewebe</title>
+  <meta name="description" content="Anbieterkennzeichnung und Kontakt für das Weltgewebe." />
+</svelte:head>
+
+<main class="legal-page">
+  <h1>Impressum</h1>
+  <p>Angaben gemäß § 5 DDG</p>
+  <address>
+    Alexander Mohr<br />
+    Huskoppelallee 13<br />
+    23795 Klein Rönnau<br />
+    Deutschland
+  </address>
+
+  <h2>Kontakt</h2>
+  <p>
+    E-Mail: <a href="mailto:kontakt@weltweberei.org">kontakt@weltweberei.org</a><br />
+    Telefon: <a href="tel:+4915563658682">+49 155 63658682</a>
+  </p>
+
+  <p><a href="/datenschutz">Datenschutzerklärung</a> · <a href="/map">Zur Karte</a></p>
+</main>
+
+<style>
+  .legal-page { max-width: 48rem; margin: 0 auto; padding: 2rem 1.25rem 4rem; font: 1rem/1.6 system-ui, sans-serif; }
+  h1, h2 { line-height: 1.2; }
+  address { font-style: normal; }
+  a { color: inherit; text-decoration-thickness: .1em; text-underline-offset: .15em; }
+</style>

--- a/apps/web/static/favicon.svg
+++ b/apps/web/static/favicon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title id="title">Weltgewebe</title>
+  <rect width="128" height="128" rx="24" fill="#f5f1e8"/>
+  <g fill="none" stroke="#2f4538" stroke-width="8" stroke-linecap="round">
+    <path d="M24 32c20 0 20 64 40 64s20-64 40-64"/>
+    <path d="M24 96c20 0 20-64 40-64s20 64 40 64"/>
+  </g>
+  <circle cx="64" cy="64" r="9" fill="#b45f45"/>
+</svg>

--- a/apps/web/static/manifest.webmanifest
+++ b/apps/web/static/manifest.webmanifest
@@ -1,0 +1,19 @@
+{
+  "name": "Weltgewebe",
+  "short_name": "Weltgewebe",
+  "description": "Commons, Knoten, Garnrollen und ihre Beziehungen gemeinsam auf einer Karte verwalten.",
+  "lang": "de",
+  "start_url": "/map",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#f5f1e8",
+  "theme_color": "#f5f1e8",
+  "icons": [
+    {
+      "src": "/favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    }
+  ]
+}

--- a/apps/web/static/robots.txt
+++ b/apps/web/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://weltgewebe.net/sitemap.xml

--- a/apps/web/static/sitemap.xml
+++ b/apps/web/static/sitemap.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://weltgewebe.net/map</loc></url>
+  <url><loc>https://weltgewebe.net/login</loc></url>
+  <url><loc>https://weltgewebe.net/impressum</loc></url>
+  <url><loc>https://weltgewebe.net/datenschutz</loc></url>
+</urlset>

--- a/apps/web/tests/public-web-surfaces.spec.ts
+++ b/apps/web/tests/public-web-surfaces.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("public web truth", () => {
+  test("declares German language and global metadata", async ({ page }) => {
+    await page.goto("/map");
+    await expect(page.locator("html")).toHaveAttribute("lang", "de");
+    await expect(page).toHaveTitle(/Weltgewebe/);
+    await expect(page.locator('meta[name="description"]')).toHaveAttribute(
+      "content",
+      /Commons/,
+    );
+    await expect(page.locator('link[rel="manifest"]')).toHaveAttribute(
+      "href",
+      "/manifest.webmanifest",
+    );
+  });
+
+  test("serves a real imprint page", async ({ page }) => {
+    await page.goto("/impressum");
+    await expect(
+      page.getByRole("heading", { name: "Impressum", level: 1 }),
+    ).toBeVisible();
+    await expect(page.getByText("Alexander Mohr")).toBeVisible();
+    await expect(page).toHaveTitle("Impressum – Weltgewebe");
+  });
+
+  test("serves a real privacy page", async ({ page }) => {
+    await page.goto("/datenschutz");
+    await expect(
+      page.getByRole("heading", { name: "Datenschutzerklärung", level: 1 }),
+    ).toBeVisible();
+    await expect(page.getByText(/kein.*Werbung/i)).toBeVisible();
+    await expect(page).toHaveTitle("Datenschutz – Weltgewebe");
+  });
+
+  test("serves machine-readable discovery files", async ({ request }) => {
+    const robots = await request.get("/robots.txt");
+    expect(robots.ok()).toBeTruthy();
+    expect(await robots.text()).toContain(
+      "Sitemap: https://weltgewebe.net/sitemap.xml",
+    );
+
+    const sitemap = await request.get("/sitemap.xml");
+    expect(sitemap.ok()).toBeTruthy();
+    expect(sitemap.headers()["content-type"]).toContain("xml");
+    expect(await sitemap.text()).toContain("https://weltgewebe.net/impressum");
+
+    const manifest = await request.get("/manifest.webmanifest");
+    expect(manifest.ok()).toBeTruthy();
+    const data = await manifest.json();
+    expect(data).toMatchObject({
+      name: "Weltgewebe",
+      lang: "de",
+      start_url: "/map",
+    });
+  });
+});

--- a/docs/_generated/backlinks.md
+++ b/docs/_generated/backlinks.md
@@ -987,6 +987,10 @@ Generated automatically. Do not edit.
 - [relates_to] docs/deploy/vps-http-route-smoke.md
 - [relates_to] docs/deploy/vps-http-smoke.md
 
+## infra/caddy/Caddyfile.vps
+
+- [relates_to] docs/deploy/vps-http-smoke.md
+
 ## infra/compose/compose.prod.override.yml
 
 - [relates_to] docs/deploy/public-app-base-url.md

--- a/docs/_generated/relates-to-audit.md
+++ b/docs/_generated/relates-to-audit.md
@@ -14,9 +14,9 @@ Generated automatically. Do not edit.
 
 | Metrik | Wert |
 | --- | --- |
-| Relationen gesamt | 562 |
+| Relationen gesamt | 563 |
 | — depends_on | 20 |
-| — relates_to | 530 |
+| — relates_to | 531 |
 | — supersedes | 11 |
 | — verifies | 1 |
 | relates_to Anteil | 94% |
@@ -31,7 +31,7 @@ _Keine Lücken erkannt._
 
 > Zusammenhängende Gruppen im relates_to-Graphen.
 
-**Cluster 1** (220 Dokumente):
+**Cluster 1** (221 Dokumente):
 
 - `.github/workflows/api.yml`
 - `.github/workflows/basemap-runtime-proof.yml`
@@ -216,6 +216,7 @@ _Keine Lücken erkannt._
 - `docs/weltgewebe-agenten-manifest.md`
 - `docs/zusammenstellung.md`
 - `infra/caddy/Caddyfile.http-smoke`
+- `infra/caddy/Caddyfile.vps`
 - `infra/compose/compose.prod.override.yml`
 - `infra/compose/compose.vps.override.yml`
 - `repo.meta.yaml`

--- a/docs/_generated/relations-analysis.md
+++ b/docs/_generated/relations-analysis.md
@@ -17,9 +17,9 @@ Generated automatically. Do not edit.
 | Dokumente gesamt | 164 |
 | Dokumente mit ausgehenden Relationen | 163 |
 | Dokumente als Ziel referenziert | 127 |
-| Relationen gesamt | 562 |
+| Relationen gesamt | 563 |
 | — depends_on | 20 |
-| — relates_to | 530 |
+| — relates_to | 531 |
 | — supersedes | 11 |
 | — verifies | 1 |
 | Isolierte Dokumente | 0 |

--- a/docs/deploy/vps-http-smoke.md
+++ b/docs/deploy/vps-http-smoke.md
@@ -10,6 +10,8 @@ relations:
   - type: relates_to
     target: docs/deploy/DRIFT_POLICY.md
   - type: relates_to
+    target: infra/caddy/Caddyfile.vps
+  - type: relates_to
     target: infra/caddy/Caddyfile.http-smoke
   - type: relates_to
     target: infra/compose/compose.vps.override.yml
@@ -57,3 +59,10 @@ After DNS cutover is explicitly approved, the production VPS Caddyfile remains t
 If this smoke starts the real API while database migrations are outside scope, the API must use `WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied` or the operation must stop. The rendered compose config must prove the effective value from the selected env source without printing confidential values. The VPS override must not set this variable in the service `environment`, because that would override `env_file` values. This is runtime evidence, not route-only evidence.
 
 Use `docs/deploy/vps-migration-safe-runtime-smoke.md` for that separate runtime path. The redacted source-level preflight helper is `scripts/ops/check_vps_migration_safe_runtime_env.py`; it checks only the allowed migration-mode key and the non-confidential compose source. It does not replace a separately reviewed runtime receipt, and raw rendered compose config or runtime env source contents must not be pasted as evidence.
+
+## Production public-route truth
+
+The production `infra/caddy/Caddyfile.vps` serves only existing static files and explicitly prerendered Svelte routes through `{path}.html`. It must not fall back to `/index.html` for an unknown path. This keeps deep links such as `/map`, `/login`, `/impressum` and `/datenschutz` working while preserving a real HTTP 404 for nonexistent resources.
+
+The machine-readable public files `robots.txt`, `sitemap.xml` and `manifest.webmanifest` are built as real static files. A successful response for one of those paths must therefore contain the matching file format rather than the generic application shell. Any future dynamic client-only route must be explicitly represented in the build or in a reviewed Caddy matcher; reintroducing a catch-all 200 fallback is not an acceptable compatibility fix.
+

--- a/infra/caddy/Caddyfile.vps
+++ b/infra/caddy/Caddyfile.vps
@@ -66,7 +66,9 @@
 
 	handle {
 		root * /srv/weltgewebe-web
-		try_files {path} {path}.html /index.html
+		# Serve only real files or explicitly prerendered Svelte routes.
+		# Unknown paths must remain real 404 responses instead of soft-200 app shells.
+		try_files {path} {path}.html
 		header Cache-Control "no-cache, must-revalidate"
 		file_server
 	}

--- a/scripts/ci/tests/test_vps_http_route_smoke_docs.py
+++ b/scripts/ci/tests/test_vps_http_route_smoke_docs.py
@@ -103,6 +103,12 @@ class VpsHttpRouteSmokeDocsTest(unittest.TestCase):
             with self.subTest(forbidden=forbidden):
                 self.assertNotIn(forbidden, text)
 
+    def test_production_caddyfile_preserves_real_404_semantics(self) -> None:
+        production = (self.repo / "infra" / "caddy" / "Caddyfile.vps").read_text(encoding="utf-8")
+        self.assertIn("try_files {path} {path}.html", production)
+        self.assertNotIn("try_files {path} {path}.html /index.html", production)
+        self.assertIn("Unknown paths must remain real 404 responses", production)
+
     def test_compose_override_keeps_explicit_caddyfile_selection_hook(self) -> None:
         doc_text = self.doc.read_text(encoding="utf-8")
         compose_text = self.compose_override.read_text(encoding="utf-8")


### PR DESCRIPTION
## Ziel

Beseitigt die im Komplettaudit belegten Soft-200- und Metadatenfehler der öffentlichen Weboberfläche.

## Änderungen

- echte statische Seiten für `/impressum` und `/datenschutz`
- echte `robots.txt`, `sitemap.xml` und `manifest.webmanifest`
- deutsche Dokumentsprache, globale Beschreibung, Manifest- und Favicon-Bindung
- eigenes Weltgewebe-Favicon statt Frameworksymbol
- Caddy liefert nur reale Dateien oder prerenderte Routen; unbekannte Pfade bleiben echte 404
- Browser- und Caddy-Vertragstests

## Belege

- `pnpm check`: 0 Fehler, 0 Warnungen
- `pnpm lint`: grün
- `pnpm build`: grün
- Playwright `public-web-surfaces.spec.ts`: 4/4 grün
- `python3 -m unittest scripts.ci.tests.test_vps_http_route_smoke_docs`: 8/8 grün
- `make ci-validate`: 810 + 160 + 66 Tests und alle Repository-Verträge grün

## Risiko und Grenzen

- Die 404-Änderung ist absichtlich fail-closed; vorhandene prerenderte Svelte-Routen bleiben über `{path}.html` erreichbar.
- Die Rechtstexte bilden den im Repository dokumentierten aktuellen Betreiber- und Datenschutzstand ab. Eine externe juristische Prüfung ist davon getrennt.

Bureau: `WG-AUDIT-WEB-SURFACES-001`, `WG-AUDIT-A11Y-META-001`.