### PR TITLE
fix(edge): kanonische Pfade mit Trailing Slash

### DIFF
--- a/docs/deploy/vps-http-smoke.md
+++ b/docs/deploy/vps-http-smoke.md
@@ -65,6 +65,8 @@ Use `docs/deploy/vps-migration-safe-runtime-smoke.md` for that separate runtime 
 
 The production `infra/caddy/Caddyfile.vps` serves only existing static files and explicitly prerendered Svelte routes. It accepts both SvelteKit export forms: `{path}.html` and `{path}/index.html`. It must not fall back to the root `/index.html` for an unknown path. This keeps deep links such as `/map`, `/login`, `/impressum` and `/datenschutz` working while preserving a real HTTP 404 for nonexistent resources.
 
+A request with a trailing slash is canonicalized only if removing that slash reveals an existing prerendered HTML artifact. For example, `/map/` redirects permanently to `/map`, while an unknown path such as `/does-not-exist/` remains a direct 404. The redirect preserves the query string. API, health, immutable asset and basemap handlers stay outside this HTML-only rule because their more specific handlers run first.
+
 The web application uses `adapter-static`; no SvelteKit server runs behind Caddy. Therefore `robots.txt` and `sitemap.xml` are emitted during the Vite build by the tested plugin in `apps/web/scripts/generate-public-web-assets.mjs`, not by runtime `+server.ts` routes. `PUBLIC_APP_BASE_URL` selects the public origin for staging or another explicitly configured artifact target. If it is absent, the generator uses the canonical production origin `https://weltgewebe.net`. The generator rejects origins containing paths, credentials, queries or fragments.
 
 `robots.txt` excludes `/api/` and the `noinert` debug-query variant from crawler discovery. `sitemap.xml` and the sitemap declaration in `robots.txt` are produced from the same normalized origin so they cannot diverge.

--- a/infra/caddy/Caddyfile.vps
+++ b/infra/caddy/Caddyfile.vps
@@ -64,6 +64,21 @@
 		file_server
 	}
 
+	# Canonicalize a trailing slash only when the slashless path has a real
+	# prerendered HTML artifact. Unknown slash paths remain direct 404 responses.
+	@trailingSlash path_regexp ^/.+/$
+	handle @trailingSlash {
+		route {
+			uri strip_suffix /
+			@prerendered file {
+				root /srv/weltgewebe-web
+				try_files {path}.html {path}/index.html
+			}
+			redir @prerendered {uri} 308
+			respond 404
+		}
+	}
+
 	handle {
 		root * /srv/weltgewebe-web
 		# Serve only real files or explicitly prerendered Svelte routes.

--- a/scripts/ci/tests/test_vps_http_route_smoke_docs.py
+++ b/scripts/ci/tests/test_vps_http_route_smoke_docs.py
@@ -109,6 +109,32 @@ class VpsHttpRouteSmokeDocsTest(unittest.TestCase):
         self.assertNotIn("try_files {path} {path}.html /index.html", production)
         self.assertIn("Unknown paths must remain real 404 responses", production)
 
+    def test_production_caddyfile_canonicalizes_only_existing_trailing_slash_routes(self) -> None:
+        production = (self.repo / "infra" / "caddy" / "Caddyfile.vps").read_text(encoding="utf-8")
+
+        required = [
+            "@trailingSlash path_regexp ^/.+/$",
+            "uri strip_suffix /",
+            "@prerendered file {",
+            "root /srv/weltgewebe-web",
+            "try_files {path}.html {path}/index.html",
+            "redir @prerendered {uri} 308",
+            "respond 404",
+        ]
+        for phrase in required:
+            with self.subTest(required=phrase):
+                self.assertIn(phrase, production)
+
+        self.assertLess(
+            production.index("handle_path /api/*"),
+            production.index("@trailingSlash path_regexp ^/.+/$"),
+        )
+        self.assertLess(
+            production.index("@trailingSlash path_regexp ^/.+/$"),
+            production.index("# Serve only real files or explicitly prerendered Svelte routes."),
+        )
+        self.assertIn("Unknown slash paths remain direct 404 responses", production)
+
     def test_compose_override_keeps_explicit_caddyfile_selection_hook(self) -> None:
         doc_text = self.doc.read_text(encoding="utf-8")
         compose_text = self.compose_override.read_text(encoding="utf-8")


### PR DESCRIPTION
## Anlass

Nachlauf zum produktiven Public-Web-Hardening. Bestehende prerenderte Seiten waren ohne abschließenden Schrägstrich erreichbar, während etwa `/map/` mit 404 antwortete.

## Änderung

- Caddy entfernt einen abschließenden Schrägstrich zunächst nur intern
- anschließend wird geprüft, ob für den slashlosen Pfad tatsächlich `{path}.html` oder `{path}/index.html` existiert
- nur bei vorhandenem Prerender-Artefakt folgt eine permanente 308-Weiterleitung
- Query-Parameter bleiben erhalten
- unbekannte Slash-Pfade antworten weiterhin direkt mit 404
- API-, Health-, Basemap- und unveränderliche Asset-Routen bleiben durch ihre früheren spezifischen Handler unberührt
- der Produktionsvertrag und seine CI-Prüfung wurden synchron ergänzt

## Bewusste Grenze

Es gibt weder eine allgemeine Slash-Weiterleitung noch einen SPA-Catch-All. `/does-not-exist/` bleibt ein unmittelbarer 404.

## Lokale Belege

- realer isolierter Caddy-Test:
  - `/map/` → 308 `/map`
  - `/map/?noinert=1` → 308 `/map?noinert=1`
  - Verzeichnisexport `/folder/` → 308 `/folder`
  - `/missing/` → 404
- Caddy-Syntaxprüfung lokal: grün
- Caddy-Syntaxprüfung mit exakt gepinntem Produktionsimage: grün
- Route-/Dokumentationsvertrag: 9/9 grün
- `make ci-validate`: 810 + 160 + 67 Tests und alle Repositoryverträge grün
