### PR TITLE
docs(data): Produktionswahrheit von lokalen Defaults trennen

### DIFF
--- a/docs/datenmodell.md
+++ b/docs/datenmodell.md
@@ -3,7 +3,7 @@ id: datenmodell
 title: Datenmodell
 doc_type: reference
 status: active
-summary: Aktuelles physisches Datenmodell, Quellenumschaltung und noch nicht implementiertes Zielmodell.
+summary: Aktuelles physisches Datenmodell, lokale Legacy-Defaults und PostgreSQL-Produktionsvertrag.
 relations:
   - type: relates_to
     target: architecture/overview.md
@@ -19,25 +19,34 @@ relations:
 
 ## Wichtigste Aussage
 
-PostgreSQL ist **nicht** pauschal die alleinige Quelle der Wahrheit. Für
-Domänendaten bleibt JSONL der Standard. PostgreSQL kann als Lesequelle und für
-einzelne Schreibpfade ausdrücklich aktiviert werden. Auth-Sitzungen und
-Passkey-Credentials besitzen eigene Persistenzentscheidungen.
+Der Repository-Produktionsvertrag in `infra/compose/compose.prod.yml` verwendet
+PostgreSQL als Lese- und Schreibwahrheit für Accounts/Garnrollen, Knoten und
+Fäden. Passkey-Credentials werden dort ebenfalls aus PostgreSQL gelesen und
+geschrieben; `DATABASE_URL` bindet Sitzungen und weitere DB-Pfade an dieselbe
+Persistenzschicht. Eine Aussage über den tatsächlich laufenden Server verlangt
+zusätzlich einen datierten Runtime-Beleg.
+
+JSONL bleibt der lokale, testbare Code-Default sowie ein historischer Import-,
+Export- und ausdrücklich freizugebender Rückfallpfad. Dieser lokale Default ist
+keine Aussage über die Produktionsarchitektur und kein stiller
+Produktionsfallback.
 
 ## Quellenmatrix
 
-| Domäne | Standard lesen | Standard schreiben | PostgreSQL-Option |
+| Domäne | Lokaler/Legacy-Default | Produktionsvertrag | Physische PostgreSQL-Fläche |
 |---|---|---|---|
-| Accounts/Garnrollen | JSONL | JSONL-Append | `domain_accounts`; Account-Create opt-in |
-| Knoten | JSONL | JSONL-Rewrite | `domain_nodes`; Patch opt-in |
-| Fäden | JSONL | JSONL-Append | `domain_edges`; Create opt-in |
-| Sitzungen | In-Memory ohne DB | gleicher Store | `sessions` bei konfiguriertem DB-Store |
-| Passkeys | In-Memory | In-Memory | `passkey_credentials` opt-in |
+| Accounts/Garnrollen | JSONL lesen und anhängen | PostgreSQL lesen und schreiben | `domain_accounts` |
+| Knoten | JSONL lesen und umschreiben | PostgreSQL lesen; `POST` und `PATCH` schreiben | `domain_nodes` |
+| Fäden | JSONL lesen und anhängen | PostgreSQL lesen; `POST` schreibt | `domain_edges` |
+| Sitzungen | In-Memory ohne `DATABASE_URL` | PostgreSQL bei verpflichtender `DATABASE_URL` | `sessions` |
+| Passkeys | In-Memory | PostgreSQL als Produktionsdefault | `passkey_credentials` |
 | Gespräche/Nachrichten | kein vollständiger produktiver Pfad | kein vollständiger produktiver Pfad | nur Contracts, keine Tabellen |
 
 PostgreSQL-Schreiben verlangt PostgreSQL-Lesen. Die API verweigert ungültige
 Mischzustände, damit Änderungen nach einem Neustart nicht unsichtbar werden.
-Es gibt keinen allgemeinen Dual-Write.
+Es gibt keinen allgemeinen Dual-Write. `compose.prod.yml` setzt Lesequelle und
+alle vorhandenen Domänenschreibquellen gemeinsam auf `postgres`;
+`.env.example` bleibt dagegen absichtlich eine lokal startbare JSONL-Vorlage.
 
 Für Fäden gilt unabhängig von der physischen Quelle: Freie `note`-Texte werden
 persistiert, gehören aber nicht zur öffentlichen Projektion von `GET /edges`,
@@ -65,8 +74,9 @@ Die folgende Übersicht wird aus den aktuellen Migrationen abgeleitet.
 | `last_active` | `TIMESTAMPTZ` | letzte Aktivität |
 | `expires_at` | `TIMESTAMPTZ` | serverseitiger Ablauf |
 
-Derzeit besteht kein Foreign Key auf `domain_accounts`, weil Accounts weiterhin
-aus JSONL gelesen werden können.
+Derzeit besteht kein Foreign Key auf `domain_accounts`, weil lokale Legacy-,
+Import- und ausdrücklich freigegebene Rückfallpfade weiterhin JSONL-Identitäten
+verarbeiten können.
 
 ### `domain_accounts`
 
@@ -139,15 +149,18 @@ derselben Kennung für andere Daten wird als Konflikt abgewiesen.
 | Zeitfelder | `TIMESTAMPTZ` | Erstellung, Änderung, letzte Nutzung |
 
 Die Tabelle speichert keine privaten Passkey-Schlüssel. Ein Foreign Key zu
-`domain_accounts` ist bis zum vollständigen PostgreSQL-Accountcutover bewusst
-ausgesetzt.
+`domain_accounts` bleibt bis zum belegten Legacy-Backfill und zur abschließenden
+Identitätsbereinigung bewusst ausgesetzt.
 
 ## JSONL-Modell
 
-JSONL-Datensätze folgen den JSON-Schemas in `contracts/domain`. Die API lädt sie
-beim Start in begrenzte In-Memory-Stores. Schreibpfade serialisieren
-check-and-write innerhalb eines Prozesses und verwenden `fsync`; sie sind kein
-Ersatz für eine transaktionale Mehrprozessdatenbank.
+JSONL-Datensätze folgen den JSON-Schemas in `contracts/domain`. Im lokalen oder
+ausdrücklich aktivierten Legacy-Modus lädt die API sie beim Start in begrenzte
+In-Memory-Stores. Schreibpfade serialisieren check-and-write innerhalb eines
+Prozesses und verwenden `fsync`; sie sind kein Ersatz für eine transaktionale
+Mehrprozessdatenbank. In Produktion darf JSONL nur als dokumentierter Import-,
+Export- oder Rollbackpfad eingesetzt werden, nie als stiller Ersatz für einen
+fehlgeschlagenen PostgreSQL-Pfad.
 
 ## Contracts ohne produktive Tabellen
 

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -188,20 +188,29 @@ Das ist **keine Validierung**, sondern eine **sichtbare Beobachtung**.
 
 ### Performance & Limits
 
+Die folgenden Quellenvariablen besitzen zwei bewusst getrennte Default-Ebenen:
+Der API-Code und `.env.example` halten Domänendaten lokal im JSONL-Modus. Der
+Produktions-Compose-Vertrag `infra/compose/compose.prod.yml` setzt dagegen Lesen
+und alle vorhandenen Domänenschreibpfade gemeinsam auf `postgres`. Ein laufender
+Serverzustand muss zusätzlich durch Runtime-Evidence belegt werden.
+
 - **MAX_EDGES_CACHE**: Obergrenze der beim Start geladenen Edges (Default `500000`).
   Bei Erreichen wird die Datei nicht weiter gelesen und eine Warnung geloggt.
-- **WELTGEWEBE_DOMAIN_READ_SOURCE**: Default `jsonl`.
+- **WELTGEWEBE_DOMAIN_READ_SOURCE**: lokal `jsonl`, Produktion `postgres`.
   `postgres` lädt Accounts, Knoten und Fäden beim API-Start aus den
   PostgreSQL-Domänentabellen.
-- **WELTGEWEBE_DOMAIN_ACCOUNT_WRITE_SOURCE**: Default `jsonl`.
+- **WELTGEWEBE_DOMAIN_ACCOUNT_WRITE_SOURCE**: lokal `jsonl`, Produktion `postgres`.
   `postgres` persistiert Account-Erzeugung einschließlich Auth-
   Autoprovisionierung sowie `PATCH /accounts/me/profile` für die eigene
   Garnrolle in `domain_accounts`.
-- **WELTGEWEBE_DOMAIN_NODE_WRITE_SOURCE**: Default `jsonl`.
+- **WELTGEWEBE_DOMAIN_NODE_WRITE_SOURCE**: lokal `jsonl`, Produktion `postgres`.
   `postgres` persistiert `POST /nodes` und `PATCH /nodes/{id}` in
   `domain_nodes`.
-- **WELTGEWEBE_DOMAIN_EDGE_WRITE_SOURCE**: Default `jsonl`.
+- **WELTGEWEBE_DOMAIN_EDGE_WRITE_SOURCE**: lokal `jsonl`, Produktion `postgres`.
   `postgres` persistiert `POST /edges` in `domain_edges`.
+- **WELTGEWEBE_PASSKEY_CREDENTIAL_SOURCE**: lokaler In-Memory-Default,
+  Produktion `postgres`. `postgres` persistiert Credentials und Signaturzähler
+  in `passkey_credentials`.
 
 `POST /nodes` und `POST /edges` akzeptieren optional eine UUID als
 `operation_id`. Sie wird vom Webclient einmal pro Nutzeraktion erzeugt und bei

--- a/docs/policies/orientierung.md
+++ b/docs/policies/orientierung.md
@@ -132,7 +132,10 @@ Es beschreibt:
 ## 6 · Technische Leitplanken
 
 - **Aktueller Kern:** Rust/Axum-API, statisches SvelteKit-Web, Docker Compose und Caddy.
-- **Datenwahrheit:** JSONL bleibt Standard; PostgreSQL-Pfade werden einzeln und beweisgebunden umgestellt.
+- **Datenwahrheit:** Der Produktionsvertrag nutzt PostgreSQL für Domänen-Lesen,
+  alle vorhandenen Domänenschreibpfade und Passkey-Credentials. JSONL bleibt
+  lokaler Code-Default sowie dokumentierter Import-, Test- und Rückfallpfad;
+  Liveaussagen brauchen datierte Runtime-Evidence.
 - **Events und Beobachtung:** NATS sowie Prometheus-/Grafana-/Loki-/Tempo-Konfigurationen sind vorhanden, aber kein vollständiges Event-Sourcing- oder Observability-System ist allgemein produktiv belegt.
 - **Security:** sichere Sitzungen, Proxygrenze, CI-/Contract-Checks und secret-sichere Betriebsabläufe sind reale Leitplanken; SBOM, Signaturen, automatische Rotation und Forget-Pipeline bleiben gesondert nachzuweisende Ziele.
 - **Skalierung:** Compose ist der aktuelle Standard. Nomad, Kubernetes, HA-Cluster und FinOps-Ziele sind keine heutige Betriebswahrheit.

--- a/scripts/ci/tests/test_canonical_truth_contract.py
+++ b/scripts/ci/tests/test_canonical_truth_contract.py
@@ -83,10 +83,20 @@ class CanonicalTruthContractTests(unittest.TestCase):
 
     def test_data_model_names_actual_sources_and_absent_tables(self) -> None:
         text = (ROOT / "docs/datenmodell.md").read_text(encoding="utf-8")
-        self.assertIn("JSONL der Standard", text)
+        compose_prod = (ROOT / "infra/compose/compose.prod.yml").read_text(encoding="utf-8")
+        env_example = (ROOT / ".env.example").read_text(encoding="utf-8")
+
+        self.assertIn("Repository-Produktionsvertrag", text)
+        self.assertIn("JSONL bleibt der lokale, testbare Code-Default", text)
+        self.assertIn(
+            "WELTGEWEBE_DOMAIN_READ_SOURCE: ${WELTGEWEBE_DOMAIN_READ_SOURCE:-postgres}",
+            compose_prod,
+        )
+        self.assertIn("WELTGEWEBE_DOMAIN_READ_SOURCE=jsonl", env_example)
         for table in ("sessions", "domain_accounts", "domain_nodes", "domain_edges", "passkey_credentials"):
             self.assertIn(f"`{table}`", text)
         self.assertIn("keine `conversations`, `messages`, `roles`, `outbox`", text)
+        self.assertNotIn("Domänendaten bleibt JSONL der Standard", text)
         self.assertNotIn("PostgreSQL ist die alleinige Quelle der Wahrheit", text)
 
     def test_active_privacy_docs_do_not_promise_zero_cookies(self) -> None:

--- a/scripts/ci/tests/test_production_domain_truth_docs.py
+++ b/scripts/ci/tests/test_production_domain_truth_docs.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+
+REPO = Path(__file__).resolve().parents[3]
+
+
+class ProductionDomainTruthDocsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.compose_prod = (REPO / "infra" / "compose" / "compose.prod.yml").read_text(encoding="utf-8")
+        self.env_example = (REPO / ".env.example").read_text(encoding="utf-8")
+        self.data_model = (REPO / "docs" / "datenmodell.md").read_text(encoding="utf-8")
+        self.deploy_readme = (REPO / "docs" / "deploy" / "README.md").read_text(encoding="utf-8")
+        self.orientation = (REPO / "docs" / "policies" / "orientierung.md").read_text(encoding="utf-8")
+
+    def test_production_compose_defaults_domain_and_passkeys_to_postgres(self) -> None:
+        required = [
+            "WELTGEWEBE_DOMAIN_READ_SOURCE: ${WELTGEWEBE_DOMAIN_READ_SOURCE:-postgres}",
+            "WELTGEWEBE_DOMAIN_ACCOUNT_WRITE_SOURCE: ${WELTGEWEBE_DOMAIN_ACCOUNT_WRITE_SOURCE:-postgres}",
+            "WELTGEWEBE_DOMAIN_NODE_WRITE_SOURCE: ${WELTGEWEBE_DOMAIN_NODE_WRITE_SOURCE:-postgres}",
+            "WELTGEWEBE_DOMAIN_EDGE_WRITE_SOURCE: ${WELTGEWEBE_DOMAIN_EDGE_WRITE_SOURCE:-postgres}",
+            "WELTGEWEBE_PASSKEY_CREDENTIAL_SOURCE: ${WELTGEWEBE_PASSKEY_CREDENTIAL_SOURCE:-postgres}",
+        ]
+        for phrase in required:
+            with self.subTest(required=phrase):
+                self.assertIn(phrase, self.compose_prod)
+
+    def test_local_example_deliberately_keeps_jsonl_domain_defaults(self) -> None:
+        required = [
+            "WELTGEWEBE_DOMAIN_READ_SOURCE=jsonl",
+            "WELTGEWEBE_DOMAIN_ACCOUNT_WRITE_SOURCE=jsonl",
+            "WELTGEWEBE_DOMAIN_NODE_WRITE_SOURCE=jsonl",
+            "WELTGEWEBE_DOMAIN_EDGE_WRITE_SOURCE=jsonl",
+        ]
+        for phrase in required:
+            with self.subTest(required=phrase):
+                self.assertIn(phrase, self.env_example)
+
+    def test_canonical_docs_distinguish_local_defaults_from_production_truth(self) -> None:
+        self.assertIn("Lokaler/Legacy-Default", self.data_model)
+        self.assertIn("Produktionsvertrag", self.data_model)
+        self.assertIn("keine Aussage über die Produktionsarchitektur", self.data_model)
+        self.assertIn("lokal `jsonl`, Produktion `postgres`", self.deploy_readme)
+        self.assertIn("Produktionsvertrag nutzt PostgreSQL", self.orientation)
+        self.assertIn("Liveaussagen brauchen datierte Runtime-Evidence", self.orientation)
+
+    def test_obsolete_unqualified_jsonl_truth_claims_do_not_return(self) -> None:
+        forbidden_by_file = {
+            "docs/datenmodell.md": ["Domänendaten bleibt JSONL der Standard"],
+            "docs/deploy/README.md": ["WELTGEWEBE_DOMAIN_READ_SOURCE**: Default `jsonl`"],
+            "docs/policies/orientierung.md": ["**Datenwahrheit:** JSONL bleibt Standard"],
+        }
+        contents = {
+            "docs/datenmodell.md": self.data_model,
+            "docs/deploy/README.md": self.deploy_readme,
+            "docs/policies/orientierung.md": self.orientation,
+        }
+        for filename, forbidden_phrases in forbidden_by_file.items():
+            for phrase in forbidden_phrases:
+                with self.subTest(filename=filename, forbidden=phrase):
+                    self.assertNotIn(phrase, contents[filename])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Aktive Grundlagen beschrieben JSONL weiterhin pauschal als Standard, obwohl `infra/compose/compose.prod.yml` Domänenlesen, alle vorhandenen Domänenschreibpfade und Passkey-Credentials standardmäßig auf PostgreSQL setzt. Ein bestehender Canonical-Truth-Test erzwang diese veraltete Formulierung zusätzlich.

## Änderung

- `docs/datenmodell.md` trennt nun lokalen/Legacy-Default, Produktionsvertrag und tatsächlichen Runtime-Beleg
- `docs/deploy/README.md` nennt für jede Quellenvariable den lokalen und den Produktionsdefault
- `docs/policies/orientierung.md` beschreibt PostgreSQL als Repository-Produktionsvertrag
- historische Proofberichte und Roadmaps bleiben als zeitgebundene Belege unverändert
- der bestehende Canonical-Truth-Test wird auf den aktuellen Vertrag umgestellt
- ein neuer CI-Wächter bindet aktive Dokumentation an `compose.prod.yml` und `.env.example`

## Wahrheitsgrenze

Der Patch behauptet nicht, jeder beliebige laufende Server nutze automatisch PostgreSQL. Liveaussagen benötigen weiterhin datierte Runtime-Evidence. JSONL bleibt lokaler Code-Default sowie dokumentierter Import-, Test- und Rückfallpfad; es ist kein stiller Produktionsfallback.

## Belege

- gezielte Wahrheitsverträge: 13/13 grün
- `make ci-validate`: 810 Dokumentations-/Metadatentests, 160 Agententests, 71 CI-Tests sowie alle Deploy-, Backup-, Sicherheits- und Releaseverträge grün
- keine Produktcode-, Produktionskonfigurations- oder historischen Reportänderungen
