### PR TITLE
feat(ops): redigierten Produktionsbeleg erzeugen

### DIFF
--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -244,6 +244,52 @@ Datenbank schreiben, danach In-Memory-Cache aktualisieren.
   Garnrolle dauerhaft gespeichert wurde.
 
 
+### Maschinenlesbarer Produktionsbeleg
+
+`scripts/ops/collect_production_runtime_evidence.py` erzeugt einen
+maschinenlesbaren, wertredigierten Zustandsbeleg. Die Runtime-Erhebung ist rein
+lesend und führt für jeden erlaubten Laufzeitschalter genau einen
+`printenv`-Aufruf im laufenden API-Container aus. Die vollständige Containerumgebung wird weder
+gelesen noch ausgegeben. Erlaubt sind ausschließlich:
+
+- die vier Domänen-Lese-/Schreibquellen;
+- die Passkey-Persistenzquelle;
+- der API-Migrationsmodus.
+
+Der Sammler verbindet diese Werte mit öffentlicher API-Readiness, Web- und
+API-Buildidentität sowie exakt ausgewählten Backup- und Restore-Artefakten. Ausgewählte Metadaten und Dumps müssen reguläre
+Dateien sein; Symlinks und übergroße Metadatendateien werden abgelehnt. Er
+verwendet standardmäßig dieselbe Compose-Auswahl wie der VPS-Betrieb:
+`compose.prod.yml`, danach `compose.vps.override.yml`, Projekt `weltgewebe` und
+`/etc/weltgewebe/weltgewebe.env`. Abweichende Deployments müssen ihre
+Compose-Dateien ausdrücklich und in derselben Reihenfolge mit wiederholtem
+`--compose-file` angeben.
+
+Beispiel mit konkret ausgewählten Belegen:
+
+```bash
+python3 scripts/ops/collect_production_runtime_evidence.py \
+  --backup-manifest /var/backups/weltgewebe/postgres/<exact>.sha256.manifest \
+  --restore-proof /var/backups/weltgewebe/postgres/proofs/<exact>.restore-proof \
+  --output /var/lib/weltgewebe/evidence/production-runtime.json
+```
+
+Ein optionales `--offhost-backup-manifest` muss auf ein kopiertes Manifest
+zeigen, dessen Dump im selben Verzeichnis liegt. Nur wenn dieses Abbild
+hashgleich zum ausgewählten Produktionsbackup ist, erhält der Gesamtbeleg
+`status=pass`. Ohne Off-host-Beleg lautet der Zustand `partial` und der Prozess
+endet mit Code `2`; ein gebrochener Pflichtbeweis liefert `fail` und Code `1`.
+Damit kann ein lokaler Backup-/Restore-Beleg nicht versehentlich als
+Off-host-Recovery ausgegeben werden.
+
+Die JSON-Ausgabe besitzt Schema-Version, UTC-Prüfzeitpunkt, explizite
+Read-only-/Redaktionsmarker und eine `evidence_boundary` mit bewiesenen und nicht
+bewiesenen Aussagen. Bei `--output` wird sie atomar mit Dateimodus `0600`
+geschrieben; diese ausdrücklich gewählte Berichtdatei ist die einzige Mutation
+des Sammlers. Der Bericht beweist den beobachteten Zeitpunkt, nicht zukünftige
+Verfügbarkeit oder die fachliche Richtigkeit jeder Datenbankzeile.
+
+
 ---
 
 ## 6. Deployment Snapshot

--- a/scripts/ci/tests/test_production_runtime_evidence.py
+++ b/scripts/ci/tests/test_production_runtime_evidence.py
@@ -1,0 +1,438 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import stat
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from scripts.ops import collect_production_runtime_evidence as evidence
+from scripts.ops.check_public_live_readiness import FetchResult
+
+
+NOW = datetime(2026, 7, 14, 18, 0, tzinfo=timezone.utc)
+TABLES = ",".join(evidence.EXPECTED_TABLES)
+
+
+class ProductionRuntimeEvidenceTest(unittest.TestCase):
+    def test_runtime_probe_reads_only_allowlisted_keys_individually(self) -> None:
+        calls: list[list[str]] = []
+        aliases = {
+            "WELTGEWEBE_DOMAIN_READ_SOURCE": "pg\n",
+            "WELTGEWEBE_DOMAIN_ACCOUNT_WRITE_SOURCE": "postgres\n",
+            "WELTGEWEBE_DOMAIN_NODE_WRITE_SOURCE": "db\n",
+            "WELTGEWEBE_DOMAIN_EDGE_WRITE_SOURCE": "postgres\n",
+            "WELTGEWEBE_PASSKEY_CREDENTIAL_SOURCE": "pg\n",
+            "WELTGEWEBE_API_STARTUP_MIGRATIONS": "verify-applied\n",
+        }
+
+        def runner(argv):
+            calls.append(list(argv))
+            return evidence.CommandResult(0, aliases[argv[-1]])
+
+        result = evidence.collect_runtime_modes(
+            compose_prefix=["docker", "compose", "-p", "weltgewebe"],
+            service="api",
+            runner=runner,
+        )
+
+        self.assertEqual(result["status"], "pass")
+        self.assertFalse(result["complete_environment_read"])
+        self.assertFalse(result["confidential_values_read"])
+        self.assertEqual(len(calls), len(evidence.RUNTIME_EXPECTATIONS))
+        self.assertEqual({call[-1] for call in calls}, set(evidence.RUNTIME_EXPECTATIONS))
+        for call in calls:
+            self.assertEqual(call[-5:-1], ["exec", "-T", "api", "printenv"])
+
+    def test_runtime_probe_rejects_unknown_value_without_echoing_it(self) -> None:
+        secret_like = "postgresql://operator:secret@example/db"
+
+        def runner(argv):
+            value = secret_like if argv[-1] == "WELTGEWEBE_DOMAIN_READ_SOURCE" else "postgres"
+            return evidence.CommandResult(0, value)
+
+        with self.assertRaises(evidence.EvidenceError) as caught:
+            evidence.collect_runtime_modes(
+                compose_prefix=["docker", "compose"],
+                service="api",
+                runner=runner,
+            )
+        self.assertNotIn(secret_like, str(caught.exception))
+
+    def test_runtime_probe_reports_nonproduction_modes_as_failed_checks(self) -> None:
+        def runner(argv):
+            key = argv[-1]
+            if key == "WELTGEWEBE_DOMAIN_NODE_WRITE_SOURCE":
+                return evidence.CommandResult(0, "jsonl\n")
+            if key == "WELTGEWEBE_API_STARTUP_MIGRATIONS":
+                return evidence.CommandResult(0, "run\n")
+            return evidence.CommandResult(0, "postgres\n")
+
+        result = evidence.collect_runtime_modes(
+            compose_prefix=["docker", "compose"],
+            service="api",
+            runner=runner,
+        )
+        self.assertEqual(result["status"], "fail")
+        failed = {item["key"] for item in result["checks"] if item["status"] == "fail"}
+        self.assertEqual(
+            failed,
+            {"WELTGEWEBE_DOMAIN_NODE_WRITE_SOURCE", "WELTGEWEBE_API_STARTUP_MIGRATIONS"},
+        )
+
+    def test_public_evidence_binds_ready_and_build_headers(self) -> None:
+        def fetcher(url, headers, timeout):
+            del headers, timeout
+            if url.endswith("/health/ready"):
+                body = {"status": "ok", "checks": {"database": True, "nats": True, "policy": True}}
+                return FetchResult(url, 200, {}, json.dumps(body).encode())
+            if url == "https://api.weltgewebe.net/version":
+                body = {"version": "0.1.0", "commit": "a" * 40, "build_timestamp": "2026-07-14T17:00:00Z"}
+                return FetchResult(
+                    url,
+                    200,
+                    {"X-Weltgewebe-API-Build": "a" * 40},
+                    json.dumps(body).encode(),
+                )
+            body = {"version": "0.1.0", "commit": "b" * 40}
+            return FetchResult(
+                url,
+                200,
+                {"X-Weltgewebe-Build": "b" * 40},
+                json.dumps(body).encode(),
+            )
+
+        result = evidence.collect_public_evidence(
+            domain="weltgewebe.net",
+            api_domain="api.weltgewebe.net",
+            timeout=1.0,
+            fetcher=fetcher,
+        )
+        self.assertEqual(result["status"], "pass")
+        self.assertEqual([item["status"] for item in result["checks"]], ["pass", "pass", "pass"])
+
+    def test_public_evidence_fails_when_header_and_body_commit_diverge(self) -> None:
+        def fetcher(url, headers, timeout):
+            del headers, timeout
+            if url.endswith("/health/ready"):
+                payload = {"status": "ok", "checks": {"database": True, "nats": True, "policy": True}}
+                return FetchResult(url, 200, {}, json.dumps(payload).encode())
+            if "api.weltgewebe.net" in url:
+                payload = {"version": "0.1.0", "commit": "a" * 40, "build_timestamp": "x"}
+                return FetchResult(url, 200, {"X-Weltgewebe-API-Build": "c" * 40}, json.dumps(payload).encode())
+            payload = {"version": "0.1.0", "commit": "b" * 40}
+            return FetchResult(url, 200, {"X-Weltgewebe-Build": "b" * 40}, json.dumps(payload).encode())
+
+        result = evidence.collect_public_evidence(
+            domain="weltgewebe.net",
+            api_domain="api.weltgewebe.net",
+            timeout=1.0,
+            fetcher=fetcher,
+        )
+        self.assertEqual(result["status"], "fail")
+        api = next(item for item in result["checks"] if item["name"] == "api-release-identity")
+        self.assertFalse(api["header_matches_body"])
+
+
+    def test_public_evidence_reports_unknown_api_identity_without_aborting(self) -> None:
+        def fetcher(url, headers, timeout):
+            del headers, timeout
+            if url.endswith("/health/ready"):
+                payload = {"status": "ok", "checks": {"database": True, "nats": True, "policy": True}}
+                return FetchResult(url, 200, {}, json.dumps(payload).encode())
+            if "api.weltgewebe.net" in url:
+                payload = {"version": "0.1.0", "commit": "unknown", "build_timestamp": "unknown"}
+                return FetchResult(url, 200, {}, json.dumps(payload).encode())
+            payload = {"version": "0.1.0", "commit": "b" * 40}
+            return FetchResult(url, 200, {"X-Weltgewebe-Build": "b" * 8}, json.dumps(payload).encode())
+
+        result = evidence.collect_public_evidence(
+            domain="weltgewebe.net",
+            api_domain="api.weltgewebe.net",
+            timeout=1.0,
+            fetcher=fetcher,
+        )
+        self.assertEqual(result["status"], "fail")
+        api = next(item for item in result["checks"] if item["name"] == "api-release-identity")
+        self.assertEqual(api["commit"], "unknown")
+        self.assertFalse(api["commit_valid"])
+        self.assertFalse(api["build_header_present"])
+
+    def make_backup_fixture(self, root: Path, *, created_at: str = "2026-07-14T17:00:00Z") -> tuple[Path, Path, str]:
+        backup = root / "weltgewebe-postgres-test.sql.gz"
+        backup.write_bytes(b"deterministic-backup")
+        digest = hashlib.sha256(backup.read_bytes()).hexdigest()
+        manifest = root / "weltgewebe-postgres-test.sha256.manifest"
+        manifest.write_text(
+            "\n".join(
+                [
+                    "contract=weltgewebe-postgres-backup-v1",
+                    f"created_at={created_at}",
+                    f"file={backup.name}",
+                    f"sha256={digest}",
+                    f"bytes={backup.stat().st_size}",
+                    "git_commit=" + "d" * 40,
+                    f"tables={TABLES}",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        return manifest, backup, digest
+
+    def make_restore_fixture(self, root: Path, backup: Path, digest: str, *, created_at: str = "2026-07-14T17:30:00Z") -> Path:
+        proof = root / "weltgewebe-postgres-test.restore-proof"
+        proof.write_text(
+            "\n".join(
+                [
+                    "contract=weltgewebe-postgres-restore-proof-v1",
+                    f"created_at={created_at}",
+                    f"backup_file={backup.name}",
+                    f"backup_sha256={digest}",
+                    f"tables={TABLES}",
+                    "result=ok",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        return proof
+
+    def test_backup_restore_and_offhost_evidence_bind_same_artifact(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            production = root / "production"
+            offhost = root / "offhost"
+            production.mkdir()
+            offhost.mkdir()
+            manifest, backup_file, digest = self.make_backup_fixture(production)
+            proof = self.make_restore_fixture(production, backup_file, digest)
+            offhost_backup = offhost / backup_file.name
+            offhost_backup.write_bytes(backup_file.read_bytes())
+            offhost_manifest = offhost / manifest.name
+            offhost_manifest.write_bytes(manifest.read_bytes())
+
+            backup = evidence.collect_backup_evidence(
+                manifest_path=manifest,
+                now=NOW,
+                max_age=timedelta(hours=26),
+            )
+            restore = evidence.collect_restore_evidence(
+                proof_path=proof,
+                backup=backup,
+                now=NOW,
+                max_age=timedelta(hours=192),
+            )
+            copied = evidence.collect_offhost_evidence(
+                manifest_path=offhost_manifest,
+                backup=backup,
+            )
+
+            self.assertEqual(backup["status"], "pass")
+            self.assertTrue(backup["hash_matches"])
+            self.assertEqual(restore["status"], "pass")
+            self.assertTrue(restore["backup_matches_manifest"])
+            self.assertEqual(copied["status"], "pass")
+            self.assertTrue(copied["copied_file_hash_matches"])
+
+    def test_stale_backup_is_reported_without_inflating_the_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            manifest, _, _ = self.make_backup_fixture(root, created_at="2026-07-10T00:00:00Z")
+            result = evidence.collect_backup_evidence(
+                manifest_path=manifest,
+                now=NOW,
+                max_age=timedelta(hours=26),
+            )
+            self.assertEqual(result["status"], "fail")
+            self.assertFalse(result["fresh"])
+
+    def test_restore_proof_must_match_selected_backup(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            manifest, backup_file, digest = self.make_backup_fixture(root)
+            proof = self.make_restore_fixture(root, backup_file, "e" * 64)
+            backup = evidence.collect_backup_evidence(
+                manifest_path=manifest,
+                now=NOW,
+                max_age=timedelta(hours=26),
+            )
+            restore = evidence.collect_restore_evidence(
+                proof_path=proof,
+                backup=backup,
+                now=NOW,
+                max_age=timedelta(hours=192),
+            )
+            self.assertEqual(restore["status"], "fail")
+            self.assertFalse(restore["backup_matches_manifest"])
+
+
+    def test_restore_proof_must_not_predate_selected_backup(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            manifest, backup_file, digest = self.make_backup_fixture(
+                root,
+                created_at="2026-07-14T17:00:00Z",
+            )
+            proof = self.make_restore_fixture(
+                root,
+                backup_file,
+                digest,
+                created_at="2026-07-14T16:59:59Z",
+            )
+            backup = evidence.collect_backup_evidence(
+                manifest_path=manifest,
+                now=NOW,
+                max_age=timedelta(hours=26),
+            )
+            restore = evidence.collect_restore_evidence(
+                proof_path=proof,
+                backup=backup,
+                now=NOW,
+                max_age=timedelta(hours=192),
+            )
+            self.assertEqual(restore["status"], "fail")
+            self.assertFalse(restore["not_before_backup"])
+
+    def test_offhost_is_explicitly_not_proven_when_omitted(self) -> None:
+        result = evidence.collect_offhost_evidence(manifest_path=None, backup={})
+        self.assertEqual(result["status"], "not-provided")
+        self.assertFalse(result["required_for_overall_pass"])
+
+    def test_evidence_envelope_states_scope_and_optional_offhost_boundary(self) -> None:
+        passing = {"status": "pass"}
+        payload = evidence.build_evidence(
+            public=passing,
+            runtime=passing,
+            backup=passing,
+            restore=passing,
+            offhost={"status": "not-provided", "required_for_overall_pass": False},
+            generated_at=NOW,
+        )
+        self.assertEqual(payload["status"], "partial")
+        self.assertTrue(payload["runtime_collection_read_only"])
+        self.assertFalse(payload["runtime_mutation_performed"])
+        self.assertTrue(payload["report_write_is_only_mutation"])
+        self.assertTrue(payload["values_redacted"])
+        self.assertIn(
+            "off-host recovery when no off-host manifest is supplied",
+            payload["evidence_boundary"]["does_not_prove"],
+        )
+
+
+    def test_evidence_requires_verified_offhost_copy_for_full_pass(self) -> None:
+        passing = {"status": "pass"}
+        payload = evidence.build_evidence(
+            public=passing,
+            runtime=passing,
+            backup=passing,
+            restore=passing,
+            offhost={"status": "pass", "required_for_overall_pass": True},
+            generated_at=NOW,
+        )
+        self.assertEqual(payload["status"], "pass")
+
+    def test_atomic_json_output_is_private_and_complete(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            target = Path(temp) / "nested" / "evidence.json"
+            payload = {"status": "pass", "schema_version": 1}
+            evidence.write_json_atomic(target, payload)
+            self.assertEqual(json.loads(target.read_text(encoding="utf-8")), payload)
+            mode = stat.S_IMODE(os.stat(target).st_mode)
+            self.assertEqual(mode, 0o600)
+            self.assertEqual(list(target.parent.glob(f".{target.name}.*")), [])
+
+
+    def test_deploy_docs_preserve_redaction_and_partial_status_contract(self) -> None:
+        repo = Path(__file__).resolve().parents[3]
+        text = (repo / "docs" / "deploy" / "README.md").read_text(encoding="utf-8")
+        for phrase in (
+            "collect_production_runtime_evidence.py",
+            "vollständige Containerumgebung wird weder",
+            "status=pass",
+            "Zustand `partial`",
+            "Code `2`",
+            "Dateimodus `0600`",
+            "evidence_boundary",
+        ):
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, text)
+
+
+    def test_public_text_sanitizer_does_not_echo_secret_shaped_values(self) -> None:
+        secret_like = "postgresql://operator:secret@example.test/database"
+        self.assertEqual(evidence.safe_public_text(secret_like), "<invalid>")
+        self.assertNotIn(secret_like, evidence.safe_public_text(secret_like))
+
+
+    def test_selected_metadata_and_backup_symlinks_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            real_metadata = root / "real.manifest"
+            real_metadata.write_text("contract=weltgewebe-postgres-backup-v1\n", encoding="utf-8")
+            metadata_link = root / "link.manifest"
+            metadata_link.symlink_to(real_metadata.name)
+            with self.assertRaises(evidence.EvidenceError):
+                evidence.read_key_value_file(
+                    metadata_link,
+                    allowed_keys=evidence.BACKUP_MANIFEST_KEYS,
+                )
+
+            real_backup = root / "real.sql.gz"
+            real_backup.write_bytes(b"backup")
+            backup_link = root / "link.sql.gz"
+            backup_link.symlink_to(real_backup.name)
+            with self.assertRaises(evidence.EvidenceError):
+                evidence.sha256_and_size(backup_link)
+
+    def test_metadata_size_limit_is_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            path = Path(temp) / "oversized.manifest"
+            path.write_bytes(b"x" * (evidence.MAX_EVIDENCE_METADATA_BYTES + 1))
+            with self.assertRaises(evidence.EvidenceError):
+                evidence.read_key_value_file(path, allowed_keys=evidence.BACKUP_MANIFEST_KEYS)
+
+    def test_manifest_rejects_unknown_keys_without_echoing_values(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            path = Path(temp) / "manifest"
+            path.write_text("contract=weltgewebe-postgres-backup-v1\nSECRET_TOKEN=do-not-echo\n", encoding="utf-8")
+            with self.assertRaises(evidence.EvidenceError) as caught:
+                evidence.read_key_value_file(path, allowed_keys=evidence.BACKUP_MANIFEST_KEYS)
+            self.assertNotIn("do-not-echo", str(caught.exception))
+
+    def test_invalid_hostname_and_nonpositive_freshness_fail_closed(self) -> None:
+        with self.assertRaises(evidence.EvidenceError):
+            evidence.validate_hostname("https://user:secret@example.test/path", field="domain")
+        with self.assertRaises(argparse.ArgumentTypeError):
+            evidence.positive_hours("0")
+
+    def test_compose_prefix_preserves_explicit_deployment_order(self) -> None:
+        result = evidence.build_compose_prefix(
+            docker_bin="docker",
+            project_name="weltgewebe",
+            env_file=Path("/etc/weltgewebe/weltgewebe.env"),
+            compose_files=[Path("prod.yml"), Path("vps.yml")],
+        )
+        self.assertEqual(
+            result,
+            [
+                "docker",
+                "compose",
+                "--env-file",
+                "/etc/weltgewebe/weltgewebe.env",
+                "-p",
+                "weltgewebe",
+                "-f",
+                "prod.yml",
+                "-f",
+                "vps.yml",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/tests/test_production_runtime_evidence.py
+++ b/scripts/ci/tests/test_production_runtime_evidence.py
@@ -399,7 +399,7 @@ class ProductionRuntimeEvidenceTest(unittest.TestCase):
     def test_manifest_rejects_unknown_keys_without_echoing_values(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             path = Path(temp) / "manifest"
-            path.write_text("contract=weltgewebe-postgres-backup-v1\nSECRET_TOKEN=do-not-echo\n", encoding="utf-8")
+            path.write_text("contract=weltgewebe-postgres-backup-v1\nUNEXPECTED_FIELD=do-not-echo\n", encoding="utf-8")
             with self.assertRaises(evidence.EvidenceError) as caught:
                 evidence.read_key_value_file(path, allowed_keys=evidence.BACKUP_MANIFEST_KEYS)
             self.assertNotIn("do-not-echo", str(caught.exception))

--- a/scripts/ci/tests/test_production_runtime_evidence.py
+++ b/scripts/ci/tests/test_production_runtime_evidence.py
@@ -121,7 +121,7 @@ class ProductionRuntimeEvidenceTest(unittest.TestCase):
             if url.endswith("/health/ready"):
                 payload = {"status": "ok", "checks": {"database": True, "nats": True, "policy": True}}
                 return FetchResult(url, 200, {}, json.dumps(payload).encode())
-            if "api.weltgewebe.net" in url:
+            if url == "https://api.weltgewebe.net/version":
                 payload = {"version": "0.1.0", "commit": "a" * 40, "build_timestamp": "x"}
                 return FetchResult(url, 200, {"X-Weltgewebe-API-Build": "c" * 40}, json.dumps(payload).encode())
             payload = {"version": "0.1.0", "commit": "b" * 40}
@@ -144,7 +144,7 @@ class ProductionRuntimeEvidenceTest(unittest.TestCase):
             if url.endswith("/health/ready"):
                 payload = {"status": "ok", "checks": {"database": True, "nats": True, "policy": True}}
                 return FetchResult(url, 200, {}, json.dumps(payload).encode())
-            if "api.weltgewebe.net" in url:
+            if url == "https://api.weltgewebe.net/version":
                 payload = {"version": "0.1.0", "commit": "unknown", "build_timestamp": "unknown"}
                 return FetchResult(url, 200, {}, json.dumps(payload).encode())
             payload = {"version": "0.1.0", "commit": "b" * 40}

--- a/scripts/ops/collect_production_runtime_evidence.py
+++ b/scripts/ops/collect_production_runtime_evidence.py
@@ -1,0 +1,721 @@
+#!/usr/bin/env python3
+"""Collect one runtime-read-only, value-redacted Weltgewebe production evidence envelope.
+
+The collector reads only explicitly allowlisted, non-confidential mode switches
+from the running API container. It never reads the complete container
+environment. Public readiness and release identity are fetched over HTTPS.
+Backup and restore evidence must be supplied as exact files; the collector does
+not guess which artifact is current.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import stat
+import subprocess
+import tempfile
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+try:
+    from scripts.ops.check_public_live_readiness import FetchResult, fetch_url
+except ModuleNotFoundError:  # direct execution from scripts/ops
+    from check_public_live_readiness import FetchResult, fetch_url
+
+SCHEMA_VERSION = 1
+EVIDENCE_KIND = "weltgewebe.production-runtime-evidence"
+EXPECTED_TABLES = (
+    "domain_accounts",
+    "domain_nodes",
+    "domain_edges",
+    "sessions",
+    "passkey_credentials",
+    "_sqlx_migrations",
+)
+RUNTIME_EXPECTATIONS: Mapping[str, str] = {
+    "WELTGEWEBE_DOMAIN_READ_SOURCE": "postgres",
+    "WELTGEWEBE_DOMAIN_ACCOUNT_WRITE_SOURCE": "postgres",
+    "WELTGEWEBE_DOMAIN_NODE_WRITE_SOURCE": "postgres",
+    "WELTGEWEBE_DOMAIN_EDGE_WRITE_SOURCE": "postgres",
+    "WELTGEWEBE_PASSKEY_CREDENTIAL_SOURCE": "postgres",
+    "WELTGEWEBE_API_STARTUP_MIGRATIONS": "verify-applied",
+}
+RUNTIME_ALIASES: Mapping[str, Mapping[str, str]] = {
+    "WELTGEWEBE_DOMAIN_READ_SOURCE": {
+        "jsonl": "jsonl",
+        "file": "jsonl",
+        "files": "jsonl",
+        "postgres": "postgres",
+        "pg": "postgres",
+        "db": "postgres",
+    },
+    "WELTGEWEBE_DOMAIN_ACCOUNT_WRITE_SOURCE": {
+        "jsonl": "jsonl",
+        "file": "jsonl",
+        "files": "jsonl",
+        "postgres": "postgres",
+        "pg": "postgres",
+        "db": "postgres",
+    },
+    "WELTGEWEBE_DOMAIN_NODE_WRITE_SOURCE": {
+        "jsonl": "jsonl",
+        "file": "jsonl",
+        "files": "jsonl",
+        "postgres": "postgres",
+        "pg": "postgres",
+        "db": "postgres",
+    },
+    "WELTGEWEBE_DOMAIN_EDGE_WRITE_SOURCE": {
+        "jsonl": "jsonl",
+        "file": "jsonl",
+        "files": "jsonl",
+        "postgres": "postgres",
+        "pg": "postgres",
+        "db": "postgres",
+    },
+    "WELTGEWEBE_PASSKEY_CREDENTIAL_SOURCE": {
+        "in_memory": "in_memory",
+        "memory": "in_memory",
+        "mem": "in_memory",
+        "postgres": "postgres",
+        "pg": "postgres",
+        "db": "postgres",
+    },
+    "WELTGEWEBE_API_STARTUP_MIGRATIONS": {
+        "run": "run",
+        "verify-applied": "verify-applied",
+    },
+}
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+COMMIT_RE = re.compile(r"^[0-9a-f]{7,64}$")
+SAFE_PUBLIC_TEXT_RE = re.compile(r"^[A-Za-z0-9._:+-]{1,128}$")
+SAFE_BACKUP_FILE_RE = re.compile(r"^[A-Za-z0-9._-]+\.sql\.gz$")
+SAFE_HOST_RE = re.compile(r"^(?=.{1,253}$)(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,63}$")
+BACKUP_MANIFEST_KEYS = frozenset({"contract", "created_at", "file", "sha256", "bytes", "git_commit", "tables"})
+RESTORE_PROOF_KEYS = frozenset({"contract", "created_at", "backup_file", "backup_sha256", "tables", "result"})
+MAX_EVIDENCE_METADATA_BYTES = 64 * 1024
+
+
+class EvidenceError(RuntimeError):
+    """Raised when a bounded production evidence claim cannot be established."""
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    stdout: str
+    stderr: str = ""
+
+
+Runner = Callable[[Sequence[str]], CommandResult]
+Fetcher = Callable[[str, Mapping[str, str] | None, float], FetchResult]
+
+
+def run_command(argv: Sequence[str]) -> CommandResult:
+    proc = subprocess.run(
+        list(argv),
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=15,
+    )
+    return CommandResult(proc.returncode, proc.stdout, proc.stderr)
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def format_utc(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def parse_utc(value: str, *, field: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise EvidenceError(f"{field} is not a valid ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise EvidenceError(f"{field} must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def canonical_runtime_value(key: str, raw: str) -> str:
+    value = raw.strip().lower()
+    aliases = RUNTIME_ALIASES[key]
+    if value not in aliases:
+        raise EvidenceError(f"running API returned an unsupported value for {key}")
+    return aliases[value]
+
+
+def build_compose_prefix(
+    *,
+    docker_bin: str,
+    project_name: str,
+    env_file: Path,
+    compose_files: Sequence[Path],
+) -> list[str]:
+    if not compose_files:
+        raise EvidenceError("at least one compose file is required")
+    argv = [docker_bin, "compose", "--env-file", str(env_file), "-p", project_name]
+    for compose_file in compose_files:
+        argv.extend(["-f", str(compose_file)])
+    return argv
+
+
+def collect_runtime_modes(
+    *,
+    compose_prefix: Sequence[str],
+    service: str,
+    runner: Runner = run_command,
+) -> dict[str, Any]:
+    observed: dict[str, str] = {}
+    checks: list[dict[str, object]] = []
+    for key, expected in RUNTIME_EXPECTATIONS.items():
+        argv = [*compose_prefix, "exec", "-T", service, "printenv", key]
+        try:
+            result = runner(argv)
+        except (OSError, subprocess.SubprocessError) as exc:
+            raise EvidenceError(f"could not complete runtime probe for allowlisted key {key}") from exc
+        if result.returncode != 0:
+            raise EvidenceError(f"could not read allowlisted runtime key {key} from service {service}")
+        canonical = canonical_runtime_value(key, result.stdout)
+        observed[key] = canonical
+        checks.append(
+            {
+                "key": key,
+                "status": "pass" if canonical == expected else "fail",
+                "observed": canonical,
+                "expected": expected,
+            }
+        )
+    ok = all(item["status"] == "pass" for item in checks)
+    return {
+        "status": "pass" if ok else "fail",
+        "source": "running-api-container",
+        "service": service,
+        "read_method": "one printenv call per allowlisted key",
+        "complete_environment_read": False,
+        "confidential_values_read": False,
+        "checks": checks,
+        "observed": observed,
+    }
+
+
+def lower_headers(headers: Mapping[str, str]) -> dict[str, str]:
+    return {str(key).lower(): str(value) for key, value in headers.items()}
+
+
+def fetch_json(fetcher: Fetcher, url: str, timeout: float) -> tuple[FetchResult, dict[str, Any]]:
+    try:
+        result = fetcher(url, None, timeout)
+    except Exception as exc:
+        raise EvidenceError(f"public request failed for {url}") from exc
+    try:
+        payload = json.loads(result.body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise EvidenceError(f"public endpoint returned invalid JSON: {url}") from exc
+    if not isinstance(payload, dict):
+        raise EvidenceError(f"public endpoint returned a non-object JSON value: {url}")
+    return result, payload
+
+
+def safe_public_text(value: object) -> str:
+    if isinstance(value, str) and SAFE_PUBLIC_TEXT_RE.fullmatch(value):
+        return value
+    return "<invalid>"
+
+
+def validate_hostname(value: str, *, field: str) -> str:
+    if not SAFE_HOST_RE.fullmatch(value):
+        raise EvidenceError(f"{field} is not a valid hostname")
+    return value
+
+
+def public_commit(value: object) -> tuple[str, bool]:
+    if isinstance(value, str) and COMMIT_RE.fullmatch(value):
+        return value, True
+    if value == "unknown":
+        return "unknown", False
+    return "<invalid>", False
+
+
+def commit_identities_match(header: str, body: str) -> bool:
+    if not COMMIT_RE.fullmatch(header) or not COMMIT_RE.fullmatch(body):
+        return False
+    shorter, longer = sorted((header, body), key=len)
+    return len(shorter) >= 7 and longer.startswith(shorter)
+
+
+def collect_public_evidence(
+    *,
+    domain: str,
+    api_domain: str,
+    timeout: float,
+    fetcher: Fetcher = fetch_url,
+) -> dict[str, Any]:
+    domain = validate_hostname(domain, field="domain")
+    api_domain = validate_hostname(api_domain, field="api_domain")
+    ready_result, ready = fetch_json(fetcher, f"https://{api_domain}/health/ready", timeout)
+    api_result, api_version = fetch_json(fetcher, f"https://{api_domain}/version", timeout)
+    web_result, web_version = fetch_json(fetcher, f"https://{domain}/_app/version.json", timeout)
+
+    ready_checks = ready.get("checks")
+    if not isinstance(ready_checks, dict):
+        ready_checks = {}
+    safe_ready_checks = {
+        key: ready_checks.get(key) is True for key in ("database", "nats", "policy")
+    }
+    ready_ok = (
+        ready_result.status == 200
+        and ready.get("status") == "ok"
+        and all(safe_ready_checks.values())
+    )
+
+    api_commit, api_commit_valid = public_commit(api_version.get("commit"))
+    web_commit, web_commit_valid = public_commit(web_version.get("commit"))
+    api_header = lower_headers(api_result.headers).get("x-weltgewebe-api-build", "")
+    web_header = lower_headers(web_result.headers).get("x-weltgewebe-build", "")
+    api_header_matches = api_commit_valid and commit_identities_match(api_header, api_commit)
+    web_header_matches = web_commit_valid and commit_identities_match(web_header, web_commit)
+    api_identity_ok = api_result.status == 200 and api_header_matches
+    web_identity_ok = web_result.status == 200 and web_header_matches
+
+    checks = [
+        {
+            "name": "api-readiness",
+            "status": "pass" if ready_ok else "fail",
+            "http_status": ready_result.status,
+            "checks": safe_ready_checks,
+        },
+        {
+            "name": "api-release-identity",
+            "status": "pass" if api_identity_ok else "fail",
+            "http_status": api_result.status,
+            "commit": api_commit,
+            "commit_valid": api_commit_valid,
+            "build_header_present": bool(api_header),
+            "header_matches_body": api_header_matches,
+            "version": safe_public_text(api_version.get("version")),
+            "build_timestamp": safe_public_text(api_version.get("build_timestamp")),
+        },
+        {
+            "name": "web-release-identity",
+            "status": "pass" if web_identity_ok else "fail",
+            "http_status": web_result.status,
+            "commit": web_commit,
+            "commit_valid": web_commit_valid,
+            "build_header_present": bool(web_header),
+            "header_matches_body": web_header_matches,
+            "version": safe_public_text(web_version.get("version")),
+        },
+    ]
+    ok = all(item["status"] == "pass" for item in checks)
+    return {
+        "status": "pass" if ok else "fail",
+        "transport": "public-https",
+        "checks": checks,
+    }
+
+
+def read_small_regular_text(path: Path) -> str:
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(path, flags)
+    except OSError as exc:
+        raise EvidenceError(f"could not open selected evidence metadata: {path}") from exc
+    try:
+        file_stat = os.fstat(fd)
+        if not stat.S_ISREG(file_stat.st_mode):
+            raise EvidenceError(f"selected evidence metadata is not a regular file: {path}")
+        if file_stat.st_size > MAX_EVIDENCE_METADATA_BYTES:
+            raise EvidenceError(f"selected evidence metadata exceeds the size limit: {path}")
+        with os.fdopen(fd, "rb", closefd=False) as handle:
+            raw = handle.read(MAX_EVIDENCE_METADATA_BYTES + 1)
+        if len(raw) > MAX_EVIDENCE_METADATA_BYTES:
+            raise EvidenceError(f"selected evidence metadata exceeds the size limit: {path}")
+        try:
+            return raw.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise EvidenceError(f"selected evidence metadata is not UTF-8: {path}") from exc
+    finally:
+        os.close(fd)
+
+
+def read_key_value_file(path: Path, *, allowed_keys: frozenset[str]) -> dict[str, str]:
+    text = read_small_regular_text(path)
+    values: dict[str, str] = {}
+    for line_number, raw in enumerate(text.splitlines(), start=1):
+        if not raw or raw.startswith("#"):
+            continue
+        if "=" not in raw:
+            raise EvidenceError(f"invalid evidence line {line_number} in {path.name}")
+        key, value = raw.split("=", 1)
+        if not key or key in values:
+            raise EvidenceError(f"duplicate or empty evidence key in {path.name}")
+        if key not in allowed_keys:
+            raise EvidenceError(f"unsupported evidence key in {path.name}")
+        values[key] = value
+    return values
+
+
+def require_exact_tables(value: str, *, source: str) -> list[str]:
+    observed = tuple(item for item in value.split(",") if item)
+    if observed != EXPECTED_TABLES:
+        raise EvidenceError(f"{source} does not cover the required table set")
+    return list(observed)
+
+
+def sha256_and_size(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    byte_count = 0
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(path, flags)
+    except OSError as exc:
+        raise EvidenceError(f"could not open selected backup artifact: {path}") from exc
+    try:
+        file_stat = os.fstat(fd)
+        if not stat.S_ISREG(file_stat.st_mode):
+            raise EvidenceError(f"selected backup artifact is not a regular file: {path}")
+        with os.fdopen(fd, "rb", closefd=False) as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+                byte_count += len(chunk)
+    finally:
+        os.close(fd)
+    return digest.hexdigest(), byte_count
+
+
+def collect_backup_evidence(
+    *,
+    manifest_path: Path,
+    now: datetime,
+    max_age: timedelta,
+) -> dict[str, Any]:
+    values = read_key_value_file(manifest_path, allowed_keys=BACKUP_MANIFEST_KEYS)
+    if values.get("contract") != "weltgewebe-postgres-backup-v1":
+        raise EvidenceError("backup manifest contract is not supported")
+    created = parse_utc(values.get("created_at", ""), field="backup created_at")
+    age = now.astimezone(timezone.utc) - created
+    if age.total_seconds() < 0:
+        raise EvidenceError("backup manifest timestamp is in the future")
+    expected_sha = values.get("sha256", "")
+    if not SHA256_RE.fullmatch(expected_sha):
+        raise EvidenceError("backup manifest sha256 is invalid")
+    filename = values.get("file", "")
+    if not SAFE_BACKUP_FILE_RE.fullmatch(filename) or Path(filename).name != filename:
+        raise EvidenceError("backup manifest file must be a safe .sql.gz basename")
+    backup_path = manifest_path.parent / filename
+    actual_sha, actual_bytes = sha256_and_size(backup_path)
+    try:
+        byte_count = int(values.get("bytes", ""))
+    except ValueError as exc:
+        raise EvidenceError("backup manifest bytes is invalid") from exc
+    size_matches = actual_bytes == byte_count
+    hash_matches = actual_sha == expected_sha
+    fresh = age <= max_age
+    git_commit = values.get("git_commit")
+    if git_commit:
+        git_commit_display, git_commit_valid = public_commit(git_commit)
+        if not git_commit_valid:
+            raise EvidenceError("backup manifest git_commit is invalid")
+    else:
+        git_commit_display = None
+    checks_ok = hash_matches and size_matches and fresh
+    return {
+        "status": "pass" if checks_ok else "fail",
+        "contract": values["contract"],
+        "created_at": format_utc(created),
+        "age_seconds": int(age.total_seconds()),
+        "max_age_seconds": int(max_age.total_seconds()),
+        "file": filename,
+        "sha256": expected_sha,
+        "bytes": byte_count,
+        "hash_matches": hash_matches,
+        "size_matches": size_matches,
+        "fresh": fresh,
+        "git_commit": git_commit_display,
+        "tables": require_exact_tables(values.get("tables", ""), source="backup manifest"),
+    }
+
+
+def collect_restore_evidence(
+    *,
+    proof_path: Path,
+    backup: Mapping[str, Any],
+    now: datetime,
+    max_age: timedelta,
+) -> dict[str, Any]:
+    values = read_key_value_file(proof_path, allowed_keys=RESTORE_PROOF_KEYS)
+    if values.get("contract") != "weltgewebe-postgres-restore-proof-v1":
+        raise EvidenceError("restore proof contract is not supported")
+    created = parse_utc(values.get("created_at", ""), field="restore created_at")
+    age = now.astimezone(timezone.utc) - created
+    if age.total_seconds() < 0:
+        raise EvidenceError("restore proof timestamp is in the future")
+    fresh = age <= max_age
+    backup_created = parse_utc(str(backup.get("created_at", "")), field="selected backup created_at")
+    not_before_backup = created >= backup_created
+    backup_matches = (
+        values.get("backup_file") == backup.get("file")
+        and values.get("backup_sha256") == backup.get("sha256")
+    )
+    result_ok = values.get("result") == "ok"
+    checks_ok = fresh and not_before_backup and backup_matches and result_ok
+    return {
+        "status": "pass" if checks_ok else "fail",
+        "contract": values["contract"],
+        "created_at": format_utc(created),
+        "age_seconds": int(age.total_seconds()),
+        "max_age_seconds": int(max_age.total_seconds()),
+        "backup_file": values.get("backup_file"),
+        "backup_sha256": values.get("backup_sha256"),
+        "backup_matches_manifest": backup_matches,
+        "not_before_backup": not_before_backup,
+        "result": values.get("result"),
+        "fresh": fresh,
+        "tables": require_exact_tables(values.get("tables", ""), source="restore proof"),
+    }
+
+
+def collect_offhost_evidence(
+    *,
+    manifest_path: Path | None,
+    backup: Mapping[str, Any],
+) -> dict[str, Any]:
+    if manifest_path is None:
+        return {
+            "status": "not-provided",
+            "required_for_overall_pass": False,
+            "detail": "no off-host manifest was supplied",
+        }
+    values = read_key_value_file(manifest_path, allowed_keys=BACKUP_MANIFEST_KEYS)
+    if values.get("contract") != "weltgewebe-postgres-backup-v1":
+        raise EvidenceError("off-host manifest contract is not supported")
+    offhost_name = values.get("file", "")
+    offhost_sha_expected = values.get("sha256", "")
+    if not SAFE_BACKUP_FILE_RE.fullmatch(offhost_name) or Path(offhost_name).name != offhost_name:
+        raise EvidenceError("off-host manifest file must be a safe .sql.gz basename")
+    if not SHA256_RE.fullmatch(offhost_sha_expected):
+        raise EvidenceError("off-host manifest sha256 is invalid")
+    try:
+        offhost_bytes_expected = int(values.get("bytes", ""))
+    except ValueError as exc:
+        raise EvidenceError("off-host manifest bytes is invalid") from exc
+    require_exact_tables(values.get("tables", ""), source="off-host manifest")
+    same_artifact = (
+        offhost_name == backup.get("file")
+        and offhost_sha_expected == backup.get("sha256")
+        and offhost_bytes_expected == backup.get("bytes")
+        and values.get("created_at") == backup.get("created_at")
+    )
+    try:
+        offhost_sha, offhost_bytes = sha256_and_size(manifest_path.parent / offhost_name)
+    except EvidenceError:
+        hash_matches = False
+    else:
+        hash_matches = (
+            offhost_sha == offhost_sha_expected
+            and offhost_bytes == offhost_bytes_expected
+        )
+    ok = same_artifact and hash_matches
+    return {
+        "status": "pass" if ok else "fail",
+        "required_for_overall_pass": True,
+        "file": offhost_name,
+        "sha256": offhost_sha_expected,
+        "bytes": offhost_bytes_expected,
+        "same_artifact_as_production_manifest": same_artifact,
+        "copied_file_hash_matches": hash_matches,
+    }
+
+
+def build_evidence(
+    *,
+    public: Mapping[str, Any],
+    runtime: Mapping[str, Any],
+    backup: Mapping[str, Any],
+    restore: Mapping[str, Any],
+    offhost: Mapping[str, Any],
+    generated_at: datetime,
+) -> dict[str, Any]:
+    required_sections = (public, runtime, backup, restore)
+    required_ok = all(section.get("status") == "pass" for section in required_sections)
+    if not required_ok or offhost.get("status") == "fail":
+        overall_status = "fail"
+    elif offhost.get("status") == "pass":
+        overall_status = "pass"
+    else:
+        overall_status = "partial"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "kind": EVIDENCE_KIND,
+        "status": overall_status,
+        "generated_at": format_utc(generated_at),
+        "runtime_collection_read_only": True,
+        "runtime_mutation_performed": False,
+        "report_write_is_only_mutation": True,
+        "values_redacted": True,
+        "public": dict(public),
+        "runtime_configuration": dict(runtime),
+        "backup": dict(backup),
+        "restore": dict(restore),
+        "offhost_backup": dict(offhost),
+        "evidence_boundary": {
+            "proves": [
+                "public API readiness at collection time",
+                "public web and API release identity at collection time",
+                "allowlisted persistence and migration modes in the running API container",
+                "integrity and freshness of the explicitly selected local backup",
+                "fresh successful restore proof bound to that backup",
+                "off-host copy identity only when an off-host manifest is supplied",
+            ],
+            "does_not_prove": [
+                "future availability",
+                "absence of latent application defects",
+                "completeness or semantic correctness of every database row",
+                "off-host recovery when no off-host manifest is supplied",
+                "disaster recovery for infrastructure outside the selected PostgreSQL artifacts",
+            ],
+        },
+    }
+
+
+def write_json_atomic(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    encoded = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temp_path = Path(temp_name)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_path, path)
+        directory_fd = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    finally:
+        if temp_path.exists():
+            temp_path.unlink()
+
+
+def positive_hours(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a positive number") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be greater than zero")
+    return parsed
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Collect redacted Weltgewebe production runtime evidence.")
+    parser.add_argument("--domain", default="weltgewebe.net")
+    parser.add_argument("--api-domain", default="api.weltgewebe.net")
+    parser.add_argument("--timeout", type=float, default=8.0)
+    parser.add_argument("--docker-bin", default="docker")
+    parser.add_argument("--project-name", default="weltgewebe")
+    parser.add_argument("--env-file", type=Path, default=Path("/etc/weltgewebe/weltgewebe.env"))
+    parser.add_argument(
+        "--compose-file",
+        action="append",
+        type=Path,
+        dest="compose_files",
+        default=None,
+        help="repeat for each compose file in deployment order",
+    )
+    parser.add_argument("--service", default="api")
+    parser.add_argument("--backup-manifest", type=Path, required=True)
+    parser.add_argument("--restore-proof", type=Path, required=True)
+    parser.add_argument("--offhost-backup-manifest", type=Path)
+    parser.add_argument("--backup-max-age-hours", type=positive_hours, default=26.0)
+    parser.add_argument("--restore-max-age-hours", type=positive_hours, default=192.0)
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    compose_files = args.compose_files or [
+        Path("infra/compose/compose.prod.yml"),
+        Path("infra/compose/compose.vps.override.yml"),
+    ]
+    now = utc_now()
+    try:
+        public = collect_public_evidence(
+            domain=args.domain,
+            api_domain=args.api_domain,
+            timeout=args.timeout,
+        )
+        runtime = collect_runtime_modes(
+            compose_prefix=build_compose_prefix(
+                docker_bin=args.docker_bin,
+                project_name=args.project_name,
+                env_file=args.env_file,
+                compose_files=compose_files,
+            ),
+            service=args.service,
+        )
+        backup = collect_backup_evidence(
+            manifest_path=args.backup_manifest,
+            now=now,
+            max_age=timedelta(hours=args.backup_max_age_hours),
+        )
+        restore = collect_restore_evidence(
+            proof_path=args.restore_proof,
+            backup=backup,
+            now=now,
+            max_age=timedelta(hours=args.restore_max_age_hours),
+        )
+        offhost = collect_offhost_evidence(
+            manifest_path=args.offhost_backup_manifest,
+            backup=backup,
+        )
+        payload = build_evidence(
+            public=public,
+            runtime=runtime,
+            backup=backup,
+            restore=restore,
+            offhost=offhost,
+            generated_at=now,
+        )
+    except EvidenceError as exc:
+        payload = {
+            "schema_version": SCHEMA_VERSION,
+            "kind": EVIDENCE_KIND,
+            "status": "fail",
+            "generated_at": format_utc(now),
+            "runtime_collection_read_only": True,
+            "runtime_mutation_performed": False,
+            "report_write_is_only_mutation": True,
+            "values_redacted": True,
+            "error": str(exc),
+        }
+
+    if args.output:
+        write_json_atomic(args.output, payload)
+    else:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    if payload["status"] == "pass":
+        return 0
+    if payload["status"] == "partial":
+        return 2
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Ziel

Ein Operator soll den beobachteten Produktionszustand als maschinenlesbaren, geheimnisfreien Beleg erfassen können, statt öffentliche Readiness, Laufzeitkonfiguration sowie Backup-/Restore-Nachweise manuell zusammenzutragen.

## Umsetzung

- neues Werkzeug `scripts/ops/collect_production_runtime_evidence.py`
- öffentliche API-Readiness sowie Web-/API-Buildidentität über HTTPS
- genau sechs erlaubte, nicht vertrauliche Laufzeitschalter aus dem laufenden API-Container
- keine vollständige Containerumgebung und keine Rohantwortspiegelung
- exakte, hash- und größengebundene Backup-/Restore-Artefakte
- optionale Off-host-Kopie; vollständiges `pass` nur bei verifizierter Kopie
- Zustände `pass`, `partial` und `fail` mit Exitcodes 0, 2 und 1
- atomare JSON-Ausgabe mit Dateimodus 0600 und expliziter Beweisgrenze
- Symlinks, übergroße Metadaten, unbekannte Manifestfelder, veraltete Belege und zeitlich unmögliche Restore-Beweise werden fail-closed abgelehnt

## Aktueller Livebefund

Der öffentliche Teil wurde gegen Produktion ausgeführt:

- API-Readiness: grün
- Web-Buildidentität: grün; kurzer Header ist an vollständigen Commit gebunden
- API-Buildidentität: rot, weil die laufende API `commit: unknown`, `build_timestamp: unknown` und keinen Buildheader liefert

Der Sammler kaschiert diesen bestehenden Betriebsbefund nicht. Dieser PR behebt noch nicht die API-Buildpipeline und erzeugt ohne Zugriff auf die ausgewählten Serverartefakte noch keinen vollständigen Produktionsbericht.

## Prüfungen

- gezielte Suite: 21/21 grün
- reale öffentliche Teilprüfung: erwarteter strukturierter API-Identitätsfehler
- Python-Compilecheck: grün
- `git diff --check`: grün
- `make ci-validate`: 810 Dokumentations-/Metadatentests, 160 Agententests, 92 CI-Tests sowie alle Deploy-, Backup-, Sicherheits- und Releaseverträge grün
