### PR TITLE
feat(governance): visualize derived proposal threads

### DIFF
--- a/apps/web/src/lib/components/governance/GovernanceFaden.svelte
+++ b/apps/web/src/lib/components/governance/GovernanceFaden.svelte
@@ -1,0 +1,256 @@
+<script lang="ts">
+  import type { ProposalDetail, ProposalMessage } from "$lib/api/governance";
+  import {
+    deriveGovernanceFadenSummary,
+    visibleStrandOffsets,
+  } from "./governanceFaden";
+
+  export let proposal: ProposalDetail;
+  export let messages: ProposalMessage[] = [];
+
+  $: summary = deriveGovernanceFadenSummary(proposal, messages);
+
+  function curve(
+    x1: number,
+    y1: number,
+    x2: number,
+    y2: number,
+    offset: number,
+  ): string {
+    const middleX = (x1 + x2) / 2;
+    const middleY = (y1 + y2) / 2 + offset;
+    return `M ${x1} ${y1} Q ${middleX} ${middleY} ${x2} ${y2}`;
+  }
+</script>
+
+<section
+  class="faden-card"
+  aria-labelledby="governance-faden-heading"
+  data-testid="governance-faden"
+>
+  <div class="heading-row">
+    <div>
+      <p class="eyebrow">Abgeleitete Darstellung</p>
+      <h2 id="governance-faden-heading">Fäden dieses Antrags</h2>
+    </div>
+    <strong>{summary.total} {summary.total === 1 ? "Faden" : "Fäden"}</strong>
+  </div>
+
+  <p class="explanation">
+    Diese Fäden werden aus den belegten Webungsaktionen berechnet. Sie können
+    weder angelegt noch bearbeitet oder gelöscht werden.
+  </p>
+
+  <figure>
+    <svg
+      viewBox="0 0 720 400"
+      role="img"
+      aria-label={`Antragsgewebe mit ${summary.total} abgeleiteten Fäden`}
+      preserveAspectRatio="xMidYMid meet"
+    >
+      <g class="threads applicant-threads">
+        {#each visibleStrandOffsets(summary.proposal) as offset}
+          <path d={curve(148, 82, 326, 196, offset)} />
+        {/each}
+      </g>
+      <g class="threads veto-threads">
+        {#each visibleStrandOffsets(summary.vetoes) as offset}
+          <path d={curve(572, 82, 394, 196, offset)} />
+        {/each}
+      </g>
+      <g class="threads message-threads">
+        {#each visibleStrandOffsets(summary.messages) as offset}
+          <path d={curve(148, 318, 326, 204, offset)} />
+        {/each}
+      </g>
+      <g class="threads vote-threads">
+        {#each visibleStrandOffsets(summary.votes) as offset}
+          <path d={curve(572, 318, 394, 204, offset)} />
+        {/each}
+      </g>
+
+      <g class="endpoint applicant-endpoint">
+        <circle cx="112" cy="64" r="38" />
+        <text x="112" y="60">Antrag</text>
+        <text class="count" x="112" y="78">1</text>
+      </g>
+      <g class="endpoint veto-endpoint" class:inactive={summary.vetoes === 0}>
+        <circle cx="608" cy="64" r="38" />
+        <text x="608" y="60">Vetos</text>
+        <text class="count" x="608" y="78">{summary.vetoes}</text>
+      </g>
+      <g
+        class="endpoint message-endpoint"
+        class:inactive={summary.messages === 0}
+      >
+        <circle cx="112" cy="336" r="38" />
+        <text x="112" y="332">Gespräch</text>
+        <text class="count" x="112" y="350">{summary.messages}</text>
+      </g>
+      <g class="endpoint vote-endpoint" class:inactive={summary.votes === 0}>
+        <circle cx="608" cy="336" r="38" />
+        <text x="608" y="332">Stimmen</text>
+        <text class="count" x="608" y="350">{summary.votes}</text>
+      </g>
+
+      <g class="proposal-node">
+        <circle cx="360" cy="200" r="54" />
+        <text x="360" y="194">Antrag</text>
+        <text class="proposal-title" x="360" y="214">
+          {proposal.applicant_title}
+        </text>
+      </g>
+    </svg>
+
+    <figcaption>
+      Der Antrag steht im Zentrum. Die vier Fadenbündel zeigen Antragstellung,
+      Vetos, Gesprächsbeiträge und abgegebene Stimmen.
+    </figcaption>
+  </figure>
+
+  <dl class="faden-counts">
+    <div data-testid="faden-count-proposal">
+      <dt>Antrag gestellt</dt>
+      <dd>{summary.proposal}</dd>
+    </div>
+    <div data-testid="faden-count-vetoes">
+      <dt>Vetos</dt>
+      <dd>{summary.vetoes}</dd>
+    </div>
+    <div data-testid="faden-count-messages">
+      <dt>Gesprächsbeiträge</dt>
+      <dd>{summary.messages}</dd>
+    </div>
+    <div data-testid="faden-count-votes">
+      <dt>Stimmen</dt>
+      <dd>{summary.votes}</dd>
+    </div>
+  </dl>
+</section>
+
+<style>
+  .faden-card {
+    border: 1px solid rgba(24, 37, 31, 0.16);
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.72);
+    padding: 22px;
+    margin-top: 16px;
+    overflow: hidden;
+  }
+  .heading-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 20px;
+  }
+  .heading-row strong {
+    white-space: nowrap;
+    border-radius: 999px;
+    background: #dcecdf;
+    color: #1f5b42;
+    padding: 7px 11px;
+  }
+  .eyebrow {
+    margin: 0 0 4px;
+    text-transform: uppercase;
+    letter-spacing: 0.09em;
+    font-size: 0.72rem;
+    font-weight: 750;
+    color: #4d6759;
+  }
+  h2 {
+    margin: 0;
+  }
+  .explanation,
+  figcaption {
+    color: #607168;
+    line-height: 1.5;
+  }
+  figure {
+    margin: 18px 0 0;
+  }
+  svg {
+    display: block;
+    width: 100%;
+    max-height: 420px;
+  }
+  .threads path {
+    fill: none;
+    stroke-width: 2.5;
+    stroke-linecap: round;
+    opacity: 0.72;
+  }
+  .applicant-threads path {
+    stroke: #315d48;
+  }
+  .veto-threads path {
+    stroke: #9b4d43;
+  }
+  .message-threads path {
+    stroke: #476a8a;
+  }
+  .vote-threads path {
+    stroke: #806b37;
+  }
+  .endpoint circle,
+  .proposal-node circle {
+    fill: #f8f7f1;
+    stroke: rgba(24, 37, 31, 0.34);
+    stroke-width: 2;
+  }
+  .endpoint.inactive {
+    opacity: 0.42;
+  }
+  text {
+    text-anchor: middle;
+    font-family: system-ui, sans-serif;
+    font-size: 12px;
+    font-weight: 700;
+    fill: #25382e;
+  }
+  text.count {
+    font-size: 14px;
+  }
+  .proposal-node circle {
+    fill: #1f5b42;
+    stroke: #163f30;
+  }
+  .proposal-node text {
+    fill: #fff;
+  }
+  .proposal-title {
+    font-size: 10px;
+    font-weight: 600;
+  }
+  figcaption {
+    margin-top: 8px;
+    font-size: 0.9rem;
+  }
+  .faden-counts {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 8px;
+    margin: 18px 0 0;
+  }
+  .faden-counts div {
+    border-radius: 12px;
+    background: #eeece5;
+    padding: 10px;
+  }
+  dt {
+    color: #607168;
+    font-size: 0.76rem;
+  }
+  dd {
+    margin: 3px 0 0;
+    font-weight: 760;
+  }
+  @media (max-width: 620px) {
+    .heading-row {
+      flex-direction: column;
+    }
+    .faden-counts {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+</style>

--- a/apps/web/src/lib/components/governance/ProposalDetail.svelte
+++ b/apps/web/src/lib/components/governance/ProposalDetail.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { authStore } from "$lib/auth/store";
+  import GovernanceFaden from "./GovernanceFaden.svelte";
   import {
     GovernanceApiError,
     formatRemaining,
@@ -128,6 +129,8 @@
     </header>
 
     {#if error}<div class="error" role="alert">{error}</div>{/if}
+
+    <GovernanceFaden {proposal} {messages} />
 
     {#if proposal.vetoes.length > 0}
       <section class="card" aria-labelledby="vetos-heading">

--- a/apps/web/src/lib/components/governance/governanceFaden.test.ts
+++ b/apps/web/src/lib/components/governance/governanceFaden.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import type { ProposalDetail, ProposalMessage } from "$lib/api/governance";
+import {
+  deriveGovernanceFadenSummary,
+  visibleStrandOffsets,
+} from "./governanceFaden";
+
+const proposal: ProposalDetail = {
+  id: "11111111-1111-4111-8111-111111111111",
+  kind: "weberantrag",
+  applicant_account_id: "guest-1",
+  applicant_title: "Gast",
+  status: "voting",
+  created_at: "2026-07-14T10:00:00Z",
+  consent_until: "2026-07-21T10:00:00Z",
+  voting_until: "2026-07-28T10:00:00Z",
+  veto_count: 2,
+  yes_votes: 3,
+  no_votes: 1,
+  abstain_votes: 2,
+  vetoes: [
+    {
+      weber_account_id: "weber-1",
+      weber_title: "Weber 1",
+      reason: "Einwand 1",
+      created_at: "2026-07-15T10:00:00Z",
+    },
+    {
+      weber_account_id: "weber-2",
+      weber_title: "Weber 2",
+      reason: "Einwand 2",
+      created_at: "2026-07-15T11:00:00Z",
+    },
+  ],
+};
+
+const messages: ProposalMessage[] = [
+  {
+    id: "message-1",
+    author_account_id: "weber-1",
+    author_title: "Weber 1",
+    body: "Beitrag",
+    created_at: "2026-07-15T12:00:00Z",
+  },
+];
+
+describe("governance Faden projection", () => {
+  it("derives every visible count from canonical governance records", () => {
+    expect(deriveGovernanceFadenSummary(proposal, messages)).toEqual({
+      proposal: 1,
+      vetoes: 2,
+      messages: 1,
+      votes: 6,
+      total: 10,
+    });
+  });
+
+  it("bounds only the rendered bundle while preserving stable offsets", () => {
+    expect(visibleStrandOffsets(0)).toEqual([]);
+    expect(visibleStrandOffsets(1)).toEqual([0]);
+    expect(visibleStrandOffsets(3)).toEqual([-5, 0, 5]);
+    expect(visibleStrandOffsets(100)).toHaveLength(7);
+  });
+});

--- a/apps/web/src/lib/components/governance/governanceFaden.ts
+++ b/apps/web/src/lib/components/governance/governanceFaden.ts
@@ -1,0 +1,44 @@
+import type { ProposalDetail, ProposalMessage } from "$lib/api/governance";
+
+export interface GovernanceFadenSummary {
+  proposal: 1;
+  vetoes: number;
+  messages: number;
+  votes: number;
+  total: number;
+}
+
+/**
+ * Derive the visible governance-thread counts exclusively from canonical
+ * proposal data. The visualisation never creates or persists a domain edge.
+ */
+export function deriveGovernanceFadenSummary(
+  proposal: ProposalDetail,
+  messages: ProposalMessage[],
+): GovernanceFadenSummary {
+  const vetoes = proposal.vetoes.length;
+  const votes = proposal.yes_votes + proposal.no_votes + proposal.abstain_votes;
+  const messageCount = messages.length;
+
+  return {
+    proposal: 1,
+    vetoes,
+    messages: messageCount,
+    votes,
+    total: 1 + vetoes + messageCount + votes,
+  };
+}
+
+/**
+ * Return a bounded set of parallel offsets for an SVG thread bundle. Large
+ * communities stay cheap to render; the exact count remains visible as text.
+ */
+export function visibleStrandOffsets(count: number, maximum = 7): number[] {
+  const visible = Math.min(Math.max(0, Math.trunc(count)), maximum);
+  if (visible === 0) return [];
+  if (visible === 1) return [0];
+
+  const spacing = 5;
+  const start = -((visible - 1) * spacing) / 2;
+  return Array.from({ length: visible }, (_, index) => start + index * spacing);
+}

--- a/apps/web/tests/governance.spec.ts
+++ b/apps/web/tests/governance.spec.ts
@@ -200,7 +200,26 @@ test("guest can read everything and submit only the own Weber application", asyn
     summary: "Ich möchte mitweben.",
   });
 
+  const directFadenWrites: string[] = [];
+  page.on("request", (request) => {
+    const url = new URL(request.url());
+    if (url.pathname === "/api/edges" && request.method() !== "GET") {
+      directFadenWrites.push(request.method());
+    }
+  });
+
   await page.goto(`/antraege?id=${PROPOSAL_ID}`);
+  await expect(
+    page.getByRole("heading", { name: "Fäden dieses Antrags" }),
+  ).toBeVisible();
+  await expect(page.getByTestId("faden-count-proposal")).toContainText("1");
+  await expect(page.getByTestId("faden-count-vetoes")).toContainText("0");
+  await expect(page.getByTestId("faden-count-messages")).toContainText("1");
+  await expect(page.getByTestId("faden-count-votes")).toContainText("0");
+  await expect(
+    page.getByTestId("governance-faden").locator("path"),
+  ).toHaveCount(2);
+  expect(directFadenWrites).toEqual([]);
   await expect(
     page.getByText("Willkommen im öffentlichen Gesprächsraum."),
   ).toBeVisible();

--- a/docs/specs/garnrolle-knoten-faden.md
+++ b/docs/specs/garnrolle-knoten-faden.md
@@ -146,7 +146,9 @@ Ein Faden entsteht ausschließlich als automatisch abgeleitete Visualisierung ei
 
 Beim Knotenknüpfen erzeugt der Server nach der dauerhaften Knotenanlage den zugehörigen Garnrolle-Knoten-Faden. Schlägt die Projektion nach der Knotenanlage fehl, meldet der Server den Gesamtvorgang als noch nicht erfolgreich. Eine Wiederholung derselben Operations-ID repariert die fehlende Projektion; der Browser darf weder selbst einen Faden schreiben noch „ohne Faden fortfahren“.
 
-Anträge, Vetos, Abstimmungen und Gesprächsbeiträge sind bereits als eigene dauerhafte Governance-Datensätze belegt. Ihre räumliche oder graphische Fadenprojektion wird aus diesen Datensätzen abgeleitet, sobald der jeweilige Darstellungskontext spezifiziert ist. Es entsteht dafür kein manueller Fadenschreibweg.
+Anträge, Vetos, Abstimmungen und Gesprächsbeiträge sind als eigene dauerhafte Governance-Datensätze belegt. Ihr Darstellungskontext ist die Informationsseite des jeweiligen Antrags: Der Antrag steht im Zentrum; Antragstellung, Vetos, Gesprächsbeiträge und Stimmen werden als nicht bearbeitbare Fadenbündel darum angeordnet. Die Projektion wird bei jedem Laden ausschließlich aus den Governance-Datensätzen berechnet und nicht als zweiter Domain-Edge-Bestand gespeichert.
+
+Die geografische Karte zeigt diese Governance-Fäden nicht, weil ein Antrag keinen räumlichen Ort besitzt. Exakte Aktionszahlen bleiben als Text sichtbar; nur die Zahl gleichzeitig gezeichneter paralleler Linien darf zur Renderbegrenzung gedeckelt werden. Es entsteht dafür kein manueller Fadenschreibweg.
 
 ## Erster organischer Produktfluss
 

--- a/docs/specs/governance-antraege.md
+++ b/docs/specs/governance-antraege.md
@@ -151,11 +151,14 @@ Der Button **Anträge** befindet sich im Kartenkopf oben mittig. Die Oberfläche
 - Status und verbleibende Zeit;
 - Informationsseite;
 - Vetos und Stimmenzahlen;
+- ein aus den belegten Aktionen abgeleitetes Antragsgewebe mit nicht bearbeitbaren Fadenbündeln;
 - Gesprächsraum;
 - kontextabhängige Veto- und Abstimmungsaktionen;
 - für Gäste den Weberantrag und den Gast-Austritt.
 
 Die Oberfläche darf keine Rechte simulieren. Nicht erlaubte Aktionen sind serverseitig gesperrt, auch wenn ein Client manipuliert wird.
+
+Das Antragsgewebe ist eine reine Leseprojektion auf der Informationsseite. Es zeigt den Antrag im Zentrum sowie Fadenbündel für Antragstellung, Vetos, Gesprächsbeiträge und Stimmen. Die exakten Zahlen stammen aus den Governance-Datensätzen; es werden weder öffentliche Faden-Schreibwege noch zusätzliche `domain_edges` erzeugt. Da Anträge keinen geografischen Ort besitzen, erscheint diese Projektion nicht auf der Karte.
 
 ## Erweiterung auf weitere Antragstypen
 


### PR DESCRIPTION
<!-- weltgewebe-risk: R2 -->

## Ziel

Governance-Aktionen auf der Informationsseite eines Antrags als abgeleitete, nicht bearbeitbare Fadenbündel sichtbar machen.

## Nicht-Ziele

- keine Governance-Fäden auf der geografischen Karte;
- keine zusätzlichen `domain_edges` oder zweite Datenwahrheit;
- keine Faden-Erstell-, Bearbeitungs- oder Löschoberfläche;
- keine Änderung der 7+7-Tage-Zustandsmaschine;
- noch keine weiteren Antragstypen neben dem Weberantrag.

## Zu bewahrende Invarianten

- Fäden sind ausschließlich Darstellungen belegter Webungsaktionen;
- exakte Zahlen stammen aus Antrag, Vetos, Gesprächsbeiträgen und Stimmen;
- nur die gleichzeitig gezeichnete Zahl paralleler SVG-Linien darf begrenzt werden;
- die Antragsseite sendet keinen nicht-lesenden Aufruf an `/api/edges`;
- Gäste- und Weberrechte bleiben unverändert;
- die statische Auslieferung unter `/antraege` bleibt erhalten.

## Fehlerszenarien und Rückfallweg

Die Darstellung ist eine reine Webkomponente ohne Migration oder neue Persistenz. Fehler werden durch Svelte-Typprüfung, Unit-Test, Playwright-Gegenbeweis und Produktionsbuild erkannt. Rückfallweg ist das Zurücknehmen des einzelnen Produktcommits; die kanonischen Governance-Datensätze bleiben unverändert.

## Prüfungen

- `make validate`
- `pnpm --dir apps/web lint`
- `pnpm --dir apps/web check`
- `pnpm --dir apps/web test:unit`
- `pnpm --dir apps/web exec playwright test tests/governance.spec.ts --reporter=line`
- statischer Produktionsbuild
- vollständige GitHub-CI einschließlich Web E2E und Required Merge Gate

## Reviewevidenz

Der vollständige aktuelle Diff wird über GitHub unter `pull/1439.diff` bereitgestellt. Lokales Kontrollartefakt für den fachlichen Diff: SHA-256 `6865440c77a341c1e847ef46d5fb90fc4b903749fe26a35078de397c475b036e`, 16.013 Byte. Reviewbelege werden nach finalem Basis-, Kopf- und Diff-Readback gemäß `docs/process/merge-quality-gate.md` als PR-Kommentare attestiert.

## Veröffentlichung und Liveprüfung

Nach Merge wird der commitgebundene Produktionsrelease geprüft. Belege: exakte Buildidentität, öffentliche `/antraege`-Route, Gesundheitsendpunkt und ausgeliefertes Webartefakt. Da derzeit keine echten Anträge vorliegen, wird kein künstlicher Produktionsantrag erzeugt; die visuelle Interaktion wird durch den vollständigen Browserlauf bewiesen.