### PR TITLE
fix: make review evidence pragmatic

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
 <!--
 Weltgewebe is the primary project. Replace R? with exactly one class:
-R0 = Markdown-only, at most 50 changed lines
-R1 = bounded low-risk change
-R2 = application code, API, tests, scripts or dependencies
+R0 = Markdown-only, at most 50 changed lines; CI only
+R1 = bounded low-risk change or approved raster asset; one native current-head GitHub approval is enough
+R2 = application code, API, tests, scripts or dependencies; two hash-bound reports
 R3 = auth, privacy, security, concurrency, migration, workflow, deploy or operations
 The gate rejects a class below the path-derived minimum.
 -->
@@ -37,12 +37,16 @@ Der Workflow **Review Evidence Gate** erzeugt ein herunterladbares Paket mit:
 - Reviewauftrag und maschinenlesbarem Manifest;
 - aktuellem Ergebnis der hashgebundenen Reviewattestierungen.
 
-Nicht textuell dargestellte Binär- oder Großdateien werden als `opaque_files`
-ausgewiesen und blockieren das Gate, bis ein separates Artefakt-Prüfverfahren
-vorliegt.
+Für R0 ist keine Fremdreview erforderlich. Für R1 genügt eine normale GitHub-Review
+mit **Approve**, sofern GitHub den Prüfer als `OWNER`, `MEMBER` oder `COLLABORATOR`
+ausweist und die Freigabe den aktuellen Head betrifft. R2 und R3 benötigen weiterhin die vollständigen hashgebundenen
+Berichte aus der erzeugten `*.review-request.md`.
 
-Reviewbelege gehören als PR-Kommentar in das Format aus der erzeugten
-`*.review-request.md`. Jeder neue Push oder Basiswechsel entwertet frühere Belege.
+Nicht textuell dargestellte Dateien werden als `opaque_files` ausgewiesen. Gängige
+Rastergrafiken in den festgelegten Doku- und Web-Assetpfaden sind mit mindestens
+R1 visuell prüfbar. PDF, SVG, Archive, ausführbare Dateien und andere undurchsichtige
+Artefakte blockieren weiterhin. Jeder neue Push oder Basiswechsel entwertet
+frühere hashgebundene Berichte.
 
 ## Veröffentlichung und Liveprüfung
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -39,8 +39,10 @@ Der Workflow **Review Evidence Gate** erzeugt ein herunterladbares Paket mit:
 
 Für R0 ist keine Fremdreview erforderlich. Für R1 genügt eine normale GitHub-Review
 mit **Approve**, sofern GitHub den Prüfer als `OWNER`, `MEMBER` oder `COLLABORATOR`
-ausweist und die Freigabe den aktuellen Head betrifft. R2 und R3 benötigen weiterhin die vollständigen hashgebundenen
-Berichte aus der erzeugten `*.review-request.md`.
+ausweist und die Freigabe den aktuellen Head betrifft. Bei Fork- oder
+Dependabot-PRs postet ein Maintainer danach `/review-evidence recheck`. R2 und R3
+benötigen weiterhin die vollständigen hashgebundenen Berichte aus der erzeugten
+`*.review-request.md`.
 
 Nicht textuell dargestellte Dateien werden als `opaque_files` ausgewiesen. Gängige
 Rastergrafiken in den festgelegten Doku- und Web-Assetpfaden sind mit mindestens

--- a/.github/workflows/review-evidence.yml
+++ b/.github/workflows/review-evidence.yml
@@ -5,7 +5,7 @@ name: Review Evidence Gate
   pull_request_target:
     types: [opened, synchronize, reopened, edited, ready_for_review]
   issue_comment:
-    types: [created, edited]
+    types: [created, edited, deleted]
   pull_request_review:
     types: [submitted, edited, dismissed]
   workflow_dispatch:
@@ -37,7 +37,12 @@ jobs:
         github.event_name != 'issue_comment' ||
         (
           github.event.issue.pull_request != null &&
-          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
+          (
+            contains(github.event.comment.body, '<!-- weltgewebe-review-evidence') ||
+            contains(github.event.changes.body.from, '<!-- weltgewebe-review-evidence') ||
+            startsWith(github.event.comment.body, '/review-evidence recheck')
+          )
         )
       ) &&
       (

--- a/.github/workflows/review-evidence.yml
+++ b/.github/workflows/review-evidence.yml
@@ -33,8 +33,20 @@ jobs:
   review-evidence:
     name: Review evidence gate
     if: >-
-      github.event_name != 'issue_comment' ||
-      github.event.issue.pull_request != null
+      (
+        github.event_name != 'issue_comment' ||
+        (
+          github.event.issue.pull_request != null &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+        )
+      ) &&
+      (
+        github.event_name != 'pull_request_review' ||
+        (
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.event.pull_request.user.login != 'dependabot[bot]'
+        )
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/review-evidence.yml
+++ b/.github/workflows/review-evidence.yml
@@ -6,6 +6,8 @@ name: Review Evidence Gate
     types: [opened, synchronize, reopened, edited, ready_for_review]
   issue_comment:
     types: [created, edited]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -49,7 +51,6 @@ jobs:
 
       - name: Resolve PR and evaluate exact review evidence
         id: evaluate
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
@@ -81,7 +82,7 @@ jobs:
           trap on_error ERR
 
           case "${EVENT_NAME}" in
-            pull_request_target)
+            pull_request_target|pull_request_review)
               pr_number="$(jq -r '.pull_request.number' "${EVENT_PATH}")"
               ;;
             issue_comment)
@@ -187,6 +188,9 @@ jobs:
           gh api --paginate --slurp -H "${api_header}" \
             "repos/${REPOSITORY}/issues/${pr_number}/comments?per_page=100" \
             > "${RUNNER_TEMP}/comments.json"
+          gh api --paginate --slurp -H "${api_header}" \
+            "${pr_api}/reviews?per_page=100" \
+            > "${RUNNER_TEMP}/reviews.json"
 
           trap - ERR
           python3 scripts/quality/review_governance.py evaluate-materialized \
@@ -196,7 +200,73 @@ jobs:
             --patch-file "${RUNNER_TEMP}/pr.patch" \
             --pr-body-file "${RUNNER_TEMP}/pr-body.md" \
             --comments-file "${RUNNER_TEMP}/comments.json" \
+            --reviews-file "${RUNNER_TEMP}/reviews.json" \
             --authorities-file .github/review-evidence-authorities.json
+
+      - name: Refresh current-head evidence before publication
+        id: refresh
+        if: ${{ always() && steps.evaluate.outputs.head_sha != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.evaluate.outputs.pr_number }}
+          BASE_SHA: ${{ steps.evaluate.outputs.base_sha }}
+          HEAD_SHA: ${{ steps.evaluate.outputs.head_sha }}
+          OUTPUT_DIR: ${{ steps.evaluate.outputs.output_dir }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          api_header="X-GitHub-Api-Version: ${GH_API_VERSION}"
+          pr_api="repos/${REPOSITORY}/pulls/${PR_NUMBER}"
+
+          write_refresh_failure() {
+            local message="$1"
+            jq -n --arg message "${message}" '{
+              schema_version: 1,
+              kind: "weltgewebe-review-evaluation",
+              pass: false,
+              reasons: [$message]
+            }' > "${OUTPUT_DIR}/evaluation.json"
+          }
+
+          on_error() {
+            local rc=$?
+            trap - ERR
+            write_refresh_failure "final evidence refresh failed with exit code ${rc}"
+            exit "${rc}"
+          }
+          trap on_error ERR
+
+          gh api -H "${api_header}" "${pr_api}" > "${RUNNER_TEMP}/pr-final.json"
+          jq -e --arg base "${BASE_SHA}" --arg head "${HEAD_SHA}" '
+            .state == "open" and
+            .base.ref == "main" and
+            .base.sha == $base and
+            .head.sha == $head
+          ' "${RUNNER_TEMP}/pr-final.json" >/dev/null
+          jq -r '.body // ""' "${RUNNER_TEMP}/pr-final.json" > \
+            "${RUNNER_TEMP}/pr-body-final.md"
+          gh api --paginate --slurp -H "${api_header}" \
+            "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" \
+            > "${RUNNER_TEMP}/comments-final.json"
+          gh api --paginate --slurp -H "${api_header}" \
+            "${pr_api}/reviews?per_page=100" \
+            > "${RUNNER_TEMP}/reviews-final.json"
+
+          trap - ERR
+          set +e
+          python3 scripts/quality/review_governance.py evaluate-materialized \
+            --output-dir "${OUTPUT_DIR}" \
+            --metadata-file "${RUNNER_TEMP}/metadata.json" \
+            --diff-file "${RUNNER_TEMP}/pr.diff" \
+            --patch-file "${RUNNER_TEMP}/pr.patch" \
+            --pr-body-file "${RUNNER_TEMP}/pr-body-final.md" \
+            --comments-file "${RUNNER_TEMP}/comments-final.json" \
+            --reviews-file "${RUNNER_TEMP}/reviews-final.json" \
+            --authorities-file .github/review-evidence-authorities.json
+          evaluation_rc=$?
+          set -e
+          exit "${evaluation_rc}"
 
       - name: Upload downloadable diff and review bundle
         if: ${{ always() && steps.evaluate.outputs.pr_number != '' }}
@@ -221,19 +291,28 @@ jobs:
           if [[ -f "${evaluation}" ]] && \
              [[ "$(jq -r '.pass // false' "${evaluation}")" == "true" ]]; then
             state=success
-            description='Exact diff and required review attestations are verified.'
+            description='Exact diff and required review evidence are verified.'
           else
             state=failure
             description='Review evidence is missing, stale, malformed or blocking.'
           fi
-          gh api --method POST \
-            -H "X-GitHub-Api-Version: ${GH_API_VERSION}" \
-            "repos/${REPOSITORY}/statuses/${HEAD_SHA}" \
-            -f state="${state}" \
-            -f context='Review evidence gate' \
-            -f description="${description}" \
-            -f target_url="${GITHUB_SERVER_URL}/${REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
-            >/dev/null
+
+          published=false
+          for attempt in 1 2 3; do
+            if gh api --method POST \
+              -H "X-GitHub-Api-Version: ${GH_API_VERSION}" \
+              "repos/${REPOSITORY}/statuses/${HEAD_SHA}" \
+              -f state="${state}" \
+              -f context='Review evidence gate' \
+              -f description="${description}" \
+              -f target_url="${GITHUB_SERVER_URL}/${REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+              >/dev/null; then
+              published=true
+              break
+            fi
+            sleep "${attempt}"
+          done
+          test "${published}" = true
 
       - name: Enforce review evidence result
         if: ${{ always() }}

--- a/docs/process/merge-quality-gate.md
+++ b/docs/process/merge-quality-gate.md
@@ -78,7 +78,8 @@ Bestimmte Pfade erzwingen automatisch eine Mindestklasse. Eine niedrigere
 Deklaration führt fail-closed zum Gatefehler. R0 ist nur für kleine reine
 Markdown-Änderungen zulässig. Der Dateipfad allein macht eine README unter
 `apps/` nicht zu Produktcode; sensible Dokumentationspfade wie Deploy- und
-Runbook-Dokumente bleiben dagegen R3.
+Runbook-Dokumente sowie das PR-Template und die Governance-Implementierung
+bleiben dagegen R3.
 
 ## Reviewpaket
 
@@ -143,8 +144,10 @@ GitHub stuft Tokens für Fork- und Dependabot-Reviewereignisse auf read-only her
 Der Reviewlauf wird dort deshalb bewusst übersprungen, statt mit einem
 irreführenden 403 zu scheitern. Ein Maintainer löst nach der Freigabe mit
 `/review-evidence recheck` einen `issue_comment`-Lauf auf dem vertrauenswürdigen
-Default-Branch aus. Kommentare ohne Repositoryrolle starten keinen privilegierten
-Lauf.
+Default-Branch aus. Kommentare ohne Repositoryrolle sowie gewöhnliche
+Diskussionskommentare ohne Belegmarker oder Recheck-Befehl starten keinen
+privilegierten Lauf. Bearbeitung oder Löschung eines Belegkommentars löst dagegen
+eine erneute Auswertung aus, damit ein früherer Erfolgsstatus nicht stehen bleibt.
 
 Nicht textuell dargestellte Dateien erscheinen als `opaque_files`. Häufige
 Rasterformate (`png`, `jpg`, `jpeg`, `gif`, `webp`, `avif`, `ico`) sind in den

--- a/docs/process/merge-quality-gate.md
+++ b/docs/process/merge-quality-gate.md
@@ -26,6 +26,25 @@ Dieses Dokument beschreibt den verbindlichen Qualitätsprozess für nichttrivial
 prüfbare Bindung zwischen dem tatsächlich gemergten Code und genau dem Diff, der
 geprüft wurde.
 
+## Einen PR zügig mergefähig machen
+
+Der Normalfall soll ohne manuelle Hasharbeit auskommen:
+
+1. **R0 – kleine reine Markdown-Änderung:** Risikomarker setzen und CI abwarten.
+   Eine externe Review ist nicht erforderlich. Dies gilt auch für Markdown-Dateien
+   unter `apps/`, solange höchstens 50 Zeilen geändert werden und kein sensibler
+   Pfad betroffen ist.
+2. **R1 – kleine Konfiguration, Metadaten oder sichere Rastergrafik:** Risikomarker
+   setzen und eine normale GitHub-Review mit `Approve` auf dem aktuellen Head
+   einholen. Ein JSON-Belegblock ist nicht erforderlich.
+3. **R2/R3 – Produktlogik oder sicherheitsrelevante Änderung:** Das automatisch
+   erzeugte Reviewpaket verwenden und die vollständigen hashgebundenen Berichte
+   als PR-Kommentare attestieren.
+
+Bei jedem Push werden alte Freigaben nur dann weitergezählt, wenn GitHub sie
+ausdrücklich an den neuen Head bindet. Für R2 und R3 bleiben frühere Berichte
+immer ungültig, sobald sich Head, Basis oder Diff ändern.
+
 ## Grundprinzip
 
 Ein Merge ist nur zulässig, wenn:
@@ -47,14 +66,16 @@ Jeder Pull Request enthält genau einen maschinenlesbaren Marker:
 
 | Klasse | Beispiele | Erforderliche Reviews |
 | --- | --- | --- |
-| R0 | kleine Dokumentationsänderung, höchstens 50 geänderte Zeilen | keine externe Reviewpflicht |
-| R1 | Konfiguration, Metadaten, ungefährliche Werkzeuge | mindestens ein exakter PASS-Beleg |
-| R2 | Produktlogik, API, UI, Persistenz, nichtprivilegierte CI | mindestens zwei Prüfer und zwei Reviewachsen |
+| R0 | kleine reine Markdown-Änderung, höchstens 50 geänderte Zeilen | keine externe Reviewpflicht |
+| R1 | Konfiguration, Metadaten, sichere Rastergrafiken | eine native GitHub-Freigabe auf dem aktuellen Head oder ein exakter PASS-Beleg |
+| R2 | Produktlogik, API, UI, Persistenz, nichtprivilegierte CI | zwei hashgebundene Berichte, zwei Prüfer und zwei Reviewachsen |
 | R3 | Authentifizierung, Datenschutz, Sicherheit, Migration, Deployment, privilegierte Workflows | mindestens zwei Prüfer und zwei Reviewachsen; mindestens eine Hochrisikoachse |
 
 Bestimmte Pfade erzwingen automatisch eine Mindestklasse. Eine niedrigere
 Deklaration führt fail-closed zum Gatefehler. R0 ist nur für kleine reine
-Markdown-Änderungen zulässig.
+Markdown-Änderungen zulässig. Der Dateipfad allein macht eine README unter
+`apps/` nicht zu Produktcode; sensible Dokumentationspfade wie Deploy- und
+Runbook-Dokumente bleiben dagegen R3.
 
 ## Reviewpaket
 
@@ -104,18 +125,30 @@ Der Beleg folgt genau einmal im selben Kommentar:
 ```
 
 `report_sha256` muss dem SHA-256 des getrimmten UTF-8-Texts vor dem Marker
-entsprechen. Berichte unter 120 Byte, mehrere Belegblöcke in einem Kommentar oder
-doppelt verwendete Berichtshashes zählen nicht als unabhängige Reviews.
+entsprechen. Vor dem Hashen werden `CRLF` und einzelne `CR` auf `LF` normalisiert,
+damit Browser und Betriebssysteme denselben Berichtshash erzeugen. Berichte unter
+120 Byte, mehrere Belegblöcke in einem Kommentar oder doppelt verwendete
+Berichtshashes zählen nicht als unabhängige Reviews.
 
-Nicht textuell dargestellte Binär- oder Großdateien erscheinen als
-`opaque_files`. Sie blockieren das Gate derzeit fail-closed, weil ein Textreview
-ihren tatsächlichen Inhalt nicht beweisen kann. Ein separates, hashgebundenes
-Artefakt-Prüfverfahren ist dafür eine spätere Erweiterung.
+Für R1 kann statt des Belegblocks eine native GitHub-Review mit `Approve` zählen.
+Sie muss von einem durch GitHub als `OWNER`, `MEMBER` oder `COLLABORATOR`
+ausgewiesenen Prüfer stammen und exakt den aktuellen Head-Commit betreffen. Eine aktuelle `Changes requested`-Review blockiert. Native
+Freigaben ersetzen die ausführlichen Berichte für R2 und R3 ausdrücklich nicht.
+
+Nicht textuell dargestellte Dateien erscheinen als `opaque_files`. Häufige
+Rasterformate (`png`, `jpg`, `jpeg`, `gif`, `webp`, `avif`, `ico`) sind in den
+festgelegten Doku- und Web-Assetpfaden visuell über den GitHub-Dateidiff prüfbar
+und erzwingen mindestens R1. PDF, SVG, Archive, ausführbare Dateien und Rasterbilder
+außerhalb dieser Pfade blockieren weiterhin fail-closed. Damit sind alltägliche
+Bildänderungen möglich, ohne undurchsichtige Artefakte pauschal freizugeben.
 
 Ein neuer Push, ein Basiswechsel oder ein anderer Diffhash entwertet den Beleg
 automatisch. Für dieselbe Kombination aus Prüfer und Reviewachse zählt nur der
 zeitlich neueste exakte Beleg. Ein späteres `BLOCKED` oder `FAIL` hebt einen früheren
-PASS derselben Kombination auf.
+PASS derselben Kombination auf. Der Workflow liest Kommentare und native Reviews
+unmittelbar vor der Statusveröffentlichung erneut. Gleichzeitige Reviewereignisse
+konvergieren dadurch auf den frischesten GitHub-Zustand; Zeitstempel werden als
+UTC-Datumswerte und bei Gleichstand über stabile GitHub-IDs geordnet.
 
 ## Erforderliche Prüfungen
 
@@ -166,22 +199,24 @@ Der privilegierte Workflow darf niemals:
   `.github/review-evidence-authorities.json` freigegeben ist;
 - bei internen Fehlern erfolgreich enden.
 
-Ein Review kann von einem externen Prüfer stammen und durch einen freigegebenen
-Attestierer in den PR übertragen werden. Das Feld `reviewer` bezeichnet den vom
-Attestierer benannten Prüfer; der GitHub-Kommentarautor muss zusätzlich in der
+Für R1 ist der GitHub-Reviewautor zugleich Prüfer und Attestierer. Für R2/R3 kann
+ein Review dagegen von einem externen Prüfer stammen und durch einen freigegebenen
+Attestierer in den PR übertragen werden. Das Feld `reviewer` bezeichnet dann den
+vom Attestierer benannten Prüfer; der GitHub-Kommentarautor muss zusätzlich in der
 versionierten Allowlist `.github/review-evidence-authorities.json` stehen.
 Repositoryrollen allein reichen nicht aus. Der Hash bindet die Attestation an den
 sichtbaren vollständigen Bericht. Für R2 und R3 müssen Prüferidentität, Reviewachse
 und Berichtshash jeweils verschieden sein. Technisch bewiesen werden die Identität
 des Attestierers, der Berichtshash und dessen Diffbindung – nicht eine unabhängige
-Authentifizierung der frei benannten Prüferidentität.
+Authentifizierung der frei benannten externen Prüferidentität.
 
 Alle Parser- und Bundlefunktionen stammen aus `main`. API-Daten werden nur als
 Bytes oder JSON geparst. Eine unvollständige Dateiliste, ein SHA-Wechsel, eine
 fehlende Patchdarstellung oder ein interner Fehler führt zu `evaluation.json` mit
 `pass: false` und zu einem fehlgeschlagenen Commitstatus. Dateien ohne GitHub-
-Textdarstellung werden im Manifest als `opaque_files` markiert und blockieren das
-Gate bis zu einem separaten Artefakt-Prüfverfahren.
+Textdarstellung werden im Manifest in visuell prüfbare Raster-Assets und
+blockierende undurchsichtige Dateien getrennt. Nur die eng freigegebenen
+Rasterformate und Pfade dürfen über eine aktuelle R1-Freigabe passieren.
 
 ## Merge- und Produktionsabschluss
 

--- a/docs/process/merge-quality-gate.md
+++ b/docs/process/merge-quality-gate.md
@@ -36,7 +36,10 @@ Der Normalfall soll ohne manuelle Hasharbeit auskommen:
    Pfad betroffen ist.
 2. **R1 – kleine Konfiguration, Metadaten oder sichere Rastergrafik:** Risikomarker
    setzen und eine normale GitHub-Review mit `Approve` auf dem aktuellen Head
-   einholen. Ein JSON-Belegblock ist nicht erforderlich.
+   einholen. Ein JSON-Belegblock ist nicht erforderlich. Bei internen Branches
+   wird der Status automatisch neu berechnet. Bei Fork- und Dependabot-PRs postet
+   ein Maintainer danach `/review-evidence recheck`; dieser sichere
+   Default-Branch-Pfad besitzt die nötige Statusberechtigung.
 3. **R2/R3 – Produktlogik oder sicherheitsrelevante Änderung:** Das automatisch
    erzeugte Reviewpaket verwenden und die vollständigen hashgebundenen Berichte
    als PR-Kommentare attestieren.
@@ -132,8 +135,16 @@ Berichtshashes zählen nicht als unabhängige Reviews.
 
 Für R1 kann statt des Belegblocks eine native GitHub-Review mit `Approve` zählen.
 Sie muss von einem durch GitHub als `OWNER`, `MEMBER` oder `COLLABORATOR`
-ausgewiesenen Prüfer stammen und exakt den aktuellen Head-Commit betreffen. Eine aktuelle `Changes requested`-Review blockiert. Native
-Freigaben ersetzen die ausführlichen Berichte für R2 und R3 ausdrücklich nicht.
+ausgewiesenen Prüfer stammen und exakt den aktuellen Head-Commit betreffen. Eine
+aktuelle `Changes requested`-Review blockiert. Native Freigaben ersetzen die
+ausführlichen Berichte für R2 und R3 ausdrücklich nicht.
+
+GitHub stuft Tokens für Fork- und Dependabot-Reviewereignisse auf read-only herab.
+Der Reviewlauf wird dort deshalb bewusst übersprungen, statt mit einem
+irreführenden 403 zu scheitern. Ein Maintainer löst nach der Freigabe mit
+`/review-evidence recheck` einen `issue_comment`-Lauf auf dem vertrauenswürdigen
+Default-Branch aus. Kommentare ohne Repositoryrolle starten keinen privilegierten
+Lauf.
 
 Nicht textuell dargestellte Dateien erscheinen als `opaque_files`. Häufige
 Rasterformate (`png`, `jpg`, `jpeg`, `gif`, `webp`, `avif`, `ico`) sind in den

--- a/scripts/quality/review_governance.py
+++ b/scripts/quality/review_governance.py
@@ -58,7 +58,7 @@ ALLOWED_AXES = HIGH_RISK_AXES | {
 }
 RISK_RE = re.compile(r"<!--\s*weltgewebe-risk:\s*(R[0-3])\s*-->", re.IGNORECASE)
 EVIDENCE_START_RE = re.compile(r"<!--\s*weltgewebe-review-evidence\b", re.IGNORECASE)
-EVIDENCE_END = "-->"
+EVIDENCE_END_RE = re.compile(r"\s*-->")
 
 
 class GovernanceError(RuntimeError):
@@ -165,16 +165,28 @@ def _decode_git_path(raw: bytes) -> str:
 
 
 def _parse_numstat_z(raw: bytes) -> tuple[int, int, tuple[str, ...]]:
+    """Parse Git's NUL-delimited numstat stream, including rename records.
+
+    A normal record is ``additions<TAB>deletions<TAB>path<NUL>``. For a
+    rename/copy Git emits an empty path in that record followed by the old and
+    new paths as two additional NUL-delimited fields. Filenames may contain
+    tabs, so the first record is split at most twice.
+    """
+
     additions = 0
     deletions = 0
     binary: list[str] = []
+    if not raw:
+        return additions, deletions, tuple(binary)
+
     fields = raw.split(b"\0")
-    index = 0
-    while index < len(fields):
-        entry = fields[index]
-        index += 1
+    if fields[-1] != b"":
+        raise GovernanceError("git numstat stream is not NUL terminated")
+
+    records = iter(fields[:-1])
+    for entry in records:
         if not entry:
-            continue
+            raise GovernanceError("git numstat produced an empty record")
         parts = entry.split(b"\t", 2)
         if len(parts) != 3:
             raise GovernanceError("git numstat produced a malformed record")
@@ -182,19 +194,32 @@ def _parse_numstat_z(raw: bytes) -> tuple[int, int, tuple[str, ...]]:
         if path_raw:
             path = _decode_git_path(path_raw)
         else:
-            if index + 1 >= len(fields):
-                raise GovernanceError("git numstat rename record is incomplete")
-            index += 1  # old path is intentionally not part of the changed-file set
-            path = _decode_git_path(fields[index])
-            index += 1
-        if added_raw == b"-" or deleted_raw == b"-":
+            try:
+                old_path_raw = next(records)
+                new_path_raw = next(records)
+            except StopIteration as exc:
+                raise GovernanceError(
+                    "git numstat rename record is incomplete"
+                ) from exc
+            if not old_path_raw or not new_path_raw:
+                raise GovernanceError("git numstat rename paths must not be empty")
+            path = _decode_git_path(new_path_raw)
+        if not path:
+            raise GovernanceError("git numstat path must not be empty")
+        if (added_raw == b"-") != (deleted_raw == b"-"):
+            raise GovernanceError("git numstat contains a partial binary marker")
+        if added_raw == b"-":
             binary.append(path)
             continue
         try:
-            additions += int(added_raw)
-            deletions += int(deleted_raw)
+            added = int(added_raw)
+            deleted = int(deleted_raw)
         except ValueError as exc:
             raise GovernanceError("git numstat contains non-numeric totals") from exc
+        if added < 0 or deleted < 0:
+            raise GovernanceError("git numstat contains negative totals")
+        additions += added
+        deletions += deleted
     return additions, deletions, tuple(binary)
 
 
@@ -261,6 +286,7 @@ def minimum_risk_for_paths(paths: Iterable[str]) -> str:
             in {
                 ".github/grabowski-required-checks.json",
                 ".github/review-evidence-authorities.json",
+                ".github/pull_request_template.md",
                 "scripts/quality/review_governance.py",
                 "docs/process/merge-quality-gate.md",
             }
@@ -715,33 +741,49 @@ def _numeric_id(value: Any) -> int:
     return value if isinstance(value, int) and not isinstance(value, bool) else 0
 
 
+def _decode_evidence_payload(
+    body: str, payload_start: int
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Decode one JSON object and require an adjacent comment terminator.
+
+    ``JSONDecoder.raw_decode`` tracks the JSON boundary correctly even when a
+    JSON string itself contains ``-->``. A first-substring search cannot do so.
+    """
+
+    source = body[payload_start:].lstrip()
+    try:
+        record, consumed = json.JSONDecoder().raw_decode(source)
+    except json.JSONDecodeError:
+        return None, "malformed"
+    payload_text = source[:consumed]
+    if len(payload_text.encode("utf-8")) > MAX_EVIDENCE_PAYLOAD_BYTES:
+        return None, "oversized"
+    if EVIDENCE_END_RE.match(source, consumed) is None:
+        return None, "malformed"
+    if not isinstance(record, dict):
+        return None, "malformed"
+    return record, None
+
+
 def _evidence_blocks(
     comments: Sequence[dict[str, Any]],
-) -> tuple[list[dict[str, Any]], int]:
+) -> tuple[list[dict[str, Any]], int, int]:
     evidence: list[dict[str, Any]] = []
     parse_failures = 0
+    oversized_payloads = 0
     for comment_index, comment in enumerate(comments):
         body = comment.get("body") or ""
         if not isinstance(body, str):
             continue
         starts = list(EVIDENCE_START_RE.finditer(body))
         for block_index, match in enumerate(starts):
-            end = body.find(EVIDENCE_END, match.end())
-            if end < 0:
+            record, failure = _decode_evidence_payload(body, match.end())
+            if failure is not None:
                 parse_failures += 1
+                if failure == "oversized":
+                    oversized_payloads += 1
                 continue
-            payload_text = body[match.end() : end].strip()
-            if len(payload_text.encode("utf-8")) > MAX_EVIDENCE_PAYLOAD_BYTES:
-                parse_failures += 1
-                continue
-            try:
-                record = json.loads(payload_text)
-            except json.JSONDecodeError:
-                parse_failures += 1
-                continue
-            if not isinstance(record, dict):
-                parse_failures += 1
-                continue
+            assert record is not None
             report_text = _normalized_report_text(body[: match.start()])
             report_bytes = report_text.encode("utf-8")
             record = dict(record)
@@ -763,7 +805,7 @@ def _evidence_blocks(
                 comment.get("updated_at") or comment.get("created_at") or ""
             )
             evidence.append(record)
-    return evidence, parse_failures
+    return evidence, parse_failures, oversized_payloads
 
 
 def _native_review_evidence(
@@ -865,7 +907,7 @@ def evaluate_evidence(
         if not valid:
             reasons.append(detail)
 
-    records, evidence_parse_failures = _evidence_blocks(comments)
+    records, evidence_parse_failures, oversized_evidence = _evidence_blocks(comments)
     exact: list[dict[str, Any]] = []
     stale = 0
     unauthorized = 0
@@ -995,7 +1037,20 @@ def evaluate_evidence(
             + ", ".join(record["reviewer"] for record in native_blocking)
         )
 
-    quick_approvals = native_accepted if risk_class == "R1" else []
+    attested_reviewer_ids = {
+        unicodedata.normalize("NFC", record["reviewer"]).casefold()
+        for record in accepted
+    }
+    quick_approvals = (
+        [
+            record
+            for record in native_accepted
+            if unicodedata.normalize("NFC", record["reviewer"]).casefold()
+            not in attested_reviewer_ids
+        ]
+        if risk_class == "R1"
+        else []
+    )
     required = REQUIRED_REVIEWS[risk_class]
     accepted_count = len(accepted) + len(quick_approvals)
     if accepted_count < required:
@@ -1071,6 +1126,7 @@ def evaluate_evidence(
         "stale_evidence_count": stale,
         "unauthorized_evidence_count": unauthorized,
         "malformed_evidence_count": malformed,
+        "oversized_evidence_count": oversized_evidence,
         "stale_native_review_count": stale_native,
         "unauthorized_native_review_count": unauthorized_native,
         "malformed_native_review_count": malformed_native,

--- a/scripts/quality/review_governance.py
+++ b/scripts/quality/review_governance.py
@@ -58,7 +58,6 @@ ALLOWED_AXES = HIGH_RISK_AXES | {
 }
 RISK_RE = re.compile(r"<!--\s*weltgewebe-risk:\s*(R[0-3])\s*-->", re.IGNORECASE)
 EVIDENCE_START_RE = re.compile(r"<!--\s*weltgewebe-review-evidence\b", re.IGNORECASE)
-EVIDENCE_END_RE = re.compile(r"\s*-->")
 
 
 class GovernanceError(RuntimeError):
@@ -758,7 +757,8 @@ def _decode_evidence_payload(
     payload_text = source[:consumed]
     if len(payload_text.encode("utf-8")) > MAX_EVIDENCE_PAYLOAD_BYTES:
         return None, "oversized"
-    if EVIDENCE_END_RE.match(source, consumed) is None:
+    remainder = source[consumed:].lstrip()
+    if not remainder.startswith(("-->", "--!>")):
         return None, "malformed"
     if not isinstance(record, dict):
         return None, "malformed"

--- a/scripts/quality/review_governance.py
+++ b/scripts/quality/review_governance.py
@@ -22,10 +22,20 @@ from typing import Any, Iterable, Sequence
 
 SCHEMA_VERSION = 1
 MAX_ARTIFACT_BYTES = 100 * 1024 * 1024
+MAX_EVIDENCE_PAYLOAD_BYTES = 20 * 1024
 MIN_REVIEW_REPORT_BYTES = 120
 SHA40_RE = re.compile(r"^[0-9a-f]{40}$")
 REPORT_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 GITHUB_LOGIN_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$")
+SAFE_OPAQUE_SUFFIXES = frozenset(
+    {".png", ".jpg", ".jpeg", ".gif", ".webp", ".avif", ".ico"}
+)
+SAFE_OPAQUE_PREFIXES = (
+    "docs/",
+    "apps/web/static/",
+    "apps/web/src/lib/assets/",
+    "static/",
+)
 RISK_ORDER = {"R0": 0, "R1": 1, "R2": 2, "R3": 3}
 REQUIRED_REVIEWS = {"R0": 0, "R1": 1, "R2": 2, "R3": 2}
 AUTHORIZED_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
@@ -47,10 +57,8 @@ ALLOWED_AXES = HIGH_RISK_AXES | {
     "testing",
 }
 RISK_RE = re.compile(r"<!--\s*weltgewebe-risk:\s*(R[0-3])\s*-->", re.IGNORECASE)
-EVIDENCE_RE = re.compile(
-    r"<!--\s*weltgewebe-review-evidence\s*(\{.*?\})\s*-->",
-    re.IGNORECASE | re.DOTALL,
-)
+EVIDENCE_START_RE = re.compile(r"<!--\s*weltgewebe-review-evidence\b", re.IGNORECASE)
+EVIDENCE_END = "-->"
 
 
 class GovernanceError(RuntimeError):
@@ -152,33 +160,53 @@ def _resolve_sha(repo: Path, revision: str) -> str:
     return str(output).strip()
 
 
+def _decode_git_path(raw: bytes) -> str:
+    return raw.decode("utf-8", "surrogateescape")
+
+
+def _parse_numstat_z(raw: bytes) -> tuple[int, int, tuple[str, ...]]:
+    additions = 0
+    deletions = 0
+    binary: list[str] = []
+    fields = raw.split(b"\0")
+    index = 0
+    while index < len(fields):
+        entry = fields[index]
+        index += 1
+        if not entry:
+            continue
+        parts = entry.split(b"\t", 2)
+        if len(parts) != 3:
+            raise GovernanceError("git numstat produced a malformed record")
+        added_raw, deleted_raw, path_raw = parts
+        if path_raw:
+            path = _decode_git_path(path_raw)
+        else:
+            if index + 1 >= len(fields):
+                raise GovernanceError("git numstat rename record is incomplete")
+            index += 1  # old path is intentionally not part of the changed-file set
+            path = _decode_git_path(fields[index])
+            index += 1
+        if added_raw == b"-" or deleted_raw == b"-":
+            binary.append(path)
+            continue
+        try:
+            additions += int(added_raw)
+            deletions += int(deleted_raw)
+        except ValueError as exc:
+            raise GovernanceError("git numstat contains non-numeric totals") from exc
+    return additions, deletions, tuple(binary)
+
+
 def _diff_stats(repo: Path, base_sha: str, head_sha: str) -> DiffStats:
     range_spec = f"{base_sha}...{head_sha}"
     names_raw = _git(repo, ["diff", "--name-only", "-z", "--find-renames", range_spec])
     assert isinstance(names_raw, bytes)
-    names = tuple(
-        part.decode("utf-8", "surrogateescape")
-        for part in names_raw.split(b"\0")
-        if part
-    )
+    names = tuple(_decode_git_path(part) for part in names_raw.split(b"\0") if part)
 
-    numstat_raw = _git(
-        repo, ["diff", "--numstat", "--find-renames", range_spec], text=True
-    )
-    additions = 0
-    deletions = 0
-    binary: list[str] = []
-    for line in str(numstat_raw).splitlines():
-        fields = line.split("\t", 2)
-        if len(fields) != 3:
-            continue
-        added, deleted, path = fields
-        if added == "-" or deleted == "-":
-            binary.append(path)
-            continue
-        additions += int(added)
-        deletions += int(deleted)
-    binary_files = tuple(binary)
+    numstat_raw = _git(repo, ["diff", "--numstat", "-z", "--find-renames", range_spec])
+    assert isinstance(numstat_raw, bytes)
+    additions, deletions, binary_files = _parse_numstat_z(numstat_raw)
     return DiffStats(
         names,
         additions,
@@ -205,6 +233,24 @@ def parse_risk_class(pr_body: str) -> str | None:
     return matches[0]
 
 
+def _is_safe_opaque_asset(path: str) -> bool:
+    lowered = path.lower()
+    return (
+        lowered.startswith(SAFE_OPAQUE_PREFIXES)
+        and Path(lowered).suffix in SAFE_OPAQUE_SUFFIXES
+    )
+
+
+def _partition_opaque_files(
+    paths: Iterable[str],
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    reviewable: list[str] = []
+    blocking: list[str] = []
+    for path in paths:
+        (reviewable if _is_safe_opaque_asset(path) else blocking).append(path)
+    return tuple(reviewable), tuple(blocking)
+
+
 def minimum_risk_for_paths(paths: Iterable[str]) -> str:
     minimum = "R0"
     for raw_path in paths:
@@ -216,6 +262,7 @@ def minimum_risk_for_paths(paths: Iterable[str]) -> str:
                 ".github/grabowski-required-checks.json",
                 ".github/review-evidence-authorities.json",
                 "scripts/quality/review_governance.py",
+                "docs/process/merge-quality-gate.md",
             }
             or path.startswith("infra/")
             or path.startswith("scripts/ops/")
@@ -228,6 +275,11 @@ def minimum_risk_for_paths(paths: Iterable[str]) -> str:
             or path.startswith("docs/runbooks/")
         ):
             return "R3"
+        if path.endswith(".md"):
+            continue
+        if _is_safe_opaque_asset(path):
+            minimum = max((minimum, "R1"), key=RISK_ORDER.__getitem__)
+            continue
         if (
             path.startswith("apps/api/")
             or path.startswith("apps/web/")
@@ -240,7 +292,7 @@ def minimum_risk_for_paths(paths: Iterable[str]) -> str:
             )
         ):
             minimum = "R2"
-        elif not path.endswith(".md"):
+        else:
             minimum = max((minimum, "R1"), key=RISK_ORDER.__getitem__)
     return minimum
 
@@ -343,6 +395,7 @@ def _build_bundle(
     request_path = output_dir / f"{stem}.review-request.md"
     diff_path.write_bytes(diff_bytes)
     patch_path.write_bytes(patch_bytes)
+    reviewable_opaque, blocking_opaque = _partition_opaque_files(stats.opaque_files)
 
     binding = {
         "pr_number": pr_number,
@@ -365,6 +418,8 @@ def _build_bundle(
             "deletions": stats.deletions,
             "binary_files": list(stats.binary_files),
             "opaque_files": list(stats.opaque_files),
+            "reviewable_opaque_files": list(reviewable_opaque),
+            "blocking_opaque_files": list(blocking_opaque),
         },
         "artifacts": {
             "diff": {
@@ -382,10 +437,16 @@ def _build_bundle(
     manifest_path.write_bytes(_canonical_json(manifest))
 
     opaque_note = ""
-    if stats.opaque_files:
-        opaque_note = (
-            "\n- Nicht im GitHub-Textdiff dargestellte Dateien: "
-            + ", ".join(f"`{item}`" for item in stats.opaque_files)
+    if reviewable_opaque:
+        opaque_note += (
+            "\n- Visuell im GitHub-Dateidiff zu prüfende Raster-Assets: "
+            + ", ".join(f"`{item}`" for item in reviewable_opaque)
+            + "\n"
+        )
+    if blocking_opaque:
+        opaque_note += (
+            "\n- Nicht zuverlässig prüfbare und daher blockierende Dateien: "
+            + ", ".join(f"`{item}`" for item in blocking_opaque)
             + "\n"
         )
     request = f"""# Weltgewebe – exakter Reviewauftrag
@@ -405,12 +466,13 @@ Prüfe ausschließlich den beigefügten Diff. Frühere oder spätere Versionen z
 Bewerte mindestens eine klar benannte Achse, etwa `correctness`, `security`,
 `data-integrity`, `concurrency`, `architecture`, `testing` oder `operations`.
 Benenne konkrete Befunde. Ein PASS ist nur zulässig, wenn alle Mergeblocker behoben
-oder nachvollziehbar widerlegt sind. Dateien ohne GitHub-Textdarstellung müssen
-separat geprüft oder als offener Mergeblocker benannt werden.
+oder nachvollziehbar widerlegt sind. Sichere Raster-Assets in den dokumentierten Doku-/Web-Assetpfaden müssen
+im GitHub-Dateidiff visuell geprüft werden. Andere Dateien ohne Textdarstellung
+bleiben offene Mergeblocker.
 
 Nach dem Review wird der vollständige Reviewtext als normaler Kommentartext
-vor dem Marker hinterlegt. `report_sha256` ist der SHA-256 des getrimmten
-UTF-8-Reviewtexts vor dem Marker. Danach folgt genau ein Belegblock:
+vor dem Marker hinterlegt. `report_sha256` ist der SHA-256 des getrimmten, auf LF-Zeilenumbrüche
+normalisierten UTF-8-Reviewtexts vor dem Marker. Danach folgt genau ein Belegblock:
 
 ```text
 <VOLLSTÄNDIGER REVIEWTEXT>
@@ -621,26 +683,71 @@ def _flatten_comments(raw: Any) -> list[dict[str, Any]]:
     return flattened
 
 
-def _evidence_blocks(comments: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+def _flatten_reviews(raw: Any) -> list[dict[str, Any]]:
+    if not isinstance(raw, list):
+        raise GovernanceError("reviews JSON must be a list")
+    flattened: list[dict[str, Any]] = []
+    for item in raw:
+        if isinstance(item, list):
+            flattened.extend(entry for entry in item if isinstance(entry, dict))
+        elif isinstance(item, dict):
+            flattened.append(item)
+    return flattened
+
+
+def _normalized_report_text(value: str) -> str:
+    return value.replace("\r\n", "\n").replace("\r", "\n").strip()
+
+
+def _github_timestamp(value: Any) -> dt.datetime:
+    if not isinstance(value, str) or not value:
+        return dt.datetime.min.replace(tzinfo=dt.timezone.utc)
+    try:
+        parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return dt.datetime.min.replace(tzinfo=dt.timezone.utc)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def _numeric_id(value: Any) -> int:
+    return value if isinstance(value, int) and not isinstance(value, bool) else 0
+
+
+def _evidence_blocks(
+    comments: Sequence[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], int]:
     evidence: list[dict[str, Any]] = []
+    parse_failures = 0
     for comment_index, comment in enumerate(comments):
         body = comment.get("body") or ""
         if not isinstance(body, str):
             continue
-        matches = list(EVIDENCE_RE.finditer(body))
-        for block_index, match in enumerate(matches):
+        starts = list(EVIDENCE_START_RE.finditer(body))
+        for block_index, match in enumerate(starts):
+            end = body.find(EVIDENCE_END, match.end())
+            if end < 0:
+                parse_failures += 1
+                continue
+            payload_text = body[match.end() : end].strip()
+            if len(payload_text.encode("utf-8")) > MAX_EVIDENCE_PAYLOAD_BYTES:
+                parse_failures += 1
+                continue
             try:
-                record = json.loads(match.group(1))
+                record = json.loads(payload_text)
             except json.JSONDecodeError:
+                parse_failures += 1
                 continue
             if not isinstance(record, dict):
+                parse_failures += 1
                 continue
-            report_text = body[: match.start()].strip()
+            report_text = _normalized_report_text(body[: match.start()])
             report_bytes = report_text.encode("utf-8")
             record = dict(record)
             record["_comment_index"] = comment_index
             record["_block_index"] = block_index
-            record["_comment_evidence_block_count"] = len(matches)
+            record["_comment_evidence_block_count"] = len(starts)
             record["_report_text_bytes"] = len(report_bytes)
             record["_report_text_sha256"] = _sha256(report_bytes)
             record["_author_association"] = str(
@@ -651,11 +758,69 @@ def _evidence_blocks(comments: Sequence[dict[str, Any]]) -> list[dict[str, Any]]
                 user.get("login") if isinstance(user, dict) else None
             )
             record["_comment_url"] = comment.get("html_url")
+            record["_comment_id"] = _numeric_id(comment.get("id"))
             record["_updated_at"] = (
                 comment.get("updated_at") or comment.get("created_at") or ""
             )
             evidence.append(record)
-    return evidence
+    return evidence, parse_failures
+
+
+def _native_review_evidence(
+    *,
+    reviews: Sequence[dict[str, Any]],
+    head_sha: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], int, int, int]:
+    latest: dict[str, dict[str, Any]] = {}
+    unauthorized = 0
+    malformed = 0
+    for index, review in enumerate(reviews):
+        state = str(review.get("state") or "").upper()
+        if state not in {"APPROVED", "CHANGES_REQUESTED", "DISMISSED"}:
+            continue
+        user = review.get("user") or {}
+        login = user.get("login") if isinstance(user, dict) else None
+        association = str(review.get("author_association") or "").upper()
+        if not isinstance(login, str) or not GITHUB_LOGIN_RE.fullmatch(login):
+            malformed += 1
+            continue
+        if association not in AUTHORIZED_ASSOCIATIONS:
+            unauthorized += 1
+            continue
+        commit_id = review.get("commit_id")
+        if not isinstance(commit_id, str) or not SHA40_RE.fullmatch(commit_id):
+            malformed += 1
+            continue
+        ordering = (
+            _github_timestamp(review.get("submitted_at")),
+            _numeric_id(review.get("id")),
+            index,
+        )
+        key = login.casefold()
+        previous = latest.get(key)
+        if previous is None or ordering >= previous["_ordering"]:
+            latest[key] = {
+                "reviewer": login,
+                "attester": login,
+                "state": state,
+                "commit_id": commit_id,
+                "review_axis": "github-approval",
+                "review_url": review.get("html_url"),
+                "_ordering": ordering,
+            }
+
+    accepted: list[dict[str, Any]] = []
+    blocking: list[dict[str, Any]] = []
+    stale = 0
+    for record in latest.values():
+        if record["commit_id"] != head_sha:
+            stale += 1
+            continue
+        if record["state"] == "APPROVED":
+            accepted.append(record)
+        elif record["state"] == "CHANGES_REQUESTED":
+            blocking.append(record)
+    return accepted, blocking, stale, unauthorized, malformed
 
 
 def evaluate_evidence(
@@ -664,6 +829,7 @@ def evaluate_evidence(
     risk_class: str | None,
     comments: Sequence[dict[str, Any]],
     allowed_attesters: frozenset[str],
+    reviews: Sequence[dict[str, Any]] = (),
 ) -> dict[str, Any]:
     if not allowed_attesters or any(
         not isinstance(login, str) or not GITHUB_LOGIN_RE.fullmatch(login)
@@ -680,11 +846,13 @@ def evaluate_evidence(
         )
         risk_class = "R3"
 
-    if bundle.stats.opaque_files:
+    reviewable_opaque, blocking_opaque = _partition_opaque_files(
+        bundle.stats.opaque_files
+    )
+    if blocking_opaque:
         reasons.append(
-            "opaque or binary files require a separately verified artifact-review "
-            "mechanism and currently block the review evidence gate: "
-            + ", ".join(bundle.stats.opaque_files)
+            "opaque files outside the reviewable raster-asset policy block the review evidence gate: "
+            + ", ".join(blocking_opaque)
         )
 
     minimum_risk = minimum_risk_for_paths(bundle.stats.changed_files)
@@ -697,11 +865,11 @@ def evaluate_evidence(
         if not valid:
             reasons.append(detail)
 
-    records = _evidence_blocks(comments)
+    records, evidence_parse_failures = _evidence_blocks(comments)
     exact: list[dict[str, Any]] = []
     stale = 0
     unauthorized = 0
-    malformed = 0
+    malformed = evidence_parse_failures
     for record in records:
         comment_author = str(record.get("_comment_author") or "").strip()
         if (
@@ -748,13 +916,14 @@ def evaluate_evidence(
             stale += 1
             continue
         reviewer_value = record.get("reviewer")
-        reviewer = reviewer_value.strip() if isinstance(reviewer_value, str) else ""
+        reviewer_raw = reviewer_value if isinstance(reviewer_value, str) else ""
+        reviewer = unicodedata.normalize("NFC", reviewer_raw.strip())
         report_sha256 = str(record.get("report_sha256") or "").strip()
         axis = str(record.get("review_axis") or "").strip().lower()
         verdict = str(record.get("verdict") or "").strip().upper()
         if (
             not reviewer
-            or reviewer != reviewer_value
+            or reviewer_raw != reviewer_raw.strip()
             or len(reviewer) > 120
             or any(unicodedata.category(char).startswith("C") for char in reviewer)
             or not REPORT_SHA256_RE.fullmatch(report_sha256)
@@ -763,6 +932,7 @@ def evaluate_evidence(
             or record.get("_comment_evidence_block_count") != 1
             or axis not in ALLOWED_AXES
             or verdict not in {"PASS", "BLOCKED", "FAIL"}
+            or not isinstance(record.get("findings_resolved"), bool)
         ):
             malformed += 1
             continue
@@ -776,7 +946,8 @@ def evaluate_evidence(
     for record in exact:
         key = (record["reviewer"].casefold(), record["review_axis"])
         ordering = (
-            str(record.get("_updated_at") or ""),
+            _github_timestamp(record.get("_updated_at")),
+            int(record.get("_comment_id", 0)),
             int(record.get("_comment_index", 0)),
             int(record.get("_block_index", 0)),
         )
@@ -785,7 +956,8 @@ def evaluate_evidence(
             latest[key] = record
             continue
         previous_ordering = (
-            str(previous.get("_updated_at") or ""),
+            _github_timestamp(previous.get("_updated_at")),
+            int(previous.get("_comment_id", 0)),
             int(previous.get("_comment_index", 0)),
             int(previous.get("_block_index", 0)),
         )
@@ -807,10 +979,33 @@ def evaluate_evidence(
         for record in latest.values()
         if record["verdict"] == "PASS" and record.get("findings_resolved") is True
     ]
-    required = REQUIRED_REVIEWS[risk_class]
-    if len(accepted) < required:
+    (
+        native_accepted,
+        native_blocking,
+        stale_native,
+        unauthorized_native,
+        malformed_native,
+    ) = _native_review_evidence(
+        reviews=reviews,
+        head_sha=bundle.head_sha,
+    )
+    if native_blocking:
         reasons.append(
-            f"risk {risk_class} requires {required} exact PASS reviews, found {len(accepted)}"
+            "current-head GitHub reviews request changes: "
+            + ", ".join(record["reviewer"] for record in native_blocking)
+        )
+
+    quick_approvals = native_accepted if risk_class == "R1" else []
+    required = REQUIRED_REVIEWS[risk_class]
+    accepted_count = len(accepted) + len(quick_approvals)
+    if accepted_count < required:
+        suffix = (
+            " (native current-head APPROVED reviews count for R1)"
+            if risk_class == "R1"
+            else ""
+        )
+        reasons.append(
+            f"risk {risk_class} requires {required} exact PASS reviews, found {accepted_count}{suffix}"
         )
 
     reviewer_names = {record["reviewer"].casefold() for record in accepted}
@@ -830,6 +1025,7 @@ def evaluate_evidence(
 
     accepted_summary = [
         {
+            "kind": "attested-report",
             "reviewer": record["reviewer"],
             "report_sha256": record["report_sha256"],
             "review_axis": record["review_axis"],
@@ -841,6 +1037,19 @@ def evaluate_evidence(
             key=lambda item: (item["review_axis"], item["reviewer"].casefold()),
         )
     ]
+    accepted_summary.extend(
+        {
+            "kind": "github-approval",
+            "reviewer": record["reviewer"],
+            "report_sha256": None,
+            "review_axis": "github-approval",
+            "attester": record["attester"],
+            "comment_url": record.get("review_url"),
+        }
+        for record in sorted(
+            quick_approvals, key=lambda item: item["reviewer"].casefold()
+        )
+    )
     return {
         "schema_version": SCHEMA_VERSION,
         "kind": "weltgewebe-review-evaluation",
@@ -854,12 +1063,17 @@ def evaluate_evidence(
             "merge_base_sha": bundle.merge_base_sha,
             "diff_sha256": bundle.diff_sha256,
         },
+        "reviewable_opaque_files": list(reviewable_opaque),
+        "blocking_opaque_files": list(blocking_opaque),
         "required_review_count": required,
-        "accepted_review_count": len(accepted),
+        "accepted_review_count": accepted_count,
         "accepted_reviews": accepted_summary,
         "stale_evidence_count": stale,
         "unauthorized_evidence_count": unauthorized,
         "malformed_evidence_count": malformed,
+        "stale_native_review_count": stale_native,
+        "unauthorized_native_review_count": unauthorized_native,
+        "malformed_native_review_count": malformed_native,
         "reasons": reasons,
     }
 
@@ -920,14 +1134,17 @@ def _evaluate_and_write(
     bundle: Bundle,
     risk_class: str | None,
     comments_file: Path,
+    reviews_file: Path | None,
     authorities_file: Path,
 ) -> int:
     raw_comments = _load_json(comments_file)
     comments = _flatten_comments(raw_comments)
+    reviews = _flatten_reviews(_load_json(reviews_file)) if reviews_file else []
     evaluation = evaluate_evidence(
         bundle=bundle,
         risk_class=risk_class,
         comments=comments,
+        reviews=reviews,
         allowed_attesters=load_allowed_attesters(authorities_file),
     )
     (output_dir / "evaluation.json").write_bytes(_canonical_json(evaluation))
@@ -953,6 +1170,7 @@ def _command_evaluate(args: argparse.Namespace) -> int:
             bundle=bundle,
             risk_class=risk_class,
             comments_file=Path(args.comments_file),
+            reviews_file=Path(args.reviews_file) if args.reviews_file else None,
             authorities_file=Path(args.authorities_file),
         )
     except Exception as exc:  # fail closed and preserve a machine-readable receipt
@@ -978,6 +1196,7 @@ def _command_evaluate_materialized(args: argparse.Namespace) -> int:
             bundle=bundle,
             risk_class=risk_class,
             comments_file=Path(args.comments_file),
+            reviews_file=Path(args.reviews_file) if args.reviews_file else None,
             authorities_file=Path(args.authorities_file),
         )
     except Exception as exc:  # fail closed and preserve a machine-readable receipt
@@ -1006,6 +1225,7 @@ def build_parser() -> argparse.ArgumentParser:
     evaluate.add_argument("--pr-number", required=True, type=int)
     evaluate.add_argument("--pr-body-file", required=True)
     evaluate.add_argument("--comments-file", required=True)
+    evaluate.add_argument("--reviews-file")
     evaluate.add_argument("--authorities-file", required=True)
 
     for name in ("bundle-materialized", "evaluate-materialized"):
@@ -1017,6 +1237,7 @@ def build_parser() -> argparse.ArgumentParser:
         command.add_argument("--pr-body-file", required=name == "evaluate-materialized")
         if name == "evaluate-materialized":
             command.add_argument("--comments-file", required=True)
+            command.add_argument("--reviews-file")
             command.add_argument("--authorities-file", required=True)
     return parser
 

--- a/scripts/quality/tests/test_review_governance.py
+++ b/scripts/quality/tests/test_review_governance.py
@@ -7,8 +7,8 @@ import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
-import scripts.quality.review_governance as review_governance
 from scripts.quality.review_governance import (
     Bundle,
     DiffStats,
@@ -419,9 +419,7 @@ class BundleTests(unittest.TestCase):
                 ),
                 encoding="utf-8",
             )
-            original = review_governance.MAX_ARTIFACT_BYTES
-            review_governance.MAX_ARTIFACT_BYTES = 64
-            try:
+            with mock.patch("scripts.quality.review_governance.MAX_ARTIFACT_BYTES", 64):
                 with self.assertRaisesRegex(GovernanceError, "safety limit"):
                     generate_materialized_bundle(
                         output_dir=root / "out",
@@ -430,8 +428,6 @@ class BundleTests(unittest.TestCase):
                         patch_file=patch_file,
                         risk_class="R1",
                     )
-            finally:
-                review_governance.MAX_ARTIFACT_BYTES = original
 
     def test_local_patch_uses_merge_base_not_moving_base_tip(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -893,7 +889,17 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("ref: main", self.workflow)
         self.assertIn("fetch-depth: 1", self.workflow)
         self.assertIn("persist-credentials: false", self.workflow)
-        self.assertNotIn("github.event.pull_request.head", self.workflow)
+        self.assertNotIn("github.event.pull_request.head.sha", self.workflow)
+        self.assertNotIn("github.event.pull_request.head.ref", self.workflow)
+        self.assertIn(
+            "github.event.pull_request.head.repo.full_name == github.repository",
+            self.workflow,
+        )
+        self.assertIn(
+            "github.event.pull_request.user.login != 'dependabot[bot]'",
+            self.workflow,
+        )
+        self.assertIn("github.event.comment.author_association", self.workflow)
         self.assertNotIn("actions/checkout@v", self.workflow)
         self.assertNotIn("git fetch", self.workflow)
         self.assertNotIn("refs/pull/", self.workflow)

--- a/scripts/quality/tests/test_review_governance.py
+++ b/scripts/quality/tests/test_review_governance.py
@@ -8,6 +8,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+import scripts.quality.review_governance as review_governance
 from scripts.quality.review_governance import (
     Bundle,
     DiffStats,
@@ -39,6 +40,7 @@ def _comment(
     author: str = "alex",
     report_text: str | None = None,
     report_sha256: str | None = None,
+    comment_id: int = 1,
 ) -> dict:
     report = report_text or (
         f"Unabhängiger Reviewbericht von {record.get('reviewer')} zur Achse "
@@ -47,10 +49,12 @@ def _comment(
         "geprüft. Es bleiben keine unaufgelösten Mergeblocker."
     )
     payload = dict(record)
+    normalized_report = report.replace("\r\n", "\n").replace("\r", "\n").strip()
     payload["report_sha256"] = (
-        report_sha256 or hashlib.sha256(report.strip().encode("utf-8")).hexdigest()
+        report_sha256 or hashlib.sha256(normalized_report.encode("utf-8")).hexdigest()
     )
     return {
+        "id": comment_id,
         "body": report
         + "\n<!-- weltgewebe-review-evidence\n"
         + json.dumps(payload)
@@ -66,11 +70,39 @@ def _comment(
 ALLOWED_ATTESTERS = frozenset({"alex"})
 
 
-def _evaluate(*, bundle: Bundle, risk_class: str, comments: list[dict]) -> dict:
+def _review(
+    bundle: Bundle,
+    *,
+    state: str = "APPROVED",
+    author: str = "alex",
+    association: str = "OWNER",
+    commit_id: str | None = None,
+    review_id: int = 1,
+    submitted_at: str = "2026-07-14T12:00:00Z",
+) -> dict:
+    return {
+        "id": review_id,
+        "state": state,
+        "commit_id": commit_id or bundle.head_sha,
+        "author_association": association,
+        "user": {"login": author},
+        "html_url": "https://example.invalid/native-review",
+        "submitted_at": submitted_at,
+    }
+
+
+def _evaluate(
+    *,
+    bundle: Bundle,
+    risk_class: str,
+    comments: list[dict],
+    reviews: list[dict] | None = None,
+) -> dict:
     return evaluate_evidence(
         bundle=bundle,
         risk_class=risk_class,
         comments=comments,
+        reviews=reviews or [],
         allowed_attesters=ALLOWED_ATTESTERS,
     )
 
@@ -125,6 +157,9 @@ class RiskParsingTests(unittest.TestCase):
 
     def test_sensitive_paths_raise_minimum_risk(self) -> None:
         self.assertEqual(minimum_risk_for_paths(["docs/example.md"]), "R0")
+        self.assertEqual(minimum_risk_for_paths(["apps/web/README.md"]), "R0")
+        self.assertEqual(minimum_risk_for_paths(["docs/images/map.png"]), "R1")
+        self.assertEqual(minimum_risk_for_paths(["apps/web/static/map.webp"]), "R1")
         self.assertEqual(minimum_risk_for_paths(["apps/web/src/app.ts"]), "R2")
         self.assertEqual(minimum_risk_for_paths([".github/workflows/ci.yml"]), "R3")
         self.assertEqual(
@@ -133,6 +168,10 @@ class RiskParsingTests(unittest.TestCase):
         )
         self.assertEqual(
             minimum_risk_for_paths(["scripts/quality/review_governance.py"]),
+            "R3",
+        )
+        self.assertEqual(
+            minimum_risk_for_paths(["docs/process/merge-quality-gate.md"]),
             "R3",
         )
         self.assertEqual(minimum_risk_for_paths(["apps/api/src/auth.rs"]), "R3")
@@ -208,9 +247,36 @@ class BundleTests(unittest.TestCase):
             self.assertEqual(manifest["stats"]["binary_files"], ["image.bin"])
             self.assertEqual(manifest["stats"]["opaque_files"], ["image.bin"])
             self.assertIn(
-                "Nicht im GitHub-Textdiff dargestellte Dateien",
+                "Nicht zuverlässig prüfbare und daher blockierende Dateien",
                 bundle.request_path.read_text(encoding="utf-8"),
             )
+
+    def test_local_binary_rename_uses_destination_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = Path(temp_dir) / "repo"
+            repo.mkdir()
+            _git(repo, "init", "-b", "main")
+            _git(repo, "config", "user.name", "Test")
+            _git(repo, "config", "user.email", "test@example.invalid")
+            (repo / "old.png").write_bytes(b"\x89PNG\r\n\x1a\n\x00binary")
+            _git(repo, "add", "old.png")
+            _git(repo, "commit", "-m", "base image")
+            base = _git(repo, "rev-parse", "HEAD")
+            (repo / "docs").mkdir()
+            _git(repo, "mv", "old.png", "docs/new.png")
+            _git(repo, "commit", "-m", "rename image")
+            head = _git(repo, "rev-parse", "HEAD")
+
+            bundle = generate_bundle(
+                repo=repo,
+                output_dir=Path(temp_dir) / "out",
+                base_revision=base,
+                head_revision=head,
+                pr_number=10,
+                risk_class="R1",
+            )
+            self.assertEqual(bundle.stats.changed_files, ("docs/new.png",))
+            self.assertEqual(bundle.stats.binary_files, ("docs/new.png",))
 
     def test_materialized_github_bundle_is_hash_bound_and_validated(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -327,6 +393,45 @@ class BundleTests(unittest.TestCase):
                     patch_file=patch_file,
                     risk_class="R2",
                 )
+
+    def test_materialized_bundle_enforces_artifact_size_limit(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            diff_file = root / "pr.diff"
+            patch_file = root / "pr.patch"
+            metadata_file = root / "metadata.json"
+            diff_file.write_bytes(b"diff --git a/a.txt b/a.txt\n" + b"x" * 80)
+            patch_file.write_bytes(b"p" * 80)
+            metadata_file.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "pr_number": 17,
+                        "base_sha": "a" * 40,
+                        "head_sha": "b" * 40,
+                        "merge_base_sha": "c" * 40,
+                        "changed_file_count": 1,
+                        "changed_files": ["a.txt"],
+                        "additions": 1,
+                        "deletions": 0,
+                        "opaque_files": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            original = review_governance.MAX_ARTIFACT_BYTES
+            review_governance.MAX_ARTIFACT_BYTES = 64
+            try:
+                with self.assertRaisesRegex(GovernanceError, "safety limit"):
+                    generate_materialized_bundle(
+                        output_dir=root / "out",
+                        metadata_file=metadata_file,
+                        diff_file=diff_file,
+                        patch_file=patch_file,
+                        risk_class="R1",
+                    )
+            finally:
+                review_governance.MAX_ARTIFACT_BYTES = original
 
     def test_local_patch_uses_merge_base_not_moving_base_tip(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -490,8 +595,8 @@ class EvidenceTests(unittest.TestCase):
         self.assertFalse(result["pass"])
         self.assertIn("two distinct review reports", " ".join(result["reasons"]))
 
-    def test_opaque_files_block_even_with_valid_reviews(self) -> None:
-        base = _bundle(paths=("image.png",), changed_lines=0)
+    def test_safe_raster_asset_is_reviewable_with_r1_approval(self) -> None:
+        base = _bundle(paths=("docs/images/map.png",), changed_lines=0)
         bundle = Bundle(
             pr_number=base.pr_number,
             base_sha=base.base_sha,
@@ -503,7 +608,117 @@ class EvidenceTests(unittest.TestCase):
             diff_path=base.diff_path,
             patch_path=base.patch_path,
             request_path=base.request_path,
-            stats=DiffStats(("image.png",), 0, 0, (), ("image.png",)),
+            stats=DiffStats(
+                ("docs/images/map.png",),
+                0,
+                0,
+                (),
+                ("docs/images/map.png",),
+            ),
+        )
+        result = _evaluate(
+            bundle=bundle,
+            risk_class="R1",
+            comments=[],
+            reviews=[_review(bundle)],
+        )
+        self.assertTrue(result["pass"], result["reasons"])
+        self.assertEqual(result["reviewable_opaque_files"], ["docs/images/map.png"])
+        self.assertEqual(result["blocking_opaque_files"], [])
+
+    def test_unsafe_opaque_file_still_blocks(self) -> None:
+        base = _bundle(paths=("docs/report.pdf",), changed_lines=0)
+        bundle = Bundle(
+            pr_number=base.pr_number,
+            base_sha=base.base_sha,
+            head_sha=base.head_sha,
+            merge_base_sha=base.merge_base_sha,
+            diff_sha256=base.diff_sha256,
+            patch_sha256=base.patch_sha256,
+            manifest_path=base.manifest_path,
+            diff_path=base.diff_path,
+            patch_path=base.patch_path,
+            request_path=base.request_path,
+            stats=DiffStats(("docs/report.pdf",), 0, 0, (), ("docs/report.pdf",)),
+        )
+        result = _evaluate(
+            bundle=bundle,
+            risk_class="R1",
+            comments=[],
+            reviews=[_review(bundle)],
+        )
+        self.assertFalse(result["pass"])
+        self.assertEqual(result["blocking_opaque_files"], ["docs/report.pdf"])
+        self.assertIn("opaque files outside", " ".join(result["reasons"]))
+
+    def test_r1_accepts_native_current_head_approval(self) -> None:
+        bundle = _bundle(paths=("config/example.json",))
+        result = _evaluate(
+            bundle=bundle,
+            risk_class="R1",
+            comments=[],
+            reviews=[_review(bundle)],
+        )
+        self.assertTrue(result["pass"], result["reasons"])
+        self.assertEqual(result["accepted_reviews"][0]["kind"], "github-approval")
+
+    def test_native_approval_must_match_current_head_and_does_not_replace_r2_reports(
+        self,
+    ) -> None:
+        r1_bundle = _bundle(paths=("config/example.json",))
+        stale = _evaluate(
+            bundle=r1_bundle,
+            risk_class="R1",
+            comments=[],
+            reviews=[_review(r1_bundle, commit_id="f" * 40)],
+        )
+        self.assertFalse(stale["pass"])
+        self.assertEqual(stale["stale_native_review_count"], 1)
+
+        r2_bundle = _bundle(paths=("apps/web/src/app.ts",))
+        r2 = _evaluate(
+            bundle=r2_bundle,
+            risk_class="R2",
+            comments=[],
+            reviews=[_review(r2_bundle)],
+        )
+        self.assertFalse(r2["pass"])
+        self.assertEqual(r2["accepted_review_count"], 0)
+
+    def test_native_approval_requires_trusted_github_association(self) -> None:
+        bundle = _bundle(paths=("config/example.json",))
+        result = _evaluate(
+            bundle=bundle,
+            risk_class="R1",
+            comments=[],
+            reviews=[
+                _review(
+                    bundle,
+                    author="outside-reviewer",
+                    association="CONTRIBUTOR",
+                )
+            ],
+        )
+        self.assertFalse(result["pass"])
+        self.assertEqual(result["unauthorized_native_review_count"], 1)
+
+    def test_current_head_changes_requested_blocks_r1(self) -> None:
+        bundle = _bundle(paths=("config/example.json",))
+        result = _evaluate(
+            bundle=bundle,
+            risk_class="R1",
+            comments=[],
+            reviews=[_review(bundle, state="CHANGES_REQUESTED")],
+        )
+        self.assertFalse(result["pass"])
+        self.assertIn("request changes", " ".join(result["reasons"]))
+
+    def test_report_hash_normalizes_crlf_and_bare_cr(self) -> None:
+        bundle = _bundle(paths=("config/example.json",))
+        report = (
+            "Ausführlicher Bericht zur Korrektheit.\r\n"
+            "Geprüft wurden Regressionen, Fehlerszenarien und Invarianten.\r"
+            "Es verbleiben keine Mergeblocker und alle Befunde sind aufgelöst."
         )
         result = _evaluate(
             bundle=bundle,
@@ -512,12 +727,80 @@ class EvidenceTests(unittest.TestCase):
                 _comment(
                     _record(
                         bundle, reviewer="Reviewer A", axis="correctness", risk="R1"
-                    )
+                    ),
+                    report_text=report,
                 )
             ],
         )
+        self.assertTrue(result["pass"], result["reasons"])
+
+    def test_malformed_and_multiple_evidence_blocks_are_diagnostic(self) -> None:
+        bundle = _bundle(paths=("config/example.json",))
+        malformed = {
+            "id": 1,
+            "body": "Bericht<!-- weltgewebe-review-evidence {kaputt} -->",
+            "author_association": "OWNER",
+            "user": {"login": "alex"},
+        }
+        result = _evaluate(bundle=bundle, risk_class="R1", comments=[malformed])
         self.assertFalse(result["pass"])
-        self.assertIn("opaque or binary files", " ".join(result["reasons"]))
+        self.assertEqual(result["malformed_evidence_count"], 1)
+
+        first = _comment(
+            _record(bundle, reviewer="Reviewer A", axis="correctness", risk="R1")
+        )
+        first["body"] += first["body"][
+            first["body"].index("<!-- weltgewebe-review-evidence") :
+        ]
+        result = _evaluate(bundle=bundle, risk_class="R1", comments=[first])
+        self.assertFalse(result["pass"])
+        self.assertGreaterEqual(result["malformed_evidence_count"], 2)
+
+    def test_unicode_equivalent_reviewer_names_are_not_distinct(self) -> None:
+        bundle = _bundle(paths=("apps/web/src/app.ts",))
+        composed = "Revér A"
+        decomposed = "Reve\u0301r A"
+        comments = [
+            _comment(
+                _record(bundle, reviewer=composed, axis="correctness", risk="R2"),
+                comment_id=1,
+            ),
+            _comment(
+                _record(bundle, reviewer=decomposed, axis="testing", risk="R2"),
+                comment_id=2,
+            ),
+        ]
+        result = _evaluate(bundle=bundle, risk_class="R2", comments=comments)
+        self.assertFalse(result["pass"])
+        self.assertIn("two distinct reviewer identities", " ".join(result["reasons"]))
+
+    def test_same_timestamp_uses_higher_comment_id_deterministically(self) -> None:
+        bundle = _bundle(paths=("config/example.json",))
+        passed = _comment(
+            _record(bundle, reviewer="Reviewer A", axis="correctness", risk="R1"),
+            comment_id=10,
+        )
+        blocked = _comment(
+            _record(
+                bundle,
+                reviewer="Reviewer A",
+                axis="correctness",
+                risk="R1",
+                verdict="BLOCKED",
+            ),
+            comment_id=11,
+        )
+        result = _evaluate(bundle=bundle, risk_class="R1", comments=[blocked, passed])
+        self.assertFalse(result["pass"])
+        self.assertIn("blocking verdicts", " ".join(result["reasons"]))
+
+    def test_findings_resolved_must_be_true_for_pass(self) -> None:
+        bundle = _bundle(paths=("config/example.json",))
+        record = _record(bundle, reviewer="Reviewer A", axis="correctness", risk="R1")
+        record["findings_resolved"] = False
+        result = _evaluate(bundle=bundle, risk_class="R1", comments=[_comment(record)])
+        self.assertFalse(result["pass"])
+        self.assertEqual(result["accepted_review_count"], 0)
 
     def test_evidence_schema_and_reviewer_are_strict(self) -> None:
         bundle = _bundle(paths=("config/example.json",))
@@ -606,6 +889,7 @@ class WorkflowContractTests(unittest.TestCase):
     def test_privileged_workflow_executes_only_literal_main_code(self) -> None:
         self.assertIn("pull_request_target:", self.workflow)
         self.assertIn("issue_comment:", self.workflow)
+        self.assertIn("pull_request_review:", self.workflow)
         self.assertIn("ref: main", self.workflow)
         self.assertIn("fetch-depth: 1", self.workflow)
         self.assertIn("persist-credentials: false", self.workflow)
@@ -620,6 +904,10 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("pr-after.json", self.workflow)
         self.assertIn("diff_file_count", self.workflow)
         self.assertIn("max_artifact_bytes", self.workflow)
+        self.assertIn("/reviews?per_page=100", self.workflow)
+        self.assertIn("--reviews-file", self.workflow)
+        self.assertIn("Refresh current-head evidence before publication", self.workflow)
+        self.assertNotIn("continue-on-error: true", self.workflow)
         self.assertIn(
             "scripts/quality/review_governance.py evaluate-materialized",
             self.workflow,

--- a/scripts/quality/tests/test_review_governance.py
+++ b/scripts/quality/tests/test_review_governance.py
@@ -19,6 +19,7 @@ from scripts.quality.review_governance import (
     load_allowed_attesters,
     minimum_risk_for_paths,
     parse_risk_class,
+    _parse_numstat_z,
 )
 
 
@@ -174,10 +175,31 @@ class RiskParsingTests(unittest.TestCase):
             minimum_risk_for_paths(["docs/process/merge-quality-gate.md"]),
             "R3",
         )
+        self.assertEqual(
+            minimum_risk_for_paths([".github/PULL_REQUEST_TEMPLATE.md"]),
+            "R3",
+        )
         self.assertEqual(minimum_risk_for_paths(["apps/api/src/auth.rs"]), "R3")
 
 
 class BundleTests(unittest.TestCase):
+    def test_numstat_parser_handles_tabs_and_mixed_rename_records(self) -> None:
+        raw = b"3\t2\tpath\twith-tab.txt\0-\t-\t\0old.bin\0docs/new.bin\0"
+        additions, deletions, binary = _parse_numstat_z(raw)
+        self.assertEqual((additions, deletions), (3, 2))
+        self.assertEqual(binary, ("docs/new.bin",))
+
+    def test_numstat_parser_rejects_malformed_streams(self) -> None:
+        malformed = (
+            b"1\t0\tfile.txt",
+            b"-\t1\tfile.bin\0",
+            b"1\t0\t\0old.txt\0",
+        )
+        for raw in malformed:
+            with self.subTest(raw=raw):
+                with self.assertRaises(GovernanceError):
+                    _parse_numstat_z(raw)
+
     def test_bundle_hash_is_deterministic_for_same_commits(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             repo = Path(temp_dir) / "repo"
@@ -277,6 +299,40 @@ class BundleTests(unittest.TestCase):
             )
             self.assertEqual(bundle.stats.changed_files, ("docs/new.png",))
             self.assertEqual(bundle.stats.binary_files, ("docs/new.png",))
+
+    def test_local_multiple_text_and_binary_renames_are_parsed(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = Path(temp_dir) / "repo"
+            repo.mkdir()
+            _git(repo, "init", "-b", "main")
+            _git(repo, "config", "user.name", "Test")
+            _git(repo, "config", "user.email", "test@example.invalid")
+            (repo / "old.txt").write_text("unchanged text\n", encoding="utf-8")
+            (repo / "old.png").write_bytes(b"\x89PNG\r\n\x1a\n\x00binary")
+            _git(repo, "add", "old.txt", "old.png")
+            _git(repo, "commit", "-m", "base files")
+            base = _git(repo, "rev-parse", "HEAD")
+
+            (repo / "docs").mkdir()
+            _git(repo, "mv", "old.txt", "docs/new.txt")
+            _git(repo, "mv", "old.png", "docs/new.png")
+            _git(repo, "commit", "-m", "rename files")
+            head = _git(repo, "rev-parse", "HEAD")
+
+            bundle = generate_bundle(
+                repo=repo,
+                output_dir=Path(temp_dir) / "out",
+                base_revision=base,
+                head_revision=head,
+                pr_number=11,
+                risk_class="R1",
+            )
+            self.assertEqual(
+                bundle.stats.changed_files,
+                ("docs/new.png", "docs/new.txt"),
+            )
+            self.assertEqual(bundle.stats.binary_files, ("docs/new.png",))
+            self.assertEqual(bundle.stats.changed_lines, 0)
 
     def test_materialized_github_bundle_is_hash_bound_and_validated(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -658,6 +714,24 @@ class EvidenceTests(unittest.TestCase):
         self.assertTrue(result["pass"], result["reasons"])
         self.assertEqual(result["accepted_reviews"][0]["kind"], "github-approval")
 
+    def test_r1_deduplicates_native_and_attested_review_by_identity(self) -> None:
+        bundle = _bundle(paths=("config/example.json",))
+        comment = _comment(
+            _record(bundle, reviewer="Alex", axis="correctness", risk="R1")
+        )
+        result = _evaluate(
+            bundle=bundle,
+            risk_class="R1",
+            comments=[comment],
+            reviews=[_review(bundle, author="alex")],
+        )
+        self.assertTrue(result["pass"], result["reasons"])
+        self.assertEqual(result["accepted_review_count"], 1)
+        self.assertEqual(
+            [review["kind"] for review in result["accepted_reviews"]],
+            ["attested-report"],
+        )
+
     def test_native_approval_must_match_current_head_and_does_not_replace_r2_reports(
         self,
     ) -> None:
@@ -709,6 +783,44 @@ class EvidenceTests(unittest.TestCase):
         self.assertFalse(result["pass"])
         self.assertIn("request changes", " ".join(result["reasons"]))
 
+    def test_latest_native_review_state_wins_and_dismissal_invalidates(self) -> None:
+        bundle = _bundle(paths=("config/example.json",))
+        approved = _review(
+            bundle,
+            state="APPROVED",
+            review_id=1,
+            submitted_at="2026-07-14T12:00:00Z",
+        )
+        changes_requested = _review(
+            bundle,
+            state="CHANGES_REQUESTED",
+            review_id=2,
+            submitted_at="2026-07-14T13:00:00Z",
+        )
+        blocked = _evaluate(
+            bundle=bundle,
+            risk_class="R1",
+            comments=[],
+            reviews=[approved, changes_requested],
+        )
+        self.assertFalse(blocked["pass"])
+        self.assertIn("request changes", " ".join(blocked["reasons"]))
+
+        dismissed = _review(
+            bundle,
+            state="DISMISSED",
+            review_id=3,
+            submitted_at="2026-07-14T14:00:00Z",
+        )
+        invalidated = _evaluate(
+            bundle=bundle,
+            risk_class="R1",
+            comments=[],
+            reviews=[approved, dismissed],
+        )
+        self.assertFalse(invalidated["pass"])
+        self.assertEqual(invalidated["accepted_review_count"], 0)
+
     def test_report_hash_normalizes_crlf_and_bare_cr(self) -> None:
         bundle = _bundle(paths=("config/example.json",))
         report = (
@@ -751,6 +863,41 @@ class EvidenceTests(unittest.TestCase):
         result = _evaluate(bundle=bundle, risk_class="R1", comments=[first])
         self.assertFalse(result["pass"])
         self.assertGreaterEqual(result["malformed_evidence_count"], 2)
+
+    def test_evidence_json_may_contain_html_comment_terminator_text(self) -> None:
+        bundle = _bundle(paths=("config/example.json",))
+        result = _evaluate(
+            bundle=bundle,
+            risk_class="R1",
+            comments=[
+                _comment(
+                    _record(
+                        bundle,
+                        reviewer="Reviewer --> A",
+                        axis="correctness",
+                        risk="R1",
+                    )
+                )
+            ],
+        )
+        self.assertTrue(result["pass"], result["reasons"])
+
+    def test_oversized_evidence_payload_is_reported_separately(self) -> None:
+        bundle = _bundle(paths=("config/example.json",))
+        oversized = _record(
+            bundle,
+            reviewer="R" * (21 * 1024),
+            axis="correctness",
+            risk="R1",
+        )
+        result = _evaluate(
+            bundle=bundle,
+            risk_class="R1",
+            comments=[_comment(oversized)],
+        )
+        self.assertFalse(result["pass"])
+        self.assertEqual(result["malformed_evidence_count"], 1)
+        self.assertEqual(result["oversized_evidence_count"], 1)
 
     def test_unicode_equivalent_reviewer_names_are_not_distinct(self) -> None:
         bundle = _bundle(paths=("apps/web/src/app.ts",))
@@ -900,6 +1047,15 @@ class WorkflowContractTests(unittest.TestCase):
             self.workflow,
         )
         self.assertIn("github.event.comment.author_association", self.workflow)
+        self.assertIn("types: [created, edited, deleted]", self.workflow)
+        self.assertIn(
+            "contains(github.event.comment.body, '<!-- weltgewebe-review-evidence')",
+            self.workflow,
+        )
+        self.assertIn(
+            "startsWith(github.event.comment.body, '/review-evidence recheck')",
+            self.workflow,
+        )
         self.assertNotIn("actions/checkout@v", self.workflow)
         self.assertNotIn("git fetch", self.workflow)
         self.assertNotIn("refs/pull/", self.workflow)

--- a/scripts/quality/tests/test_review_governance.py
+++ b/scripts/quality/tests/test_review_governance.py
@@ -882,6 +882,19 @@ class EvidenceTests(unittest.TestCase):
         )
         self.assertTrue(result["pass"], result["reasons"])
 
+    def test_alternate_html_comment_terminator_is_accepted(self) -> None:
+        bundle = _bundle(paths=("config/example.json",))
+        comment = _comment(
+            _record(bundle, reviewer="Reviewer A", axis="correctness", risk="R1")
+        )
+        comment["body"] = comment["body"].replace("\n-->", "\n--!>")
+        result = _evaluate(
+            bundle=bundle,
+            risk_class="R1",
+            comments=[comment],
+        )
+        self.assertTrue(result["pass"], result["reasons"])
+
     def test_oversized_evidence_payload_is_reported_separately(self) -> None:
         bundle = _bundle(paths=("config/example.json",))
         oversized = _record(


### PR DESCRIPTION
<!-- weltgewebe-risk: R3 -->

## Ziel

Das Review-Evidence-Gate soll hohe Qualität sichern, ohne kleine Änderungen unnötig zu verlangsamen.

- R1 kann durch eine native GitHub-Freigabe auf dem aktuellen Head erfüllt werden.
- R2 und R3 bleiben vollständig hash- und diffgebunden.
- Sichere Rastergrafiken in begrenzten Doku-/Web-Assetpfaden werden visuell prüfbar statt pauschal blockiert.
- PDF, SVG, Archive, ausführbare und sonstige undurchsichtige Dateien bleiben gesperrt.

## Nicht-Ziele

- keine Abschwächung von Auth-, Sicherheits-, Daten-, Migrations- oder Betriebsänderungen;
- kein allgemeiner Binärdatei-Freipass;
- keine Änderung der bestehenden GitHub-Rulesets.

## Zu bewahrende Invarianten

- privilegierter Workflow führt keinen PR-Code aus;
- R2/R3 verlangen zwei verschiedene hashgebundene Berichte und Achsen;
- jeder Head-, Basis- oder Diffwechsel entwertet die alten Berichte;
- sensible Governancepfade erzwingen R3.

## Behobene Reviewbefunde

- CRLF/LF-normalisierte Berichtshashes;
- korrekte lokale Binär-Rename-Auswertung;
- begrenzter und diagnostizierbarer Evidence-Parser;
- deterministische Reihenfolge konkurrierender Kommentare;
- Größen-, Unicode-, Mehrfachblock- und Findings-Grenztests;
- erneute GitHub-Auswertung unmittelbar vor Statuspublikation;
- Statuspublikation mit drei Versuchen;
- schnelle Bedienungsanleitung und aktualisierte PR-Vorlage.

## Verifizierte Fehlalarme

- `actions/checkout@v7.0.0` ist ein offizieller Tag und zeigt auf den verwendeten Commit.
- Risiko-Marker, unbekannte JSON-Schlüssel und Materialized-Pfade waren bereits strikt validiert.
- GitHub-Logins unterstützen keine Unterstriche; die bestehende Regex entspricht dieser Regel.

## Prüfungen

- `python3 -m unittest scripts.quality.tests.test_review_governance`: 36/36
- `ruff check` und `ruff format --check`: PASS
- YAML-Parsing und `git diff --check`: PASS
- `make validate`: 810 Docmeta-, 160 Agenten- und 92 CI-Tests sowie alle Struktur- und Shellverträge PASS

## Rückfallweg

Der PR ist ein einzelner Governance-Commit und kann ohne Daten- oder Deploymentmigration vollständig revertiert werden.
