### PR TITLE
perf: add domain scale foundation

### DIFF
--- a/.github/workflows/domain-scale.yml
+++ b/.github/workflows/domain-scale.yml
@@ -53,7 +53,6 @@ jobs:
           --health-retries 20
     env:
       DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5432/postgres
-      DOMAIN_SCALE_DIR: ${{ runner.temp }}/domain-scale-ci
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # tag: v7.0.0
 
@@ -82,6 +81,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          DOMAIN_SCALE_DIR="${RUNNER_TEMP}/domain-scale-ci"
           rm -rf "${DOMAIN_SCALE_DIR}"
           mkdir -p "${DOMAIN_SCALE_DIR}/plans"
           python3 -B scripts/performance/domain_scale.py generate \

--- a/.github/workflows/domain-scale.yml
+++ b/.github/workflows/domain-scale.yml
@@ -1,0 +1,68 @@
+---
+name: domain-scale
+
+"on":
+  pull_request:
+    branches: [main]
+    paths:
+      - "configs/performance/domain-scale.v1.json"
+      - "scripts/performance/**"
+      - "scripts/tests/test_domain_scale.py"
+      - "docs/blueprints/domain-scale-foundation.md"
+      - ".github/workflows/domain-scale.yml"
+  push:
+    branches: [main]
+    paths:
+      - "configs/performance/domain-scale.v1.json"
+      - "scripts/performance/**"
+      - "scripts/tests/test_domain_scale.py"
+      - "docs/blueprints/domain-scale-foundation.md"
+      - ".github/workflows/domain-scale.yml"
+  workflow_dispatch: {}
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  foundation:
+    name: Domain scale foundation
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # tag: v7.0.0
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # tag: v5
+        with:
+          python-version-file: '.python-version'
+
+      - name: Validate scale contract
+        run: python3 -B scripts/performance/domain_scale.py validate
+
+      - name: Run scale tooling tests
+        run: python3 -B scripts/tests/test_domain_scale.py
+
+      - name: Render deterministic smoke fixture and SQL
+        shell: bash
+        run: |
+          set -euo pipefail
+          output_dir=$(mktemp -d)
+          trap 'rm -rf "${output_dir}"' EXIT
+          python3 -B scripts/performance/domain_scale.py generate \
+            --profile smoke \
+            --output-dir "${output_dir}/fixture"
+          python3 -B scripts/performance/domain_scale.py render-load \
+            --manifest "${output_dir}/fixture/manifest.json" \
+            --output "${output_dir}/load.sql"
+          python3 -B scripts/performance/domain_scale.py render-workload \
+            --manifest "${output_dir}/fixture/manifest.json" \
+            --plan-dir "${output_dir}/plans" \
+            --output "${output_dir}/workload.sql"
+          test -s "${output_dir}/load.sql"
+          test -s "${output_dir}/workload.sql"

--- a/.github/workflows/domain-scale.yml
+++ b/.github/workflows/domain-scale.yml
@@ -8,6 +8,8 @@ name: domain-scale
       - "configs/performance/domain-scale.v1.json"
       - "scripts/performance/**"
       - "scripts/tests/test_domain_scale.py"
+      - "apps/api/migrations/20260531000001_create_domain_nodes.up.sql"
+      - "apps/api/migrations/20260531000002_create_domain_edges.up.sql"
       - "docs/blueprints/domain-scale-foundation.md"
       - ".github/workflows/domain-scale.yml"
   push:
@@ -16,6 +18,8 @@ name: domain-scale
       - "configs/performance/domain-scale.v1.json"
       - "scripts/performance/**"
       - "scripts/tests/test_domain_scale.py"
+      - "apps/api/migrations/20260531000001_create_domain_nodes.up.sql"
+      - "apps/api/migrations/20260531000002_create_domain_edges.up.sql"
       - "docs/blueprints/domain-scale-foundation.md"
       - ".github/workflows/domain-scale.yml"
   workflow_dispatch: {}
@@ -34,7 +38,22 @@ jobs:
   foundation:
     name: Domain scale foundation
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
+    services:
+      postgres:
+        image: postgres:16@sha256:be01cf82fc7dbba824acf0a82e150b4b360f3ff93c6631d7844af431e841a95c
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d postgres"
+          --health-interval 2s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5432/postgres
+      DOMAIN_SCALE_DIR: ${{ runner.temp }}/domain-scale-ci
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # tag: v7.0.0
 
@@ -42,27 +61,57 @@ jobs:
         with:
           python-version-file: '.python-version'
 
+      - name: Install PostgreSQL client
+        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends postgresql-client
+
       - name: Validate scale contract
         run: python3 -B scripts/performance/domain_scale.py validate
 
       - name: Run scale tooling tests
         run: python3 -B scripts/tests/test_domain_scale.py
 
-      - name: Render deterministic smoke fixture and SQL
+      - name: Create production-shaped PostgreSQL tables
         shell: bash
         run: |
           set -euo pipefail
-          output_dir=$(mktemp -d)
-          trap 'rm -rf "${output_dir}"' EXIT
+          psql "${DATABASE_URL}" -v ON_ERROR_STOP=1 \
+            -f apps/api/migrations/20260531000001_create_domain_nodes.up.sql \
+            -f apps/api/migrations/20260531000002_create_domain_edges.up.sql
+
+      - name: Load CI fixture and verify real PostgreSQL plans
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf "${DOMAIN_SCALE_DIR}"
+          mkdir -p "${DOMAIN_SCALE_DIR}/plans"
           python3 -B scripts/performance/domain_scale.py generate \
-            --profile smoke \
-            --output-dir "${output_dir}/fixture"
+            --profile ci \
+            --output-dir "${DOMAIN_SCALE_DIR}/fixture"
           python3 -B scripts/performance/domain_scale.py render-load \
-            --manifest "${output_dir}/fixture/manifest.json" \
-            --output "${output_dir}/load.sql"
+            --manifest "${DOMAIN_SCALE_DIR}/fixture/manifest.json" \
+            --output "${DOMAIN_SCALE_DIR}/load.sql"
+          psql "${DATABASE_URL}" -v ON_ERROR_STOP=1 -f "${DOMAIN_SCALE_DIR}/load.sql"
+          test "$(psql "${DATABASE_URL}" -Atc 'SELECT count(*) FROM weltgewebe_perf.domain_nodes')" = "20000"
+          test "$(psql "${DATABASE_URL}" -Atc 'SELECT count(*) FROM weltgewebe_perf.domain_edges')" = "100000"
           python3 -B scripts/performance/domain_scale.py render-workload \
-            --manifest "${output_dir}/fixture/manifest.json" \
-            --plan-dir "${output_dir}/plans" \
-            --output "${output_dir}/workload.sql"
-          test -s "${output_dir}/load.sql"
-          test -s "${output_dir}/workload.sql"
+            --manifest "${DOMAIN_SCALE_DIR}/fixture/manifest.json" \
+            --plan-dir "${DOMAIN_SCALE_DIR}/plans" \
+            --output "${DOMAIN_SCALE_DIR}/workload.sql"
+          psql "${DATABASE_URL}" -v ON_ERROR_STOP=1 -f "${DOMAIN_SCALE_DIR}/workload.sql"
+          python3 -B scripts/performance/domain_scale.py check \
+            --manifest "${DOMAIN_SCALE_DIR}/fixture/manifest.json" \
+            --plan-dir "${DOMAIN_SCALE_DIR}/plans" \
+            --report "${DOMAIN_SCALE_DIR}/report.json"
+
+      - name: Upload PostgreSQL plan evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        with:
+          name: domain-scale-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/domain-scale-ci/fixture/manifest.json
+            ${{ runner.temp }}/domain-scale-ci/load.sql
+            ${{ runner.temp }}/domain-scale-ci/workload.sql
+            ${{ runner.temp }}/domain-scale-ci/plans/*.json
+            ${{ runner.temp }}/domain-scale-ci/report.json
+          if-no-files-found: warn

--- a/.github/workflows/domain-scale.yml
+++ b/.github/workflows/domain-scale.yml
@@ -81,7 +81,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          DOMAIN_SCALE_DIR="${RUNNER_TEMP}/domain-scale-ci"
+          DOMAIN_SCALE_DIR="${RUNNER_TEMP:?RUNNER_TEMP is required}/domain-scale-ci"
           rm -rf "${DOMAIN_SCALE_DIR}"
           mkdir -p "${DOMAIN_SCALE_DIR}/plans"
           python3 -B scripts/performance/domain_scale.py generate \

--- a/configs/performance/domain-scale.v1.json
+++ b/configs/performance/domain-scale.v1.json
@@ -22,26 +22,38 @@
   },
   "plan_budgets": {
     "calibration_required": true,
-    "enforced_profiles": ["scale_100k", "scale_1m"],
+    "enforced_profiles": ["ci", "scale_100k", "scale_1m"],
     "max_temp_blocks": 0,
     "workloads": {
       "node_cursor": {
-        "forbidden_node_types": ["Seq Scan", "Sort"]
+        "forbidden_node_types": ["Seq Scan", "Sort"],
+        "required_index": "domain_nodes_pkey",
+        "required_index_cond_contains": ["id"]
       },
       "edge_cursor": {
-        "forbidden_node_types": ["Seq Scan", "Sort"]
+        "forbidden_node_types": ["Seq Scan", "Sort"],
+        "required_index": "domain_edges_pkey",
+        "required_index_cond_contains": ["id"]
       },
       "bbox": {
-        "forbidden_node_types": ["Seq Scan"]
+        "forbidden_node_types": ["Seq Scan"],
+        "required_index": "domain_nodes_lat_lon_idx",
+        "required_index_cond_contains": ["lat", "lon"]
       },
       "outbound_neighbors": {
-        "forbidden_node_types": ["Seq Scan"]
+        "forbidden_node_types": ["Seq Scan"],
+        "required_index": "domain_edges_source_id_idx",
+        "required_index_cond_contains": ["source_id"]
       },
       "inbound_neighbors": {
-        "forbidden_node_types": ["Seq Scan"]
+        "forbidden_node_types": ["Seq Scan"],
+        "required_index": "domain_edges_target_id_idx",
+        "required_index_cond_contains": ["target_id"]
       },
       "kind_filter": {
-        "forbidden_node_types": ["Seq Scan"]
+        "forbidden_node_types": ["Seq Scan"],
+        "required_index": "domain_nodes_kind_idx",
+        "required_index_cond_contains": ["kind"]
       }
     }
   }

--- a/configs/performance/domain-scale.v1.json
+++ b/configs/performance/domain-scale.v1.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": 1,
+  "seed": "weltgewebe-domain-scale-v1",
+  "database_schema": "weltgewebe_perf",
+  "profiles": {
+    "smoke": {
+      "nodes": 1000,
+      "edges": 5000
+    },
+    "ci": {
+      "nodes": 20000,
+      "edges": 100000
+    },
+    "scale_100k": {
+      "nodes": 100000,
+      "edges": 500000
+    },
+    "scale_1m": {
+      "nodes": 1000000,
+      "edges": 5000000
+    }
+  },
+  "plan_budgets": {
+    "calibration_required": true,
+    "enforced_profiles": ["scale_100k", "scale_1m"],
+    "max_temp_blocks": 0,
+    "workloads": {
+      "node_cursor": {
+        "forbidden_node_types": ["Seq Scan", "Sort"]
+      },
+      "edge_cursor": {
+        "forbidden_node_types": ["Seq Scan", "Sort"]
+      },
+      "bbox": {
+        "forbidden_node_types": ["Seq Scan"]
+      },
+      "outbound_neighbors": {
+        "forbidden_node_types": ["Seq Scan"]
+      },
+      "inbound_neighbors": {
+        "forbidden_node_types": ["Seq Scan"]
+      },
+      "kind_filter": {
+        "forbidden_node_types": ["Seq Scan"]
+      }
+    }
+  }
+}

--- a/configs/performance/domain-scale.v1.json
+++ b/configs/performance/domain-scale.v1.json
@@ -28,32 +28,32 @@
       "node_cursor": {
         "forbidden_node_types": ["Seq Scan", "Sort"],
         "required_index": "domain_nodes_pkey",
-        "required_index_cond_contains": ["id"]
+        "required_index_cond_identifiers": ["id"]
       },
       "edge_cursor": {
         "forbidden_node_types": ["Seq Scan", "Sort"],
         "required_index": "domain_edges_pkey",
-        "required_index_cond_contains": ["id"]
+        "required_index_cond_identifiers": ["id"]
       },
       "bbox": {
         "forbidden_node_types": ["Seq Scan"],
         "required_index": "domain_nodes_lat_lon_idx",
-        "required_index_cond_contains": ["lat", "lon"]
+        "required_index_cond_identifiers": ["lat", "lon"]
       },
       "outbound_neighbors": {
         "forbidden_node_types": ["Seq Scan"],
         "required_index": "domain_edges_source_id_idx",
-        "required_index_cond_contains": ["source_id"]
+        "required_index_cond_identifiers": ["source_id"]
       },
       "inbound_neighbors": {
         "forbidden_node_types": ["Seq Scan"],
         "required_index": "domain_edges_target_id_idx",
-        "required_index_cond_contains": ["target_id"]
+        "required_index_cond_identifiers": ["target_id"]
       },
       "kind_filter": {
         "forbidden_node_types": ["Seq Scan"],
         "required_index": "domain_nodes_kind_idx",
-        "required_index_cond_contains": ["kind"]
+        "required_index_cond_identifiers": ["kind"]
       }
     }
   }

--- a/docs/_generated/backlinks.md
+++ b/docs/_generated/backlinks.md
@@ -784,6 +784,7 @@ Generated automatically. Do not edit.
 ## docs/roadmap.md
 
 - [relates_to] docs/blueprints/blueprint-agent-safety-control-layer.md
+- [relates_to] docs/blueprints/domain-scale-foundation.md
 - [relates_to] docs/blueprints/kartenklarheit.md
 - [relates_to] docs/blueprints/map-blaupause.md
 - [relates_to] docs/blueprints/ui-blaupause.md

--- a/docs/_generated/backlinks.md
+++ b/docs/_generated/backlinks.md
@@ -261,6 +261,7 @@ Generated automatically. Do not edit.
 
 ## docs/blueprints/domain-data-postgres-cutover.md
 
+- [relates_to] docs/blueprints/domain-scale-foundation.md
 - [relates_to] docs/reports/domain-account-email-uniqueness-audit.md
 - [relates_to] docs/reports/domain-account-write-path-proof.md
 - [relates_to] docs/reports/domain-backfill-proof.md
@@ -340,6 +341,7 @@ Generated automatically. Do not edit.
 
 - [relates_to] docs/adr/0043-edge-vs-conversation.md
 - [relates_to] docs/architekturstruktur.md
+- [relates_to] docs/blueprints/domain-scale-foundation.md
 - [relates_to] docs/domain/vocabulary.md
 - [relates_to] docs/reports/optimierungsbericht.md
 - [relates_to] docs/runbooks/db-recovery.md

--- a/docs/_generated/doc-index.md
+++ b/docs/_generated/doc-index.md
@@ -57,6 +57,7 @@ Generated automatically. Do not edit.
 | docs.architecture.overview | Architekturüberblick | architecture | active | docs/architekturstruktur.md |
 | docs.blueprints.agent-operability | Minimaler Agent-Operability-Kern | blueprint | draft | docs/blueprints/agent-operability-blaupause.md |
 | docs.blueprints.agent-safety-control-layer | Blueprint — Agent Safety Control Layer | blueprint | draft | docs/blueprints/blueprint-agent-safety-control-layer.md |
+| docs.blueprints.domain-scale-foundation | Domain Scale Foundation | blueprint | active | docs/blueprints/domain-scale-foundation.md |
 | docs.blueprints.kartenklarheit | Blaupause zur Optimierung der Karte | blueprint | deprecated | docs/blueprints/kartenklarheit.md |
 | docs.blueprints.kartenklarheit-phase6 | Kartenklarheit Phase 6: Der Wahrheitsbeweis | blueprint | deprecated | docs/blueprints/kartenklarheit-phase6.md |
 | docs.blueprints.kartenklarheit-roadmap | Roadmap - Kartenklarheit | roadmap | deprecated | docs/blueprints/kartenklarheit-roadmap.md |

--- a/docs/_generated/relates-to-audit.md
+++ b/docs/_generated/relates-to-audit.md
@@ -14,9 +14,9 @@ Generated automatically. Do not edit.
 
 | Metrik | Wert |
 | --- | --- |
-| Relationen gesamt | 573 |
+| Relationen gesamt | 574 |
 | — depends_on | 20 |
-| — relates_to | 541 |
+| — relates_to | 542 |
 | — supersedes | 11 |
 | — verifies | 1 |
 | relates_to Anteil | 94% |

--- a/docs/_generated/relates-to-audit.md
+++ b/docs/_generated/relates-to-audit.md
@@ -14,9 +14,9 @@ Generated automatically. Do not edit.
 
 | Metrik | Wert |
 | --- | --- |
-| Relationen gesamt | 571 |
+| Relationen gesamt | 573 |
 | — depends_on | 20 |
-| — relates_to | 539 |
+| — relates_to | 541 |
 | — supersedes | 11 |
 | — verifies | 1 |
 | relates_to Anteil | 94% |
@@ -31,7 +31,7 @@ _Keine Lücken erkannt._
 
 > Zusammenhängende Gruppen im relates_to-Graphen.
 
-**Cluster 1** (222 Dokumente):
+**Cluster 1** (223 Dokumente):
 
 - `.github/workflows/api.yml`
 - `.github/workflows/basemap-runtime-proof.yml`
@@ -75,6 +75,7 @@ _Keine Lücken erkannt._
 - `docs/blueprints/doc-structure-task-control-roadmap.md`
 - `docs/blueprints/doc-structure-task-control.md`
 - `docs/blueprints/domain-data-postgres-cutover.md`
+- `docs/blueprints/domain-scale-foundation.md`
 - `docs/blueprints/kartenklarheit-phase6.md`
 - `docs/blueprints/kartenklarheit-roadmap.md`
 - `docs/blueprints/kartenklarheit.md`

--- a/docs/_generated/relations-analysis.md
+++ b/docs/_generated/relations-analysis.md
@@ -17,9 +17,9 @@ Generated automatically. Do not edit.
 | Dokumente gesamt | 167 |
 | Dokumente mit ausgehenden Relationen | 166 |
 | Dokumente als Ziel referenziert | 128 |
-| Relationen gesamt | 573 |
+| Relationen gesamt | 574 |
 | — depends_on | 20 |
-| — relates_to | 541 |
+| — relates_to | 542 |
 | — supersedes | 11 |
 | — verifies | 1 |
 | Isolierte Dokumente | 0 |
@@ -44,6 +44,7 @@ Generated automatically. Do not edit.
 - ⚠️ High inbound count (12): `docs/blueprints/domain-data-postgres-cutover.md` — central dependency, review carefully
 - ⚠️ High inbound count (11): `docs/blueprints/auth-roadmap.md` — central dependency, review carefully
 - ⚠️ High inbound count (11): `docs/deployment.md` — central dependency, review carefully
+- ⚠️ High inbound count (10): `docs/roadmap.md` — central dependency, review carefully
 
 ### Zyklen (depends_on)
 
@@ -71,6 +72,7 @@ _Keine Zyklen gefunden._
 - `docs/blueprints/domain-data-postgres-cutover.md` — 12 eingehende Relationen
 - `docs/blueprints/auth-roadmap.md` — 11 eingehende Relationen
 - `docs/deployment.md` — 11 eingehende Relationen
+- `docs/roadmap.md` — 10 eingehende Relationen
 
 ### Isolierte Dokumente
 

--- a/docs/_generated/relations-analysis.md
+++ b/docs/_generated/relations-analysis.md
@@ -14,12 +14,12 @@ Generated automatically. Do not edit.
 
 | Metrik | Wert |
 | --- | --- |
-| Dokumente gesamt | 166 |
-| Dokumente mit ausgehenden Relationen | 165 |
+| Dokumente gesamt | 167 |
+| Dokumente mit ausgehenden Relationen | 166 |
 | Dokumente als Ziel referenziert | 128 |
-| Relationen gesamt | 571 |
+| Relationen gesamt | 573 |
 | — depends_on | 20 |
-| — relates_to | 539 |
+| — relates_to | 541 |
 | — supersedes | 11 |
 | — verifies | 1 |
 | Isolierte Dokumente | 0 |
@@ -41,8 +41,8 @@ Generated automatically. Do not edit.
 - ⚠️ High inbound count (14): `docs/reports/auth-status-matrix.md` — central dependency, review carefully
 - ⚠️ High inbound count (13): `docs/adr/ADR-0007__auth-persistence-production-db-path.md` — central dependency, review carefully
 - ⚠️ High inbound count (13): `docs/reports/optimierungsstatus.md` — central dependency, review carefully
+- ⚠️ High inbound count (12): `docs/blueprints/domain-data-postgres-cutover.md` — central dependency, review carefully
 - ⚠️ High inbound count (11): `docs/blueprints/auth-roadmap.md` — central dependency, review carefully
-- ⚠️ High inbound count (11): `docs/blueprints/domain-data-postgres-cutover.md` — central dependency, review carefully
 - ⚠️ High inbound count (11): `docs/deployment.md` — central dependency, review carefully
 
 ### Zyklen (depends_on)
@@ -68,8 +68,8 @@ _Keine Zyklen gefunden._
 - `docs/reports/auth-status-matrix.md` — 14 eingehende Relationen
 - `docs/adr/ADR-0007__auth-persistence-production-db-path.md` — 13 eingehende Relationen
 - `docs/reports/optimierungsstatus.md` — 13 eingehende Relationen
+- `docs/blueprints/domain-data-postgres-cutover.md` — 12 eingehende Relationen
 - `docs/blueprints/auth-roadmap.md` — 11 eingehende Relationen
-- `docs/blueprints/domain-data-postgres-cutover.md` — 11 eingehende Relationen
 - `docs/deployment.md` — 11 eingehende Relationen
 
 ### Isolierte Dokumente

--- a/docs/blueprints/domain-scale-foundation.md
+++ b/docs/blueprints/domain-scale-foundation.md
@@ -113,8 +113,17 @@ Knotenarten und Beziehungen wiederholbar. Die ersten Fäden bilden zusätzlich
 einen geschlossenen Ring über alle Knoten. Somit besitzt jeder Knoten garantiert
 mindestens eine eingehende und eine ausgehende Verbindung; Nachbarschaftsmessungen
 laufen nicht versehentlich gegen einen leeren Fall. Das Manifest enthält
-SHA-256-Werte für beide CSV-Dateien. Eine nachträgliche Veränderung wird vor dem
-Rendern der SQL-Dateien abgewiesen.
+SHA-256-Werte für beide CSV-Dateien. Zusätzlich werden CSV-Kopfzeilen und reale
+Zeilenzahlen gegen das Manifest geprüft. Profilname, konfigurierte Profilgrößen
+und Konfigurationshash müssen exakt zusammenpassen. Ein großes Datenpaket kann
+sich dadurch nicht als kleines, budgetfreies Profil ausgeben. Eine nachträgliche
+Veränderung wird vor dem Rendern der SQL-Dateien abgewiesen.
+
+Für die Knotenartmessung ist `Projekt` gezielt selten: genau jeder hundertste
+Knoten trägt diese Art. Das bildet eine selektive Filterabfrage ab, bei der der
+Knotenartindex sinnvoll ist. Ein breiter Filter mit etwa 20 Prozent Treffern
+dürfte dagegen berechtigt einen vollständigen Tabellendurchlauf wählen und wäre
+kein geeigneter Nachweis für die Indexfunktion.
 
 ## Gemessene Abfragen
 
@@ -136,13 +145,19 @@ Schreibaufwand und Zeitwerte in maschinenlesbarer Form.
 
 Der Prüfer blockiert zunächst nur eindeutig schädliche Planformen:
 
-- kein `Seq Scan` für die kanonischen großen Listen- und Suchabfragen,
+- kein `Seq Scan` für die kanonischen Listen- und Suchabfragen,
 - kein zusätzlicher `Sort` für die ID-Cursor,
-- keine temporären Blöcke.
+- keine temporären Blöcke,
+- für jede Abfrage der fachlich vorgesehene Index,
+- eine tatsächlich ausgeführte `Index Cond` mit den erwarteten Spalten.
 
-Die harten Planbudgets gelten nur für `scale_100k` und `scale_1m`. Bei den
-kleinen Profilen darf PostgreSQL einen vollständigen Tabellendurchlauf wählen,
-falls dieser tatsächlich günstiger ist; dort werden die Pläne nur beobachtet.
+Damit reicht ein beliebiger `Index Scan` nicht aus. Beispielsweise muss eine
+Nachbarschaftsabfrage den Index auf `source_id` beziehungsweise `target_id`
+verwenden; ein Primärschlüssel-Scan mit nachträglichem Filter gilt als Fehler.
+
+Die harten Planbudgets gelten für `ci`, `scale_100k` und `scale_1m`. Nur das
+kleine Profil `smoke` bleibt rein beobachtend, weil PostgreSQL bei 1.000 Knoten
+berechtigt einen vollständigen Tabellendurchlauf wählen kann.
 
 Zeitgrenzen bleiben ausdrücklich unkalibriert. Eine allgemeine Grenze ohne
 festgelegte Hardware, PostgreSQL-Konfiguration, Warm-up und Wiederholungszahl
@@ -182,8 +197,10 @@ python3 -B scripts/performance/domain_scale.py render-workload \
 ```
 
 Die beiden SQL-Dateien werden anschließend mit `psql` gegen eine ausdrücklich
-bestimmte Benchmark-Datenbank ausgeführt. Danach prüft der folgende Befehl die
-JSON-Abfragepläne:
+bestimmte Benchmark-Datenbank ausgeführt. Der GitHub-Workflow lädt dafür das
+Profil `ci` mit 20.000 Knoten und 100.000 Fäden in ein echtes PostgreSQL 16,
+führt alle sechs Abfragen aus und archiviert die JSON-Pläne als CI-Beleg.
+Danach prüft der folgende Befehl die JSON-Abfragepläne:
 
 ```bash
 python3 -B scripts/performance/domain_scale.py check \
@@ -191,6 +208,10 @@ python3 -B scripts/performance/domain_scale.py check \
   --plan-dir /tmp/weltgewebe-domain-scale/plans \
   --report /tmp/weltgewebe-domain-scale/report.json
 ```
+
+Auch bei einer Budgetverletzung wird `report.json` mit `status: fail` atomar
+geschrieben, bevor der Prozess mit einem Fehlercode endet. Automatisierungen
+verlieren dadurch nicht gerade im Fehlerfall ihre Diagnose.
 
 ## Folgeschnitte
 

--- a/docs/blueprints/domain-scale-foundation.md
+++ b/docs/blueprints/domain-scale-foundation.md
@@ -95,9 +95,17 @@ Er darf nicht:
 - das Schema `public` verwerfen,
 - den Testdatensatz ohne Hashprüfung verwenden.
 
-Die Unit-Tests prüfen diese Grenze statisch. PostgreSQL-Berechtigungen bleiben
-die zweite Schutzschicht: Ein Benchmark-Benutzer sollte keine Rechte zum
-Verwerfen produktiver Tabellen besitzen.
+Unit-Tests und der echte PostgreSQL-CI-Lauf prüfen diese Grenze. Der CI-Lauf
+verwendet den ephemeren Container-Superuser und besitzt daher keine zweite
+Berechtigungsschicht. Bei manuellen oder dauerhaften Messumgebungen soll dagegen
+ein eigener Benchmark-Benutzer ohne Rechte zum Verwerfen produktiver Tabellen
+verwendet werden.
+
+Dateipfade, die in psql-Metabefehle wie `\copy` oder `\o` gelangen, müssen
+absolute kontrollierte Pfade sein und dürfen nur ASCII-Buchstaben, Ziffern,
+Schrägstrich, Punkt, Unterstrich oder Bindestrich enthalten. Leerzeichen,
+Apostrophe, Backslashes und Steuerzeichen werden abgewiesen. Damit hängt die
+Sicherheitsgrenze nicht von mehrdeutigen psql-Escapingregeln ab.
 
 ## Determinismus
 
@@ -149,9 +157,12 @@ Der Prüfer blockiert zunächst nur eindeutig schädliche Planformen:
 - kein zusätzlicher `Sort` für die ID-Cursor,
 - keine temporären Blöcke,
 - für jede Abfrage der fachlich vorgesehene Index,
-- eine tatsächlich ausgeführte `Index Cond` mit den erwarteten Spalten.
+- eine tatsächlich ausgeführte `Index Cond` mit den erwarteten SQL-Bezeichnern,
+- mindestens einen ausgeführten Durchlauf des betreffenden Indexknotens.
 
-Damit reicht ein beliebiger `Index Scan` nicht aus. Beispielsweise muss eine
+Die Bezeichner werden exakt ausgewertet: `id` zählt nicht als Treffer innerhalb
+von `source_id`, und `lat` nicht innerhalb von `latitude`. Damit reicht ein
+beliebiger `Index Scan` nicht aus. Beispielsweise muss eine
 Nachbarschaftsabfrage den Index auf `source_id` beziehungsweise `target_id`
 verwenden; ein Primärschlüssel-Scan mit nachträglichem Filter gilt als Fehler.
 
@@ -197,7 +208,8 @@ python3 -B scripts/performance/domain_scale.py render-workload \
 ```
 
 Die beiden SQL-Dateien werden anschließend mit `psql` gegen eine ausdrücklich
-bestimmte Benchmark-Datenbank ausgeführt. Der GitHub-Workflow lädt dafür das
+bestimmte Benchmark-Datenbank ausgeführt. Der Ausführungspfad muss dabei die oben
+beschriebene kontrollierte Pfadform erfüllen. Der GitHub-Workflow lädt dafür das
 Profil `ci` mit 20.000 Knoten und 100.000 Fäden in ein echtes PostgreSQL 16,
 führt alle sechs Abfragen aus und archiviert die JSON-Pläne als CI-Beleg.
 Danach prüft der folgende Befehl die JSON-Abfragepläne:

--- a/docs/blueprints/domain-scale-foundation.md
+++ b/docs/blueprints/domain-scale-foundation.md
@@ -1,0 +1,206 @@
+---
+id: docs.blueprints.domain-scale-foundation
+title: Domain Scale Foundation
+doc_type: blueprint
+status: active
+canonicality: planning
+summary: Reproduzierbarer PostgreSQL-Prüfstand für große Weltgewebe-Graphen und belegbare Abfragebudgets.
+owner: architecture
+organ: architecture
+role: plan
+lifecycle_state: active
+relations:
+  - type: relates_to
+    target: docs/blueprints/domain-data-postgres-cutover.md
+  - type: relates_to
+    target: docs/datenmodell.md
+verifies_with:
+  - scripts/tests/test_domain_scale.py
+depends_on:
+  - apps/api/migrations/20260531000001_create_domain_nodes.up.sql
+  - apps/api/migrations/20260531000002_create_domain_edges.up.sql
+---
+
+# Domain Scale Foundation
+
+## Zweck
+
+Weltgewebe soll perspektivisch einen großen Graphen mit vielen gleichzeitigen
+Lese- und Schreibvorgängen tragen. Vor Änderungen am Laufzeit-Datenpfad braucht
+das Projekt deshalb einen reproduzierbaren Prüfstand.
+
+Der Prüfstand beantwortet drei Fragen:
+
+1. Wie verhalten sich die aktuellen PostgreSQL-Tabellen bei großen Datenmengen?
+2. Welche Abfragen verwenden Indizes und welche fallen auf vollständige
+   Tabellendurchläufe zurück?
+3. Verbessert eine spätere Änderung den belegten Zustand oder verschiebt sie
+   nur Kosten an eine andere Stelle?
+
+## Begriffe
+
+**Lastprofil** bezeichnet eine festgelegte Datenmenge. Das kleinste Profil
+prüft den Mechanismus schnell in CI. Die größeren Profile sind für einen
+leistungsfähigen Testrechner oder eine produktionsnahe Datenbank bestimmt.
+
+**Abfrageplan** ist PostgreSQLs Ausführungsweg für eine SQL-Abfrage. Ein
+`Index Scan` entspricht grob dem Nachschlagen in einem Register. Ein
+`Seq Scan` liest dagegen eine Tabelle vollständig. Ein vollständiger Durchlauf
+ist bei kleinen Tabellen oft korrekt, kann bei Millionen Datensätzen aber zum
+Engpass werden.
+
+**Kalibrierung** bedeutet, Zeitgrenzen erst auf einer festgelegten Hardware und
+mit wiederholten Messungen zu bestimmen. Dieser erste Schnitt erfindet deshalb
+keine allgemeingültigen Millisekunden-Budgets.
+
+## Profile
+
+| Profil | Knoten | Fäden | Zweck |
+|---|---:|---:|---|
+| `smoke` | 1.000 | 5.000 | schneller Funktionsnachweis |
+| `ci` | 20.000 | 100.000 | regelmäßiger Integrationslauf |
+| `scale_100k` | 100.000 | 500.000 | mittlere Lastmessung |
+| `scale_1m` | 1.000.000 | 5.000.000 | produktionsnahe Skalierungsprüfung |
+
+Die Werte liegen in
+`configs/performance/domain-scale.v1.json`. Änderungen an Profilen oder
+Budgets sind damit überprüfbare Vertragsänderungen und keine versteckten
+Skriptparameter.
+
+## Sicherheitsgrenze
+
+Der Loader arbeitet ausschließlich im fest reservierten Schema
+`weltgewebe_perf`. Andere Namen – auch weitere scheinbare Testschemas – werden
+abgewiesen. Dadurch können weder `public` noch PostgreSQL-Systemschemas als
+Löschziel eingeschleust werden.
+
+Er darf:
+
+- dieses Benchmark-Schema verwerfen und neu anlegen,
+- die Strukturen der öffentlichen Domänentabellen mit `LIKE ... INCLUDING ALL`
+  übernehmen,
+- generierte CSV-Dateien dort laden,
+- Statistiken mit `ANALYZE` aktualisieren.
+
+Schema-Neuanlage, beide CSV-Importe, Statistikaufbau und Zeilenzählung liegen
+in einer Transaktion. Schlägt ein Schritt fehl, stellt PostgreSQL den vorherigen
+Benchmark-Zustand wieder her, statt ein halbfertiges Schema zurückzulassen.
+
+Er darf nicht:
+
+- `public.domain_nodes` oder `public.domain_edges` leeren,
+- Produktionsdaten überschreiben,
+- das Schema `public` verwerfen,
+- den Testdatensatz ohne Hashprüfung verwenden.
+
+Die Unit-Tests prüfen diese Grenze statisch. PostgreSQL-Berechtigungen bleiben
+die zweite Schutzschicht: Ein Benchmark-Benutzer sollte keine Rechte zum
+Verwerfen produktiver Tabellen besitzen.
+
+## Determinismus
+
+Jeder Knoten und jeder Faden wird aus folgenden Eingaben abgeleitet:
+
+- festem Seed,
+- Profilname,
+- Datensatznummer,
+- Feldrolle.
+
+Die Ableitung erfolgt über SHA-256. Dadurch sind Reihenfolge, Koordinaten,
+Knotenarten und Beziehungen wiederholbar. Die ersten Fäden bilden zusätzlich
+einen geschlossenen Ring über alle Knoten. Somit besitzt jeder Knoten garantiert
+mindestens eine eingehende und eine ausgehende Verbindung; Nachbarschaftsmessungen
+laufen nicht versehentlich gegen einen leeren Fall. Das Manifest enthält
+SHA-256-Werte für beide CSV-Dateien. Eine nachträgliche Veränderung wird vor dem
+Rendern der SQL-Dateien abgewiesen.
+
+## Gemessene Abfragen
+
+Der erste Kanon umfasst:
+
+- Knoten-Cursor,
+- Faden-Cursor,
+- geografischen Ausschnitt,
+- ausgehende Nachbarschaft,
+- eingehende Nachbarschaft,
+- Filter nach Knotenart.
+
+Jede Abfrage wird mit
+`EXPLAIN (ANALYZE, BUFFERS, WAL, FORMAT JSON)` ausgeführt. PostgreSQL liefert
+damit neben dem gewählten Weg auch Pufferzugriffe, temporäre Blöcke,
+Schreibaufwand und Zeitwerte in maschinenlesbarer Form.
+
+## Erste Budgets
+
+Der Prüfer blockiert zunächst nur eindeutig schädliche Planformen:
+
+- kein `Seq Scan` für die kanonischen großen Listen- und Suchabfragen,
+- kein zusätzlicher `Sort` für die ID-Cursor,
+- keine temporären Blöcke.
+
+Die harten Planbudgets gelten nur für `scale_100k` und `scale_1m`. Bei den
+kleinen Profilen darf PostgreSQL einen vollständigen Tabellendurchlauf wählen,
+falls dieser tatsächlich günstiger ist; dort werden die Pläne nur beobachtet.
+
+Zeitgrenzen bleiben ausdrücklich unkalibriert. Eine allgemeine Grenze ohne
+festgelegte Hardware, PostgreSQL-Konfiguration, Warm-up und Wiederholungszahl
+wäre Scheingenauigkeit.
+
+## Ausführung
+
+Konfiguration prüfen:
+
+```bash
+python3 -B scripts/performance/domain_scale.py validate
+```
+
+Deterministische Daten erzeugen:
+
+```bash
+python3 -B scripts/performance/domain_scale.py generate \
+  --profile smoke \
+  --output-dir /tmp/weltgewebe-domain-scale
+```
+
+SQL zum sicheren Laden rendern:
+
+```bash
+python3 -B scripts/performance/domain_scale.py render-load \
+  --manifest /tmp/weltgewebe-domain-scale/manifest.json \
+  --output /tmp/weltgewebe-domain-scale/load.sql
+```
+
+Messabfragen rendern:
+
+```bash
+python3 -B scripts/performance/domain_scale.py render-workload \
+  --manifest /tmp/weltgewebe-domain-scale/manifest.json \
+  --plan-dir /tmp/weltgewebe-domain-scale/plans \
+  --output /tmp/weltgewebe-domain-scale/workload.sql
+```
+
+Die beiden SQL-Dateien werden anschließend mit `psql` gegen eine ausdrücklich
+bestimmte Benchmark-Datenbank ausgeführt. Danach prüft der folgende Befehl die
+JSON-Abfragepläne:
+
+```bash
+python3 -B scripts/performance/domain_scale.py check \
+  --manifest /tmp/weltgewebe-domain-scale/manifest.json \
+  --plan-dir /tmp/weltgewebe-domain-scale/plans \
+  --report /tmp/weltgewebe-domain-scale/report.json
+```
+
+## Folgeschnitte
+
+Dieser Prüfstand verändert den API-Datenpfad noch nicht. Die nächsten
+Laufzeitschritte müssen auf seinen Messungen aufbauen:
+
+1. vollständiges Vorladen aller Knoten entfernen,
+2. Kartenabfragen räumlich und begrenzt aus PostgreSQL lesen,
+3. Listen per Cursor paginieren,
+4. Nachbarschaften begrenzt laden,
+5. Speicher-, Verbindungs- und Überlastbudgets messen,
+6. erst danach PostGIS oder zusätzliche Indizes einführen.
+
+Die Trennung verhindert, dass eine vermeintliche Optimierung gleichzeitig
+Messgrundlage und untersuchten Datenpfad verändert.

--- a/docs/blueprints/domain-scale-foundation.md
+++ b/docs/blueprints/domain-scale-foundation.md
@@ -14,6 +14,8 @@ relations:
     target: docs/blueprints/domain-data-postgres-cutover.md
   - type: relates_to
     target: docs/datenmodell.md
+  - type: relates_to
+    target: docs/roadmap.md
 verifies_with:
   - scripts/tests/test_domain_scale.py
 depends_on:

--- a/scripts/performance/__init__.py
+++ b/scripts/performance/__init__.py
@@ -1,0 +1,1 @@
+"""Performance tooling for production-shaped Weltgewebe load tests."""

--- a/scripts/performance/domain_scale.py
+++ b/scripts/performance/domain_scale.py
@@ -22,6 +22,9 @@ DEFAULT_CONFIG = Path("configs/performance/domain-scale.v1.json")
 BENCHMARK_SCHEMA = "weltgewebe_perf"
 SCHEMA_RE = re.compile(r"^[a-z_][a-z0-9_]*$")
 NODE_KINDS = ("Ort", "Projekt", "Person", "Ressource", "Gespraech")
+RARE_NODE_KIND = "Projekt"
+COMMON_NODE_KINDS = tuple(kind for kind in NODE_KINDS if kind != RARE_NODE_KIND)
+RARE_NODE_KIND_INTERVAL = 100
 EDGE_KINDS = ("bezieht_sich_auf", "wirkt_mit", "liegt_bei", "teilt", "antwortet_auf")
 WORKLOAD_ORDER = (
     "node_cursor",
@@ -31,6 +34,9 @@ WORKLOAD_ORDER = (
     "inbound_neighbors",
     "kind_filter",
 )
+NODE_HEADER = ("id", "kind", "title", "lat", "lon", "created_at", "updated_at", "payload")
+EDGE_HEADER = ("id", "source_id", "target_id", "edge_kind", "created_at", "payload")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 
 
 class DomainScaleError(RuntimeError):
@@ -49,6 +55,28 @@ def sha256_file(path: Path) -> str:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def _csv_data_row_count(path: Path, expected_header: Sequence[str]) -> int:
+    try:
+        with path.open(encoding="utf-8", newline="") as handle:
+            reader = csv.reader(handle)
+            try:
+                header = next(reader)
+            except StopIteration as exc:
+                raise DomainScaleError(f"fixture CSV is empty: {path}") from exc
+            if tuple(header) != tuple(expected_header):
+                raise DomainScaleError(f"fixture CSV header mismatch: {path}")
+            count = 0
+            for row_number, row in enumerate(reader, start=2):
+                if len(row) != len(expected_header):
+                    raise DomainScaleError(
+                        f"fixture CSV row {row_number} has {len(row)} columns, expected {len(expected_header)}: {path}"
+                    )
+                count += 1
+            return count
+    except OSError as exc:
+        raise DomainScaleError(f"cannot read fixture CSV {path}: {exc}") from exc
 
 
 def load_config(path: Path) -> dict[str, Any]:
@@ -116,13 +144,30 @@ def validate_config(config: Mapping[str, Any]) -> None:
     if not isinstance(workloads, dict) or tuple(workloads) != WORKLOAD_ORDER:
         raise DomainScaleError("workloads must list the canonical workload set in canonical order")
     for name, rules in workloads.items():
-        if not isinstance(rules, dict) or set(rules) != {"forbidden_node_types"}:
-            raise DomainScaleError(f"workload {name} must define forbidden_node_types")
+        expected_rule_keys = {
+            "forbidden_node_types",
+            "required_index",
+            "required_index_cond_contains",
+        }
+        if not isinstance(rules, dict) or set(rules) != expected_rule_keys:
+            raise DomainScaleError(
+                f"workload {name} must define forbidden_node_types, required_index and required_index_cond_contains"
+            )
         node_types = rules["forbidden_node_types"]
         if not isinstance(node_types, list) or not node_types:
             raise DomainScaleError(f"workload {name} forbidden_node_types must be non-empty")
         if any(not isinstance(item, str) or not item for item in node_types):
             raise DomainScaleError(f"workload {name} contains an invalid node type")
+        required_index = rules["required_index"]
+        if not isinstance(required_index, str) or not SCHEMA_RE.fullmatch(required_index):
+            raise DomainScaleError(f"workload {name} required_index must be a safe index name")
+        condition_tokens = rules["required_index_cond_contains"]
+        if not isinstance(condition_tokens, list) or not condition_tokens:
+            raise DomainScaleError(
+                f"workload {name} required_index_cond_contains must be a non-empty list"
+            )
+        if any(not isinstance(item, str) or not item for item in condition_tokens):
+            raise DomainScaleError(f"workload {name} contains an invalid index-condition token")
 
 
 def _digest(seed: str, *parts: object) -> bytes:
@@ -156,7 +201,11 @@ def _timestamp(index: int) -> str:
 
 def _node_rows(seed: str, profile_name: str, count: int) -> Iterable[list[str]]:
     for index in range(count):
-        kind = _choice(seed, NODE_KINDS, profile_name, "node-kind", index)
+        kind = (
+            RARE_NODE_KIND
+            if index % RARE_NODE_KIND_INTERVAL == 0
+            else _choice(seed, COMMON_NODE_KINDS, profile_name, "node-kind", index)
+        )
         lat = -85.0 + 170.0 * _unit_float(seed, profile_name, "lat", index)
         lon = -180.0 + 360.0 * _unit_float(seed, profile_name, "lon", index)
         created_at = _timestamp(index)
@@ -254,12 +303,12 @@ def generate_fixture(config_path: Path, profile_name: str, output_dir: Path) -> 
 
     _atomic_csv(
         nodes_path,
-        ("id", "kind", "title", "lat", "lon", "created_at", "updated_at", "payload"),
+        NODE_HEADER,
         _node_rows(config["seed"], profile_name, profile["nodes"]),
     )
     _atomic_csv(
         edges_path,
-        ("id", "source_id", "target_id", "edge_kind", "created_at", "payload"),
+        EDGE_HEADER,
         _edge_rows(config["seed"], profile_name, profile["edges"], profile["nodes"]),
     )
 
@@ -284,8 +333,24 @@ def load_manifest(path: Path) -> dict[str, Any]:
         manifest = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         raise DomainScaleError(f"cannot read fixture manifest {path}: {exc}") from exc
-    if not isinstance(manifest, dict) or manifest.get("schema_version") != 1:
+    expected_keys = {
+        "schema_version",
+        "generator",
+        "config_sha256",
+        "database_schema",
+        "profile",
+        "counts",
+        "files",
+    }
+    if not isinstance(manifest, dict) or set(manifest) != expected_keys:
+        raise DomainScaleError("fixture manifest must contain the canonical schema_version 1 fields")
+    if manifest.get("schema_version") != 1:
         raise DomainScaleError("fixture manifest must use schema_version 1")
+    if manifest.get("generator") != "scripts/performance/domain_scale.py":
+        raise DomainScaleError("fixture manifest contains an unknown generator")
+    config_sha256 = manifest.get("config_sha256")
+    if not isinstance(config_sha256, str) or not SHA256_RE.fullmatch(config_sha256):
+        raise DomainScaleError("fixture manifest contains an invalid config_sha256")
     schema = manifest.get("database_schema")
     if (
         not isinstance(schema, str)
@@ -293,35 +358,77 @@ def load_manifest(path: Path) -> dict[str, Any]:
         or schema != BENCHMARK_SCHEMA
     ):
         raise DomainScaleError("fixture manifest must use the reserved benchmark schema")
+    profile = manifest.get("profile")
+    if not isinstance(profile, str) or not SCHEMA_RE.fullmatch(profile):
+        raise DomainScaleError("fixture manifest contains an invalid profile")
     counts = manifest.get("counts")
-    if not isinstance(counts, dict) or any(
-        not isinstance(counts.get(key), int) or counts[key] <= 0 for key in ("nodes", "edges")
-    ):
+    if not isinstance(counts, dict) or set(counts) != {"nodes", "edges"}:
         raise DomainScaleError("fixture manifest contains invalid counts")
-    files = manifest.get("files")
-    if not isinstance(files, dict):
-        raise DomainScaleError("fixture manifest contains no files")
     for key in ("nodes", "edges"):
+        value = counts.get(key)
+        if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+            raise DomainScaleError("fixture manifest contains invalid counts")
+    files = manifest.get("files")
+    if not isinstance(files, dict) or set(files) != {"nodes", "edges"}:
+        raise DomainScaleError("fixture manifest contains invalid files")
+    expected_files = {
+        "nodes": (NODE_HEADER, counts["nodes"]),
+        "edges": (EDGE_HEADER, counts["edges"]),
+    }
+    for key, (header, expected_count) in expected_files.items():
         entry = files.get(key)
         if not isinstance(entry, dict) or set(entry) != {"name", "sha256"}:
             raise DomainScaleError(f"fixture manifest contains an invalid {key} file entry")
         name = entry["name"]
+        digest = entry["sha256"]
         if not isinstance(name, str) or Path(name).name != name:
             raise DomainScaleError(f"fixture manifest {key} filename must be local")
+        if not isinstance(digest, str) or not SHA256_RE.fullmatch(digest):
+            raise DomainScaleError(f"fixture manifest {key} sha256 is invalid")
         file_path = path.parent / name
         if not file_path.is_file():
             raise DomainScaleError(f"fixture file is missing: {file_path}")
-        if sha256_file(file_path) != entry["sha256"]:
+        if sha256_file(file_path) != digest:
             raise DomainScaleError(f"fixture file hash mismatch: {file_path}")
+        actual_count = _csv_data_row_count(file_path, header)
+        if actual_count != expected_count:
+            raise DomainScaleError(
+                f"fixture CSV row count mismatch for {key}: manifest={expected_count}, actual={actual_count}"
+            )
     return manifest
+
+
+def bind_manifest_to_config(
+    manifest: Mapping[str, Any], config: Mapping[str, Any], config_sha256: str
+) -> None:
+    validate_config(config)
+    if manifest.get("config_sha256") != config_sha256:
+        raise DomainScaleError("fixture manifest was generated from another scale config")
+    profile_name = manifest.get("profile")
+    if profile_name not in config["profiles"]:
+        raise DomainScaleError(f"fixture manifest references unknown profile {profile_name!r}")
+    expected_counts = config["profiles"][profile_name]
+    if manifest.get("counts") != expected_counts:
+        raise DomainScaleError(
+            f"fixture manifest counts do not match configured profile {profile_name!r}"
+        )
+
+
+def load_bound_manifest(path: Path, config_path: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+    config = load_config(config_path)
+    manifest = load_manifest(path)
+    bind_manifest_to_config(manifest, config, sha256_file(config_path))
+    return config, manifest
 
 
 def _sql_literal(value: str) -> str:
     return "'" + value.replace("'", "''") + "'"
 
 
-def render_load_sql(manifest_path: Path, output_path: Path) -> None:
-    manifest = load_manifest(manifest_path)
+def render_load_sql(
+    manifest_path: Path, output_path: Path, config_path: Path = DEFAULT_CONFIG
+) -> None:
+    _, manifest = load_bound_manifest(manifest_path, config_path)
     schema = manifest["database_schema"]
     nodes_path = (manifest_path.parent / manifest["files"]["nodes"]["name"]).resolve()
     edges_path = (manifest_path.parent / manifest["files"]["edges"]["name"]).resolve()
@@ -357,8 +464,13 @@ def _explain_block(name: str, plan_dir: Path, query: str) -> str:
     )
 
 
-def render_workload_sql(manifest_path: Path, plan_dir: Path, output_path: Path) -> None:
-    manifest = load_manifest(manifest_path)
+def render_workload_sql(
+    manifest_path: Path,
+    plan_dir: Path,
+    output_path: Path,
+    config_path: Path = DEFAULT_CONFIG,
+) -> None:
+    _, manifest = load_bound_manifest(manifest_path, config_path)
     schema = manifest["database_schema"]
     node_count = manifest["counts"]["nodes"]
     edge_count = manifest["counts"]["edges"]
@@ -380,22 +492,22 @@ def render_workload_sql(manifest_path: Path, plan_dir: Path, output_path: Path) 
         _explain_block(
             "bbox",
             plan_dir,
-            f"SELECT id, kind, title, lat, lon FROM {schema}.domain_nodes WHERE lat BETWEEN -10.0 AND 10.0 AND lon BETWEEN -10.0 AND 10.0 ORDER BY id ASC LIMIT 5000",
+            f"SELECT id, kind, title, lat, lon FROM {schema}.domain_nodes WHERE lat BETWEEN -10.0 AND 10.0 AND lon BETWEEN -10.0 AND 10.0 LIMIT 5000",
         ),
         _explain_block(
             "outbound_neighbors",
             plan_dir,
-            f"SELECT id, source_id, target_id, edge_kind FROM {schema}.domain_edges WHERE source_id = {_sql_literal(neighbor_node)} ORDER BY id ASC LIMIT 5000",
+            f"SELECT id, source_id, target_id, edge_kind FROM {schema}.domain_edges WHERE source_id = {_sql_literal(neighbor_node)} LIMIT 5000",
         ),
         _explain_block(
             "inbound_neighbors",
             plan_dir,
-            f"SELECT id, source_id, target_id, edge_kind FROM {schema}.domain_edges WHERE target_id = {_sql_literal(neighbor_node)} ORDER BY id ASC LIMIT 5000",
+            f"SELECT id, source_id, target_id, edge_kind FROM {schema}.domain_edges WHERE target_id = {_sql_literal(neighbor_node)} LIMIT 5000",
         ),
         _explain_block(
             "kind_filter",
             plan_dir,
-            f"SELECT id, kind, title FROM {schema}.domain_nodes WHERE kind = 'Projekt' ORDER BY id ASC LIMIT 5000",
+            f"SELECT id, kind, title FROM {schema}.domain_nodes WHERE kind = 'Projekt' LIMIT 500",
         ),
     ]
     sql = "\\set ON_ERROR_STOP on\n\\pset format unaligned\n\\pset tuples_only on\n" + "\n".join(blocks)
@@ -403,17 +515,54 @@ def render_workload_sql(manifest_path: Path, plan_dir: Path, output_path: Path) 
     output_path.write_text(sql, encoding="utf-8", newline="\n")
 
 
-def _plan_node_types(plan: Mapping[str, Any]) -> list[str]:
-    result: list[str] = []
-    node_type = plan.get("Node Type")
-    if isinstance(node_type, str):
-        result.append(node_type)
+def _plan_nodes(plan: Mapping[str, Any]) -> Iterable[Mapping[str, Any]]:
+    yield plan
     children = plan.get("Plans", [])
     if isinstance(children, list):
         for child in children:
             if isinstance(child, dict):
-                result.extend(_plan_node_types(child))
-    return result
+                yield from _plan_nodes(child)
+
+
+def _plan_node_types(plan: Mapping[str, Any]) -> list[str]:
+    return [
+        node_type
+        for node in _plan_nodes(plan)
+        if isinstance((node_type := node.get("Node Type")), str)
+    ]
+
+
+def _index_evidence(
+    plan: Mapping[str, Any], required_index: str, condition_tokens: Sequence[str]
+) -> list[dict[str, str]]:
+    evidence: list[dict[str, str]] = []
+    for node in _plan_nodes(plan):
+        if node.get("Index Name") != required_index:
+            continue
+        condition = node.get("Index Cond")
+        if not isinstance(condition, str) or not condition.strip():
+            continue
+        lowered = condition.lower()
+        if not all(token.lower() in lowered for token in condition_tokens):
+            continue
+        evidence.append(
+            {
+                "node_type": str(node.get("Node Type", "")),
+                "index_name": required_index,
+                "index_cond": condition,
+            }
+        )
+    return evidence
+
+
+def _temp_blocks(plan: Mapping[str, Any]) -> int:
+    total = 0
+    for node in _plan_nodes(plan):
+        for key in ("Temp Read Blocks", "Temp Written Blocks"):
+            value = node.get(key, 0)
+            if isinstance(value, int) and not isinstance(value, bool):
+                total += value
+    return total
 
 
 def _read_explain(path: Path) -> dict[str, Any]:
@@ -444,13 +593,22 @@ def check_plans(
         path = plan_dir / f"{workload}.json"
         document = _read_explain(path)
         plan = document["Plan"]
+        rules = budgets["workloads"][workload]
         node_types = _plan_node_types(plan)
-        forbidden = budgets["workloads"][workload]["forbidden_node_types"]
+        forbidden = rules["forbidden_node_types"]
         present_forbidden = sorted(set(node_types).intersection(forbidden))
-        temp_blocks = int(plan.get("Temp Read Blocks", 0)) + int(plan.get("Temp Written Blocks", 0))
+        required_index = rules["required_index"]
+        index_evidence = _index_evidence(
+            plan, required_index, rules["required_index_cond_contains"]
+        )
+        temp_blocks = _temp_blocks(plan)
         if budget_enforced and present_forbidden:
             failures.append(
                 f"{workload}: forbidden PostgreSQL plan nodes: {', '.join(present_forbidden)}"
+            )
+        if budget_enforced and not index_evidence:
+            failures.append(
+                f"{workload}: required index {required_index} with a matching Index Cond was not executed"
             )
         if budget_enforced and temp_blocks > max_temp_blocks:
             failures.append(
@@ -458,11 +616,13 @@ def check_plans(
             )
         results[workload] = {
             "node_types": node_types,
+            "required_index": required_index,
+            "required_index_evidence": index_evidence,
             "temp_blocks": temp_blocks,
             "planning_time_ms": document.get("Planning Time"),
             "execution_time_ms": document.get("Execution Time"),
         }
-    report = {
+    return {
         "schema_version": 1,
         "status": "fail" if failures else "pass",
         "profile": profile_name,
@@ -471,9 +631,6 @@ def check_plans(
         "failures": failures,
         "workloads": results,
     }
-    if failures:
-        raise DomainScaleError("; ".join(failures))
-    return report
 
 
 def _write_report(path: Path | None, report: Mapping[str, Any]) -> None:
@@ -520,17 +677,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             manifest = generate_fixture(args.config, args.profile, args.output_dir)
             _write_report(None, manifest)
         elif args.command == "render-load":
-            render_load_sql(args.manifest, args.output)
+            render_load_sql(args.manifest, args.output, args.config)
             _write_report(None, {"schema_version": 1, "status": "pass", "output": str(args.output)})
         elif args.command == "render-workload":
-            render_workload_sql(args.manifest, args.plan_dir, args.output)
+            render_workload_sql(args.manifest, args.plan_dir, args.output, args.config)
             _write_report(None, {"schema_version": 1, "status": "pass", "output": str(args.output)})
         elif args.command == "check":
             manifest = load_manifest(args.manifest)
-            if manifest["config_sha256"] != sha256_file(args.config):
-                raise DomainScaleError("fixture manifest was generated from another scale config")
+            bind_manifest_to_config(manifest, config, sha256_file(args.config))
             report = check_plans(config, args.plan_dir, manifest["profile"])
             _write_report(args.report, report)
+            if report["status"] != "pass":
+                print("domain-scale: " + "; ".join(report["failures"]), file=sys.stderr)
+                return 2
         else:
             parser.error(f"unsupported command {args.command}")
     except DomainScaleError as exc:

--- a/scripts/performance/domain_scale.py
+++ b/scripts/performance/domain_scale.py
@@ -21,6 +21,7 @@ from typing import Any, Iterable, Mapping, Sequence
 DEFAULT_CONFIG = Path("configs/performance/domain-scale.v1.json")
 BENCHMARK_SCHEMA = "weltgewebe_perf"
 SCHEMA_RE = re.compile(r"^[a-z_][a-z0-9_]*$")
+PSQL_SAFE_PATH_RE = re.compile(r"^/[A-Za-z0-9_./-]+$")
 NODE_KINDS = ("Ort", "Projekt", "Person", "Ressource", "Gespraech")
 RARE_NODE_KIND = "Projekt"
 COMMON_NODE_KINDS = tuple(kind for kind in NODE_KINDS if kind != RARE_NODE_KIND)
@@ -147,11 +148,11 @@ def validate_config(config: Mapping[str, Any]) -> None:
         expected_rule_keys = {
             "forbidden_node_types",
             "required_index",
-            "required_index_cond_contains",
+            "required_index_cond_identifiers",
         }
         if not isinstance(rules, dict) or set(rules) != expected_rule_keys:
             raise DomainScaleError(
-                f"workload {name} must define forbidden_node_types, required_index and required_index_cond_contains"
+                f"workload {name} must define forbidden_node_types, required_index and required_index_cond_identifiers"
             )
         node_types = rules["forbidden_node_types"]
         if not isinstance(node_types, list) or not node_types:
@@ -161,10 +162,10 @@ def validate_config(config: Mapping[str, Any]) -> None:
         required_index = rules["required_index"]
         if not isinstance(required_index, str) or not SCHEMA_RE.fullmatch(required_index):
             raise DomainScaleError(f"workload {name} required_index must be a safe index name")
-        condition_tokens = rules["required_index_cond_contains"]
+        condition_tokens = rules["required_index_cond_identifiers"]
         if not isinstance(condition_tokens, list) or not condition_tokens:
             raise DomainScaleError(
-                f"workload {name} required_index_cond_contains must be a non-empty list"
+                f"workload {name} required_index_cond_identifiers must be a non-empty list"
             )
         if any(not isinstance(item, str) or not item for item in condition_tokens):
             raise DomainScaleError(f"workload {name} contains an invalid index-condition token")
@@ -425,6 +426,15 @@ def _sql_literal(value: str) -> str:
     return "'" + value.replace("'", "''") + "'"
 
 
+def _psql_meta_path_literal(path: Path) -> str:
+    value = str(path.resolve())
+    if not PSQL_SAFE_PATH_RE.fullmatch(value):
+        raise DomainScaleError(
+            "psql file paths must be absolute and contain only ASCII letters, digits, '/', '.', '_' or '-'"
+        )
+    return _sql_literal(value)
+
+
 def render_load_sql(
     manifest_path: Path, output_path: Path, config_path: Path = DEFAULT_CONFIG
 ) -> None:
@@ -439,8 +449,8 @@ CREATE SCHEMA {schema};
 CREATE TABLE {schema}.domain_nodes (LIKE public.domain_nodes INCLUDING ALL);
 CREATE TABLE {schema}.domain_edges (LIKE public.domain_edges INCLUDING ALL);
 
-\\copy {schema}.domain_nodes (id, kind, title, lat, lon, created_at, updated_at, payload) FROM {_sql_literal(str(nodes_path))} WITH (FORMAT csv, HEADER true)
-\\copy {schema}.domain_edges (id, source_id, target_id, edge_kind, created_at, payload) FROM {_sql_literal(str(edges_path))} WITH (FORMAT csv, HEADER true)
+\\copy {schema}.domain_nodes (id, kind, title, lat, lon, created_at, updated_at, payload) FROM {_psql_meta_path_literal(nodes_path)} WITH (FORMAT csv, HEADER true)
+\\copy {schema}.domain_edges (id, source_id, target_id, edge_kind, created_at, payload) FROM {_psql_meta_path_literal(edges_path)} WITH (FORMAT csv, HEADER true)
 
 ANALYZE {schema}.domain_nodes;
 ANALYZE {schema}.domain_edges;
@@ -458,7 +468,7 @@ COMMIT;
 def _explain_block(name: str, plan_dir: Path, query: str) -> str:
     plan_path = (plan_dir / f"{name}.json").resolve()
     return (
-        f"\\o {_sql_literal(str(plan_path))}\n"
+        f"\\o {_psql_meta_path_literal(plan_path)}\n"
         f"EXPLAIN (ANALYZE, BUFFERS, WAL, FORMAT JSON) {query};\n"
         "\\o\n"
     )
@@ -532,24 +542,62 @@ def _plan_node_types(plan: Mapping[str, Any]) -> list[str]:
     ]
 
 
+def _sql_condition_identifiers(condition: str) -> set[str]:
+    """Return exact SQL identifiers outside single-quoted string literals."""
+
+    without_literals: list[str] = []
+    index = 0
+    in_literal = False
+    while index < len(condition):
+        char = condition[index]
+        if char == "'":
+            if in_literal and index + 1 < len(condition) and condition[index + 1] == "'":
+                without_literals.extend((" ", " "))
+                index += 2
+                continue
+            in_literal = not in_literal
+            without_literals.append(" ")
+        elif in_literal:
+            without_literals.append(" ")
+        else:
+            without_literals.append(char)
+        index += 1
+    if in_literal:
+        return set()
+    return {
+        match.group(0).lower()
+        for match in re.finditer(r"[A-Za-z_][A-Za-z0-9_]*", "".join(without_literals))
+    }
+
+
 def _index_evidence(
-    plan: Mapping[str, Any], required_index: str, condition_tokens: Sequence[str]
-) -> list[dict[str, str]]:
-    evidence: list[dict[str, str]] = []
+    plan: Mapping[str, Any], required_index: str, condition_identifiers: Sequence[str]
+) -> list[dict[str, Any]]:
+    required_identifiers = {identifier.lower() for identifier in condition_identifiers}
+    evidence: list[dict[str, Any]] = []
     for node in _plan_nodes(plan):
         if node.get("Index Name") != required_index:
             continue
         condition = node.get("Index Cond")
         if not isinstance(condition, str) or not condition.strip():
             continue
-        lowered = condition.lower()
-        if not all(token.lower() in lowered for token in condition_tokens):
+        actual_loops = node.get("Actual Loops")
+        if (
+            not isinstance(actual_loops, (int, float))
+            or isinstance(actual_loops, bool)
+            or actual_loops <= 0
+        ):
+            continue
+        identifiers = _sql_condition_identifiers(condition)
+        if not required_identifiers.issubset(identifiers):
             continue
         evidence.append(
             {
                 "node_type": str(node.get("Node Type", "")),
                 "index_name": required_index,
                 "index_cond": condition,
+                "index_cond_identifiers": sorted(identifiers),
+                "actual_loops": actual_loops,
             }
         )
     return evidence
@@ -599,7 +647,7 @@ def check_plans(
         present_forbidden = sorted(set(node_types).intersection(forbidden))
         required_index = rules["required_index"]
         index_evidence = _index_evidence(
-            plan, required_index, rules["required_index_cond_contains"]
+            plan, required_index, rules["required_index_cond_identifiers"]
         )
         temp_blocks = _temp_blocks(plan)
         if budget_enforced and present_forbidden:

--- a/scripts/performance/domain_scale.py
+++ b/scripts/performance/domain_scale.py
@@ -1,0 +1,543 @@
+#!/usr/bin/env python3
+"""Generate and verify production-shaped Weltgewebe PostgreSQL scale fixtures.
+
+The tool deliberately operates on a dedicated benchmark schema. It never writes
+or truncates the public domain tables.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import sys
+import tempfile
+from typing import Any, Iterable, Mapping, Sequence
+
+DEFAULT_CONFIG = Path("configs/performance/domain-scale.v1.json")
+BENCHMARK_SCHEMA = "weltgewebe_perf"
+SCHEMA_RE = re.compile(r"^[a-z_][a-z0-9_]*$")
+NODE_KINDS = ("Ort", "Projekt", "Person", "Ressource", "Gespraech")
+EDGE_KINDS = ("bezieht_sich_auf", "wirkt_mit", "liegt_bei", "teilt", "antwortet_auf")
+WORKLOAD_ORDER = (
+    "node_cursor",
+    "edge_cursor",
+    "bbox",
+    "outbound_neighbors",
+    "inbound_neighbors",
+    "kind_filter",
+)
+
+
+class DomainScaleError(RuntimeError):
+    """Raised when a scale fixture or query plan violates its contract."""
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return (json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n").encode(
+        "utf-8"
+    )
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_config(path: Path) -> dict[str, Any]:
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise DomainScaleError(f"cannot read scale config {path}: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise DomainScaleError("scale config must be a JSON object")
+    validate_config(parsed)
+    return parsed
+
+
+def validate_config(config: Mapping[str, Any]) -> None:
+    allowed_top = {"schema_version", "seed", "database_schema", "profiles", "plan_budgets"}
+    extra = sorted(set(config) - allowed_top)
+    if extra:
+        raise DomainScaleError(f"unknown scale config keys: {', '.join(extra)}")
+    if config.get("schema_version") != 1:
+        raise DomainScaleError("schema_version must be 1")
+    seed = config.get("seed")
+    if not isinstance(seed, str) or not seed or len(seed) > 128:
+        raise DomainScaleError("seed must be a non-empty string of at most 128 characters")
+    schema = config.get("database_schema")
+    if not isinstance(schema, str) or not SCHEMA_RE.fullmatch(schema):
+        raise DomainScaleError("database_schema must be a safe lowercase PostgreSQL identifier")
+    if schema != BENCHMARK_SCHEMA:
+        raise DomainScaleError(
+            f"database_schema must be the reserved benchmark schema {BENCHMARK_SCHEMA!r}"
+        )
+
+    profiles = config.get("profiles")
+    if not isinstance(profiles, dict) or not profiles:
+        raise DomainScaleError("profiles must be a non-empty object")
+    for name, profile in profiles.items():
+        if not isinstance(name, str) or not SCHEMA_RE.fullmatch(name):
+            raise DomainScaleError(f"invalid profile name: {name!r}")
+        if not isinstance(profile, dict) or set(profile) != {"nodes", "edges"}:
+            raise DomainScaleError(f"profile {name} must contain exactly nodes and edges")
+        for key in ("nodes", "edges"):
+            value = profile[key]
+            if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+                raise DomainScaleError(f"profile {name} {key} must be a positive integer")
+        if profile["nodes"] < 2:
+            raise DomainScaleError(f"profile {name} must contain at least two nodes")
+        if profile["edges"] < profile["nodes"]:
+            raise DomainScaleError(f"profile {name} must contain at least one edge per node")
+
+    budgets = config.get("plan_budgets")
+    if not isinstance(budgets, dict):
+        raise DomainScaleError("plan_budgets must be an object")
+    if budgets.get("calibration_required") is not True:
+        raise DomainScaleError("calibration_required must remain true until hardware baselines exist")
+    enforced_profiles = budgets.get("enforced_profiles")
+    if not isinstance(enforced_profiles, list) or not enforced_profiles:
+        raise DomainScaleError("enforced_profiles must be a non-empty list")
+    if any(not isinstance(name, str) or name not in profiles for name in enforced_profiles):
+        raise DomainScaleError("enforced_profiles must reference known profiles")
+    if len(set(enforced_profiles)) != len(enforced_profiles):
+        raise DomainScaleError("enforced_profiles may not contain duplicates")
+    max_temp_blocks = budgets.get("max_temp_blocks")
+    if not isinstance(max_temp_blocks, int) or isinstance(max_temp_blocks, bool) or max_temp_blocks < 0:
+        raise DomainScaleError("max_temp_blocks must be a non-negative integer")
+    workloads = budgets.get("workloads")
+    if not isinstance(workloads, dict) or tuple(workloads) != WORKLOAD_ORDER:
+        raise DomainScaleError("workloads must list the canonical workload set in canonical order")
+    for name, rules in workloads.items():
+        if not isinstance(rules, dict) or set(rules) != {"forbidden_node_types"}:
+            raise DomainScaleError(f"workload {name} must define forbidden_node_types")
+        node_types = rules["forbidden_node_types"]
+        if not isinstance(node_types, list) or not node_types:
+            raise DomainScaleError(f"workload {name} forbidden_node_types must be non-empty")
+        if any(not isinstance(item, str) or not item for item in node_types):
+            raise DomainScaleError(f"workload {name} contains an invalid node type")
+
+
+def _digest(seed: str, *parts: object) -> bytes:
+    material = "\x1f".join((seed, *(str(part) for part in parts))).encode("utf-8")
+    return hashlib.sha256(material).digest()
+
+
+def _choice(seed: str, values: Sequence[str], *parts: object) -> str:
+    return values[int.from_bytes(_digest(seed, *parts)[:8], "big") % len(values)]
+
+
+def _unit_float(seed: str, *parts: object) -> float:
+    return int.from_bytes(_digest(seed, *parts)[:8], "big") / float(1 << 64)
+
+
+def _node_id(index: int) -> str:
+    return f"node-{index:012d}"
+
+
+def _edge_id(index: int) -> str:
+    return f"edge-{index:012d}"
+
+
+def _timestamp(index: int) -> str:
+    day = 1 + (index % 28)
+    hour = (index // 28) % 24
+    minute = (index // (28 * 24)) % 60
+    second = (index // (28 * 24 * 60)) % 60
+    return f"2026-01-{day:02d}T{hour:02d}:{minute:02d}:{second:02d}Z"
+
+
+def _node_rows(seed: str, profile_name: str, count: int) -> Iterable[list[str]]:
+    for index in range(count):
+        kind = _choice(seed, NODE_KINDS, profile_name, "node-kind", index)
+        lat = -85.0 + 170.0 * _unit_float(seed, profile_name, "lat", index)
+        lon = -180.0 + 360.0 * _unit_float(seed, profile_name, "lon", index)
+        created_at = _timestamp(index)
+        payload = {
+            "scale_fixture": True,
+            "scale_profile": profile_name,
+            "summary": f"Deterministic scale node {index}",
+            "tags": [kind.lower(), f"bucket-{index % 64:02d}"],
+        }
+        yield [
+            _node_id(index),
+            kind,
+            f"Scale node {index}",
+            f"{lat:.8f}",
+            f"{lon:.8f}",
+            created_at,
+            created_at,
+            json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")),
+        ]
+
+
+def _edge_rows(seed: str, profile_name: str, edge_count: int, node_count: int) -> Iterable[list[str]]:
+    for index in range(edge_count):
+        if index < node_count:
+            source_index = index
+            target_index = (index + 1) % node_count
+        else:
+            source_index = int.from_bytes(
+                _digest(seed, profile_name, "edge-source", index)[:8], "big"
+            ) % node_count
+            target_index = int.from_bytes(
+                _digest(seed, profile_name, "edge-target", index)[:8], "big"
+            ) % node_count
+            if target_index == source_index:
+                target_index = (target_index + 1) % node_count
+        edge_kind = _choice(seed, EDGE_KINDS, profile_name, "edge-kind", index)
+        payload = {
+            "scale_fixture": True,
+            "scale_profile": profile_name,
+            "source_type": "Node",
+            "target_type": "Node",
+        }
+        yield [
+            _edge_id(index),
+            _node_id(source_index),
+            _node_id(target_index),
+            edge_kind,
+            _timestamp(index),
+            json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")),
+        ]
+
+
+def _atomic_csv(path: Path, header: Sequence[str], rows: Iterable[Sequence[str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="") as handle:
+            writer = csv.writer(handle, lineterminator="\n")
+            writer.writerow(header)
+            writer.writerows(rows)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
+def _atomic_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(canonical_json_bytes(value))
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
+def generate_fixture(config_path: Path, profile_name: str, output_dir: Path) -> dict[str, Any]:
+    config = load_config(config_path)
+    profiles = config["profiles"]
+    if profile_name not in profiles:
+        raise DomainScaleError(f"unknown profile {profile_name!r}")
+    profile = profiles[profile_name]
+    output_dir.mkdir(parents=True, exist_ok=True)
+    nodes_path = output_dir / "domain_nodes.csv"
+    edges_path = output_dir / "domain_edges.csv"
+    manifest_path = output_dir / "manifest.json"
+
+    _atomic_csv(
+        nodes_path,
+        ("id", "kind", "title", "lat", "lon", "created_at", "updated_at", "payload"),
+        _node_rows(config["seed"], profile_name, profile["nodes"]),
+    )
+    _atomic_csv(
+        edges_path,
+        ("id", "source_id", "target_id", "edge_kind", "created_at", "payload"),
+        _edge_rows(config["seed"], profile_name, profile["edges"], profile["nodes"]),
+    )
+
+    manifest = {
+        "schema_version": 1,
+        "generator": "scripts/performance/domain_scale.py",
+        "config_sha256": sha256_file(config_path),
+        "database_schema": config["database_schema"],
+        "profile": profile_name,
+        "counts": {"nodes": profile["nodes"], "edges": profile["edges"]},
+        "files": {
+            "nodes": {"name": nodes_path.name, "sha256": sha256_file(nodes_path)},
+            "edges": {"name": edges_path.name, "sha256": sha256_file(edges_path)},
+        },
+    }
+    _atomic_json(manifest_path, manifest)
+    return manifest
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    try:
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise DomainScaleError(f"cannot read fixture manifest {path}: {exc}") from exc
+    if not isinstance(manifest, dict) or manifest.get("schema_version") != 1:
+        raise DomainScaleError("fixture manifest must use schema_version 1")
+    schema = manifest.get("database_schema")
+    if (
+        not isinstance(schema, str)
+        or not SCHEMA_RE.fullmatch(schema)
+        or schema != BENCHMARK_SCHEMA
+    ):
+        raise DomainScaleError("fixture manifest must use the reserved benchmark schema")
+    counts = manifest.get("counts")
+    if not isinstance(counts, dict) or any(
+        not isinstance(counts.get(key), int) or counts[key] <= 0 for key in ("nodes", "edges")
+    ):
+        raise DomainScaleError("fixture manifest contains invalid counts")
+    files = manifest.get("files")
+    if not isinstance(files, dict):
+        raise DomainScaleError("fixture manifest contains no files")
+    for key in ("nodes", "edges"):
+        entry = files.get(key)
+        if not isinstance(entry, dict) or set(entry) != {"name", "sha256"}:
+            raise DomainScaleError(f"fixture manifest contains an invalid {key} file entry")
+        name = entry["name"]
+        if not isinstance(name, str) or Path(name).name != name:
+            raise DomainScaleError(f"fixture manifest {key} filename must be local")
+        file_path = path.parent / name
+        if not file_path.is_file():
+            raise DomainScaleError(f"fixture file is missing: {file_path}")
+        if sha256_file(file_path) != entry["sha256"]:
+            raise DomainScaleError(f"fixture file hash mismatch: {file_path}")
+    return manifest
+
+
+def _sql_literal(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def render_load_sql(manifest_path: Path, output_path: Path) -> None:
+    manifest = load_manifest(manifest_path)
+    schema = manifest["database_schema"]
+    nodes_path = (manifest_path.parent / manifest["files"]["nodes"]["name"]).resolve()
+    edges_path = (manifest_path.parent / manifest["files"]["edges"]["name"]).resolve()
+    sql = f"""\\set ON_ERROR_STOP on
+BEGIN;
+DROP SCHEMA IF EXISTS {schema} CASCADE;
+CREATE SCHEMA {schema};
+CREATE TABLE {schema}.domain_nodes (LIKE public.domain_nodes INCLUDING ALL);
+CREATE TABLE {schema}.domain_edges (LIKE public.domain_edges INCLUDING ALL);
+
+\\copy {schema}.domain_nodes (id, kind, title, lat, lon, created_at, updated_at, payload) FROM {_sql_literal(str(nodes_path))} WITH (FORMAT csv, HEADER true)
+\\copy {schema}.domain_edges (id, source_id, target_id, edge_kind, created_at, payload) FROM {_sql_literal(str(edges_path))} WITH (FORMAT csv, HEADER true)
+
+ANALYZE {schema}.domain_nodes;
+ANALYZE {schema}.domain_edges;
+
+SELECT 'nodes' AS relation, count(*) AS rows FROM {schema}.domain_nodes
+UNION ALL
+SELECT 'edges' AS relation, count(*) AS rows FROM {schema}.domain_edges
+ORDER BY relation;
+COMMIT;
+"""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(sql, encoding="utf-8", newline="\n")
+
+
+def _explain_block(name: str, plan_dir: Path, query: str) -> str:
+    plan_path = (plan_dir / f"{name}.json").resolve()
+    return (
+        f"\\o {_sql_literal(str(plan_path))}\n"
+        f"EXPLAIN (ANALYZE, BUFFERS, WAL, FORMAT JSON) {query};\n"
+        "\\o\n"
+    )
+
+
+def render_workload_sql(manifest_path: Path, plan_dir: Path, output_path: Path) -> None:
+    manifest = load_manifest(manifest_path)
+    schema = manifest["database_schema"]
+    node_count = manifest["counts"]["nodes"]
+    edge_count = manifest["counts"]["edges"]
+    middle_node = _node_id(node_count // 2)
+    middle_edge = _edge_id(edge_count // 2)
+    neighbor_node = _node_id(node_count // 3)
+    plan_dir.mkdir(parents=True, exist_ok=True)
+    blocks = [
+        _explain_block(
+            "node_cursor",
+            plan_dir,
+            f"SELECT id, kind, title, lat, lon FROM {schema}.domain_nodes WHERE id > {_sql_literal(middle_node)} ORDER BY id ASC LIMIT 1000",
+        ),
+        _explain_block(
+            "edge_cursor",
+            plan_dir,
+            f"SELECT id, source_id, target_id, edge_kind FROM {schema}.domain_edges WHERE id > {_sql_literal(middle_edge)} ORDER BY id ASC LIMIT 1000",
+        ),
+        _explain_block(
+            "bbox",
+            plan_dir,
+            f"SELECT id, kind, title, lat, lon FROM {schema}.domain_nodes WHERE lat BETWEEN -10.0 AND 10.0 AND lon BETWEEN -10.0 AND 10.0 ORDER BY id ASC LIMIT 5000",
+        ),
+        _explain_block(
+            "outbound_neighbors",
+            plan_dir,
+            f"SELECT id, source_id, target_id, edge_kind FROM {schema}.domain_edges WHERE source_id = {_sql_literal(neighbor_node)} ORDER BY id ASC LIMIT 5000",
+        ),
+        _explain_block(
+            "inbound_neighbors",
+            plan_dir,
+            f"SELECT id, source_id, target_id, edge_kind FROM {schema}.domain_edges WHERE target_id = {_sql_literal(neighbor_node)} ORDER BY id ASC LIMIT 5000",
+        ),
+        _explain_block(
+            "kind_filter",
+            plan_dir,
+            f"SELECT id, kind, title FROM {schema}.domain_nodes WHERE kind = 'Projekt' ORDER BY id ASC LIMIT 5000",
+        ),
+    ]
+    sql = "\\set ON_ERROR_STOP on\n\\pset format unaligned\n\\pset tuples_only on\n" + "\n".join(blocks)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(sql, encoding="utf-8", newline="\n")
+
+
+def _plan_node_types(plan: Mapping[str, Any]) -> list[str]:
+    result: list[str] = []
+    node_type = plan.get("Node Type")
+    if isinstance(node_type, str):
+        result.append(node_type)
+    children = plan.get("Plans", [])
+    if isinstance(children, list):
+        for child in children:
+            if isinstance(child, dict):
+                result.extend(_plan_node_types(child))
+    return result
+
+
+def _read_explain(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise DomainScaleError(f"cannot read PostgreSQL plan {path}: {exc}") from exc
+    if not isinstance(payload, list) or len(payload) != 1 or not isinstance(payload[0], dict):
+        raise DomainScaleError(f"PostgreSQL plan {path} must contain one FORMAT JSON result")
+    document = payload[0]
+    if not isinstance(document.get("Plan"), dict):
+        raise DomainScaleError(f"PostgreSQL plan {path} has no root Plan")
+    return document
+
+
+def check_plans(
+    config: Mapping[str, Any], plan_dir: Path, profile_name: str
+) -> dict[str, Any]:
+    validate_config(config)
+    if profile_name not in config["profiles"]:
+        raise DomainScaleError(f"unknown plan profile {profile_name!r}")
+    budgets = config["plan_budgets"]
+    budget_enforced = profile_name in budgets["enforced_profiles"]
+    max_temp_blocks = budgets["max_temp_blocks"]
+    results: dict[str, Any] = {}
+    failures: list[str] = []
+    for workload in WORKLOAD_ORDER:
+        path = plan_dir / f"{workload}.json"
+        document = _read_explain(path)
+        plan = document["Plan"]
+        node_types = _plan_node_types(plan)
+        forbidden = budgets["workloads"][workload]["forbidden_node_types"]
+        present_forbidden = sorted(set(node_types).intersection(forbidden))
+        temp_blocks = int(plan.get("Temp Read Blocks", 0)) + int(plan.get("Temp Written Blocks", 0))
+        if budget_enforced and present_forbidden:
+            failures.append(
+                f"{workload}: forbidden PostgreSQL plan nodes: {', '.join(present_forbidden)}"
+            )
+        if budget_enforced and temp_blocks > max_temp_blocks:
+            failures.append(
+                f"{workload}: temporary blocks {temp_blocks} exceed budget {max_temp_blocks}"
+            )
+        results[workload] = {
+            "node_types": node_types,
+            "temp_blocks": temp_blocks,
+            "planning_time_ms": document.get("Planning Time"),
+            "execution_time_ms": document.get("Execution Time"),
+        }
+    report = {
+        "schema_version": 1,
+        "status": "fail" if failures else "pass",
+        "profile": profile_name,
+        "budget_enforced": budget_enforced,
+        "calibration_required": budgets["calibration_required"],
+        "failures": failures,
+        "workloads": results,
+    }
+    if failures:
+        raise DomainScaleError("; ".join(failures))
+    return report
+
+
+def _write_report(path: Path | None, report: Mapping[str, Any]) -> None:
+    if path is not None:
+        _atomic_json(path, report)
+    sys.stdout.buffer.write(canonical_json_bytes(report))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("validate", help="validate the scale contract")
+
+    generate = subparsers.add_parser("generate", help="generate deterministic CSV fixtures")
+    generate.add_argument("--profile", required=True)
+    generate.add_argument("--output-dir", type=Path, required=True)
+
+    load_sql = subparsers.add_parser("render-load", help="render isolated PostgreSQL load SQL")
+    load_sql.add_argument("--manifest", type=Path, required=True)
+    load_sql.add_argument("--output", type=Path, required=True)
+
+    workload_sql = subparsers.add_parser("render-workload", help="render EXPLAIN workload SQL")
+    workload_sql.add_argument("--manifest", type=Path, required=True)
+    workload_sql.add_argument("--plan-dir", type=Path, required=True)
+    workload_sql.add_argument("--output", type=Path, required=True)
+
+    check = subparsers.add_parser("check", help="check PostgreSQL FORMAT JSON plans")
+    check.add_argument("--manifest", type=Path, required=True)
+    check.add_argument("--plan-dir", type=Path, required=True)
+    check.add_argument("--report", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        config = load_config(args.config)
+        if args.command == "validate":
+            _write_report(None, {"schema_version": 1, "status": "pass", "config": str(args.config)})
+        elif args.command == "generate":
+            manifest = generate_fixture(args.config, args.profile, args.output_dir)
+            _write_report(None, manifest)
+        elif args.command == "render-load":
+            render_load_sql(args.manifest, args.output)
+            _write_report(None, {"schema_version": 1, "status": "pass", "output": str(args.output)})
+        elif args.command == "render-workload":
+            render_workload_sql(args.manifest, args.plan_dir, args.output)
+            _write_report(None, {"schema_version": 1, "status": "pass", "output": str(args.output)})
+        elif args.command == "check":
+            manifest = load_manifest(args.manifest)
+            if manifest["config_sha256"] != sha256_file(args.config):
+                raise DomainScaleError("fixture manifest was generated from another scale config")
+            report = check_plans(config, args.plan_dir, manifest["profile"])
+            _write_report(args.report, report)
+        else:
+            parser.error(f"unsupported command {args.command}")
+    except DomainScaleError as exc:
+        print(f"domain-scale: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_domain_scale.py
+++ b/scripts/tests/test_domain_scale.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.performance import domain_scale  # noqa: E402
+
+
+CONFIG = ROOT / "configs/performance/domain-scale.v1.json"
+
+
+class DomainScaleTests(unittest.TestCase):
+    def test_config_requires_the_reserved_benchmark_schema(self) -> None:
+        config = domain_scale.load_config(CONFIG)
+        self.assertEqual(config["database_schema"], domain_scale.BENCHMARK_SCHEMA)
+        for schema in ("public", "pg_catalog", "information_schema", "other_benchmark"):
+            with self.subTest(schema=schema):
+                unsafe = dict(config)
+                unsafe["database_schema"] = schema
+                with self.assertRaisesRegex(domain_scale.DomainScaleError, "reserved benchmark schema"):
+                    domain_scale.validate_config(unsafe)
+
+    def test_smoke_fixture_is_deterministic_and_has_exact_counts(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            first = root / "first"
+            second = root / "second"
+            manifest_a = domain_scale.generate_fixture(CONFIG, "smoke", first)
+            manifest_b = domain_scale.generate_fixture(CONFIG, "smoke", second)
+            self.assertEqual(manifest_a, manifest_b)
+            for filename in ("domain_nodes.csv", "domain_edges.csv", "manifest.json"):
+                self.assertEqual((first / filename).read_bytes(), (second / filename).read_bytes())
+
+            with (first / "domain_nodes.csv").open(encoding="utf-8", newline="") as handle:
+                node_rows = list(csv.DictReader(handle))
+            with (first / "domain_edges.csv").open(encoding="utf-8", newline="") as handle:
+                edge_rows = list(csv.DictReader(handle))
+            self.assertEqual(len(node_rows), 1000)
+            self.assertEqual(len(edge_rows), 5000)
+            self.assertTrue(all(row["source_id"] != row["target_id"] for row in edge_rows))
+            node_ids = {row["id"] for row in node_rows}
+            self.assertEqual({row["source_id"] for row in edge_rows}, node_ids)
+            self.assertEqual({row["target_id"] for row in edge_rows}, node_ids)
+
+    def test_load_sql_isolated_to_benchmark_schema(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            fixture = root / "fixture"
+            domain_scale.generate_fixture(CONFIG, "smoke", fixture)
+            output = root / "load.sql"
+            domain_scale.render_load_sql(fixture / "manifest.json", output)
+            sql = output.read_text(encoding="utf-8")
+            self.assertIn("DROP SCHEMA IF EXISTS weltgewebe_perf CASCADE", sql)
+            self.assertIn("LIKE public.domain_nodes INCLUDING ALL", sql)
+            self.assertIn("LIKE public.domain_edges INCLUDING ALL", sql)
+            self.assertNotIn("DROP SCHEMA IF EXISTS public", sql)
+            self.assertNotIn("TRUNCATE", sql.upper())
+            self.assertNotIn("DELETE FROM public", sql)
+            self.assertEqual(sql.count("COMMIT;"), 1)
+            self.assertLess(sql.index("\\copy weltgewebe_perf.domain_edges"), sql.index("COMMIT;"))
+
+    def test_workload_sql_renders_all_format_json_plans(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            fixture = root / "fixture"
+            plans = root / "plans"
+            domain_scale.generate_fixture(CONFIG, "smoke", fixture)
+            output = root / "workload.sql"
+            domain_scale.render_workload_sql(fixture / "manifest.json", plans, output)
+            sql = output.read_text(encoding="utf-8")
+            self.assertEqual(sql.count("EXPLAIN (ANALYZE, BUFFERS, WAL, FORMAT JSON)"), 6)
+            for workload in domain_scale.WORKLOAD_ORDER:
+                self.assertIn(f"{workload}.json", sql)
+
+    def test_plan_checker_accepts_index_plans_and_rejects_seq_scan(self) -> None:
+        config = domain_scale.load_config(CONFIG)
+        good_plan = [
+            {
+                "Plan": {
+                    "Node Type": "Limit",
+                    "Temp Read Blocks": 0,
+                    "Temp Written Blocks": 0,
+                    "Plans": [{"Node Type": "Index Scan", "Relation Name": "domain_nodes"}],
+                },
+                "Planning Time": 0.2,
+                "Execution Time": 1.5,
+            }
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            plan_dir = Path(directory)
+            for workload in domain_scale.WORKLOAD_ORDER:
+                (plan_dir / f"{workload}.json").write_text(
+                    json.dumps(good_plan), encoding="utf-8", newline="\n"
+                )
+            report = domain_scale.check_plans(config, plan_dir, "scale_100k")
+            self.assertEqual(report["status"], "pass")
+            self.assertTrue(report["budget_enforced"])
+            self.assertTrue(report["calibration_required"])
+
+            bad_plan = [
+                {
+                    "Plan": {
+                        "Node Type": "Seq Scan",
+                        "Temp Read Blocks": 0,
+                        "Temp Written Blocks": 0,
+                    },
+                    "Planning Time": 0.1,
+                    "Execution Time": 10.0,
+                }
+            ]
+            (plan_dir / "node_cursor.json").write_text(
+                json.dumps(bad_plan), encoding="utf-8", newline="\n"
+            )
+            with self.assertRaisesRegex(domain_scale.DomainScaleError, "Seq Scan"):
+                domain_scale.check_plans(config, plan_dir, "scale_100k")
+
+            observation = domain_scale.check_plans(config, plan_dir, "smoke")
+            self.assertEqual(observation["status"], "pass")
+            self.assertFalse(observation["budget_enforced"])
+            self.assertIn("Seq Scan", observation["workloads"]["node_cursor"]["node_types"])
+
+    def test_manifest_detects_fixture_tampering(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory) / "fixture"
+            domain_scale.generate_fixture(CONFIG, "smoke", fixture)
+            with (fixture / "domain_nodes.csv").open("a", encoding="utf-8") as handle:
+                handle.write("tampered\n")
+            with self.assertRaisesRegex(domain_scale.DomainScaleError, "hash mismatch"):
+                domain_scale.load_manifest(fixture / "manifest.json")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_domain_scale.py
+++ b/scripts/tests/test_domain_scale.py
@@ -154,6 +154,14 @@ class DomainScaleTests(unittest.TestCase):
             self.assertEqual(failed["status"], "fail")
             self.assertTrue(any("domain_nodes_lat_lon" in item for item in failed["failures"]))
 
+            _write_good_plans(config, plan_dir)
+            wrong_condition = _good_plan(config, "bbox")
+            wrong_condition[0]["Plan"]["Plans"][0]["Index Cond"] = "(id IS NOT NULL)"  # type: ignore[index]
+            _write_json(plan_dir / "bbox.json", wrong_condition)
+            condition_failed = domain_scale.check_plans(config, plan_dir, "ci")
+            self.assertEqual(condition_failed["status"], "fail")
+            self.assertTrue(any("matching Index Cond" in item for item in condition_failed["failures"]))
+
     def test_plan_checker_rejects_seq_scan_and_nested_temp_blocks(self) -> None:
         config = domain_scale.load_config(CONFIG)
         with tempfile.TemporaryDirectory() as directory:

--- a/scripts/tests/test_domain_scale.py
+++ b/scripts/tests/test_domain_scale.py
@@ -27,7 +27,7 @@ def _write_json(path: Path, value: object) -> None:
 def _good_plan(config: dict[str, object], workload: str) -> list[dict[str, object]]:
     rules = config["plan_budgets"]["workloads"][workload]  # type: ignore[index]
     condition = " AND ".join(
-        f"({token} IS NOT NULL)" for token in rules["required_index_cond_contains"]  # type: ignore[index]
+        f"({token} IS NOT NULL)" for token in rules["required_index_cond_identifiers"]  # type: ignore[index]
     )
     return [
         {
@@ -40,6 +40,7 @@ def _good_plan(config: dict[str, object], workload: str) -> list[dict[str, objec
                         "Node Type": "Index Scan",
                         "Index Name": rules["required_index"],  # type: ignore[index]
                         "Index Cond": condition,
+                        "Actual Loops": 1,
                     }
                 ],
             },
@@ -115,6 +116,26 @@ class DomainScaleTests(unittest.TestCase):
             self.assertEqual(sql.count("COMMIT;"), 1)
             self.assertLess(sql.index("\\copy weltgewebe_perf.domain_edges"), sql.index("COMMIT;"))
 
+    def test_psql_meta_paths_reject_parser_metacharacters(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            unsafe_fixture = root / "path with space" / "fixture"
+            domain_scale.generate_fixture(CONFIG, "smoke", unsafe_fixture)
+            with self.assertRaisesRegex(domain_scale.DomainScaleError, "psql file paths"):
+                domain_scale.render_load_sql(
+                    unsafe_fixture / "manifest.json", root / "load.sql", CONFIG
+                )
+
+            safe_fixture = root / "safe-fixture"
+            domain_scale.generate_fixture(CONFIG, "smoke", safe_fixture)
+            with self.assertRaisesRegex(domain_scale.DomainScaleError, "psql file paths"):
+                domain_scale.render_workload_sql(
+                    safe_fixture / "manifest.json",
+                    root / "plans'quoted",
+                    root / "workload.sql",
+                    CONFIG,
+                )
+
     def test_workload_sql_targets_filter_indexes_without_unrelated_ordering(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -148,7 +169,6 @@ class DomainScaleTests(unittest.TestCase):
 
             wrong_index = _good_plan(config, "bbox")
             wrong_index[0]["Plan"]["Plans"][0]["Index Name"] = "domain_nodes_pkey"  # type: ignore[index]
-            wrong_index[0]["Plan"]["Plans"][0]["Index Cond"] = "(id IS NOT NULL)"  # type: ignore[index]
             _write_json(plan_dir / "bbox.json", wrong_index)
             failed = domain_scale.check_plans(config, plan_dir, "ci")
             self.assertEqual(failed["status"], "fail")
@@ -156,11 +176,21 @@ class DomainScaleTests(unittest.TestCase):
 
             _write_good_plans(config, plan_dir)
             wrong_condition = _good_plan(config, "bbox")
-            wrong_condition[0]["Plan"]["Plans"][0]["Index Cond"] = "(id IS NOT NULL)"  # type: ignore[index]
+            wrong_condition[0]["Plan"]["Plans"][0]["Index Cond"] = (
+                "(latitude IS NOT NULL) AND (longitude IS NOT NULL)"
+            )  # type: ignore[index]
             _write_json(plan_dir / "bbox.json", wrong_condition)
             condition_failed = domain_scale.check_plans(config, plan_dir, "ci")
             self.assertEqual(condition_failed["status"], "fail")
             self.assertTrue(any("matching Index Cond" in item for item in condition_failed["failures"]))
+
+            _write_good_plans(config, plan_dir)
+            not_executed = _good_plan(config, "bbox")
+            not_executed[0]["Plan"]["Plans"][0]["Actual Loops"] = 0  # type: ignore[index]
+            _write_json(plan_dir / "bbox.json", not_executed)
+            execution_failed = domain_scale.check_plans(config, plan_dir, "ci")
+            self.assertEqual(execution_failed["status"], "fail")
+            self.assertTrue(any("was not executed" in item for item in execution_failed["failures"]))
 
     def test_plan_checker_rejects_seq_scan_and_nested_temp_blocks(self) -> None:
         config = domain_scale.load_config(CONFIG)

--- a/scripts/tests/test_domain_scale.py
+++ b/scripts/tests/test_domain_scale.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import csv
 import json
 from pathlib import Path
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -16,18 +17,60 @@ from scripts.performance import domain_scale  # noqa: E402
 
 
 CONFIG = ROOT / "configs/performance/domain-scale.v1.json"
+SCRIPT = ROOT / "scripts/performance/domain_scale.py"
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.write_text(json.dumps(value, sort_keys=True) + "\n", encoding="utf-8", newline="\n")
+
+
+def _good_plan(config: dict[str, object], workload: str) -> list[dict[str, object]]:
+    rules = config["plan_budgets"]["workloads"][workload]  # type: ignore[index]
+    condition = " AND ".join(
+        f"({token} IS NOT NULL)" for token in rules["required_index_cond_contains"]  # type: ignore[index]
+    )
+    return [
+        {
+            "Plan": {
+                "Node Type": "Limit",
+                "Temp Read Blocks": 0,
+                "Temp Written Blocks": 0,
+                "Plans": [
+                    {
+                        "Node Type": "Index Scan",
+                        "Index Name": rules["required_index"],  # type: ignore[index]
+                        "Index Cond": condition,
+                    }
+                ],
+            },
+            "Planning Time": 0.2,
+            "Execution Time": 1.5,
+        }
+    ]
+
+
+def _write_good_plans(config: dict[str, object], plan_dir: Path) -> None:
+    plan_dir.mkdir(parents=True, exist_ok=True)
+    for workload in domain_scale.WORKLOAD_ORDER:
+        _write_json(plan_dir / f"{workload}.json", _good_plan(config, workload))
 
 
 class DomainScaleTests(unittest.TestCase):
-    def test_config_requires_the_reserved_benchmark_schema(self) -> None:
+    def test_config_requires_reserved_schema_and_index_contracts(self) -> None:
         config = domain_scale.load_config(CONFIG)
         self.assertEqual(config["database_schema"], domain_scale.BENCHMARK_SCHEMA)
+        self.assertIn("ci", config["plan_budgets"]["enforced_profiles"])
         for schema in ("public", "pg_catalog", "information_schema", "other_benchmark"):
             with self.subTest(schema=schema):
                 unsafe = dict(config)
                 unsafe["database_schema"] = schema
                 with self.assertRaisesRegex(domain_scale.DomainScaleError, "reserved benchmark schema"):
                     domain_scale.validate_config(unsafe)
+
+        broken = json.loads(json.dumps(config))
+        del broken["plan_budgets"]["workloads"]["bbox"]["required_index"]
+        with self.assertRaisesRegex(domain_scale.DomainScaleError, "required_index"):
+            domain_scale.validate_config(broken)
 
     def test_smoke_fixture_is_deterministic_and_has_exact_counts(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -46,6 +89,10 @@ class DomainScaleTests(unittest.TestCase):
                 edge_rows = list(csv.DictReader(handle))
             self.assertEqual(len(node_rows), 1000)
             self.assertEqual(len(edge_rows), 5000)
+            self.assertEqual(
+                sum(row["kind"] == domain_scale.RARE_NODE_KIND for row in node_rows),
+                10,
+            )
             self.assertTrue(all(row["source_id"] != row["target_id"] for row in edge_rows))
             node_ids = {row["id"] for row in node_rows}
             self.assertEqual({row["source_id"] for row in edge_rows}, node_ids)
@@ -57,7 +104,7 @@ class DomainScaleTests(unittest.TestCase):
             fixture = root / "fixture"
             domain_scale.generate_fixture(CONFIG, "smoke", fixture)
             output = root / "load.sql"
-            domain_scale.render_load_sql(fixture / "manifest.json", output)
+            domain_scale.render_load_sql(fixture / "manifest.json", output, CONFIG)
             sql = output.read_text(encoding="utf-8")
             self.assertIn("DROP SCHEMA IF EXISTS weltgewebe_perf CASCADE", sql)
             self.assertIn("LIKE public.domain_nodes INCLUDING ALL", sql)
@@ -68,44 +115,50 @@ class DomainScaleTests(unittest.TestCase):
             self.assertEqual(sql.count("COMMIT;"), 1)
             self.assertLess(sql.index("\\copy weltgewebe_perf.domain_edges"), sql.index("COMMIT;"))
 
-    def test_workload_sql_renders_all_format_json_plans(self) -> None:
+    def test_workload_sql_targets_filter_indexes_without_unrelated_ordering(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             fixture = root / "fixture"
             plans = root / "plans"
             domain_scale.generate_fixture(CONFIG, "smoke", fixture)
             output = root / "workload.sql"
-            domain_scale.render_workload_sql(fixture / "manifest.json", plans, output)
+            domain_scale.render_workload_sql(fixture / "manifest.json", plans, output, CONFIG)
             sql = output.read_text(encoding="utf-8")
             self.assertEqual(sql.count("EXPLAIN (ANALYZE, BUFFERS, WAL, FORMAT JSON)"), 6)
             for workload in domain_scale.WORKLOAD_ORDER:
                 self.assertIn(f"{workload}.json", sql)
+            self.assertIn("WHERE id >", sql)
+            self.assertIn("ORDER BY id ASC LIMIT 1000", sql)
+            self.assertIn("WHERE kind = 'Projekt' LIMIT 500", sql)
+            self.assertNotIn("WHERE kind = 'Projekt' ORDER BY", sql)
+            self.assertNotIn("ORDER BY id ASC LIMIT 5000", sql)
+            self.assertIn("WHERE source_id = 'node-", sql)
+            self.assertIn("WHERE target_id = 'node-", sql)
 
-    def test_plan_checker_accepts_index_plans_and_rejects_seq_scan(self) -> None:
+    def test_plan_checker_requires_the_workload_specific_index_condition(self) -> None:
         config = domain_scale.load_config(CONFIG)
-        good_plan = [
-            {
-                "Plan": {
-                    "Node Type": "Limit",
-                    "Temp Read Blocks": 0,
-                    "Temp Written Blocks": 0,
-                    "Plans": [{"Node Type": "Index Scan", "Relation Name": "domain_nodes"}],
-                },
-                "Planning Time": 0.2,
-                "Execution Time": 1.5,
-            }
-        ]
         with tempfile.TemporaryDirectory() as directory:
             plan_dir = Path(directory)
-            for workload in domain_scale.WORKLOAD_ORDER:
-                (plan_dir / f"{workload}.json").write_text(
-                    json.dumps(good_plan), encoding="utf-8", newline="\n"
-                )
-            report = domain_scale.check_plans(config, plan_dir, "scale_100k")
+            _write_good_plans(config, plan_dir)
+            report = domain_scale.check_plans(config, plan_dir, "ci")
             self.assertEqual(report["status"], "pass")
             self.assertTrue(report["budget_enforced"])
-            self.assertTrue(report["calibration_required"])
+            for workload in domain_scale.WORKLOAD_ORDER:
+                self.assertTrue(report["workloads"][workload]["required_index_evidence"])
 
+            wrong_index = _good_plan(config, "bbox")
+            wrong_index[0]["Plan"]["Plans"][0]["Index Name"] = "domain_nodes_pkey"  # type: ignore[index]
+            wrong_index[0]["Plan"]["Plans"][0]["Index Cond"] = "(id IS NOT NULL)"  # type: ignore[index]
+            _write_json(plan_dir / "bbox.json", wrong_index)
+            failed = domain_scale.check_plans(config, plan_dir, "ci")
+            self.assertEqual(failed["status"], "fail")
+            self.assertTrue(any("domain_nodes_lat_lon" in item for item in failed["failures"]))
+
+    def test_plan_checker_rejects_seq_scan_and_nested_temp_blocks(self) -> None:
+        config = domain_scale.load_config(CONFIG)
+        with tempfile.TemporaryDirectory() as directory:
+            plan_dir = Path(directory)
+            _write_good_plans(config, plan_dir)
             bad_plan = [
                 {
                     "Plan": {
@@ -117,16 +170,22 @@ class DomainScaleTests(unittest.TestCase):
                     "Execution Time": 10.0,
                 }
             ]
-            (plan_dir / "node_cursor.json").write_text(
-                json.dumps(bad_plan), encoding="utf-8", newline="\n"
-            )
-            with self.assertRaisesRegex(domain_scale.DomainScaleError, "Seq Scan"):
-                domain_scale.check_plans(config, plan_dir, "scale_100k")
+            _write_json(plan_dir / "node_cursor.json", bad_plan)
+            failed = domain_scale.check_plans(config, plan_dir, "ci")
+            self.assertEqual(failed["status"], "fail")
+            self.assertTrue(any("Seq Scan" in item for item in failed["failures"]))
 
             observation = domain_scale.check_plans(config, plan_dir, "smoke")
             self.assertEqual(observation["status"], "pass")
             self.assertFalse(observation["budget_enforced"])
             self.assertIn("Seq Scan", observation["workloads"]["node_cursor"]["node_types"])
+
+            _write_good_plans(config, plan_dir)
+            temp_plan = _good_plan(config, "kind_filter")
+            temp_plan[0]["Plan"]["Plans"][0]["Temp Written Blocks"] = 1  # type: ignore[index]
+            _write_json(plan_dir / "kind_filter.json", temp_plan)
+            temp_failed = domain_scale.check_plans(config, plan_dir, "ci")
+            self.assertTrue(any("temporary blocks" in item for item in temp_failed["failures"]))
 
     def test_manifest_detects_fixture_tampering(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -136,6 +195,114 @@ class DomainScaleTests(unittest.TestCase):
                 handle.write("tampered\n")
             with self.assertRaisesRegex(domain_scale.DomainScaleError, "hash mismatch"):
                 domain_scale.load_manifest(fixture / "manifest.json")
+
+    def test_manifest_rejects_self_consistent_row_count_lie(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory) / "fixture"
+            domain_scale.generate_fixture(CONFIG, "smoke", fixture)
+            nodes = fixture / "domain_nodes.csv"
+            rows = nodes.read_text(encoding="utf-8").splitlines()
+            nodes.write_text("\n".join(rows + [rows[1]]) + "\n", encoding="utf-8", newline="\n")
+            manifest_path = fixture / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["files"]["nodes"]["sha256"] = domain_scale.sha256_file(nodes)
+            _write_json(manifest_path, manifest)
+            with self.assertRaisesRegex(domain_scale.DomainScaleError, "row count mismatch"):
+                domain_scale.load_manifest(manifest_path)
+
+    def test_manifest_rejects_schema_path_and_missing_fields(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for mutation, message in (
+                (("database_schema", "public"), "reserved benchmark schema"),
+                (("files.nodes.name", "../../etc/passwd"), "filename must be local"),
+            ):
+                fixture = root / mutation[0].replace(".", "-")
+                domain_scale.generate_fixture(CONFIG, "smoke", fixture)
+                manifest_path = fixture / "manifest.json"
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+                if mutation[0] == "database_schema":
+                    manifest["database_schema"] = mutation[1]
+                else:
+                    manifest["files"]["nodes"]["name"] = mutation[1]
+                _write_json(manifest_path, manifest)
+                with self.assertRaisesRegex(domain_scale.DomainScaleError, message):
+                    domain_scale.load_manifest(manifest_path)
+
+            fixture = root / "missing"
+            domain_scale.generate_fixture(CONFIG, "smoke", fixture)
+            manifest_path = fixture / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            del manifest["profile"]
+            _write_json(manifest_path, manifest)
+            with self.assertRaisesRegex(domain_scale.DomainScaleError, "canonical"):
+                domain_scale.load_manifest(manifest_path)
+
+    def test_manifest_profile_counts_and_config_hash_are_bound(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            fixture = root / "fixture"
+            domain_scale.generate_fixture(CONFIG, "smoke", fixture)
+            manifest_path = fixture / "manifest.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["profile"] = "ci"
+            _write_json(manifest_path, manifest)
+            with self.assertRaisesRegex(domain_scale.DomainScaleError, "counts do not match"):
+                domain_scale.load_bound_manifest(manifest_path, CONFIG)
+
+            domain_scale.generate_fixture(CONFIG, "smoke", fixture)
+            altered_config = root / "altered-config.json"
+            altered_config.write_text(
+                json.dumps(domain_scale.load_config(CONFIG), indent=4) + "\n",
+                encoding="utf-8",
+                newline="\n",
+            )
+            with self.assertRaisesRegex(domain_scale.DomainScaleError, "another scale config"):
+                domain_scale.load_bound_manifest(fixture / "manifest.json", altered_config)
+
+    def test_cli_writes_failure_report_before_nonzero_exit(self) -> None:
+        base_config = domain_scale.load_config(CONFIG)
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            config = json.loads(json.dumps(base_config))
+            config["profiles"] = {"ci": {"nodes": 2, "edges": 2}}
+            config["plan_budgets"]["enforced_profiles"] = ["ci"]
+            config_path = root / "config.json"
+            config_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8", newline="\n")
+            fixture = root / "fixture"
+            domain_scale.generate_fixture(config_path, "ci", fixture)
+            plan_dir = root / "plans"
+            _write_good_plans(config, plan_dir)
+            wrong = _good_plan(config, "outbound_neighbors")
+            wrong[0]["Plan"]["Plans"][0]["Index Name"] = "domain_edges_pkey"  # type: ignore[index]
+            _write_json(plan_dir / "outbound_neighbors.json", wrong)
+            report_path = root / "report.json"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-B",
+                    str(SCRIPT),
+                    "--config",
+                    str(config_path),
+                    "check",
+                    "--manifest",
+                    str(fixture / "manifest.json"),
+                    "--plan-dir",
+                    str(plan_dir),
+                    "--report",
+                    str(report_path),
+                ],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 2)
+            self.assertTrue(report_path.is_file())
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            self.assertEqual(report["status"], "fail")
+            self.assertIn("required index", result.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- weltgewebe-risk: R3 -->

## Zweck

Legt einen reproduzierbaren PostgreSQL-Prüfstand für die schrittweise Volllast-Optimierung des Weltgewebes an, ohne die parallel bearbeiteten API-Datenpfade zu verändern.

## Inhalt

- deterministische Lastprofile bis 1 Mio. Knoten und 5 Mio. Fäden
- strikt an Konfiguration, Profil, Zeilenzahlen und SHA-256 gebundene CSV-Manifeste
- Loader ausschließlich im reservierten Schema `weltgewebe_perf`
- vollständig transaktionaler Import
- sechs kanonische `EXPLAIN (ANALYZE, BUFFERS, WAL, FORMAT JSON)`-Workloads
- Nachweis des fachlich richtigen Indexes, exakter SQL-Bezeichner und ausgeführter `Index Cond`
- Ausführungsbeleg des Indexknotens durch `Actual Loops > 0`
- profilabhängige Planbudgets
- kontrollierte, mehrdeutigkeitsfreie Dateipfade für `psql`-Metabefehle
- echter PostgreSQL-16-Lauf im eigenen CI-Workflow
- atomare Erfolgs- und Fehlerberichte sowie archivierte Planbelege

## Prüfung

- 12 Unit- und Negativtests: PASS
- Python-Kompilierung und Konfigurationsprüfung: PASS
- realer PostgreSQL-16-Lauf mit 20.000 Knoten und 100.000 Fäden: PASS
- exakte Index-, SQL-Bezeichner-, `Index Cond`- und Ausführungsbelege für alle sechs Workloads: PASS
- isolierte Negativtests für falschen Indexnamen, falsche Bedingung und nicht ausgeführten Plan: PASS
- Dokument-Schema, Relationen und Planungsregistrierung: PASS
- Generated-Files- und Diff-Guards: PASS

## Grenze

Dieser PR verändert keinen produktiven API-Datenpfad. Bounded Reads, Cursor-/BBox-Abfragen, Cache-Rückbau und Überlaststeuerung folgen nach Integration der laufenden Knotenarbeiten und werden gegen diesen Prüfstand gemessen.