### PR TITLE
Document retirement of Heimberry DynDNS path

### DIFF
--- a/docs/_generated/backlinks.md
+++ b/docs/_generated/backlinks.md
@@ -427,7 +427,6 @@ Generated automatically. Do not edit.
 - [relates_to] docs/deploy/heim-first-phase0.md
 - [relates_to] docs/deploy/heimserver.integration.md
 - [relates_to] docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md
-- [relates_to] docs/runbooks/weltgewebe-ddns-runtime-verification.md
 
 ## docs/deploy/heimserver.integration.md
 
@@ -472,6 +471,7 @@ Generated automatically. Do not edit.
 
 - [relates_to] docs/deploy/README.md
 - [relates_to] docs/deploy/vps-http-smoke.md
+- [relates_to] docs/runbooks/weltgewebe-ddns-runtime-verification.md
 
 ## docs/deployment.md
 

--- a/docs/_generated/doc-index.md
+++ b/docs/_generated/doc-index.md
@@ -159,7 +159,7 @@ Generated automatically. Do not edit.
 | runbooks.incident-response | Incident Response Runbook | reference | active | docs/runbooks/incident-response.md |
 | runbooks.ops.runbook.weltgewebe-selfhost-deploy | Selfhost-Deploy Runbook | reference | deprecated | docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md |
 | runbooks.uv-tooling | UV-Tooling | reference | active | docs/runbooks/uv-tooling.md |
-| runbooks.weltgewebe-ddns-runtime-verification | Weltgewebe DynDNS Runtime-Verifikation | runbook | active | docs/runbooks/weltgewebe-ddns-runtime-verification.md |
+| runbooks.weltgewebe-ddns-runtime-verification | Weltgewebe Heimberry-DDNS-Stilllegung verifizieren | runbook | active | docs/runbooks/weltgewebe-ddns-runtime-verification.md |
 | specs.auth-api | Auth API Spec | reference | active | docs/specs/auth-api.md |
 | specs.auth-blueprint | Auth Blueprint | reference | active | docs/specs/auth-blueprint.md |
 | specs.auth-state-machine | Auth State Machine | reference | active | docs/specs/auth-state-machine.md |

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -29,7 +29,7 @@ Heimserver-Pfad ist retired/deprecated und kein Produktionsziel mehr.
 **Weitere Dokumente:**
 
 - [VPS-Deployment](vps.md) – kanonisches Produktionsrunbook für `wg-prod-1`
-- [Domain-/Providerarchitektur und DDNS-Handoff](domain-mail-migration-ionos-to-inwx-mailbox-brevo.md) – historischer Providerstand, Implementierungsbesitz und Runtime-Beweisgrenze
+- [Domain-/Providerarchitektur und historischer DDNS-Pfad](domain-mail-migration-ionos-to-inwx-mailbox-brevo.md) – Providerstand, stillgelegter Heimberry-Schreibpfad und Runtime-Beweisgrenze
 - [Sekundäre Domain-Webflächen](secondary-domain-web-surfaces.md) – Artefakt- und Handoff-Vertrag für die Weltweberei-Informationsfläche und den späteren Heimserver-Edge (keine öffentliche Einsatzbereitschaft)
 - [Deployment-Änderungsprotokoll](./CHANGELOG.md) – Infrastrukturänderungen und deren Auswirkungen
 - [Drift-Taxonomie & Guard-Policy](./DRIFT_POLICY.md) – Klassifizierung und Handling von Drift

--- a/docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md
+++ b/docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md
@@ -37,7 +37,7 @@ Die IONOS-Kündigung wurde nach menschlicher Freigabe durchgeführt. Ein reprodu
 
 - **Registrar:** INWX
 - **Autoritative DNS-Verwaltung:** INWX
-- **Web/API:** Die öffentlichen A-Records für Apex, `www` und `api` werden dynamisch durch den Heimberry-DDNS-Dienst gepflegt. Keine statische WAN-IP ist kanonische Repository-Wahrheit.
+- **Web/API:** Die öffentlichen A-Records für Apex, `www` und `api` zeigen auf den kanonischen Public-VPS-Pfad `wg-prod-1`. Heimberry besitzt keinen aktiven DNS-Schreibpfad mehr. Die konkrete VPS-Adresse ist zu jedem Prüfzeitpunkt aus einer unabhängigen, freigegebenen Deployment-Identität zu bestimmen und anschließend gegen autoritative DNS- und Runtime-Evidence zu prüfen.
 
 ### weltweb.net
 
@@ -56,48 +56,74 @@ Die IONOS-Kündigung wurde nach menschlicher Freigabe durchgeführt. Ein reprodu
 - **mailbox.org:** `kontakt@weltgewebe.net` (menschliche Inbound/Outbound-Mail). Betriebsfähig und belegt.
 - **Brevo:** `noreply@login.weltgewebe.net` (technische Magic-Link-Mail). Betriebsfähig und belegt.
 
-## 4. DNS- und DDNS-Prinzip
+## 4. DNS- und historischer DDNS-Pfad
 
-Die Produktions-Runtime erfordert keine statische WAN-IP. Das Routing erfolgt primär über DDNS für `weltgewebe.net`. Die öffentliche URL der Anwendung wird zusätzlich in `docs/deploy/public-app-base-url.md` vertraglich geregelt.
+Der kanonische öffentliche Produktionspfad ist `wg-prod-1` gemäß
+`runtime/README.md` und `docs/deploy/vps.md`. Die drei öffentlichen A-Records
+für `weltgewebe.net`, `www.weltgewebe.net` und `api.weltgewebe.net` müssen auf
+den ausdrücklich freigegebenen VPS zeigen. Eine wechselnde Heim-WAN-Adresse ist
+kein zulässiges Produktionsziel.
 
-### Implementierungsbesitz
+### Historischer Implementierungsbesitz
 
-Dieses Repository besitzt den öffentlichen Vertrag, nicht die Heimberry-Implementierung. Der Implementierungsbesitzer ist das Repository `heimgewebe/heimserver`. Dort liegen die kanonischen Pfade:
+Der dauerhafte Sollvertrag ist im Fremdrepository `heimgewebe/heimserver`
+durch Commit `heimgewebe/heimserver@15dfbd6cc1c8899ec030ac6666464db4bc132c71` gebunden. In diesem Commit
+verlangen `ops/systemd/weltgewebe-ddns.service` und
+`ops/systemd/weltgewebe-ddns.timer` den expliziten Marker
+`/etc/weltgewebe-ddns/ENABLE_RETIRED_RUNTIME`; das Installationsskript
+`scripts/heimberry/install_weltgewebe_ddns.sh` weist den früheren
+`--activate`-Pfad fail-closed ab und bietet nur die kontrollierte Stilllegung
+`--retire` an.
 
-- `scripts/heimberry/weltgewebe_ddns.py` – fail-closed Reconciliation-Client,
-- `scripts/heimberry/install_weltgewebe_ddns.sh` – Installation, read-only Driftprüfung und explizite Aktivierung,
-- `ops/systemd/weltgewebe-ddns.service` und `ops/systemd/weltgewebe-ddns.timer` – Laufzeitsteuerung,
-- `runbooks/weltgewebe-dyndns.md` – Betrieb, Diagnose und Rollback.
+Diese Fremdrepo-Referenz belegt die versionierte Implementierung, nicht ihren
+fortdauernden Livezustand. Credentials und installierter Runtime-Zustand bleiben
+außerhalb dieses Repositories und müssen separat geprüft werden.
 
-Die repository-übergreifende Runtime-Abnahme steht in `docs/runbooks/weltgewebe-ddns-runtime-verification.md`.
-
-Die öffentliche Host-Allowlist ist exakt:
+Die ehemalige öffentliche Host-Allowlist war exakt:
 
 - `weltgewebe.net`,
 - `www.weltgewebe.net`,
 - `api.weltgewebe.net`.
 
-Weitere öffentliche DynDNS-Hosts, Wildcards oder eine statische WAN-IP benötigen eine neue Architekturentscheidung. Credentials und installierter Runtime-Zustand gehören nicht in dieses Repository.
+Diese historische Begrenzung erteilt keine aktuelle DNS-Ownership. Eine spätere
+Reaktivierung erfordert eine neue Architekturentscheidung, eine explizite
+Freigabe des DNS-Zielbilds und frische Ende-zu-Ende-Belege.
 
 ### Beweisgrenze
 
-Ein grüner Repository-Test im Implementierungsrepo beweist Quellcode, Installervertrag und deterministische Gegenwelten. Er beweist weder, dass Heimberry bereits aktualisiert wurde, noch dass DNS, Edge und Anwendung live den Zielzustand erfüllen.
+Ein vollständiger aktueller Runtime-Nachweis erfordert separat:
 
-Ein vollständiger Runtime-Nachweis erfordert separat:
+1. `runtime/README.md`, `docs/deploy/vps.md` und eine aktuelle Deployment-Identität weisen `wg-prod-1` sowie die unabhängig bestimmte erwartete VPS-Adresse aus,
+2. alle drei autoritativen INWX-Nameserver liefern für alle drei Hosts genau diesen erwarteten VPS-A-Record,
+3. öffentliches HTTPS antwortet für Apex, `www` und `api`,
+4. die kanonischen API-Health-Pfade antworten erfolgreich,
+5. `weltgewebe-ddns.timer` auf Heimberry ist `disabled` und `inactive`,
+6. seit der Stilllegung wurden keine weiteren DDNS-Schreibereignisse des Heimberry-Dienstes protokolliert.
 
-1. installierte Programm- und Unit-Dateien stimmen mit einem exakten gemergten `heimserver`-Commit überein,
-2. Service und Timer besitzen den erwarteten Zustand,
-3. alle drei autoritativen INWX-Nameserver liefern für alle drei erlaubten Hosts den erwarteten einzelnen A-Record,
-4. öffentliches HTTPS antwortet für Apex, `www` und `api`,
-5. der kanonische API-Health-Pfad antwortet erfolgreich,
-6. Heimberry besitzt keinen eingehenden öffentlichen DDNS-Dienst und App-, Admin- oder Datenbankports sind nicht direkt exponiert.
+Ein Repository-Test, Merge-Dump oder früherer DDNS-Abnahmebericht ersetzt diese
+Livebelege nicht.
 
-Live-Aktivierung erfolgt erst nach Review und Merge des Implementierungscommits. Ein PR, ein Merge-Dump oder ein erfolgreicher Health-Bericht ersetzt diesen Runtime-Nachweis nicht.
+### Zeitgebundene Livebeobachtung vom 16. Juli 2026
+
+Zwischen 03:58 und 04:00 Uhr CEST wurde auf Heimberry folgender Zustand gelesen:
+
+- installierte Service-Unit: SHA-256 `b1ecad62a69ce94ff203e2a4e4d0d387f88efe5abed58cf27309fd88f81ea8f8`,
+- installierte Timer-Unit: SHA-256 `72da42bdd9aa83e89c5f248f6977a047469c8fe415527994591a6383b5b191c5`,
+- beide Units enthalten den Marker-Schutz aus Heimserver-Commit `15dfbd6cc1c8899ec030ac6666464db4bc132c71`,
+- `weltgewebe-ddns.timer` ist `disabled` und `inactive`,
+- der Aktivierungsmarker fehlt,
+- `systemctl --failed` meldet keine fehlgeschlagenen Units,
+- seit dem dokumentierten Timer-Stopp am 16. Juli 2026 um 02:40:05 Uhr CEST
+  wurden bis 04:00 Uhr keine Ereignisse `dyndns.update_started` oder
+  `dyndns.host_updated` mehr gefunden.
+
+Dieser Abschnitt ist ein datierter Beobachtungsbeleg, keine dauerhafte
+Wahrheitsgarantie. Für eine spätere Betriebsentscheidung muss die obige
+Beweiskette erneut ausgeführt werden.
 
 ## 5. Wiederherstellungsgrenze
 
-Ein IONOS-Rollback ist nicht mehr verfügbar.
-Wiederherstellung erfolgt durch Korrektur der INWX-Zone, der DDNS-Konfiguration oder der aktuellen Runtime.
+Ein IONOS-Rollback ist nicht mehr verfügbar. Wiederherstellung erfolgt durch Korrektur der INWX-Zone oder der aktuellen VPS-Runtime. Der Heimberry-DDNS-Pfad ist kein Standardrollback und darf nur nach einer neuen, ausdrücklich freigegebenen Architekturentscheidung reaktiviert werden.
 
 ## 6. Offener Restbestand
 

--- a/docs/reports/domain-provider-role-finding.md
+++ b/docs/reports/domain-provider-role-finding.md
@@ -33,7 +33,7 @@ relations:
 
 ### weltgewebe.net
 
-- **Web/API**: Betriebsfähig. Die öffentlichen A-Records werden dynamisch durch den Heimberry-DDNS-Dienst gepflegt.
+- **Web/API**: Betriebsfähig über den kanonischen Public-VPS-Pfad `wg-prod-1`. Der frühere Heimberry-DDNS-Schreibpfad ist stillgelegt.
 - **Mail (Human)**: mailbox.org. (Betriebsfähig).
 - **Mail (Technical Login)**: Brevo (`noreply@login.weltgewebe.net`). (Betriebsfähig).
 

--- a/docs/reports/inwx-zone-reconciliation-plan.md
+++ b/docs/reports/inwx-zone-reconciliation-plan.md
@@ -32,7 +32,7 @@ relations:
 
 ## Ergebnis
 
-- `weltgewebe.net` nutzt INWX und dynamisches DDNS.
+- Damals dokumentierter Zwischenstand: `weltgewebe.net` nutzte INWX und dynamisches DDNS. Dieser Pfad wurde durch `wg-prod-1` abgelöst und ist nicht mehr operativ.
 - IONOS ist gekündigt.
 - Die damaligen statischen IP-, IONOS- und Rollbackannahmen sind nicht mehr gültig.
 - `weltweb.net` und `weltweberei.org` bleiben unter `DEPLOY-DNS-001` offen.

--- a/docs/runbooks/domain-mail-cutover.md
+++ b/docs/runbooks/domain-mail-cutover.md
@@ -39,7 +39,8 @@ relations:
 ## Recovery-Grenze
 
 Ein IONOS-Rollback ist nicht mehr verfügbar.
-Aktuelle Fehler werden über INWX-Zonenkorrektur, DDNS-, Edge- und
-Runtime-Prüfung behandelt.
+Aktuelle Fehler werden über INWX-Zonenkorrektur sowie Edge- und
+VPS-Runtime-Prüfung behandelt. Der frühere Heimberry-DDNS-Pfad ist kein
+Rollback.
 
 Der historische Vollinhalt bleibt über die Git-Historie nachvollziehbar.

--- a/docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md
+++ b/docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md
@@ -24,11 +24,14 @@ zu einem **self-hosted Heimserver-Deployment mit edge-caddy**.
 > [!NOTE]
 > **Historische DNS-Phase**
 > Dieses Dokument beschreibt den historischen Schritt von Netlify zu IONOS.
-> Der heutige Zustand von `weltgewebe.net` nutzt INWX und dynamisches DDNS. Die Nebendomains sind DNS-seitig noch offen.
+> Der heutige Zustand von `weltgewebe.net` nutzt INWX und den kanonischen
+> Public-VPS-Pfad `wg-prod-1`. Der frühere Heimberry-DDNS-Schreibpfad ist
+> stillgelegt; die Nebendomains sind DNS-seitig noch offen.
 >
-> Die aktuelle DDNS-Installation und Runtime-Abnahme steht ausschließlich in
+> Die aktuelle Prüfanweisung für die Stilllegung steht in
 > `docs/runbooks/weltgewebe-ddns-runtime-verification.md`. Die folgenden
-> IONOS-Beispiele sind keine heutige Betriebsanweisung.
+> IONOS-, Heimserver- und Portforward-Beispiele sind keine heutige
+> Betriebsanweisung.
 
 Die damalige Migration beinhaltete:
 

--- a/docs/runbooks/weltgewebe-ddns-runtime-verification.md
+++ b/docs/runbooks/weltgewebe-ddns-runtime-verification.md
@@ -1,49 +1,145 @@
 ---
 id: runbooks.weltgewebe-ddns-runtime-verification
-title: Weltgewebe DynDNS Runtime-Verifikation
+title: Weltgewebe Heimberry-DDNS-Stilllegung verifizieren
 doc_type: runbook
 status: active
-summary: Kontrollierte Ende-zu-Ende-Abnahme des Heimberry-DynDNS-Dienstes.
+summary: Aktive, wiederholbare Sicherheitsprüfung des stillgelegten Heimberry-DDNS-Schreibpfads.
 relations:
   - type: relates_to
     target: docs/runbooks/README.md
   - type: relates_to
     target: docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md
   - type: relates_to
-    target: docs/deploy/heimserver.deployment.md
+    target: docs/deploy/vps.md
   - type: relates_to
     target: docs/runbooks/incident-response.md
 ---
 
-# Weltgewebe DynDNS Runtime-Verifikation
+# Weltgewebe Heimberry-DDNS-Stilllegung verifizieren
 
-## Vertrag
+## Zweck
 
-Die Implementierung gehört zu `heimgewebe/heimserver`. Erlaubt sind ausschließlich `weltgewebe.net`, `www.weltgewebe.net` und `api.weltgewebe.net`. Ein Pull Request oder Repository-Test beweist noch keinen installierten Runtime-Zustand. Die Abnahme erfolgt erst nach Review und Merge des zu installierenden Heimserver-Commits.
+Der DDNS-Dienst ist stillgelegt; dieses Runbook bleibt aktiv. Es prüft, dass der
+frühere Heimberry-Schreibpfad weiterhin inaktiv und fail-closed ist, während die
+öffentliche Weltgewebe-Runtime auf `wg-prod-1` läuft.
 
-## Erforderliche Belege
+Die versionierte Härtung ist an Commit
+`heimgewebe/heimserver@15dfbd6cc1c8899ec030ac6666464db4bc132c71`
+gebunden. Maßgeblich sind dort die beiden Systemd-Units unter `ops/systemd/`
+sowie `scripts/heimberry/install_weltgewebe_ddns.sh`. Diese Referenz belegt den
+Sollvertrag, nicht den fortdauernden Livezustand.
 
-1. Der saubere Heimserver-Checkout steht auf einem exakten Commit von `main`; dessen Hash wird im Abschlussbericht festgehalten.
-2. Updater, Service und Timer stimmen bytegenau mit diesem Checkout überein. Der Standard-Installer wird vor der Aktivierung ausgeführt und anschließend mit `--check` geprüft.
-3. `--activate` beendet den unmittelbaren Service-Lauf erfolgreich, bevor der Timer aktiviert wird. Erwartet werden `Result=success`, `ExecMainStatus=0` sowie ein aktiver und aktivierter Timer.
-4. Jeder der drei autoritativen INWX-Nameserver liefert für jeden der drei erlaubten Hosts genau einen A-Record mit der aktuellen öffentlichen IPv4.
-5. HTTPS antwortet für Apex, `www` und `api` ohne TLS-Fehler.
-6. `https://weltgewebe.net/api/health/live` und `https://api.weltgewebe.net/health/live` antworten erfolgreich.
-7. Heimberry besitzt keinen Listener des DynDNS-Prozesses. Auf dem Heimserver meldet `ops/checks/preflight.sh` keine direkte Exposition der App- oder Datenbankports 8080 und 5432.
-8. Journald enthält keine Credential-Werte.
+## Beweisquellen
 
-## Referenzbefehle
+1. `runtime/README.md` und `docs/deploy/vps.md` weisen `wg-prod-1` als
+   kanonischen Produktionspfad aus.
+2. Die erwartete VPS-Adresse stammt aus einer aktuellen, freigegebenen
+   Deployment-Identität oder einem Deployment-Receipt. Sie darf nicht aus den
+   DNS-Antworten abgeleitet werden, die gerade geprüft werden.
+3. `weltgewebe-ddns.timer` auf Heimberry ist `disabled` und `inactive`.
+4. Service und Timer enthalten den Schutz
+   `ConditionPathExists=/etc/weltgewebe-ddns/ENABLE_RETIRED_RUNTIME`.
+5. Der Aktivierungsmarker fehlt.
+6. Die delegierten Nameserver entsprechen exakt den drei erwarteten
+   INWX-Nameservern. Diese liefern für Apex, `www` und `api` jeweils genau den
+   unabhängig bestimmten VPS-A-Record.
+7. Apex, `www` und die kanonischen API-Health-Pfade antworten ohne TLS- oder
+   HTTP-Fehler.
+8. Seit dem Stilllegungszeitpunkt wurden keine neuen DDNS-Schreibereignisse des
+   Heimberry-Dienstes protokolliert.
+9. Credential-Werte werden weder gelesen noch in Belege übernommen.
 
-Auf Heimberry: `git pull --ff-only origin main`, Commit mit `git rev-parse HEAD` festhalten, Standard-Installer, `--check` und erst danach `--activate` ausführen. Anschließend alle neun Nameserver-/Host-Kombinationen mit `dig +time=3 +tries=1 +noall +comments +answer` prüfen. HTTPS muss für Apex, `www` und `api` antworten; zusätzlich müssen `/api/health/live` am Apex und `/health/live` am API-Host erfolgreich sein.
+## Read-only-Prüfung
+
+`EXPECTED_VPS_A` muss aus einer unabhängigen Deployment-Quelle stammen.
+`RETIRED_SINCE` ist der belegte Stilllegungszeitpunkt mit Zeitzone.
+
+```bash
+set -euo pipefail
+
+: "${EXPECTED_VPS_A:?set from the approved wg-prod-1 deployment identity}"
+: "${RETIRED_SINCE:?set to the evidenced retirement timestamp}"
+
+expected_nameservers=(ns.inwx.de ns2.inwx.de ns3.inwx.eu)
+hosts=(weltgewebe.net www.weltgewebe.net api.weltgewebe.net)
+urls=(
+  https://weltgewebe.net/
+  https://www.weltgewebe.net/
+  https://weltgewebe.net/api/health/live
+  https://api.weltgewebe.net/health/live
+)
+
+mapfile -t delegated_nameservers < <(
+  dig +short NS weltgewebe.net | sed 's/\.$//' | sed '/^$/d' | sort -u
+)
+mapfile -t sorted_expected_nameservers < <(
+  printf '%s\n' "${expected_nameservers[@]}" | sort -u
+)
+[[ "${delegated_nameservers[*]}" == "${sorted_expected_nameservers[*]}" ]]
+
+state=$(systemctl is-enabled weltgewebe-ddns.timer 2>/dev/null || true)
+[[ "$state" == disabled ]]
+state=$(systemctl is-active weltgewebe-ddns.timer 2>/dev/null || true)
+[[ "$state" == inactive ]]
+
+for unit in weltgewebe-ddns.service weltgewebe-ddns.timer; do
+  systemctl cat "$unit" |
+    grep -Fqx 'ConditionPathExists=/etc/weltgewebe-ddns/ENABLE_RETIRED_RUNTIME'
+done
+sudo test ! -e /etc/weltgewebe-ddns/ENABLE_RETIRED_RUNTIME
+
+for nameserver in "${expected_nameservers[@]}"; do
+  for host in "${hosts[@]}"; do
+    mapfile -t answers < <(
+      dig +short @"$nameserver" "$host" A | sed '/^$/d' | sort -u
+    )
+    [[ ${#answers[@]} -eq 1 ]]
+    [[ "${answers[0]}" == "$EXPECTED_VPS_A" ]]
+  done
+done
+
+for url in "${urls[@]}"; do
+  curl --fail --silent --show-error --location --output /dev/null "$url"
+done
+
+journal_args=(
+  -u weltgewebe-ddns.service
+  --since "$RETIRED_SINCE"
+  --grep 'dyndns.update_started|dyndns.host_updated'
+  --no-pager
+  --output cat
+)
+if journalctl "${journal_args[@]}" | grep -q .; then
+  echo 'unexpected DDNS write event after retirement' >&2
+  exit 1
+fi
+```
+
+Die Prüfung schreibt weder DNS noch Systemd-Zustand. Ein Fehler beendet sie
+fail-closed. Der Abschlussbeleg enthält die eingesetzten Erwartungswerte, den
+Zeitstempel, die delegierten Nameserver, die neun autoritativen DNS-Antworten,
+die vier HTTPS-Prüfungen und die Unit-Zustände, aber keine Credentials.
+
+## Letzter datierter Beobachtungsbeleg
+
+Am 16. Juli 2026 zwischen 03:58 und 04:00 Uhr CEST wurden die installierten
+Unit-Hashes `b1ecad62…a8f8` und `72da42bd…1c5`, der fehlende Marker, der Zustand
+`disabled`/`inactive`, null fehlgeschlagene Units und keine neuen, durch den
+Heimberry-Dienst protokollierten Schreibereignisse seit 02:40:05 Uhr CEST
+beobachtet. Die vollständigen Hashes stehen in
+`docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md`.
+
+Dieser Beleg altert und ersetzt keine frische Ausführung der Prüfung.
 
 ## Fail-closed Kriterien
 
-`SERVFAIL`, `REFUSED`, fehlende DNS-Statuszeilen, mehrere A-Records, eine abweichende Adresse, ein fehlgeschlagener Healthcheck oder eine direkte Portexposition lassen die Abnahme scheitern. Repository-Health-Berichte und Merge-Dumps ersetzen keinen dieser Runtime-Belege.
+Die Prüfung scheitert bei aktivem oder aktiviertem Timer, vorhandenem Marker,
+fehlendem Unit-Schutz, unerwarteten Nameservern oder A-Records, TLS-/HTTP-Fehlern
+oder neuen DDNS-Schreibereignissen. Ein fehlender Beleg gilt nicht als Erfolg.
 
-## Nachweisformat
+## Wiederherstellung
 
-Der Abschlussbericht enthält Zeitstempel, Heimserver-Commit, Dateivergleiche, Service- und Timerzustand, neun autoritative DNS-Prüfungen, drei HTTPS-Prüfungen, beide Healthchecks sowie die Expositionsprüfungen auf Heimberry und Heimserver.
-
-## Rollback
-
-Bei einem Fehler wird `weltgewebe-ddns.timer` deaktiviert. Programm und Units werden aus dem letzten freigegebenen Heimserver-Commit wiederhergestellt. Credentials werden weder gelöscht noch in Berichte kopiert. Eine statische WAN-IP in Git ist kein zulässiger Rollback.
+Die Standardmaßnahme ist die Korrektur der INWX-Zone oder der VPS-Runtime. Eine
+Reaktivierung des Heimberry-DDNS-Pfads ist kein operativer Rollback. Sie verlangt
+eine neue Architekturentscheidung, explizite DNS-Freigabe und einen separaten,
+reviewten Patch. Providerdateien werden bei der Stilllegung nicht gelöscht.


### PR DESCRIPTION
<!-- weltgewebe-risk: R3 -->

## Summary
- align provider and deployment documentation with the canonical `wg-prod-1` runtime
- retire the Heimberry DDNS writer while keeping its verification runbook active
- define a fail-closed, read-only retirement proof with independent DNS expectations
- reconcile active and archived provider truth sources
- regenerate protected documentation indexes

## Evidence
- `make validate`: 1,062 tests plus schema, relations, links and guards passed
- extracted runbook command passed `bash -n` and `shellcheck -s bash -S style`
- GitHub Docs & Shell Hygiene, CI, guard, PostgreSQL and CodeQL checks passed on the current head

## Safety boundary
No production DNS values or services are changed by this documentation patch. The runbook is read-only; reactivation remains a separately reviewed architecture decision.