### PR TITLE
ops: make reconciler Docker config writable

### DIFF
--- a/scripts/ci/tests/test_deploy_exact_commit_integration.py
+++ b/scripts/ci/tests/test_deploy_exact_commit_integration.py
@@ -247,6 +247,7 @@ class DeployExactCommitIntegrationTests(unittest.TestCase):
                 """\
                 #!/usr/bin/env python3
                 import json
+                import os
                 import sys
                 from datetime import datetime, timezone
                 from pathlib import Path
@@ -254,34 +255,39 @@ class DeployExactCommitIntegrationTests(unittest.TestCase):
                 args = sys.argv[1:]
                 commit = args[args.index("--expected-commit") + 1]
                 output = Path(args[args.index("--output") + 1])
+                marker = os.environ.get("TEST_DEPLOY_MARKER")
+                deployed = marker is None or Path(marker).exists()
+                observed_commit = commit if deployed else os.environ["PUBLIC_COMMIT"]
+                passed = observed_commit == commit
                 payload = {
                     "schema_version": 2,
                     "expected_commit": commit,
                     "verified_at": datetime.now(timezone.utc).isoformat(),
-                    "pass": True,
-                    "reasons": [],
+                    "pass": passed,
+                    "reasons": [] if passed else ["public commit differs"],
                     "frontend": {
                         "url": "https://example.invalid/_app/version.json",
                         "status": 200,
-                        "commit": commit,
-                        "version": commit[:8],
+                        "commit": observed_commit,
+                        "version": observed_commit[:8],
                         "headers": {"cache-control": "no-store"},
                         "error": None,
                     },
                     "api": {
                         "url": "https://example.invalid/api/version",
                         "status": 200,
-                        "commit": commit,
+                        "commit": observed_commit,
                         "version": "0.1.0",
                         "headers": {
-                            "x-weltgewebe-api-build": commit,
-                            "x-weltgewebe-build": commit[:8],
+                            "x-weltgewebe-api-build": observed_commit,
+                            "x-weltgewebe-build": observed_commit[:8],
                         },
                         "error": None,
                     },
                 }
                 output.parent.mkdir(parents=True, exist_ok=True)
                 output.write_text(json.dumps(payload) + "\\n", encoding="utf-8")
+                raise SystemExit(0 if passed else 1)
                 """
             ),
             encoding="utf-8",
@@ -293,7 +299,12 @@ class DeployExactCommitIntegrationTests(unittest.TestCase):
         forbidden_deploy.chmod(0o755)
 
         successful_deploy = self.bin / "successful-deploy"
-        successful_deploy.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+        successful_deploy.write_text(
+            "#!/usr/bin/env bash\nset -euo pipefail\n"
+            ': "${TEST_DEPLOY_MARKER:?}"\n'
+            'touch "$TEST_DEPLOY_MARKER"\n',
+            encoding="utf-8",
+        )
         successful_deploy.chmod(0o755)
 
     def base_environment(self) -> dict[str, str]:
@@ -360,6 +371,7 @@ class DeployExactCommitIntegrationTests(unittest.TestCase):
                 "WELTGEWEBE_DEPLOY_HELPER": str(self.bin / "successful-deploy"),
                 "WELTGEWEBE_MIN_FREE_KIB": "1",
                 "PUBLIC_COMMIT": "0" * 40,
+                "TEST_DEPLOY_MARKER": str(self.root / "deploy-complete"),
             }
         )
         argv = self.privileged(

--- a/scripts/ci/tests/test_deploy_exact_commit_integration.py
+++ b/scripts/ci/tests/test_deploy_exact_commit_integration.py
@@ -179,7 +179,29 @@ class DeployExactCommitIntegrationTests(unittest.TestCase):
 
     def make_command_shims(self) -> None:
         docker = self.bin / "docker"
-        docker.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+        docker.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                expected_config="$WELTGEWEBE_DEPLOY_STATE_ROOT/docker-config"
+                [[ "${DOCKER_CONFIG:-}" == "$expected_config" ]] || {
+                  printf 'unexpected DOCKER_CONFIG: %s\n' "${DOCKER_CONFIG:-<unset>}" >&2
+                  exit 91
+                }
+                [[ -d "$DOCKER_CONFIG" ]] || {
+                  printf 'DOCKER_CONFIG directory is missing\n' >&2
+                  exit 92
+                }
+                [[ "$(stat -c %a "$DOCKER_CONFIG")" == "700" ]] || {
+                  printf 'DOCKER_CONFIG mode is not 700\n' >&2
+                  exit 93
+                }
+                cat "$TEST_WEB_ARTIFACT"
+                """
+            ),
+            encoding="utf-8",
+        )
         docker.chmod(0o755)
 
         curl = self.bin / "curl"
@@ -198,19 +220,20 @@ class DeployExactCommitIntegrationTests(unittest.TestCase):
                     shift
                   fi
                 done
+                public_commit="${PUBLIC_COMMIT:-$TEST_COMMIT}"
                 if [[ "$url" == *"/api/version" ]]; then
                   if [[ -n "$headers" ]]; then
                     {
                       printf 'HTTP/1.1 200 OK\\r\\n'
-                      printf 'X-Weltgewebe-API-Build: %s\\r\\n' "$TEST_COMMIT"
-                      printf 'X-Weltgewebe-Build: %s\\r\\n' "${TEST_COMMIT:0:8}"
+                      printf 'X-Weltgewebe-API-Build: %s\\r\\n' "$public_commit"
+                      printf 'X-Weltgewebe-Build: %s\\r\\n' "${public_commit:0:8}"
                       printf '\\r\\n'
                     } > "$headers"
                   fi
-                  printf '{"commit":"%s","version":"0.1.0"}\\n' "$TEST_COMMIT"
+                  printf '{"commit":"%s","version":"0.1.0"}\\n' "$public_commit"
                 else
                   printf '{"commit":"%s","version":"%s"}\\n' \
-                    "$TEST_COMMIT" "${TEST_COMMIT:0:8}"
+                    "$public_commit" "${public_commit:0:8}"
                 fi
                 """
             ),
@@ -269,6 +292,10 @@ class DeployExactCommitIntegrationTests(unittest.TestCase):
         forbidden_deploy.write_text("#!/usr/bin/env bash\nexit 99\n", encoding="utf-8")
         forbidden_deploy.chmod(0o755)
 
+        successful_deploy = self.bin / "successful-deploy"
+        successful_deploy.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+        successful_deploy.chmod(0o755)
+
     def base_environment(self) -> dict[str, str]:
         inherited_path = os.environ.get("PATH", "/usr/bin:/bin")
         return {
@@ -284,6 +311,7 @@ class DeployExactCommitIntegrationTests(unittest.TestCase):
             "WELTGEWEBE_API_VERSION_URL": "https://example.invalid/api/version",
             "TEST_COMMIT": self.commit,
             "TEST_REMOTE": str(self.remote),
+            "TEST_WEB_ARTIFACT": str(self.artifact),
         }
 
     def deploy(self, *, advance: bool) -> subprocess.CompletedProcess[str]:
@@ -322,6 +350,39 @@ class DeployExactCommitIntegrationTests(unittest.TestCase):
             ]
         )
         return run(argv, check=False)
+
+    def reconcile_stale_public_commit(self) -> subprocess.CompletedProcess[str]:
+        reconcile_env = self.base_environment()
+        reconcile_env.update(
+            {
+                "WELTGEWEBE_BUILD_USER": "root",
+                "WELTGEWEBE_LIVE_VERIFIER": str(self.bin / "verify-public"),
+                "WELTGEWEBE_DEPLOY_HELPER": str(self.bin / "successful-deploy"),
+                "WELTGEWEBE_MIN_FREE_KIB": "1",
+                "PUBLIC_COMMIT": "0" * 40,
+            }
+        )
+        argv = self.privileged(
+            [
+                "env",
+                *[f"{key}={value}" for key, value in reconcile_env.items()],
+                str(RECONCILE_SCRIPT),
+            ]
+        )
+        return run(argv, check=False)
+
+    def test_reconciler_exports_private_docker_config_to_build(self) -> None:
+        result = self.reconcile_stale_public_commit()
+        docker_config = self.state / "docker-config"
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(docker_config.stat().st_uid, 0)
+        self.assertEqual(docker_config.stat().st_gid, 0)
+        self.assertEqual(docker_config.stat().st_mode & 0o777, 0o700)
+        self.restore_test_ownership()
+        receipt = json.loads(
+            (self.state / "reconcile-receipts" / f"{self.commit}.json").read_text()
+        )
+        self.assertEqual(receipt["result"], "verified")
 
     def test_success_marks_exact_commit_current(self) -> None:
         result = self.deploy(advance=False)

--- a/scripts/ci/tests/test_production_reconciler_contract.py
+++ b/scripts/ci/tests/test_production_reconciler_contract.py
@@ -81,6 +81,9 @@ class ProductionReconcilerContractTests(unittest.TestCase):
         self.assertIn("original web artifact hash", script)
         self.assertIn('ln -sfn "receipts/$target_commit.json"', script)
         self.assertIn('chmod 0600 "$artifact"', script)
+        self.assertIn('DOCKER_CONFIG="$STATE_ROOT/docker-config"', script)
+        self.assertIn("export DOCKER_CONFIG", script)
+        self.assertIn('"$DEPLOY_RECEIPT_ROOT" "$DOCKER_CONFIG"', script)
 
     def test_reconciler_build_cannot_write_release_or_source(self) -> None:
         script = self.read("scripts/ops/reconcile-production-main-vps.sh")
@@ -127,6 +130,7 @@ class ProductionReconcilerContractTests(unittest.TestCase):
         self.assertIn('git -C "$REPO_DIR" show "$COMMIT:$source_path"', script)
         self.assertIn("production-reconciler.env", script)
         self.assertIn("installed-contract.sha256", script)
+        self.assertIn("/var/lib/weltgewebe-main-reconciler/docker-config", script)
         self.assertNotIn("Environment=WELTGEWEBE_BUILD_USER=alex", script)
 
     def test_github_contract_serializes_main_observers(self) -> None:

--- a/scripts/ops/install-production-reconciler.sh
+++ b/scripts/ops/install-production-reconciler.sh
@@ -111,7 +111,8 @@ install -d -o root -g root -m 0711 /var/lib/weltgewebe-main-reconciler
 install -d -o root -g root -m 0700 \
   /var/lib/weltgewebe-main-reconciler/artifacts \
   /var/lib/weltgewebe-main-reconciler/receipts \
-  /var/lib/weltgewebe-main-reconciler/reconcile-receipts
+  /var/lib/weltgewebe-main-reconciler/reconcile-receipts \
+  /var/lib/weltgewebe-main-reconciler/docker-config
 install -d -o root -g root -m 0755 /opt/weltgewebe-releases
 
 manifest="/var/lib/weltgewebe-main-reconciler/installed-contract.sha256"

--- a/scripts/ops/reconcile-production-main-vps.sh
+++ b/scripts/ops/reconcile-production-main-vps.sh
@@ -5,6 +5,8 @@ SOURCE_CHECKOUT="${WELTGEWEBE_SOURCE_CHECKOUT:-/opt/weltgewebe}"
 RELEASE_ROOT="${WELTGEWEBE_RELEASE_ROOT:-/opt/weltgewebe-releases}"
 RUNTIME_ENV="${WELTGEWEBE_RUNTIME_ENV:-/etc/weltgewebe/weltgewebe.env}"
 STATE_ROOT="${WELTGEWEBE_DEPLOY_STATE_ROOT:-/var/lib/weltgewebe-main-reconciler}"
+DOCKER_CONFIG="$STATE_ROOT/docker-config"
+export DOCKER_CONFIG
 BUILD_USER="${WELTGEWEBE_BUILD_USER:-alex}"
 FRONTEND_URL="${WELTGEWEBE_FRONTEND_VERSION_URL:-https://weltgewebe.net/_app/version.json}"
 API_URL="${WELTGEWEBE_API_VERSION_URL:-https://weltgewebe.net/api/version}"
@@ -265,7 +267,8 @@ for command_name in git docker sha256sum flock install id rm mv awk getent chmod
 done
 
 install -d -o root -g root -m 0711 "$STATE_ROOT"
-install -d -o root -g root -m 0700 "$ARTIFACT_ROOT" "$RECEIPT_ROOT" "$DEPLOY_RECEIPT_ROOT"
+install -d -o root -g root -m 0700 \
+  "$ARTIFACT_ROOT" "$RECEIPT_ROOT" "$DEPLOY_RECEIPT_ROOT" "$DOCKER_CONFIG"
 install -d -o root -g root -m 0755 "$RELEASE_ROOT"
 exec 9> "$LOCK_FILE"
 if ! flock -n 9; then


### PR DESCRIPTION
<!-- weltgewebe-risk: R3 -->

## Zweck

Der Produktions-Reconciler läuft mit `ProtectHome=true`. Docker Buildx versucht ohne explizites `DOCKER_CONFIG` unter `/root/.docker` zu schreiben und scheitert dadurch fail-closed. Dieser Patch bindet Docker-Konfiguration an ein root-eigenes, privates Unterverzeichnis des bestehenden Reconciler-State-Roots.

## Änderung

- `DOCKER_CONFIG=$STATE_ROOT/docker-config` wird früh gesetzt und exportiert.
- Installer und Laufskript legen das Verzeichnis root-eigen mit Modus `0700` an.
- Vertragsprüfungen sichern Ableitung, Export und Installer-Konsistenz.
- Ein privilegierter Integrationstest prüft am gestarteten Docker-Shim Pfad, Existenz, Besitz und Modus des tatsächlich geerbten `DOCKER_CONFIG`.
- Der Test modelliert getrennt den veralteten öffentlichen Zustand vor dem Deployment und den Zielcommit nach dem Deployment.
- Die systemd-Härtung `ProtectHome=true` bleibt unverändert.

## Exakte Diffbindung

- Basis: `f4ca791c21b49b161dffce886d4858a05d83d667`
- Head: `fadf48b14d0f7154e7f6ed03d8af4652adeca220`
- vollständiger aktueller GitHub-Diff: 11703 Bytes
- GitHub-Diff SHA-256: `4514121907c7e19840d4f1b83d8e9bc5b7019634f55d02281290fc89d184ae08`
- vollständiger binärer lokaler Git-Patch: 11766 Bytes
- binärer Patch SHA-256: `eb38f6e4745d100580ba13602481cd7cf39ae3bf7e2c53701d9f9160fd523941`

Der Review-Evidence-Gate bindet an den über die GitHub-Diff-API materialisierten Hash. Das Workflow-Artefakt `Exact review diff artifact` bindet zusätzlich an den binären `git diff --binary`-Patch. Die unterschiedlichen Bytes und Hashes sind formatspezifisch; beide sind hier explizit dokumentiert.

## Prüfungen

- `bash -n` für Installer und Reconciler: bestanden
- `python -m py_compile` für den erweiterten Integrationstest: bestanden
- Ruff für den erweiterten Integrationstest: bestanden
- `git diff --check`: bestanden
- `test_production_reconciler_contract`: 8/8 bestanden
- Privilegierter Integrationstest und vollständige GitHub-CI: werden für diesen exakten Head erneut ausgeführt

## Review-Nachlauf

Ein unabhängiges Codex-Review eines früheren Heads meldete eine niedrige Testlücke: Die Vererbung von `DOCKER_CONFIG` wurde nur statisch geprüft. Diese Lücke ist im aktuellen Head durch einen ausführenden Docker-Shim-Test geschlossen. Der erste Testlauf zeigte zusätzlich, dass der alte Verifier-Shim versehentlich bereits vor dem Deployment den Zielcommit simulierte; der aktuelle Head trennt Vorher- und Nachherzustand mit einem Deployment-Marker. Frühere Reviewaussagen sind wegen des neuen Heads nicht als Evidence gültig.

## Produktionskontext

Der aktive Reconciler auf wg-prod-1 hat den ursprünglichen Zielcommit erfolgreich gebaut und validiert, ist aber beim Compose-Start mit `mkdir /root/.docker: read-only file system` ausgestiegen. Der Timer wurde kontrolliert angehalten, nicht deaktiviert. Der bisherige öffentliche Commit bleibt gesund ausgeliefert. Fremde Dirty-States wurden nicht verändert.