### PR TITLE
ci: bind Kubernetes proofs to exact workflow state

### DIFF
--- a/.github/workflows/kubernetes-platform.yml
+++ b/.github/workflows/kubernetes-platform.yml
@@ -63,7 +63,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
-      SOURCE_REF: ${{ github.head_ref || github.ref_name }}
       CLUSTER_NAME: wg-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # tag: v7.0.0
@@ -72,12 +71,19 @@ jobs:
           python-version: "3.10"
       - name: Install proof dependency
         run: python -m pip install --disable-pip-version-check 'PyYAML==6.0.3'
-      - name: Run isolated GitOps reference proof
-        run: >-
-          python scripts/platform/kind_reference.py proof
-          --cluster "$CLUSTER_NAME"
-          --mode gitops
-          --source-ref "$SOURCE_REF"
+      - name: Run event-bound platform reference proof
+        shell: bash
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            python scripts/platform/kind_reference.py proof \
+              --cluster "$CLUSTER_NAME" \
+              --mode direct
+          else
+            python scripts/platform/kind_reference.py proof \
+              --cluster "$CLUSTER_NAME" \
+              --mode gitops \
+              --source-commit "$GITHUB_SHA"
+          fi
       - name: Collect failure diagnostics
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4

--- a/.github/workflows/kubernetes-platform.yml
+++ b/.github/workflows/kubernetes-platform.yml
@@ -71,19 +71,19 @@ jobs:
           python-version: "3.10"
       - name: Install proof dependency
         run: python -m pip install --disable-pip-version-check 'PyYAML==6.0.3'
-      - name: Run event-bound platform reference proof
-        shell: bash
-        run: |
-          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
-            python scripts/platform/kind_reference.py proof \
-              --cluster "$CLUSTER_NAME" \
-              --mode direct
-          else
-            python scripts/platform/kind_reference.py proof \
-              --cluster "$CLUSTER_NAME" \
-              --mode gitops \
-              --source-commit "$GITHUB_SHA"
-          fi
+      - name: Run pull-request direct reference proof
+        if: github.event_name == 'pull_request'
+        run: >-
+          python scripts/platform/kind_reference.py proof
+          --cluster "$CLUSTER_NAME"
+          --mode direct
+      - name: Run commit-bound GitOps reference proof
+        if: github.event_name != 'pull_request'
+        run: >-
+          python scripts/platform/kind_reference.py proof
+          --cluster "$CLUSTER_NAME"
+          --mode gitops
+          --source-commit "$GITHUB_SHA"
       - name: Collect failure diagnostics
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4

--- a/platform/README.md
+++ b/platform/README.md
@@ -56,4 +56,4 @@ make platform-render
 make platform-kind-proof
 ```
 
-Der vollständige GitOps-Beweis läuft im Workflow `kubernetes-platform` gegen einen eindeutig benannten, kurzlebigen kind-Cluster.
+Der Workflow `kubernetes-platform` prüft Pull Requests im Direct-Modus gegen den exakt ausgecheckten Merge-Zustand. Nach einem Push auf `main` und bei manuellen Läufen prüft er zusätzlich die vollständige Flux-/GitOps-Kette gegen einen eindeutig benannten, kurzlebigen kind-Cluster.

--- a/runbooks/kubernetes-local-reference.md
+++ b/runbooks/kubernetes-local-reference.md
@@ -57,6 +57,9 @@ Ein Git-Branch muss bereits veröffentlicht sein:
 
 ```bash
 python3 scripts/platform/kind_reference.py proof   --cluster weltgewebe-reference-gitops   --mode gitops   --source-ref <branch>
+
+# Für einen unveränderlichen CI-/Releasebeweis statt eines beweglichen Branches:
+python3 scripts/platform/kind_reference.py proof   --cluster weltgewebe-reference-commit   --mode gitops   --source-commit <vollständiger-git-commit>
 ```
 
 Zusätzlich wird ein absichtlicher Replica-Drift gesetzt und durch Flux korrigiert.

--- a/scripts/ci/tests/test_kubernetes_platform_contract.py
+++ b/scripts/ci/tests/test_kubernetes_platform_contract.py
@@ -41,6 +41,56 @@ class KubernetesPlatformContractTests(unittest.TestCase):
         result = self.validator.validate(render=False)
         self.assertEqual(result["status"], "pass")
 
+    def test_ci_proof_binds_pull_requests_to_checked_out_merge_state(self) -> None:
+        workflow = (ROOT / ".github/workflows/kubernetes-platform.yml").read_text()
+        self.assertIn('if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then', workflow)
+        pull_request_branch, gitops_branch = workflow.split(
+            'if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then', 1
+        )[1].split("else", 1)
+        self.assertIn("--mode direct", pull_request_branch)
+        self.assertNotIn("--source-ref", pull_request_branch)
+        self.assertIn("--mode gitops", gitops_branch)
+        self.assertIn('--source-commit "$GITHUB_SHA"', gitops_branch)
+        self.assertNotIn("SOURCE_REF:", workflow)
+        self.assertNotIn("github.head_ref || github.ref_name", workflow)
+
+    def test_source_binding_fails_before_cluster_work_for_invalid_modes(self) -> None:
+        commit = "0123456789abcdef0123456789abcdef01234567"
+        self.reference.validate_source_binding(
+            "direct", source_ref=None, source_commit=None
+        )
+        self.reference.validate_source_binding(
+            "gitops", source_ref=None, source_commit=commit
+        )
+        self.reference.validate_source_binding(
+            "gitops", source_ref="main", source_commit=None
+        )
+        invalid = (
+            ("direct", "main", None, "invalid for direct"),
+            ("direct", None, commit, "invalid for direct"),
+            ("gitops", None, None, "exactly one"),
+            ("gitops", "main", commit, "exactly one"),
+            ("gitops", None, "abc", "full lowercase"),
+        )
+        for mode, source_ref, source_commit, message in invalid:
+            with self.subTest(mode=mode, source_ref=source_ref), self.assertRaisesRegex(
+                self.reference.ProofError, message
+            ):
+                self.reference.validate_source_binding(
+                    mode, source_ref=source_ref, source_commit=source_commit
+                )
+
+    def test_flux_source_can_bind_exact_commit_or_explicit_branch(self) -> None:
+        commit = "0123456789abcdef0123456789abcdef01234567"
+        by_commit = self.reference.flux_source_document(commit=commit)
+        by_branch = self.reference.flux_source_document(branch="main")
+        self.assertEqual(by_commit["spec"]["ref"], {"commit": commit})
+        self.assertEqual(by_branch["spec"]["ref"], {"branch": "main"})
+        with self.assertRaisesRegex(self.reference.ProofError, "exactly one"):
+            self.reference.flux_source_document()
+        with self.assertRaisesRegex(self.reference.ProofError, "exactly one"):
+            self.reference.flux_source_document(branch="main", commit=commit)
+
     def test_nonlocal_overlays_reject_local_fixture_markers(self) -> None:
         production = "platform/apps/weltgewebe/overlays/production"
         for marker in self.validator.LOCAL_FIXTURE_SENTINELS:

--- a/scripts/ci/tests/test_kubernetes_platform_contract.py
+++ b/scripts/ci/tests/test_kubernetes_platform_contract.py
@@ -54,6 +54,35 @@ class KubernetesPlatformContractTests(unittest.TestCase):
         self.assertNotIn("SOURCE_REF:", workflow)
         self.assertNotIn("github.head_ref || github.ref_name", workflow)
 
+    def test_cli_parser_accepts_exact_source_commit(self) -> None:
+        commit = "0123456789abcdef0123456789abcdef01234567"
+        args = self.reference.argument_parser().parse_args(
+            [
+                "proof",
+                "--cluster",
+                "reference",
+                "--mode",
+                "gitops",
+                "--source-commit",
+                commit,
+            ]
+        )
+        self.assertEqual(args.command, "proof")
+        self.assertEqual(args.source_commit, commit)
+        self.assertIsNone(args.source_ref)
+        with self.assertRaises(SystemExit):
+            self.reference.argument_parser().parse_args(
+                [
+                    "proof",
+                    "--mode",
+                    "gitops",
+                    "--source-ref",
+                    "main",
+                    "--source-commit",
+                    commit,
+                ]
+            )
+
     def test_source_binding_fails_before_cluster_work_for_invalid_modes(self) -> None:
         commit = "0123456789abcdef0123456789abcdef01234567"
         self.reference.validate_source_binding(

--- a/scripts/ci/tests/test_kubernetes_platform_contract.py
+++ b/scripts/ci/tests/test_kubernetes_platform_contract.py
@@ -109,6 +109,22 @@ class KubernetesPlatformContractTests(unittest.TestCase):
                     mode, source_ref=source_ref, source_commit=source_commit
                 )
 
+    def test_commit_source_must_match_local_workspace_head(self) -> None:
+        commit = "0123456789abcdef0123456789abcdef01234567"
+        self.reference.validate_workspace_binding(
+            source_commit=None, workspace_commit=commit
+        )
+        self.reference.validate_workspace_binding(
+            source_commit=commit, workspace_commit=commit
+        )
+        with self.assertRaisesRegex(
+            self.reference.ProofError, "exact local workspace HEAD"
+        ):
+            self.reference.validate_workspace_binding(
+                source_commit="fedcba9876543210fedcba9876543210fedcba98",
+                workspace_commit=commit,
+            )
+
     def test_flux_source_can_bind_exact_commit_or_explicit_branch(self) -> None:
         commit = "0123456789abcdef0123456789abcdef01234567"
         by_commit = self.reference.flux_source_document(commit=commit)

--- a/scripts/ci/tests/test_kubernetes_platform_contract.py
+++ b/scripts/ci/tests/test_kubernetes_platform_contract.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import shlex
 import subprocess
 import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
+
+import yaml
 
 ROOT = Path(__file__).resolve().parents[3]
 
@@ -42,17 +45,45 @@ class KubernetesPlatformContractTests(unittest.TestCase):
         self.assertEqual(result["status"], "pass")
 
     def test_ci_proof_binds_pull_requests_to_checked_out_merge_state(self) -> None:
-        workflow = (ROOT / ".github/workflows/kubernetes-platform.yml").read_text()
-        self.assertIn('if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then', workflow)
-        pull_request_branch, gitops_branch = workflow.split(
-            'if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then', 1
-        )[1].split("else", 1)
-        self.assertIn("--mode direct", pull_request_branch)
-        self.assertNotIn("--source-ref", pull_request_branch)
-        self.assertIn("--mode gitops", gitops_branch)
-        self.assertIn('--source-commit "$GITHUB_SHA"', gitops_branch)
-        self.assertNotIn("SOURCE_REF:", workflow)
-        self.assertNotIn("github.head_ref || github.ref_name", workflow)
+        workflow_path = ROOT / ".github/workflows/kubernetes-platform.yml"
+        workflow_text = workflow_path.read_text()
+        workflow = yaml.safe_load(workflow_text)
+        steps = workflow["jobs"]["kind-gitops-proof"]["steps"]
+        named_steps = {step["name"]: step for step in steps if "name" in step}
+
+        direct = named_steps["Run pull-request direct reference proof"]
+        gitops = named_steps["Run commit-bound GitOps reference proof"]
+
+        self.assertEqual(direct["if"], "github.event_name == 'pull_request'")
+        self.assertEqual(gitops["if"], "github.event_name != 'pull_request'")
+        self.assertEqual(
+            shlex.split(direct["run"]),
+            [
+                "python",
+                "scripts/platform/kind_reference.py",
+                "proof",
+                "--cluster",
+                "$CLUSTER_NAME",
+                "--mode",
+                "direct",
+            ],
+        )
+        self.assertEqual(
+            shlex.split(gitops["run"]),
+            [
+                "python",
+                "scripts/platform/kind_reference.py",
+                "proof",
+                "--cluster",
+                "$CLUSTER_NAME",
+                "--mode",
+                "gitops",
+                "--source-commit",
+                "$GITHUB_SHA",
+            ],
+        )
+        self.assertNotIn("SOURCE_REF:", workflow_text)
+        self.assertNotIn("github.head_ref || github.ref_name", workflow_text)
 
     def test_cli_parser_accepts_exact_source_commit(self) -> None:
         commit = "0123456789abcdef0123456789abcdef01234567"
@@ -95,11 +126,13 @@ class KubernetesPlatformContractTests(unittest.TestCase):
             "gitops", source_ref="main", source_commit=None
         )
         invalid = (
+            ("unsupported", None, commit, "unsupported proof mode"),
             ("direct", "main", None, "invalid for direct"),
             ("direct", None, commit, "invalid for direct"),
             ("gitops", None, None, "exactly one"),
             ("gitops", "main", commit, "exactly one"),
             ("gitops", None, "abc", "full lowercase"),
+            ("gitops", None, "A" * 40, "full lowercase"),
         )
         for mode, source_ref, source_commit, message in invalid:
             with self.subTest(mode=mode, source_ref=source_ref), self.assertRaisesRegex(

--- a/scripts/platform/kind_reference.py
+++ b/scripts/platform/kind_reference.py
@@ -941,17 +941,23 @@ def proof(args: argparse.Namespace) -> dict[str, Any]:
             delete_owned_cluster(kind, args.cluster)
 
 
-def main() -> int:
+def argument_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="command", required=True)
     proof_parser = subparsers.add_parser("proof")
     proof_parser.add_argument("--cluster", default=DEFAULT_CLUSTER)
     proof_parser.add_argument("--mode", choices=("direct", "gitops"), default="direct")
-    proof_parser.add_argument("--source-ref")
+    source_group = proof_parser.add_mutually_exclusive_group()
+    source_group.add_argument("--source-ref")
+    source_group.add_argument("--source-commit")
     proof_parser.add_argument("--keep", action="store_true")
     down_parser = subparsers.add_parser("down")
     down_parser.add_argument("--cluster", default=DEFAULT_CLUSTER)
-    args = parser.parse_args()
+    return parser
+
+
+def main() -> int:
+    args = argument_parser().parse_args()
     try:
         receipt = tool_receipt()
         if args.command == "down":

--- a/scripts/platform/kind_reference.py
+++ b/scripts/platform/kind_reference.py
@@ -6,6 +6,7 @@ import hashlib
 import ipaddress
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -20,6 +21,7 @@ CACHE = ROOT / ".cache/weltgewebe-platform"
 MARKERS = CACHE / "clusters"
 KUBECONFIGS = CACHE / "kubeconfigs"
 DEFAULT_CLUSTER = "weltgewebe-reference"
+FULL_GIT_OBJECT_ID = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})")
 GATEWAY_API_ARTIFACTS = (
     "gateway_api_gatewayclasses",
     "gateway_api_gateways",
@@ -369,24 +371,27 @@ def namespace_document(name: str, *, data_client: bool = False) -> dict[str, Any
     }
 
 
+def has_exactly_one_value(*values: str | None) -> bool:
+    return sum(bool(value) for value in values) == 1
+
+
 def validate_source_binding(
     mode: str, *, source_ref: str | None, source_commit: str | None
 ) -> None:
+    if mode not in {"direct", "gitops"}:
+        raise ProofError(f"unsupported proof mode: {mode}")
     if mode == "direct":
         if source_ref or source_commit:
             raise ProofError(
                 "--source-ref and --source-commit are invalid for direct mode"
             )
         return
-    if bool(source_ref) == bool(source_commit):
+    if not has_exactly_one_value(source_ref, source_commit):
         raise ProofError(
             "exactly one of --source-ref or --source-commit is required "
             "for gitops mode"
         )
-    if source_commit and (
-        len(source_commit) not in (40, 64)
-        or any(character not in "0123456789abcdef" for character in source_commit)
-    ):
+    if source_commit and FULL_GIT_OBJECT_ID.fullmatch(source_commit) is None:
         raise ProofError("--source-commit must be a full lowercase Git object id")
 
 
@@ -403,7 +408,7 @@ def validate_workspace_binding(
 def flux_source_document(
     *, branch: str | None = None, commit: str | None = None
 ) -> dict[str, Any]:
-    if bool(branch) == bool(commit):
+    if not has_exactly_one_value(branch, commit):
         raise ProofError("exactly one Flux source branch or commit is required")
     document = yaml.safe_load((ROOT / "platform/clusters/local/source.yaml").read_text())
     document["spec"]["ref"] = {"branch": branch} if branch else {"commit": commit}

--- a/scripts/platform/kind_reference.py
+++ b/scripts/platform/kind_reference.py
@@ -390,6 +390,16 @@ def validate_source_binding(
         raise ProofError("--source-commit must be a full lowercase Git object id")
 
 
+def validate_workspace_binding(
+    *, source_commit: str | None, workspace_commit: str
+) -> None:
+    if source_commit and source_commit != workspace_commit:
+        raise ProofError(
+            "--source-commit must equal the exact local workspace HEAD "
+            f"({workspace_commit})"
+        )
+
+
 def flux_source_document(
     *, branch: str | None = None, commit: str | None = None
 ) -> dict[str, Any]:
@@ -851,6 +861,14 @@ def proof(args: argparse.Namespace) -> dict[str, Any]:
         source_ref=args.source_ref,
         source_commit=args.source_commit,
     )
+    if output(["git", "status", "--porcelain"]):
+        raise ProofError("reference proof requires a clean, commit-bound worktree")
+    commit = output(["git", "rev-parse", "HEAD"])
+    validate_workspace_binding(
+        source_commit=args.source_commit,
+        workspace_commit=commit,
+    )
+    timestamp = output(["git", "show", "-s", "--format=%cI", "HEAD"])
     require_host_tools()
     receipt = tool_receipt()
     tools = receipt["tools"]
@@ -860,10 +878,6 @@ def proof(args: argparse.Namespace) -> dict[str, Any]:
     flux = tools["flux"]
     helm = tools["helm"]
     assert_available_cluster_name(kind, args.cluster)
-    if output(["git", "status", "--porcelain"]):
-        raise ProofError("reference proof requires a clean, commit-bound worktree")
-    commit = output(["git", "rev-parse", "HEAD"])
-    timestamp = output(["git", "show", "-s", "--format=%cI", "HEAD"])
     app_namespace = "weltgewebe"
     created = False
     try:

--- a/scripts/platform/kind_reference.py
+++ b/scripts/platform/kind_reference.py
@@ -369,9 +369,34 @@ def namespace_document(name: str, *, data_client: bool = False) -> dict[str, Any
     }
 
 
-def flux_source_document(branch: str) -> dict[str, Any]:
+def validate_source_binding(
+    mode: str, *, source_ref: str | None, source_commit: str | None
+) -> None:
+    if mode == "direct":
+        if source_ref or source_commit:
+            raise ProofError(
+                "--source-ref and --source-commit are invalid for direct mode"
+            )
+        return
+    if bool(source_ref) == bool(source_commit):
+        raise ProofError(
+            "exactly one of --source-ref or --source-commit is required "
+            "for gitops mode"
+        )
+    if source_commit and (
+        len(source_commit) not in (40, 64)
+        or any(character not in "0123456789abcdef" for character in source_commit)
+    ):
+        raise ProofError("--source-commit must be a full lowercase Git object id")
+
+
+def flux_source_document(
+    *, branch: str | None = None, commit: str | None = None
+) -> dict[str, Any]:
+    if bool(branch) == bool(commit):
+        raise ProofError("exactly one Flux source branch or commit is required")
     document = yaml.safe_load((ROOT / "platform/clusters/local/source.yaml").read_text())
-    document["spec"]["ref"] = {"branch": branch}
+    document["spec"]["ref"] = {"branch": branch} if branch else {"commit": commit}
     return document
 
 
@@ -380,8 +405,13 @@ def apply_direct(kubectl: str, kustomize: str, path: str) -> None:
     run([kubectl, "apply", "-f", "-"], input_text=rendered)
 
 
-def apply_flux_data(kubectl: str, branch: str) -> None:
-    apply_yaml(kubectl, flux_source_document(branch))
+def apply_flux_data(
+    kubectl: str, *, source_ref: str | None = None, source_commit: str | None = None
+) -> None:
+    apply_yaml(
+        kubectl,
+        flux_source_document(branch=source_ref, commit=source_commit),
+    )
     apply_file(kubectl, ROOT / "platform/clusters/local/local-data.yaml")
     apply_file(kubectl, ROOT / "platform/clusters/local/migration.yaml")
     wait_condition(kubectl, "flux-system", "gitrepository/weltgewebe", "Ready")
@@ -816,6 +846,11 @@ def diagnostic_snapshot(kubectl: str, name: str) -> None:
 
 
 def proof(args: argparse.Namespace) -> dict[str, Any]:
+    validate_source_binding(
+        args.mode,
+        source_ref=args.source_ref,
+        source_commit=args.source_commit,
+    )
     require_host_tools()
     receipt = tool_receipt()
     tools = receipt["tools"]
@@ -856,9 +891,11 @@ def proof(args: argparse.Namespace) -> dict[str, Any]:
         )
         run([kubectl, "wait", "--for=condition=Ready", "nodes", "--all", "--timeout=5m"])
         if args.mode == "gitops":
-            if not args.source_ref:
-                raise ProofError("--source-ref is required for gitops mode")
-            apply_flux_data(kubectl, args.source_ref)
+            apply_flux_data(
+                kubectl,
+                source_ref=args.source_ref,
+                source_commit=args.source_commit,
+            )
         else:
             apply_direct(kubectl, kustomize, "platform/infrastructure/local-data")
             wait_rollout(kubectl, "weltgewebe-data", "deployment/postgres")
@@ -876,6 +913,7 @@ def proof(args: argparse.Namespace) -> dict[str, Any]:
             "cluster": args.cluster,
             "mode": args.mode,
             "source_ref": args.source_ref,
+            "source_commit": args.source_commit,
             "commit": commit,
             "tool_lock_sha256": receipt["lock_sha256"],
             "image_ids": image_ids,


### PR DESCRIPTION
<!-- weltgewebe-risk: R3 -->

## Problem

PR #1454 used the raw PR branch as the Flux source while GitHub Actions built images from the checked-out merge commit. Fork pull requests could therefore target a branch that does not exist in the upstream repository, and images could be proved against different manifests.

## Change

- run pull-request proofs in direct mode against the exact checked-out merge state;
- run the full Flux/GitOps proof after pushes to `main` and in manual runs;
- bind GitOps runs to the exact `GITHUB_SHA` instead of a moving branch;
- represent direct and GitOps proofs as separate GitHub Actions steps with explicit event conditions;
- allow the reference runner to select exactly one branch or full commit and reject unsupported modes or ambiguous bindings;
- require a commit-bound proof source to equal the local workspace HEAD;
- record the selected source commit in the proof receipt;
- parse the workflow structurally as YAML in contract tests and verify exact command arguments instead of splitting Bash source text.

## Verification

- 39 focused platform contract tests;
- all eight Kustomize targets rendered and validated;
- Python compile and Ruff checks;
- structural workflow-YAML verification;
- `git diff --check`;
- current `main` merged without conflict;
- final commit-bound three-node kind/Flux proof passed on `8776169abf706d532295da61d9f3b454bd1015f7`;
- Flux fetched and applied that exact revision, replaced both API pods, repaired replica drift, verified Gateway/Web/API, and deleted the proof cluster;
- proof receipt SHA-256: `db26bea9ea9158161e602ed3cd99cd918287a5dd23bc1a63542fef49eb131e7f`;
- exact R3 review-evidence gate passed with correctness and operations reports bound to diff SHA-256 `9e691cb2336a7e0a1c1e7be6b22b8803fceb0ee85aee8d9c24416066e2308ab6`.

## Boundaries

No Kubernetes workload, production overlay, secret, deployment, DNS, or live runtime is changed.