### PR TITLE
fix(web): focus application target after client navigation

### DIFF
--- a/apps/web/src/routes/antraege/+page.svelte
+++ b/apps/web/src/routes/antraege/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { onMount } from "svelte";
-  import { goto } from "$app/navigation";
+  import { onMount, tick } from "svelte";
+  import { afterNavigate, goto } from "$app/navigation";
   import { page } from "$app/stores";
   import { authStore } from "$lib/auth/store";
   import ProposalDetail from "$lib/components/governance/ProposalDetail.svelte";
@@ -20,6 +20,7 @@
   let summary = "";
   let submitting = false;
   let leaving = false;
+  let applicationSection: HTMLElement | null = null;
 
   $: selectedProposalId = $page.url.searchParams.get("id");
   $: statusFilter = $page.url.searchParams.get("status");
@@ -104,9 +105,20 @@
     }
   }
 
+  async function focusApplicationSection(url: URL): Promise<void> {
+    if (url.hash !== "#antrag-stellen") return;
+    await tick();
+    applicationSection?.focus();
+  }
+
+  afterNavigate(({ to }) => {
+    if (to) void focusApplicationSection(to.url);
+  });
+
   onMount(async () => {
     await authStore.checkAuth();
     await refresh();
+    await focusApplicationSection($page.url);
   });
 </script>
 
@@ -129,7 +141,7 @@
   </header>
 
   {#if isGuest}
-    <section id="antrag-stellen" class="guest-card" aria-labelledby="weberstatus-heading">
+    <section id="antrag-stellen" class="guest-card" aria-labelledby="weberstatus-heading" tabindex="-1" bind:this={applicationSection}>
       <div>
         <p class="eyebrow">Dein Status: Gast</p>
         <h2 id="weberstatus-heading">Weberstatus beantragen</h2>

--- a/apps/web/tests/governance.spec.ts
+++ b/apps/web/tests/governance.spec.ts
@@ -254,13 +254,53 @@ test("a guest reaches the Weber application as a distinct weaving action", async
   await mockApiResponses(page, {
     auth: { authenticated: true, account_id: GUEST_ID, role: "gast" },
   });
+  await installGovernanceRoutes(page);
   await page.goto("/map");
   await page.getByTestId("tool-fan-trigger").click();
   await page.getByTestId("tool-fan-weave").click();
-  await expect(page.getByTestId("tool-fan-create-proposal")).toHaveAttribute(
+  const applicationAction = page.getByTestId("tool-fan-create-proposal");
+  await expect(applicationAction).toHaveAttribute(
     "href",
     "/antraege#antrag-stellen",
   );
+  await applicationAction.click();
+  await expect(page).toHaveURL(/\/antraege#antrag-stellen$/);
+  await expect(page.locator("#antrag-stellen")).toBeFocused();
+});
+
+test("client-side hash navigation focuses the Weber application without remounting", async ({
+  page,
+}) => {
+  await mockApiResponses(page, {
+    auth: { authenticated: true, account_id: GUEST_ID, role: "gast" },
+  });
+  await installGovernanceRoutes(page);
+  await page.goto("/antraege");
+  await expect(
+    page.getByRole("heading", { name: "Weberstatus beantragen" }),
+  ).toBeVisible();
+
+  await page.evaluate(() => {
+    (window as Window & { __intraPageProbe?: string }).__intraPageProbe =
+      "preserved";
+    const link = document.createElement("a");
+    link.href = "/antraege#antrag-stellen";
+    link.textContent = "Zum Antrag";
+    link.dataset.testid = "intra-page-application-link";
+    document.body.appendChild(link);
+  });
+  await page.getByTestId("intra-page-application-link").click();
+
+  await expect(page).toHaveURL(/\/antraege#antrag-stellen$/);
+  await expect(page.locator("#antrag-stellen")).toBeFocused();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (window as Window & { __intraPageProbe?: string }).__intraPageProbe,
+      ),
+    )
+    .toBe("preserved");
 });
 
 test("guest can read everything and submit only the own Weber application", async ({


### PR DESCRIPTION
<!-- weltgewebe-risk: R2 -->

## Ergebnis

Der Webungsweg `Antrag stellen` verschiebt nach clientseitiger Navigation den Tastatur- und Screenreader-Fokus zuverlässig auf den Weberantrag.

## Umsetzung

- Hashziel `#antrag-stellen` ist programmatisch fokussierbar.
- `afterNavigate` behandelt Navigationen, bei denen die Antragsseite nicht neu gemountet wird.
- Der initiale Aufruf wartet zusätzlich auf Authentifizierung und Antragsdaten, bevor der Fokus gesetzt wird.
- Regressionstests belegen sowohl den realen Kartenweg als auch eine reine Intra-Page-Navigation ohne Reload.

## Prüfung

- `pnpm check:ci`
- `pnpm lint`
- `pnpm test:unit`
- `pnpm run build:e2e`
- vollständige `tests/governance.spec.ts`
- gezielte Fokusfälle: 2/2 bestanden

## Review-Einordnung

Die im Ausgangsreview behauptete Geometriefunktion `announceGeometryChange()` existiert auf dem gemergten `main` nicht. Beide Fächer schließen Suche und Karteninhalt vor dem Öffnen; deshalb können während der Fächertransition derzeit keine Such-Richtungsmarker falsch vermessen werden. Eine zusätzliche Transition-/DOM-Cache-Architektur wurde bewusst nicht eingeführt.
