### PR TITLE
fix(web): focus application target after client navigation

### DIFF
--- a/apps/web/src/routes/antraege/+page.svelte
+++ b/apps/web/src/routes/antraege/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { onMount } from "svelte";
-  import { goto } from "$app/navigation";
+  import { onMount, tick } from "svelte";
+  import { afterNavigate, goto } from "$app/navigation";
   import { page } from "$app/stores";
   import { authStore } from "$lib/auth/store";
   import ProposalDetail from "$lib/components/governance/ProposalDetail.svelte";
@@ -20,6 +20,10 @@
   let summary = "";
   let submitting = false;
   let leaving = false;
+  type ApplicationFocusRequest = "initial" | "navigation";
+
+  let applicationSection: HTMLElement | null = null;
+  let pendingApplicationFocus: ApplicationFocusRequest | null = null;
 
   $: selectedProposalId = $page.url.searchParams.get("id");
   $: statusFilter = $page.url.searchParams.get("status");
@@ -104,8 +108,41 @@
     }
   }
 
+  async function focusPendingApplicationSection(): Promise<boolean> {
+    const request = pendingApplicationFocus;
+    if (!request) return false;
+    await tick();
+    if (!applicationSection) return false;
+
+    if (request === "initial") {
+      const active = document.activeElement;
+      if (
+        active &&
+        active !== document.body &&
+        active !== document.documentElement
+      ) {
+        pendingApplicationFocus = null;
+        return false;
+      }
+    }
+
+    applicationSection.focus();
+    pendingApplicationFocus = null;
+    return document.activeElement === applicationSection;
+  }
+
+  afterNavigate(({ to, type }) => {
+    if (to?.url.hash !== "#antrag-stellen") {
+      pendingApplicationFocus = null;
+      return;
+    }
+    pendingApplicationFocus = type === "enter" ? "initial" : "navigation";
+    void focusPendingApplicationSection();
+  });
+
   onMount(async () => {
     await authStore.checkAuth();
+    await focusPendingApplicationSection();
     await refresh();
   });
 </script>
@@ -129,7 +166,7 @@
   </header>
 
   {#if isGuest}
-    <section id="antrag-stellen" class="guest-card" aria-labelledby="weberstatus-heading">
+    <section id="antrag-stellen" class="guest-card" aria-labelledby="weberstatus-heading" tabindex="-1" bind:this={applicationSection}>
       <div>
         <p class="eyebrow">Dein Status: Gast</p>
         <h2 id="weberstatus-heading">Weberstatus beantragen</h2>

--- a/apps/web/tests/governance.spec.ts
+++ b/apps/web/tests/governance.spec.ts
@@ -40,9 +40,16 @@ async function installGovernanceRoutes(
   options: {
     initialStatus?: "consent" | "voting";
     existingApplicantId?: string;
+    deferListResponse?: boolean;
   } = {},
 ) {
   let currentStatus = options.initialStatus ?? "consent";
+  let resolveListResponse: (() => void) | null = null;
+  const listResponseGate = options.deferListResponse
+    ? new Promise<void>((resolve) => {
+        resolveListResponse = resolve;
+      })
+    : null;
   const requests: Array<{ method: string; pathname: string; body: unknown }> =
     [];
 
@@ -54,6 +61,7 @@ async function installGovernanceRoutes(
     requests.push({ method, pathname: url.pathname, body });
 
     if (url.pathname === "/api/proposals" && method === "GET") {
+      if (listResponseGate) await listResponseGate;
       return route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -148,6 +156,7 @@ async function installGovernanceRoutes(
   return {
     requests,
     setStatus: (status: "consent" | "voting") => (currentStatus = status),
+    releaseListResponse: () => resolveListResponse?.(),
   };
 }
 
@@ -254,13 +263,97 @@ test("a guest reaches the Weber application as a distinct weaving action", async
   await mockApiResponses(page, {
     auth: { authenticated: true, account_id: GUEST_ID, role: "gast" },
   });
+  const governance = await installGovernanceRoutes(page, {
+    deferListResponse: true,
+  });
   await page.goto("/map");
   await page.getByTestId("tool-fan-trigger").click();
   await page.getByTestId("tool-fan-weave").click();
-  await expect(page.getByTestId("tool-fan-create-proposal")).toHaveAttribute(
+  const applicationAction = page.getByTestId("tool-fan-create-proposal");
+  await expect(applicationAction).toHaveAttribute(
     "href",
     "/antraege#antrag-stellen",
   );
+  await applicationAction.click();
+  await expect(page).toHaveURL(/\/antraege#antrag-stellen$/);
+  await expect(page.locator("#antrag-stellen")).toBeFocused({ timeout: 500 });
+  expect(
+    governance.requests.some(
+      (entry) => entry.method === "GET" && entry.pathname === "/api/proposals",
+    ),
+  ).toBe(true);
+  governance.releaseListResponse();
+});
+
+test("client-side hash navigation focuses the Weber application without remounting", async ({
+  page,
+}) => {
+  await mockApiResponses(page, {
+    auth: { authenticated: true, account_id: GUEST_ID, role: "gast" },
+  });
+  await installGovernanceRoutes(page);
+  await page.goto("/antraege");
+  await expect(
+    page.getByRole("heading", { name: "Weberstatus beantragen" }),
+  ).toBeVisible();
+
+  await page.evaluate(() => {
+    (window as Window & { __intraPageProbe?: string }).__intraPageProbe =
+      "preserved";
+    const link = document.createElement("a");
+    link.href = "/antraege#antrag-stellen";
+    link.textContent = "Zum Antrag";
+    link.dataset.testid = "intra-page-application-link";
+    document.body.appendChild(link);
+  });
+  await page.getByTestId("intra-page-application-link").click();
+
+  await expect(page).toHaveURL(/\/antraege#antrag-stellen$/);
+  await expect(page.locator("#antrag-stellen")).toBeFocused();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (window as Window & { __intraPageProbe?: string }).__intraPageProbe,
+      ),
+    )
+    .toBe("preserved");
+});
+
+test("initial hash load does not steal focus after the user moves it", async ({
+  page,
+}) => {
+  await mockApiResponses(page, {
+    auth: { authenticated: true, account_id: GUEST_ID, role: "gast" },
+  });
+  let releaseAuthResponse!: () => void;
+  const authResponseGate = new Promise<void>((resolve) => {
+    releaseAuthResponse = resolve;
+  });
+  await page.route("**/api/auth/me", async (route) => {
+    await authResponseGate;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        authenticated: true,
+        account_id: GUEST_ID,
+        role: "gast",
+      }),
+    });
+  });
+  await installGovernanceRoutes(page);
+  await page.goto("/antraege#antrag-stellen");
+
+  const backLink = page.getByRole("link", { name: "Zum Gewebe" });
+  await backLink.focus();
+  await expect(backLink).toBeFocused();
+  releaseAuthResponse();
+
+  await expect(
+    page.getByRole("heading", { name: "Weberstatus beantragen" }),
+  ).toBeVisible();
+  await expect(backLink).toBeFocused();
 });
 
 test("guest can read everything and submit only the own Weber application", async ({


### PR DESCRIPTION
<!-- weltgewebe-risk: R2 -->

## Ergebnis

Der Webungsweg `Antrag stellen` verschiebt nach clientseitiger Navigation den Tastatur- und Screenreader-Fokus zuverlässig auf den Weberantrag, ohne bei einem direkten Seitenaufruf später den bereits bewegten Nutzerfokus zurückzuholen.

## Umsetzung

- Hashziel `#antrag-stellen` ist programmatisch fokussierbar.
- `afterNavigate` unterscheidet den dokumentierten Navigationstyp `enter` von clientseitigen Navigationen.
- Nutzerinitiierte Navigation fokussiert das Ziel nach geklärter Authentifizierung und ausdrücklich vor dem Antrags-Fetch.
- Beim initialen Seitenaufruf wird der Fokus nur gesetzt, solange der Nutzer ihn nicht selbst bewegt hat.
- Regressionstests blockieren Auth- beziehungsweise Datenantworten gezielt und beweisen das Timing, statt nur auf ein irgendwann eintretendes Ergebnis zu warten.

## Prüfung

- `pnpm check:ci`
- `pnpm lint`
- `pnpm test:unit`
- `pnpm run build:e2e`
- vollständige `tests/governance.spec.ts`
- drei gezielte Fokusfälle: 3/3 bestanden

## Review-Nachlauf

Ein erster externer Korrektheitsreview blockierte die vorherige Variante wegen möglichem verspätetem Focus-Stealing. Der Befund wurde übernommen und mit zwei zusätzlichen Timingverträgen abgesichert. PR #1459 wird deshalb ohne Force-Push durch diesen neuen, sauber gebundenen PR ersetzt.

## Bewusst nicht umgesetzt

Die im Ausgangsreview genannte Funktion `announceGeometryChange()` existiert auf dem gemergten `main` nicht. Beide Fächer schließen Suche und Karteninhalt vor dem Öffnen; während der Transition existieren daher derzeit keine Such-Richtungsmarker, die falsch vermessen werden könnten. Zusätzliche Transition-Listener und DOM-Caches würden den aktuellen Code ohne belegten Nutzen verkomplizieren.
