### PR TITLE
fix(privacy): make radius projection non-reversible

### DIFF
--- a/apps/api/migrations/20260718000001_radius_projection_privacy.down.sql
+++ b/apps/api/migrations/20260718000001_radius_projection_privacy.down.sql
@@ -6,11 +6,20 @@
 -- fail-closed cutover for every currently mapped radius account instead of
 -- restoring or retaining a public radius state. Private locations remain
 -- available for a later safe reactivation.
-UPDATE domain_accounts
-SET map_state = 'not_on_map',
-    radius_m = 0,
-    private_payload = private_payload - 'radius_projection' - 'visibility',
-    updated_at = NOW()
-WHERE map_state = 'radius'
-   OR radius_m > 0
-   OR private_payload->>'visibility' = 'approximate';
+DO $$
+DECLARE
+    affected_rows BIGINT;
+BEGIN
+    UPDATE domain_accounts
+    SET map_state = 'not_on_map',
+        radius_m = 0,
+        private_payload = private_payload - 'radius_projection' - 'visibility',
+        updated_at = NOW()
+    WHERE map_state = 'radius'
+       OR radius_m > 0
+       OR private_payload->>'visibility' = 'approximate';
+
+    GET DIAGNOSTICS affected_rows = ROW_COUNT;
+    RAISE NOTICE 'radius projection privacy rollback hid % account(s)', affected_rows;
+END
+$$;

--- a/apps/api/migrations/20260718000001_radius_projection_privacy.down.sql
+++ b/apps/api/migrations/20260718000001_radius_projection_privacy.down.sql
@@ -1,0 +1,16 @@
+-- Intentionally irreversible security rollback.
+--
+-- A rollback may occur after accounts have created safe random radius bindings.
+-- Older application versions would ignore those bindings and recreate the known
+-- reversible id-based projection. Therefore the down migration repeats the
+-- fail-closed cutover for every currently mapped radius account instead of
+-- restoring or retaining a public radius state. Private locations remain
+-- available for a later safe reactivation.
+UPDATE domain_accounts
+SET map_state = 'not_on_map',
+    radius_m = 0,
+    private_payload = private_payload - 'radius_projection' - 'visibility',
+    updated_at = NOW()
+WHERE map_state = 'radius'
+   OR radius_m > 0
+   OR private_payload->>'visibility' = 'approximate';

--- a/apps/api/migrations/20260718000001_radius_projection_privacy.up.sql
+++ b/apps/api/migrations/20260718000001_radius_projection_privacy.up.sql
@@ -3,11 +3,20 @@
 -- deterministic backfill: every existing radius account is hidden until its
 -- owner explicitly saves the profile and receives a private random binding.
 -- The exact private location remains intact for that controlled reactivation.
-UPDATE domain_accounts
-SET map_state = 'not_on_map',
-    radius_m = 0,
-    private_payload = private_payload - 'radius_projection' - 'visibility',
-    updated_at = NOW()
-WHERE map_state = 'radius'
-   OR radius_m > 0
-   OR private_payload->>'visibility' = 'approximate';
+DO $$
+DECLARE
+    affected_rows BIGINT;
+BEGIN
+    UPDATE domain_accounts
+    SET map_state = 'not_on_map',
+        radius_m = 0,
+        private_payload = private_payload - 'radius_projection' - 'visibility',
+        updated_at = NOW()
+    WHERE map_state = 'radius'
+       OR radius_m > 0
+       OR private_payload->>'visibility' = 'approximate';
+
+    GET DIAGNOSTICS affected_rows = ROW_COUNT;
+    RAISE NOTICE 'radius projection privacy cutover hid % account(s)', affected_rows;
+END
+$$;

--- a/apps/api/migrations/20260718000001_radius_projection_privacy.up.sql
+++ b/apps/api/migrations/20260718000001_radius_projection_privacy.up.sql
@@ -1,0 +1,13 @@
+-- Security cutover for issue #1464. Historical radius positions were derived
+-- from public account ids and were therefore reversible. There is no safe
+-- deterministic backfill: every existing radius account is hidden until its
+-- owner explicitly saves the profile and receives a private random binding.
+-- The exact private location remains intact for that controlled reactivation.
+UPDATE domain_accounts
+SET map_state = 'not_on_map',
+    radius_m = 0,
+    private_payload = private_payload - 'radius_projection' - 'visibility',
+    updated_at = NOW()
+WHERE map_state = 'radius'
+   OR radius_m > 0
+   OR private_payload->>'visibility' = 'approximate';

--- a/apps/api/src/domain_db.rs
+++ b/apps/api/src/domain_db.rs
@@ -14,7 +14,8 @@ use uuid::Uuid;
 use crate::auth::accounts::AccountStore;
 use crate::auth::role::Role;
 use crate::routes::accounts::{
-    map_json_to_public_account, AccountInternal, Location as AccountLocation,
+    ensure_radius_projection_value, map_json_to_public_account, radius_projection_public_pos,
+    AccountInternal, Location as AccountLocation, RADIUS_PROJECTION_KEY,
 };
 use crate::routes::auth::MAX_EMAIL_LEN;
 use crate::routes::edges::{Edge, LifecycleTimestamp};
@@ -405,6 +406,9 @@ fn account_row_to_internal(row: AccountRow) -> Option<AccountInternal> {
     }
     if let (Some(lat), Some(lon)) = (location_lat, location_lon) {
         record.insert("location".to_string(), json!({ "lat": lat, "lon": lon }));
+    }
+    if let Some(projection) = private_payload.get(RADIUS_PROJECTION_KEY) {
+        record.insert(RADIUS_PROJECTION_KEY.to_string(), projection.clone());
     }
     record.insert(
         "radius_m".to_string(),
@@ -1059,13 +1063,12 @@ impl NewDomainAccountRow {
     /// - `map_state` is `not_on_map`, `exact`, or `radius`; legacy `ron` fields
     ///   only force the privacy-safe `not_on_map` state
     /// - the deprecated database `mode` column receives NULL for new writes
-    /// - `radius_m` is bumped to 250 when `visibility == "approximate"` and 0
-    ///   (idempotent with the loader, which only adjusts when the stored radius
-    ///   is still 0)
-    /// - `private_payload` preserves only `visibility` and
-    ///   `suppress_public_pos` where needed for compatibility. Phase E-A
-    ///   `POST /accounts` does not accept `suppress_public_pos` in the request
-    ///   payload; privacy on create uses `visibility=private` (or loader defaults).
+    /// - `radius_m` is accepted only from 50 through 5,000 metres for a
+    ///   radius projection; historical approximate records without a valid
+    ///   private binding fail closed as `not_on_map`
+    /// - `private_payload` preserves legacy visibility fields where needed and
+    ///   the typed private `radius_projection` binding. The binding is never
+    ///   copied into `AccountPublic` or an outbox payload.
     /// - `created_at` / `updated_at` are taken from the record if present, else
     ///   NULL. The current create path never sets them, so account-create rows
     ///   store NULL — identical to JSONL-create followed by Phase C backfill.
@@ -1146,21 +1149,45 @@ impl NewDomainAccountRow {
                 anyhow::bail!("invalid account map_state: {state}");
             }
         }
+        let radius_requested = explicit_map_state == Some("radius")
+            || visibility == Some("approximate")
+            || radius_m > 0;
+        if radius_requested && radius_m == 0 {
+            radius_m = 250;
+        }
+        let private_location = match (location_lat, location_lon) {
+            (Some(lat), Some(lon)) => Some(AccountLocation { lat, lon }),
+            _ => None,
+        };
+        let valid_radius_projection = if radius_requested {
+            u32::try_from(radius_m)
+                .ok()
+                .filter(|radius_m| (50..=5_000).contains(radius_m))
+                .and_then(|radius_m| {
+                    private_location.as_ref().and_then(|location| {
+                        radius_projection_public_pos(
+                            v.get(RADIUS_PROJECTION_KEY),
+                            location,
+                            radius_m,
+                        )
+                    })
+                })
+        } else {
+            None
+        };
         let map_state = if legacy_not_on_map
             || explicit_map_state == Some("not_on_map")
-            || location_lat.is_none()
-            || location_lon.is_none()
+            || private_location.is_none()
         {
             radius_m = 0;
             "not_on_map".to_string()
-        } else if explicit_map_state == Some("radius")
-            || visibility == Some("approximate")
-            || radius_m > 0
-        {
-            if radius_m == 0 {
-                radius_m = 250;
+        } else if radius_requested {
+            if valid_radius_projection.is_some() {
+                "radius".to_string()
+            } else {
+                radius_m = 0;
+                "not_on_map".to_string()
             }
-            "radius".to_string()
         } else {
             radius_m = 0;
             "exact".to_string()
@@ -1182,6 +1209,9 @@ impl NewDomainAccountRow {
             if vis == "private" {
                 priv_map.insert("suppress_public_pos".to_string(), Value::Bool(true));
             }
+        }
+        if let Some(projection) = v.get(RADIUS_PROJECTION_KEY) {
+            priv_map.insert(RADIUS_PROJECTION_KEY.to_string(), projection.clone());
         }
         let private_payload = if priv_map.is_empty() {
             "{}".to_string()
@@ -1375,16 +1405,18 @@ pub async fn update_account_profile_in_postgres(
         .begin()
         .await
         .map_err(AccountProfileUpdateError::Database)?;
-    let existing: Option<(Option<f64>, Option<f64>)> = sqlx::query_as(
-        "SELECT location_lat, location_lon FROM domain_accounts WHERE id = $1 FOR UPDATE",
+    let existing: Option<(Option<f64>, Option<f64>, String)> = sqlx::query_as(
+        "SELECT location_lat, location_lon, private_payload::text \
+         FROM domain_accounts WHERE id = $1 FOR UPDATE",
     )
     .bind(account_id)
     .fetch_optional(&mut *tx)
     .await
     .map_err(AccountProfileUpdateError::Database)?;
-    let Some((existing_lat, existing_lon)) = existing else {
+    let Some((existing_lat, existing_lon, existing_private_text)) = existing else {
         return Err(AccountProfileUpdateError::NotFound);
     };
+    let existing_private_payload = parse_payload(&existing_private_text);
 
     let effective_location = update
         .location
@@ -1410,6 +1442,27 @@ pub async fn update_account_profile_in_postgres(
     let mut private_map = Map::new();
     if let Some(address) = &update.address {
         private_map.insert("address".to_string(), Value::String(address.clone()));
+    }
+    if let Some(existing_projection) = existing_private_payload.get(RADIUS_PROJECTION_KEY) {
+        // Preserve the old binding while hidden so re-enabling the same private
+        // location and radius does not create a sequence of intersectable points.
+        private_map.insert(
+            RADIUS_PROJECTION_KEY.to_string(),
+            existing_projection.clone(),
+        );
+    }
+    if update.map_state == "radius" {
+        let location = effective_location
+            .as_ref()
+            .ok_or(AccountProfileUpdateError::MissingLocation)?;
+        let radius_m =
+            u32::try_from(update.radius_m).map_err(|_| AccountProfileUpdateError::Mapping)?;
+        let projection = ensure_radius_projection_value(
+            existing_private_payload.get(RADIUS_PROJECTION_KEY),
+            location,
+            radius_m,
+        );
+        private_map.insert(RADIUS_PROJECTION_KEY.to_string(), projection);
     }
     let private_payload = serde_json::to_string(&Value::Object(private_map))
         .map_err(AccountProfileUpdateError::Serialization)?;
@@ -1830,7 +1883,11 @@ mod write_path_tests {
 
     /// The create route builds exactly this record shape before persistence.
     fn create_record() -> Value {
-        json!({
+        let location = AccountLocation {
+            lat: 53.5,
+            lon: 10.0,
+        };
+        let mut record = json!({
             "id": "writepath-unit-1",
             "type": "garnrolle",
             "map_state": "radius",
@@ -1838,10 +1895,12 @@ mod write_path_tests {
             "summary": "A summary",
             "tags": ["x", "y"],
             "role": "weber",
-            "location": { "lat": 53.5, "lon": 10.0 },
+            "location": { "lat": location.lat, "lon": location.lon },
             "radius_m": 250,
             "email": "unit@example.test"
-        })
+        });
+        record[RADIUS_PROJECTION_KEY] = ensure_radius_projection_value(None, &location, 250);
+        record
     }
 
     #[test]
@@ -1874,6 +1933,7 @@ mod write_path_tests {
         assert!(private.get("mode").is_none());
         assert!(private.get("visibility").is_none());
         assert!(private.get("ron_flag").is_none());
+        assert!(private.get(RADIUS_PROJECTION_KEY).is_some());
     }
 
     #[test]
@@ -1930,7 +1990,7 @@ mod write_path_tests {
     }
 
     #[test]
-    fn approximate_zero_radius_becomes_250() {
+    fn legacy_approximate_without_binding_fails_closed() {
         let record = json!({
             "id": "writepath-unit-approx",
             "type": "garnrolle",
@@ -1940,7 +2000,10 @@ mod write_path_tests {
             "radius_m": 0
         });
         let row = NewDomainAccountRow::from_jsonl_record(&record).expect("map");
-        assert_eq!(row.radius_m, 250);
+        assert_eq!(row.map_state, "not_on_map");
+        assert_eq!(row.radius_m, 0);
+        assert_eq!(row.location_lat, Some(53.5));
+        assert_eq!(row.location_lon, Some(10.0));
     }
 
     #[test]

--- a/apps/api/src/domain_db.rs
+++ b/apps/api/src/domain_db.rs
@@ -14,8 +14,9 @@ use uuid::Uuid;
 use crate::auth::accounts::AccountStore;
 use crate::auth::role::Role;
 use crate::routes::accounts::{
-    ensure_radius_projection_value, map_json_to_public_account, radius_projection_public_pos,
-    AccountInternal, Location as AccountLocation, RADIUS_PROJECTION_KEY,
+    ensure_radius_projection_value, map_json_to_public_account, radius_projection_matches_location,
+    radius_projection_public_pos, AccountInternal, Location as AccountLocation, MAX_RADIUS_M,
+    MIN_RADIUS_M, RADIUS_PROJECTION_KEY,
 };
 use crate::routes::auth::MAX_EMAIL_LEN;
 use crate::routes::edges::{Edge, LifecycleTimestamp};
@@ -1142,17 +1143,23 @@ impl NewDomainAccountRow {
             || v.get("suppress_public_pos")
                 .and_then(|value| value.as_bool())
                 .unwrap_or(false);
-        let mut radius_m: i64 = v.get("radius_m").and_then(|v| v.as_u64()).unwrap_or(0) as i64;
+        let radius_raw = v.get("radius_m").and_then(|v| v.as_u64()).unwrap_or(0);
+        let mut radius_m = i64::try_from(radius_raw).unwrap_or(0);
+        let invalid_radius = radius_raw > 0
+            && u32::try_from(radius_raw)
+                .ok()
+                .is_none_or(|radius_m| !(MIN_RADIUS_M..=MAX_RADIUS_M).contains(&radius_m));
         let explicit_map_state = v.get("map_state").and_then(|v| v.as_str());
         if let Some(state) = explicit_map_state {
             if !matches!(state, "not_on_map" | "exact" | "radius") {
                 anyhow::bail!("invalid account map_state: {state}");
             }
         }
-        let radius_requested = explicit_map_state == Some("radius")
+        let radius_requested = invalid_radius
+            || explicit_map_state == Some("radius")
             || visibility == Some("approximate")
             || radius_m > 0;
-        if radius_requested && radius_m == 0 {
+        if radius_requested && radius_m == 0 && !invalid_radius {
             radius_m = 250;
         }
         let private_location = match (location_lat, location_lon) {
@@ -1162,7 +1169,7 @@ impl NewDomainAccountRow {
         let valid_radius_projection = if radius_requested {
             u32::try_from(radius_m)
                 .ok()
-                .filter(|radius_m| (50..=5_000).contains(radius_m))
+                .filter(|radius_m| (MIN_RADIUS_M..=MAX_RADIUS_M).contains(radius_m))
                 .and_then(|radius_m| {
                     private_location.as_ref().and_then(|location| {
                         radius_projection_public_pos(
@@ -1443,13 +1450,18 @@ pub async fn update_account_profile_in_postgres(
     if let Some(address) = &update.address {
         private_map.insert("address".to_string(), Value::String(address.clone()));
     }
-    if let Some(existing_projection) = existing_private_payload.get(RADIUS_PROJECTION_KEY) {
-        // Preserve the old binding while hidden so re-enabling the same private
-        // location and radius does not create a sequence of intersectable points.
-        private_map.insert(
-            RADIUS_PROJECTION_KEY.to_string(),
-            existing_projection.clone(),
-        );
+    if let (Some(existing_projection), Some(location)) = (
+        existing_private_payload.get(RADIUS_PROJECTION_KEY),
+        effective_location.as_ref(),
+    ) {
+        // Preserve the old binding while hidden only when it still belongs to
+        // the current private location. A private move discards the stale anchor.
+        if radius_projection_matches_location(Some(existing_projection), location) {
+            private_map.insert(
+                RADIUS_PROJECTION_KEY.to_string(),
+                existing_projection.clone(),
+            );
+        }
     }
     if update.map_state == "radius" {
         let location = effective_location
@@ -1480,7 +1492,7 @@ pub async fn update_account_profile_in_postgres(
            location_lat = COALESCE($5, location_lat), \
            location_lon = COALESCE($6, location_lon), \
            public_payload = (public_payload - 'summary' - 'tags') || $7::jsonb, \
-           private_payload = (private_payload - 'address' - 'visibility' - 'suppress_public_pos' - 'ron_flag') || $8::jsonb, \
+           private_payload = (private_payload - 'address' - 'visibility' - 'suppress_public_pos' - 'ron_flag' - 'radius_projection') || $8::jsonb, \
            updated_at = now() \
          WHERE id = $1 \
          RETURNING id, kind, title, mode, map_state, radius_m, disabled, \
@@ -1998,6 +2010,22 @@ mod write_path_tests {
             "location": { "lat": 53.5, "lon": 10.0 },
             "visibility": "approximate",
             "radius_m": 0
+        });
+        let row = NewDomainAccountRow::from_jsonl_record(&record).expect("map");
+        assert_eq!(row.map_state, "not_on_map");
+        assert_eq!(row.radius_m, 0);
+        assert_eq!(row.location_lat, Some(53.5));
+        assert_eq!(row.location_lon, Some(10.0));
+    }
+
+    #[test]
+    fn oversized_radius_fails_closed_without_integer_wraparound() {
+        let record = json!({
+            "id": "writepath-unit-oversized-radius",
+            "type": "garnrolle",
+            "title": "Oversized radius",
+            "location": { "lat": 53.5, "lon": 10.0 },
+            "radius_m": u64::MAX
         });
         let row = NewDomainAccountRow::from_jsonl_record(&record).expect("map");
         assert_eq!(row.map_state, "not_on_map");

--- a/apps/api/src/routes/accounts.rs
+++ b/apps/api/src/routes/accounts.rs
@@ -37,10 +37,13 @@ use uuid::Uuid;
 
 const EARTH_RADIUS_M: f64 = 6_371_008.8;
 const LOCATION_MATCH_EPSILON_DEGREES: f64 = 1e-9;
+const POLE_COSINE_EPSILON: f64 = 1e-12;
 const RADIUS_DISTANCE_EPSILON_M: f64 = 0.05;
 const MIN_RADIUS_PUBLIC_OFFSET_M: f64 = 0.01;
-const MIN_RADIUS_M: u32 = 50;
-const MAX_RADIUS_M: u32 = 5_000;
+const UNIT_F64_SHIFT: u32 = 11;
+const UNIT_F64_SCALE: f64 = 9_007_199_254_740_992.0; // 2^53
+pub(crate) const MIN_RADIUS_M: u32 = 50;
+pub(crate) const MAX_RADIUS_M: u32 = 5_000;
 const RADIUS_PROJECTION_VERSION: u8 = 1;
 pub(crate) const RADIUS_PROJECTION_KEY: &str = "radius_projection";
 
@@ -210,6 +213,7 @@ fn great_circle_distance_m(a: &Location, b: &Location) -> f64 {
 }
 
 fn destination_point(anchor: &Location, distance_m: f64, bearing_rad: f64) -> Location {
+    let bearing_rad = bearing_rad.rem_euclid(std::f64::consts::TAU);
     let angular_distance = distance_m / EARTH_RADIUS_M;
     let lat1 = anchor.lat.to_radians();
     let lon1 = anchor.lon.to_radians();
@@ -221,7 +225,7 @@ fn destination_point(anchor: &Location, distance_m: f64, bearing_rad: f64) -> Lo
     // The usual initial-bearing formula becomes 0/0 at the exact poles.
     // Handle those coordinates explicitly so longitude still carries the
     // random angular component instead of collapsing to the anchor meridian.
-    if cos_lat1.abs() < 1e-12 {
+    if cos_lat1.abs() < POLE_COSINE_EPSILON {
         let lat2 = if anchor.lat.is_sign_positive() {
             std::f64::consts::FRAC_PI_2 - angular_distance
         } else {
@@ -257,10 +261,12 @@ fn cryptographic_unit_pair() -> (f64, f64) {
     let mut second = [0_u8; 8];
     first.copy_from_slice(&digest[..8]);
     second.copy_from_slice(&digest[8..16]);
-    let denominator = (u64::MAX as f64) + 1.0;
-    let u = (u64::from_be_bytes(first) as f64 + 0.5) / denominator;
-    let v = (u64::from_be_bytes(second) as f64 + 0.5) / denominator;
-    (u.clamp(f64::EPSILON, 1.0), v.clamp(0.0, 1.0))
+    // IEEE-754 f64 has 53 bits of integer precision. Taking the upper
+    // 53 bits avoids rounding a u64 to 1.0 or introducing uneven buckets.
+    let u =
+        ((u64::from_be_bytes(first) >> UNIT_F64_SHIFT) as f64 / UNIT_F64_SCALE).max(f64::EPSILON);
+    let v = (u64::from_be_bytes(second) >> UNIT_F64_SHIFT) as f64 / UNIT_F64_SCALE;
+    (u, v)
 }
 
 fn generate_radius_projection(location: &Location, radius_m: u32) -> RadiusProjectionBinding {
@@ -292,6 +298,8 @@ fn validated_radius_projection(
     }
     let binding = parse_radius_projection(value?)?;
     let distance_m = great_circle_distance_m(location, &binding.public_pos);
+    // Unknown binding versions remain fail-closed. A future format needs an
+    // explicit migration or compatibility decoder, never a broad <= acceptance.
     if binding.version != RADIUS_PROJECTION_VERSION
         || binding.radius_m != radius_m
         || !location_is_valid(&binding.anchor)
@@ -311,6 +319,16 @@ pub(crate) fn radius_projection_public_pos(
     radius_m: u32,
 ) -> Option<Location> {
     validated_radius_projection(value, location, radius_m).map(|binding| binding.public_pos)
+}
+
+pub(crate) fn radius_projection_matches_location(
+    value: Option<&Value>,
+    location: &Location,
+) -> bool {
+    let Some(binding) = value.and_then(parse_radius_projection) else {
+        return false;
+    };
+    validated_radius_projection(value, location, binding.radius_m).is_some()
 }
 
 pub(crate) fn ensure_radius_projection_value(
@@ -402,7 +420,8 @@ pub(crate) fn map_json_to_public_account(v: &Value) -> Option<AccountPublic> {
         (Some(lat), Some(lon)) => Some(Location { lat, lon }),
         _ => None,
     };
-    let radius_requested = explicit_map_state == Some("radius")
+    let radius_requested = invalid_radius
+        || explicit_map_state == Some("radius")
         || radius_m > 0
         || legacy_visibility == Some("approximate");
     let radius_public_pos = if radius_requested && !invalid_radius {
@@ -869,6 +888,15 @@ fn update_jsonl_profile_record(
             StatusCode::BAD_REQUEST,
             "a map location is required for this visibility".to_string(),
         ));
+    }
+    if update.map_state != "radius" {
+        let binding_matches_current_location =
+            effective_location.as_ref().is_some_and(|location| {
+                radius_projection_matches_location(object.get(RADIUS_PROJECTION_KEY), location)
+            });
+        if !binding_matches_current_location {
+            object.remove(RADIUS_PROJECTION_KEY);
+        }
     }
     if update.map_state == "radius" {
         let location = effective_location
@@ -1473,6 +1501,22 @@ mod tests {
     }
 
     #[test]
+    fn oversized_radius_without_explicit_state_fails_closed() {
+        let input = json!({
+            "id": "oversized-radius",
+            "type": "garnrolle",
+            "title": "Oversized radius",
+            "location": { "lat": 53.5, "lon": 10.0 },
+            "radius_m": u64::MAX,
+        });
+
+        let account = map_json_to_public_account(&input).expect("valid account");
+        assert_eq!(account.map_state, GarnrolleMapState::NotOnMap);
+        assert_eq!(account.radius_m, 0);
+        assert!(account.public_pos.is_none());
+    }
+
+    #[test]
     fn private_projection_is_reused_and_never_serialized_publicly() {
         let location = Location {
             lat: 53.5585,
@@ -1522,6 +1566,63 @@ mod tests {
         assert!(radius_projection_public_pos(Some(&resized), &first_location, 750).is_some());
         assert!(radius_projection_public_pos(Some(&first), &moved_location, 500).is_none());
         assert!(radius_projection_public_pos(Some(&first), &first_location, 750).is_none());
+    }
+
+    #[test]
+    fn cryptographic_samples_use_half_open_unit_interval() {
+        for _ in 0..1_024 {
+            let (radial, angular) = cryptographic_unit_pair();
+            assert!(radial > 0.0 && radial < 1.0);
+            assert!((0.0..1.0).contains(&angular));
+        }
+    }
+
+    #[test]
+    fn radius_boundary_tolerance_is_small_and_geometrically_sufficient() {
+        let anchors = [
+            Location {
+                lat: 53.5585,
+                lon: 10.058,
+            },
+            Location {
+                lat: 89.9999,
+                lon: 179.9999,
+            },
+            Location {
+                lat: 90.0,
+                lon: 42.0,
+            },
+            Location {
+                lat: 0.0,
+                lon: 179.9999,
+            },
+        ];
+        let radius_m = MAX_RADIUS_M;
+        for anchor in anchors {
+            let boundary = RadiusProjectionBinding {
+                version: RADIUS_PROJECTION_VERSION,
+                anchor: anchor.clone(),
+                radius_m,
+                public_pos: destination_point(&anchor, f64::from(radius_m), 1.2345),
+            };
+            let boundary_value = serde_json::to_value(boundary).expect("boundary binding");
+            assert!(
+                validated_radius_projection(Some(&boundary_value), &anchor, radius_m).is_some()
+            );
+
+            let outside = RadiusProjectionBinding {
+                version: RADIUS_PROJECTION_VERSION,
+                anchor: anchor.clone(),
+                radius_m,
+                public_pos: destination_point(
+                    &anchor,
+                    f64::from(radius_m) + RADIUS_DISTANCE_EPSILON_M + 0.10,
+                    1.2345,
+                ),
+            };
+            let outside_value = serde_json::to_value(outside).expect("outside binding");
+            assert!(validated_radius_projection(Some(&outside_value), &anchor, radius_m).is_none());
+        }
     }
 
     #[test]
@@ -1769,6 +1870,39 @@ mod profile_update_tests {
         assert_eq!(updated["address"], "Neue Adresse");
         assert_eq!(effective_location.unwrap().lat, 53.5);
         assert_eq!(updated["location"]["lat"], 53.5);
+    }
+
+    #[test]
+    fn jsonl_update_discards_binding_after_private_location_change() {
+        let old_location = Location {
+            lat: 53.5,
+            lon: 10.0,
+        };
+        let projection = ensure_radius_projection_value(None, &old_location, 250);
+        let mut record = json!({
+            "id": "own-account",
+            "type": "garnrolle",
+            "title": "Alt",
+            "role": "weber",
+            "map_state": "not_on_map",
+            "radius_m": 0,
+            "location": old_location
+        });
+        record[RADIUS_PROJECTION_KEY] = projection;
+        let update = validate_profile_update(request(
+            GarnrolleMapState::NotOnMap,
+            None,
+            Some(Location {
+                lat: 53.6,
+                lon: 10.1,
+            }),
+        ))
+        .expect("not-on-map profile with new private location");
+
+        let (updated, _) = update_jsonl_profile_record(record, &update).expect("update record");
+        assert!(updated.get(RADIUS_PROJECTION_KEY).is_none());
+        assert_eq!(updated["location"]["lat"], 53.6);
+        assert_eq!(updated["location"]["lon"], 10.1);
     }
 
     #[test]

--- a/apps/api/src/routes/accounts.rs
+++ b/apps/api/src/routes/accounts.rs
@@ -23,6 +23,7 @@ use axum::{
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 use std::{
     collections::{HashMap, HashSet},
     env,
@@ -34,8 +35,14 @@ use tokio::{
 };
 use uuid::Uuid;
 
-const METERS_PER_DEGREE: f64 = 111_000.0;
-const COS_LAT_FLOOR: f64 = 1e-3;
+const EARTH_RADIUS_M: f64 = 6_371_008.8;
+const LOCATION_MATCH_EPSILON_DEGREES: f64 = 1e-9;
+const RADIUS_DISTANCE_EPSILON_M: f64 = 0.05;
+const MIN_RADIUS_PUBLIC_OFFSET_M: f64 = 0.01;
+const MIN_RADIUS_M: u32 = 50;
+const MAX_RADIUS_M: u32 = 5_000;
+const RADIUS_PROJECTION_VERSION: u8 = 1;
+pub(crate) const RADIUS_PROJECTION_KEY: &str = "radius_projection";
 
 fn in_dir() -> PathBuf {
     env::var("GEWEBE_IN_DIR")
@@ -159,52 +166,161 @@ pub struct AccountInternal {
     pub webauthn_user_id: Uuid,
 }
 
-/// Simple deterministic pseudo-random number generator based on ID
-fn stable_hash(s: &str) -> u64 {
-    let mut hash: u64 = 5381;
-    for c in s.bytes() {
-        hash = ((hash << 5).wrapping_add(hash)) + c as u64;
-    }
-    hash
+/// Private, persisted binding for one radius projection.
+///
+/// The binding lives only in JSONL's private record or PostgreSQL
+/// `private_payload`. It is never part of [`AccountPublic`]. The exact anchor is
+/// duplicated deliberately: it lets every API instance verify that a stored
+/// projection still belongs to the current private location and radius before
+/// exposing the public point.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+struct RadiusProjectionBinding {
+    version: u8,
+    anchor: Location,
+    radius_m: u32,
+    public_pos: Location,
 }
 
-/// Calculates the public position based on the real location and radius.
-/// Uses a deterministic "jitter" based on the ID so the position doesn't jump around on every request.
-fn calculate_jittered_pos(lat: f64, lon: f64, radius_m: u32, id: &str) -> Location {
-    if radius_m == 0 {
-        return Location { lat, lon };
+fn location_is_valid(location: &Location) -> bool {
+    location.lat.is_finite()
+        && location.lon.is_finite()
+        && (-90.0..=90.0).contains(&location.lat)
+        && (-180.0..=180.0).contains(&location.lon)
+}
+
+fn longitude_delta_degrees(a: f64, b: f64) -> f64 {
+    let delta = (a - b).abs().rem_euclid(360.0);
+    delta.min(360.0 - delta)
+}
+
+fn locations_match(a: &Location, b: &Location) -> bool {
+    (a.lat - b.lat).abs() <= LOCATION_MATCH_EPSILON_DEGREES
+        && longitude_delta_degrees(a.lon, b.lon) <= LOCATION_MATCH_EPSILON_DEGREES
+}
+
+fn great_circle_distance_m(a: &Location, b: &Location) -> f64 {
+    let lat1 = a.lat.to_radians();
+    let lat2 = b.lat.to_radians();
+    let delta_lat = lat2 - lat1;
+    let delta_lon = (b.lon - a.lon).to_radians();
+    let haversine =
+        (delta_lat / 2.0).sin().powi(2) + lat1.cos() * lat2.cos() * (delta_lon / 2.0).sin().powi(2);
+    2.0 * EARTH_RADIUS_M * haversine.clamp(0.0, 1.0).sqrt().asin()
+}
+
+fn destination_point(anchor: &Location, distance_m: f64, bearing_rad: f64) -> Location {
+    let angular_distance = distance_m / EARTH_RADIUS_M;
+    let lat1 = anchor.lat.to_radians();
+    let lon1 = anchor.lon.to_radians();
+    let sin_lat1 = lat1.sin();
+    let cos_lat1 = lat1.cos();
+    let sin_angular = angular_distance.sin();
+    let cos_angular = angular_distance.cos();
+
+    // The usual initial-bearing formula becomes 0/0 at the exact poles.
+    // Handle those coordinates explicitly so longitude still carries the
+    // random angular component instead of collapsing to the anchor meridian.
+    if cos_lat1.abs() < 1e-12 {
+        let lat2 = if anchor.lat.is_sign_positive() {
+            std::f64::consts::FRAC_PI_2 - angular_distance
+        } else {
+            -std::f64::consts::FRAC_PI_2 + angular_distance
+        };
+        let lon2 = lon1 + bearing_rad;
+        let lon_degrees = (lon2.to_degrees() + 180.0).rem_euclid(360.0) - 180.0;
+        return Location {
+            lat: lat2.to_degrees().clamp(-90.0, 90.0),
+            lon: lon_degrees,
+        };
     }
 
-    // Seed the RNG with the ID
-    let seed = stable_hash(id);
-
-    // Generate two offsets in range [-1.0, 1.0] derived from seed
-    // We mix bits to get different values for x and y
-    let r1 = ((seed & 0xFFFF) as f64 / 65535.0) * 2.0 - 1.0;
-    let r2 = (((seed >> 16) & 0xFFFF) as f64 / 65535.0) * 2.0 - 1.0;
-
-    // Scale by radius (converted to degrees)
-    // We simply use a square box jitter for simplicity in this minimal core.
-    // A circle would be better but requires sin/cos and proper distance calc.
-    // For visual obfuscation, this is sufficient "phantom world".
-    let lat_offset = (r1 * radius_m as f64) / METERS_PER_DEGREE;
-
-    // Near the poles cos(latitude) approaches 0 which would explode the offset or
-    // even lead to division by zero. Clamp the denominator to a reasonable floor
-    // so that the longitude offset remains bounded and plausible instead of
-    // merely finite.
-    let cos_lat = lat.to_radians().cos().max(COS_LAT_FLOOR);
-    let lon_offset = (r2 * radius_m as f64) / (METERS_PER_DEGREE * cos_lat);
-
-    let mut lon_jittered = (lon + lon_offset).rem_euclid(360.0);
-    if lon_jittered > 180.0 {
-        lon_jittered -= 360.0;
-    }
+    let lat2 = (sin_lat1 * cos_angular + cos_lat1 * sin_angular * bearing_rad.cos())
+        .clamp(-1.0, 1.0)
+        .asin();
+    let lon2 = lon1
+        + (bearing_rad.sin() * sin_angular * cos_lat1).atan2(cos_angular - sin_lat1 * lat2.sin());
+    let lon_degrees = (lon2.to_degrees() + 180.0).rem_euclid(360.0) - 180.0;
 
     Location {
-        lat: (lat + lat_offset).clamp(-90.0, 90.0),
-        lon: lon_jittered,
+        lat: lat2.to_degrees().clamp(-90.0, 90.0),
+        lon: lon_degrees,
     }
+}
+
+fn cryptographic_unit_pair() -> (f64, f64) {
+    // `Uuid::new_v4` is backed by the operating-system CSPRNG. Hashing removes
+    // UUID version/variant bit structure before the bytes are mapped to two
+    // independent unit-interval values.
+    let digest = Sha256::digest(Uuid::new_v4().as_bytes());
+    let mut first = [0_u8; 8];
+    let mut second = [0_u8; 8];
+    first.copy_from_slice(&digest[..8]);
+    second.copy_from_slice(&digest[8..16]);
+    let denominator = (u64::MAX as f64) + 1.0;
+    let u = (u64::from_be_bytes(first) as f64 + 0.5) / denominator;
+    let v = (u64::from_be_bytes(second) as f64 + 0.5) / denominator;
+    (u.clamp(f64::EPSILON, 1.0), v.clamp(0.0, 1.0))
+}
+
+fn generate_radius_projection(location: &Location, radius_m: u32) -> RadiusProjectionBinding {
+    let (radial_sample, angular_sample) = cryptographic_unit_pair();
+    // sqrt(u) gives a uniform area distribution over the circle. The tiny
+    // lower bound excludes the exact residence even after floating-point
+    // rounding without materially changing the area distribution.
+    let distance_m = (f64::from(radius_m) * radial_sample.sqrt()).max(MIN_RADIUS_PUBLIC_OFFSET_M);
+    let bearing_rad = std::f64::consts::TAU * angular_sample;
+    RadiusProjectionBinding {
+        version: RADIUS_PROJECTION_VERSION,
+        anchor: location.clone(),
+        radius_m,
+        public_pos: destination_point(location, distance_m, bearing_rad),
+    }
+}
+
+fn parse_radius_projection(value: &Value) -> Option<RadiusProjectionBinding> {
+    serde_json::from_value(value.clone()).ok()
+}
+
+fn validated_radius_projection(
+    value: Option<&Value>,
+    location: &Location,
+    radius_m: u32,
+) -> Option<RadiusProjectionBinding> {
+    if !(MIN_RADIUS_M..=MAX_RADIUS_M).contains(&radius_m) || !location_is_valid(location) {
+        return None;
+    }
+    let binding = parse_radius_projection(value?)?;
+    let distance_m = great_circle_distance_m(location, &binding.public_pos);
+    if binding.version != RADIUS_PROJECTION_VERSION
+        || binding.radius_m != radius_m
+        || !location_is_valid(&binding.anchor)
+        || !location_is_valid(&binding.public_pos)
+        || !locations_match(&binding.anchor, location)
+        || distance_m < MIN_RADIUS_PUBLIC_OFFSET_M
+        || distance_m > f64::from(radius_m) + RADIUS_DISTANCE_EPSILON_M
+    {
+        return None;
+    }
+    Some(binding)
+}
+
+pub(crate) fn radius_projection_public_pos(
+    value: Option<&Value>,
+    location: &Location,
+    radius_m: u32,
+) -> Option<Location> {
+    validated_radius_projection(value, location, radius_m).map(|binding| binding.public_pos)
+}
+
+pub(crate) fn ensure_radius_projection_value(
+    existing: Option<&Value>,
+    location: &Location,
+    radius_m: u32,
+) -> Value {
+    let binding = validated_radius_projection(existing, location, radius_m)
+        .unwrap_or_else(|| generate_radius_projection(location, radius_m));
+    serde_json::to_value(binding).expect("radius projection serialization is infallible")
 }
 
 pub(crate) fn map_json_to_public_account(v: &Value) -> Option<AccountPublic> {
@@ -247,7 +363,15 @@ pub(crate) fn map_json_to_public_account(v: &Value) -> Option<AccountPublic> {
         });
     }
 
-    let mut radius_m = v.get("radius_m").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+    let radius_raw = v.get("radius_m").and_then(|v| v.as_u64()).unwrap_or(0);
+    let mut radius_m = match u32::try_from(radius_raw) {
+        Ok(radius_m) => radius_m,
+        Err(_) => {
+            tracing::warn!(%id, radius_raw, "suppressing account with unsupported radius_m");
+            0
+        }
+    };
+    let invalid_radius = radius_raw > 0 && !(MIN_RADIUS_M..=MAX_RADIUS_M).contains(&radius_m);
 
     // Legacy compatibility is read-only. Old `type=ron`, `mode=ron` or
     // `ron_flag=true` records become an ordinary Garnrolle that is not on the
@@ -274,17 +398,36 @@ pub(crate) fn map_json_to_public_account(v: &Value) -> Option<AccountPublic> {
             .and_then(|value| value.as_bool())
             .unwrap_or(false);
 
+    let internal_location = match (lat, lon) {
+        (Some(lat), Some(lon)) => Some(Location { lat, lon }),
+        _ => None,
+    };
+    let radius_requested = explicit_map_state == Some("radius")
+        || radius_m > 0
+        || legacy_visibility == Some("approximate");
+    let radius_public_pos = if radius_requested && !invalid_radius {
+        internal_location.as_ref().and_then(|location| {
+            radius_projection_public_pos(v.get(RADIUS_PROJECTION_KEY), location, radius_m)
+        })
+    } else {
+        None
+    };
+
     let map_state = if legacy_not_on_map
         || explicit_map_state == Some("not_on_map")
-        || lat.is_none()
-        || lon.is_none()
+        || internal_location.is_none()
     {
         GarnrolleMapState::NotOnMap
-    } else if explicit_map_state == Some("radius")
-        || radius_m > 0
-        || legacy_visibility == Some("approximate")
-    {
-        GarnrolleMapState::Radius
+    } else if radius_requested {
+        if radius_public_pos.is_some() {
+            GarnrolleMapState::Radius
+        } else {
+            tracing::warn!(
+                account_id = %id,
+                "suppressing radius account without a valid private projection binding"
+            );
+            GarnrolleMapState::NotOnMap
+        }
     } else {
         GarnrolleMapState::Exact
     };
@@ -305,11 +448,10 @@ pub(crate) fn map_json_to_public_account(v: &Value) -> Option<AccountPublic> {
         })
         .unwrap_or_default();
 
-    let public_pos = match (map_state, lat, lon) {
-        (GarnrolleMapState::Exact | GarnrolleMapState::Radius, Some(lat), Some(lon)) => {
-            Some(calculate_jittered_pos(lat, lon, radius_m, &id))
-        }
-        _ => None,
+    let public_pos = match map_state {
+        GarnrolleMapState::Exact => internal_location,
+        GarnrolleMapState::Radius => radius_public_pos,
+        GarnrolleMapState::NotOnMap => None,
     };
 
     Some(AccountPublic {
@@ -688,7 +830,7 @@ fn validate_profile_update(
                 return Err(bad("address is required for a mapped Garnrolle"));
             }
             let radius = payload.radius_m.unwrap_or(250);
-            if !(50..=5_000).contains(&radius) {
+            if !(MIN_RADIUS_M..=MAX_RADIUS_M).contains(&radius) {
                 return Err(bad("radius_m must be between 50 and 5000"));
             }
             (i64::from(radius), "radius".to_string())
@@ -727,6 +869,20 @@ fn update_jsonl_profile_record(
             StatusCode::BAD_REQUEST,
             "a map location is required for this visibility".to_string(),
         ));
+    }
+    if update.map_state == "radius" {
+        let location = effective_location
+            .as_ref()
+            .expect("mapped location checked above");
+        let radius_m = u32::try_from(update.radius_m).map_err(|_| {
+            (
+                StatusCode::BAD_REQUEST,
+                "radius_m is outside the supported range".to_string(),
+            )
+        })?;
+        let projection =
+            ensure_radius_projection_value(object.get(RADIUS_PROJECTION_KEY), location, radius_m);
+        object.insert(RADIUS_PROJECTION_KEY.to_string(), projection);
     }
 
     object.insert("type".to_string(), json!("garnrolle"));
@@ -938,12 +1094,11 @@ pub async fn update_own_garnrolle_profile(
 /// ## radius_m semantics
 ///
 /// - `radius_m=0` (default): `public_pos` equals `location` exactly.
-/// - `radius_m>0`: `public_pos` is a **deterministic, ID-based jitter** of
-///   `location` within a square bounding box of ±`radius_m` meters. The jitter
-///   is derived from a djb2 hash of the account ID and is guaranteed non-zero
-///   (the hash bucket values can never produce exactly 0.0 offset for either
-///   axis). This is not a fake field: the API actually obfuscates the position
-///   when a non-zero radius is requested.
+/// - `radius_m>0`: a cryptographically random point inside the true radius is
+///   persisted in the private account payload. The same private binding is
+///   reused across reloads and temporary map hiding. It is rotated only when
+///   the private location or radius changes. Records without a valid binding
+///   fail closed as `not_on_map`.
 ///
 /// ## role=admin in v0
 ///
@@ -1016,8 +1171,10 @@ pub async fn create_account(
     let radius_m: u32 = match payload.get("radius_m") {
         None | Some(Value::Null) => 0,
         Some(v) => match v.as_u64() {
-            Some(n) if n <= u32::MAX as u64 => n as u32,
-            _ => return Err(bad("radius_m must be a non-negative integer")),
+            Some(0) => 0,
+            Some(n) if n <= u64::from(MAX_RADIUS_M) && n >= u64::from(MIN_RADIUS_M) => n as u32,
+            Some(_) => return Err(bad("radius_m must be 0 or between 50 and 5000")),
+            None => return Err(bad("radius_m must be a non-negative integer")),
         },
     };
 
@@ -1075,6 +1232,13 @@ pub async fn create_account(
         json!(if radius_m > 0 { "radius" } else { "exact" }),
     );
     record.insert("radius_m".into(), json!(radius_m));
+    if radius_m > 0 {
+        let private_location = Location { lat, lon };
+        record.insert(
+            RADIUS_PROJECTION_KEY.into(),
+            ensure_radius_projection_value(None, &private_location, radius_m),
+        );
+    }
     if let Some(e) = &email {
         record.insert("email".into(), json!(e));
     }
@@ -1185,15 +1349,6 @@ mod tests {
     use super::*;
     use serde_json::json;
 
-    /// Calculate circular distance between two longitude values
-    fn lon_delta(a: f64, b: f64) -> f64 {
-        let mut d = (a - b).abs();
-        if d > 180.0 {
-            d = 360.0 - d;
-        }
-        d
-    }
-
     #[test]
     fn test_guard_public_view_never_leaks_location() {
         let input = json!({
@@ -1301,137 +1456,141 @@ mod tests {
     }
 
     #[test]
-    fn test_public_pos_remains_finite_near_poles() {
-        let lat: f64 = 89.9999;
+    fn legacy_radius_without_private_binding_fails_closed() {
         let input = json!({
-            "id": "polar-test",
+            "id": "legacy-radius",
             "type": "garnrolle",
-            "title": "Polar Account",
-            "location": { "lat": lat, "lon": 10.0 },
-            "visibility": "approximate",
+            "title": "Legacy radius",
+            "location": { "lat": 53.5, "lon": 10.0 },
+            "map_state": "radius",
             "radius_m": 500,
         });
 
-        let account = map_json_to_public_account(&input).expect("Mapping failed");
-        let public_pos = account.public_pos.expect("public position present");
-
-        let max_deg_lat = 500.0 / METERS_PER_DEGREE;
-        // Correctly scale expected longitude jitter by 1/cos(lat)
-        let cos_lat = lat.to_radians().cos().max(COS_LAT_FLOOR);
-        let max_deg_lon = max_deg_lat / cos_lat;
-
-        assert!(public_pos.lat.is_finite());
-        assert!(public_pos.lon.is_finite());
-        assert!(public_pos.lat <= 90.0 && public_pos.lat >= -90.0);
-        assert!(public_pos.lon <= 180.0 && public_pos.lon >= -180.0);
-        assert!(
-            (public_pos.lat - lat).abs() <= max_deg_lat + 1e-6,
-            "lat jitter exceeded expected bound"
-        );
-        assert!(
-            lon_delta(public_pos.lon, 10.0) <= max_deg_lon + 1e-6,
-            "lon jitter exceeded expected bound"
-        );
+        let account = map_json_to_public_account(&input).expect("valid account");
+        assert_eq!(account.map_state, GarnrolleMapState::NotOnMap);
+        assert_eq!(account.radius_m, 0);
+        assert!(account.public_pos.is_none());
     }
 
     #[test]
-    fn test_public_pos_remains_finite_near_south_pole() {
-        let lat: f64 = -89.9999;
-        let input = json!({
-            "id": "south-polar-test",
+    fn private_projection_is_reused_and_never_serialized_publicly() {
+        let location = Location {
+            lat: 53.5585,
+            lon: 10.058,
+        };
+        let projection = ensure_radius_projection_value(None, &location, 500);
+        let reused = ensure_radius_projection_value(Some(&projection), &location, 500);
+        assert_eq!(projection, reused);
+
+        let mut input = json!({
+            "id": "safe-radius",
             "type": "garnrolle",
-            "title": "South Polar Account",
-            "location": { "lat": lat, "lon": 10.0 },
-            "visibility": "approximate",
+            "title": "Safe radius",
+            "location": location,
+            "map_state": "radius",
             "radius_m": 500,
         });
+        input[RADIUS_PROJECTION_KEY] = projection;
 
-        let account = map_json_to_public_account(&input).expect("Mapping failed");
-        let public_pos = account.public_pos.expect("public position present");
-
-        let max_deg_lat = 500.0 / METERS_PER_DEGREE;
-        // Correctly scale expected longitude jitter by 1/cos(lat)
-        let cos_lat = lat.to_radians().cos().max(COS_LAT_FLOOR);
-        let max_deg_lon = max_deg_lat / cos_lat;
-
-        assert!(public_pos.lat.is_finite());
-        assert!(public_pos.lon.is_finite());
-        assert!(public_pos.lat <= 90.0 && public_pos.lat >= -90.0);
-        assert!(public_pos.lon <= 180.0 && public_pos.lon >= -180.0);
-        assert!(
-            (public_pos.lat - lat).abs() <= max_deg_lat + 1e-6,
-            "lat jitter exceeded expected bound"
-        );
-        assert!(
-            lon_delta(public_pos.lon, 10.0) <= max_deg_lon + 1e-6,
-            "lon jitter exceeded expected bound"
-        );
+        let account = map_json_to_public_account(&input).expect("valid account");
+        assert_eq!(account.map_state, GarnrolleMapState::Radius);
+        assert_eq!(account.radius_m, 500);
+        assert!(account.public_pos.is_some());
+        let output = serde_json::to_value(account).expect("public serialization");
+        assert!(output.get("location").is_none());
+        assert!(output.get(RADIUS_PROJECTION_KEY).is_none());
+        assert!(output.get("anchor").is_none());
     }
 
     #[test]
-    fn test_jitter_scaling_at_high_latitudes() {
-        // At 60 degrees latitude, cos(60) = 0.5.
-        // The longitude offset should be scaled by exactly 1 / cos(latitude) compared to the equator.
+    fn private_projection_rotates_when_location_or_radius_changes() {
+        let first_location = Location {
+            lat: 53.5585,
+            lon: 10.058,
+        };
+        let moved_location = Location {
+            lat: 53.5586,
+            lon: 10.058,
+        };
+        let first = ensure_radius_projection_value(None, &first_location, 500);
+        let moved = ensure_radius_projection_value(Some(&first), &moved_location, 500);
+        let resized = ensure_radius_projection_value(Some(&first), &first_location, 750);
 
-        let radius_m = 111_000;
-        let lat = 60.0;
-
-        // Find any ID that produces a non-zero longitude jitter to avoid divide-by-zero.
-        let id = (0..100)
-            .map(|i| i.to_string())
-            .find(|id| calculate_jittered_pos(0.0, 0.0, radius_m, id).lon.abs() > 1e-6)
-            .expect("expected deterministic id with non-zero longitude jitter");
-
-        let equator = calculate_jittered_pos(0.0, 0.0, radius_m, &id);
-        let high_lat = calculate_jittered_pos(lat, 0.0, radius_m, &id);
-
-        let equator_lon = equator.lon.abs();
-        let high_lat_lon = high_lat.lon.abs();
-
-        assert!(
-            equator_lon > 1e-6,
-            "fixture id must produce non-zero longitude jitter"
-        );
-
-        let expected_scale = 1.0 / lat.to_radians().cos();
-        let observed_scale = high_lat_lon / equator_lon;
-
-        assert!(
-            (observed_scale - expected_scale).abs() < 1e-6,
-            "longitude jitter should scale by 1/cos(latitude); expected {}, got {}",
-            expected_scale,
-            observed_scale
-        );
+        assert_ne!(first, moved);
+        assert_ne!(first, resized);
+        assert!(radius_projection_public_pos(Some(&moved), &moved_location, 500).is_some());
+        assert!(radius_projection_public_pos(Some(&resized), &first_location, 750).is_some());
+        assert!(radius_projection_public_pos(Some(&first), &moved_location, 500).is_none());
+        assert!(radius_projection_public_pos(Some(&first), &first_location, 750).is_none());
     }
 
     #[test]
-    fn test_jitter_wraparound() {
-        // Test that longitude wraps correctly across the dateline (180/-180)
-        let radius_m = 500_000; // ~5 degrees at equator
-        let lat = 0.0;
-        let lon = 179.0;
+    fn generated_projection_stays_inside_true_circle_at_poles_and_dateline() {
+        let anchors = [
+            Location {
+                lat: 53.5585,
+                lon: 10.058,
+            },
+            Location {
+                lat: 89.9999,
+                lon: 179.9999,
+            },
+            Location {
+                lat: 90.0,
+                lon: 42.0,
+            },
+            Location {
+                lat: -89.9999,
+                lon: -179.9999,
+            },
+            Location {
+                lat: -90.0,
+                lon: -42.0,
+            },
+            Location {
+                lat: 0.0,
+                lon: 179.9999,
+            },
+        ];
+        let radius_m = 5_000;
 
-        // We need a specific ID that pushes longitude POSITIVE (East)
-        // lon (179) + offset (> 1) should wrap to negative (e.g. -179)
-
-        let mut wrapped = false;
-
-        for i in 0..1000 {
-            let id = format!("test-wrap-{}", i);
-            let pos = calculate_jittered_pos(lat, lon, radius_m, &id);
-
-            // If we wrapped, pos.lon should be negative (e.g. -178, -179)
-            // Original is 179.
-            if pos.lon < 0.0 {
-                wrapped = true;
-                // Verify it's valid longitude
-                assert!(pos.lon >= -180.0);
-                assert!(pos.lon <= 180.0);
-                break;
+        for anchor in anchors {
+            for _ in 0..64 {
+                let projection = ensure_radius_projection_value(None, &anchor, radius_m);
+                let public = radius_projection_public_pos(Some(&projection), &anchor, radius_m)
+                    .expect("generated projection validates");
+                assert!(location_is_valid(&public));
+                let distance_m = great_circle_distance_m(&anchor, &public);
+                assert!(distance_m >= MIN_RADIUS_PUBLIC_OFFSET_M);
+                assert!(distance_m <= f64::from(radius_m) + RADIUS_DISTANCE_EPSILON_M);
             }
         }
+    }
 
-        assert!(wrapped, "Jitter should be able to wrap around the dateline");
+    #[test]
+    fn tampered_or_mismatched_binding_is_suppressed() {
+        let location = Location {
+            lat: 53.5585,
+            lon: 10.058,
+        };
+        let mut projection = ensure_radius_projection_value(None, &location, 500);
+        projection["public_pos"] = json!({ "lat": location.lat, "lon": location.lon });
+        assert!(radius_projection_public_pos(Some(&projection), &location, 500).is_none());
+        projection["public_pos"] = json!({ "lat": -20.0, "lon": -20.0 });
+        assert!(radius_projection_public_pos(Some(&projection), &location, 500).is_none());
+
+        let mut input = json!({
+            "id": "tampered-radius",
+            "type": "garnrolle",
+            "title": "Tampered radius",
+            "location": location,
+            "map_state": "radius",
+            "radius_m": 500,
+        });
+        input[RADIUS_PROJECTION_KEY] = projection;
+        let account = map_json_to_public_account(&input).expect("valid account");
+        assert_eq!(account.map_state, GarnrolleMapState::NotOnMap);
+        assert!(account.public_pos.is_none());
     }
 }
 

--- a/apps/api/tests/api_accounts_create.rs
+++ b/apps/api/tests/api_accounts_create.rs
@@ -320,6 +320,41 @@ async fn invalid_input_returns_400() -> Result<()> {
         .await?;
     assert_eq!(res.status(), StatusCode::BAD_REQUEST);
 
+    // Radius below the supported privacy range.
+    let res = app
+        .clone()
+        .oneshot(post_accounts(
+            Some(&cookie),
+            r#"{"title":"X","location":{"lat":1.0,"lon":2.0},"radius_m":49}"#,
+        ))
+        .await?;
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+
+    // Radius above the supported privacy range.
+    let res = app
+        .clone()
+        .oneshot(post_accounts(
+            Some(&cookie),
+            r#"{"title":"X","location":{"lat":1.0,"lon":2.0},"radius_m":5001}"#,
+        ))
+        .await?;
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+
+    // Boundary values remain valid.
+    for radius_m in [50_u32, 5_000_u32] {
+        let id = uuid::Uuid::new_v4();
+        let response = app
+            .clone()
+            .oneshot(post_accounts(
+                Some(&cookie),
+                &format!(
+                    r#"{{"id":"{id}","title":"Boundary","location":{{"lat":1.0,"lon":2.0}},"radius_m":{radius_m}}}"#
+                ),
+            ))
+            .await?;
+        assert_eq!(response.status(), StatusCode::CREATED);
+    }
+
     // Missing location.
     let res = app
         .clone()
@@ -492,12 +527,11 @@ async fn radius_m_zero_public_pos_is_exact() -> Result<()> {
     Ok(())
 }
 
-/// radius_m>0: public_pos must be deterministically jittered — not the exact
-/// input location. This proves radius_m is not a fake field: the API actually
-/// applies obfuscation rather than accepting the value and silently ignoring it.
+/// radius_m>0: the API creates a private random projection, exposes only its
+/// public point and keeps that point inside the declared geodesic radius.
 #[tokio::test]
 #[serial]
-async fn radius_m_positive_jitters_public_pos() -> Result<()> {
+async fn radius_m_positive_uses_private_projection_inside_true_radius() -> Result<()> {
     let tmp = tempfile::tempdir()?;
     let in_dir = tmp.path().join("in");
     std::fs::create_dir_all(&in_dir)?;
@@ -505,7 +539,6 @@ async fn radius_m_positive_jitters_public_pos() -> Result<()> {
 
     let (app, cookie, _state) = app_with_operator(&in_dir, "admin1", Role::Admin).await?;
 
-    // Use a fixed id so the jitter is deterministic across test runs.
     let id = "33333333-3333-4333-8333-333333333333";
     let lat = 53.5503_f64;
     let lon = 9.9932_f64;
@@ -516,7 +549,7 @@ async fn radius_m_positive_jitters_public_pos() -> Result<()> {
         .oneshot(post_accounts(
             Some(&cookie),
             &format!(
-                r#"{{"id":"{id}","title":"Jittered","location":{{"lat":{lat},"lon":{lon}}},"radius_m":{radius_m}}}"#
+                r#"{{"id":"{id}","title":"Radius","location":{{"lat":{lat},"lon":{lon}}},"radius_m":{radius_m}}}"#
             ),
         ))
         .await?;
@@ -524,59 +557,53 @@ async fn radius_m_positive_jitters_public_pos() -> Result<()> {
 
     let bytes = body::to_bytes(res.into_body(), usize::MAX).await?;
     let created: serde_json::Value = serde_json::from_slice(&bytes)?;
-
-    let jitter_lat = created["public_pos"]["lat"]
+    let public_lat = created["public_pos"]["lat"]
         .as_f64()
         .context("public_pos.lat must be a number")?;
-    let jitter_lon = created["public_pos"]["lon"]
+    let public_lon = created["public_pos"]["lon"]
         .as_f64()
         .context("public_pos.lon must be a number")?;
 
-    // location must never be exposed publicly.
+    assert_eq!(created["map_state"], "radius");
+    assert_eq!(created["radius_m"], radius_m);
     assert!(created.get("location").is_none());
+    assert!(created.get("radius_projection").is_none());
+    assert!(created.get("anchor").is_none());
 
-    // radius_m>0 => public_pos must NOT equal the exact submitted location.
-    // (The jitter algorithm derives r1, r2 from a djb2 hash: r1 = (hash & 0xFFFF)/65535*2-1.
-    // r1==0 would require hash & 0xFFFF == 32767.5 — impossible for integers — so
-    // jitter is guaranteed non-zero for any id.)
-    assert_ne!(
-        jitter_lat, lat,
-        "radius_m>0: public_pos.lat must differ from exact location.lat (jitter not applied)"
+    fn great_circle_distance_m(lat1: f64, lon1: f64, lat2: f64, lon2: f64) -> f64 {
+        const EARTH_RADIUS_M: f64 = 6_371_008.8;
+        let lat1 = lat1.to_radians();
+        let lat2 = lat2.to_radians();
+        let delta_lat = lat2 - lat1;
+        let delta_lon = (lon2 - lon1).to_radians();
+        let haversine = (delta_lat / 2.0).sin().powi(2)
+            + lat1.cos() * lat2.cos() * (delta_lon / 2.0).sin().powi(2);
+        2.0 * EARTH_RADIUS_M * haversine.clamp(0.0, 1.0).sqrt().asin()
+    }
+
+    let distance_m = great_circle_distance_m(lat, lon, public_lat, public_lon);
+    assert!(
+        distance_m > 0.0,
+        "radius projection must not expose the exact residence"
     );
-    assert_ne!(
-        jitter_lon, lon,
-        "radius_m>0: public_pos.lon must differ from exact location.lon (jitter not applied)"
+    assert!(
+        distance_m <= f64::from(radius_m) + 0.05,
+        "public point is {distance_m}m away, outside the declared {radius_m}m radius"
     );
 
-    // The jitter must stay within the declared radius (square bounding box in degrees).
-    let max_deg = radius_m as f64 / 111_000.0;
-    assert!(
-        (jitter_lat - lat).abs() <= max_deg + 1e-9,
-        "public_pos.lat jitter exceeds radius bound: |{jitter_lat} - {lat}| > {max_deg}"
-    );
-    // longitude bound is scaled by 1/cos(lat) near equator; use generous tolerance.
-    let cos_lat = lat.to_radians().cos().max(1e-3);
-    let max_deg_lon = max_deg / cos_lat;
-    let lon_delta = {
-        let d = (jitter_lon - lon).abs();
-        if d > 180.0 {
-            360.0 - d
-        } else {
-            d
-        }
-    };
-    assert!(
-        lon_delta <= max_deg_lon + 1e-9,
-        "public_pos.lon jitter exceeds radius bound: lon_delta={lon_delta} > {max_deg_lon}"
-    );
+    let persisted = std::fs::read_to_string(in_dir.join("demo.accounts.jsonl"))?;
+    let record: serde_json::Value = serde_json::from_str(persisted.trim())?;
+    assert!(record.get("radius_projection").is_some());
+    assert_eq!(record["location"]["lat"], lat);
+    assert_eq!(record["location"]["lon"], lon);
     Ok(())
 }
 
-/// radius_m>0 with the same id and location produces the same public_pos on every
-/// request (deterministic jitter, stable across GET).
+/// The random point is generated once and persisted privately. Reads of the
+/// same account reuse that binding instead of deriving a point from public data.
 #[tokio::test]
 #[serial]
-async fn radius_m_positive_public_pos_is_deterministic() -> Result<()> {
+async fn radius_m_positive_public_pos_is_stable_after_persistence() -> Result<()> {
     let tmp = tempfile::tempdir()?;
     let in_dir = tmp.path().join("in");
     std::fs::create_dir_all(&in_dir)?;
@@ -589,48 +616,30 @@ async fn radius_m_positive_public_pos_is_deterministic() -> Result<()> {
     let lon = 9.99_f64;
     let radius_m = 250_u32;
 
-    // POST: create the account and record the public_pos from the 201 response.
     let res = app
         .clone()
         .oneshot(post_accounts(
             Some(&cookie),
             &format!(
-                r#"{{"id":"{id}","title":"Det","location":{{"lat":{lat},"lon":{lon}}},"radius_m":{radius_m}}}"#
+                r#"{{"id":"{id}","title":"Stable","location":{{"lat":{lat},"lon":{lon}}},"radius_m":{radius_m}}}"#
             ),
         ))
         .await?;
     assert_eq!(res.status(), StatusCode::CREATED);
     let bytes = body::to_bytes(res.into_body(), usize::MAX).await?;
     let created: serde_json::Value = serde_json::from_slice(&bytes)?;
-    let post_lat = created["public_pos"]["lat"]
-        .as_f64()
-        .context("public_pos.lat")?;
-    let post_lon = created["public_pos"]["lon"]
-        .as_f64()
-        .context("public_pos.lon")?;
+    let post_pos = created["public_pos"].clone();
 
-    // GET /accounts/{id}: the same public_pos must be returned.
     let res = app
         .oneshot(axum::http::Request::get(format!("/accounts/{id}")).body(body::Body::empty())?)
         .await?;
     assert_eq!(res.status(), StatusCode::OK);
     let bytes = body::to_bytes(res.into_body(), usize::MAX).await?;
     let fetched: serde_json::Value = serde_json::from_slice(&bytes)?;
-    let get_lat = fetched["public_pos"]["lat"]
-        .as_f64()
-        .context("public_pos.lat in GET")?;
-    let get_lon = fetched["public_pos"]["lon"]
-        .as_f64()
-        .context("public_pos.lon in GET")?;
 
-    assert_eq!(
-        post_lat, get_lat,
-        "public_pos.lat must be deterministic: POST={post_lat}, GET={get_lat}"
-    );
-    assert_eq!(
-        post_lon, get_lon,
-        "public_pos.lon must be deterministic: POST={post_lon}, GET={get_lon}"
-    );
+    assert_eq!(post_pos, fetched["public_pos"]);
+    assert!(fetched.get("location").is_none());
+    assert!(fetched.get("radius_projection").is_none());
     Ok(())
 }
 
@@ -740,6 +749,104 @@ async fn weber_updates_only_own_jsonl_garnrolle_and_reads_private_profile() -> R
     let own = cache.get(own_id).context("own account in cache")?;
     assert_eq!(own.public.title, "Meine gesetzte Garnrolle");
     assert_eq!(own.public.map_state, GarnrolleMapState::Exact);
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn weber_radius_profile_keeps_projection_binding_private_and_stable() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let in_dir = tmp.path().join("in");
+    std::fs::create_dir_all(&in_dir)?;
+    let _env = set_gewebe_in_dir(&in_dir);
+    let account_id = "weber-radius-profile-1";
+    std::fs::write(
+        in_dir.join("demo.accounts.jsonl"),
+        serde_json::json!({
+            "id": account_id,
+            "type": "garnrolle",
+            "title": "Radius Garnrolle",
+            "role": "weber",
+            "map_state": "not_on_map",
+            "radius_m": 0
+        })
+        .to_string()
+            + "\n",
+    )?;
+    let (app, cookie, _state) = app_with_operator(&in_dir, account_id, Role::Weber).await?;
+
+    let radius_body = r#"{
+      "title":"Radius Garnrolle",
+      "summary":"Privat gebunden",
+      "tags":["interest:Commons"],
+      "address":"Poelsweg 2, Hamburg",
+      "map_state":"radius",
+      "radius_m":250,
+      "location":{"lat":53.5604,"lon":10.0630}
+    }"#;
+    let response = app
+        .clone()
+        .oneshot(patch_own_profile(Some(&cookie), radius_body))
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = body::to_bytes(response.into_body(), usize::MAX).await?;
+    let profile: serde_json::Value = serde_json::from_slice(&bytes)?;
+    assert_eq!(profile["map_state"], "radius");
+    assert_eq!(profile["radius_m"], 250);
+    assert!(profile.get("radius_projection").is_none());
+    assert!(profile.get("public_pos").is_none());
+
+    let read_latest_binding = || -> Result<serde_json::Value> {
+        let contents = std::fs::read_to_string(in_dir.join("demo.accounts.jsonl"))?;
+        let record = contents
+            .lines()
+            .rev()
+            .map(serde_json::from_str::<serde_json::Value>)
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .find(|record| record["id"] == account_id)
+            .context("latest radius profile record")?;
+        Ok(record["radius_projection"].clone())
+    };
+    let initial_binding = read_latest_binding()?;
+    assert_eq!(initial_binding["version"], 1);
+    assert_eq!(initial_binding["radius_m"], 250);
+
+    let response = app
+        .clone()
+        .oneshot(patch_own_profile(
+            Some(&cookie),
+            r#"{
+              "title":"Radius Garnrolle",
+              "summary":"Privat gebunden",
+              "tags":["interest:Commons"],
+              "address":"Poelsweg 2, Hamburg",
+              "map_state":"not_on_map"
+            }"#,
+        ))
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(read_latest_binding()?, initial_binding);
+
+    let response = app
+        .clone()
+        .oneshot(patch_own_profile(Some(&cookie), radius_body))
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(read_latest_binding()?, initial_binding);
+
+    let response = app
+        .oneshot(
+            Request::get("/accounts/me/profile")
+                .header("Cookie", &cookie)
+                .body(body::Body::empty())?,
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = body::to_bytes(response.into_body(), usize::MAX).await?;
+    let reloaded: serde_json::Value = serde_json::from_slice(&bytes)?;
+    assert!(reloaded.get("radius_projection").is_none());
+    assert!(reloaded.get("public_pos").is_none());
     Ok(())
 }
 

--- a/apps/api/tests/db_domain_account_write_path.rs
+++ b/apps/api/tests/db_domain_account_write_path.rs
@@ -1145,6 +1145,36 @@ async fn own_garnrolle_profile_persists_privately_and_reloads_from_postgres() ->
     assert_eq!(rotated_account.public.map_state, GarnrolleMapState::Radius);
     assert_eq!(rotated_account.public.radius_m, 450);
 
+    // Moving the private location while hidden must discard the old binding.
+    // Otherwise private storage would retain an obsolete residence anchor.
+    let response = app
+        .clone()
+        .oneshot(patch_own_profile(
+            &cookie,
+            r#"{
+              "title":"Meine PostgreSQL Garnrolle",
+              "summary":"Dauerhaft gespeichert",
+              "tags":["skill:Kochen","interest:Commons"],
+              "map_state":"not_on_map",
+              "location":{"lat":53.5700,"lon":10.0700}
+            }"#,
+        ))
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let moved_private_text: String =
+        sqlx::query_scalar("SELECT private_payload::text FROM domain_accounts WHERE id = $1")
+            .bind(PROFILE_ID)
+            .fetch_one(&pool)
+            .await?;
+    let moved_private: serde_json::Value = serde_json::from_str(&moved_private_text)?;
+    assert!(moved_private.get("radius_projection").is_none());
+    let moved_reload = load_accounts_from_postgres(&pool).await?;
+    let moved_account = moved_reload
+        .get(PROFILE_ID)
+        .context("moved hidden reload")?;
+    assert_eq!(moved_account.public.map_state, GarnrolleMapState::NotOnMap);
+    assert!(moved_account.public.public_pos.is_none());
+
     clean(&pool).await;
     Ok(())
 }

--- a/apps/api/tests/db_domain_account_write_path.rs
+++ b/apps/api/tests/db_domain_account_write_path.rs
@@ -90,6 +90,17 @@ const WEBAUTHN_STABLE_ID: &str = "aaaaaaaa-aaaa-4aaa-8aaa-000000000004";
 const STEP_UP_EMAIL_ID: &str = "aaaaaaaa-aaaa-4aaa-8aaa-000000000030";
 const STEP_UP_EMAIL_DUP_ID: &str = "aaaaaaaa-aaaa-4aaa-8aaa-000000000031";
 
+fn great_circle_distance_m(lat1: f64, lon1: f64, lat2: f64, lon2: f64) -> f64 {
+    const EARTH_RADIUS_M: f64 = 6_371_008.8;
+    let lat1 = lat1.to_radians();
+    let lat2 = lat2.to_radians();
+    let delta_lat = lat2 - lat1;
+    let delta_lon = (lon2 - lon1).to_radians();
+    let haversine =
+        (delta_lat / 2.0).sin().powi(2) + lat1.cos() * lat2.cos() * (delta_lon / 2.0).sin().powi(2);
+    2.0 * EARTH_RADIUS_M * haversine.clamp(0.0, 1.0).sqrt().asin()
+}
+
 type PersistedProfileRow = (
     String,
     String,
@@ -377,13 +388,13 @@ async fn account_create_persists_stable_webauthn_user_id_across_reload() -> Resu
     Ok(())
 }
 
-/// Privacy-sensitive proof: a non-zero radius persists the REAL residence and
-/// radius (never the jittered public_pos), the response is obfuscated, and the
-/// loader reproduces the exact same deterministic jitter on reload.
+/// Privacy-sensitive proof: a non-zero radius persists the real residence and
+/// one private random projection binding. The public response never contains
+/// either private value, and the loader reuses the persisted point after reload.
 #[tokio::test]
 #[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
 #[serial]
-async fn postgres_account_create_radius_persists_obfuscated_public_pos() -> Result<()> {
+async fn postgres_account_create_radius_persists_private_projection() -> Result<()> {
     let pool = connect_pool().await;
     run_migrations(&pool).await;
     clean(&pool).await;
@@ -410,43 +421,70 @@ async fn postgres_account_create_radius_persists_obfuscated_public_pos() -> Resu
 
     let pub_lat = created["public_pos"]["lat"].as_f64().context("pub lat")?;
     let pub_lon = created["public_pos"]["lon"].as_f64().context("pub lon")?;
-    // radius_m>0 => public_pos must be jittered, not the exact residence.
-    assert_ne!(pub_lat, lat, "radius>0 must obfuscate latitude");
-    assert_ne!(pub_lon, lon, "radius>0 must obfuscate longitude");
+    assert_eq!(created["map_state"], "radius");
+    assert_eq!(created["radius_m"], radius_m);
     assert!(created.get("location").is_none());
+    assert!(created.get("radius_projection").is_none());
+    assert!(created.get("anchor").is_none());
+    let distance_m = great_circle_distance_m(lat, lon, pub_lat, pub_lon);
+    assert!(
+        distance_m > 0.0,
+        "radius projection must not expose the exact residence"
+    );
+    assert!(distance_m <= f64::from(radius_m) + 0.05);
 
-    // DB stores the real residence and radius — never the jittered public_pos.
-    let (db_lat, db_lon, radius): (Option<f64>, Option<f64>, i64) = sqlx::query_as(
-        "SELECT location_lat, location_lon, radius_m FROM domain_accounts WHERE id = $1",
+    let (db_lat, db_lon, radius, private_text, public_text): (
+        Option<f64>,
+        Option<f64>,
+        i64,
+        String,
+        String,
+    ) = sqlx::query_as(
+        "SELECT location_lat, location_lon, radius_m, private_payload::text, public_payload::text \
+         FROM domain_accounts WHERE id = $1",
     )
     .bind(id)
     .fetch_one(&pool)
     .await
     .expect("radius account row");
-    assert!(
-        (db_lat.unwrap() - lat).abs() < 1e-9,
-        "DB must store the real residence latitude"
-    );
-    assert!(
-        (db_lon.unwrap() - lon).abs() < 1e-9,
-        "DB must store the real residence longitude"
-    );
+    assert!((db_lat.unwrap() - lat).abs() < 1e-9);
+    assert!((db_lon.unwrap() - lon).abs() < 1e-9);
     assert_eq!(radius, 500);
+    let private_payload: serde_json::Value = serde_json::from_str(&private_text)?;
+    let public_payload: serde_json::Value = serde_json::from_str(&public_text)?;
+    let binding = private_payload
+        .get("radius_projection")
+        .context("private radius projection binding")?;
+    assert_eq!(binding["version"], 1);
+    assert_eq!(binding["radius_m"], radius_m);
+    assert_eq!(binding["anchor"]["lat"], lat);
+    assert_eq!(binding["anchor"]["lon"], lon);
+    assert!(public_payload.get("radius_projection").is_none());
 
-    // Loader reproduces the exact same deterministic jitter (stable by id).
+    let outbox_text: String = sqlx::query_scalar(
+        "SELECT payload::text FROM domain_outbox
+         WHERE aggregate_type = 'account' AND aggregate_id = $1
+         ORDER BY id DESC LIMIT 1",
+    )
+    .bind(id)
+    .fetch_one(&pool)
+    .await
+    .expect("account outbox event");
+    let outbox_payload: serde_json::Value = serde_json::from_str(&outbox_text)?;
+    assert_eq!(outbox_payload["aggregate_id"], id);
+    assert!(outbox_payload.get("radius_projection").is_none());
+    assert!(outbox_payload.get("location").is_none());
+    assert!(outbox_payload.get("public_pos").is_none());
+    assert!(!outbox_text.contains(&lat.to_string()));
+    assert!(!outbox_text.contains(&lon.to_string()));
+
     let reloaded = load_accounts_from_postgres(&pool)
         .await
         .expect("reload accounts");
     let internal = reloaded.get(id).expect("radius account reloaded");
     let pos = internal.public.public_pos.as_ref().expect("public_pos");
-    assert!(
-        (pos.lat - pub_lat).abs() < 1e-9,
-        "loader must reproduce the POST jitter latitude"
-    );
-    assert!(
-        (pos.lon - pub_lon).abs() < 1e-9,
-        "loader must reproduce the POST jitter longitude"
-    );
+    assert!((pos.lat - pub_lat).abs() < 1e-9);
+    assert!((pos.lon - pub_lon).abs() < 1e-9);
 
     assert!(!in_dir.join("demo.accounts.jsonl").exists());
 
@@ -943,6 +981,9 @@ async fn own_garnrolle_profile_persists_privately_and_reloads_from_postgres() ->
     assert_eq!(public_payload["summary"], "Dauerhaft gespeichert");
     assert_eq!(public_payload["tags"][0], "skill:Kochen");
     assert_eq!(private_payload["address"], "Poelsweg 2, Hamburg");
+    let initial_projection = private_payload["radius_projection"].clone();
+    assert_eq!(initial_projection["version"], 1);
+    assert_eq!(initial_projection["radius_m"], 300);
     assert_eq!(row.7.as_deref(), Some("profile-owner@example.test"));
     assert_eq!(row.8.as_deref(), Some(WEBAUTHN_ID));
 
@@ -961,6 +1002,11 @@ async fn own_garnrolle_profile_persists_privately_and_reloads_from_postgres() ->
     assert_eq!(reloaded_account.public.title, "Meine PostgreSQL Garnrolle");
     assert_eq!(reloaded_account.public.map_state, GarnrolleMapState::Radius);
     assert_eq!(reloaded_account.public.radius_m, 300);
+    let initial_public_pos = reloaded_account
+        .public
+        .public_pos
+        .clone()
+        .context("initial radius public position")?;
     assert_eq!(
         reloaded_account.email.as_deref(),
         Some("profile-owner@example.test")
@@ -1026,6 +1072,78 @@ async fn own_garnrolle_profile_persists_privately_and_reloads_from_postgres() ->
     let hidden_account = hidden_reload.get(PROFILE_ID).context("hidden account")?;
     assert_eq!(hidden_account.public.map_state, GarnrolleMapState::NotOnMap);
     assert!(hidden_account.public.public_pos.is_none());
+    let hidden_private_text: String =
+        sqlx::query_scalar("SELECT private_payload::text FROM domain_accounts WHERE id = $1")
+            .bind(PROFILE_ID)
+            .fetch_one(&pool)
+            .await?;
+    let hidden_private: serde_json::Value = serde_json::from_str(&hidden_private_text)?;
+    assert_eq!(hidden_private["radius_projection"], initial_projection);
+
+    // Re-enable the same location and radius. The private binding and public
+    // point must remain stable, preventing intersection attacks through toggles.
+    let response = app
+        .clone()
+        .oneshot(patch_own_profile(
+            &cookie,
+            r#"{
+              "title":"Meine PostgreSQL Garnrolle",
+              "summary":"Dauerhaft gespeichert",
+              "tags":["skill:Kochen","interest:Commons"],
+              "address":"Poelsweg 2, Hamburg",
+              "map_state":"radius",
+              "radius_m":300,
+              "location":{"lat":53.5604,"lon":10.0630}
+            }"#,
+        ))
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let same_reload = load_accounts_from_postgres(&pool).await?;
+    let same_account = same_reload.get(PROFILE_ID).context("same radius reload")?;
+    assert_eq!(
+        same_account.public.public_pos.as_ref(),
+        Some(&initial_public_pos)
+    );
+    let same_private_text: String =
+        sqlx::query_scalar("SELECT private_payload::text FROM domain_accounts WHERE id = $1")
+            .bind(PROFILE_ID)
+            .fetch_one(&pool)
+            .await?;
+    let same_private: serde_json::Value = serde_json::from_str(&same_private_text)?;
+    assert_eq!(same_private["radius_projection"], initial_projection);
+
+    // A radius change rotates the binding exactly once and the new value stays
+    // stable on reload.
+    let response = app
+        .clone()
+        .oneshot(patch_own_profile(
+            &cookie,
+            r#"{
+              "title":"Meine PostgreSQL Garnrolle",
+              "summary":"Dauerhaft gespeichert",
+              "tags":["skill:Kochen","interest:Commons"],
+              "address":"Poelsweg 2, Hamburg",
+              "map_state":"radius",
+              "radius_m":450,
+              "location":{"lat":53.5604,"lon":10.0630}
+            }"#,
+        ))
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let rotated_private_text: String =
+        sqlx::query_scalar("SELECT private_payload::text FROM domain_accounts WHERE id = $1")
+            .bind(PROFILE_ID)
+            .fetch_one(&pool)
+            .await?;
+    let rotated_private: serde_json::Value = serde_json::from_str(&rotated_private_text)?;
+    assert_ne!(rotated_private["radius_projection"], initial_projection);
+    assert_eq!(rotated_private["radius_projection"]["radius_m"], 450);
+    let rotated_reload = load_accounts_from_postgres(&pool).await?;
+    let rotated_account = rotated_reload
+        .get(PROFILE_ID)
+        .context("rotated radius reload")?;
+    assert_eq!(rotated_account.public.map_state, GarnrolleMapState::Radius);
+    assert_eq!(rotated_account.public.radius_m, 450);
 
     clean(&pool).await;
     Ok(())

--- a/apps/api/tests/db_domain_backfill.rs
+++ b/apps/api/tests/db_domain_backfill.rs
@@ -337,7 +337,7 @@ async fn import_edges(pool: &sqlx::PgPool, content: &str) -> BackfillReport {
 ///
 /// JSONL uses "type" for kind (matching AccountPublic serialisation).
 /// location lat/lon are the private residence coordinates, stored in
-/// location_lat/location_lon — not the jittered public_pos.
+/// location_lat/location_lon — never the public radius projection.
 /// Duplicate emails are audited and reported but not blocked (Phase B policy).
 async fn import_accounts(pool: &sqlx::PgPool, content: &str) -> BackfillReport {
     let mut report = BackfillReport::default();
@@ -741,8 +741,9 @@ async fn domain_backfill_edges_deterministic_and_idempotent() {
     pool.close().await;
 }
 
-/// Proves that two legacy account fixtures normalize to canonical Garnrollen
-/// with correct map states and re-import idempotently.
+/// Proves that two legacy account fixtures normalize to canonical Garnrollen,
+/// with an unbound historical radius account failing closed, and re-import
+/// idempotently.
 #[tokio::test]
 #[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
 async fn domain_backfill_accounts_deterministic_and_idempotent() {
@@ -766,7 +767,9 @@ async fn domain_backfill_accounts_deterministic_and_idempotent() {
         "no duplicate emails in clean fixture"
     );
 
-    // Field mapping for a legacy approximate account.
+    // Field mapping for a legacy approximate account. Historical records have
+    // no private random projection, so the import must preserve the residence
+    // privately but suppress the public radius state.
     type AccountProjectionRow = (
         String,
         Option<String>,
@@ -788,7 +791,7 @@ async fn domain_backfill_accounts_deterministic_and_idempotent() {
 
     assert_eq!(kind, "garnrolle");
     assert_eq!(mode, None);
-    assert_eq!(map_state, "radius");
+    assert_eq!(map_state, "not_on_map");
     assert_eq!(role, "weber");
     assert_eq!(email.as_deref(), Some("alpha@proof.example"));
     assert!(
@@ -816,13 +819,13 @@ async fn domain_backfill_accounts_deterministic_and_idempotent() {
         "hidden account must have NULL location_lon"
     );
 
-    // radius_m type: stored as BIGINT, bound as i64
+    // Unsafe historical radius is cleared while private coordinates remain.
     let (radius_m,): (i64,) = sqlx::query_as("SELECT radius_m FROM domain_accounts WHERE id = $1")
         .bind("backfill-proof-account-alpha")
         .fetch_one(&pool)
         .await
         .expect("radius_m must be readable");
-    assert_eq!(radius_m, 100);
+    assert_eq!(radius_m, 0);
 
     // Second import (idempotency)
     let r2 = import_accounts(&pool, ACCOUNT_FIXTURE).await;
@@ -1100,15 +1103,15 @@ async fn domain_backfill_legacy_account_semantics() {
     assert_eq!(mode, None);
     assert_eq!(map_state, "not_on_map");
 
-    // legacy-approximate: visibility: "approximate" + zero radius
+    // legacy-approximate: no private projection binding, therefore fail closed
     let (radius_m, map_state): (i64, String) = sqlx::query_as(
         "SELECT radius_m, map_state FROM domain_accounts WHERE id = 'legacy-approximate'",
     )
     .fetch_one(&pool)
     .await
     .expect("legacy-approximate must exist");
-    assert_eq!(radius_m, 250);
-    assert_eq!(map_state, "radius");
+    assert_eq!(radius_m, 0);
+    assert_eq!(map_state, "not_on_map");
 
     sqlx::query("DELETE FROM domain_accounts WHERE id LIKE 'legacy-%'")
         .execute(&pool)

--- a/apps/api/tests/db_domain_read_path.rs
+++ b/apps/api/tests/db_domain_read_path.rs
@@ -151,28 +151,42 @@ async fn accounts_loader_respects_mode_column_ron_even_with_location() {
 #[tokio::test]
 #[ignore]
 #[serial]
-async fn accounts_loader_approximate_radius_zero_becomes_250() {
+async fn accounts_loader_requires_valid_private_radius_binding() {
     let pool = prepare_pool().await;
     sqlx::query(
         "INSERT INTO domain_accounts \
          (id, kind, title, mode, map_state, radius_m, disabled, location_lat, location_lon, role, public_payload, private_payload) \
          VALUES \
-         ('rp-account-approximate', 'garnrolle', 'Approximate', 'verortet', 'exact', 0, false, 53.55, 9.99, 'gast', '{}'::jsonb, '{\"visibility\":\"approximate\"}'::jsonb)",
+         ('rp-account-approximate', 'garnrolle', 'Legacy approximate', 'verortet', 'radius', 250, false, 53.55, 9.99, 'gast', '{}'::jsonb, '{\"visibility\":\"approximate\"}'::jsonb), \
+         ('rp-account-safe-radius', 'garnrolle', 'Safe radius', NULL, 'radius', 250, false, 53.55, 9.99, 'gast', '{}'::jsonb, \
+          '{\"radius_projection\":{\"version\":1,\"anchor\":{\"lat\":53.55,\"lon\":9.99},\"radius_m\":250,\"public_pos\":{\"lat\":53.5505,\"lon\":9.99}}}'::jsonb)",
     )
     .execute(&pool)
     .await
-    .expect("insert approximate account");
+    .expect("insert radius accounts");
 
     let store = load_accounts_from_postgres(&pool)
         .await
         .expect("load accounts");
-    let account = store
+    let legacy = store
         .get("rp-account-approximate")
-        .expect("approximate account present");
+        .expect("legacy approximate account present");
+    let safe = store
+        .get("rp-account-safe-radius")
+        .expect("safe radius account present");
 
-    assert_eq!(account.public.map_state, GarnrolleMapState::Radius);
-    assert_eq!(account.public.radius_m, 250);
-    assert!(account.public.public_pos.is_some());
+    assert_eq!(legacy.public.map_state, GarnrolleMapState::NotOnMap);
+    assert_eq!(legacy.public.radius_m, 0);
+    assert!(legacy.public.public_pos.is_none());
+
+    assert_eq!(safe.public.map_state, GarnrolleMapState::Radius);
+    assert_eq!(safe.public.radius_m, 250);
+    let public_pos = safe.public.public_pos.as_ref().expect("safe public point");
+    assert!((public_pos.lat - 53.5505).abs() < 1e-9);
+    assert!((public_pos.lon - 9.99).abs() < 1e-9);
+    let public_json = serde_json::to_value(&safe.public).expect("serialize safe account");
+    assert!(public_json.get("radius_projection").is_none());
+    assert!(public_json.get("location").is_none());
     clean(&pool).await;
 }
 

--- a/apps/api/tests/db_domain_schema_migrations.rs
+++ b/apps/api/tests/db_domain_schema_migrations.rs
@@ -217,6 +217,127 @@ async fn domain_schema_tables_exist_after_migration() {
     pool.close().await;
 }
 
+/// Security cutover proof: an historical radius row is never re-exposed by
+/// the new migration or its intentionally irreversible down migration.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
+async fn radius_privacy_migration_hides_legacy_rows_irreversibly() {
+    let pool = connect_pool().await;
+    run_migrations(&pool).await;
+
+    sqlx::query("DELETE FROM domain_accounts WHERE id IN ('radius-migration-legacy', 'radius-migration-exact')")
+        .execute(&pool)
+        .await
+        .expect("pre-test cleanup failed");
+    sqlx::query(
+        "INSERT INTO domain_accounts (
+             id, kind, title, mode, map_state, radius_m, role,
+             location_lat, location_lon, public_payload, private_payload
+         ) VALUES
+         ('radius-migration-legacy', 'garnrolle', 'Legacy radius', NULL, 'radius', 500, 'weber',
+          53.5, 10.0, '{}'::jsonb,
+          '{\"visibility\":\"approximate\",\"radius_projection\":{\"legacy\":true},\"keep\":\"yes\"}'::jsonb),
+         ('radius-migration-exact', 'garnrolle', 'Exact', NULL, 'exact', 0, 'weber',
+          53.6, 10.1, '{}'::jsonb, '{\"keep\":\"exact\"}'::jsonb)",
+    )
+    .execute(&pool)
+    .await
+    .expect("insert migration fixtures");
+
+    sqlx::raw_sql(include_str!(
+        "../migrations/20260718000001_radius_projection_privacy.up.sql"
+    ))
+    .execute(&pool)
+    .await
+    .expect("apply radius privacy migration");
+
+    let (map_state, radius_m, lat, lon, private_text): (
+        String,
+        i64,
+        Option<f64>,
+        Option<f64>,
+        String,
+    ) = sqlx::query_as(
+        "SELECT map_state, radius_m, location_lat, location_lon, private_payload::text
+         FROM domain_accounts WHERE id = 'radius-migration-legacy'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("read migrated radius row");
+    assert_eq!(map_state, "not_on_map");
+    assert_eq!(radius_m, 0);
+    assert_eq!(lat, Some(53.5));
+    assert_eq!(lon, Some(10.0));
+    let private_payload: serde_json::Value =
+        serde_json::from_str(&private_text).expect("private payload json");
+    assert_eq!(private_payload["keep"], "yes");
+    assert!(private_payload.get("visibility").is_none());
+    assert!(private_payload.get("radius_projection").is_none());
+
+    let (exact_state, exact_radius, exact_private): (String, i64, String) = sqlx::query_as(
+        "SELECT map_state, radius_m, private_payload::text
+         FROM domain_accounts WHERE id = 'radius-migration-exact'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("read exact control row");
+    assert_eq!(exact_state, "exact");
+    assert_eq!(exact_radius, 0);
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&exact_private).unwrap()["keep"],
+        "exact"
+    );
+
+    // Simulate a safe radius binding created after the forward migration. A
+    // rollback must hide this row as well, because old application code would
+    // otherwise ignore the private binding and expose the reversible legacy
+    // projection again.
+    sqlx::query(
+        r#"UPDATE domain_accounts
+         SET map_state = 'radius', radius_m = 250,
+             private_payload = private_payload ||
+               '{"radius_projection":{"version":1,"anchor":{"lat":53.6,"lon":10.1},"radius_m":250,"public_pos":{"lat":53.6005,"lon":10.1}}}'::jsonb
+         WHERE id = 'radius-migration-exact'"#,
+    )
+    .execute(&pool)
+    .await
+    .expect("create post-cutover safe radius row");
+
+    sqlx::raw_sql(include_str!(
+        "../migrations/20260718000001_radius_projection_privacy.down.sql"
+    ))
+    .execute(&pool)
+    .await
+    .expect("apply irreversible down migration");
+    for id in ["radius-migration-legacy", "radius-migration-exact"] {
+        let (state_after_down, radius_after_down, lat_after_down, private_after_down): (
+            String,
+            i64,
+            Option<f64>,
+            String,
+        ) = sqlx::query_as(
+            "SELECT map_state, radius_m, location_lat, private_payload::text
+             FROM domain_accounts WHERE id = $1",
+        )
+        .bind(id)
+        .fetch_one(&pool)
+        .await
+        .expect("read row after down migration");
+        assert_eq!(state_after_down, "not_on_map");
+        assert_eq!(radius_after_down, 0);
+        assert!(lat_after_down.is_some(), "private location must remain");
+        let private_after_down: serde_json::Value =
+            serde_json::from_str(&private_after_down).expect("private payload after down");
+        assert!(private_after_down.get("radius_projection").is_none());
+    }
+
+    sqlx::query("DELETE FROM domain_accounts WHERE id IN ('radius-migration-legacy', 'radius-migration-exact')")
+        .execute(&pool)
+        .await
+        .expect("post-test cleanup failed");
+    pool.close().await;
+}
+
 /// Verifies that a row can be inserted into and read back from domain_nodes,
 /// domain_edges, and domain_accounts using the schema defined in Phase B.
 ///

--- a/docs/blueprints/domain-data-postgres-cutover.md
+++ b/docs/blueprints/domain-data-postgres-cutover.md
@@ -189,11 +189,14 @@ Konkrete Abweichungen und offene Constraints bleiben je Phase zu prüfen.
   `private_payload jsonb` oder über klar benannte Einzelspalten.
 - Explizite Spalten: `radius_m`, `role`, `email`, `webauthn_user_id`,
   Statusfelder wie `disabled`, dazu `created_at` und `updated_at`.
-- `public_pos` ist **keine gespeicherte Spalte**. Sie ist eine deterministische
-  Laufzeit-Projektion aus `location_lat`, `location_lon`, `radius_m` und `id`
-  via `calculate_jittered_pos` (verifiziert in `apps/api/src/routes/accounts.rs`).
-  Eine spätere Migration kann eine materialisierte Spalte ergänzen, wenn der
-  Lese-Aufwand das rechtfertigt; das ist aber eine explizite Folge-Entscheidung.
+- `public_pos` ist **keine gespeicherte Spalte**. Bei `map_state=exact` wird
+  sie aus der privaten Position projiziert. Bei `map_state=radius` stammt sie
+  aus einer kryptografisch zufälligen, typisierten Bindung im
+  `private_payload`. Diese Bindung bleibt bei unverändertem Ort und Radius
+  stabil, wird bei deren Änderung ersetzt und erscheint nie in öffentlichen
+  Antworten oder Domain-Events. Historische Radiuszeilen ohne gültige Bindung
+  werden seit Migration `20260718000001_radius_projection_privacy` fail-closed
+  als `not_on_map` behandelt.
 - Schreibpfad-Abdeckung: Der Cutover muss nicht nur Account-Erzeugung,
   sondern auch spätere Account-Mutationen abdecken, insbesondere
   Step-up-E-Mail-Änderungen und WebAuthn-Credential-Writeback. Die Spalte

--- a/docs/datenmodell.md
+++ b/docs/datenmodell.md
@@ -89,8 +89,12 @@ verarbeiten können.
 | Restfelder | `public_payload`, `private_payload` |
 
 E-Mail-Adressen besitzen einen trim-/case-normalisierten partiellen Unique-Index.
-`public_pos` wird nicht gespeichert, sondern aus privater Position, Radius und
-ID deterministisch abgeleitet.
+Bei `map_state=radius` wird `public_pos` aus einer kryptografisch zufälligen,
+privat persistierten Projektionsbindung gelesen. Sie bleibt bei unverändertem Ort
+und Radius stabil, auch nach zeitweisem Ausblenden, und wird erst bei Änderung
+eines dieser Werte ersetzt. Fehlt eine gültige Bindung, wird die Garnrolle
+fail-closed als `not_on_map` projiziert. Die private Position und die Bindung
+erscheinen nie in der öffentlichen Account-Antwort.
 
 `kind` ist auf `garnrolle` begrenzt. `map_state` enthält `not_on_map`, `exact`
 oder `radius`. Die frühere Spalte `mode` ist nullable, besitzt keinen Default und

--- a/docs/reports/domain-account-write-path-proof.md
+++ b/docs/reports/domain-account-write-path-proof.md
@@ -34,6 +34,13 @@ relations:
 
 # Domain Account Write Path Proof
 
+> **Sicherheitsnachtrag 2026-07-18:** Die in diesem historischen Phase-E-A-Beleg
+> beschriebene ID-deterministische Radiusprojektion ist durch Issue #1464 und
+> Migration `20260718000001_radius_projection_privacy` abgelöst. Radiuspunkte
+> stammen nun aus einer privat persistierten kryptografischen Zufallsbindung;
+> Altbestände ohne gültige Bindung werden fail-closed ausgeblendet. Die übrigen
+> Aussagen dieses Berichts bleiben historische Evidenz ihres damaligen Stands.
+
 ## Scope
 
 Dieser Proof dokumentiert OPT-ARC-001 **Phase E-A** als bewusst engen,
@@ -168,12 +175,11 @@ Neue PostgreSQL-Account-Create-Zeilen persistieren damit eine stabile
 `load_accounts_from_postgres` nach einem Reload wiederherstellt. Bestehende
 NULL-Werte bleiben über den Legacy-Fallback unterstützt.
 
-`public_pos` ist **keine** gespeicherte Spalte: Sie wird beim Lesen
-deterministisch aus `location_lat`/`location_lon`/`radius_m`/`id` berechnet.
-Das private Feld `location` wird nie serialisiert. `public_pos` ist die
-öffentliche Projektion; bei `radius_m = 0` kann sie exakt den eingereichten
-Koordinaten entsprechen, bei `radius_m > 0` wird sie deterministisch
-gejittert.
+`public_pos` ist **keine** eigene Tabellenspalte. Bei `radius_m = 0` kann sie
+exakt den eingereichten Koordinaten entsprechen. Seit dem Sicherheitsnachtrag
+2026-07-18 wird sie bei Radiusdarstellung aus einer privaten, persistierten
+Zufallsbindung gelesen. Weder die exakte Position noch diese Bindung werden
+öffentlich serialisiert.
 
 ## Validierung
 
@@ -205,9 +211,10 @@ Testfälle:
   Erfolg (201), korrekte Spalten/Payloads, Cache enthält den Account sofort,
   kein JSONL-Append; DB, Cache und `load_accounts_from_postgres` verwenden
   dieselbe parsebare `webauthn_user_id`.
-- `postgres_account_create_radius_persists_obfuscated_public_pos`:
-  Bei `radius_m>0` speichert die DB die reale Residenz und den Radius, die
-  Antwort ist gejittert, der Loader reproduziert exakt denselben Jitter.
+- `postgres_account_create_radius_persists_private_projection`:
+  Bei `radius_m>0` speichert die DB die reale Residenz, den Radius und die
+  private Zufallsbindung. Die Antwort enthält nur den Punkt innerhalb des
+  geodätischen Radius; Loader und mehrere Instanzen lesen dieselbe Bindung.
 - `postgres_account_create_duplicate_id_conflicts_without_side_effects`:
   Primärschlüsselkollision → `409`, keine Überschreibung, kein Cache-Update,
   kein JSONL.

--- a/docs/reports/domain-backfill-proof.md
+++ b/docs/reports/domain-backfill-proof.md
@@ -24,6 +24,11 @@ relations:
 
 # Domain Backfill Proof
 
+> **Sicherheitsnachtrag 2026-07-18:** Historische Radius-/Approximate-Datensätze
+> ohne private Zufallsbindung werden beim Import nicht mehr öffentlich
+> rekonstruiert. Private Koordinaten bleiben erhalten, während `map_state` und
+> `radius_m` fail-closed auf `not_on_map` beziehungsweise `0` gesetzt werden.
+
 ## Scope
 
 Phase C only: deterministic JSONL→PostgreSQL import proof for domain data (nodes, edges, accounts).
@@ -94,7 +99,7 @@ These paths are unchanged. JSONL is the active runtime truth until Phase D/E.
 | `mode` | `mode` | `"verortet"` or `"ron"` |
 | `radius_m` | `radius_m` (BIGINT) | Bound as `i64`; default 0 |
 | `disabled` | `disabled` | Default: `false` |
-| `location.lat` | `location_lat` | Private residence; not the jittered `public_pos` |
+| `location.lat` | `location_lat` | Private residence; never the public radius projection |
 | `location.lon` | `location_lon` | Private residence |
 | `role` | `role` | Default: `"gast"` |
 | `email` | `email` | Optional |
@@ -102,7 +107,7 @@ These paths are unchanged. JSONL is the active runtime truth until Phase D/E.
 | `created_at` | `created_at` (TIMESTAMPTZ) | Optional |
 | `updated_at` | `updated_at` (TIMESTAMPTZ) | Optional |
 | `summary`, `tags` | `public_payload` (JSONB) | Public fields not in explicit columns |
-| — | `private_payload` (JSONB) | Preserves legacy operational fields such as visibility, ron_flag, explicit mode and suppress_public_pos for Phase-D reconstruction |
+| `radius_projection` und Legacy-Felder | `private_payload` (JSONB) | Sichere Bindungen bleiben privat; Legacy-Radius ohne gültige Bindung wird nicht öffentlich reaktiviert |
 
 ## Idempotency Contract
 

--- a/docs/specs/privacy-api.md
+++ b/docs/specs/privacy-api.md
@@ -55,6 +55,14 @@ Die öffentliche Ansicht darf nur die gewählte Sichtbarkeit zeigen:
 Die interne Adresse und die exakten Koordinaten bleiben getrennt von der
 öffentlichen Projektion, sofern nicht exakt sichtbare Anzeige gewählt wurde.
 
+Für `radius` erzeugt der Server einmalig einen kryptografisch zufälligen Punkt
+innerhalb eines echten geodätischen Kreises von 50 bis 5.000 Metern. Die dazu
+gehörige Bindung wird ausschließlich privat persistiert. Sie bleibt bei
+unverändertem Ort und Radius auch nach zeitweisem Ausblenden stabil, damit kein
+neuer Punkt eine Schnittmengenattacke ermöglicht. Erst eine Änderung des
+privaten Orts oder Radius erzeugt eine neue Bindung. Fehlt eine gültige Bindung,
+wird die Garnrolle ohne öffentliche Position als `not_on_map` behandelt.
+
 ## Zielendpunkte
 
 Die endgültigen Namen sind noch offen. Semantisch braucht das System:


### PR DESCRIPTION
<!-- weltgewebe-risk: R3 -->

## Ziel

Ersetzt die aus öffentlicher Account-ID und Radius rückrechenbare Radius-Verortung durch eine private, persistierte Zufallsbindung.

Closes #1464

## Sicherheitsvertrag

- kryptografisch zufälliger öffentlicher Punkt innerhalb eines echten geodätischen Kreises
- private Bindung bleibt bei unverändertem Ort und Radius über Reloads, Instanzen und zeitweises `not_on_map` stabil
- Rotation nur bei Änderung von privatem Ort oder Radius
- ein privater Ortswechsel löscht den veralteten Projektionsanker
- fehlende, manipulierte, übergroße oder historische Bindungen führen fail-closed zu `not_on_map`
- Bindung und private Position erscheinen weder in öffentlichen Antworten noch im Eigenprofil oder im Outbox-Ereignis
- einheitlicher Radiusvertrag: 50–5.000 Meter in API und Importpfaden
- Pol- und Datumsgrenzen explizit getestet
- unbekannte Bindungsversionen bleiben fail-closed

## Migration

`20260718000001_radius_projection_privacy` blendet historische unsichere Radiusprofile aus, erhält aber die private Position. Es gibt keinen sicheren deterministischen Backfill.

Die Down-Migration ist absichtlich ebenfalls fail-closed: Auch nach dem Cutover erzeugte sichere Radiusprofile werden bei einem Versionsrollback ausgeblendet, damit alter Anwendungscode sie nicht erneut ID-basiert projiziert. Beide Richtungen melden nur die Anzahl betroffener Accounts über PostgreSQL `NOTICE`; Account-IDs werden nicht protokolliert.

## Reviewkorrekturen

Übernommen wurden:

- Fail-closed bei übergroßen oder nicht darstellbaren Legacy-Radien ohne Integer-Überlauf;
- Löschung veralteter privater Anker nach einem echten Ortswechsel;
- 53-Bit-Abbildung der Zufallswerte passend zur `f64`-Mantisse;
- normalisierter Winkel und benannte Polschwelle;
- reale Grenztests für die enge 5-cm-Geometrietoleranz;
- gemeinsame Radiuskonstanten für API und Datenbankimport;
- migrationsseitige Anzahlmeldung.

Nicht übernommen wurden eine 10-Meter-Außentoleranz, pauschale Annahme älterer Bindungsversionen, Löschung bei bloßem Sichtbarkeitswechsel sowie ein Cache-/Geo-Großrefactoring. Diese Punkte würden entweder den Datenschutzvertrag schwächen oder den Sicherheits-Hotfix unnötig verbreitern.

## Folgen

Historische Radiusprofile müssen vom jeweiligen Account erneut gespeichert werden, bevor sie wieder auf der Karte erscheinen. Das ist eine bewusste Datenschutzentscheidung.

## Verifikation

- `RUSTUP_TOOLCHAIN=1.89.0 CARGO_BUILD_JOBS=4 just ci` in bereinigter Task-Umgebung
- `cargo clippy -p weltgewebe-api --all-targets --all-features -- -D warnings`
- `make validate`
- vollständige PostgreSQL-/JetStream-Suite mit allen ignorierten Datenbank-, Mehrinstanz-, Outbox-, Governance-, Passkey- und Sitzungstests
- JSONL-Persistenz, Reload, Hide/Re-enable-Stabilität und Rotation
- privater Ortswechsel entfernt alte Bindung in JSONL und PostgreSQL
- übergroße Legacy-Radien bleiben verborgen
- Vorwärts- und Rückwärtsmigration samt `NOTICE`
- Outbox-Leak-Prüfung

Alle finalen Läufe auf dem rebasierten Head: Exit 0.

## Review-Bindung

- Basis: `691f663a278bc4f29e8e7a75b23d9538ac7039c6`
- Head: `fcb58b833a25ba89ae06a44c5da911986cb84db0`
- GitHub-API-Diff SHA-256: `1f469e541cec02573eb67fa3dc901757bf447d77795b4bed16a9d9528db15192`
