### PR TITLE
fix(platform): harden HA proof boundaries

### DIFF
--- a/.github/workflows/kubernetes-platform.yml
+++ b/.github/workflows/kubernetes-platform.yml
@@ -138,3 +138,9 @@ jobs:
           path: .cache/weltgewebe-platform/failures/
           if-no-files-found: ignore
           retention-days: 14
+      - name: Reconcile owned HA proof resources
+        if: always()
+        run: >-
+          python scripts/platform/ha_reference.py down
+          --cluster "$CLUSTER_NAME"
+          --commit "$(git rev-parse HEAD)"

--- a/scripts/ci/tests/test_kubernetes_ha_contract.py
+++ b/scripts/ci/tests/test_kubernetes_ha_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
 import sys
 import tempfile
@@ -227,7 +228,7 @@ class KubernetesHaContractTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             artifact = Path(directory) / "release.yaml"
             artifact.write_text(
-                "\n".join(f"image: {image}" for image in tagged) + "\n",
+                "".join(f"---\nimage: {image}\n" for image in tagged),
                 encoding="utf-8",
             )
             with mock.patch.object(self.ha.ref, "run") as run:
@@ -267,25 +268,27 @@ class KubernetesHaContractTests(unittest.TestCase):
             "ghcr.io/cloudnative-pg/plugin-barman-cloud-sidecar:v0.13.0"
         )
         encoded = self.ha.base64.b64encode(sidecar_tag.encode()).decode()
-        wrapped = "\n".join(
-            f"    {encoded[index:index + 72]}"
-            for index in range(0, len(encoded), 72)
-        )
         source = (
-            "apiVersion: v1\ndata:\n  SIDECAR_IMAGE: |\n"
-            f"{wrapped}\n---\nimage: "
-            "ghcr.io/cloudnative-pg/plugin-barman-cloud:v0.13.0\n"
+            "apiVersion: v1\nkind: Secret\nmetadata:\n  name: sidecar\n"
+            f'data:\n  SIDECAR_IMAGE: "{encoded}"\n---\n'
+            "apiVersion: apps/v1\nkind: Deployment\nspec:\n  template:\n"
+            "    spec:\n      containers:\n        - name: controller\n"
+            "          image: ghcr.io/cloudnative-pg/plugin-barman-cloud:v0.13.0\n"
         )
         rendered = self.ha.render_barman_cloud_manifest(source)
-        self.assertNotIn(sidecar_tag, rendered)
-        self.assertNotIn(
-            "ghcr.io/cloudnative-pg/plugin-barman-cloud:v0.13.0", rendered
+        documents = list(self.ha.yaml.safe_load_all(rendered))
+        secret = next(item for item in documents if item.get("kind") == "Secret")
+        deployment = next(
+            item for item in documents if item.get("kind") == "Deployment"
         )
-        self.assertIn(self.ha.BARMAN_CLOUD_PLUGIN_IMAGE, rendered)
-        digest_encoded = self.ha.base64.b64encode(
-            self.ha.BARMAN_CLOUD_SIDECAR_IMAGE.encode()
-        ).decode()
-        self.assertIn(f"SIDECAR_IMAGE: {digest_encoded}", rendered)
+        self.assertEqual(
+            self.ha.base64.b64decode(secret["data"]["SIDECAR_IMAGE"]).decode(),
+            self.ha.BARMAN_CLOUD_SIDECAR_IMAGE,
+        )
+        self.assertEqual(
+            deployment["spec"]["template"]["spec"]["containers"][0]["image"],
+            self.ha.BARMAN_CLOUD_PLUGIN_IMAGE,
+        )
 
     def test_barman_plugin_install_waits_and_verifies_digest_images(self) -> None:
         secret_payload = json.dumps(
@@ -322,7 +325,9 @@ class KubernetesHaContractTests(unittest.TestCase):
             "kubectl", "cnpg-system", "deployment/barman-cloud", "8m"
         )
 
-    def test_barman_instance_sidecars_are_verified_for_all_three_pods(self) -> None:
+    def test_barman_instance_sidecars_are_running_ready_and_digest_bound(self) -> None:
+        digest = self.ha.BARMAN_CLOUD_SIDECAR_IMAGE.rsplit("@", 1)[1]
+
         def pod(name: str) -> dict[str, object]:
             return {
                 "metadata": {"name": name},
@@ -335,7 +340,20 @@ class KubernetesHaContractTests(unittest.TestCase):
                     ],
                     "containers": [],
                 },
+                "status": {
+                    "initContainerStatuses": [
+                        {
+                            "name": "plugin-barman-cloud",
+                            "imageID": f"ghcr.io/cloudnative-pg/sidecar@{digest}",
+                            "ready": True,
+                            "state": {
+                                "running": {"startedAt": "2026-07-18T08:00:00Z"}
+                            },
+                        }
+                    ]
+                },
             }
+
         with mock.patch.object(
             self.ha.ref,
             "output",
@@ -346,9 +364,40 @@ class KubernetesHaContractTests(unittest.TestCase):
             observed = self.ha.verify_barman_sidecar_images(
                 "kubectl", "postgres-ha"
             )
-        self.assertEqual(
-            observed, [self.ha.BARMAN_CLOUD_SIDECAR_IMAGE] * 3
-        )
+        self.assertEqual(sorted(observed), ["postgres-1", "postgres-2", "postgres-3"])
+        self.assertTrue(all(item["ready"] is True for item in observed.values()))
+
+    def test_barman_instance_sidecar_validation_fails_closed_when_not_ready(self) -> None:
+        payload = {
+            "items": [
+                {
+                    "metadata": {"name": "postgres-1"},
+                    "spec": {
+                        "initContainers": [
+                            {
+                                "name": "plugin-barman-cloud",
+                                "image": self.ha.BARMAN_CLOUD_SIDECAR_IMAGE,
+                            }
+                        ]
+                    },
+                    "status": {
+                        "initContainerStatuses": [
+                            {
+                                "name": "plugin-barman-cloud",
+                                "imageID": self.ha.BARMAN_CLOUD_SIDECAR_IMAGE,
+                                "ready": False,
+                                "state": {"waiting": {"reason": "Starting"}},
+                            }
+                        ]
+                    },
+                }
+            ]
+        }
+        with mock.patch.object(
+            self.ha.ref, "output", return_value=json.dumps(payload)
+        ):
+            with self.assertRaisesRegex(self.ha.ref.ProofError, "not running and ready"):
+                self.ha.verify_barman_sidecar_images("kubectl", "postgres-ha")
 
     def cnpg_release_fixture(self) -> str:
         tagged = "ghcr.io/cloudnative-pg/cloudnative-pg:1.30.0"
@@ -712,10 +761,72 @@ spec:
         environment = run.call_args.kwargs["env"]
         self.assertNotIn("ephemeral-sensitive-value", argv)
         self.assertEqual(environment["PROOF_SECRET"], "ephemeral-sensitive-value")
-        self.assertNotIn(
-            "AWS_SECRET_ACCESS_KEY=",
-            (ROOT / "scripts/platform/ha_reference.py").read_text(),
+
+    def test_pitr_boundary_uses_and_verifies_postgres_clock(self) -> None:
+        with mock.patch.object(self.ha, "psql", side_effect=["", "t"]) as psql:
+            self.ha.wait_for_pitr_boundary(
+                "kubectl", "2026-07-18T08:00:00.000000Z"
+            )
+        self.assertEqual(psql.call_args_list[0].args[1], "SELECT pg_sleep(2)")
+        self.assertIn("clock_timestamp()", psql.call_args_list[1].args[1])
+
+    def test_pitr_boundary_fails_closed_before_the_database_clock_crosses(self) -> None:
+        with mock.patch.object(self.ha, "psql", side_effect=["", "f"]):
+            with self.assertRaisesRegex(
+                self.ha.ref.ProofError, "did not cross PITR target"
+            ):
+                self.ha.wait_for_pitr_boundary(
+                    "kubectl", "2026-07-18T08:00:00.000000Z"
+                )
+
+    def test_cluster_context_binding_uses_cluster_specific_kubeconfig(self) -> None:
+        path = ROOT / ".cache/test-restore-kubeconfig.yaml"
+
+        def configure(_kind: str, _cluster: str) -> Path:
+            self.ha.os.environ["KUBECONFIG"] = str(path)
+            return path
+
+        with (
+            mock.patch.object(
+                self.ha.ref, "configure_cluster_access", side_effect=configure
+            ),
+            mock.patch.object(self.ha.ref, "output", return_value="kind-proof-restore"),
+            mock.patch.dict(self.ha.os.environ, {}, clear=False),
+        ):
+            self.assertEqual(
+                self.ha.require_active_cluster_context(
+                    "kind", "kubectl", "proof-restore"
+                ),
+                "kubectl",
+            )
+
+    def test_main_redacts_subprocess_output_and_logs_constant_success(self) -> None:
+        parser = mock.Mock()
+        parser.parse_args.return_value = self.ha.argparse.Namespace(
+            command="proof", cluster="proof", keep=False
         )
+        secret = "ephemeral-sensitive-value"
+        failure = self.ha.subprocess.CalledProcessError(
+            23, ["tool"], output=secret, stderr=secret
+        )
+        with (
+            mock.patch.object(self.ha, "argument_parser", return_value=parser),
+            mock.patch.object(self.ha.ref, "tool_receipt", return_value={}),
+            mock.patch.object(self.ha, "prove", side_effect=failure),
+            mock.patch("sys.stderr", new_callable=io.StringIO) as stderr,
+        ):
+            self.assertEqual(self.ha.main(), 1)
+        self.assertNotIn(secret, stderr.getvalue())
+        self.assertIn("status 23", stderr.getvalue())
+
+        with (
+            mock.patch.object(self.ha, "argument_parser", return_value=parser),
+            mock.patch.object(self.ha.ref, "tool_receipt", return_value={}),
+            mock.patch.object(self.ha, "prove", return_value={"secret": secret}),
+            mock.patch("sys.stdout", new_callable=io.StringIO) as stdout,
+        ):
+            self.assertEqual(self.ha.main(), 0)
+        self.assertEqual(json.loads(stdout.getvalue()), {"status": "pass"})
 
     def test_postgres_operand_keeps_version_and_digest(self) -> None:
         image = self.ha.POSTGRES_IMAGE

--- a/scripts/platform/ha_reference.py
+++ b/scripts/platform/ha_reference.py
@@ -6,7 +6,6 @@ import base64
 import hashlib
 import json
 import os
-import re
 import secrets
 import subprocess
 import sys
@@ -74,6 +73,22 @@ def create_kind_cluster(kind: str, name: str, image: str, config: str, commit: s
     except Exception:
         ref.delete_owned_cluster(kind, name)
         raise
+
+
+def require_active_cluster_context(kind: str, kubectl: str, cluster: str) -> str:
+    kubeconfig = ref.configure_cluster_access(kind, cluster)
+    expected_context = f"kind-{cluster}"
+    observed_context = ref.output([kubectl, "config", "current-context"])
+    if observed_context != expected_context:
+        raise ref.ProofError(
+            f"kubectl context mismatch for {cluster}: {observed_context!r}"
+        )
+    if os.environ.get("KUBECONFIG") != str(kubeconfig):
+        raise ref.ProofError(
+            f"kubectl kubeconfig mismatch for {cluster}: "
+            f"{os.environ.get('KUBECONFIG')!r}"
+        )
+    return kubectl
 
 
 def apply_secret_contracts(kubectl: str, app_password: str, s3_secret_key: str) -> None:
@@ -238,16 +253,79 @@ def cnpg_webhook_ready(kubectl: str) -> bool:
     return result.returncode == 0
 
 
+def _load_yaml_documents(source: str, release_name: str) -> list[Any]:
+    try:
+        documents = [
+            document
+            for document in yaml.safe_load_all(source)
+            if document is not None
+        ]
+    except yaml.YAMLError as error:
+        raise ref.ProofError(f"{release_name} is not valid YAML") from error
+    if not documents:
+        raise ref.ProofError(f"{release_name} contains no YAML documents")
+    return documents
+
+
+def _replace_exact_yaml_scalar(
+    value: Any, expected: str, replacement: str
+) -> tuple[Any, int]:
+    if isinstance(value, dict):
+        rewritten: dict[Any, Any] = {}
+        count = 0
+        for key, item in value.items():
+            rewritten_item, observed = _replace_exact_yaml_scalar(
+                item, expected, replacement
+            )
+            rewritten[key] = rewritten_item
+            count += observed
+        return rewritten, count
+    if isinstance(value, list):
+        rewritten_items: list[Any] = []
+        count = 0
+        for item in value:
+            rewritten_item, observed = _replace_exact_yaml_scalar(
+                item, expected, replacement
+            )
+            rewritten_items.append(rewritten_item)
+            count += observed
+        return rewritten_items, count
+    if value == expected:
+        return replacement, 1
+    return value, 0
+
+
+def rewrite_yaml_documents(
+    source: str,
+    replacements: dict[str, tuple[str, int]],
+    release_name: str,
+) -> list[Any]:
+    documents = _load_yaml_documents(source, release_name)
+    for tagged, (digest_bound, expected_count) in replacements.items():
+        rewritten_documents: list[Any] = []
+        observed_count = 0
+        for document in documents:
+            rewritten, observed = _replace_exact_yaml_scalar(
+                document, tagged, digest_bound
+            )
+            rewritten_documents.append(rewritten)
+            observed_count += observed
+        if observed_count != expected_count:
+            raise ref.ProofError(
+                f"{release_name} image reference changed unexpectedly: "
+                f"{tagged} occurred {observed_count} times, expected {expected_count}"
+            )
+        documents = rewritten_documents
+    return documents
+
+
 def render_cnpg_manifest(source: str) -> str:
     tagged = "ghcr.io/cloudnative-pg/cloudnative-pg:1.30.0"
-    if source.count(tagged) != 2:
-        raise ref.ProofError(
-            "CloudNativePG release image reference changed unexpectedly"
-        )
-    try:
-        documents = list(yaml.safe_load_all(source.replace(tagged, CNPG_OPERATOR_IMAGE)))
-    except yaml.YAMLError as exc:
-        raise ref.ProofError("CloudNativePG release manifest is invalid YAML") from exc
+    documents = rewrite_yaml_documents(
+        source,
+        {tagged: (CNPG_OPERATOR_IMAGE, 2)},
+        "CloudNativePG release",
+    )
     deployments = [
         document
         for document in documents
@@ -268,10 +346,7 @@ def render_cnpg_manifest(source: str) -> str:
         "type": "RollingUpdate",
         "rollingUpdate": {"maxSurge": 0, "maxUnavailable": 1},
     }
-    pod_spec = (
-        spec.setdefault("template", {})
-        .setdefault("spec", {})
-    )
+    pod_spec = spec.setdefault("template", {}).setdefault("spec", {})
     affinity = pod_spec.setdefault("affinity", {})
     pod_anti_affinity = affinity.setdefault("podAntiAffinity", {})
     required = pod_anti_affinity.setdefault(
@@ -284,17 +359,12 @@ def render_cnpg_manifest(source: str) -> str:
     required.append(
         {
             "labelSelector": {
-                "matchLabels": {
-                    "app.kubernetes.io/name": "cloudnative-pg"
-                }
+                "matchLabels": {"app.kubernetes.io/name": "cloudnative-pg"}
             },
             "topologyKey": "kubernetes.io/hostname",
         }
     )
-    return yaml.safe_dump_all(
-        documents, sort_keys=False, explicit_start=True
-    )
-
+    return yaml.safe_dump_all(documents, sort_keys=False, explicit_start=True)
 
 def verify_cnpg_operator_ha(kubectl: str) -> list[str]:
     ref.wait_rollout(
@@ -401,11 +471,12 @@ def apply_digest_locked_manifest(
     artifact: str,
     replacements: dict[str, str],
 ) -> None:
-    source = Path(artifact).read_text(encoding="utf-8")
-    for tagged, digest in replacements.items():
-        if source.count(tagged) != 1:
-            raise ref.ProofError(f"release image reference changed unexpectedly: {tagged}")
-        source = source.replace(tagged, digest)
+    documents = rewrite_yaml_documents(
+        Path(artifact).read_text(encoding="utf-8"),
+        {tagged: (digest, 1) for tagged, digest in replacements.items()},
+        "digest-locked release",
+    )
+    source = yaml.safe_dump_all(documents, sort_keys=False, explicit_start=True)
     ref.run(
         [
             kubectl,
@@ -418,7 +489,6 @@ def apply_digest_locked_manifest(
         ],
         input_text=source,
     )
-
 
 def install_cert_manager(kubectl: str, artifact: str) -> None:
     apply_digest_locked_manifest(kubectl, artifact, CERT_MANAGER_IMAGES)
@@ -477,46 +547,44 @@ def install_cert_manager(kubectl: str, artifact: str) -> None:
 
 
 def render_barman_cloud_manifest(source: str) -> str:
-    tagged = "ghcr.io/cloudnative-pg/plugin-barman-cloud:v0.13.0"
-    if source.count(tagged) != 1:
+    controller_tagged = "ghcr.io/cloudnative-pg/plugin-barman-cloud:v0.13.0"
+    documents = rewrite_yaml_documents(
+        source,
+        {controller_tagged: (BARMAN_CLOUD_PLUGIN_IMAGE, 1)},
+        "Barman Cloud release",
+    )
+    matching_secrets = [
+        document
+        for document in documents
+        if isinstance(document, dict)
+        and document.get("kind") == "Secret"
+        and isinstance(document.get("data"), dict)
+        and "SIDECAR_IMAGE" in document["data"]
+    ]
+    if len(matching_secrets) != 1:
         raise ref.ProofError(
-            "Barman Cloud release image reference changed unexpectedly"
+            "Barman Cloud sidecar secret changed unexpectedly: "
+            f"{len(matching_secrets)} matching Secrets"
         )
-    source = source.replace(tagged, BARMAN_CLOUD_PLUGIN_IMAGE)
+    secret = matching_secrets[0]
+    encoded = "".join(str(secret["data"]["SIDECAR_IMAGE"]).split())
+    try:
+        decoded = base64.b64decode(encoded, validate=True).decode("utf-8")
+    except (ValueError, UnicodeDecodeError) as error:
+        raise ref.ProofError(
+            "Barman Cloud sidecar secret is not valid UTF-8 base64"
+        ) from error
     sidecar_tagged = (
         "ghcr.io/cloudnative-pg/plugin-barman-cloud-sidecar:v0.13.0"
     )
-    pattern = re.compile(
-        r"(?m)^  SIDECAR_IMAGE: \|\n((?:    [A-Za-z0-9+/=]+\n)+)"
-    )
-    matches = list(pattern.finditer(source))
-    if len(matches) != 1:
-        raise ref.ProofError(
-            "Barman Cloud sidecar secret changed unexpectedly"
-        )
-    encoded = "".join(
-        line.strip() for line in matches[0].group(1).splitlines()
-    )
-    try:
-        decoded = base64.b64decode(encoded, validate=True).decode("utf-8")
-    except (ValueError, UnicodeDecodeError) as exc:
-        raise ref.ProofError(
-            "Barman Cloud sidecar secret is not valid UTF-8 base64"
-        ) from exc
     if decoded != sidecar_tagged:
         raise ref.ProofError(
             f"Barman Cloud sidecar reference changed unexpectedly: {decoded}"
         )
-    digest_encoded = base64.b64encode(
+    secret["data"]["SIDECAR_IMAGE"] = base64.b64encode(
         BARMAN_CLOUD_SIDECAR_IMAGE.encode("utf-8")
     ).decode("ascii")
-    match = matches[0]
-    return (
-        source[: match.start()]
-        + f"  SIDECAR_IMAGE: {digest_encoded}\n"
-        + source[match.end() :]
-    )
-
+    return yaml.safe_dump_all(documents, sort_keys=False, explicit_start=True)
 
 def apply_barman_cloud_manifest(kubectl: str, artifact: str) -> None:
     source = render_barman_cloud_manifest(
@@ -602,7 +670,9 @@ def install_barman_cloud_plugin(kubectl: str, artifact: str) -> None:
         raise ref.ProofError(f"Barman Cloud plugin image is not digest-bound: {observed}")
 
 
-def verify_barman_sidecar_images(kubectl: str, cluster: str) -> list[str]:
+def verify_barman_sidecar_images(
+    kubectl: str, cluster: str
+) -> dict[str, dict[str, object]]:
     payload = json.loads(
         ref.output(
             [
@@ -618,23 +688,66 @@ def verify_barman_sidecar_images(kubectl: str, cluster: str) -> list[str]:
             ]
         )
     )
-    images = []
+    expected_digest = BARMAN_CLOUD_SIDECAR_IMAGE.rsplit("@", 1)[1]
+    observed: dict[str, dict[str, object]] = {}
     for pod in payload.get("items", []):
-        containers = (
-            pod.get("spec", {}).get("initContainers", [])
-            + pod.get("spec", {}).get("containers", [])
-        )
-        images.extend(
-            container.get("image", "")
+        name = str(pod.get("metadata", {}).get("name", ""))
+        containers = [
+            *pod.get("spec", {}).get("initContainers", []),
+            *pod.get("spec", {}).get("containers", []),
+        ]
+        sidecars = [
+            container
             for container in containers
             if container.get("name") == "plugin-barman-cloud"
-        )
-    if len(images) != 3 or set(images) != {BARMAN_CLOUD_SIDECAR_IMAGE}:
+        ]
+        if len(sidecars) != 1:
+            raise ref.ProofError(
+                f"PostgreSQL pod {name} has {len(sidecars)} Barman sidecars"
+            )
+        declared_image = str(sidecars[0].get("image", ""))
+        if declared_image != BARMAN_CLOUD_SIDECAR_IMAGE:
+            raise ref.ProofError(
+                f"PostgreSQL pod {name} has an unbound Barman sidecar: "
+                f"{declared_image}"
+            )
+        statuses = [
+            *pod.get("status", {}).get("initContainerStatuses", []),
+            *pod.get("status", {}).get("containerStatuses", []),
+        ]
+        sidecar_statuses = [
+            status
+            for status in statuses
+            if status.get("name") == "plugin-barman-cloud"
+        ]
+        if len(sidecar_statuses) != 1:
+            raise ref.ProofError(
+                f"PostgreSQL pod {name} has {len(sidecar_statuses)} Barman statuses"
+            )
+        status = sidecar_statuses[0]
+        image_id = str(status.get("imageID", ""))
+        running = status.get("state", {}).get("running", {})
+        started_at = running.get("startedAt")
+        if not image_id.endswith(expected_digest):
+            raise ref.ProofError(
+                f"PostgreSQL pod {name} runs an unbound Barman image ID: {image_id}"
+            )
+        if status.get("ready") is not True or not started_at:
+            raise ref.ProofError(
+                f"PostgreSQL pod {name} Barman sidecar is not running and ready"
+            )
+        observed[name] = {
+            "declared_image": declared_image,
+            "image_id": image_id,
+            "ready": True,
+            "started_at": started_at,
+        }
+    if len(observed) != 3:
         raise ref.ProofError(
-            f"Barman Cloud instance sidecars are not digest-bound for {cluster}: {images}"
+            f"Barman Cloud requires exactly three ready instance sidecars for "
+            f"{cluster}: {sorted(observed)}"
         )
-    return sorted(images)
-
+    return observed
 
 def current_primary(kubectl: str, cluster: str = "postgres-ha") -> str:
     return ref.output([kubectl, "-n", "weltgewebe-data", "get", f"cluster/{cluster}", "-o", "jsonpath={.status.currentPrimary}"])
@@ -696,6 +809,19 @@ def psql(kubectl: str, sql: str, *, cluster: str = "postgres-ha") -> str:
     if not primary:
         raise ref.ProofError(f"PostgreSQL cluster {cluster} has no current primary")
     return ref.output([kubectl, "-n", "weltgewebe-data", "exec", primary, "--", "psql", "-d", "weltgewebe", "-Atqc", sql])
+
+
+def wait_for_pitr_boundary(kubectl: str, target_time: str) -> None:
+    psql(kubectl, "SELECT pg_sleep(2)")
+    escaped_target = target_time.replace("'", "''")
+    crossed = psql(
+        kubectl,
+        f"SELECT clock_timestamp() > '{escaped_target}'::timestamptz",
+    )
+    if crossed != "t":
+        raise ref.ProofError(
+            f"PostgreSQL clock did not cross PITR target {target_time}"
+        )
 
 
 def pod_topology(kubectl: str, namespace: str, selector: str) -> dict[str, dict[str, str]]:
@@ -1256,6 +1382,7 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
     try:
         create_kind_cluster(kind, args.cluster, receipt["kubernetes"]["kind_node_image"], "platform/clusters/ha/kind.yaml", commit)
         created_primary = True
+        kubectl = require_active_cluster_context(kind, kubectl, args.cluster)
         image_ids = ref.build_images(kind, args.cluster, commit, timestamp)
         image_ids.update(
             prepare_api_upgrade_candidate(kind, args.cluster, commit)
@@ -1368,7 +1495,7 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
         )
         backup = wait_backup_complete(kubectl, backup_name)
         target_time = psql(kubectl, "SELECT to_char(clock_timestamp() AT TIME ZONE 'UTC','YYYY-MM-DD\"T\"HH24:MI:SS.US\"Z\"')")
-        time.sleep(2)
+        wait_for_pitr_boundary(kubectl, target_time)
         insert_domain_node(kubectl, after_id, "T004 after PITR target")
         primary_wal_archive = measure_wal_archive(
             kubectl, cluster="postgres-ha"
@@ -1376,7 +1503,9 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
 
         create_kind_cluster(kind, restore_name, receipt["kubernetes"]["kind_node_image"], "platform/clusters/ha/restore-kind.yaml", commit)
         created_restore = True
-        restore_kubectl = kubectl
+        restore_kubectl = require_active_cluster_context(
+            kind, kubectl, restore_name
+        )
         ref.run([restore_kubectl, "wait", "--for=condition=Ready", "nodes", "--all", "--timeout=8m"])
         ref.apply_file(restore_kubectl, ROOT / "platform/infrastructure/ha-data/namespace.yaml")
         apply_secret_contracts(restore_kubectl, app_password, s3_secret_key)
@@ -1538,16 +1667,18 @@ def main() -> int:
             delete_external_object_store(args.cluster, args.commit)
             print(json.dumps({"status": "deleted", "cluster": args.cluster}))
             return 0
-        result = prove(args)
+        prove(args)
     except (ref.ProofError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as error:
-        print(f"HA recovery proof failed: {error}", file=sys.stderr)
         if isinstance(error, subprocess.CalledProcessError):
-            print(error.stdout or "", file=sys.stderr)
-            print(error.stderr or "", file=sys.stderr)
+            detail = f"subprocess exited with status {error.returncode}"
+        elif isinstance(error, subprocess.TimeoutExpired):
+            detail = "subprocess timed out"
+        else:
+            detail = str(error)
+        print(f"HA recovery proof failed: {detail}", file=sys.stderr)
         return 1
-    print(json.dumps(result, sort_keys=True))
+    print(json.dumps({"status": "pass"}, sort_keys=True))
     return 0
-
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/scripts/platform/validate_platform.py
+++ b/scripts/platform/validate_platform.py
@@ -300,6 +300,22 @@ def _assert_ha_contract() -> None:
         if marker not in config:
             raise ContractError(f"HA NATS config lacks {marker}")
 
+    app_base = PLATFORM / "apps/weltgewebe/base"
+    app_budgets = {
+        document["metadata"]["name"]: document
+        for filename in ("api-pdb.yaml", "web-pdb.yaml")
+        for document in _documents(app_base / filename)
+    }
+    for name in ("weltgewebe-api", "weltgewebe-web"):
+        budget = app_budgets.get(name)
+        if budget is None or budget.get("kind") != "PodDisruptionBudget":
+            raise ContractError(f"HA application lacks disruption budget {name}")
+        if budget.get("spec", {}).get("minAvailable") != 1:
+            raise ContractError(f"HA application disruption budget {name} differs from the contract")
+        labels = budget.get("spec", {}).get("selector", {}).get("matchLabels", {})
+        if labels.get("app.kubernetes.io/name") != name:
+            raise ContractError(f"HA application disruption budget {name} selects the wrong pods")
+
     patch_docs = list(_documents(PLATFORM / "apps/weltgewebe/overlays/ha/deployment-patch.yaml"))
     api = next(item for item in patch_docs if item["metadata"]["name"] == "weltgewebe-api")
     api_spec = api.get("spec", {})
@@ -354,6 +370,23 @@ def _assert_ha_contract() -> None:
             raise ContractError(f"HA proof runner lacks {marker}")
     if "kind: Secret" in "\n".join(path.read_text() for path in (PLATFORM / "infrastructure/ha-data").glob("*.yaml")):
         raise ContractError("HA manifests commit a Secret")
+
+    workflow = yaml.safe_load((ROOT / ".github/workflows/kubernetes-platform.yml").read_text())
+    steps = workflow["jobs"]["kind-ha-recovery-proof"]["steps"]
+    cleanup = next(
+        (item for item in steps if item.get("name") == "Reconcile owned HA proof resources"),
+        None,
+    )
+    if cleanup is None or cleanup.get("if") != "always()":
+        raise ContractError("HA workflow lacks unconditional owned-resource reconciliation")
+    cleanup_command = cleanup.get("run", "")
+    for marker in (
+        "ha_reference.py down",
+        '--cluster "$CLUSTER_NAME"',
+        '--commit "$(git rev-parse HEAD)"',
+    ):
+        if marker not in cleanup_command:
+            raise ContractError(f"HA workflow cleanup lacks {marker}")
 
 
 def _assert_compose_parity() -> None:


### PR DESCRIPTION
## Ausgangslage

PR #1462 hat die HA-, Upgrade-, Failover- und PITR-Referenzzelle bereits gemergt. Dieser Folge-PR portiert ausschließlich die noch fehlenden Härtungen aus der Review von PR #1463 auf den aktuellen Hauptstand.

## Änderungen

- Release-Manifeste werden als YAML-Dokumentbäume verarbeitet; Imagewerte werden nur als exakte Skalare ersetzt.
- Das Barman-Sidecar-Secret wird strukturell gefunden und unabhängig von Block-, Quote- oder Zeilenumbruchformaten umgeschrieben.
- Die drei Barman-Instanz-Sidecars müssen nicht nur deklariert, sondern mit digestgebundener Runtime-Image-ID tatsächlich laufend und `ready` sein.
- Die PITR-Grenze wartet auf der PostgreSQL-Uhr und verifiziert, dass diese den Zielzeitpunkt überschritten hat.
- Primär- und Restorecluster werden über Kubeconfig und aktuellen Kontext explizit zurückgelesen.
- Der Workflow räumt eigene Ressourcen mit `if: always()` und dem tatsächlich ausgecheckten `HEAD` auf.
- API- und Web-PDBs werden im Plattformvertrag gegen Entfernung oder falsche Selektoren geschützt.
- Unterprozessausgaben werden bei Fehlern nicht mehr ins Log gespiegelt; Erfolgsausgabe ist konstant.
- Die spröde Quelltextsuche nach `AWS_SECRET_ACCESS_KEY=` wurde entfernt; der Laufzeittest auf argv/Environment bleibt bestehen.

## Bewusst nicht geändert

- API- und Web-PDBs waren bereits vorhanden.
- Restorecluster, drei Zonen, Sidecar-Digests und fortgesetzte WAL-Archivierung wurden in #1462 bereits geprüft.
- Der NATS-Box-Pod wird mit dem eigentumsgebundenen Kind-Cluster entfernt; `--keep` bewahrt ihn absichtlich für Diagnosen.
- Zusätzliche Chaosmodi und eine Modulaufteilung bleiben separate Erweiterungen.

## Lokale Prüfung auf Head a02e517077cad55c6c82b7d3c467449676b7c9c0

- gelockte Originalartefakte per SHA-256 bestätigt
- CloudNativePG: 26 YAML-Dokumente transformiert und erneut geparst
- cert-manager: 47 YAML-Dokumente transformiert und erneut geparst
- Barman Cloud: 17 YAML-Dokumente transformiert und erneut geparst
- fokussierte Härtungstests: PASS
- vollständiger HA-Testkorpus: 43/43 PASS
- Ruff: PASS
- `git diff --check`: PASS
- vollständiger Repositoryvertrag `make validate`: PASS

Der reale GitHub-HA-/PITR-Beweis bleibt mergeblockierend.

<!-- weltgewebe-risk: R3 -->