### PR TITLE
docs(search): define Semantic Search v1 contract

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -66,6 +66,7 @@ check:     # quick hygiene check
 	just test
 	just check-demo-data
 	just contracts-domain-check
+	just contracts-search-check
 	cargo deny check
 
 # ---------- Compose ----------

--- a/Justfile
+++ b/Justfile
@@ -160,5 +160,8 @@ smoke-account-create:
 contracts-domain-check:
 	./scripts/contracts-domain-check.sh
 
+contracts-search-check:
+	python3 -m scripts.search.validate_relevance_goldset
+
 check-demo-data:
 	pnpm exec tsx scripts/verify-demo-data.ts

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ validate-core:
 	python3 -m scripts.docmeta.export_docs_index
 	python3 -m scripts.docmeta.generate_audit_gaps
 	python3 -m scripts.docmeta.check_links
+	python3 -m scripts.search.validate_relevance_goldset
 
 generate-system-map:
 	python3 -m scripts.docmeta.generate_system_map

--- a/architecture/semantic-search.md
+++ b/architecture/semantic-search.md
@@ -1,0 +1,344 @@
+---
+id: architecture.semantic-search
+title: Semantic Search v1
+summary: Verbindliche Wahrheits-, Sichtbarkeits-, Ranking-, Modell- und Betriebsgrenzen für die interne hybride Knotensuche.
+doc_type: architecture
+status: canonical
+canonicality: normative
+lifecycle_state: active
+role: norm
+organ: product-domain
+owner: product-domain
+last_reviewed: 2026-07-18
+review_after: 2026-10-18
+depends_on:
+  - overview
+  - architecture.weltgewebe-os
+  - specs.garnrolle-knoten-faden
+relations:
+  - type: relates_to
+    target: architecture/security.md
+  - type: relates_to
+    target: docs/specs/federation-core.md
+  - type: relates_to
+    target: docs/specs/ui-interaction.md
+verifies_with:
+  - contracts/search/relevance-goldset.schema.json
+  - contracts/search/examples/relevance-goldset.example.json
+  - scripts/search/validate_relevance_goldset.py
+  - scripts/ci/tests/test_semantic_search_contract.py
+---
+
+# Semantic Search v1
+
+## 1. Entscheidung und Geltung
+
+Die nützliche Semantik-Schicht wird direkt in `heimgewebe/weltgewebe` integriert. Sie ist keine allgemeine Semantikplattform und kein eigener Dienst. Ihr Zweck ist ausschließlich eine interne, hybride und sichtbarkeitsgebundene Suche nach Weltgewebe-Knoten sowie eine klar getrennte Oberfläche „Ähnliche Knoten“.
+
+PostgreSQL ist die einzige persistente Wahrheit der späteren Suchprojektion. Lexikalische Repräsentationen, Embeddings, Rangmerkmale und Indexzustände sind vollständig regenerierbare Projektionen aus kanonischen Knotenrevisionen.
+
+T001 ist ein Architektur- und Testgrundlagen-Schnitt. Es führt weder Datenbankmigrationen noch Suchrouten, Embedding-Provider, Worker, Backfills, Weboberflächen, Produktionsänderungen oder SemantAH-Stilllegung ein.
+
+## 2. Dialektik und alternative Sinnachse
+
+**These:** Ein semantischer Retrieval-Anteil kann natürliche Anfragen auffangen, die exakte Begriffe, Tags oder Schreibweisen verfehlen. Innerhalb des Weltgewebes kann er dieselben Sichtbarkeits-, Lösch-, Revisions- und Multi-Instance-Grenzen wie die übrige Domänenlogik verwenden.
+
+**Antithese:** PostgreSQL-Volltext und Trigramme können den praktisch relevanten Gewinn bereits liefern. Ein externer Vektorindex oder Cloud-Provider würde eine zweite Zustandswahrheit, neue Kosten- und Verfügbarkeitsabhängigkeiten sowie schwierigere Löschfortpflanzung erzeugen.
+
+**Synthese:** Die Suche bleibt hybrid und messgetrieben. Exakte und lexikalische Signale führen. Semantik ergänzt sie nur, wenn T002 einen praktisch relevanten Mehrwert belegt. Das kleinste lokale mehrsprachige Modell gewinnt, sofern es die Qualitätsgrenzen erfüllt. ANN oder HNSW wird erst nach einem gemessenen PostgreSQL-Skalierungsengpass erwogen.
+
+Wird kurzfristige Liefergeschwindigkeit höher als Datenschutz und Wahrheitsgrenzen gewichtet, wäre ein externer Embedding-Dienst schneller. Dieser Pfad ist verworfen. Wird ausschließlich lokale Souveränität gewichtet, könnte ein großes lokales Modell ohne Nutzenbeleg gewählt werden. Auch dieser Pfad ist verworfen: Relevanzgewinn pro Betriebsaufwand ist maßgeblich.
+
+## 3. Belegter Ausgangszustand
+
+Am T001-Basisstand `4b9b0507e5d54eaa285d91dbb47a3f2cf74f4ccc` gilt:
+
+- `apps/web/src/lib/stores/mapView.ts` führt eine clientseitige Teilstringsuche über höchstens zehn bereits sichtbare Kartenmarker aus.
+- Bestehende Filter begrenzen den Markerbestand vor dieser Suche.
+- Eine serverseitige Search-API, PostgreSQL-Volltextsuche, Trigramm-Suche, Embedding-Projektion, ein Embedding-Worker und eine belegte `pgvector`-Fähigkeit existieren nicht.
+- `architecture/overview.md` beschreibt JSONL weiterhin als Code-Default und PostgreSQL als expliziten Opt-in-Pfad.
+
+Diese Ausgangslage darf nicht als bereits vorhandene hybride Suche dargestellt werden.
+
+## 4. Aktivierungsgrenze zwischen JSONL und PostgreSQL
+
+Die serverseitige hybride Suche darf nur aktiviert werden, wenn Knoten im PostgreSQL-Domänenmodus kanonisch gelesen und geschrieben werden. Ein PostgreSQL-Suchindex über einem gleichzeitig kanonischen JSONL-Bestand wäre eine konkurrierende Wahrheit und ist verboten.
+
+Bis zum belegten PostgreSQL-Domänencutover bleibt die bestehende clientseitige Teilstringsuche die reale Produktfunktion. Nach T006/T007 ist die serverseitige hybride Suche der Primärpfad. Die clientseitige lexikalische Suche darf dann nur als technisch klar gekennzeichneter, begrenzter Notfall-Fallback über bereits an den Client ausgelieferte sichtbare Projektionen bestehen.
+
+Der Fallback darf keine verborgenen Daten nachladen, keine eigene dauerhafte Suchwahrheit speichern und keine semantischen oder kuratierten Beziehungen behaupten.
+
+## 5. Wahrheits- und Projektionsvertrag
+
+Kanonisch bleiben Domänenzeilen und ihre fachlichen Revisionen in PostgreSQL. Die Suchprojektion darf keinen Knoten, Text oder Sichtbarkeitszustand führen, der nicht aus dieser Wahrheit rekonstruierbar ist.
+
+Die spätere Projektion enthält mindestens:
+
+- `node_id`
+- `source_revision`
+- `content_sha256`
+- `title`
+- `tags`
+- `searchable_text`
+- lexikalische Suchrepräsentation
+- optionales Embedding
+- Provider
+- Modell-ID
+- Modellrevision
+- Dimension
+- Indexgeneration
+- Sichtbarkeitsklasse
+- Indexierungsstatus
+- `indexed_at`
+
+Der physische Tabellen- und Indextyp wird in T003 festgelegt. T001 behauptet weder eine vorhandene Migration noch eine installierte PostgreSQL-Erweiterung.
+
+Suche ist kein fachlicher Schreibpfad. Ähnlichkeit darf niemals automatisch Fäden oder kuratierte Beziehungen erzeugen, Knoten zusammenführen, Knoten löschen, Moderationsentscheidungen treffen oder Sichtbarkeit erweitern.
+
+## 6. Dokumentbildung und Datenminimierung
+
+Nur tatsächlich suchbare Knotenfelder dürfen in `searchable_text` oder ein Embedding eingehen:
+
+- Titel
+- Kurzbeschreibung
+- ausführlicher Informationstext
+- Tags
+- Knotenart
+- Sprache
+- ausdrücklich öffentlich freigegebener Ortsname
+- fachlich zulässige Handlungsbegriffe
+
+Reihenfolge, Feldmarkierungen und Normalisierung müssen deterministisch sein, damit derselbe Knotenstand denselben `content_sha256` erzeugt.
+
+Ausgeschlossen sind:
+
+- E-Mail-Adressen
+- Sitzungen und Authentifizierungsdaten
+- private Account- oder Garnrollenfelder
+- interne Moderationsdaten
+- private Gespräche
+- verborgene oder interne Orte
+- nicht sichtbare historische Versionen
+- technische Auditdaten
+- Secrets, Tokens und Provider-Schlüssel
+- personenbezogene Felder ohne ausdrücklichen Suchzweck
+
+Garnrollen werden in v1 nicht eingebettet. Die bestehende sichtbare Garnrollensuche bleibt lexikalisch, bis ein eigener Datenschutz- und Zweckbindungsvertrag beschlossen ist.
+
+## 7. Sichtbarkeit vor Retrieval
+
+Sichtbarkeit und Löschstatus werden in derselben serverseitigen Kandidatenauswahl wie die lexikalischen und semantischen Signale angewendet. Ein System, das zunächst verborgene Kandidaten rankt und sie anschließend entfernt, ist nicht konform.
+
+Es gelten mindestens diese Invarianten:
+
+1. Ein nicht sichtbarer Knoten ist weder Volltext- noch Vektorkandidat.
+2. Ein gelöschter Knoten ist ab wirksamer Löschung in keiner aktiven Generation suchbar.
+3. Sichtbarkeitsentzug wirkt mindestens so streng wie eine Inhaltsänderung und invalidiert betroffene Projektionen.
+4. Ein veralteter Worker darf weder eine frühere Revision noch eine frühere Sichtbarkeit zurückschreiben.
+5. Cache, Fallback und „Ähnliche Knoten“ verwenden dieselbe zulässige Kandidatenmenge.
+6. Föderierte Projektionen berücksichtigen Ursprung, Reichweite und lokale Annahmeregeln; `global` bedeutet nicht automatisch indexiert.
+
+Die konkreten SQL-Prädikate und Reichweitenabbildungen gehören zu T003, T005 und T006. Bis sie vollständig belegbar sind, bleibt die neue Search-API fail-closed.
+
+## 8. Retrieval- und Rankingvertrag
+
+Reine Vektorsuche ist verboten. Die Rangfolge besitzt harte Prioritätsklassen:
+
+1. exakter normalisierter Titel
+2. exaktes normalisiertes Tag
+3. Titelpräfix
+4. Schreibfehlertoleranz über PostgreSQL-Trigramme
+5. PostgreSQL-Volltext
+6. semantische Ähnlichkeit
+7. stabile Tie-Breaks
+
+Ein semantisch ähnlicher Treffer darf einen exakten Titel- oder Tagtreffer nicht verdrängen. Bestehende Filter begrenzen Kandidaten vor dem Ranking. Stabile Tie-Breaks verwenden mindestens eine deterministische Objektidentität und dürfen nicht von Prozessreihenfolge oder zufälliger Vektorausgabe abhängen.
+
+„Ähnliche Knoten“ ist eine eigene, ausdrücklich maschinell berechnete Oberfläche. Sie ist weder Faden noch kuratierte Beziehung und verwendet denselben Sichtbarkeits- und Generationsvertrag wie die Suche.
+
+## 9. Modell- und Providervertrag
+
+T002 vergleicht:
+
+- die heutige lexikalische Suche
+- PostgreSQL-Volltext und Trigramme
+- ein kompaktes lokales mehrsprachiges Embedding-Modell
+- lokales `qwen3-embedding:8b` als Qualitätsmaßstab
+- optional einen kostenlosen OpenRouter-Embedding-Endpunkt als begrenzten Gegenkandidaten
+
+OpenRouter-Free ist nur zulässig:
+
+- mit synthetischen oder nachweislich nicht sensiblen Texten
+- mit festem kleinem Auftragsbudget
+- ohne Annahme eines vorhandenen API-Schlüssels
+- ohne Produktionsabhängigkeit
+- ohne stillen Wechsel auf einen kostenpflichtigen Endpunkt
+- ohne Speicherung von Secrets oder Rohantworten im Repository
+
+Cloud gewinnt nur bei einem klaren, praktisch relevanten Qualitätsvorsprung und nach ausdrücklicher Kostenfreigabe. Andernfalls gewinnt das kleinste lokale Modell, das die Qualitätsgates erfüllt.
+
+## 10. Generationen und Dimensionssicherheit
+
+Eine aktive Indexgeneration bindet mindestens:
+
+- Provider
+- Modell-ID
+- Modellrevision
+- Dimension
+- Dokumentbildungsrevision
+- Normalisierungsrevision
+- Erzeugungszeit und Aktivierungszustand
+
+Ein Wechsel eines dieser Merkmale erzeugt eine vollständige neue Generation. Vektoren verschiedener Generationen werden niemals in derselben Kandidatenauswahl gemischt.
+
+Eine neue Generation wird vollständig aufgebaut und geprüft, bevor sie atomar aktiviert wird. Ein Rückwechsel aktiviert nur eine vollständig konsistente vorherige Generation oder baut sie neu auf.
+
+## 11. Projektion und Worker
+
+Der spätere Worker ist idempotent und revisionsgebunden:
+
+1. Er liest Knoten-ID und Quellrevision.
+2. Er bildet das minimierte Suchdokument deterministisch.
+3. Er berechnet Hash, lexikalische Repräsentation und optional das Embedding.
+4. Vor dem Schreiben liest er die aktuelle Quellrevision erneut.
+5. Nur die noch aktuelle Revision darf die Projektion ersetzen.
+6. Provider-Ausfall markiert semantische Arbeit als ausstehend, blockiert aber keine Knotenmutation.
+7. Löschung und Sichtbarkeitsentzug invalidieren alle betroffenen Generationen.
+8. Backfill und laufende Aktualisierung verwenden denselben Schreibvertrag.
+
+Mehrere API- oder Worker-Instanzen dürfen denselben Auftrag wiederholen, ohne doppelte fachliche Wirkung oder Rückwärtslauf.
+
+## 12. Vorgesehene interne Codegrenze
+
+Die reale Codeorganisation wird in T004 bis T006 schrittweise ergänzt. Der bevorzugte Zuschnitt liegt innerhalb von `apps/api`, nicht in einer neuen Runtime:
+
+```text
+apps/api/src/search/
+  contract.rs
+  document.rs
+  lexical.rs
+  semantic.rs
+  ranking.rs
+  visibility.rs
+  repository.rs
+  worker.rs
+  metrics.rs
+  provider/
+apps/api/src/routes/search.rs
+apps/api/src/bin/search-backfill.rs
+apps/api/src/bin/search-evaluate.rs
+```
+
+Die genaue Dateigrenze darf an bestehende Rust-Module angepasst werden. Verboten bleibt eine separate `apps/semantic-service`-Runtime.
+
+## 13. Goldset-Vertrag
+
+`contracts/search/relevance-goldset.schema.json` definiert ein maschinenlesbares Format. Das eingecheckte Beispiel ist ausschließlich synthetisch.
+
+Jeder Fall enthält mindestens:
+
+- stabile Fall-ID
+- Sprache
+- Anfrage
+- sichtbaren Suchkontext
+- relevante Knoten-IDs
+- erwartete Rangklasse
+- ausgeschlossene Knoten-IDs
+- überprüfbare Begründung
+- `contains_personal_data: false`
+
+Relevante IDs müssen sichtbar sein. Ausgeschlossene IDs dürfen nicht sichtbar oder relevant sein. Der Validator verweigert E-Mail-ähnliche Inhalte, damit Testdaten nicht versehentlich zu einem Transportweg für personenbezogene Daten werden.
+
+Das Goldset misst Retrievalqualität, nicht gesellschaftliche Wahrheit. Bewertungen müssen begründet und bei fachlichen Änderungen versioniert werden.
+
+## 14. Qualitäts- und Freigabegates
+
+Vor T008 müssen mindestens belegt sein:
+
+- Exakte Titel- und Tagtreffer bleiben auf Rang 1.
+- Mindestens 85 Prozent relevanter natürlicher Goldset-Anfragen liefern einen relevanten Top-3-Treffer.
+- Falsche Top-1-Treffer nehmen gegenüber der lexikalischen Basis nicht zu.
+- Gelöschte oder unsichtbare Inhalte erscheinen nie.
+- Embedding-Ausfall blockiert keine Knotenänderung.
+- Veraltete Worker überschreiben keine neueren Revisionen.
+- Ein vollständiger Indexneuaufbau ist reproduzierbar.
+- Modellwechsel sind generationsgebunden.
+- Multi-Instance-Betrieb bleibt konsistent.
+- Backup, Restore und PITR umfassen die Projektion oder belegen deren vollständige Regeneration.
+- Externe API-Kosten sind hart begrenzt.
+- ANN oder HNSW wird ohne gemessenen Bedarf nicht eingeführt.
+
+Basis und Kandidaten werden getrennt berichtet. Ein gemittelter Gesamtscore darf Regressionen bei exakten Treffern oder Sichtbarkeit nicht verdecken.
+
+## 15. Betrieb und Beobachtbarkeit
+
+Später mindestens beobachtbar sind:
+
+- Rückstand nach Indexierungsstatus
+- Alter der ältesten ausstehenden Revision
+- aktive Generation und Modellidentität
+- verworfene veraltete Worker-Ergebnisse
+- Providerfehler und begrenzte Retryzahl
+- Suchlatenz nach Retrievalanteil
+- Fallback-Nutzung
+- Goldset-Ergebnis pro Rankingklasse
+- Rebuild-Dauer und Ergebnis
+
+Metriken enthalten keine Rohqueries, privaten Texte oder Embeddings, solange dafür kein eigener Datenschutzvertrag besteht.
+
+## 16. Hard Cut und Nichtziele
+
+Nicht Bestandteil der Zielarchitektur sind:
+
+- separate SemantAH-Runtime
+- JSONL-Persistenz der Suchprojektion
+- eigenständiger `indexd`-Dienst
+- dauerhafte Git- oder Cargo-Abhängigkeit auf SemantAH
+- allgemeine Namespace-Plattformabstraktionen
+- Obsidian-Pipeline, Wissensgraph oder Related-Blöcke
+- Knowledge Observatory oder Daily Insights
+- HausKI- oder RepoBrief-Rollen
+- Commonworld-Anbindung
+- Shadow-Modus
+- automatische Fäden, Beziehungen, Löschungen oder Zusammenführungen aus Ähnlichkeit
+- ANN-/HNSW-Arbeit ohne gemessenen Weltgewebe-Engpass
+
+Brauchbare SemantAH-Konzepte wie Providergrenzen, Dimensionsprüfung, Normalisierung, deterministische Cosinus-Referenzsuche, Benchmarks und Tests dürfen zielgerichtet neu implementiert werden. SemantAH-Code wird nicht als dauerhafte Abhängigkeit übernommen.
+
+## 17. Taskgrenzen
+
+- **T001:** Architekturvertrag, Goldset-Format, synthetisches Beispiel und Validator.
+- **T002:** Relevanzbasis und Modellvergleich.
+- **T003:** PostgreSQL-Suchschema, Volltext, Trigramme und belegte `pgvector`-Fähigkeit.
+- **T004:** interner Embedding- und Rankingkern.
+- **T005:** idempotente Projektion, Worker, Backfill und Löschfortpflanzung.
+- **T006:** hybride serverseitige Such-API.
+- **T007:** Webintegration und getrennte „Ähnliche Knoten“.
+- **T008:** vollständige Abnahme, direkter Rollout und öffentlicher Live-Beweis.
+- **T009:** SemantAH stilllegen, archivieren und Bureau/Systemkatalog bereinigen.
+
+Erst nach erfolgreichem T008-Beweis darf T009 `SEMANTAH-USEFULNESS-V1`, `SEMANTAH-INDEXD-SCALING-V1` und `SEMANTAH-E2E-PORTABILITY-V1` superseden oder schließen.
+
+## 18. Stopbedingungen
+
+Die Initiative wird gestoppt oder neu geschnitten, wenn:
+
+- Sichtbarkeit nicht vor Retrieval durchsetzbar ist,
+- PostgreSQL keine tragfähige Projektions- und Wiederherstellungsgrenze bietet,
+- FTS und Trigramme den relevanten Nutzen bereits ohne Embeddings liefern,
+- lokale Modelle die Qualitätsgrenzen klar verfehlen und keine ausdrückliche Kostenfreigabe besteht,
+- der Betriebsaufwand den gemessenen Relevanzgewinn überwiegt oder
+- die Suche eine zweite fachliche Wahrheit oder automatische Beziehungssemantik erzeugen würde.
+
+## 19. Nicht behaupteter Zustand
+
+Dieser Vertrag belegt nicht:
+
+- installierte oder produktionsfähige `pgvector`-Unterstützung
+- eine gewählte Embedding-Modell-ID
+- eine vorhandene Search-API
+- laufende Worker oder Backfills
+- verbesserte reale Relevanz
+- gesunden Produktionsbetrieb
+- einen öffentlichen Live-Beweis
+- die Freigabe zur Archivierung von SemantAH

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -41,6 +41,22 @@ Das Script führt zwei Schritte aus:
 
 Sind alle Checks erfolgreich, ist der Stand kompatibel zur CI-Validierung.
 
+## Semantic-Search-Goldset validieren
+
+Der Vertrag unter `contracts/search/relevance-goldset.schema.json` beschreibt synthetische, sichtbarkeitsgebundene Relevanzfälle für die geplante hybride Knotensuche. Das eingecheckte Beispiel wird ohne externe Python-Abhängigkeit geprüft:
+
+```sh
+python3 -m scripts.search.validate_relevance_goldset
+```
+
+Oder über Just:
+
+```sh
+just contracts-search-check
+```
+
+Der Validator prüft Schemaform, eindeutige Fall-IDs, sichtbare relevante Knoten, unsichtbare Ausschlüsse und das Verbot E-Mail-ähnlicher Testdaten. Er bewertet noch keine reale Suchqualität; Baselines und Modellkandidaten folgen in T002.
+
 ### Typische Fehler & Hinweise
 
 - **„ajv: command not found“**

--- a/contracts/search/examples/relevance-goldset.example.json
+++ b/contracts/search/examples/relevance-goldset.example.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": 1,
+  "dataset_id": "weltgewebe-semantic-search-v1-synthetic",
+  "description": "Synthetische Relevanz- und Sichtbarkeitsfälle für den Semantic-Search-v1-Vertrag.",
+  "privacy_class": "synthetic",
+  "cases": [
+    {
+      "id": "search-exact-title-community-garden",
+      "language": "de",
+      "query": "Gemeinschaftsgarten Altona",
+      "visibility_context": {
+        "viewer_scope": "public",
+        "visible_node_ids": ["syn-node-community-garden", "syn-node-seed-library", "syn-node-repair-cafe"],
+        "active_filters": {"kinds": [], "tags": [], "languages": ["de"]}
+      },
+      "relevant_node_ids": ["syn-node-community-garden"],
+      "expected_rank_class": "exact_title",
+      "excluded_node_ids": ["syn-node-private-garden"],
+      "rationale": "Ein exakter Titel muss unabhängig von semantischer Ähnlichkeit Rang eins belegen.",
+      "contains_personal_data": false
+    },
+    {
+      "id": "search-exact-tag-tool-sharing",
+      "language": "de",
+      "query": "werkzeug-teilen",
+      "visibility_context": {
+        "viewer_scope": "public",
+        "visible_node_ids": ["syn-node-tool-library", "syn-node-repair-cafe", "syn-node-seed-library"],
+        "active_filters": {"kinds": [], "tags": ["werkzeug-teilen"], "languages": ["de"]}
+      },
+      "relevant_node_ids": ["syn-node-tool-library"],
+      "expected_rank_class": "exact_tag",
+      "excluded_node_ids": ["syn-node-private-workshop"],
+      "rationale": "Ein exaktes Tag bleibt vor Volltext- und Vektorsignalen priorisiert.",
+      "contains_personal_data": false
+    },
+    {
+      "id": "search-typo-repair-workshop",
+      "language": "de",
+      "query": "Fahrrad Reparatur Werstatt",
+      "visibility_context": {
+        "viewer_scope": "public",
+        "visible_node_ids": ["syn-node-bike-workshop", "syn-node-tool-library", "syn-node-community-garden"],
+        "active_filters": {"kinds": ["Werkstatt"], "tags": [], "languages": ["de"]}
+      },
+      "relevant_node_ids": ["syn-node-bike-workshop"],
+      "expected_rank_class": "typo",
+      "excluded_node_ids": ["syn-node-hidden-bike-cellar"],
+      "rationale": "Trigramme sollen einen einfachen Schreibfehler ohne semantische Vorrangnahme auffangen.",
+      "contains_personal_data": false
+    },
+    {
+      "id": "search-semantic-shared-bike-repair",
+      "language": "de",
+      "query": "Wo kann ich mein kaputtes Fahrrad gemeinsam reparieren?",
+      "visibility_context": {
+        "viewer_scope": "public",
+        "visible_node_ids": ["syn-node-bike-workshop", "syn-node-tool-library", "syn-node-community-garden"],
+        "active_filters": {"kinds": [], "tags": [], "languages": ["de"]}
+      },
+      "relevant_node_ids": ["syn-node-bike-workshop"],
+      "expected_rank_class": "semantic",
+      "excluded_node_ids": ["syn-node-private-bike-help"],
+      "rationale": "Die natürliche Anfrage darf semantisch ergänzt werden, ohne unsichtbare Hilfsangebote als Kandidaten zu verwenden.",
+      "contains_personal_data": false
+    }
+  ]
+}

--- a/contracts/search/relevance-goldset.schema.json
+++ b/contracts/search/relevance-goldset.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://weltgewebe.org/schemas/search/relevance-goldset.schema.json",
+  "title": "Weltgewebe Semantic Search Relevance Goldset",
+  "description": "Synthetic, visibility-bound relevance cases for deterministic evaluation of hybrid node search.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "dataset_id", "description", "privacy_class", "cases"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "dataset_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._-]{2,79}$"},
+    "description": {"type": "string", "minLength": 1, "maxLength": 500},
+    "privacy_class": {"const": "synthetic"},
+    "cases": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "language", "query", "visibility_context", "relevant_node_ids", "expected_rank_class", "excluded_node_ids", "rationale", "contains_personal_data"],
+        "properties": {
+          "id": {"type": "string", "pattern": "^search-[a-z0-9][a-z0-9-]{2,79}$"},
+          "language": {"type": "string", "pattern": "^[a-z]{2}(?:-[A-Z]{2})?$"},
+          "query": {"type": "string", "minLength": 1, "maxLength": 300},
+          "visibility_context": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["viewer_scope", "visible_node_ids", "active_filters"],
+            "properties": {
+              "viewer_scope": {"enum": ["public", "local", "neighbourhood"]},
+              "visible_node_ids": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "pattern": "^syn-node-[a-z0-9][a-z0-9-]{2,79}$"}},
+              "active_filters": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["kinds", "tags", "languages"],
+                "properties": {
+                  "kinds": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1, "maxLength": 100}},
+                  "tags": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1, "maxLength": 64}},
+                  "languages": {"type": "array", "uniqueItems": true, "items": {"type": "string", "pattern": "^[a-z]{2}(?:-[A-Z]{2})?$"}}
+                }
+              }
+            }
+          },
+          "relevant_node_ids": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "pattern": "^syn-node-[a-z0-9][a-z0-9-]{2,79}$"}},
+          "expected_rank_class": {"enum": ["exact_title", "exact_tag", "title_prefix", "typo", "full_text", "semantic"]},
+          "excluded_node_ids": {"type": "array", "uniqueItems": true, "items": {"type": "string", "pattern": "^syn-node-[a-z0-9][a-z0-9-]{2,79}$"}},
+          "rationale": {"type": "string", "minLength": 1, "maxLength": 1000},
+          "contains_personal_data": {"const": false}
+        }
+      }
+    }
+  }
+}

--- a/docs/_generated/implicit-dependencies.md
+++ b/docs/_generated/implicit-dependencies.md
@@ -28,6 +28,7 @@ Generated automatically. Do not edit.
 | Makefile (validate-core) | scripts.docmeta.export_docs_index | `python3 -m scripts.docmeta.export_docs_index` | *unclear* |
 | Makefile (validate-core) | scripts.docmeta.generate_audit_gaps | `python3 -m scripts.docmeta.generate_audit_gaps` | *unclear* |
 | Makefile (validate-core) | scripts.docmeta.check_links | `python3 -m scripts.docmeta.check_links` | *unclear* |
+| Makefile (validate-core) | scripts.search.validate_relevance_goldset | `python3 -m scripts.search.validate_relevance_goldset` | *unclear* |
 | Makefile (generate-system-map) | scripts.docmeta.generate_system_map | `python3 -m scripts.docmeta.generate_system_map` | *unclear* |
 | Makefile (validate-guards) | scripts/docmeta/repo-structure-guard.sh | `bash scripts/docmeta/repo-structure-guard.sh` | *unclear* |
 | Makefile (validate-guards) | scripts/docmeta/docs-relations-guard.sh | `bash scripts/docmeta/docs-relations-guard.sh` | *unclear* |

--- a/docs/_generated/system-map.md
+++ b/docs/_generated/system-map.md
@@ -15,6 +15,7 @@ Source: scripts/docmeta/generate_system_map.py
 
 |id|path|role|organ|status|last_reviewed|depends_on|verifies_with|missing_scripts|
 |---|---|---|---|---|---|---|---|---|
+|architecture.semantic-search|architecture/semantic-search.md|norm|product-domain|canonical|2026-07-18|overview, architecture.weltgewebe-os, specs.garnrolle-knoten-faden|contracts/search/examples/relevance-goldset.example.json, contracts/search/relevance-goldset.schema.json, scripts/ci/tests/test_semantic_search_contract.py, scripts/search/validate_relevance_goldset.py||
 |architecture.weltgewebe-os|architecture/weltgewebe-os.md|norm|governance|canonical|2026-07-15|overview|||
 |docmeta.schema|architecture/docmeta.schema.md|norm|docmeta|canonical|2026-06-09||scripts/docmeta/check_doc_review_age.py, scripts/docmeta/check_repo_index_consistency.py, scripts/docmeta/generate_system_map.py, scripts/docmeta/validate_relations.py||
 |overview|architecture/overview.md|norm|governance|canonical|2026-07-11||||

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,7 @@ Diese Dokumente präzisieren Teilbereiche, sind aber nicht als eigene kanonische
 - [Weltgewebe OS](../architecture/weltgewebe-os.md)
 - [Architecture Overview](../architecture/overview.md)
 - [Security Architecture](../architecture/security.md)
+- [Semantic Search v1](../architecture/semantic-search.md)
 - [Techstack](techstack.md)
 - [Datenmodell](datenmodell.md)
 - [Repositorystruktur](architekturstruktur.md)

--- a/manifest/repo-index.yaml
+++ b/manifest/repo-index.yaml
@@ -6,6 +6,7 @@ zones:
       - overview.md
       - weltgewebe-os.md
       - security.md
+      - semantic-search.md
       - docmeta.schema.md
   policy:
     path: docs/policies/

--- a/scripts/ci/tests/test_semantic_search_contract.py
+++ b/scripts/ci/tests/test_semantic_search_contract.py
@@ -1,0 +1,80 @@
+"""Regression tests for the Semantic Search v1 architecture and goldset contract."""
+
+from __future__ import annotations
+
+import copy
+import json
+import unittest
+from pathlib import Path
+
+from scripts.search.validate_relevance_goldset import ValidationError, validate_goldset
+
+ROOT = Path(__file__).resolve().parents[3]
+SCHEMA_PATH = ROOT / "contracts/search/relevance-goldset.schema.json"
+DATASET_PATH = ROOT / "contracts/search/examples/relevance-goldset.example.json"
+ARCHITECTURE_PATH = ROOT / "architecture/semantic-search.md"
+
+
+class SemanticSearchContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+        cls.dataset = json.loads(DATASET_PATH.read_text(encoding="utf-8"))
+
+    def test_checked_in_goldset_is_valid_and_synthetic(self) -> None:
+        validate_goldset(self.dataset, self.schema)
+        self.assertEqual(self.dataset["privacy_class"], "synthetic")
+        self.assertTrue(all(case["contains_personal_data"] is False for case in self.dataset["cases"]))
+
+    def test_duplicate_case_ids_are_rejected(self) -> None:
+        dataset = copy.deepcopy(self.dataset)
+        dataset["cases"].append(copy.deepcopy(dataset["cases"][0]))
+        with self.assertRaisesRegex(ValidationError, "duplicate case id"):
+            validate_goldset(dataset, self.schema)
+
+    def test_relevant_node_outside_visible_context_is_rejected(self) -> None:
+        dataset = copy.deepcopy(self.dataset)
+        dataset["cases"][0]["relevant_node_ids"] = ["syn-node-not-visible"]
+        with self.assertRaisesRegex(ValidationError, "not visible"):
+            validate_goldset(dataset, self.schema)
+
+    def test_excluded_node_inside_visible_context_is_rejected(self) -> None:
+        dataset = copy.deepcopy(self.dataset)
+        dataset["cases"][0]["excluded_node_ids"] = ["syn-node-community-garden"]
+        with self.assertRaisesRegex(ValidationError, "excluded nodes are visible"):
+            validate_goldset(dataset, self.schema)
+
+    def test_personal_data_flag_is_rejected(self) -> None:
+        dataset = copy.deepcopy(self.dataset)
+        dataset["cases"][0]["contains_personal_data"] = True
+        with self.assertRaisesRegex(ValidationError, "expected constant False"):
+            validate_goldset(dataset, self.schema)
+
+    def test_email_like_content_is_rejected_even_with_false_flag(self) -> None:
+        dataset = copy.deepcopy(self.dataset)
+        dataset["cases"][0]["query"] = "Kontakt person@example.invalid"
+        with self.assertRaisesRegex(ValidationError, "email-like"):
+            validate_goldset(dataset, self.schema)
+
+    def test_architecture_names_hard_boundaries_and_current_reality(self) -> None:
+        text = ARCHITECTURE_PATH.read_text(encoding="utf-8")
+        required = (
+            "PostgreSQL ist die einzige persistente Wahrheit",
+            "Reine Vektorsuche ist verboten",
+            "Sichtbarkeit und Löschstatus werden in derselben serverseitigen",
+            "Garnrollen werden in v1 nicht eingebettet",
+            "Eine serverseitige Search-API",
+            "JSONL weiterhin als Code-Default",
+            "T001 ist ein Architektur- und Testgrundlagen-Schnitt",
+            "separate SemantAH-Runtime",
+        )
+        for phrase in required:
+            self.assertIn(phrase, text)
+
+    def test_manifest_registers_canonical_architecture_document(self) -> None:
+        manifest = (ROOT / "manifest/repo-index.yaml").read_text(encoding="utf-8")
+        self.assertIn("- semantic-search.md", manifest)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/search/__init__.py
+++ b/scripts/search/__init__.py
@@ -1,0 +1,1 @@
+"""Semantic Search contract tooling."""

--- a/scripts/search/validate_relevance_goldset.py
+++ b/scripts/search/validate_relevance_goldset.py
@@ -1,0 +1,183 @@
+"""Validate the Semantic Search v1 relevance goldset without external dependencies."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SCHEMA = ROOT / "contracts/search/relevance-goldset.schema.json"
+DEFAULT_DATASET = ROOT / "contracts/search/examples/relevance-goldset.example.json"
+EMAIL_LIKE = re.compile(r"(?i)\b[a-z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-z0-9-]+(?:\.[a-z0-9-]+)+\b")
+
+
+class ValidationError(ValueError):
+    """Raised when schema or cross-field invariants are violated."""
+
+
+def _join(path: str, child: str | int) -> str:
+    return f"{path}[{child}]" if isinstance(child, int) else f"{path}.{child}"
+
+
+def _canonical(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _matches_type(value: Any, expected: str) -> bool:
+    if expected == "object":
+        return isinstance(value, dict)
+    if expected == "array":
+        return isinstance(value, list)
+    if expected == "string":
+        return isinstance(value, str)
+    if expected == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if expected == "boolean":
+        return isinstance(value, bool)
+    if expected == "null":
+        return value is None
+    raise ValidationError(f"unsupported schema type: {expected}")
+
+
+def validate_schema_subset(instance: Any, schema: dict[str, Any], path: str = "$") -> None:
+    """Validate the JSON-Schema draft-07 subset used by the checked-in contract."""
+
+    if "const" in schema and instance != schema["const"]:
+        raise ValidationError(f"{path}: expected constant {schema['const']!r}")
+    if "enum" in schema and instance not in schema["enum"]:
+        raise ValidationError(f"{path}: value {instance!r} is not in {schema['enum']!r}")
+
+    expected = schema.get("type")
+    if expected is not None:
+        allowed = [expected] if isinstance(expected, str) else expected
+        if not any(_matches_type(instance, item) for item in allowed):
+            raise ValidationError(f"{path}: expected type {allowed!r}")
+
+    if isinstance(instance, dict):
+        properties = schema.get("properties", {})
+        missing = [key for key in schema.get("required", []) if key not in instance]
+        if missing:
+            raise ValidationError(f"{path}: missing required properties {missing!r}")
+        if schema.get("additionalProperties") is False:
+            extra = sorted(set(instance) - set(properties))
+            if extra:
+                raise ValidationError(f"{path}: unexpected properties {extra!r}")
+        for key, value in instance.items():
+            child_schema = properties.get(key)
+            if child_schema is not None:
+                validate_schema_subset(value, child_schema, _join(path, key))
+
+    if isinstance(instance, list):
+        minimum = schema.get("minItems")
+        maximum = schema.get("maxItems")
+        if minimum is not None and len(instance) < minimum:
+            raise ValidationError(f"{path}: requires at least {minimum} items")
+        if maximum is not None and len(instance) > maximum:
+            raise ValidationError(f"{path}: permits at most {maximum} items")
+        if schema.get("uniqueItems"):
+            values = [_canonical(item) for item in instance]
+            if len(values) != len(set(values)):
+                raise ValidationError(f"{path}: duplicate array items are forbidden")
+        item_schema = schema.get("items")
+        if item_schema is not None:
+            for index, value in enumerate(instance):
+                validate_schema_subset(value, item_schema, _join(path, index))
+
+    if isinstance(instance, str):
+        minimum = schema.get("minLength")
+        maximum = schema.get("maxLength")
+        if minimum is not None and len(instance) < minimum:
+            raise ValidationError(f"{path}: requires at least {minimum} characters")
+        if maximum is not None and len(instance) > maximum:
+            raise ValidationError(f"{path}: permits at most {maximum} characters")
+        pattern = schema.get("pattern")
+        if pattern is not None and re.fullmatch(pattern, instance) is None:
+            raise ValidationError(f"{path}: does not match pattern {pattern!r}")
+
+
+def _walk_strings(value: Any):
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, list):
+        for item in value:
+            yield from _walk_strings(item)
+    elif isinstance(value, dict):
+        for item in value.values():
+            yield from _walk_strings(item)
+
+
+def validate_goldset(dataset: dict[str, Any], schema: dict[str, Any]) -> None:
+    """Apply schema validation and visibility/privacy invariants."""
+
+    validate_schema_subset(dataset, schema)
+    case_ids: set[str] = set()
+
+    for index, case in enumerate(dataset["cases"]):
+        case_path = f"$.cases[{index}]"
+        case_id = case["id"]
+        if case_id in case_ids:
+            raise ValidationError(f"{case_path}.id: duplicate case id {case_id!r}")
+        case_ids.add(case_id)
+
+        visible = set(case["visibility_context"]["visible_node_ids"])
+        relevant = set(case["relevant_node_ids"])
+        excluded = set(case["excluded_node_ids"])
+
+        missing = sorted(relevant - visible)
+        if missing:
+            raise ValidationError(f"{case_path}.relevant_node_ids: relevant nodes are not visible: {missing!r}")
+        visible_excluded = sorted(excluded & visible)
+        if visible_excluded:
+            raise ValidationError(f"{case_path}.excluded_node_ids: excluded nodes are visible: {visible_excluded!r}")
+        overlap = sorted(relevant & excluded)
+        if overlap:
+            raise ValidationError(f"{case_path}: nodes cannot be both relevant and excluded: {overlap!r}")
+
+    for text in _walk_strings(dataset):
+        if EMAIL_LIKE.search(text):
+            raise ValidationError("goldset contains an email-like value")
+
+
+def load_json_object(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValidationError(f"{path}: cannot load JSON: {error}") from error
+    if not isinstance(value, dict):
+        raise ValidationError(f"{path}: top-level JSON value must be an object")
+    return value
+
+
+def validate_files(schema_path: Path, dataset_path: Path) -> None:
+    schema = load_json_object(schema_path)
+    if schema.get("$schema") != "http://json-schema.org/draft-07/schema#":
+        raise ValidationError(f"{schema_path}: expected JSON Schema draft-07")
+    validate_goldset(load_json_object(dataset_path), schema)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Validate a Weltgewebe Semantic Search relevance goldset.")
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    parser.add_argument("--dataset", type=Path, default=DEFAULT_DATASET)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        validate_files(args.schema, args.dataset)
+    except ValidationError as error:
+        print(f"semantic-search goldset invalid: {error}", file=sys.stderr)
+        return 1
+    print(f"semantic-search goldset valid: schema={args.schema} dataset={args.dataset}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
<!-- weltgewebe-risk: R2 -->

## Phase

T001 ist der Architektur- und Testgrundlagen-Schnitt. Er implementiert noch keine Datenbank, Search-API, Embeddings, Worker, Weboberfläche oder Produktion.

## Inhalt

- kanonischer Semantic-Search-v1-Vertrag
- explizite JSONL/PostgreSQL-Aktivierungsgrenze
- Sichtbarkeit vor Kandidatenauswahl
- harte hybride Rankingklassen; reine Vektorsuche verboten
- Modell-, Generations-, Datenschutz-, Worker- und Hard-Cut-Grenzen
- synthetisches Goldset-Schema und Beispiel
- Standardbibliothek-Validator und acht Regressionstests
- kanonische Manifest-, Navigations-, Systemkarten- und Abhängigkeitsregistrierung
- direkt ausführbares Just-Rezept `contracts-search-check`

## Behobener Reviewbefund

Der erste Gegenreview fand, dass `just check` das Ziel `contracts-search-check` aufrief, ohne dass das Rezept definiert war. Der finale Head definiert das Rezept; direkte Ausführung und Rezeptinventur sind belegt grün.

## Nicht behauptet

Keine pgvector-Fähigkeit, Modellwahl, Search-API, laufende Projektion, Relevanzverbesserung, Produktionsreife, öffentlicher Live-Beweis oder SemantAH-Archivierungsfreigabe.

## Exakte Bindung

- Basis: `e025715fbcbcbcc64f98efc8ef8cfb1455530888`
- Head: `43ef0b6361150e89d5a57d24ecc774cc5c256a7a`
- vollständiger GitHub-Diff-SHA256: `745483199f2b955a8ac37521445a85f8b9543e92ecf3ff69ed99b3a21ae7554f`
- vollständiger Diff: https://github.com/heimgewebe/weltgewebe/pull/1485.diff

## Lokale Prüfungen

- `just contracts-search-check`: PASS
- Just-Rezeptinventur enthält `contracts-search-check`: PASS
- acht Semantic-Search-Regressionstests: PASS
- `python3 -m scripts.docmeta.generate_implicit_dependencies --check`: PASS
- Generated-Files-Guard: PASS
- `make validate-core validate-guards`: PASS
- `git diff --check`: PASS

Die vollständige GitHub-CI und das R2-Review-Evidence-Gate bleiben vor Merge maßgeblich.