### PR TITLE
fix: reconcile production migrations before deploy

### DIFF
--- a/audit/impl-registry.yaml
+++ b/audit/impl-registry.yaml
@@ -312,6 +312,21 @@ implementations:
       - scripts/ci/tests/test_kubernetes_platform_contract.py
       - .github/workflows/kubernetes-platform.yml
 
+  - id: impl.workflow.production-migration-reconcile
+    path: scripts/ops/deploy-exact-commit-vps.sh
+    impl_type: workflow
+    status: active
+    criticality: high
+    evidence_level: ci
+    documented_by:
+      - docs/deploy/merge-to-live.md
+      - docs/deployment.md
+    verified_by:
+      - scripts/ci/tests/test_production_reconciler_contract.py
+      - scripts/ci/tests/test_deploy_exact_commit_integration.py
+      - scripts/tests/test_weltgewebe_up_deploy_scope.sh
+      - .github/workflows/production-live-contract.yml
+
   - id: impl.guard.kubernetes-platform
     path: scripts/platform/validate_platform.py
     impl_type: guard

--- a/docs/_generated/doc-coverage.md
+++ b/docs/_generated/doc-coverage.md
@@ -19,4 +19,4 @@ Generated automatically. Do not edit.
 | Platform | 100% | 1 | 1 |
 | Schema | 100% | 1 | 1 |
 | Service | 100% | 6 | 6 |
-| Workflow | 100% | 4 | 4 |
+| Workflow | 100% | 5 | 5 |

--- a/docs/deploy/merge-to-live.md
+++ b/docs/deploy/merge-to-live.md
@@ -53,11 +53,14 @@ jedem abgeschlossenen Lauf erneut mit einem Abstand von zwei Minuten. Der Dienst
    `main` nicht weitergewandert ist;
 9. legt einen getrennten root-eigenen Release-Worktree unter
    `/opt/weltgewebe-releases/<commit>` an und prüft dessen Git-Integrität;
-10. bindet die kanonischen root-eigenen PMTiles schreibgeschützt ein und ruft
-    den vorhandenen fail-closed arbeitenden `weltgewebe-up`-Pfad auf;
-11. liest Frontend, API und beide Build-Header über begrenzte GET-Anfragen
+10. bindet die kanonischen root-eigenen PMTiles schreibgeschützt ein, führt
+    den idempotenten, API-begrenzten Migrations-Scope aus und prüft danach erneut,
+    dass `origin/main` unverändert ist;
+11. ruft erst anschließend den vollständigen fail-closed arbeitenden
+    `weltgewebe-up`-Pfad auf;
+12. liest Frontend, API und beide Build-Header über begrenzte GET-Anfragen
     öffentlich zurück;
-12. aktualisiert den Zeiger auf den verifizierten Stand nur, wenn ein letzter
+13. aktualisiert den Zeiger auf den verifizierten Stand nur, wenn ein letzter
     Remote-Readback weiterhin denselben `origin/main`-Commit ergibt.
 
 Der Produktionsserver benötigt dadurch weder den Heim-PC noch einen allgemein

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -133,8 +133,11 @@ Beide begrenzten Pfade:
 - werden durch eine hostweite `flock`-Sperre gegen parallele Deployläufe geschützt;
 - behandeln `db`, `nats` und `caddy` als geschützte Dienste und brechen ab,
   wenn sich deren Containeridentität während des Laufs ändert;
-- verweigern den Start, wenn PostgreSQL oder NATS nicht bereits laufen; auf dem
-  VPS muss zusätzlich Caddy bereits laufen.
+- verweigern den Start, wenn PostgreSQL oder NATS nicht bereits laufen; der
+  API-Scope verlangt auf dem VPS zusätzlich ein laufendes Caddy. Der
+  Migration-Scope darf Caddy dagegen bereits fehlend vorfinden, damit er einen
+  durch eine ausstehende Migration verursachten Gesamtausfall beheben kann. Ein
+  vorhandenes Caddy bleibt in beiden Scopes identitätsgeschützt.
 
 Mit `--plan-only` wird der JSON-Plan erzeugt, ohne einen Container zu verändern.
 Der Scope `api` erzwingt `WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied`.

--- a/scripts/ci/tests/test_deploy_exact_commit_integration.py
+++ b/scripts/ci/tests/test_deploy_exact_commit_integration.py
@@ -142,7 +142,10 @@ class DeployExactCommitIntegrationTests(unittest.TestCase):
                 """\
                 #!/usr/bin/env bash
                 set -euo pipefail
-                if [[ "${ADVANCE_REMOTE_ON_DEPLOY:-0}" == "1" ]]; then
+                if [[ -n "${TEST_UP_LOG:-}" ]]; then
+                  printf '%s\n' "$*" >> "$TEST_UP_LOG"
+                fi
+                if [[ "${ADVANCE_REMOTE_ON_DEPLOY:-0}" == "1" && " $* " != *" --deploy-scope migration "* ]]; then
                   work="$(mktemp -d)"
                   git clone --quiet "$TEST_REMOTE" "$work/repo"
                   git -C "$work/repo" config user.name "Integration Test"
@@ -404,6 +407,7 @@ class DeployExactCommitIntegrationTests(unittest.TestCase):
             "TEST_COMMIT": self.commit,
             "TEST_REMOTE": str(self.remote),
             "TEST_WEB_ARTIFACT": str(self.artifact),
+            "TEST_UP_LOG": str(self.root / "weltgewebe-up.log"),
         }
 
     def deploy(self, *, advance: bool) -> subprocess.CompletedProcess[str]:
@@ -481,6 +485,12 @@ class DeployExactCommitIntegrationTests(unittest.TestCase):
         result = self.deploy(advance=False)
         self.restore_test_ownership()
         self.assertEqual(result.returncode, 0, result.stderr)
+        deploy_calls = (self.root / "weltgewebe-up.log").read_text(encoding="utf-8").splitlines()
+        self.assertEqual(len(deploy_calls), 2)
+        self.assertIn("--deploy-scope migration", deploy_calls[0])
+        self.assertNotIn("--with-caddy", deploy_calls[0])
+        self.assertIn("--with-caddy", deploy_calls[1])
+        self.assertNotIn("--deploy-scope migration", deploy_calls[1])
         receipt_path = self.state / "receipts" / f"{self.commit}.json"
         receipt = json.loads(receipt_path.read_text())
         self.assertEqual(receipt["result"], "verified")

--- a/scripts/ci/tests/test_deploy_exact_commit_integration.py
+++ b/scripts/ci/tests/test_deploy_exact_commit_integration.py
@@ -145,7 +145,7 @@ class DeployExactCommitIntegrationTests(unittest.TestCase):
                 if [[ -n "${TEST_UP_LOG:-}" ]]; then
                   printf '%s\n' "$*" >> "$TEST_UP_LOG"
                 fi
-                if [[ "${ADVANCE_REMOTE_ON_DEPLOY:-0}" == "1" && " $* " != *" --deploy-scope migration "* ]]; then
+                if [[ ("${ADVANCE_REMOTE_ON_MIGRATION:-0}" == "1" && " $* " == *" --deploy-scope migration "*) || ("${ADVANCE_REMOTE_ON_DEPLOY:-0}" == "1" && " $* " != *" --deploy-scope migration "*) ]]; then
                   work="$(mktemp -d)"
                   git clone --quiet "$TEST_REMOTE" "$work/repo"
                   git -C "$work/repo" config user.name "Integration Test"
@@ -410,9 +410,14 @@ class DeployExactCommitIntegrationTests(unittest.TestCase):
             "TEST_UP_LOG": str(self.root / "weltgewebe-up.log"),
         }
 
-    def deploy(self, *, advance: bool) -> subprocess.CompletedProcess[str]:
+    def deploy(
+        self, *, advance: bool, advance_after_migration: bool = False
+    ) -> subprocess.CompletedProcess[str]:
         deploy_env = self.base_environment()
         deploy_env["ADVANCE_REMOTE_ON_DEPLOY"] = "1" if advance else "0"
+        deploy_env["ADVANCE_REMOTE_ON_MIGRATION"] = (
+            "1" if advance_after_migration else "0"
+        )
         argv = self.privileged(
             [
                 "env",
@@ -497,6 +502,19 @@ class DeployExactCommitIntegrationTests(unittest.TestCase):
         self.assertEqual(receipt["observed_main_after_deploy"], self.commit)
         current = (self.state / "current.json").resolve()
         self.assertEqual(current, receipt_path)
+
+    def test_main_advancing_after_migration_is_superseded_before_full_deploy(self) -> None:
+        result = self.deploy(advance=False, advance_after_migration=True)
+        self.restore_test_ownership()
+        self.assertEqual(result.returncode, 75, result.stderr)
+        deploy_calls = (self.root / "weltgewebe-up.log").read_text(encoding="utf-8").splitlines()
+        self.assertEqual(len(deploy_calls), 1)
+        self.assertIn("--deploy-scope migration", deploy_calls[0])
+        receipt_path = self.state / "receipts" / f"{self.commit}.json"
+        receipt = json.loads(receipt_path.read_text())
+        self.assertEqual(receipt["result"], "superseded_after_migration")
+        self.assertNotEqual(receipt["observed_main_after_deploy"], self.commit)
+        self.assertFalse((self.state / "current.json").exists())
 
     def test_main_advancing_during_deploy_is_not_marked_current(self) -> None:
         result = self.deploy(advance=True)

--- a/scripts/ci/tests/test_production_reconciler_contract.py
+++ b/scripts/ci/tests/test_production_reconciler_contract.py
@@ -28,6 +28,18 @@ class ProductionReconcilerContractTests(unittest.TestCase):
         self.assertIn('api_body_file="$(mktemp', script)
         self.assertIn("awk -F':'", script)
 
+    def test_deploy_helper_runs_bounded_migrations_before_full_deploy(self) -> None:
+        script = self.read("scripts/ops/deploy-exact-commit-vps.sh")
+        migration = script.index("run_release_deploy migration")
+        post_migration_main = script.index('remote_main="$(fetch_main)"', migration)
+        full = script.index("run_release_deploy full", post_migration_main)
+        public_readback = script.index('api_headers="$(mktemp', full)
+        self.assertLess(migration, post_migration_main)
+        self.assertLess(post_migration_main, full)
+        self.assertLess(full, public_readback)
+        self.assertIn("origin/main advanced after the migration phase", script)
+        self.assertIn("--deploy-scope migration", script)
+
     def test_deploy_helper_preserves_legacy_checkout_and_binds_main(self) -> None:
         script = self.read("scripts/ops/deploy-exact-commit-vps.sh")
         self.assertIn("+refs/heads/main:refs/remotes/origin/main", script)

--- a/scripts/ci/tests/test_production_reconciler_contract.py
+++ b/scripts/ci/tests/test_production_reconciler_contract.py
@@ -37,7 +37,9 @@ class ProductionReconcilerContractTests(unittest.TestCase):
         self.assertLess(migration, post_migration_main)
         self.assertLess(post_migration_main, full)
         self.assertLess(full, public_readback)
-        self.assertIn("origin/main advanced after the migration phase", script)
+        self.assertIn('write_deploy_receipt "superseded_after_migration"', script)
+        self.assertIn("production_deployment=superseded_after_migration", script)
+        self.assertIn("exit 75", script)
         self.assertIn("--deploy-scope migration", script)
 
     def test_deploy_helper_preserves_legacy_checkout_and_binds_main(self) -> None:

--- a/scripts/ops/deploy-exact-commit-vps.sh
+++ b/scripts/ops/deploy-exact-commit-vps.sh
@@ -39,6 +39,24 @@ fail() {
   exit 1
 }
 
+run_release_deploy() {
+  local scope="$1"
+  local -a arguments=(--no-pull --force-build --no-build-web)
+  case "$scope" in
+    migration)
+      arguments+=(--deploy-scope migration)
+      ;;
+    full)
+      arguments+=(--with-caddy)
+      ;;
+    *)
+      fail "unsupported release deployment scope: $scope"
+      ;;
+  esac
+  DEPLOY_TARGET=vps ENV_FILE="$RUNTIME_ENV" \
+    "$release_dir/scripts/weltgewebe-up" "${arguments[@]}"
+}
+
 require_command() {
   command -v "$1" > /dev/null 2>&1 || fail "required command not found: $1"
 }
@@ -292,9 +310,20 @@ last_observed_main="$remote_main"
 started_at="$(date --utc +%Y-%m-%dT%H:%M:%SZ)"
 write_deploy_receipt "deploying" "" "" "" "$remote_main"
 receipt_started=true
-DEPLOY_TARGET=vps ENV_FILE="$RUNTIME_ENV" \
-  "$release_dir/scripts/weltgewebe-up" \
-  --no-pull --force-build --no-build-web --with-caddy
+
+# Apply all pending embedded migrations through the existing bounded API-only
+# path before the full stack is reconciled. The migration scope restores the
+# API to verify-applied itself and leaves PostgreSQL, NATS and any existing
+# Caddy container untouched. This is intentionally idempotent when no migration
+# is pending.
+run_release_deploy migration
+
+remote_main="$(fetch_main)"
+last_observed_main="$remote_main"
+[[ "$remote_main" == "$COMMIT" ]] ||
+  fail "origin/main advanced after the migration phase: expected $COMMIT, got $remote_main"
+
+run_release_deploy full
 
 api_headers="$(mktemp "$STATE_ROOT/.api-headers.XXXXXX")"
 api_body_file="$(mktemp "$STATE_ROOT/.api-body.XXXXXX")"

--- a/scripts/ops/deploy-exact-commit-vps.sh
+++ b/scripts/ops/deploy-exact-commit-vps.sh
@@ -320,8 +320,13 @@ run_release_deploy migration
 
 remote_main="$(fetch_main)"
 last_observed_main="$remote_main"
-[[ "$remote_main" == "$COMMIT" ]] ||
-  fail "origin/main advanced after the migration phase: expected $COMMIT, got $remote_main"
+if [[ "$remote_main" != "$COMMIT" ]]; then
+  completed_at="$(date --utc +%Y-%m-%dT%H:%M:%SZ)"
+  write_deploy_receipt "superseded_after_migration" "$completed_at" "$api_commit" "$frontend_commit" "$remote_main"
+  receipt_terminal=true
+  echo "production_deployment=superseded_after_migration commit=$COMMIT current=$remote_main" >&2
+  exit 75
+fi
 
 run_release_deploy full
 

--- a/scripts/tests/test_weltgewebe_up_deploy_scope.sh
+++ b/scripts/tests/test_weltgewebe_up_deploy_scope.sh
@@ -271,6 +271,32 @@ PY
 assert_contains "$out_migration" "Running automatic migration-mode restore"
 echo "PASS: migration scope is API-only and automatically restores verify-applied"
 
+# Migration recovery must remain possible when Caddy is already absent. Existing
+# DB and NATS containers are still mandatory and protected.
+repo_migration_no_caddy="$(new_repo migration-no-caddy)"
+state_migration_no_caddy="$WORK_ROOT/migration-no-caddy-state"
+mkdir -p "$state_migration_no_caddy"
+mock_bin_migration_no_caddy="$(setup_mocks "$state_migration_no_caddy")"
+out_migration_no_caddy="$( (cd "$repo_migration_no_caddy" && PATH="$mock_bin_migration_no_caddy:/usr/bin:/bin" MOCK_STATE="$state_migration_no_caddy" WELTGEWEBE_DEPLOY_LOCK_FILE="$state_migration_no_caddy/deploy.lock" MOCK_MISSING_SERVICE=caddy REPO_DIR="$repo_migration_no_caddy" ENV_FILE="$repo_migration_no_caddy/.env" DEPLOY_TARGET=vps WELTGEWEBE_STATE_DIR="$repo_migration_no_caddy/.ops" WELTGEWEBE_SCOPED_API_HEALTH_TIMEOUT_SECONDS=2 bash scripts/weltgewebe-up --no-pull --no-build --deploy-scope migration) 2>&1)"
+[[ "$(wc -l < "$state_migration_no_caddy/compose-up.log")" -eq 2 ]] || fail "migration recovery without caddy should execute two API-only compose calls"
+assert_contains "$out_migration_no_caddy" "Running automatic migration-mode restore"
+assert_not_contains "$out_migration_no_caddy" "requires the protected caddy service"
+echo "PASS: migration scope can recover an API when Caddy is already absent"
+
+# The ordinary API scope must keep its stricter VPS dependency on Caddy.
+repo_api_no_caddy="$(new_repo api-no-caddy)"
+state_api_no_caddy="$WORK_ROOT/api-no-caddy-state"
+mkdir -p "$state_api_no_caddy"
+mock_bin_api_no_caddy="$(setup_mocks "$state_api_no_caddy")"
+set +e
+out_api_no_caddy="$( (cd "$repo_api_no_caddy" && PATH="$mock_bin_api_no_caddy:/usr/bin:/bin" MOCK_STATE="$state_api_no_caddy" WELTGEWEBE_DEPLOY_LOCK_FILE="$state_api_no_caddy/deploy.lock" MOCK_MISSING_SERVICE=caddy REPO_DIR="$repo_api_no_caddy" ENV_FILE="$repo_api_no_caddy/.env" DEPLOY_TARGET=vps WELTGEWEBE_STATE_DIR="$repo_api_no_caddy/.ops" bash scripts/weltgewebe-up --no-pull --no-build --deploy-scope api) 2>&1)"
+rc_api_no_caddy=$?
+set -e
+[[ "$rc_api_no_caddy" -ne 0 ]] || fail "API scope without Caddy should fail"
+[[ ! -s "$state_api_no_caddy/mutation.log" ]] || fail "API scope without Caddy still mutated compose"
+assert_contains "$out_api_no_caddy" "requires the protected caddy service"
+echo "PASS: API scope still rejects a missing VPS Caddy before mutation"
+
 # A failed migration-active API start must still attempt an API-only verify-applied restore.
 repo_migration_failure="$(new_repo migration-failure)"
 state_migration_failure="$WORK_ROOT/migration-failure-state"

--- a/scripts/weltgewebe-up
+++ b/scripts/weltgewebe-up
@@ -1833,8 +1833,8 @@ else
         exit 1
       fi
     done
-    if [[ "$DEPLOY_TARGET" == "vps" && (-z "${PROTECTED_IDS_BEFORE[caddy]}" || "${PROTECTED_IDS_BEFORE[caddy]}" == "__not_configured__") ]]; then
-      echo "ERROR: bounded VPS deploy requires the protected caddy service to be running." >&2
+    if [[ "$DEPLOY_TARGET" == "vps" && "$DEPLOY_SCOPE" == "api" && (-z "${PROTECTED_IDS_BEFORE[caddy]}" || "${PROTECTED_IDS_BEFORE[caddy]}" == "__not_configured__") ]]; then
+      echo "ERROR: bounded VPS API deploy requires the protected caddy service to be running." >&2
       exit 1
     fi
   fi


### PR DESCRIPTION
## Ergebnis

Der exakte VPS-Deploy führt künftig vor dem vollständigen Stack-Deploy den bereits vorhandenen, API-begrenzten Migration-Scope aus. Danach wird `origin/main` erneut geprüft und erst anschließend der vollständige Deploy samt öffentlichem Commit-Readback ausgeführt.

## Belegte Ursache

Nach PR #1480 verweigerte die API den Start korrekt, weil Migration `20260718000001_radius_projection_privacy` unter `WELTGEWEBE_API_STARTUP_MIGRATIONS=verify-applied` noch ausstand. Der Reconciler nutzte den vorhandenen Migration-Scope nicht. Nach dem fehlgeschlagenen Voll-Deploy waren PostgreSQL und NATS gesund, die API in einer Neustartschleife und Caddy bereits abwesend.

## Änderungen

- Migration-Scope vor Voll-Deploy im kanonischen exakten Deploy-Helfer
- erneuter `origin/main`-Readback zwischen Migration und Voll-Deploy
- Migration-Recovery darf ein bereits fehlendes VPS-Caddy vorfinden
- der normale API-Scope verlangt weiterhin ein laufendes Caddy
- PostgreSQL, NATS und vorhandenes Caddy bleiben identitätsgeschützt
- Restore auf `verify-applied` bleibt Aufgabe des bestehenden Migration-Scopes
- Reconcilervertrag, Integrationstest, Scope-Regressionen, Dokumentation und Implementierungsregister aktualisiert

## Tests

- `bash -n scripts/ops/deploy-exact-commit-vps.sh`
- `bash -n scripts/weltgewebe-up`
- `python3 -m unittest scripts.ci.tests.test_production_reconciler_contract -v`
- `bash scripts/tests/test_weltgewebe_up_deploy_scope.sh`
- `RUSTUP_TOOLCHAIN=1.89.0 CARGO_BUILD_JOBS=4 just ci`
- `git diff --check origin/main...HEAD`
- Arbeitsbaum nach Tests sauber

Die vier root-gebundenen lokalen Integrationsfälle bleiben auf dem Heim-PC mangels passwortlosem `sudo` lokal übersprungen und werden durch CI bewertet. Kein unsicherer Ersatzpfad wurde verwendet.

## Produktionsgrenze

Dieser PR behauptet noch keinen Liveabschluss. Nach Merge müssen der kanonische Reconciler installiert, die Migration aggregiert verifiziert und Frontend/API/Readiness/Receipts auf denselben neuen Main-Commit zurückgelesen werden.

Closes #1486

<!-- weltgewebe-risk: R3 -->