### PR TITLE
feat(nodes): reject stale collective mutations

### DIFF
--- a/apps/api/src/domain_db.rs
+++ b/apps/api/src/domain_db.rs
@@ -5,7 +5,7 @@
 //! mixed-source writes and silent fallback.
 
 use anyhow::{Context, Result};
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Timelike, Utc};
 use futures_util::TryStreamExt;
 use serde_json::{json, Map, Value};
 use sqlx::PgPool;
@@ -24,6 +24,15 @@ use crate::routes::nodes::{Location, Node};
 use crate::state::OrderedCache;
 
 const DEFAULT_TIMESTAMP: &str = "1970-01-01T00:00:00Z";
+
+/// PostgreSQL stores `timestamptz` with microsecond precision. Canonicalising
+/// before persistence keeps response/cache versions byte-identical to a later
+/// authoritative database read, which is required for stable `If-Match` tags.
+fn postgres_timestamp_precision(value: DateTime<Utc>) -> DateTime<Utc> {
+    value
+        .with_nanosecond(value.timestamp_subsec_micros() * 1_000)
+        .expect("microsecond timestamp is always valid")
+}
 
 /// One client-generated create operation, scoped to the authenticated account.
 /// Resource ids and timestamps remain server-owned; this key only identifies a
@@ -624,6 +633,28 @@ fn serialize_node_payload(node: &Node) -> Result<String, serde_json::Error> {
     serde_json::to_string(&Value::Object(payload_map))
 }
 
+/// Load one node from PostgreSQL for an authoritative mutation precondition check.
+///
+/// Callers must hold the per-node mutation guard while comparing the returned
+/// `updated_at` value and performing the subsequent mutation.
+pub async fn load_node_from_postgres(
+    pool: &PgPool,
+    id: &str,
+) -> Result<Option<Node>, NodeWriteError> {
+    let row: Option<NodeRow> = sqlx::query_as(
+        "SELECT id, kind, title, lat, lon, created_at, updated_at, payload::text \
+         FROM domain_nodes WHERE id = $1",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .map_err(NodeWriteError::Database)?;
+
+    row.map(node_from_row)
+        .transpose()
+        .map_err(NodeWriteError::Mapping)
+}
+
 /// Apply a patch to one `domain_nodes` row inside a transaction.
 ///
 /// Semantics:
@@ -697,7 +728,7 @@ pub async fn patch_node_in_postgres(
         serde_json::to_string(&payload).map_err(NodeWriteError::Serialization)?;
 
     let new_updated_at = if has_changes {
-        let now = chrono::Utc::now();
+        let now = postgres_timestamp_precision(chrono::Utc::now());
         sqlx::query(
             "UPDATE domain_nodes \
              SET payload = $2::jsonb, updated_at = $3 \
@@ -733,10 +764,13 @@ pub async fn patch_node_in_postgres(
     Ok(final_node)
 }
 
-pub async fn replace_node_in_postgres(pool: &PgPool, node: &Node) -> Result<(), NodeWriteError> {
+pub async fn replace_node_in_postgres(
+    pool: &PgPool,
+    node: &Node,
+) -> Result<DateTime<Utc>, NodeWriteError> {
     let payload = serialize_node_payload(node).map_err(NodeWriteError::Serialization)?;
     let updated_at = DateTime::parse_from_rfc3339(&node.updated_at)
-        .map(|value| value.with_timezone(&Utc))
+        .map(|value| postgres_timestamp_precision(value.with_timezone(&Utc)))
         .map_err(|error| NodeWriteError::Mapping(anyhow::Error::new(error)))?;
     let result = sqlx::query(
         "UPDATE domain_nodes \
@@ -756,7 +790,7 @@ pub async fn replace_node_in_postgres(pool: &PgPool, node: &Node) -> Result<(), 
     if result.rows_affected() == 0 {
         return Err(NodeWriteError::NotFound);
     }
-    Ok(())
+    Ok(updated_at)
 }
 
 pub async fn delete_node_with_edges_in_postgres(

--- a/apps/api/src/routes/collective_write_guard.rs
+++ b/apps/api/src/routes/collective_write_guard.rs
@@ -2,7 +2,7 @@ use std::{future::Future, sync::OnceLock};
 
 use axum::{
     extract::{Path, State},
-    http::StatusCode,
+    http::{header::IF_MATCH, HeaderMap, StatusCode},
     response::{IntoResponse, Response},
     Extension, Json,
 };
@@ -12,11 +12,12 @@ use tokio::sync::{Mutex, MutexGuard, Semaphore, SemaphorePermit};
 
 use crate::{
     config::{DomainNodeWriteSource, DomainReadSource},
+    domain_db,
     middleware::auth::AuthContext,
     state::ApiState,
 };
 
-use super::nodes;
+use super::{domain_write_guard::reject_node_patch_unless_writable, nodes};
 
 // PostgreSQL node mutations are serialized per node id across API instances.
 // A bounded process-local stripe queue prevents same-node waiters from occupying
@@ -35,7 +36,9 @@ static LOCAL_NODE_LOCKS: OnceLock<Vec<Mutex<()>>> = OnceLock::new();
 static POSTGRES_NODE_MUTATION_SLOTS: OnceLock<Semaphore> = OnceLock::new();
 
 enum NodeMutationGuard {
-    None,
+    Local {
+        _guard: MutexGuard<'static, ()>,
+    },
     Postgres {
         _guard: MutexGuard<'static, ()>,
         _slot: SemaphorePermit<'static>,
@@ -78,19 +81,18 @@ async fn acquire_node_mutation_guard(
     state: &ApiState,
     node_id: &str,
 ) -> Result<NodeMutationGuard, Response> {
-    // JSONL handlers already serialize their whole-file writes through
-    // `state.nodes_persist`; adding another global lock would only duplicate
-    // contention. PostgreSQL creates use server-generated ids and their own
-    // idempotency/uniqueness transaction, so only existing-node mutations need
-    // this cross-instance guard.
+    // Every existing-node mutation takes the same process-local stripe. For
+    // JSONL this makes the version check atomic with the existing handler's
+    // file/cache mutation. PostgreSQL additionally takes a cross-instance
+    // advisory lock below.
+    let guard = local_node_lock(node_id).lock().await;
     if !uses_postgres_node_persistence(state) {
-        return Ok(NodeMutationGuard::None);
+        return Ok(NodeMutationGuard::Local { _guard: guard });
     }
 
-    // Take the per-node stripe first so same-node waiters do not consume the
-    // global pool budget. The slot then guarantees enough free connections for
-    // the mutation helper and unrelated database traffic.
-    let guard = local_node_lock(node_id).lock().await;
+    // Same-node waiters do not consume the global pool budget. The slot then
+    // guarantees enough free connections for the authoritative version read,
+    // the mutation helper, and unrelated database traffic.
     let slot = postgres_node_mutation_slots()
         .acquire()
         .await
@@ -143,7 +145,7 @@ async fn acquire_node_mutation_guard(
 
 async fn release_node_mutation_guard(guard: NodeMutationGuard) {
     match guard {
-        NodeMutationGuard::None => {}
+        NodeMutationGuard::Local { _guard } => {}
         NodeMutationGuard::Postgres {
             _guard,
             _slot,
@@ -163,6 +165,13 @@ async fn run_node_mutation<F>(state: &ApiState, node_id: &str, mutation: F) -> R
 where
     F: Future<Output = Response>,
 {
+    // Applicability and storage-mode errors take precedence over HTTP
+    // preconditions. This preserves the existing fail-closed write contract
+    // and avoids reading or locking a node for a mutation that cannot run.
+    if let Err((status, message)) = reject_node_patch_unless_writable(state) {
+        return (status, message).into_response();
+    }
+
     let guard = match acquire_node_mutation_guard(state, node_id).await {
         Ok(guard) => guard,
         Err(response) => return response,
@@ -182,14 +191,79 @@ pub async fn create_node_serialized(
         .into_response()
 }
 
+async fn current_node_for_precondition(
+    state: &ApiState,
+    id: &str,
+) -> Result<Option<nodes::Node>, Response> {
+    if uses_postgres_node_persistence(state) {
+        let pool = state.db_pool.as_ref().ok_or_else(|| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "PostgreSQL pool unavailable for collective node precondition",
+            )
+                .into_response()
+        })?;
+        return domain_db::load_node_from_postgres(pool, id)
+            .await
+            .map_err(|error| {
+                tracing::error!(%error, node_id = %id, "failed to load authoritative node version");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "failed to verify collective node write precondition",
+                )
+                    .into_response()
+            });
+    }
+
+    let cache = state.nodes.read().await;
+    Ok(cache.get(id).cloned())
+}
+
+fn check_node_precondition(
+    node: Option<nodes::Node>,
+    id: &str,
+    headers: &HeaderMap,
+) -> Result<(), Box<Response>> {
+    let Some(node) = node else {
+        return Ok(()); // Let the underlying handler return 404
+    };
+
+    let if_match = headers.get(IF_MATCH).and_then(|h| h.to_str().ok());
+    let expected_etag = format!("\"{}\"", node.updated_at);
+
+    match if_match {
+        Some(etag) if etag == expected_etag => Ok(()),
+        Some(_) => {
+            tracing::info!(node_id = %id, provided = ?if_match, expected = %expected_etag, "Precondition failed: concurrent modification detected");
+            Err(Box::new(
+                (StatusCode::PRECONDITION_FAILED, Json(node)).into_response(),
+            ))
+        }
+        None => {
+            tracing::info!(node_id = %id, "Precondition required: missing If-Match header");
+            Err(Box::new(
+                (StatusCode::PRECONDITION_REQUIRED, Json(node)).into_response(),
+            ))
+        }
+    }
+}
+
 pub async fn patch_node_serialized(
     State(state): State<ApiState>,
     Path(id): Path<String>,
+    headers: HeaderMap,
     Json(payload): Json<nodes::UpdateNode>,
 ) -> Response {
     let mutation_state = state.clone();
     let mutation_id = id.clone();
     run_node_mutation(&state, &id, async move {
+        let node = match current_node_for_precondition(&mutation_state, &mutation_id).await {
+            Ok(node) => node,
+            Err(response) => return response,
+        };
+        if let Err(response) = check_node_precondition(node, &mutation_id, &headers) {
+            return *response;
+        }
         nodes::patch_node(State(mutation_state), Path(mutation_id), Json(payload))
             .await
             .into_response()
@@ -200,11 +274,19 @@ pub async fn patch_node_serialized(
 pub async fn replace_node_serialized(
     State(state): State<ApiState>,
     Path(id): Path<String>,
+    headers: HeaderMap,
     Json(payload): Json<Value>,
 ) -> Response {
     let mutation_state = state.clone();
     let mutation_id = id.clone();
     run_node_mutation(&state, &id, async move {
+        let node = match current_node_for_precondition(&mutation_state, &mutation_id).await {
+            Ok(node) => node,
+            Err(response) => return response,
+        };
+        if let Err(response) = check_node_precondition(node, &mutation_id, &headers) {
+            return *response;
+        }
         nodes::replace_node(State(mutation_state), Path(mutation_id), Json(payload))
             .await
             .into_response()
@@ -215,10 +297,18 @@ pub async fn replace_node_serialized(
 pub async fn delete_node_serialized(
     State(state): State<ApiState>,
     Path(id): Path<String>,
+    headers: HeaderMap,
 ) -> Response {
     let mutation_state = state.clone();
     let mutation_id = id.clone();
     run_node_mutation(&state, &id, async move {
+        let node = match current_node_for_precondition(&mutation_state, &mutation_id).await {
+            Ok(node) => node,
+            Err(response) => return response,
+        };
+        if let Err(response) = check_node_precondition(node, &mutation_id, &headers) {
+            return *response;
+        }
         nodes::delete_node(State(mutation_state), Path(mutation_id))
             .await
             .into_response()
@@ -260,5 +350,66 @@ mod tests {
             stripes.len() > 1,
             "different node ids must not all share one process-local lock"
         );
+    }
+
+    #[test]
+    fn precondition_missing_yields_428() {
+        let headers = HeaderMap::new();
+        let node = nodes::Node {
+            id: "1".into(),
+            kind: "test".into(),
+            title: "Test".into(),
+            created_at: "2026".into(),
+            updated_at: "2026-07-18T12:00:00Z".into(),
+            summary: None,
+            info: None,
+            tags: vec![],
+            address: None,
+            location: nodes::Location { lat: 0.0, lon: 0.0 },
+        };
+
+        let err = check_node_precondition(Some(node), "1", &headers).unwrap_err();
+        assert_eq!(err.status(), StatusCode::PRECONDITION_REQUIRED);
+    }
+
+    #[test]
+    fn precondition_mismatch_yields_412() {
+        let mut headers = HeaderMap::new();
+        headers.insert(IF_MATCH, "\"old-time\"".parse().unwrap());
+        let node = nodes::Node {
+            id: "1".into(),
+            kind: "test".into(),
+            title: "Test".into(),
+            created_at: "2026".into(),
+            updated_at: "2026-07-18T12:00:00Z".into(),
+            summary: None,
+            info: None,
+            tags: vec![],
+            address: None,
+            location: nodes::Location { lat: 0.0, lon: 0.0 },
+        };
+
+        let err = check_node_precondition(Some(node), "1", &headers).unwrap_err();
+        assert_eq!(err.status(), StatusCode::PRECONDITION_FAILED);
+    }
+
+    #[test]
+    fn precondition_match_yields_ok() {
+        let mut headers = HeaderMap::new();
+        headers.insert(IF_MATCH, "\"2026-07-18T12:00:00Z\"".parse().unwrap());
+        let node = nodes::Node {
+            id: "1".into(),
+            kind: "test".into(),
+            title: "Test".into(),
+            created_at: "2026".into(),
+            updated_at: "2026-07-18T12:00:00Z".into(),
+            summary: None,
+            info: None,
+            tags: vec![],
+            address: None,
+            location: nodes::Location { lat: 0.0, lon: 0.0 },
+        };
+
+        assert!(check_node_precondition(Some(node), "1", &headers).is_ok());
     }
 }

--- a/apps/api/src/routes/nodes.rs
+++ b/apps/api/src/routes/nodes.rs
@@ -2066,7 +2066,7 @@ pub async fn replace_node(
         .get(&id)
         .cloned()
         .ok_or(NodeMutationError::Status(StatusCode::NOT_FOUND))?;
-    let node = Node {
+    let mut node = Node {
         id: existing.id,
         kind: validated.kind,
         title: validated.title,
@@ -2096,13 +2096,16 @@ pub async fn replace_node(
                 .db_pool
                 .as_ref()
                 .ok_or(NodeMutationError::Status(StatusCode::INTERNAL_SERVER_ERROR))?;
-            replace_node_in_postgres(pool, &node).await.map_err(|error| match error {
-                NodeWriteError::NotFound => NodeMutationError::Status(StatusCode::NOT_FOUND),
-                other => {
-                    tracing::error!(%other, node_id = %id, "failed to replace node in PostgreSQL");
-                    NodeMutationError::Status(StatusCode::INTERNAL_SERVER_ERROR)
-                }
-            })?;
+            let persisted_updated_at = replace_node_in_postgres(pool, &node)
+                .await
+                .map_err(|error| match error {
+                    NodeWriteError::NotFound => NodeMutationError::Status(StatusCode::NOT_FOUND),
+                    other => {
+                        tracing::error!(%other, node_id = %id, "failed to replace node in PostgreSQL");
+                        NodeMutationError::Status(StatusCode::INTERNAL_SERVER_ERROR)
+                    }
+                })?;
+            node.updated_at = persisted_updated_at.to_rfc3339();
         }
     }
 

--- a/apps/api/tests/api_collective_mutations.rs
+++ b/apps/api/tests/api_collective_mutations.rs
@@ -140,16 +140,118 @@ fn write_fixture(path: &Path, content: &str) {
     fs::write(path, content).expect("write fixture");
 }
 
-fn mutation_request(method: &str, uri: &str, cookie: &str, payload: &str) -> Request<body::Body> {
-    Request::builder()
+const INITIAL_NODE_ETAG: &str = "\"2026-01-01T00:00:00Z\"";
+
+fn mutation_request_with_etag(
+    method: &str,
+    uri: &str,
+    cookie: &str,
+    payload: &str,
+    etag: Option<&str>,
+) -> Request<body::Body> {
+    let mut request = Request::builder()
         .method(method)
         .uri(uri)
         .header("Content-Type", "application/json")
         .header("Cookie", cookie)
         .header("Host", "localhost")
-        .header("Origin", "http://localhost")
+        .header("Origin", "http://localhost");
+    if let Some(etag) = etag {
+        request = request.header("If-Match", etag);
+    }
+    request
         .body(body::Body::from(payload.to_string()))
         .expect("valid request")
+}
+
+fn mutation_request(method: &str, uri: &str, cookie: &str, payload: &str) -> Request<body::Body> {
+    let etag = matches!(method, "PUT" | "PATCH" | "DELETE").then_some(INITIAL_NODE_ETAG);
+    mutation_request_with_etag(method, uri, cookie, payload, etag)
+}
+
+#[tokio::test]
+#[serial]
+async fn node_replace_requires_current_if_match_version() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let in_dir = tmp.path().join("in");
+    let nodes_path = in_dir.join("demo.nodes.jsonl");
+    write_fixture(
+        &nodes_path,
+        concat!(
+            r#"{"id":"n1","kind":"Werkstatt","title":"Alt","address":"Alt 1","location":{"lat":53.5,"lon":10.0},"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}"#,
+            "\n",
+        ),
+    );
+    let _env = set_gewebe_in_dir(&in_dir);
+    let state = state_for_role(Role::Weber).await?;
+    let (app, cookie) = authenticated_app(state.clone()).await;
+    let payload = r#"{"title":"Neu","kind":"Werkstatt","address":"Neu 1","location":{"lat":53.55,"lon":10.05},"tags":[]}"#;
+
+    let missing = mutation_request_with_etag("PUT", "/nodes/n1", &cookie, payload, None);
+    let response = app.clone().oneshot(missing).await?;
+    assert_eq!(response.status(), StatusCode::PRECONDITION_REQUIRED);
+    let body = body::to_bytes(response.into_body(), usize::MAX).await?;
+    let current: serde_json::Value = serde_json::from_slice(&body)?;
+    assert_eq!(current["updated_at"], "2026-01-01T00:00:00Z");
+
+    let stale = mutation_request_with_etag(
+        "PUT",
+        "/nodes/n1",
+        &cookie,
+        payload,
+        Some("\"2025-12-31T23:59:59Z\""),
+    );
+    let response = app.clone().oneshot(stale).await?;
+    assert_eq!(response.status(), StatusCode::PRECONDITION_FAILED);
+    let body = body::to_bytes(response.into_body(), usize::MAX).await?;
+    let current: serde_json::Value = serde_json::from_slice(&body)?;
+    assert_eq!(current["title"], "Alt");
+    assert_eq!(
+        state
+            .nodes
+            .read()
+            .await
+            .get("n1")
+            .map(|node| node.title.as_str()),
+        Some("Alt"),
+    );
+
+    // RFC 9110 normal request checks take precedence over preconditions: this
+    // endpoint cannot replace a missing node, so it remains a 404 rather than
+    // evaluating the supplied validator as a 412.
+    let missing_node = mutation_request_with_etag(
+        "PUT",
+        "/nodes/missing",
+        &cookie,
+        payload,
+        Some(INITIAL_NODE_ETAG),
+    );
+    assert_eq!(
+        app.clone().oneshot(missing_node).await?.status(),
+        StatusCode::NOT_FOUND,
+    );
+
+    let current = mutation_request_with_etag(
+        "PUT",
+        "/nodes/n1",
+        &cookie,
+        payload,
+        Some(INITIAL_NODE_ETAG),
+    );
+    let response = app.oneshot(current).await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        state
+            .nodes
+            .read()
+            .await
+            .get("n1")
+            .map(|node| node.title.as_str()),
+        Some("Neu"),
+    );
+    assert!(fs::read_to_string(nodes_path)?.contains(r#""title":"Neu""#));
+
+    Ok(())
 }
 
 #[tokio::test]
@@ -205,15 +307,22 @@ async fn weber_can_replace_shared_node_and_delete_node_cascade() -> Result<()> {
     let node: serde_json::Value = serde_json::from_slice(&bytes)?;
     assert_eq!(node["title"], "Gemeinsam gepflegt");
     assert_eq!(node["created_at"], "2026-01-01T00:00:00Z");
+    let current_etag = format!(
+        "\"{}\"",
+        node["updated_at"]
+            .as_str()
+            .expect("replace response has updated_at"),
+    );
 
     // PUT intentionally shares the create contract: coordinates are nested
     // under `location`. Flat `lat`/`lon` fields must fail rather than silently
     // drifting away from the TypeScript client contract.
-    let flat_location = mutation_request(
+    let flat_location = mutation_request_with_etag(
         "PUT",
         "/nodes/n1",
         &cookie,
         r#"{"title":"Falscher Vertrag","kind":"Werkstatt","address":"Neu 1","lat":53.55,"lon":10.05,"tags":[]}"#,
+        Some(&current_etag),
     );
     let response = app.clone().oneshot(flat_location).await?;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
@@ -227,7 +336,8 @@ async fn weber_can_replace_shared_node_and_delete_node_cascade() -> Result<()> {
         Some("Gemeinsam gepflegt")
     );
 
-    let delete_node = mutation_request("DELETE", "/nodes/n1", &cookie, "");
+    let delete_node =
+        mutation_request_with_etag("DELETE", "/nodes/n1", &cookie, "", Some(&current_etag));
     let response = app.clone().oneshot(delete_node).await?;
     assert_eq!(response.status(), StatusCode::NO_CONTENT);
     assert!(state.nodes.read().await.get("n1").is_none());
@@ -664,15 +774,29 @@ async fn concurrent_replace_and_delete_leave_one_coherent_jsonl_result() -> Resu
     let replace_status = replace_response?.status();
     let delete_status = delete_response?.status();
 
-    assert_eq!(delete_status, StatusCode::NO_CONTENT);
-    assert!(matches!(
-        replace_status,
-        StatusCode::OK | StatusCode::NOT_FOUND
-    ));
-    assert!(state.nodes.read().await.get("n1").is_none());
-    assert!(state.edges.read().await.get("e1").is_none());
-    assert!(!fs::read_to_string(&nodes_path)?.contains(r#""id":"n1""#));
-    assert!(!fs::read_to_string(&edges_path)?.contains(r#""id":"e1""#));
+    match (replace_status, delete_status) {
+        (StatusCode::OK, StatusCode::PRECONDITION_FAILED) => {
+            assert_eq!(
+                state
+                    .nodes
+                    .read()
+                    .await
+                    .get("n1")
+                    .map(|node| node.title.as_str()),
+                Some("Parallel gepflegt"),
+            );
+            assert!(state.edges.read().await.get("e1").is_some());
+            assert!(fs::read_to_string(&nodes_path)?.contains("Parallel gepflegt"));
+            assert!(fs::read_to_string(&edges_path)?.contains(r#""id":"e1""#));
+        }
+        (StatusCode::NOT_FOUND, StatusCode::NO_CONTENT) => {
+            assert!(state.nodes.read().await.get("n1").is_none());
+            assert!(state.edges.read().await.get("e1").is_none());
+            assert!(!fs::read_to_string(&nodes_path)?.contains(r#""id":"n1""#));
+            assert!(!fs::read_to_string(&edges_path)?.contains(r#""id":"e1""#));
+        }
+        other => panic!("unexpected concurrent mutation result: {other:?}"),
+    }
 
     Ok(())
 }
@@ -691,6 +815,21 @@ async fn guest_cannot_mutate_shared_elements() -> Result<()> {
     let _env = set_gewebe_in_dir(&in_dir);
     let state = state_for_role(Role::Gast).await?;
     let (app, cookie) = authenticated_app(state).await;
+
+    let replace_without_precondition = mutation_request_with_etag(
+        "PUT",
+        "/nodes/n1",
+        &cookie,
+        r#"{"title":"Verboten","kind":"Werkstatt","address":"Neu 1","location":{"lat":53.55,"lon":10.05}}"#,
+        None,
+    );
+    assert_eq!(
+        app.clone()
+            .oneshot(replace_without_precondition)
+            .await?
+            .status(),
+        StatusCode::FORBIDDEN,
+    );
 
     let replace = mutation_request(
         "PUT",

--- a/apps/api/tests/api_nodes.rs
+++ b/apps/api/tests/api_nodes.rs
@@ -129,6 +129,15 @@ fn write_lines(path: &PathBuf, lines: &[&str]) {
     fs::write(path, lines.join("\n")).unwrap();
 }
 
+fn node_etag(node: &serde_json::Value) -> String {
+    format!(
+        "\"{}\"",
+        node["updated_at"]
+            .as_str()
+            .expect("node response must contain updated_at"),
+    )
+}
+
 /// Helper: Ensures correct setup order (File Write -> Env -> State Init)
 async fn app_with_nodes(in_dir: &std::path::Path, lines: &[&str]) -> (Router, EnvGuard) {
     let nodes_path = in_dir.join("demo.nodes.jsonl");
@@ -265,22 +274,32 @@ async fn nodes_patch_info_lifecycle() -> anyhow::Result<()> {
         .layer(axum::middleware::from_fn(require_csrf))
         .with_state(state);
 
+    let req = Request::get("/nodes/n1").body(body::Body::empty())?;
+    let res = app.clone().oneshot(req).await?;
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = body::to_bytes(res.into_body(), usize::MAX).await?;
+    let initial: serde_json::Value = serde_json::from_slice(&body)?;
+    let mut current_etag = node_etag(&initial);
+
     // 1. Update info -> "New Info"
     // Note: We MUST provide Origin or Referer because a session cookie is present,
-    // otherwise CSRF middleware will block it.
+    // otherwise CSRF middleware will block it. The latest node version is also
+    // required so an older browser cannot silently overwrite a newer mutation.
     let req = Request::patch("/nodes/n1")
         .header("Content-Type", "application/json")
         .header("Cookie", &cookie_val)
         .header("Host", "localhost")
         .header("Origin", "http://localhost")
+        .header("If-Match", &current_etag)
         .body(body::Body::from(r#"{"info":"New Info"}"#))?;
     let res = app.clone().oneshot(req).await?;
     assert_eq!(res.status(), StatusCode::OK);
 
-    // Check response
+    // Check response and carry its exact version into the next mutation.
     let body = body::to_bytes(res.into_body(), usize::MAX).await?;
     let v: serde_json::Value = serde_json::from_slice(&body)?;
     assert_eq!(v["info"], "New Info");
+    current_etag = node_etag(&v);
 
     // Check persistence by reading via GET
     let req = Request::get("/nodes/n1").body(body::Body::empty())?;
@@ -295,12 +314,14 @@ async fn nodes_patch_info_lifecycle() -> anyhow::Result<()> {
         .header("Cookie", &cookie_val)
         .header("Host", "localhost")
         .header("Origin", "http://localhost")
+        .header("If-Match", &current_etag)
         .body(body::Body::from(r#"{}"#))?;
     let res = app.clone().oneshot(req).await?;
     assert_eq!(res.status(), StatusCode::OK);
     let body = body::to_bytes(res.into_body(), usize::MAX).await?;
     let v: serde_json::Value = serde_json::from_slice(&body)?;
     assert_eq!(v["info"], "New Info"); // Still there
+    current_etag = node_etag(&v);
 
     // 3. Set info to null -> Info removed
     let req = Request::patch("/nodes/n1")
@@ -308,6 +329,7 @@ async fn nodes_patch_info_lifecycle() -> anyhow::Result<()> {
         .header("Cookie", &cookie_val)
         .header("Host", "localhost")
         .header("Origin", "http://localhost")
+        .header("If-Match", &current_etag)
         .body(body::Body::from(r#"{"info":null}"#))?;
     let res = app.clone().oneshot(req).await?;
     assert_eq!(res.status(), StatusCode::OK);
@@ -368,6 +390,8 @@ async fn postgres_read_source_blocks_node_patch_without_persisting() -> anyhow::
         .layer(axum::middleware::from_fn(require_csrf))
         .with_state(state.clone());
 
+    // No If-Match on purpose: the storage-mode guard is a normal request
+    // applicability check and must reject this mutation before preconditions.
     let req = Request::patch("/nodes/n1")
         .header("Content-Type", "application/json")
         .header("Cookie", &cookie_val)

--- a/apps/api/tests/db_domain_node_write_path.rs
+++ b/apps/api/tests/db_domain_node_write_path.rs
@@ -85,6 +85,8 @@ const NODE_B: &str = "writepath-node-bbbbbbbbb";
 const NODE_404: &str = "writepath-node-not-found";
 const NODE_NULL_LOC: &str = "writepath-node-null-location";
 const NODE_BAD_PAYLOAD: &str = "writepath-node-bad-payload";
+const SEEDED_NODE_ETAG: &str = "\"2026-01-01T00:00:00+00:00\"";
+const JSONL_NODE_ETAG: &str = "\"2024-01-01T00:00:00Z\"";
 
 async fn clean(pool: &PgPool) {
     pool.execute("DELETE FROM domain_edges WHERE id LIKE 'writepath-edge-%'")
@@ -119,8 +121,10 @@ async fn seed_node(pool: &PgPool, id: &str, info: Option<&str>, steckbrief: Opti
         (None, None) => "{}".to_string(),
     };
     sqlx::query(
-        "INSERT INTO domain_nodes (id, kind, title, lat, lon, payload) \
-         VALUES ($1, 'test', 'Test Node', 53.5, 10.0, $2::jsonb)",
+        "INSERT INTO domain_nodes (id, kind, title, lat, lon, created_at, updated_at, payload) \
+         VALUES ($1, 'test', 'Test Node', 53.5, 10.0, \
+                 '2026-01-01T00:00:00Z'::timestamptz, \
+                 '2026-01-01T00:00:00Z'::timestamptz, $2::jsonb)",
     )
     .bind(id)
     .bind(&payload)
@@ -259,7 +263,7 @@ async fn postgres_write_app(pool: PgPool, operator_id: &str) -> Result<(Router, 
     Ok((app, cookie, state))
 }
 
-fn patch_node_req(cookie: &str, id: &str, json_body: &str) -> Request<body::Body> {
+fn patch_node_req(cookie: &str, id: &str, json_body: &str, etag: &str) -> Request<body::Body> {
     Request::builder()
         .method("PATCH")
         .uri(format!("/nodes/{id}"))
@@ -267,11 +271,12 @@ fn patch_node_req(cookie: &str, id: &str, json_body: &str) -> Request<body::Body
         .header("Host", "localhost")
         .header("Origin", "http://localhost")
         .header("Cookie", cookie)
+        .header("If-Match", etag)
         .body(body::Body::from(json_body.to_string()))
         .unwrap()
 }
 
-fn replace_node_req(cookie: &str, id: &str, title: &str) -> Request<body::Body> {
+fn replace_node_req(cookie: &str, id: &str, title: &str, etag: &str) -> Request<body::Body> {
     Request::builder()
         .method("PUT")
         .uri(format!("/nodes/{id}"))
@@ -279,6 +284,7 @@ fn replace_node_req(cookie: &str, id: &str, title: &str) -> Request<body::Body> 
         .header("Host", "localhost")
         .header("Origin", "http://localhost")
         .header("Cookie", cookie)
+        .header("If-Match", etag)
         .body(body::Body::from(
             serde_json::json!({
                 "title": title,
@@ -312,7 +318,12 @@ async fn postgres_node_patch_persists_and_reload_sees_change() -> Result<()> {
 
     let res = app
         .clone()
-        .oneshot(patch_node_req(&cookie, NODE_A, r#"{"info": "new info"}"#))
+        .oneshot(patch_node_req(
+            &cookie,
+            NODE_A,
+            r#"{"info": "new info"}"#,
+            SEEDED_NODE_ETAG,
+        ))
         .await?;
     assert_eq!(res.status(), StatusCode::OK);
 
@@ -371,7 +382,12 @@ async fn postgres_node_patch_has_no_jsonl_side_effect() -> Result<()> {
         postgres_write_app(pool.clone(), "10000000-0000-0000-0000-000000000002").await?;
 
     let res = app
-        .oneshot(patch_node_req(&cookie, NODE_B, r#"{"info": "updated"}"#))
+        .oneshot(patch_node_req(
+            &cookie,
+            NODE_B,
+            r#"{"info": "updated"}"#,
+            SEEDED_NODE_ETAG,
+        ))
         .await?;
     assert_eq!(res.status(), StatusCode::OK);
 
@@ -404,7 +420,12 @@ async fn postgres_node_patch_not_found_returns_404() -> Result<()> {
         postgres_write_app(pool.clone(), "10000000-0000-0000-0000-000000000003").await?;
 
     let res = app
-        .oneshot(patch_node_req(&cookie, NODE_404, r#"{"info": "ghost"}"#))
+        .oneshot(patch_node_req(
+            &cookie,
+            NODE_404,
+            r#"{"info": "ghost"}"#,
+            SEEDED_NODE_ETAG,
+        ))
         .await?;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
 
@@ -513,7 +534,12 @@ async fn postgres_read_jsonl_node_write_is_blocked() -> Result<()> {
         .with_state(state.clone());
 
     let res = app
-        .oneshot(patch_node_req(&cookie, NODE_A, r#"{"info": "blocked"}"#))
+        .oneshot(patch_node_req(
+            &cookie,
+            NODE_A,
+            r#"{"info": "blocked"}"#,
+            SEEDED_NODE_ETAG,
+        ))
         .await?;
     assert_eq!(res.status(), StatusCode::CONFLICT);
 
@@ -562,7 +588,7 @@ async fn postgres_node_patch_removes_steckbrief() -> Result<()> {
 
     // Patch with no info change (no-op for info) — only steckbrief cleanup.
     let res = app
-        .oneshot(patch_node_req(&cookie, NODE_A, r#"{}"#))
+        .oneshot(patch_node_req(&cookie, NODE_A, r#"{}"#, SEEDED_NODE_ETAG))
         .await?;
     assert_eq!(res.status(), StatusCode::OK);
 
@@ -695,6 +721,7 @@ async fn jsonl_default_node_patch_compiles_and_routes_correctly() -> Result<()> 
             &cookie,
             "writepath-node-jsonl-1",
             r#"{"info": "via jsonl"}"#,
+            JSONL_NODE_ETAG,
         ))
         .await?;
     assert_eq!(res.status(), StatusCode::OK);
@@ -1504,7 +1531,138 @@ async fn delete_node_rejects_invalid_postgres_edge_type_without_partial_mutation
     Ok(())
 }
 
-/// R. Distinct-node mutations cannot consume the whole five-connection pool
+/// R. The ETag returned by a PostgreSQL PUT must match the persisted
+/// microsecond-precision timestamp and be reusable immediately.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
+#[serial]
+async fn postgres_replace_response_etag_is_reusable() -> Result<()> {
+    let pool = connect_pool().await;
+    run_migrations(&pool).await;
+    clean(&pool).await;
+    seed_node(&pool, NODE_A, Some("before"), None).await;
+
+    let tmp = tempfile::tempdir()?;
+    let in_dir = tmp.path().join("in");
+    std::fs::create_dir_all(&in_dir)?;
+    let _env = set_gewebe_in_dir(&in_dir);
+    let (app, cookie, _state) =
+        postgres_write_app(pool.clone(), "10000000-0000-0000-0000-000000000096").await?;
+
+    let first_response = app
+        .clone()
+        .oneshot(replace_node_req(
+            &cookie,
+            NODE_A,
+            "First replace",
+            SEEDED_NODE_ETAG,
+        ))
+        .await?;
+    assert_eq!(first_response.status(), StatusCode::OK);
+    let first_body = body::to_bytes(first_response.into_body(), usize::MAX).await?;
+    let first_node: serde_json::Value = serde_json::from_slice(&first_body)?;
+    let reusable_etag = format!(
+        "\"{}\"",
+        first_node["updated_at"]
+            .as_str()
+            .expect("replace response has updated_at"),
+    );
+
+    let second_response = app
+        .oneshot(replace_node_req(
+            &cookie,
+            NODE_A,
+            "Second replace",
+            &reusable_etag,
+        ))
+        .await?;
+    assert_eq!(second_response.status(), StatusCode::OK);
+    let second_body = body::to_bytes(second_response.into_body(), usize::MAX).await?;
+    let second_node: serde_json::Value = serde_json::from_slice(&second_body)?;
+    assert_eq!(second_node["title"], "Second replace");
+
+    let persisted_updated_at: chrono::DateTime<chrono::Utc> =
+        sqlx::query_scalar("SELECT updated_at FROM domain_nodes WHERE id = $1")
+            .bind(NODE_A)
+            .fetch_one(&pool)
+            .await?;
+    assert_eq!(second_node["updated_at"], persisted_updated_at.to_rfc3339(),);
+
+    clean(&pool).await;
+    Ok(())
+}
+
+/// S. A second API instance must compare `If-Match` against PostgreSQL,
+/// not against its stale process-local cache.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
+#[serial]
+async fn stale_second_instance_cache_cannot_overwrite_newer_postgres_node() -> Result<()> {
+    let pool = connect_pool().await;
+    run_migrations(&pool).await;
+    clean(&pool).await;
+    seed_node(&pool, NODE_A, Some("before"), None).await;
+
+    let tmp = tempfile::tempdir()?;
+    let in_dir = tmp.path().join("in");
+    std::fs::create_dir_all(&in_dir)?;
+    let _env = set_gewebe_in_dir(&in_dir);
+
+    let (first_app, first_cookie, _first_state) =
+        postgres_write_app(pool.clone(), "10000000-0000-0000-0000-000000000097").await?;
+    let (second_app, second_cookie, second_state) =
+        postgres_write_app(pool.clone(), "10000000-0000-0000-0000-000000000098").await?;
+
+    assert_eq!(
+        second_state
+            .nodes
+            .read()
+            .await
+            .get(NODE_A)
+            .map(|node| node.updated_at.as_str()),
+        Some("2026-01-01T00:00:00+00:00"),
+    );
+
+    let first_response = first_app
+        .oneshot(patch_node_req(
+            &first_cookie,
+            NODE_A,
+            r#"{"info": "first instance wins"}"#,
+            SEEDED_NODE_ETAG,
+        ))
+        .await?;
+    assert_eq!(first_response.status(), StatusCode::OK);
+    let first_body = body::to_bytes(first_response.into_body(), usize::MAX).await?;
+    let first_node: serde_json::Value = serde_json::from_slice(&first_body)?;
+    assert_eq!(first_node["info"], "first instance wins");
+    assert_ne!(first_node["updated_at"], "2026-01-01T00:00:00+00:00");
+
+    let stale_response = second_app
+        .oneshot(patch_node_req(
+            &second_cookie,
+            NODE_A,
+            r#"{"info": "stale overwrite"}"#,
+            SEEDED_NODE_ETAG,
+        ))
+        .await?;
+    assert_eq!(stale_response.status(), StatusCode::PRECONDITION_FAILED);
+    let stale_body = body::to_bytes(stale_response.into_body(), usize::MAX).await?;
+    let current_node: serde_json::Value = serde_json::from_slice(&stale_body)?;
+    assert_eq!(current_node["info"], "first instance wins");
+    assert_eq!(current_node["updated_at"], first_node["updated_at"]);
+
+    let persisted_info: Option<String> =
+        sqlx::query_scalar("SELECT payload->>'info' FROM domain_nodes WHERE id = $1")
+            .bind(NODE_A)
+            .fetch_one(&pool)
+            .await?;
+    assert_eq!(persisted_info.as_deref(), Some("first instance wins"));
+
+    clean(&pool).await;
+    Ok(())
+}
+
+/// T. Distinct-node mutations cannot consume the whole five-connection pool
 /// with advisory-lock transactions while every request waits for a second
 /// connection to perform its update.
 #[tokio::test]
@@ -1539,16 +1697,36 @@ async fn concurrent_distinct_node_replaces_preserve_pool_headroom() -> Result<()
 
     let requests = async {
         tokio::join!(
-            app.clone()
-                .oneshot(replace_node_req(&cookie, ids[0], "Parallel 1")),
-            app.clone()
-                .oneshot(replace_node_req(&cookie, ids[1], "Parallel 2")),
-            app.clone()
-                .oneshot(replace_node_req(&cookie, ids[2], "Parallel 3")),
-            app.clone()
-                .oneshot(replace_node_req(&cookie, ids[3], "Parallel 4")),
-            app.clone()
-                .oneshot(replace_node_req(&cookie, ids[4], "Parallel 5")),
+            app.clone().oneshot(replace_node_req(
+                &cookie,
+                ids[0],
+                "Parallel 1",
+                SEEDED_NODE_ETAG
+            )),
+            app.clone().oneshot(replace_node_req(
+                &cookie,
+                ids[1],
+                "Parallel 2",
+                SEEDED_NODE_ETAG
+            )),
+            app.clone().oneshot(replace_node_req(
+                &cookie,
+                ids[2],
+                "Parallel 3",
+                SEEDED_NODE_ETAG
+            )),
+            app.clone().oneshot(replace_node_req(
+                &cookie,
+                ids[3],
+                "Parallel 4",
+                SEEDED_NODE_ETAG
+            )),
+            app.clone().oneshot(replace_node_req(
+                &cookie,
+                ids[4],
+                "Parallel 5",
+                SEEDED_NODE_ETAG
+            )),
         )
     };
     let responses = tokio::time::timeout(Duration::from_secs(10), requests)

--- a/apps/web/src/lib/api/domainWrites.ts
+++ b/apps/web/src/lib/api/domainWrites.ts
@@ -6,10 +6,12 @@ import type { GarnrolleMapState, Location, Node } from "$lib/map/types";
  */
 export class ApiRequestError extends Error {
   status: number;
-  constructor(status: number) {
+  body?: unknown;
+  constructor(status: number, body?: unknown) {
     super(`API request failed with status ${status}`);
     this.name = "ApiRequestError";
     this.status = status;
+    this.body = body;
   }
 }
 
@@ -17,15 +19,22 @@ async function requestJson<T>(
   path: string,
   method: "POST" | "PATCH" | "PUT",
   payload: unknown,
+  etag?: string,
 ): Promise<T> {
+  const headers: HeadersInit = { "Content-Type": "application/json" };
+  if (etag) {
+    headers["If-Match"] = `"${etag}"`;
+  }
   const res = await fetch(path, {
     method,
-    headers: { "Content-Type": "application/json" },
+    headers,
     body: JSON.stringify(payload),
     credentials: "include",
   });
   if (!res.ok) {
-    throw new ApiRequestError(res.status);
+    const body =
+      res.status === 412 ? await res.json().catch(() => undefined) : undefined;
+    throw new ApiRequestError(res.status, body);
   }
   return res.json();
 }
@@ -34,21 +43,36 @@ async function postJson<T>(path: string, payload: unknown): Promise<T> {
   return requestJson<T>(path, "POST", payload);
 }
 
-async function patchJson<T>(path: string, payload: unknown): Promise<T> {
-  return requestJson<T>(path, "PATCH", payload);
+async function patchJson<T>(
+  path: string,
+  payload: unknown,
+  etag?: string,
+): Promise<T> {
+  return requestJson<T>(path, "PATCH", payload, etag);
 }
 
-async function putJson<T>(path: string, payload: unknown): Promise<T> {
-  return requestJson<T>(path, "PUT", payload);
+async function putJson<T>(
+  path: string,
+  payload: unknown,
+  etag?: string,
+): Promise<T> {
+  return requestJson<T>(path, "PUT", payload, etag);
 }
 
-async function deleteResource(path: string): Promise<void> {
+async function deleteResource(path: string, etag?: string): Promise<void> {
+  const headers: HeadersInit = {};
+  if (etag) {
+    headers["If-Match"] = `"${etag}"`;
+  }
   const res = await fetch(path, {
     method: "DELETE",
+    headers,
     credentials: "include",
   });
   if (!res.ok) {
-    throw new ApiRequestError(res.status);
+    const body =
+      res.status === 412 ? await res.json().catch(() => undefined) : undefined;
+    throw new ApiRequestError(res.status, body);
   }
 }
 
@@ -122,11 +146,12 @@ export interface ReplaceNodePayload {
 export function replaceNode(
   id: string,
   payload: ReplaceNodePayload,
+  etag?: string,
 ): Promise<Node> {
-  return putJson<Node>(`/api/nodes/${encodeURIComponent(id)}`, payload);
+  return putJson<Node>(`/api/nodes/${encodeURIComponent(id)}`, payload, etag);
 }
 
 /** DELETE /api/nodes/:id — delete a node and its derived connected edges. */
-export function deleteNode(id: string): Promise<void> {
-  return deleteResource(`/api/nodes/${encodeURIComponent(id)}`);
+export function deleteNode(id: string, etag?: string): Promise<void> {
+  return deleteResource(`/api/nodes/${encodeURIComponent(id)}`, etag);
 }

--- a/apps/web/src/lib/components/panels/NodePanel.svelte
+++ b/apps/web/src/lib/components/panels/NodePanel.svelte
@@ -38,6 +38,7 @@
   let formLat = "";
   let formLon = "";
   let formTags = "";
+  let conflictNode: NodeDetails | null = null;
 
   interface NodeDetails {
     id: string;
@@ -121,6 +122,7 @@
     formLon = location ? String(location.lon) : "";
     formTags = (nodeDetails?.tags || fallback?.tags || []).join(", ");
     mutationError = "";
+    conflictNode = null;
     editing = true;
   }
 
@@ -135,6 +137,9 @@
       }
       if (error.status === 409) {
         return "Der Knoten konnte wegen eines Datenkonflikts nicht geändert werden. Es wurde nichts verändert.";
+      }
+      if (error.status === 428) {
+        return "Die geladene Knotenversion ist unvollständig. Bitte öffne den Knoten erneut und versuche es noch einmal.";
       }
     }
     return "Die Änderung konnte nicht gespeichert werden.";
@@ -164,30 +169,50 @@
     saving = true;
     mutationError = "";
     try {
-      const updatedNode = await replaceNode(id, {
-        title: formTitle.trim(),
-        kind: formKind.trim(),
-        address: formAddress.trim(),
-        location: { lat, lon },
-        summary: formSummary.trim() || undefined,
-        info: formInfo.trim() || undefined,
-        tags: Array.from(
-          new Set(
-            formTags
-              .split(",")
-              .map((tag) => tag.trim())
-              .filter(Boolean),
+      const updatedNode = await replaceNode(
+        id,
+        {
+          title: formTitle.trim(),
+          kind: formKind.trim(),
+          address: formAddress.trim(),
+          location: { lat, lon },
+          summary: formSummary.trim() || undefined,
+          info: formInfo.trim() || undefined,
+          tags: Array.from(
+            new Set(
+              formTags
+                .split(",")
+                .map((tag) => tag.trim())
+                .filter(Boolean),
+            ),
           ),
-        ),
-      });
+        },
+        nodeDetails?.updated_at,
+      );
       detailsLoader.setDetails({
         ...(nodeDetails ?? {}),
         ...updatedNode,
       } as NodeDetails);
+      conflictNode = null;
       editing = false;
       dispatch("domainChanged", { kind: "node", id, action: "updated" });
     } catch (error) {
-      mutationError = mutationMessage(error);
+      if (
+        error instanceof ApiRequestError &&
+        error.status === 412 &&
+        error.body
+      ) {
+        const currentNode = error.body as NodeDetails;
+        mutationError =
+          "Der Knoten wurde in der Zwischenzeit geändert. Dein Entwurf bleibt erhalten. Vergleiche ihn mit dem aktuellen Stand und speichere anschließend erneut.";
+        conflictNode = currentNode;
+        detailsLoader.setDetails({
+          ...(nodeDetails ?? {}),
+          ...currentNode,
+        } as NodeDetails);
+      } else {
+        mutationError = mutationMessage(error);
+      }
     } finally {
       saving = false;
     }
@@ -204,10 +229,23 @@
     deleting = true;
     mutationError = "";
     try {
-      await deleteNode(id);
+      await deleteNode(id, nodeDetails?.updated_at);
       dispatch("domainChanged", { kind: "node", id, action: "deleted" });
     } catch (error) {
-      mutationError = mutationMessage(error);
+      if (
+        error instanceof ApiRequestError &&
+        error.status === 412 &&
+        error.body
+      ) {
+        mutationError =
+          "Der Knoten wurde in der Zwischenzeit geändert und konnte nicht gelöscht werden. Die Ansicht zeigt nun den aktuellen Stand.";
+        detailsLoader.setDetails({
+          ...(nodeDetails ?? {}),
+          ...(error.body as object),
+        } as NodeDetails);
+      } else {
+        mutationError = mutationMessage(error);
+      }
     } finally {
       deleting = false;
     }
@@ -256,6 +294,37 @@
       </label>
 
       {#if mutationError}<p class="error" role="alert">{mutationError}</p>{/if}
+      {#if conflictNode}
+        <section class="conflict-current" aria-label="Aktueller Serverstand">
+          <strong>Aktueller Stand im Weltgewebe</strong>
+          <dl>
+            <div>
+              <dt>Titel</dt>
+              <dd>{conflictNode.title}</dd>
+            </div>
+            <div>
+              <dt>Knotenart</dt>
+              <dd>{conflictNode.kind}</dd>
+            </div>
+            {#if conflictNode.summary}<div>
+                <dt>Kurzbeschreibung</dt>
+                <dd>{conflictNode.summary}</dd>
+              </div>{/if}
+            {#if conflictNode.info}<div>
+                <dt>Information</dt>
+                <dd>{conflictNode.info}</dd>
+              </div>{/if}
+            {#if conflictNode.address}<div>
+                <dt>Adresse</dt>
+                <dd>{conflictNode.address}</dd>
+              </div>{/if}
+            {#if conflictNode.tags?.length}<div>
+                <dt>Schlagwörter</dt>
+                <dd>{conflictNode.tags.join(", ")}</dd>
+              </div>{/if}
+          </dl>
+        </section>
+      {/if}
       <div class="form-actions">
         <button
           type="button"
@@ -509,6 +578,29 @@
     margin: 0;
     color: #a33;
     font-weight: 650;
+  }
+  .conflict-current {
+    border: 1px solid color-mix(in srgb, #a33 35%, transparent);
+    border-radius: 0.5rem;
+    padding: 0.75rem;
+  }
+  .conflict-current dl {
+    display: grid;
+    gap: 0.4rem;
+    margin: 0.55rem 0 0;
+  }
+  .conflict-current dl div {
+    display: grid;
+    grid-template-columns: minmax(6rem, auto) 1fr;
+    gap: 0.65rem;
+  }
+  .conflict-current dt {
+    font-weight: 600;
+  }
+  .conflict-current dd {
+    margin: 0;
+    overflow-wrap: anywhere;
+    white-space: pre-wrap;
   }
   @media (max-width: 420px) {
     .coordinate-grid,

--- a/apps/web/tests/node-mutations.spec.ts
+++ b/apps/web/tests/node-mutations.spec.ts
@@ -46,6 +46,7 @@ test.describe("Knoten bearbeiten und löschen", () => {
     );
     await panel.getByRole("button", { name: "Änderungen speichern" }).click();
     const putRequest = await putRequestPromise;
+    expect(putRequest.headers()["if-match"]).toMatch(/^".+"$/);
     expect(putRequest.postDataJSON()).toMatchObject({
       title: "Gemeinsam gepflegter Knoten",
       summary: "Aktualisierte öffentliche Kurzbeschreibung",
@@ -68,7 +69,8 @@ test.describe("Knoten bearbeiten und löschen", () => {
         /\/api\/nodes\/[^/]+$/.test(new URL(request.url()).pathname),
     );
     await panel.getByRole("button", { name: "Knoten löschen" }).click();
-    await deleteRequestPromise;
+    const deleteRequest = await deleteRequestPromise;
+    expect(deleteRequest.headers()["if-match"]).toMatch(/^".+"$/);
 
     await expect(panel).toHaveCount(0);
     await expect(page.locator(".map-marker")).toHaveCount(
@@ -92,6 +94,83 @@ test.describe("Knoten bearbeiten und löschen", () => {
     );
     await expect(
       panel.getByRole("button", { name: "Knoten löschen" }),
+    ).toHaveCount(0);
+  });
+
+  test("bewahrt den Entwurf bei 412 und speichert nach bewusstem Vergleich erneut", async ({
+    page,
+  }) => {
+    await mockApiResponses(page, {
+      auth: { authenticated: true, account_id: "e2e-weber", role: "weber" },
+    });
+
+    const observedIfMatch: string[] = [];
+    let putAttempt = 0;
+    await page.route("**/api/nodes/*", async (route, request) => {
+      if (request.method() !== "PUT") {
+        await route.fallback();
+        return;
+      }
+      observedIfMatch.push(request.headers()["if-match"] ?? "");
+      putAttempt += 1;
+      if (putAttempt === 1) {
+        await route.fulfill({
+          status: 412,
+          contentType: "application/json",
+          body: JSON.stringify({
+            id: "fake-id",
+            title: "Neuer Titel vom Server",
+            kind: "Ort",
+            summary: "Neue Kurzbeschreibung vom Server",
+            address: "Adresse",
+            location: { lat: 0, lon: 0 },
+            tags: ["server"],
+            updated_at: "2026-07-18T10:00:00Z",
+          }),
+        });
+        return;
+      }
+
+      const payload = request.postDataJSON();
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: "fake-id",
+          ...payload,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-07-18T10:01:00Z",
+        }),
+      });
+    });
+
+    await page.goto("/map");
+    const panel = await openFirstNode(page);
+    await panel.getByRole("button", { name: "Bearbeiten" }).click();
+    await panel.getByLabel("Titel").fill("Mein Konflikt");
+    await panel.getByRole("button", { name: "Änderungen speichern" }).click();
+
+    expect(observedIfMatch[0]).toMatch(/^".+"$/);
+    await expect(
+      panel.getByText(
+        "Der Knoten wurde in der Zwischenzeit geändert. Dein Entwurf bleibt erhalten. Vergleiche ihn mit dem aktuellen Stand und speichere anschließend erneut.",
+      ),
+    ).toBeVisible();
+    await expect(panel.getByLabel("Titel")).toHaveValue("Mein Konflikt");
+    const current = panel.getByRole("region", {
+      name: "Aktueller Serverstand",
+    });
+    await expect(current).toContainText("Neuer Titel vom Server");
+    await expect(current).toContainText("Neue Kurzbeschreibung vom Server");
+    await expect(
+      panel.getByRole("button", { name: "Änderungen speichern" }),
+    ).toBeVisible();
+
+    await panel.getByRole("button", { name: "Änderungen speichern" }).click();
+    expect(observedIfMatch[1]).toBe('"2026-07-18T10:00:00Z"');
+    await expect(panel.locator("h3")).toHaveText("Mein Konflikt");
+    await expect(
+      panel.getByRole("button", { name: "Änderungen speichern" }),
     ).toHaveCount(0);
   });
 });


### PR DESCRIPTION
<!-- weltgewebe-risk: R2 -->

## Problem

Gemeinsam bearbeitete Knoten konnten durch einen älteren Browserstand still überschrieben werden. Das war besonders bei parallelen Webern oder mehreren geöffneten Tabs riskant.

## Lösung

- verlangt für `PUT`, `PATCH` und `DELETE /nodes/{id}` eine exakte `If-Match`-Versionsmarke
- antwortet bei fehlender Vorbedingung mit `428`, bei veraltetem Stand mit `412` und dem aktuellen Knoten
- serialisiert Prüfung und Mutation pro Knoten für JSONL
- liest und sperrt die maßgebliche PostgreSQL-Version unter einem instanzübergreifenden Advisory Lock
- kanonisiert PostgreSQL-Zeitstempel auf Mikrosekunden, damit zurückgegebene ETags sofort wiederverwendbar sind
- erhält bei `412` den lokalen Formularentwurf und zeigt den aktuellen Serverstand für einen bewussten zweiten Speicherversuch

## Grenzen

Diese Scheibe schützt kooperierende Weltgewebe-API-Instanzen. Eine spätere Folgescheibe soll einen opaken monotonen Revisionswert und eine speicherseitig bedingte Mutation einführen. Auditspur, Löschpolitik, Missbrauchsschutz und Mutationsbeobachtung bleiben eigene Teile von `WELTGEWEBE-PR-MAINTENANCE-V2-T005`.

## Prüfung

- `cargo clippy --all-targets -- -D warnings`
- `cargo test --locked` — vollständige Rust-Suite bestanden
- `cargo test --test api_collective_mutations` — 10 bestanden
- `cargo test --test api_nodes` — 20 bestanden
- echte PostgreSQL-16-Suite `db_domain_node_write_path` — 20 bestanden
- `pnpm check` — 0 Fehler, 0 Warnungen
- `pnpm lint`
- `pnpm exec playwright test node-mutations.spec.ts` — 3 bestanden
- exakte Reviewbasis `e4fe01e8..f58b6060`; zwei unabhängige R2-Berichte werden hashgebunden veröffentlicht

## Bureau

- Event 719: robuster opaker Revisionsvertrag
- Event 720: obsolete ActionBar-Aufgabe verworfen
- Event 721: Feld-für-Feld-Konfliktvergleich
- Event 722: explizite PostgreSQL-Guard-Freigabe
