### PR TITLE
Agent Operability Convergence v1: kanonischer Repo-Vertrag

### DIFF
--- a/.github/workflows/agent-safety-preflight.yml
+++ b/.github/workflows/agent-safety-preflight.yml
@@ -25,7 +25,13 @@ name: agent-safety-preflight
       - "docs/_generated/agent-readiness.md"
       - "agent-policy.yaml"
       - "AGENTS.md"
+      - "agent-contract.json"
       - "repo.meta.yaml"
+      - ".wgx/generated-artifacts.yml"
+      - "README.md"
+      - "docs/policies/agent-reading-protocol.md"
+      - "scripts/docmeta/agent_entrypoint_smoke.py"
+      - "scripts/docmeta/tests/test_agent_entrypoint_smoke.py"
       - ".github/workflows/agent-safety-preflight.yml"
   workflow_dispatch: {}
 
@@ -50,6 +56,9 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # tag: v5
         with:
           python-version-file: '.python-version'
+
+      - name: Install dependencies
+        run: pip install PyYAML==6.0.2
 
       - name: Run agent unit and CLI contract tests
         run: python3 -m unittest discover scripts/agent/tests/ -v
@@ -145,8 +154,15 @@ jobs:
             scripts.docmeta.tests.test_agent_readiness_smoke_contract \
             -v
 
+      - name: Run agent entrypoint smoke tests
+        run: |
+          python3 -m scripts.docmeta.agent_entrypoint_smoke
+          python3 -m unittest scripts.docmeta.tests.test_agent_entrypoint_smoke -v
+
       - name: Validate agent contracts (Python)
-        run: python3 -m scripts.agent.validate_agent_contracts
+        run: |
+          python3 -m scripts.agent.validate_agent_contracts
+          python3 -m scripts.agent.validate_repo_agent_contract
 
       - name: Check handoff fixture digest is fresh
         run: python3 -m scripts.agent.update_handoff_fixtures --check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ All agents MUST follow the [Agent Reading Protocol](docs/policies/agent-reading-
 2. **Conflict Resolution:** Domain contracts and `agent-contract.json` lead for agent operability; broader truth precedence remains in `repo.meta.yaml` (`truth_model.precedence`).
 3. **No Interpolation:** Silent interpolation is FORBIDDEN. Explicitly name missing gaps.
 4. **Abort Rule:** Agents MUST abort if contradictions are unresolvable, necessary files are missing, or target proof is impossible.
-5. **Navigation vs Truth:** `docs/index.md` is strictly navigation. `docs/_generated/*` is diagnostic only; direct agent edits are forbidden. Declared trusted generators may refresh derived targets.
+5. **Navigation vs Truth:** `docs/index.md` is strictly navigation. `docs/_generated/*` is diagnostic only; direct agent edits are forbidden. Declared trusted generators may refresh only contract-allowlisted derived targets; `secrets/` and `snapshots/` are never generator targets.
 
 These core rules derive from `agent-contract.json`, `repo.meta.yaml`, and the Agent Reading Protocol.
 
@@ -56,7 +56,8 @@ python3 -m scripts.agent.validate_repo_agent_contract
 ## Generated Artifacts
 
 - Direct agent edits under generated/forbidden prefixes are forbidden.
-- Only generators declared in the registry referenced by the contract may write derived targets.
+- Only generators declared in the registry referenced by the contract may write targets under `generated_artifacts.allowed_target_prefixes` (currently only `docs/_generated/`).
+- `secrets/` and `snapshots/` remain forbidden for both direct edits and generator output.
 - Prefer named validation profiles over free-form shell authority; task `validation_commands` remain transitional fixtures until profile migration completes.
 
 ## Task-Scoped Documents

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,10 +4,13 @@ title: AGENTS
 doc_type: policy
 status: active
 canonicality: canonical
-summary: Agent configuration and operational boundaries for Weltgewebe.
+summary: Progressive agent entry card for Weltgewebe; machine authority lives in agent-contract.json.
 ---
 
 # AGENTS
+
+Canonical entry card and orientation guide for agents working in this repository.
+While **`agent-contract.json`** defines the strict machine-readable path, check, and generator authority, this document canonically defines the progressive entry sequence and human-facing context.
 
 ## Binding Reading Protocol
 
@@ -15,182 +18,71 @@ All agents MUST follow the [Agent Reading Protocol](docs/policies/agent-reading-
 
 **Core Rules (Strictly Binding):**
 
-1. **Reading Order:** `repo.meta.yaml` -> `AGENTS.md` -> `agent-policy.yaml` -> `docs/policies/agent-reading-protocol.md`
-2. **Conflict Resolution:** Kanonisch und vollständig definiert in `repo.meta.yaml` (`truth_model.precedence`).
+1. **Reading Order:** `agent-contract.json` -> `repo.meta.yaml` -> `AGENTS.md` -> `agent-policy.yaml` -> `docs/policies/agent-reading-protocol.md`
+2. **Conflict Resolution:** Domain contracts and `agent-contract.json` lead for agent operability; broader truth precedence remains in `repo.meta.yaml` (`truth_model.precedence`).
 3. **No Interpolation:** Silent interpolation is FORBIDDEN. Explicitly name missing gaps.
 4. **Abort Rule:** Agents MUST abort if contradictions are unresolvable, necessary files are missing, or target proof is impossible.
-5. **Navigation vs Truth:** `docs/index.md` is strictly navigation (`navigational_indices`). `docs/_generated/*` is strictly diagnostic (`generated_diagnostics`).
+5. **Navigation vs Truth:** `docs/index.md` is strictly navigation. `docs/_generated/*` is diagnostic only; direct agent edits are forbidden. Declared trusted generators may refresh derived targets.
 
-These core rules derive from the canonical definitions in `repo.meta.yaml` and the `Agent Reading Protocol`. They override implicit interpretation.
-
-## Purpose
-
-Agent configuration, operational boundaries, and strict coding guidelines for Weltgewebe. This document defines how agents navigate the repository, canonical files, and the rules for CI-ready code contributions.
-
-## Read This First
-
-1. Begin with `repo.meta.yaml` and `docs/policies/agent-reading-protocol.md` to understand the truth structure. Navigation can be found in `docs/index.md`.
-2. Read the "Coding Guidelines" below. Sie definieren, wie Code-Snippets syntaktisch korrekt, ausführbar und CI-tauglich vorgeschlagen werden müssen – statt nur „so ungefähr“ zu passen.
+These core rules derive from `agent-contract.json`, `repo.meta.yaml`, and the Agent Reading Protocol.
 
 ## Canonical Sources
 
-- `repo.meta.yaml`
-- `AGENTS.md`
-- `agent-policy.yaml`
-- `docs/policies/agent-reading-protocol.md`
-- `docs/policies/architecture-critique.md` (cognitive module; canonical, but excluded from default reading order; activated via protocol rules)
+| Source | Role |
+|---|---|
+| `agent-contract.json` | Canonical machine agent norm (paths, checks, generators, architecture roles) |
+| `repo.meta.yaml` | Repo truth model; overlapping path/check fields are a Compatibility Projection |
+| `AGENTS.md` | This progressive entry card |
+| `agent-policy.yaml` | Compatibility Projection of write-scope fields plus human-review hints |
+| `docs/policies/agent-reading-protocol.md` | Binding read/abort protocol |
+| `docs/policies/architecture-critique.md` | Cognitive module; not default reading order |
 
-## Discovery Rules
+## Architecture Split
+
+- **Repository role:** `repo_contract_authority` — portable contracts, validators, readiness, and CI checks.
+- **Operator role:** `external_operator_execution` (Grabowski) — workspace, lease, execution, review, publish, recovery, cleanup.
+- **Rejected:** a second generic repository-owned write operator / free-form write mode.
+
+## Safe / Guarded / Forbidden (summary)
+
+Authoritative arrays live only in `agent-contract.json`; use Validator/CLI.
+
+Validate with:
+
+```bash
+python3 -m scripts.agent.validate_repo_agent_contract
+```
+
+## Generated Artifacts
+
+- Direct agent edits under generated/forbidden prefixes are forbidden.
+- Only generators declared in the registry referenced by the contract may write derived targets.
+- Prefer named validation profiles over free-form shell authority; task `validation_commands` remain transitional fixtures until profile migration completes.
+
+## Task-Scoped Documents
+
+Load only what the task needs:
+
+- Roadmap / status / auth / UI / map / deploy / agent-operability: `docs/roadmap.md`, the relevant sub-roadmap, and the matching status matrix or report
+- Agent safety architecture: `docs/blueprints/blueprint-agent-safety-control-layer.md`
+- Write-scope baseline: `docs/security/agent-write-scope-baseline.md`
+
+## Coding Safety
+
+- Inspect the real file before proposing or changing code; do not invent repository structure or APIs.
+- Keep snippets syntactically valid and directly executable. Show complete affected blocks; mark omissions explicitly.
+- Preserve literal shell syntax, quoting, spacing, paths, and redirections. Do not compress commands into pseudo-tokens.
+- Emit success only after the relevant operation succeeded. Mandatory checks must not hide failures with `|| true`, `|| echo`, or equivalent fallbacks.
+- Reject non-finite frontend numbers with `Number.isFinite` and apply domain bounds before values reach rendering, coordinates, opacity, widths, radii, or sizes.
+- State uncertainty explicitly and verify CI-relevant behavior with the real build, lint, or test command instead of assuming success.
+
+## Discovery
 
 Scan `.github/workflows/`, `apps/`, `contracts/`, `docs/`, `infra/`, `scripts/`, and `tests/` for changes.
 
-## Roadmap Synchronization
-
-For tasks that change roadmap, status, auth, UI, map, deployment, or
-agent-operability documents, agents MUST also consult:
-
-1. `docs/roadmap.md` — coordination layer
-2. the relevant sub-roadmap, for example `docs/blueprints/auth-roadmap.md`
-3. the relevant status matrix or report, for example
-   `docs/reports/auth-status-matrix.md`
-
-`docs/roadmap.md` is not a higher-precedence truth source. It is a
-synchronization surface. If it diverges from a sub-roadmap or status matrix,
-the sub-roadmap or status matrix leads and `docs/roadmap.md` must be updated
-or the drift must be explicitly documented.
-
-Only update `docs/roadmap.md` when the relevant sub-roadmap or status report
-already documents and substantiates the status change.
-
-## Generated Files
-
-Files in `docs/_generated/` are automatically generated and protected.
-
-## Safe Read Paths
-
-- `README.md`
-- `AGENTS.md`
-- `docs/`
-
-## Guarded / Risky Paths
-
-- `.github/workflows/`
-- `apps/`
-- `contracts/`
-- `docs/`
-- `infra/`
-- `scripts/`
-
-## Required Checks
-
-- `repo-structure-guard`
-- `docs-relations-guard`
-- `generated-files-guard`
-- `coverage-guard`
-
 ## Common Traps
 
-Do not manually edit `docs/_generated/` files. Ensure new code or docs are linked.
-
-## Open Gaps
-
-Ensure that critical infrastructure changes are added to `audit/impl-registry.yaml`.
-
-## Coding Guidelines
-
-### 1. Allgemeine Arbeitsweise
-
-- Immer echte Dateien bevorzugen: Bevor du Code vorschlägst oder analysierst, musst du nach der realen Datei im Repo suchen und von dort aus arbeiten. Rate nicht frei, wenn die Datei existiert.
-- Keine „stilisierten“ Snippets: Verwende keine verkürzten Schreibweisen wie SECONDS end oder zerstückelte Redirections (devtcpHOSTPORT). Alles, was du zeigst, muss so in einer echten Datei kompilierbar bzw. ausführbar sein.
-- Vollständige Blöcke: Wenn du Funktionen oder Skripte änderst, zeige immer den ganzen betroffenen Block (z.B. komplette Funktion, komplettes Skript), nicht nur einzelne zerhackte Zeilen.
-- Kennzeichnung von Auslassungen: Wenn du Teile weglässt, markiere das explizit mit Kommentaren wie // ... oder # ... ohne die Syntax zu zerstören.
-
-### 2. Regeln für Node-/JS-Snippets (z.B. assert-web-budget.mjs)
-
-- Erfolgsmeldungen nur bei tatsächlichem Erfolg:
-  `console.log('Frontend performance budget matches expected thresholds')` oder ähnliche Erfolgsmeldungen dürfen nur ausgeführt werden, wenn vorher kein Fehler geworfen wurde.
-- Wenn du throw verwendest, achte darauf, dass die Logik so strukturiert ist, dass bei Fehlern kein „Alles ok“ im CI-Log erscheint.
-- Saubere Fehlermeldungen: Keine überflüssigen Zeichen am Ende von Template Strings, z.B. kein abschließendes Komma nach ${actual}.
-- Fehlermeldungen müssen klar, einzeilig und ohne überflüssige Interpunktion sein.
-- Strikte Typprüfungen: Wenn du Performance-Budgets oder Konfigwerte prüfst, nutze Muster wie:
-
-```javascript
-if (typeof actual !== 'number' || Number.isNaN(actual)) {
-  throw new Error(`Performance budget value ${key} must be a number`)
-}
-```
-
-- Vergleiche erwartete und tatsächliche Werte explizit und wirf Fehler mit verständlicher Botschaft:
-
-```javascript
-if (actual !== expectedValue) {
-  throw new Error(
-    `Performance budget key ${key} expected ${expectedValue} but found ${actual}`
-  )
-}
-```
-
-### 3. Regeln für Shell-Skripte (z.B. db-wait.sh)
-
-- POSIX- oder Bash-Syntax niemals „optisch vereinfachen“.
-- [ und ] brauchen immer Leerzeichen:
-
-```bash
-while [ "$SECONDS" -lt "$end" ]; do
-```
-
-- Redirections brauchen echte Pfade und Slashes:
-
-```bash
-echo >"/dev/tcp/$HOST/$PORT" 2>/dev/null
-```
-
-- Keine pseudo-kompakten, zusammengeklebten Tokens (z.B. SECONDS end, devtcpHOSTPORT, devnull).
-- Variablen und Defaults: Verwende klare Standardwerte mit ${VAR:-default} und weise sie oben zu, z.B.:
-
-```bash
-HOST=${PGHOST:-localhost}
-PORT=${PGPORT:-5432}
-TIMEOUT=${DB_WAIT_TIMEOUT:-60}
-INTERVAL=${DB_WAIT_INTERVAL:-2}
-```
-
-- Zeit-Logik korrekt schreiben. Integer-Deklaration sauber:
-
-```bash
-declare -i end=$SECONDS+$TIMEOUT
-```
-
-- Timeout-Schleife:
-
-```bash
-while [ "$SECONDS" -lt "$end" ]; do
-  if echo >"/dev/tcp/$HOST/$PORT" 2>/dev/null; then
-    printf 'Postgres is available at %s:%s\n' "$HOST" "$PORT"
-    exit 0
-  fi
-  sleep "$INTERVAL"
-done
-
-printf 'Timed out waiting for Postgres at %s:%s after %s seconds\n' \
-  "$HOST" "$PORT" "$TIMEOUT" >&2
-exit 1
-```
-
-- Kein Pseudocode in echten Skripten: Wenn du ein Snippet als Beispiel zeigst, das nicht 1:1 lauffähig ist, musst du das ausdrücklich als Pseudocode markieren. In echten Dateien darfst du nur ausführbaren Code vorschlagen.
-
-### 4. Verhalten bei Unsicherheit
-
-- Wenn du dir bei einer Datei, Syntax oder Semantik nicht sicher bist, sage das explizit und schlage eine mögliche Variante vor.
-- Bitte darum, den realen Build- oder Lint-Fehler zu posten, statt so zu tun, als wäre alles sicher.
-- Bevor du Änderungen an CI-relevanten Skripten vorschlägst (Node, Bash, YAML), simuliere gedanklich mindestens:
-  - Läuft das Skript von set -e / errexit umgeben sauber durch?
-  - Sind alle Erfolgsmeldungen wirklich nur im Erfolgsfall sichtbar?
-
-### 5. Zielbild
-
-- Code-Vorschläge aus dieser Umgebung sollen direkt lauffähig, syntaktisch korrekt und CI-tauglich sein – ohne händische Nachkorrekturen von offensichtlichen Tipp- und Syntaxfehlern.
-
-### 6. Frontend Numeric Validation
-
-When mapping numeric data to frontend visual properties or coordinates, first reject non-finite values with `typeof value === 'number' && Number.isFinite(value)` so `NaN` and `Infinity` cannot reach WebGL/rendering code. Then apply domain-specific bounds before rendering or map movement, for example latitude/longitude ranges for coordinates, `0..1` for opacity, and non-negative bounded values for weights, widths, radii, or sizes.
+- Do not manually edit `docs/_generated/`.
+- Do not treat Compatibility Projections as a second authority.
+- Do not treat readiness `plan` pass as write/publish/deploy readiness.
+- Critical infrastructure changes belong in `audit/impl-registry.yaml`.

--- a/Justfile
+++ b/Justfile
@@ -60,14 +60,21 @@ test:      # run tests (PostgreSQL-backed tests are skipped; see note below)
 	@echo "note: DB-backed tests (#[ignore]) were skipped — they need a live PostgreSQL."
 	@echo "      CI runs them with --include-ignored (.github/workflows/api.yml)."
 
-check:     # quick hygiene check
-	just fmt
+# Write-free hygiene check. Formatting that mutates sources is `just fmt`.
+# This recipe must not invoke formatters or generators in write mode.
+check:     # quick hygiene check (no writes)
+	cargo fmt --all -- --check
 	just clippy
 	just test
 	just check-demo-data
 	just contracts-domain-check
 	just contracts-search-check
+	just agent-contract-check
 	cargo deny check
+
+# Validate the canonical repository agent contract (strict JSON + projection parity).
+agent-contract-check:
+	python3 -m scripts.agent.validate_repo_agent_contract
 
 # ---------- Compose ----------
 up:        # dev stack up (dev profile)
@@ -158,10 +165,10 @@ smoke-account-create:
 
 # ---------- Contracts ----------
 contracts-domain-check:
-	./scripts/contracts-domain-check.sh
+	./scripts/contracts-domain-check.sh --check
 
 contracts-search-check:
 	python3 -m scripts.search.validate_relevance_goldset
 
 check-demo-data:
-	pnpm exec tsx scripts/verify-demo-data.ts
+	pnpm exec tsx scripts/verify-demo-data.ts --dry-run

--- a/README.md
+++ b/README.md
@@ -49,19 +49,20 @@ aktualisiert und sind keine eigenständige Wahrheits- oder Entscheidungsschicht.
 | Welche Dokumente und Wissensbereiche existieren? | [`docs/index.md`](docs/index.md) |
 | Wie wird deployt? | [`docs/deploy/README.md`](docs/deploy/README.md) |
 | Welche Begriffe gelten fachlich? | [`docs/domain/vocabulary.md`](docs/domain/vocabulary.md) |
-| Welche Quellen haben Vorrang? | [`repo.meta.yaml`](repo.meta.yaml) |
+| Welche Quellen haben Vorrang? | [`repo.meta.yaml`](repo.meta.yaml), Agent-Norm: [`agent-contract.json`](agent-contract.json) |
 
 ## Für Agents
 
 Vor Änderungen gilt diese Leseordnung:
 
-1. [`repo.meta.yaml`](repo.meta.yaml)
-2. [`AGENTS.md`](AGENTS.md)
-3. [`agent-policy.yaml`](agent-policy.yaml)
-4. [`docs/policies/agent-reading-protocol.md`](docs/policies/agent-reading-protocol.md)
-5. [`docs/index.md`](docs/index.md) als Navigation, nicht als Wahrheitsquelle
-6. die betroffenen Contracts, Migrationen, Runtime-Konfigurationen und Tests
-7. erst danach Planungsdokumente und historische Berichte
+1. [`agent-contract.json`](agent-contract.json)
+2. [`repo.meta.yaml`](repo.meta.yaml)
+3. [`AGENTS.md`](AGENTS.md)
+4. [`agent-policy.yaml`](agent-policy.yaml)
+5. [`docs/policies/agent-reading-protocol.md`](docs/policies/agent-reading-protocol.md)
+6. [`docs/index.md`](docs/index.md) als Navigation, nicht als Wahrheitsquelle
+7. die betroffenen Contracts, Migrationen, Runtime-Konfigurationen und Tests
+8. erst danach Planungsdokumente und historische Berichte
 
 Bei einem Widerspruch zwischen Statusdokument und ausführbarem Vertrag wird
 nicht interpoliert. Der Widerspruch wird benannt und aufgelöst.

--- a/agent-contract.json
+++ b/agent-contract.json
@@ -25,6 +25,8 @@
   ],
   "guarded_write_paths": [
     ".github/workflows/",
+    ".wgx/generated-artifacts.yml",
+    "agent-contract.json",
     "apps/",
     "contracts/",
     "docs/",
@@ -79,7 +81,10 @@
   "generated_artifacts": {
     "direct_agent_edit": "forbidden",
     "derived_write_authority": "trusted_generators_only",
-    "trusted_generator_registry": ".wgx/generated-artifacts.yml"
+    "trusted_generator_registry": ".wgx/generated-artifacts.yml",
+    "allowed_target_prefixes": [
+      "docs/_generated/"
+    ]
   },
   "compatibility_projections": [
     {

--- a/agent-contract.json
+++ b/agent-contract.json
@@ -1,0 +1,107 @@
+{
+  "schema_version": "1",
+  "contract_id": "weltgewebe.repo.agent-contract",
+  "architecture": {
+    "repo_role": "repo_contract_authority",
+    "operator_role": "external_operator_execution",
+    "operator_name": "grabowski",
+    "repo_generic_write_mode": "rejected"
+  },
+  "reading_order": [
+    "agent-contract.json",
+    "repo.meta.yaml",
+    "AGENTS.md",
+    "agent-policy.yaml",
+    "docs/policies/agent-reading-protocol.md"
+  ],
+  "safe_read_paths": [
+    "agent-contract.json",
+    "repo.meta.yaml",
+    "AGENTS.md",
+    "agent-policy.yaml",
+    "docs/policies/agent-reading-protocol.md",
+    "README.md",
+    "docs/"
+  ],
+  "guarded_write_paths": [
+    ".github/workflows/",
+    "apps/",
+    "contracts/",
+    "docs/",
+    "infra/",
+    "platform/",
+    "scripts/"
+  ],
+  "forbidden_write_paths": [
+    "docs/_generated/",
+    "secrets/",
+    "snapshots/"
+  ],
+  "required_checks": [
+    "repo-structure-guard",
+    "docs-relations-guard",
+    "generated-files-guard",
+    "coverage-guard"
+  ],
+  "local_checks_before_patch": [
+    "repo-structure-guard",
+    "docs-relations-guard",
+    "generated-files-guard",
+    "coverage-guard",
+    "lint",
+    "test"
+  ],
+  "validation_profiles": {
+    "agent_contract": {
+      "description": "Validate the canonical repository agent contract and its schema-bound fixtures.",
+      "named_checks": [
+        "repo-agent-contract",
+        "agent-contracts"
+      ]
+    },
+    "agent_safety": {
+      "description": "Existing agent-safety preflight, handoff, dry-run, and readiness checks.",
+      "named_checks": [
+        "agent-safety-preflight",
+        "agent-readiness-check"
+      ]
+    },
+    "docs_guards": {
+      "description": "Repository structure and documentation guard profile.",
+      "named_checks": [
+        "repo-structure-guard",
+        "docs-relations-guard",
+        "generated-files-guard",
+        "coverage-guard"
+      ]
+    }
+  },
+  "generated_artifacts": {
+    "direct_agent_edit": "forbidden",
+    "derived_write_authority": "trusted_generators_only",
+    "trusted_generator_registry": ".wgx/generated-artifacts.yml"
+  },
+  "compatibility_projections": [
+    {
+      "path": "repo.meta.yaml",
+      "role": "compatibility_projection",
+      "projected_fields": {
+        "safe_read_paths": "safe_read_paths",
+        "guarded_write_paths": "guarded_write_paths",
+        "forbidden_write_paths": "forbidden_write_paths",
+        "required_checks": "required_checks"
+      }
+    },
+    {
+      "path": "agent-policy.yaml",
+      "role": "compatibility_projection",
+      "projected_fields": {
+        "safe_read_paths": "safe_read_paths",
+        "guarded_write_paths": "guarded_write_paths",
+        "forbidden_write_paths": "forbidden_write_paths",
+        "local_checks_before_patch": "required_checks_before_patch"
+      }
+    }
+  ],
+  "format_rationale": "Strict JSON is canonical; PyYAML with duplicate-key rejection is used only to read existing compatibility and generator registries; no YAML mini-parser and no second authority."
+}

--- a/agent-policy.yaml
+++ b/agent-policy.yaml
@@ -13,6 +13,8 @@ safe_read_paths:
 
 guarded_write_paths:
   - .github/workflows/
+  - .wgx/generated-artifacts.yml
+  - agent-contract.json
   - apps/
   - contracts/
   - docs/

--- a/agent-policy.yaml
+++ b/agent-policy.yaml
@@ -1,7 +1,14 @@
 ---
+# Compatibility Projection of agent-contract.json.
+# Not an independent authority. Projected path/check fields must stay in exact
+# parity with the canonical machine norm; drift fails repo-agent-contract checks.
 safe_read_paths:
-  - README.md
+  - agent-contract.json
+  - repo.meta.yaml
   - AGENTS.md
+  - agent-policy.yaml
+  - docs/policies/agent-reading-protocol.md
+  - README.md
   - docs/
 
 guarded_write_paths:
@@ -10,8 +17,8 @@ guarded_write_paths:
   - contracts/
   - docs/
   - infra/
+  - platform/
   - scripts/
-  - src/
 
 forbidden_write_paths:
   - docs/_generated/
@@ -23,7 +30,6 @@ requires_target_proof_for:
   - apps/
   - deployment/
   - infra/
-  - src/
 
 required_checks_before_patch:
   - repo-structure-guard

--- a/contracts/agent/agent-contract.schema.json
+++ b/contracts/agent/agent-contract.schema.json
@@ -1,0 +1,249 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://weltgewebe.org/schemas/agent/agent-contract.schema.json",
+  "title": "Repository Agent Contract",
+  "description": "Canonical machine-readable repository agent norm for Weltgewebe. Strict JSON only; YAML projections are non-authoritative mirrors.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "contract_id",
+    "architecture",
+    "reading_order",
+    "safe_read_paths",
+    "guarded_write_paths",
+    "forbidden_write_paths",
+    "required_checks",
+    "local_checks_before_patch",
+    "validation_profiles",
+    "generated_artifacts",
+    "compatibility_projections",
+    "format_rationale"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": ["1"]
+    },
+    "contract_id": {
+      "type": "string",
+      "enum": ["weltgewebe.repo.agent-contract"]
+    },
+    "architecture": {
+      "$ref": "#/definitions/architecture"
+    },
+    "reading_order": {
+      "type": "array",
+      "minItems": 4,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "pattern": "\\S"
+      }
+    },
+    "safe_read_paths": {
+      "$ref": "#/definitions/pathList"
+    },
+    "guarded_write_paths": {
+      "$ref": "#/definitions/pathList"
+    },
+    "forbidden_write_paths": {
+      "$ref": "#/definitions/pathList"
+    },
+    "required_checks": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "pattern": "\\S"
+      }
+    },
+    "local_checks_before_patch": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "pattern": "\\S"
+      }
+    },
+    "validation_profiles": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "agent_contract",
+        "agent_safety",
+        "docs_guards"
+      ],
+      "properties": {
+        "agent_contract": {
+          "$ref": "#/definitions/validationProfile"
+        },
+        "agent_safety": {
+          "$ref": "#/definitions/validationProfile"
+        },
+        "docs_guards": {
+          "$ref": "#/definitions/validationProfile"
+        }
+      }
+    },
+    "generated_artifacts": {
+      "$ref": "#/definitions/generatedArtifacts"
+    },
+    "compatibility_projections": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/definitions/compatibilityProjection"
+      }
+    },
+    "format_rationale": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "\\S"
+    }
+  },
+  "definitions": {
+    "pathList": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "pattern": "\\S"
+      }
+    },
+    "architecture": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repo_role",
+        "operator_role",
+        "operator_name",
+        "repo_generic_write_mode"
+      ],
+      "properties": {
+        "repo_role": {
+          "type": "string",
+          "enum": ["repo_contract_authority"]
+        },
+        "operator_role": {
+          "type": "string",
+          "enum": ["external_operator_execution"]
+        },
+        "operator_name": {
+          "type": "string",
+          "enum": ["grabowski"]
+        },
+        "repo_generic_write_mode": {
+          "type": "string",
+          "enum": ["rejected"]
+        }
+      }
+    },
+    "validationProfile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["description", "named_checks"],
+      "properties": {
+        "description": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "\\S"
+        },
+        "named_checks": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S"
+          }
+        }
+      }
+    },
+    "generatedArtifacts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "direct_agent_edit",
+        "derived_write_authority",
+        "trusted_generator_registry"
+      ],
+      "properties": {
+        "direct_agent_edit": {
+          "type": "string",
+          "enum": ["forbidden"]
+        },
+        "derived_write_authority": {
+          "type": "string",
+          "enum": ["trusted_generators_only"]
+        },
+        "trusted_generator_registry": {
+          "type": "string",
+          "enum": [".wgx/generated-artifacts.yml"]
+        }
+      }
+    },
+
+    "compatibilityProjection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "role", "projected_fields"],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "\\S"
+        },
+        "role": {
+          "type": "string",
+          "enum": ["compatibility_projection"]
+        },
+        "projected_fields": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "safe_read_paths",
+            "guarded_write_paths",
+            "forbidden_write_paths"
+          ],
+          "properties": {
+            "safe_read_paths": {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "\\S"
+            },
+            "guarded_write_paths": {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "\\S"
+            },
+            "forbidden_write_paths": {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "\\S"
+            },
+            "required_checks": {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "\\S"
+            },
+            "local_checks_before_patch": {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "\\S"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/contracts/agent/agent-contract.schema.json
+++ b/contracts/agent/agent-contract.schema.json
@@ -34,7 +34,7 @@
     },
     "reading_order": {
       "type": "array",
-      "minItems": 4,
+      "minItems": 5,
       "uniqueItems": true,
       "items": {
         "type": "string",
@@ -175,7 +175,8 @@
       "required": [
         "direct_agent_edit",
         "derived_write_authority",
-        "trusted_generator_registry"
+        "trusted_generator_registry",
+        "allowed_target_prefixes"
       ],
       "properties": {
         "direct_agent_edit": {
@@ -189,6 +190,16 @@
         "trusted_generator_registry": {
           "type": "string",
           "enum": [".wgx/generated-artifacts.yml"]
+        },
+        "allowed_target_prefixes": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": ["docs/_generated/"]
+          }
         }
       }
     },

--- a/docs/_generated/agent-readiness.md
+++ b/docs/_generated/agent-readiness.md
@@ -12,21 +12,29 @@ Generated automatically. Do not edit.
 
 ## Overall Status
 
-- **Overall:** pass
-- **Reason:** All capabilities declared in the readiness matrix passed their configured checks.
+- **Overall:** plan_ready
+- **Reason:** Repository logic supports planning and validation. Execution relies on external operator.
 
 ## Capability Matrix
 
-| Capability | Status | Hard | Evidence | Missing | Rationale |
-|---|---|---:|---|---|---|
-| agent_policy | pass | no | `AGENTS.md`, `agent-policy.yaml` | - | Agenten brauchen dokumentierte Grenzen und Schreibregeln. |
-| safety_preflight | pass | no | `scripts/agent/check_agent_preflight.py`, `scripts/agent/tests/test_check_agent_preflight.py`, `.github/workflows/agent-safety-preflight.yml`, `docs/security/agent-write-scope-baseline.md` | - | Report-only Preflight schafft belastbare Baseline vor Blocking. |
-| claim_evidence_spine | pass | yes | `docs/claims/registry.yml`, `scripts/docmeta/validate_claim_registry.py` | - | Ohne Claim-Registry und Validator fehlt maschinenlesbare Evidenzbindung. |
-| agent_contracts | pass | yes | `contracts/agent/task.schema.json` | - | Contracts definieren maschinenlesbare Agent-Task-Grenzen. |
-| handoff_validation | pass | yes | See Handoff Evidence | - | Handoff-Checks begrenzen unvollstaendige oder unsichere Uebergaben. Required files and the canonical CLI smoke both pass. |
-| non_ideal_guard | pass | yes | `scripts/agent/check_non_ideal_task.py`, `scripts/agent/tests/test_check_non_ideal_task.py` | - | Non-Ideal-Guard erkennt riskante Ausnahmefaelle vor Ausfuehrung. |
-| dry_run_runner | pass | yes | `scripts/agent/run_task.py`, `scripts/agent/tests/test_run_task.py`, `tests/fixtures/agent/valid-doc-drift-task.json` | - | Dry-Run Runner prueft Agentenpfade ohne schreibende Seiteneffekte. Required files and the canonical dry-run smoke both pass. |
-| run_evidence_lite | pass | yes | `contracts/agent/validation.schema.json`, `contracts/agent/run-result.schema.json`, `scripts/agent/json_contract.py`, `scripts/agent/run_task.py`, `scripts/agent/tests/test_json_contract.py`, `scripts/agent/tests/test_run_task.py`, `scripts/agent/validate_agent_contracts.py`, `scripts/contracts-agent-check.sh`, `docs/reference/agent-run-evidence-lite.md`, `tests/fixtures/agent/validation-valid.json`, `tests/fixtures/agent/run-result-valid.json`, `tests/fixtures/agent/valid-doc-drift-task.json` | - | Erfolgreiche geplante Dry-Runs muessen ein schema-valides, task- und revisionsgebundenes Evidenzbuendel atomar publizieren. Required files and the functional persistence smoke both pass. |
+| Dimension | Capability | Status | Hard | Evidence | Missing | Rationale |
+|---|---|---|---:|---|---|---|
+| discover | discover | pass | yes | `agent-contract.json`, `contracts/agent/agent-contract.schema.json`, `AGENTS.md`, `scripts/agent/validate_repo_agent_contract.py`, `scripts/docmeta/agent_entrypoint_smoke.py` | - | The repository must expose a deterministic machine contract, entry card, validator, and entrypoint smoke before planning. |
+| understand | agent_policy | pass | no | `AGENTS.md`, `agent-policy.yaml` | - | Agenten brauchen dokumentierte Grenzen und Schreibregeln. |
+| understand | agent_contracts | pass | yes | `contracts/agent/task.schema.json` | - | Contracts definieren maschinenlesbare Agent-Task-Grenzen. |
+| plan | dry_run_runner | pass | yes | `scripts/agent/run_task.py`, `scripts/agent/tests/test_run_task.py`, `tests/fixtures/agent/valid-doc-drift-task.json` | - | Dry-Run Runner prueft Agentenpfade ohne schreibende Seiteneffekte. Required files and the canonical dry-run smoke both pass. |
+| workspace | workspace | open | no | - | `external_operator_execution` | Capability resides with the external operator (Grabowski). |
+| write | write | open | no | - | `external_operator_execution` | Capability resides with the external operator (Grabowski). |
+| validate | safety_preflight | pass | no | `scripts/agent/check_agent_preflight.py`, `scripts/agent/tests/test_check_agent_preflight.py`, `.github/workflows/agent-safety-preflight.yml`, `docs/security/agent-write-scope-baseline.md` | - | Report-only Preflight schafft belastbare Baseline vor Blocking. |
+| validate | claim_evidence_spine | pass | yes | `docs/claims/registry.yml`, `scripts/docmeta/validate_claim_registry.py` | - | Ohne Claim-Registry und Validator fehlt maschinenlesbare Evidenzbindung. |
+| validate | handoff_validation | pass | yes | See Handoff Evidence | - | Handoff-Checks begrenzen unvollstaendige oder unsichere Uebergaben. Required files and the canonical CLI smoke both pass. |
+| validate | non_ideal_guard | pass | yes | `scripts/agent/check_non_ideal_task.py`, `scripts/agent/tests/test_check_non_ideal_task.py` | - | Non-Ideal-Guard erkennt riskante Ausnahmefaelle vor Ausfuehrung. |
+| validate | run_evidence_lite | pass | yes | `contracts/agent/validation.schema.json`, `contracts/agent/run-result.schema.json`, `scripts/agent/json_contract.py`, `scripts/agent/run_task.py`, `scripts/agent/tests/test_json_contract.py`, `scripts/agent/tests/test_run_task.py`, `scripts/agent/validate_agent_contracts.py`, `scripts/contracts-agent-check.sh`, `docs/reference/agent-run-evidence-lite.md`, `tests/fixtures/agent/validation-valid.json`, `tests/fixtures/agent/run-result-valid.json`, `tests/fixtures/agent/valid-doc-drift-task.json` | - | Erfolgreiche geplante Dry-Runs muessen ein schema-valides, task- und revisionsgebundenes Evidenzbuendel atomar publizieren. Required files and the functional persistence smoke both pass. |
+| review | review | open | no | - | `external_operator_execution` | Capability resides with the external operator (Grabowski). |
+| publish | publish | open | no | - | `external_operator_execution` | Capability resides with the external operator (Grabowski). |
+| deploy | deploy | open | no | - | `external_operator_execution` | Capability resides with the external operator (Grabowski). |
+| cleanup | cleanup | open | no | - | `external_operator_execution` | Capability resides with the external operator (Grabowski). |
+| recovery | recovery | open | no | - | `external_operator_execution` | Capability resides with the external operator (Grabowski). |
 
 ## Handoff Evidence
 
@@ -44,7 +52,17 @@ Generated automatically. Do not edit.
 
 ## Residual Gaps
 
-- No residual hard gaps detected.
+- No residual hard repository gaps detected.
+
+## External Operator Dependencies
+
+- `workspace` / `workspace`: provided by the external operator (Grabowski), not by this repository.
+- `write` / `write`: provided by the external operator (Grabowski), not by this repository.
+- `review` / `review`: provided by the external operator (Grabowski), not by this repository.
+- `publish` / `publish`: provided by the external operator (Grabowski), not by this repository.
+- `deploy` / `deploy`: provided by the external operator (Grabowski), not by this repository.
+- `cleanup` / `cleanup`: provided by the external operator (Grabowski), not by this repository.
+- `recovery` / `recovery`: provided by the external operator (Grabowski), not by this repository.
 
 ## Interpretation Rule
 

--- a/docs/_generated/agent-readiness.md
+++ b/docs/_generated/agent-readiness.md
@@ -19,7 +19,7 @@ Generated automatically. Do not edit.
 
 | Dimension | Capability | Status | Hard | Evidence | Missing | Rationale |
 |---|---|---|---:|---|---|---|
-| discover | discover | pass | yes | `agent-contract.json`, `contracts/agent/agent-contract.schema.json`, `AGENTS.md`, `scripts/agent/validate_repo_agent_contract.py`, `scripts/docmeta/agent_entrypoint_smoke.py` | - | The repository must expose a deterministic machine contract, entry card, validator, and entrypoint smoke before planning. |
+| discover | discover | pass | yes | `agent-contract.json`, `contracts/agent/agent-contract.schema.json`, `AGENTS.md`, `scripts/agent/validate_repo_agent_contract.py`, `scripts/docmeta/agent_entrypoint_smoke.py` | - | The repository must expose a deterministic machine contract, entry card, validator, and entrypoint smoke before planning. The canonical contract validator and entrypoint smoke both pass. |
 | understand | agent_policy | pass | no | `AGENTS.md`, `agent-policy.yaml` | - | Agenten brauchen dokumentierte Grenzen und Schreibregeln. |
 | understand | agent_contracts | pass | yes | `contracts/agent/task.schema.json` | - | Contracts definieren maschinenlesbare Agent-Task-Grenzen. |
 | plan | dry_run_runner | pass | yes | `scripts/agent/run_task.py`, `scripts/agent/tests/test_run_task.py`, `tests/fixtures/agent/valid-doc-drift-task.json` | - | Dry-Run Runner prueft Agentenpfade ohne schreibende Seiteneffekte. Required files and the canonical dry-run smoke both pass. |

--- a/docs/blueprints/blueprint-agent-safety-control-layer.md
+++ b/docs/blueprints/blueprint-agent-safety-control-layer.md
@@ -744,6 +744,8 @@ Der Übergang zur neuen Trennung von Repo-Validation und Extern-Execution erford
 ##### PR 10 — Migration: Akzeptanzkriterien
 
 - Der Agent-Contract definiert explizit `repo_role: repo_contract_authority` und `operator_role: external_operator_execution`.
+- Autoritätsdateien (`agent-contract.json`, `.wgx/generated-artifacts.yml`) sind ausdrücklich bewachte Schreibziele.
+- Trusted Generators dürfen ausschließlich Ziele unter `generated_artifacts.allowed_target_prefixes` erzeugen; `secrets/` und `snapshots/` sind ausgeschlossen.
 - `repo_generic_write_mode: rejected` ist manifestiert.
 - Freie Shell-Kommandos sind als deprecated / Übergangsformat dokumentiert.
 - Paralleler Betrieb ist durch Checks (z.B. Projection Drift) abgesichert.

--- a/docs/blueprints/blueprint-agent-safety-control-layer.md
+++ b/docs/blueprints/blueprint-agent-safety-control-layer.md
@@ -717,54 +717,41 @@ Gefährliche Statuslügen werden blockiert.
 - Blueprint `active` ohne verified Claim-Gruppe scheitert.
 - Modus startet warn, wird später blocking.
 
-### Welle 6 — Gated Write Mode
+### Welle 6 — External Operator Execution (Migration & Delegation)
 
-#### PR 10 — agent/write-mode-opt-in
+Der ursprünglich geplante generische repo-eigene `--write`-Runner wird **verworfen**.
 
-##### PR 10 — agent/write-mode-opt-in: Zweck
+**Architekturentscheidung:**
+- **Das Repository** besitzt Contract, Validator und Prüfprofile (Validation-Profiles). Es entscheidet, *was* erlaubt ist und *wie* es geprüft wird.
+- **Grabowski** (oder ein kompatibler externer Operator) besitzt Workspace, Lease, Mutation, Review, Veröffentlichung, Recovery und Cleanup.
 
-Echte Agent-Writes werden möglich, aber nur streng begrenzt.
+Das Repository ist nicht der ausführende Agent, sondern die normative Definitions- und Validierungsschicht.
 
-##### PR 10 — agent/write-mode-opt-in: Voraussetzungen
+#### PR 10 — Migration zu External Operator Execution
 
-- Safety Preflight pass
-- Readiness hard fail aktiv
-- Minimal Claim Spine pass
-- Impl Registry Critical pass
-- Minimal Contracts + Guard pass
-- Dry-Run Runner pass
-- Run Evidence Lite pass
+##### Phasenweiser Migrationsplan
 
-##### PR 10 — agent/write-mode-opt-in: Befehl
+Der Übergang zur neuen Trennung von Repo-Validation und Extern-Execution erfordert einen strikten, phasenweisen Migrationsplan. Nichts darf gelöscht werden, bevor Consumer und Tests migriert sind.
 
-```bash
-python scripts/agent/run_task.py --write tasks/WG-TASK-....yml
-```
+1. **Paralleler Betrieb:** Der neue `agent-contract.json` Validator (`validate_repo_agent_contract.py`) und der bestehende Preflight laufen doppelt in CI (`agent-safety-preflight.yml`).
+2. **YAML-Projektionen:** Die alten `agent-policy.yaml` und `repo.meta.yaml` werden als "Compatibility Projections" geführt. Der Contract-Validator prüft auf Drift.
+3. **Ausführungsprofile:** Freie task-gesteuerte Shell-Kommandos (`validation_commands`) sind nur ein Übergangsformat. Sie besitzen künftig keine Ausführungsautorität mehr. Zukünftige Ausführungen müssen benannte, geprüfte Profile (`validation_profiles`) aus dem Contract nutzen.
+4. **Rückbaukriterien:**
+   - Der doppelte Preflight darf erst zurückgebaut werden, wenn alle Consumer auf den Strict-JSON Contract und die Profil-Validierung umgestellt haben und alle Paritätstests (`validate_projection_parity`) dauerhaft grün bleiben.
+   - Der YAML-Minimalparser und manuelle Taskprojektionen werden erst entfernt, wenn Grabowski/Operator nachweislich den JSON-Contract nativ nutzt.
 
-##### PR 10 — agent/write-mode-opt-in: Einschränkungen
+##### PR 10 — Migration: Akzeptanzkriterien
 
-- nur `allowed_paths`
-- kein `docs/_generated` direkt
-- kein delete ohne `delete_allowed`
-- kein workflow ohne `task_type=ci_change`
-- kein infra ohne `task_type=infra_change` und `proof_ref`
-- kein roadmap done ohne `claim.status=verified`
+- Der Agent-Contract definiert explizit `repo_role: repo_contract_authority` und `operator_role: external_operator_execution`.
+- `repo_generic_write_mode: rejected` ist manifestiert.
+- Freie Shell-Kommandos sind als deprecated / Übergangsformat dokumentiert.
+- Paralleler Betrieb ist durch Checks (z.B. Projection Drift) abgesichert.
 
-##### PR 10 — agent/write-mode-opt-in: Akzeptanzkriterien
+#### PR 11 — run-evidence-full (Operator-Driven)
 
-- Ein kleiner Doku-Code-Drift-Fix läuft end-to-end.
-- Patch wird erzeugt.
-- Validation läuft.
-- Run-Artefakt wird erzeugt.
-- Status bleibt partial, bis CI/Claim-Evidence grün ist.
+Vollständige Observability wird vom externen Operator getrieben.
 
-#### PR 11 — agent/run-evidence-full
-
-##### PR 11 — agent/run-evidence-full: Zweck
-
-Vollständige Agent-Observability.
-
-##### PR 11 — agent/run-evidence-full: Artefakte
+##### Artefakte
 
 ```text
 artifacts/agent-runs/<run-id>/
@@ -777,26 +764,7 @@ artifacts/agent-runs/<run-id>/
   run-result.json
 ```
 
-##### PR 11 — agent/run-evidence-full: Regel
-
-Agent darf:
-
-```yaml
-decision: pass_proposed
-```
-
-Agent darf nicht:
-
-```yaml
-repo-status: done
-```
-
-##### PR 11 — agent/run-evidence-full: Akzeptanzkriterien
-
-- Dry-Run und Write-Run erzeugen vollständige, schema-valide Evidence.
-- `decision.yml` verweist auf Claims, Validation und Residual Gaps.
-- `changed-files.txt` stimmt mit tatsächlichem Diff überein.
-- Evidence kann von Claim-Checks gelesen werden.
+Der externe Operator schreibt die Artefakte und nutzt die repo-eigenen Profil-Validatoren, um den Handoff-Status auf `pass_proposed` zu setzen.
 
 ### Welle 7 — Skalierung
 

--- a/docs/blueprints/blueprint-agent-safety-control-layer.md
+++ b/docs/blueprints/blueprint-agent-safety-control-layer.md
@@ -722,6 +722,7 @@ Gefährliche Statuslügen werden blockiert.
 Der ursprünglich geplante generische repo-eigene `--write`-Runner wird **verworfen**.
 
 **Architekturentscheidung:**
+
 - **Das Repository** besitzt Contract, Validator und Prüfprofile (Validation-Profiles). Es entscheidet, *was* erlaubt ist und *wie* es geprüft wird.
 - **Grabowski** (oder ein kompatibler externer Operator) besitzt Workspace, Lease, Mutation, Review, Veröffentlichung, Recovery und Cleanup.
 

--- a/docs/policies/agent-reading-protocol.md
+++ b/docs/policies/agent-reading-protocol.md
@@ -41,12 +41,13 @@ Ziel:
 
 Agenten MÜSSEN in dieser Reihenfolge lesen:
 
-1. `repo.meta.yaml`
-2. `AGENTS.md`
-3. `agent-policy.yaml`
-4. die in `manifest/repo-index.yaml` registrierten kanonischen Dokumente sowie einschlägige Contracts und ADRs
-5. `docs/index.md` (nur Navigation)
-6. `docs/_generated/*` (nur Diagnose)
+1. `agent-contract.json` (kanonische maschinenlesbare Agent-Norm)
+2. `repo.meta.yaml` (Repo-Truth-Model; Pfad-/Check-Felder sind Compatibility Projection)
+3. `AGENTS.md` (progressive menschliche Eintrittskarte)
+4. `agent-policy.yaml` (Compatibility Projection der Schreibgrenzen)
+5. die in `manifest/repo-index.yaml` registrierten kanonischen Dokumente sowie einschlägige Contracts und ADRs
+6. `docs/index.md` (nur Navigation)
+7. `docs/_generated/*` (nur Diagnose; direkte Agent-Edits verboten)
 
 ---
 
@@ -75,6 +76,8 @@ Artefakte unter `docs/_generated/*`:
 - spiegeln Zustand
 - zeigen Drift
 - sind NICHT kanonisch
+- dürfen von Agents nicht direkt editiert werden
+- dürfen nur durch in `agent-contract.json` deklarierte trusted generators geschrieben werden
 
 ---
 

--- a/repo.meta.yaml
+++ b/repo.meta.yaml
@@ -94,6 +94,8 @@ safe_read_paths:
 
 guarded_write_paths:
   - .github/workflows/
+  - .wgx/generated-artifacts.yml
+  - agent-contract.json
   - apps/
   - contracts/
   - docs/

--- a/repo.meta.yaml
+++ b/repo.meta.yaml
@@ -31,6 +31,7 @@ cognitive_modules:
     - docs/policies/architecture-critique.md
 
 canonical_sources:
+  - agent-contract.json
   - repo.meta.yaml
   - manifest/repo-index.yaml
   - AGENTS.md
@@ -79,9 +80,16 @@ generated_artifacts:
   - docs/_generated/report-lifecycle.md
   - docs/_generated/report-lifecycle-inventory.md
 
+# Compatibility Projection of agent-contract.json for path/check fields below.
+# Not an independent authority for agent write scope. Exact parity is enforced
+# by scripts/agent/validate_repo_agent_contract.py.
 safe_read_paths:
-  - README.md
+  - agent-contract.json
+  - repo.meta.yaml
   - AGENTS.md
+  - agent-policy.yaml
+  - docs/policies/agent-reading-protocol.md
+  - README.md
   - docs/
 
 guarded_write_paths:
@@ -95,6 +103,8 @@ guarded_write_paths:
 
 forbidden_write_paths:
   - docs/_generated/
+  - secrets/
+  - snapshots/
 
 required_checks:
   - repo-structure-guard
@@ -123,9 +133,12 @@ keywords:
 
 agent_reading:
   protocol: docs/policies/agent-reading-protocol.md
+  machine_norm: agent-contract.json
 
 truth_model:
   # The canonical machine truth is defined in the precedence array below.
+  # Agent path/check authority lives in agent-contract.json; overlapping fields
+  # above are a Compatibility Projection only.
   abort_on_conflict: true
   interpolation_allowed: false
   precedence:
@@ -133,6 +146,7 @@ truth_model:
       paths: ["contracts/domain/*.schema.json"]
     - class: canonical_policies
       paths:
+        - "agent-contract.json"
         - "repo.meta.yaml"
         - "AGENTS.md"
         - "agent-policy.yaml"

--- a/scripts/agent/tests/test_just_check_safety.py
+++ b/scripts/agent/tests/test_just_check_safety.py
@@ -4,18 +4,32 @@ from __future__ import annotations
 
 import re
 import unittest
+from dataclasses import dataclass
 from pathlib import Path
 
 from scripts.docmeta.docmeta import REPO_ROOT
 
 
-JUST_RECIPE = re.compile(r"^([a-z][a-z0-9_-]*):(?:\s+[^#]+)?(?:\s+#.*)?$")
-JUST_CALL = re.compile(r"^just\s+([a-z][a-z0-9_-]*)(?:\s|$)")
-SOFT_FAILURE = re.compile(r"\|\|\s*(?:true\b|:\s*(?:$|;)|echo\b)")
+JUST_RECIPE = re.compile(
+    r"^([a-z][a-z0-9_-]*):(?:\s+([^#]*?))?(?:\s+#.*)?$"
+)
+JUST_CALL = re.compile(r"^@?just\s+([a-z][a-z0-9_-]*)(?:\s|$)")
+SOFT_FAILURE = re.compile(
+    r"(?:\|\|\s*(?:true\b|:\s*(?:$|;)|echo\b|exit\s+0\b))"
+    r"|(?:;\s*(?:true\b|:\s*(?:$|;)|exit\s+0\b))"
+)
+RECIPE_NAME = re.compile(r"^[a-z][a-z0-9_-]*$")
 
 
-def parse_recipes(content: str) -> dict[str, list[str]]:
-    recipes: dict[str, list[str]] = {}
+@dataclass(frozen=True)
+class Recipe:
+    dependencies: list[str]
+    commands: list[str]
+
+
+def parse_recipes(content: str) -> dict[str, Recipe]:
+    dependencies: dict[str, list[str]] = {}
+    commands: dict[str, list[str]] = {}
     current: str | None = None
 
     for raw_line in content.splitlines():
@@ -23,15 +37,43 @@ def parse_recipes(content: str) -> dict[str, list[str]]:
             match = JUST_RECIPE.fullmatch(raw_line)
             current = match.group(1) if match else None
             if current is not None:
-                recipes[current] = []
+                header = (match.group(2) or "").strip()
+                dependencies[current] = [
+                    token
+                    for token in header.split()
+                    if RECIPE_NAME.fullmatch(token)
+                ]
+                commands[current] = []
             continue
         if current is not None and raw_line.startswith(("\t", " ")):
-            recipes[current].append(raw_line.strip())
+            commands[current].append(raw_line.strip())
 
-    return recipes
+    return {
+        name: Recipe(dependencies=dependencies[name], commands=commands[name])
+        for name in commands
+    }
 
 
-def reachable_recipes(recipes: dict[str, list[str]], root: str) -> list[str]:
+def logical_commands(lines: list[str]) -> list[str]:
+    commands: list[str] = []
+    pending = ""
+    for raw_line in lines:
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        if pending:
+            line = f"{pending} {line}"
+        if line.endswith("\\"):
+            pending = line[:-1].rstrip()
+            continue
+        commands.append(line)
+        pending = ""
+    if pending:
+        commands.append(pending)
+    return commands
+
+
+def reachable_recipes(recipes: dict[str, Recipe], root: str) -> list[str]:
     pending = [root]
     visited: list[str] = []
 
@@ -42,8 +84,11 @@ def reachable_recipes(recipes: dict[str, list[str]], root: str) -> list[str]:
         if name not in recipes:
             raise AssertionError(f"Referenced Just recipe is missing: {name}")
         visited.append(name)
-        for line in recipes[name]:
-            command = line.split("#", 1)[0].strip()
+        recipe = recipes[name]
+        for dependency in recipe.dependencies:
+            if dependency not in visited:
+                pending.append(dependency)
+        for command in logical_commands(recipe.commands):
             match = JUST_CALL.match(command)
             if match and match.group(1) not in visited:
                 pending.append(match.group(1))
@@ -52,6 +97,30 @@ def reachable_recipes(recipes: dict[str, list[str]], root: str) -> list[str]:
 
 
 class TestJustCheckSafety(unittest.TestCase):
+    def test_dependency_recipes_are_reachable(self):
+        recipes = parse_recipes(
+            "check: indirect\n\tjust direct\nindirect:\n\tcargo fmt -- --check\n"
+            "direct:\n\tpython3 -m unittest\n"
+        )
+        self.assertEqual(reachable_recipes(recipes, "check"), ["check", "indirect", "direct"])
+
+    def test_logical_commands_join_continuations(self):
+        self.assertEqual(
+            logical_commands(["command || \\", "exit 0"]),
+            ["command || exit 0"],
+        )
+
+    def test_soft_failure_patterns_are_detected(self):
+        for command in (
+            "check || true",
+            "check || echo skipped",
+            "check || exit 0",
+            "check; true",
+            "check; exit 0",
+        ):
+            with self.subTest(command=command):
+                self.assertIsNotNone(SOFT_FAILURE.search(command))
+
     def test_just_check_is_write_free_and_fail_closed(self):
         justfile_path = Path(REPO_ROOT) / "Justfile"
         self.assertTrue(justfile_path.is_file(), "Justfile is missing")
@@ -64,11 +133,7 @@ class TestJustCheckSafety(unittest.TestCase):
 
         has_cargo_fmt_check = False
         for recipe_name in reachable:
-            for raw_line in recipes[recipe_name]:
-                line = raw_line.split("#", 1)[0].strip()
-                if not line:
-                    continue
-
+            for line in logical_commands(recipes[recipe_name].commands):
                 self.assertIsNone(
                     SOFT_FAILURE.search(line),
                     f"{recipe_name} hides a mandatory check failure: {line}",

--- a/scripts/agent/tests/test_just_check_safety.py
+++ b/scripts/agent/tests/test_just_check_safety.py
@@ -1,0 +1,124 @@
+"""Tests for the write-free safety of the `check` recipe in Justfile."""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+from scripts.docmeta.docmeta import REPO_ROOT
+
+
+JUST_RECIPE = re.compile(r"^([a-z][a-z0-9_-]*):(?:\s+[^#]+)?(?:\s+#.*)?$")
+JUST_CALL = re.compile(r"^just\s+([a-z][a-z0-9_-]*)(?:\s|$)")
+SOFT_FAILURE = re.compile(r"\|\|\s*(?:true\b|:\s*(?:$|;)|echo\b)")
+
+
+def parse_recipes(content: str) -> dict[str, list[str]]:
+    recipes: dict[str, list[str]] = {}
+    current: str | None = None
+
+    for raw_line in content.splitlines():
+        if raw_line and not raw_line[0].isspace():
+            match = JUST_RECIPE.fullmatch(raw_line)
+            current = match.group(1) if match else None
+            if current is not None:
+                recipes[current] = []
+            continue
+        if current is not None and raw_line.startswith(("\t", " ")):
+            recipes[current].append(raw_line.strip())
+
+    return recipes
+
+
+def reachable_recipes(recipes: dict[str, list[str]], root: str) -> list[str]:
+    pending = [root]
+    visited: list[str] = []
+
+    while pending:
+        name = pending.pop(0)
+        if name in visited:
+            continue
+        if name not in recipes:
+            raise AssertionError(f"Referenced Just recipe is missing: {name}")
+        visited.append(name)
+        for line in recipes[name]:
+            command = line.split("#", 1)[0].strip()
+            match = JUST_CALL.match(command)
+            if match and match.group(1) not in visited:
+                pending.append(match.group(1))
+
+    return visited
+
+
+class TestJustCheckSafety(unittest.TestCase):
+    def test_just_check_is_write_free_and_fail_closed(self):
+        justfile_path = Path(REPO_ROOT) / "Justfile"
+        self.assertTrue(justfile_path.is_file(), "Justfile is missing")
+
+        recipes = parse_recipes(justfile_path.read_text(encoding="utf-8"))
+        reachable = reachable_recipes(recipes, "check")
+        self.assertIn("check-demo-data", reachable)
+        self.assertIn("contracts-domain-check", reachable)
+        self.assertIn("agent-contract-check", reachable)
+
+        has_cargo_fmt_check = False
+        for recipe_name in reachable:
+            for raw_line in recipes[recipe_name]:
+                line = raw_line.split("#", 1)[0].strip()
+                if not line:
+                    continue
+
+                self.assertIsNone(
+                    SOFT_FAILURE.search(line),
+                    f"{recipe_name} hides a mandatory check failure: {line}",
+                )
+                self.assertNotIn(
+                    "set +e", line, f"{recipe_name} disables fail-closed execution"
+                )
+                self.assertNotIn(
+                    "just fmt", line, "just fmt found in check path (mutates sources)"
+                )
+
+                if "cargo fmt" in line:
+                    self.assertIn(
+                        "--check", line, "cargo fmt without --check found in check path"
+                    )
+                    if "cargo fmt --all -- --check" in line:
+                        has_cargo_fmt_check = True
+
+                self.assertNotIn(
+                    "make generate", line, "make generate found in check path (mutates)"
+                )
+                self.assertNotIn(
+                    "just generate", line, "just generate found in check path (mutates)"
+                )
+
+                if "generate" in line or "generator" in line:
+                    if "python" in line or "bash" in line or "./" in line:
+                        self.assertTrue(
+                            "--check" in line or "--dry-run" in line,
+                            f"generator called in write mode from {recipe_name}: {line}",
+                        )
+
+                if "verify-demo-data.ts" in line:
+                    self.assertIn(
+                        "--dry-run",
+                        line,
+                        "demo-data verification must be explicitly write-free",
+                    )
+                if "contracts-domain-check.sh" in line:
+                    self.assertIn(
+                        "--check",
+                        line,
+                        "domain contract validation must use check mode",
+                    )
+
+        self.assertTrue(
+            has_cargo_fmt_check,
+            "cargo fmt --all -- --check must be present in the check recipe",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/agent/tests/test_validate_repo_agent_contract.py
+++ b/scripts/agent/tests/test_validate_repo_agent_contract.py
@@ -5,7 +5,10 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from scripts.agent.validate_repo_agent_contract import validate_repo_agent_contract
+from scripts.agent.validate_repo_agent_contract import (
+    READING_ORDER_REQUIRED_PREFIX,
+    validate_repo_agent_contract,
+)
 
 VALID_CONTRACT = {
     "architecture": {
@@ -22,7 +25,11 @@ VALID_CONTRACT = {
         "docs/policies/agent-reading-protocol.md",
     ],
     "safe_read_paths": ["src/"],
-    "guarded_write_paths": ["src/"],
+    "guarded_write_paths": [
+        ".wgx/generated-artifacts.yml",
+        "agent-contract.json",
+        "src/",
+    ],
     "forbidden_write_paths": ["docs/_generated/"],
     "required_checks": ["just test"],
     "local_checks_before_patch": ["just check"],
@@ -30,6 +37,7 @@ VALID_CONTRACT = {
         "direct_agent_edit": "forbidden",
         "derived_write_authority": "trusted_generators_only",
         "trusted_generator_registry": ".wgx/generated-artifacts.yml",
+        "allowed_target_prefixes": ["docs/_generated/"],
     },
     "validation_profiles": {"generator_profile": {"named_checks": ["generator check"]}},
     "compatibility_projections": [
@@ -89,6 +97,22 @@ class TestValidateRepoAgentContract(unittest.TestCase):
 
     def write_json(self, rel_path, data):
         self.write_file(rel_path, json.dumps(data))
+
+    def test_repository_schema_requires_full_reading_order(self):
+        repo_root = Path(__file__).resolve().parents[3]
+        schema = json.loads(
+            (repo_root / "contracts/agent/agent-contract.schema.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        self.assertEqual(
+            schema["properties"]["reading_order"]["minItems"],
+            len(READING_ORDER_REQUIRED_PREFIX),
+        )
+
+    def test_repository_contract_and_schema_validate_together(self):
+        repo_root = Path(__file__).resolve().parents[3]
+        self.assertEqual(validate_repo_agent_contract(repo_root), [])
 
     def test_valid_contract(self):
         findings = validate_repo_agent_contract(self.repo_root)
@@ -197,9 +221,56 @@ class TestValidateRepoAgentContract(unittest.TestCase):
         findings = validate_repo_agent_contract(self.repo_root)
         self.assertTrue(
             any(
-                "must stay under a forbidden_write_paths prefix" in f["message"]
+                "must stay under an allowed_target_prefixes prefix" in f["message"]
                 for f in findings
             )
+        )
+
+    def test_generated_secret_target_is_rejected(self):
+        registry = """
+        artifacts:
+          - path: secrets/generated-token.txt
+            kind: generated
+            generator: ["python3", "gen.py"]
+        """
+        self.write_file(".wgx/generated-artifacts.yml", registry)
+        findings = validate_repo_agent_contract(self.repo_root)
+        self.assertTrue(
+            any(
+                f["code"] == "AGENT_CONTRACT_REGISTRY_ERROR"
+                and "allowed_target_prefixes" in f["message"]
+                for f in findings
+            )
+        )
+
+    def test_authority_files_must_be_guarded(self):
+        contract = dict(VALID_CONTRACT)
+        contract["guarded_write_paths"] = ["src/"]
+        self.write_json("agent-contract.json", contract)
+        findings = validate_repo_agent_contract(self.repo_root)
+        self.assertTrue(
+            any(
+                f["code"] == "AGENT_CONTRACT_AUTHORITY_GUARD"
+                and "agent-contract.json" in f["message"]
+                for f in findings
+            )
+        )
+        self.assertTrue(
+            any(
+                f["code"] == "AGENT_CONTRACT_AUTHORITY_GUARD"
+                and ".wgx/generated-artifacts.yml" in f["message"]
+                for f in findings
+            )
+        )
+
+    def test_generated_target_prefixes_are_fixed(self):
+        contract = dict(VALID_CONTRACT)
+        contract["generated_artifacts"] = dict(VALID_CONTRACT["generated_artifacts"])
+        contract["generated_artifacts"]["allowed_target_prefixes"] = ["secrets/"]
+        self.write_json("agent-contract.json", contract)
+        findings = validate_repo_agent_contract(self.repo_root)
+        self.assertTrue(
+            any(f["code"] == "AGENT_CONTRACT_GENERATED_TARGETS" for f in findings)
         )
 
     def test_duplicate_generator_write(self):

--- a/scripts/agent/tests/test_validate_repo_agent_contract.py
+++ b/scripts/agent/tests/test_validate_repo_agent_contract.py
@@ -1,0 +1,342 @@
+"""Tests for scripts.agent.validate_repo_agent_contract."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.agent.validate_repo_agent_contract import validate_repo_agent_contract
+
+VALID_CONTRACT = {
+    "architecture": {
+        "repo_role": "repo_contract_authority",
+        "operator_role": "external_operator_execution",
+        "operator_name": "grabowski",
+        "repo_generic_write_mode": "rejected",
+    },
+    "reading_order": [
+        "agent-contract.json",
+        "repo.meta.yaml",
+        "AGENTS.md",
+        "agent-policy.yaml",
+        "docs/policies/agent-reading-protocol.md",
+    ],
+    "safe_read_paths": ["src/"],
+    "guarded_write_paths": ["src/"],
+    "forbidden_write_paths": ["docs/_generated/"],
+    "required_checks": ["just test"],
+    "local_checks_before_patch": ["just check"],
+    "generated_artifacts": {
+        "direct_agent_edit": "forbidden",
+        "derived_write_authority": "trusted_generators_only",
+        "trusted_generator_registry": ".wgx/generated-artifacts.yml",
+    },
+    "validation_profiles": {"generator_profile": {"named_checks": ["generator check"]}},
+    "compatibility_projections": [
+        {
+            "role": "compatibility_projection",
+            "path": "repo.meta.yaml",
+            "projected_fields": {"safe_read_paths": "read_paths"},
+        },
+        {
+            "role": "compatibility_projection",
+            "path": "agent-policy.yaml",
+            "projected_fields": {"safe_read_paths": "safe_reads"},
+        },
+    ],
+}
+
+VALID_SCHEMA = {"$schema": "http://json-schema.org/draft-07/schema#", "type": "object"}
+
+VALID_REPO_META = """
+# Compatibility Projection
+read_paths:
+  - "src/"
+"""
+
+VALID_AGENT_POLICY = """
+# Compatibility Projection
+safe_reads:
+  - "src/"
+"""
+
+VALID_REGISTRY = """
+schema_version: 1
+artifacts:
+  - path: docs/_generated/output.md
+    kind: generated
+    generator: ["python3", "gen.py"]
+"""
+
+
+class TestValidateRepoAgentContract(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo_root = Path(self.tmp.name)
+        (self.repo_root / "contracts" / "agent").mkdir(parents=True)
+        (self.repo_root / ".wgx").mkdir(parents=True)
+        self.write_json("contracts/agent/agent-contract.schema.json", VALID_SCHEMA)
+        self.write_json("agent-contract.json", VALID_CONTRACT)
+        self.write_file("repo.meta.yaml", VALID_REPO_META)
+        self.write_file("agent-policy.yaml", VALID_AGENT_POLICY)
+        self.write_file(".wgx/generated-artifacts.yml", VALID_REGISTRY)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def write_file(self, rel_path, content):
+        (self.repo_root / rel_path).write_text(content, encoding="utf-8")
+
+    def write_json(self, rel_path, data):
+        self.write_file(rel_path, json.dumps(data))
+
+    def test_valid_contract(self):
+        findings = validate_repo_agent_contract(self.repo_root)
+        self.assertEqual(findings, [])
+
+    def test_duplicate_json_key(self):
+        content = json.dumps(VALID_CONTRACT)
+        content = content[:-1] + ', "safe_read_paths": ["other/"]}'
+        self.write_file("agent-contract.json", content)
+        findings = validate_repo_agent_contract(self.repo_root)
+        self.assertTrue(
+            any(
+                f["code"] == "AGENT_CONTRACT_CHECK_ERROR"
+                and "duplicate json key" in f["message"].lower()
+                for f in findings
+            )
+        )
+
+    def test_nan_infinity(self):
+        content = json.dumps(VALID_CONTRACT)
+        content = content[:-1] + ', "invalid": NaN}'
+        self.write_file("agent-contract.json", content)
+        findings = validate_repo_agent_contract(self.repo_root)
+        self.assertTrue(
+            any(
+                f["code"] == "AGENT_CONTRACT_CHECK_ERROR"
+                and "nan" in f["message"].lower()
+                for f in findings
+            )
+        )
+
+    def test_schema_error(self):
+        schema = {"type": "array"}
+        self.write_json("contracts/agent/agent-contract.schema.json", schema)
+        findings = validate_repo_agent_contract(self.repo_root)
+        self.assertTrue(any(f["code"] == "AGENT_CONTRACT_SCHEMA" for f in findings))
+
+    def test_wrong_architecture_role(self):
+        contract = dict(VALID_CONTRACT)
+        contract["architecture"] = dict(VALID_CONTRACT["architecture"])
+        contract["architecture"]["repo_role"] = "wrong_role"
+        self.write_json("agent-contract.json", contract)
+        findings = validate_repo_agent_contract(self.repo_root)
+        self.assertTrue(
+            any(f["code"] == "AGENT_CONTRACT_ARCHITECTURE" for f in findings)
+        )
+
+    def test_reading_order_error(self):
+        contract = dict(VALID_CONTRACT)
+        contract["reading_order"] = ["repo.meta.yaml", "agent-contract.json"]
+        self.write_json("agent-contract.json", contract)
+        findings = validate_repo_agent_contract(self.repo_root)
+        self.assertTrue(
+            any(f["code"] == "AGENT_CONTRACT_READING_ORDER" for f in findings)
+        )
+
+    def test_projection_drift_repo_meta(self):
+        self.write_file("repo.meta.yaml", VALID_REPO_META.replace("src/", "docs/"))
+        findings = validate_repo_agent_contract(self.repo_root)
+        self.assertTrue(
+            any(
+                f["code"] == "AGENT_CONTRACT_PROJECTION_DRIFT"
+                and "repo.meta.yaml" in f["path"]
+                for f in findings
+            )
+        )
+
+    def test_projection_drift_agent_policy(self):
+        self.write_file(
+            "agent-policy.yaml", VALID_AGENT_POLICY.replace("src/", "docs/")
+        )
+        findings = validate_repo_agent_contract(self.repo_root)
+        self.assertTrue(
+            any(
+                f["code"] == "AGENT_CONTRACT_PROJECTION_DRIFT"
+                and "agent-policy.yaml" in f["path"]
+                for f in findings
+            )
+        )
+
+    def test_missing_projection_marker(self):
+        self.write_file("repo.meta.yaml", "read_paths:\n  - src/")
+        findings = validate_repo_agent_contract(self.repo_root)
+        self.assertTrue(
+            any(f["code"] == "AGENT_CONTRACT_PROJECTION_MARKER" for f in findings)
+        )
+
+    def test_direct_generated_edits_not_forbidden(self):
+        contract = dict(VALID_CONTRACT)
+        contract["generated_artifacts"] = dict(VALID_CONTRACT["generated_artifacts"])
+        contract["generated_artifacts"]["direct_agent_edit"] = "allowed"
+        self.write_json("agent-contract.json", contract)
+        findings = validate_repo_agent_contract(self.repo_root)
+        self.assertTrue(
+            any("direct agent edits" in f["message"].lower() for f in findings)
+        )
+
+    def test_generator_target_outside_forbidden_paths(self):
+        registry = """
+        artifacts:
+          - path: src/output.md
+            kind: generated
+            generator: ["python3", "gen.py"]
+        """
+        self.write_file(".wgx/generated-artifacts.yml", registry)
+        findings = validate_repo_agent_contract(self.repo_root)
+        self.assertTrue(
+            any(
+                "must stay under a forbidden_write_paths prefix" in f["message"]
+                for f in findings
+            )
+        )
+
+    def test_duplicate_generator_write(self):
+        registry = """
+        artifacts:
+          - path: docs/_generated/out1.md
+            kind: generated
+            generator: ["python3", "gen.py"]
+          - path: docs/_generated/out1.md
+            kind: generated
+            generator: ["python3", "gen.py"]
+        """
+        self.write_file(".wgx/generated-artifacts.yml", registry)
+        findings = validate_repo_agent_contract(self.repo_root)
+        self.assertTrue(
+            any("duplicate artifact path" in f["message"] for f in findings)
+        )
+
+    def test_missing_registry(self):
+        (self.repo_root / ".wgx" / "generated-artifacts.yml").unlink()
+        findings = validate_repo_agent_contract(self.repo_root)
+        self.assertTrue(
+            any("generator registry file is missing" in f["message"] for f in findings)
+        )
+
+    def test_invalid_registry_yaml(self):
+        self.write_file(".wgx/generated-artifacts.yml", "invalid: yaml: :")
+        findings = validate_repo_agent_contract(self.repo_root)
+        self.assertTrue(
+            any(f["code"] == "AGENT_CONTRACT_REGISTRY_ERROR" for f in findings)
+        )
+
+    def test_missing_yaml(self):
+        (self.repo_root / "repo.meta.yaml").unlink()
+        findings = validate_repo_agent_contract(self.repo_root)
+        self.assertTrue(
+            any(
+                "missing" in f["message"] and "repo.meta.yaml" in f["path"]
+                for f in findings
+            )
+        )
+
+    def test_invalid_yaml(self):
+        self.write_file("repo.meta.yaml", "Compatibility Projection\ninvalid: yaml: :")
+        findings = validate_repo_agent_contract(self.repo_root)
+        self.assertTrue(
+            any(f["code"] == "AGENT_CONTRACT_PROJECTION_YAML_ERROR" for f in findings)
+        )
+
+    def test_duplicate_key_projection(self):
+        self.write_file("repo.meta.yaml", "Compatibility Projection\nread_paths:\n  - src/\nread_paths:\n  - other/")
+        findings = validate_repo_agent_contract(self.repo_root)
+        self.assertTrue(
+            any(f["code"] == "AGENT_CONTRACT_PROJECTION_YAML_ERROR" for f in findings)
+        )
+
+    def test_duplicate_key_registry(self):
+        registry = """
+schema_version: 1
+artifacts:
+  - path: docs/_generated/out1.md
+    kind: generated
+    generator: ["python3", "gen.py"]
+artifacts:
+  - path: docs/_generated/out2.md
+    kind: generated
+    generator: ["python3", "gen.py"]
+"""
+        self.write_file(".wgx/generated-artifacts.yml", registry)
+        findings = validate_repo_agent_contract(self.repo_root)
+        self.assertTrue(
+            any(f["code"] == "AGENT_CONTRACT_REGISTRY_ERROR" and "duplicate key" in f["message"].lower() for f in findings)
+        )
+
+    def test_bad_registry_path(self):
+        contract = dict(VALID_CONTRACT)
+        contract["generated_artifacts"] = dict(VALID_CONTRACT["generated_artifacts"])
+        contract["generated_artifacts"]["trusted_generator_registry"] = "/etc/passwd"
+        self.write_json("agent-contract.json", contract)
+        findings = validate_repo_agent_contract(self.repo_root)
+        self.assertTrue(
+            any(f["code"] == "AGENT_CONTRACT_REGISTRY_ERROR" and "must be exactly" in f["message"] for f in findings)
+        )
+
+    def test_absolute_artifact_path_is_rejected(self):
+        registry = """
+artifacts:
+  - path: /tmp/output.md
+    kind: generated
+    generator: ["python3", "gen.py"]
+"""
+        self.write_file(".wgx/generated-artifacts.yml", registry)
+        findings = validate_repo_agent_contract(self.repo_root)
+        self.assertTrue(
+            any(
+                f["code"] == "AGENT_CONTRACT_REGISTRY_ERROR"
+                and "repository-relative" in f["message"]
+                for f in findings
+            )
+        )
+
+    def test_projection_path_traversal_is_rejected(self):
+        contract = dict(VALID_CONTRACT)
+        contract["compatibility_projections"] = [
+            {
+                "role": "compatibility_projection",
+                "path": "../repo.meta.yaml",
+                "projected_fields": {"safe_read_paths": "read_paths"},
+            }
+        ]
+        self.write_json("agent-contract.json", contract)
+        findings = validate_repo_agent_contract(self.repo_root)
+        self.assertTrue(
+            any(
+                f["code"] == "AGENT_CONTRACT_PROJECTION"
+                and "repository-relative" in f["message"]
+                for f in findings
+            )
+        )
+
+    def test_empty_generator_argument_is_rejected(self):
+        registry = """
+artifacts:
+  - path: docs/_generated/output.md
+    kind: generated
+    generator: ["python3", ""]
+"""
+        self.write_file(".wgx/generated-artifacts.yml", registry)
+        findings = validate_repo_agent_contract(self.repo_root)
+        self.assertTrue(
+            any(
+                f["code"] == "AGENT_CONTRACT_REGISTRY_ERROR"
+                and "generator must be a list of strings" in f["message"]
+                for f in findings
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/agent/validate_repo_agent_contract.py
+++ b/scripts/agent/validate_repo_agent_contract.py
@@ -1,0 +1,659 @@
+#!/usr/bin/env python3
+"""Validate the canonical repository agent contract and projection parity.
+
+The repository owns machine-readable agent norms as strict JSON. YAML files that
+still expose overlapping path/check fields are compatibility projections only.
+This validator:
+
+1. loads agent-contract.json with the strict JSON contract loader
+2. validates it against contracts/agent/agent-contract.schema.json
+3. enforces semantic invariants beyond pure schema shape
+4. checks exact parity of declared projection fields in YAML mirrors
+
+The established PyYAML parser is used to load projections. Extraction is limited
+to the declared top-level list keys that the contract itself names.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+import yaml
+
+
+class StrictSafeLoader(yaml.SafeLoader):
+    def construct_mapping(self, node, deep=False):
+        mapping = {}
+        for key_node, value_node in node.value:
+            key = self.construct_object(key_node, deep=deep)
+            if key in mapping:
+                raise yaml.constructor.ConstructorError(
+                    f"found duplicate key {key!r}", key_node.start_mark
+                )
+            mapping[key] = self.construct_object(value_node, deep=deep)
+        return mapping
+
+StrictSafeLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    StrictSafeLoader.construct_mapping
+)
+
+def load_yaml_strict(text: str) -> Any:
+    return yaml.load(text, Loader=StrictSafeLoader)
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scripts.agent.json_contract import (
+    DuplicateKeyError,
+    UnsupportedSchemaError,
+    load_json_strict,
+    validate_instance,
+)
+from scripts.docmeta.docmeta import REPO_ROOT
+
+CONTRACT_REL = "agent-contract.json"
+SCHEMA_REL = "contracts/agent/agent-contract.schema.json"
+
+READING_ORDER_REQUIRED_PREFIX = [
+    "agent-contract.json",
+    "repo.meta.yaml",
+    "AGENTS.md",
+    "agent-policy.yaml",
+    "docs/policies/agent-reading-protocol.md",
+]
+
+ARCHITECTURE_REQUIRED = {
+    "repo_role": "repo_contract_authority",
+    "operator_role": "external_operator_execution",
+    "operator_name": "grabowski",
+    "repo_generic_write_mode": "rejected",
+}
+
+
+def _finding(code: str, path: str, message: str) -> dict[str, str]:
+    return {"code": code, "path": path, "message": message}
+
+
+def extract_top_level_string_list(text: str, key: str) -> list[str] | Exception | None:
+    """Extract one top-level YAML list of scalar strings, or return Exception if invalid YAML."""
+    try:
+        data = load_yaml_strict(text)
+        if isinstance(data, dict):
+            value = data.get(key)
+            if isinstance(value, list) and all(isinstance(v, str) for v in value):
+                return value
+    except yaml.YAMLError as e:
+        return e
+    except Exception as e:
+        return e
+    return None
+
+
+def _is_safe_repo_relative_file_path(path: str) -> bool:
+    if not path or "\\" in path:
+        return False
+    parsed = PurePosixPath(path)
+    return not parsed.is_absolute() and ".." not in parsed.parts and path == parsed.as_posix()
+
+
+def _path_is_under_prefix(path: str, prefix: str) -> bool:
+    if prefix.endswith("/"):
+        return path == prefix[:-1] or path.startswith(prefix)
+    return path == prefix or path.startswith(prefix + "/")
+
+
+def _is_generated_target(path: str, forbidden_write_paths: list[str]) -> bool:
+    for prefix in forbidden_write_paths:
+        if _path_is_under_prefix(path, prefix):
+            return True
+    return False
+
+
+def validate_semantic_invariants(
+    repo_root: Path, contract: dict[str, Any]
+) -> list[dict[str, str]]:
+    findings: list[dict[str, str]] = []
+
+    architecture = contract.get("architecture")
+    if not isinstance(architecture, dict):
+        findings.append(
+            _finding(
+                "AGENT_CONTRACT_ARCHITECTURE",
+                "$.architecture",
+                "architecture block is required",
+            )
+        )
+    else:
+        for key, expected in ARCHITECTURE_REQUIRED.items():
+            if architecture.get(key) != expected:
+                findings.append(
+                    _finding(
+                        "AGENT_CONTRACT_ARCHITECTURE",
+                        f"$.architecture.{key}",
+                        f"expected {expected!r}",
+                    )
+                )
+
+    reading_order = contract.get("reading_order")
+    if not isinstance(reading_order, list):
+        findings.append(
+            _finding(
+                "AGENT_CONTRACT_READING_ORDER",
+                "$.reading_order",
+                "reading_order must be an array",
+            )
+        )
+    else:
+        prefix = READING_ORDER_REQUIRED_PREFIX
+        if reading_order[: len(prefix)] != prefix:
+            findings.append(
+                _finding(
+                    "AGENT_CONTRACT_READING_ORDER",
+                    "$.reading_order",
+                    "reading_order must start with the canonical agent entry sequence",
+                )
+            )
+        if "agent-contract.json" not in reading_order:
+            findings.append(
+                _finding(
+                    "AGENT_CONTRACT_READING_ORDER",
+                    "$.reading_order",
+                    "agent-contract.json must appear in reading_order",
+                )
+            )
+
+    for field in (
+        "safe_read_paths",
+        "guarded_write_paths",
+        "forbidden_write_paths",
+        "required_checks",
+        "local_checks_before_patch",
+    ):
+        value = contract.get(field)
+        if not isinstance(value, list) or not value:
+            findings.append(
+                _finding(
+                    "AGENT_CONTRACT_PATHS",
+                    f"$.{field}",
+                    f"{field} must be a non-empty list",
+                )
+            )
+
+    forbidden = contract.get("forbidden_write_paths")
+    if isinstance(forbidden, list) and "docs/_generated/" not in forbidden:
+        findings.append(
+            _finding(
+                "AGENT_CONTRACT_FORBIDDEN",
+                "$.forbidden_write_paths",
+                "docs/_generated/ must be a direct forbidden write path",
+            )
+        )
+
+    generated = contract.get("generated_artifacts")
+    if not isinstance(generated, dict):
+        findings.append(
+            _finding(
+                "AGENT_CONTRACT_GENERATED",
+                "$.generated_artifacts",
+                "generated_artifacts block is required",
+            )
+        )
+        return findings
+
+    if generated.get("direct_agent_edit") != "forbidden":
+        findings.append(
+            _finding(
+                "AGENT_CONTRACT_GENERATED",
+                "$.generated_artifacts.direct_agent_edit",
+                "direct agent edits of generated artifacts must be forbidden",
+            )
+        )
+    if generated.get("derived_write_authority") != "trusted_generators_only":
+        findings.append(
+            _finding(
+                "AGENT_CONTRACT_GENERATED",
+                "$.generated_artifacts.derived_write_authority",
+                "only trusted generators may write derived artifacts",
+            )
+        )
+
+    registry_path = generated.get("trusted_generator_registry")
+    if not isinstance(registry_path, str) or not registry_path.strip():
+        findings.append(
+            _finding(
+                "AGENT_CONTRACT_GENERATED",
+                "$.generated_artifacts.trusted_generator_registry",
+                "trusted_generator_registry path is required",
+            )
+        )
+        return findings
+
+    if registry_path != ".wgx/generated-artifacts.yml":
+        findings.append(
+            _finding(
+                "AGENT_CONTRACT_REGISTRY_ERROR",
+                registry_path,
+                "trusted_generator_registry must be exactly '.wgx/generated-artifacts.yml'",
+            )
+        )
+        return findings
+
+    abs_registry = repo_root / registry_path
+    if not abs_registry.is_file():
+        findings.append(
+            _finding(
+                "AGENT_CONTRACT_REGISTRY_MISSING",
+                registry_path,
+                "generator registry file is missing",
+            )
+        )
+        return findings
+
+    try:
+        registry_text = abs_registry.read_text(encoding="utf-8")
+        registry_data = load_yaml_strict(registry_text)
+    except (yaml.YAMLError, OSError, TypeError, ValueError) as e:
+        findings.append(
+            _finding(
+                "AGENT_CONTRACT_REGISTRY_ERROR",
+                registry_path,
+                f"invalid YAML: {e}",
+            )
+        )
+        return findings
+
+    if not isinstance(registry_data, dict):
+        findings.append(
+            _finding(
+                "AGENT_CONTRACT_REGISTRY_ERROR",
+                registry_path,
+                "registry must be an object",
+            )
+        )
+        return findings
+
+    artifacts = registry_data.get("artifacts")
+    if not isinstance(artifacts, list):
+        findings.append(
+            _finding(
+                "AGENT_CONTRACT_REGISTRY_ERROR",
+                f"{registry_path}:artifacts",
+                "artifacts must be a list",
+            )
+        )
+        return findings
+
+    seen_paths: set[str] = set()
+    forbidden_list = forbidden if isinstance(forbidden, list) else ["docs/_generated/"]
+
+    for index, artifact in enumerate(artifacts):
+        base = f"{registry_path}:artifacts[{index}]"
+        if not isinstance(artifact, dict):
+            findings.append(
+                _finding(
+                    "AGENT_CONTRACT_REGISTRY_ERROR",
+                    base,
+                    "artifact entry must be an object",
+                )
+            )
+            continue
+
+        path = artifact.get("path")
+        if not isinstance(path, str) or not path.strip():
+            findings.append(
+                _finding(
+                    "AGENT_CONTRACT_REGISTRY_ERROR",
+                    f"{base}.path",
+                    "artifact path is required",
+                )
+            )
+            continue
+
+        if not _is_safe_repo_relative_file_path(path):
+            findings.append(
+                _finding(
+                    "AGENT_CONTRACT_REGISTRY_ERROR",
+                    f"{base}.path",
+                    "artifact path must be a normalized repository-relative file path",
+                )
+            )
+            continue
+
+        if path in seen_paths:
+            findings.append(
+                _finding(
+                    "AGENT_CONTRACT_REGISTRY_ERROR",
+                    f"{base}.path",
+                    f"duplicate artifact path: {path}",
+                )
+            )
+        seen_paths.add(path)
+
+        kind = artifact.get("kind")
+        if kind == "generated":
+            if not _is_generated_target(path, forbidden_list):
+                findings.append(
+                    _finding(
+                        "AGENT_CONTRACT_REGISTRY_ERROR",
+                        f"{base}.path",
+                        "generated artifact must stay under a forbidden_write_paths prefix",
+                    )
+                )
+
+            generator = artifact.get("generator")
+            if not isinstance(generator, list) or not generator:
+                findings.append(
+                    _finding(
+                        "AGENT_CONTRACT_REGISTRY_ERROR",
+                        f"{base}.generator",
+                        "generated artifact must declare a non-empty generator argv list",
+                    )
+                )
+            elif not all(isinstance(v, str) and v.strip() for v in generator):
+                findings.append(
+                    _finding(
+                        "AGENT_CONTRACT_REGISTRY_ERROR",
+                        f"{base}.generator",
+                        "generator must be a list of strings",
+                    )
+                )
+
+        checks = artifact.get("checks")
+        if checks is not None:
+            if not isinstance(checks, list):
+                findings.append(
+                    _finding(
+                        "AGENT_CONTRACT_REGISTRY_ERROR",
+                        f"{base}.checks",
+                        "checks must be a list of argv lists",
+                    )
+                )
+            else:
+                for c_idx, check in enumerate(checks):
+                    if not isinstance(check, list) or not check or not all(
+                        isinstance(v, str) and v.strip() for v in check
+                    ):
+                        findings.append(
+                            _finding(
+                                "AGENT_CONTRACT_REGISTRY_ERROR",
+                                f"{base}.checks[{c_idx}]",
+                                "each check must be an argv list of strings",
+                            )
+                        )
+
+    profiles = contract.get("validation_profiles")
+    if not isinstance(profiles, dict) or not profiles:
+        findings.append(
+            _finding(
+                "AGENT_CONTRACT_PROFILES",
+                "$.validation_profiles",
+                "named validation profiles are required",
+            )
+        )
+    else:
+        for name, profile in profiles.items():
+            if not isinstance(profile, dict):
+                findings.append(
+                    _finding(
+                        "AGENT_CONTRACT_PROFILES",
+                        f"$.validation_profiles.{name}",
+                        "profile must be an object",
+                    )
+                )
+                continue
+            named_checks = profile.get("named_checks")
+            if not isinstance(named_checks, list) or not named_checks:
+                findings.append(
+                    _finding(
+                        "AGENT_CONTRACT_PROFILES",
+                        f"$.validation_profiles.{name}.named_checks",
+                        "profile must declare named_checks",
+                    )
+                )
+
+    return findings
+
+
+def validate_projection_parity(
+    repo_root: Path, contract: dict[str, Any]
+) -> list[dict[str, str]]:
+    findings: list[dict[str, str]] = []
+    projections = contract.get("compatibility_projections")
+    if not isinstance(projections, list):
+        return [
+            _finding(
+                "AGENT_CONTRACT_PROJECTION",
+                "$.compatibility_projections",
+                "compatibility_projections must be an array",
+            )
+        ]
+
+    for index, projection in enumerate(projections):
+        base = f"$.compatibility_projections[{index}]"
+        if not isinstance(projection, dict):
+            findings.append(
+                _finding(
+                    "AGENT_CONTRACT_PROJECTION",
+                    base,
+                    "projection must be an object",
+                )
+            )
+            continue
+        if projection.get("role") != "compatibility_projection":
+            findings.append(
+                _finding(
+                    "AGENT_CONTRACT_PROJECTION",
+                    f"{base}.role",
+                    "projection role must be compatibility_projection",
+                )
+            )
+
+        rel_path = projection.get("path")
+        if not isinstance(rel_path, str) or not rel_path.strip():
+            findings.append(
+                _finding(
+                    "AGENT_CONTRACT_PROJECTION",
+                    f"{base}.path",
+                    "projection path is required",
+                )
+            )
+            continue
+
+        if not _is_safe_repo_relative_file_path(rel_path):
+            findings.append(
+                _finding(
+                    "AGENT_CONTRACT_PROJECTION",
+                    f"{base}.path",
+                    "projection path must be a normalized repository-relative file path",
+                )
+            )
+            continue
+
+        abs_path = repo_root / rel_path
+        if not abs_path.is_file():
+            findings.append(
+                _finding(
+                    "AGENT_CONTRACT_PROJECTION",
+                    rel_path,
+                    "compatibility projection file is missing",
+                )
+            )
+            continue
+
+        text = abs_path.read_text(encoding="utf-8")
+        marker_tokens = (
+            "compatibility projection",
+            "compatibility_projection",
+            "Compatibility Projection",
+        )
+        if not any(token in text for token in marker_tokens):
+            findings.append(
+                _finding(
+                    "AGENT_CONTRACT_PROJECTION_MARKER",
+                    rel_path,
+                    "projection must declare itself as a Compatibility Projection",
+                )
+            )
+
+        field_map = projection.get("projected_fields")
+        if not isinstance(field_map, dict):
+            findings.append(
+                _finding(
+                    "AGENT_CONTRACT_PROJECTION",
+                    f"{base}.projected_fields",
+                    "projected_fields must be an object",
+                )
+            )
+            continue
+
+        for canonical_field, projection_key in field_map.items():
+            expected = contract.get(canonical_field)
+            if not isinstance(expected, list):
+                findings.append(
+                    _finding(
+                        "AGENT_CONTRACT_PROJECTION",
+                        f"$.{canonical_field}",
+                        "canonical projected field must be a list",
+                    )
+                )
+                continue
+            if not isinstance(projection_key, str) or not projection_key.strip():
+                findings.append(
+                    _finding(
+                        "AGENT_CONTRACT_PROJECTION",
+                        f"{base}.projected_fields.{canonical_field}",
+                        "projection key must be a non-empty string",
+                    )
+                )
+                continue
+            actual = extract_top_level_string_list(text, projection_key)
+            if isinstance(actual, Exception):
+                findings.append(
+                    _finding(
+                        "AGENT_CONTRACT_PROJECTION_YAML_ERROR",
+                        f"{rel_path}",
+                        f"invalid YAML format: {actual}",
+                    )
+                )
+                continue
+            if actual is None:
+                findings.append(
+                    _finding(
+                        "AGENT_CONTRACT_PROJECTION_DRIFT",
+                        f"{rel_path}:{projection_key}",
+                        f"could not extract projected list for {projection_key}",
+                    )
+                )
+                continue
+            if actual != expected:
+                findings.append(
+                    _finding(
+                        "AGENT_CONTRACT_PROJECTION_DRIFT",
+                        f"{rel_path}:{projection_key}",
+                        (
+                            f"projection drift for {canonical_field}: "
+                            f"expected {expected!r}, found {actual!r}"
+                        ),
+                    )
+                )
+
+    return findings
+
+
+def validate_repo_agent_contract(repo_root: Path) -> list[dict[str, str]]:
+    findings: list[dict[str, str]] = []
+    contract_path = repo_root / CONTRACT_REL
+    schema_path = repo_root / SCHEMA_REL
+
+    try:
+        if not contract_path.is_file():
+            return [
+                _finding(
+                    "AGENT_CONTRACT_MISSING",
+                    CONTRACT_REL,
+                    "canonical agent-contract.json is missing",
+                )
+            ]
+        if not schema_path.is_file():
+            return [
+                _finding(
+                    "AGENT_CONTRACT_SCHEMA_MISSING",
+                    SCHEMA_REL,
+                    "agent-contract schema is missing",
+                )
+            ]
+
+        contract = load_json_strict(contract_path)
+        schema = load_json_strict(schema_path)
+        if not isinstance(contract, dict) or not isinstance(schema, dict):
+            return [
+                _finding(
+                    "AGENT_CONTRACT_TYPE",
+                    CONTRACT_REL,
+                    "contract and schema roots must be objects",
+                )
+            ]
+
+        schema_findings = validate_instance(contract, schema)
+        for item in schema_findings:
+            findings.append(
+                _finding(
+                    "AGENT_CONTRACT_SCHEMA",
+                    item.get("path", "$"),
+                    item.get("message", "schema violation"),
+                )
+            )
+
+        findings.extend(validate_semantic_invariants(repo_root, contract))
+        findings.extend(validate_projection_parity(repo_root, contract))
+    except (
+        OSError,
+        json.JSONDecodeError,
+        DuplicateKeyError,
+        UnsupportedSchemaError,
+        ValueError,
+    ) as exc:
+        findings.append(
+            _finding(
+                "AGENT_CONTRACT_CHECK_ERROR",
+                CONTRACT_REL,
+                str(exc),
+            )
+        )
+
+    unique: dict[tuple[str, str, str], dict[str, str]] = {}
+    for finding in findings:
+        key = (finding["code"], finding["path"], finding["message"])
+        unique[key] = finding
+    return [unique[key] for key in sorted(unique)]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate the canonical repository agent contract"
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(REPO_ROOT),
+        help="Repository root (default: detected repo root)",
+    )
+    args = parser.parse_args(argv)
+    findings = validate_repo_agent_contract(Path(args.repo_root))
+    payload = {
+        "status": "valid" if not findings else "invalid",
+        "contract": CONTRACT_REL,
+        "schema": SCHEMA_REL,
+        "findings_count": len(findings),
+        "findings": findings,
+    }
+    print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0 if not findings else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/agent/validate_repo_agent_contract.py
+++ b/scripts/agent/validate_repo_agent_contract.py
@@ -74,6 +74,13 @@ ARCHITECTURE_REQUIRED = {
     "repo_generic_write_mode": "rejected",
 }
 
+AUTHORITY_GUARDED_PATHS = [
+    ".wgx/generated-artifacts.yml",
+    "agent-contract.json",
+]
+
+ALLOWED_GENERATED_TARGET_PREFIXES = ["docs/_generated/"]
+
 
 def _finding(code: str, path: str, message: str) -> dict[str, str]:
     return {"code": code, "path": path, "message": message}
@@ -184,6 +191,18 @@ def validate_semantic_invariants(
                 )
             )
 
+    guarded = contract.get("guarded_write_paths")
+    if isinstance(guarded, list):
+        for authority_path in AUTHORITY_GUARDED_PATHS:
+            if authority_path not in guarded:
+                findings.append(
+                    _finding(
+                        "AGENT_CONTRACT_AUTHORITY_GUARD",
+                        "$.guarded_write_paths",
+                        f"authority path must be guarded: {authority_path}",
+                    )
+                )
+
     forbidden = contract.get("forbidden_write_paths")
     if isinstance(forbidden, list) and "docs/_generated/" not in forbidden:
         findings.append(
@@ -221,6 +240,29 @@ def validate_semantic_invariants(
                 "only trusted generators may write derived artifacts",
             )
         )
+
+    allowed_target_prefixes = generated.get("allowed_target_prefixes")
+    if allowed_target_prefixes != ALLOWED_GENERATED_TARGET_PREFIXES:
+        findings.append(
+            _finding(
+                "AGENT_CONTRACT_GENERATED_TARGETS",
+                "$.generated_artifacts.allowed_target_prefixes",
+                (
+                    "allowed_target_prefixes must be exactly "
+                    f"{ALLOWED_GENERATED_TARGET_PREFIXES!r}"
+                ),
+            )
+        )
+    if isinstance(forbidden, list):
+        for prefix in ALLOWED_GENERATED_TARGET_PREFIXES:
+            if prefix not in forbidden:
+                findings.append(
+                    _finding(
+                        "AGENT_CONTRACT_GENERATED_TARGETS",
+                        "$.forbidden_write_paths",
+                        f"trusted generated target prefix must remain directly forbidden: {prefix}",
+                    )
+                )
 
     registry_path = generated.get("trusted_generator_registry")
     if not isinstance(registry_path, str) or not registry_path.strip():
@@ -289,7 +331,6 @@ def validate_semantic_invariants(
         return findings
 
     seen_paths: set[str] = set()
-    forbidden_list = forbidden if isinstance(forbidden, list) else ["docs/_generated/"]
 
     for index, artifact in enumerate(artifacts):
         base = f"{registry_path}:artifacts[{index}]"
@@ -336,12 +377,12 @@ def validate_semantic_invariants(
 
         kind = artifact.get("kind")
         if kind == "generated":
-            if not _is_generated_target(path, forbidden_list):
+            if not _is_generated_target(path, ALLOWED_GENERATED_TARGET_PREFIXES):
                 findings.append(
                     _finding(
                         "AGENT_CONTRACT_REGISTRY_ERROR",
                         f"{base}.path",
-                        "generated artifact must stay under a forbidden_write_paths prefix",
+                        "generated artifact must stay under an allowed_target_prefixes prefix",
                     )
                 )
 

--- a/scripts/docmeta/agent_entrypoint_smoke.py
+++ b/scripts/docmeta/agent_entrypoint_smoke.py
@@ -10,12 +10,13 @@ It deliberately verifies only a few hard, deterministic invariants — robust te
 markers, not semantic full-text analysis — so that legitimate doc rewrites are
 not punished:
 
-  1. README.md spells out the binding reading order (repo.meta.yaml, AGENTS.md,
-     agent-policy.yaml, docs/policies/agent-reading-protocol.md, docs/index.md).
+  1. README.md spells out the binding reading order (agent-contract.json,
+     repo.meta.yaml, AGENTS.md, agent-policy.yaml,
+     docs/policies/agent-reading-protocol.md, docs/index.md).
   2. AGENTS.md references the Agent Reading Protocol and carries the reading
-     order (repo.meta.yaml before agent-policy.yaml).
+     order (agent-contract.json before repo.meta.yaml before agent-policy.yaml).
   3. docs/policies/agent-reading-protocol.md carries the same start order
-     (repo.meta.yaml, AGENTS.md, agent-policy.yaml).
+     (agent-contract.json, repo.meta.yaml, AGENTS.md, agent-policy.yaml).
   4. docs/index.md marks itself as navigation, not a truth layer.
   5. docs/tasks/README.md frames docs/tasks/ as work control (not a second truth
      layer) and describes `generate_task_index.py --check` as a write-free drift
@@ -55,6 +56,7 @@ TASK_INDEX_WORKFLOW = ".github/workflows/task-index.yml"
 
 # Reading-order entries that README.md must reference explicitly.
 READING_ORDER_TOKENS = (
+    "agent-contract.json",
     "repo.meta.yaml",
     "agents.md",
     "agent-policy.yaml",
@@ -180,12 +182,27 @@ def check_agents_reading_protocol(repo_root):
         errors.append("AGENTS.md: missing reference to the Agent Reading Protocol")
     if "reading order" not in norm and "lesereihenfolge" not in norm:
         errors.append("AGENTS.md: missing 'Reading Order' section marker")
-    for token in ("repo.meta.yaml", "agent-policy.yaml", "agent-reading-protocol.md"):
+    for token in (
+        "agent-contract.json",
+        "repo.meta.yaml",
+        "agent-policy.yaml",
+        "agent-reading-protocol.md",
+    ):
         if token not in norm:
             errors.append(f"AGENTS.md: reading order does not mention {token}")
     body = _norm(_strip_frontmatter(text))
+    contract_idx = _first_index(body, "agent-contract.json")
     meta_idx = _first_index(body, "repo.meta.yaml")
     policy_idx = _first_index(body, "agent-policy.yaml")
+    if (
+        contract_idx != -1
+        and meta_idx != -1
+        and contract_idx > meta_idx
+    ):
+        errors.append(
+            "AGENTS.md: reading order is out of sequence "
+            "(agent-contract.json must precede repo.meta.yaml)"
+        )
     if meta_idx != -1 and policy_idx != -1 and meta_idx > policy_idx:
         errors.append(
             "AGENTS.md: reading order is out of sequence "
@@ -202,14 +219,29 @@ def check_protocol_reading_order(repo_root):
     errors = []
     if "reading order" not in norm and "lesereihenfolge" not in norm:
         errors.append("docs/policies/agent-reading-protocol.md: missing reading-order section marker")
-    for token in ("repo.meta.yaml", "agents.md", "agent-policy.yaml"):
+    for token in (
+        "agent-contract.json",
+        "repo.meta.yaml",
+        "agents.md",
+        "agent-policy.yaml",
+    ):
         if token not in norm:
             errors.append(
                 f"docs/policies/agent-reading-protocol.md: start order does not mention {token}"
             )
     body = _norm(_strip_frontmatter(text))
+    contract_idx = _first_index(body, "agent-contract.json")
     meta_idx = _first_index(body, "repo.meta.yaml")
     policy_idx = _first_index(body, "agent-policy.yaml")
+    if (
+        contract_idx != -1
+        and meta_idx != -1
+        and contract_idx > meta_idx
+    ):
+        errors.append(
+            "docs/policies/agent-reading-protocol.md: start order is out of sequence "
+            "(agent-contract.json must precede repo.meta.yaml)"
+        )
     if meta_idx != -1 and policy_idx != -1 and meta_idx > policy_idx:
         errors.append(
             "docs/policies/agent-reading-protocol.md: start order is out of sequence "

--- a/scripts/docmeta/generate_agent_readiness.py
+++ b/scripts/docmeta/generate_agent_readiness.py
@@ -23,7 +23,8 @@ from scripts.agent.json_contract import (
     validate_instance,
 )
 from scripts.agent.validate_handoff import validate_handoff
-from scripts.docmeta import validate_claim_registry
+from scripts.agent.validate_repo_agent_contract import validate_repo_agent_contract
+from scripts.docmeta import agent_entrypoint_smoke, validate_claim_registry
 from scripts.docmeta.docmeta import REPO_ROOT
 
 
@@ -124,6 +125,59 @@ def _capability_failure(
         evidence=presence.evidence,
         missing=[missing_item],
         rationale=f"{presence.rationale} Functional smoke failed{suffix}",
+    )
+
+
+def _evaluate_discovery_contract(root: Path) -> CapabilityResult:
+    presence = _evaluate_required_files(
+        root=root,
+        cap_id="discover",
+        dimension="discover",
+        title="Repository discovery contract",
+        hard=True,
+        required_files=DISCOVERY_REQUIRED_FILES,
+        rationale=(
+            "The repository must expose a deterministic machine contract, "
+            "entry card, validator, and entrypoint smoke before planning."
+        ),
+    )
+    if presence.status != "pass":
+        return presence
+
+    try:
+        contract_findings = validate_repo_agent_contract(root)
+        entrypoint_findings = agent_entrypoint_smoke.run_checks(root)
+    except (OSError, RuntimeError, ValueError) as exc:
+        return _capability_failure(
+            presence, "functional discovery smoke", str(exc)
+        )
+
+    if contract_findings:
+        diagnostic = json.dumps(
+            contract_findings[:3], ensure_ascii=False, sort_keys=True
+        )
+        return _capability_failure(
+            presence, "functional discovery smoke", diagnostic
+        )
+    if entrypoint_findings:
+        return _capability_failure(
+            presence,
+            "functional discovery smoke",
+            "; ".join(entrypoint_findings[:3]),
+        )
+
+    return CapabilityResult(
+        id=presence.id,
+        dimension=presence.dimension,
+        title=presence.title,
+        hard=presence.hard,
+        status="pass",
+        evidence=presence.evidence,
+        missing=[],
+        rationale=(
+            f"{presence.rationale} The canonical contract validator and "
+            "entrypoint smoke both pass."
+        ),
     )
 
 
@@ -701,20 +755,7 @@ def _external_capability(cap_id: str, dimension: str, title: str) -> CapabilityR
 def evaluate_capabilities(repo_root: Path) -> list[CapabilityResult]:
     results: list[CapabilityResult] = []
 
-    results.append(
-        _evaluate_required_files(
-            root=repo_root,
-            cap_id="discover",
-            dimension="discover",
-            title="Repository discovery contract",
-            hard=True,
-            required_files=DISCOVERY_REQUIRED_FILES,
-            rationale=(
-                "The repository must expose a deterministic machine contract, "
-                "entry card, validator, and entrypoint smoke before planning."
-            ),
-        )
-    )
+    results.append(_evaluate_discovery_contract(repo_root))
 
     results.append(
         _evaluate_required_files(

--- a/scripts/docmeta/generate_agent_readiness.py
+++ b/scripts/docmeta/generate_agent_readiness.py
@@ -30,6 +30,7 @@ from scripts.docmeta.docmeta import REPO_ROOT
 @dataclass(frozen=True)
 class CapabilityResult:
     id: str
+    dimension: str
     title: str
     hard: bool
     status: str
@@ -61,6 +62,14 @@ DRY_RUN_REQUIRED_FILES = [
     "scripts/agent/tests/test_run_task.py",
     DRY_RUN_TASK_FILE,
 ]
+DISCOVERY_REQUIRED_FILES = [
+    "agent-contract.json",
+    "contracts/agent/agent-contract.schema.json",
+    "AGENTS.md",
+    "scripts/agent/validate_repo_agent_contract.py",
+    "scripts/docmeta/agent_entrypoint_smoke.py",
+]
+
 RUN_EVIDENCE_REQUIRED_FILES = [
     "contracts/agent/validation.schema.json",
     "contracts/agent/run-result.schema.json",
@@ -87,6 +96,7 @@ def _handoff_failure(
     suffix = f": {diagnostic}" if diagnostic else "."
     return CapabilityResult(
         id=presence.id,
+        dimension=presence.dimension,
         title=presence.title,
         hard=presence.hard,
         status="fail",
@@ -107,6 +117,7 @@ def _capability_failure(
     suffix = f": {diagnostic}" if diagnostic else "."
     return CapabilityResult(
         id=presence.id,
+        dimension=presence.dimension,
         title=presence.title,
         hard=presence.hard,
         status="fail",
@@ -120,6 +131,7 @@ def _evaluate_handoff_validation(root: Path) -> CapabilityResult:
     presence = _evaluate_required_files(
         root=root,
         cap_id="handoff_validation",
+        dimension="validate",
         title="Handoff validation",
         hard=True,
         required_files=HANDOFF_REQUIRED_FILES,
@@ -173,6 +185,7 @@ def _evaluate_handoff_validation(root: Path) -> CapabilityResult:
 
     return CapabilityResult(
         id=presence.id,
+        dimension=presence.dimension,
         title=presence.title,
         hard=presence.hard,
         status="pass",
@@ -295,6 +308,7 @@ def _evaluate_dry_run_runner(root: Path) -> CapabilityResult:
     presence = _evaluate_required_files(
         root=root,
         cap_id="dry_run_runner",
+        dimension="plan",
         title="Dry-run runner",
         hard=True,
         required_files=DRY_RUN_REQUIRED_FILES,
@@ -366,6 +380,7 @@ def _evaluate_dry_run_runner(root: Path) -> CapabilityResult:
 
     return CapabilityResult(
         id=presence.id,
+        dimension=presence.dimension,
         title=presence.title,
         hard=presence.hard,
         status="pass",
@@ -382,6 +397,7 @@ def _evaluate_run_evidence_lite(root: Path) -> CapabilityResult:
     presence = _evaluate_required_files(
         root=root,
         cap_id="run_evidence_lite",
+        dimension="validate",
         title="Run evidence lite",
         hard=True,
         required_files=RUN_EVIDENCE_REQUIRED_FILES,
@@ -566,6 +582,7 @@ def _evaluate_run_evidence_lite(root: Path) -> CapabilityResult:
 
     return CapabilityResult(
         id=presence.id,
+        dimension=presence.dimension,
         title=presence.title,
         hard=presence.hard,
         status="pass",
@@ -610,6 +627,7 @@ def _files_for_regex(root: Path, search_roots: Iterable[str], regex: str) -> lis
 def _evaluate_required_files(
     root: Path,
     cap_id: str,
+    dimension: str,
     title: str,
     hard: bool,
     required_files: list[str],
@@ -622,6 +640,7 @@ def _evaluate_required_files(
         if path.exists() and not path.is_file():
             return CapabilityResult(
                 id=cap_id,
+                dimension=dimension,
                 title=title,
                 hard=hard,
                 status="fail",
@@ -643,12 +662,39 @@ def _evaluate_required_files(
 
     return CapabilityResult(
         id=cap_id,
+        dimension=dimension,
         title=title,
         hard=hard,
         status=status,
         evidence=evidence,
         missing=missing,
         rationale=rationale,
+    )
+
+DIMENSIONS = [
+    "discover",
+    "understand",
+    "plan",
+    "workspace",
+    "write",
+    "validate",
+    "review",
+    "publish",
+    "deploy",
+    "cleanup",
+    "recovery",
+]
+
+def _external_capability(cap_id: str, dimension: str, title: str) -> CapabilityResult:
+    return CapabilityResult(
+        id=cap_id,
+        dimension=dimension,
+        title=title,
+        hard=False,
+        status="open",
+        evidence=[],
+        missing=["external_operator_execution"],
+        rationale="Capability resides with the external operator (Grabowski).",
     )
 
 
@@ -658,7 +704,23 @@ def evaluate_capabilities(repo_root: Path) -> list[CapabilityResult]:
     results.append(
         _evaluate_required_files(
             root=repo_root,
+            cap_id="discover",
+            dimension="discover",
+            title="Repository discovery contract",
+            hard=True,
+            required_files=DISCOVERY_REQUIRED_FILES,
+            rationale=(
+                "The repository must expose a deterministic machine contract, "
+                "entry card, validator, and entrypoint smoke before planning."
+            ),
+        )
+    )
+
+    results.append(
+        _evaluate_required_files(
+            root=repo_root,
             cap_id="agent_policy",
+            dimension="understand",
             title="Agent policy baseline",
             hard=False,
             required_files=["AGENTS.md", "agent-policy.yaml"],
@@ -669,7 +731,25 @@ def evaluate_capabilities(repo_root: Path) -> list[CapabilityResult]:
     results.append(
         _evaluate_required_files(
             root=repo_root,
+            cap_id="agent_contracts",
+            dimension="understand",
+            title="Agent contracts",
+            hard=True,
+            required_files=["contracts/agent/task.schema.json"],
+            rationale="Contracts definieren maschinenlesbare Agent-Task-Grenzen.",
+        )
+    )
+
+    results.append(_evaluate_dry_run_runner(repo_root))
+
+    results.append(_external_capability("workspace", "workspace", "Workspace Management"))
+    results.append(_external_capability("write", "write", "Code Mutation"))
+
+    results.append(
+        _evaluate_required_files(
+            root=repo_root,
             cap_id="safety_preflight",
+            dimension="validate",
             title="Safety preflight guard",
             hard=False,
             required_files=[
@@ -686,6 +766,7 @@ def evaluate_capabilities(repo_root: Path) -> list[CapabilityResult]:
         _evaluate_required_files(
             root=repo_root,
             cap_id="claim_evidence_spine",
+            dimension="validate",
             title="Claim evidence spine",
             hard=True,
             required_files=[
@@ -696,23 +777,13 @@ def evaluate_capabilities(repo_root: Path) -> list[CapabilityResult]:
         )
     )
 
-    results.append(
-        _evaluate_required_files(
-            root=repo_root,
-            cap_id="agent_contracts",
-            title="Agent contracts",
-            hard=True,
-            required_files=["contracts/agent/task.schema.json"],
-            rationale="Contracts definieren maschinenlesbare Agent-Task-Grenzen.",
-        )
-    )
-
     results.append(_evaluate_handoff_validation(repo_root))
 
     results.append(
         _evaluate_required_files(
             root=repo_root,
             cap_id="non_ideal_guard",
+            dimension="validate",
             title="Non-ideal guard",
             hard=True,
             required_files=[
@@ -723,8 +794,13 @@ def evaluate_capabilities(repo_root: Path) -> list[CapabilityResult]:
         )
     )
 
-    results.append(_evaluate_dry_run_runner(repo_root))
     results.append(_evaluate_run_evidence_lite(repo_root))
+
+    results.append(_external_capability("review", "review", "Review and Approval"))
+    results.append(_external_capability("publish", "publish", "Publish Artifacts"))
+    results.append(_external_capability("deploy", "deploy", "Deploy Changes"))
+    results.append(_external_capability("cleanup", "cleanup", "Cleanup Workspaces"))
+    results.append(_external_capability("recovery", "recovery", "State Recovery"))
 
     for result in results:
         if result.status not in VALID_STATUSES:
@@ -739,7 +815,6 @@ def determine_overall_status(
     hard_gaps = [r.id for r in results if r.hard and r.status != "pass"]
     failing = [r.id for r in results if r.status == "fail"]
     passing = [r.id for r in results if r.status == "pass"]
-    partial = [r.id for r in results if r.status == "partial"]
 
     if failing:
         reason = f"Inconsistent capability state detected: {', '.join(failing)}"
@@ -747,21 +822,21 @@ def determine_overall_status(
 
     if hard_gaps:
         reason = f"Hard capabilities are still missing: {', '.join(hard_gaps)}"
-        return "partial", reason, hard_gaps
+        return "not_execution_ready", reason, hard_gaps
 
-    if len(passing) == len(results):
-        return (
-            "pass",
-            "All capabilities declared in the readiness matrix passed their configured checks.",
-            [],
-        )
-
-    if not passing and not partial:
-        return (
-            "open",
-            "No capability evidence detected yet.",
-            [r.id for r in results if r.hard],
-        )
+    if all(r.status in ["pass", "open"] for r in results):
+        if any(r.status == "pass" for r in results):
+            return (
+                "plan_ready",
+                "Repository logic supports planning and validation. Execution relies on external operator.",
+                [],
+            )
+        else:
+            return (
+                "open",
+                "No capability evidence detected yet.",
+                [r.id for r in results if r.hard],
+            )
 
     return "partial", "Capabilities are partially implemented.", hard_gaps
 
@@ -792,11 +867,15 @@ def render_report(
     lines.append("")
     lines.append("## Capability Matrix")
     lines.append("")
-    lines.append("| Capability | Status | Hard | Evidence | Missing | Rationale |")
-    lines.append("|---|---|---:|---|---|---|")
+    lines.append("| Dimension | Capability | Status | Hard | Evidence | Missing | Rationale |")
+    lines.append("|---|---|---|---:|---|---|---|")
 
     handoff_evidence: list[str] = []
-    for result in results:
+
+    # Sort results by DIMENSIONS order
+    sorted_results = sorted(results, key=lambda r: DIMENSIONS.index(r.dimension))
+
+    for result in sorted_results:
         if result.id == "handoff_validation":
             handoff_evidence = result.evidence
             evidence = "See Handoff Evidence"
@@ -811,7 +890,7 @@ def render_report(
         )
         hard = "yes" if result.hard else "no"
         lines.append(
-            f"| {result.id} | {result.status} | {hard} | {evidence} | "
+            f"| {result.dimension} | {result.id} | {result.status} | {hard} | {evidence} | "
             f"{missing} | {result.rationale} |"
         )
 
@@ -830,7 +909,25 @@ def render_report(
         for capability in hard_gaps:
             lines.append(f"- Hard capability missing: {capability}")
     else:
-        lines.append("- No residual hard gaps detected.")
+        lines.append("- No residual hard repository gaps detected.")
+
+    lines.append("")
+    lines.append("## External Operator Dependencies")
+    lines.append("")
+    external_dependencies = [
+        result
+        for result in sorted_results
+        if result.status == "open"
+        and "external_operator_execution" in result.missing
+    ]
+    if external_dependencies:
+        for result in external_dependencies:
+            lines.append(
+                f"- `{result.dimension}` / `{result.id}`: "
+                "provided by the external operator (Grabowski), not by this repository."
+            )
+    else:
+        lines.append("- No external operator dependencies detected.")
 
     lines.append("")
     lines.append("## Interpretation Rule")

--- a/scripts/docmeta/tests/test_agent_entrypoint_smoke.py
+++ b/scripts/docmeta/tests/test_agent_entrypoint_smoke.py
@@ -15,16 +15,17 @@ import scripts.docmeta.agent_entrypoint_smoke as smoke
 CONSISTENT = {
     "README.md": (
         "# Demo\n\n"
-        "Wahrheit folgt `repo.meta.yaml` und dem Agent Reading Protocol. "
+        "Wahrheit folgt `agent-contract.json`, `repo.meta.yaml` und dem Agent Reading Protocol. "
         "`docs/index.md` ist Navigation, keine Wahrheitsschicht. "
         "`docs/_generated/*` ist Diagnose, nicht Ursprung.\n\n"
         "## Für Agents\n\n"
         "Verbindliche Leseordnung vor jedem Patch:\n\n"
-        "1. `repo.meta.yaml`\n"
-        "2. `AGENTS.md`\n"
-        "3. `agent-policy.yaml`\n"
-        "4. `docs/policies/agent-reading-protocol.md`\n"
-        "5. `docs/index.md`\n\n"
+        "1. `agent-contract.json`\n"
+        "2. `repo.meta.yaml`\n"
+        "3. `AGENTS.md`\n"
+        "4. `agent-policy.yaml`\n"
+        "5. `docs/policies/agent-reading-protocol.md`\n"
+        "6. `docs/index.md`\n\n"
         "## Task-Control\n\n"
         "Task-Index-Check-Modus (`generate_task_index.py --check`) und CI-Guard "
         "(`.github/workflows/task-index.yml`) sind vorhanden.\n\n"
@@ -36,8 +37,8 @@ CONSISTENT = {
         "# AGENTS\n\n"
         "All agents MUST follow the Agent Reading Protocol "
         "(docs/policies/agent-reading-protocol.md).\n\n"
-        "Reading Order: `repo.meta.yaml` -> `AGENTS.md` -> `agent-policy.yaml` -> "
-        "`docs/policies/agent-reading-protocol.md`.\n"
+        "Reading Order: `agent-contract.json` -> `repo.meta.yaml` -> `AGENTS.md` -> "
+        "`agent-policy.yaml` -> `docs/policies/agent-reading-protocol.md`.\n"
     ),
     "docs/index.md": (
         "---\nid: docs.index\ntitle: Index\nstatus: active\nsummary: test\n---\n\n"
@@ -58,7 +59,8 @@ CONSISTENT = {
         "summary: test\n---\n\n"
         "# Agent Reading Protocol\n\n"
         "## Lesereihenfolge\n\n"
-        "1. `repo.meta.yaml`\n2. `AGENTS.md`\n3. `agent-policy.yaml`\n\n"
+        "1. `agent-contract.json`\n2. `repo.meta.yaml`\n3. `AGENTS.md`\n"
+        "4. `agent-policy.yaml`\n\n"
         "## _generated\n\n"
         "`docs/_generated/*` ist Diagnose, nicht Ursprung.\n"
     ),
@@ -197,7 +199,7 @@ class TestAgentEntrypointSmoke(unittest.TestCase):
     def test_missing_reading_order_entry_fails(self):
         self._write(
             "README.md",
-            CONSISTENT["README.md"].replace("4. `docs/policies/agent-reading-protocol.md`\n", ""),
+            CONSISTENT["README.md"].replace("5. `docs/policies/agent-reading-protocol.md`\n", ""),
         )
         errors = smoke.run_checks(self.root)
         self.assertTrue(
@@ -289,7 +291,7 @@ class TestAgentEntrypointSmoke(unittest.TestCase):
         self._write(
             "README.md",
             CONSISTENT["README.md"].replace(
-                "4. `docs/policies/agent-reading-protocol.md`\n",
+                "5. `docs/policies/agent-reading-protocol.md`\n",
                 "",
             )
             + "\nQuick link: `docs/policies/agent-reading-protocol.md`\n",
@@ -308,8 +310,33 @@ class TestAgentEntrypointSmoke(unittest.TestCase):
         self._write(
             "README.md",
             CONSISTENT["README.md"].replace(
-                "2. `AGENTS.md`\n3. `agent-policy.yaml`\n",
-                "2. `agent-policy.yaml`\n3. `AGENTS.md`\n",
+                "3. `AGENTS.md`\n4. `agent-policy.yaml`\n",
+                "3. `agent-policy.yaml`\n4. `AGENTS.md`\n",
+            ),
+        )
+        errors = smoke.run_checks(self.root)
+        self.assertTrue(
+            any("README.md: reading order is out of sequence" in e for e in errors),
+            errors,
+        )
+
+    def test_missing_agent_contract_json_fails(self):
+        self._write(
+            "README.md",
+            CONSISTENT["README.md"].replace("1. `agent-contract.json`\n", ""),
+        )
+        errors = smoke.run_checks(self.root)
+        self.assertTrue(
+            any("README.md: missing reading-order entry: agent-contract.json" in e for e in errors),
+            errors,
+        )
+
+    def test_agent_contract_json_out_of_sequence_fails(self):
+        self._write(
+            "README.md",
+            CONSISTENT["README.md"].replace(
+                "1. `agent-contract.json`\n2. `repo.meta.yaml`\n",
+                "1. `repo.meta.yaml`\n2. `agent-contract.json`\n",
             ),
         )
         errors = smoke.run_checks(self.root)

--- a/scripts/docmeta/tests/test_generate_agent_readiness.py
+++ b/scripts/docmeta/tests/test_generate_agent_readiness.py
@@ -151,7 +151,7 @@ class TestGenerateAgentReadiness(unittest.TestCase):
         self.assertEqual(status["safety_preflight"], "pass")
         self.assertEqual(status["claim_evidence_spine"], "open")
         self.assertEqual(status["agent_contracts"], "open")
-        self.assertEqual(overall, "partial")
+        self.assertEqual(overall, "not_execution_ready")
         self.assertIn("Hard capabilities are still missing", reason)
         self.assertNotIn("- **Overall:** pass", report)
 
@@ -161,14 +161,15 @@ class TestGenerateAgentReadiness(unittest.TestCase):
         results = gen.evaluate_capabilities(self.root)
         overall, _reason, _hard_missing = gen.determine_overall_status(results)
 
-        self.assertIn(overall, {"open", "partial"})
+        self.assertIn(overall, {"open", "partial", "not_execution_ready"})
         self.assertNotEqual(overall, "pass")
         self.assertIn("claim_evidence_spine", report)
         self.assertIn("agent_contracts", report)
         self.assertIn("dry_run_runner", report)
 
     def test_all_hard_capabilities_present_yields_pass(self):
-        self._touch("AGENTS.md")
+        for rel_path in gen.DISCOVERY_REQUIRED_FILES:
+            self._touch(rel_path)
         self._touch("agent-policy.yaml")
         self._touch("scripts/agent/check_agent_preflight.py")
         self._touch("scripts/agent/tests/test_check_agent_preflight.py")
@@ -185,13 +186,11 @@ class TestGenerateAgentReadiness(unittest.TestCase):
         gen.generate(self.root)
         results = gen.evaluate_capabilities(self.root)
         status = self._status_map(results)
-        overall, _reason, _hard_missing = gen.determine_overall_status(results)
+        overall, _reason, hard_missing = gen.determine_overall_status(results)
 
-        hard_non_pass = [
-            result.id for result in results if result.hard and result.status != "pass"
-        ]
-        self.assertEqual(overall, "pass")
-        self.assertEqual(hard_non_pass, [])
+        self.assertEqual(overall, "plan_ready")
+        self.assertEqual(hard_missing, [])
+        self.assertEqual(status["discover"], "pass")
         self.assertEqual(status["claim_evidence_spine"], "pass")
         self.assertEqual(status["agent_contracts"], "pass")
         self.assertEqual(status["handoff_validation"], "pass")
@@ -213,6 +212,7 @@ class TestGenerateAgentReadiness(unittest.TestCase):
 
         self.assertIn("## Capability Matrix", report)
         self.assertIn("## Residual Gaps", report)
+        self.assertIn("## External Operator Dependencies", report)
         self.assertIn("## Interpretation Rule", report)
         self.assertRegex(report, r"\| agent_policy \| (pass|partial|open|fail) \|")
         self.assertRegex(report, r"\| safety_preflight \| (pass|partial|open|fail) \|")
@@ -220,6 +220,30 @@ class TestGenerateAgentReadiness(unittest.TestCase):
             report, r"\| claim_evidence_spine \| (pass|partial|open|fail) \|"
         )
         self.assertRegex(report, r"\| run_evidence_lite \| (pass|partial|open|fail) \|")
+
+    def test_discovery_is_repo_capability_and_external_dependencies_are_explicit(self):
+        for rel_path in gen.DISCOVERY_REQUIRED_FILES:
+            self._touch(rel_path)
+
+        results = gen.evaluate_capabilities(self.root)
+        status = self._status_map(results)
+        self.assertEqual(status["discover"], "pass")
+
+        report = gen.generate(self.root).read_text(encoding="utf-8")
+        self.assertIn("## External Operator Dependencies", report)
+        self.assertIn("`workspace` / `workspace`", report)
+        self.assertNotIn("discover` / `discover`", report)
+
+    def test_missing_discovery_is_hard_gap(self):
+        results = gen.evaluate_capabilities(self.root)
+        discovery = next(item for item in results if item.id == "discover")
+        overall, reason, hard_gaps = gen.determine_overall_status(results)
+
+        self.assertTrue(discovery.hard)
+        self.assertIn(discovery.status, {"open", "partial", "fail"})
+        self.assertIn("discover", hard_gaps)
+        self.assertIn(overall, {"not_execution_ready", "fail"})
+        self.assertIn("discover", reason)
 
     def test_handoff_single_artifact_is_partial_not_pass(self):
         self._touch("contracts/agent/handoff.schema.json", "{}\n")

--- a/scripts/docmeta/tests/test_generate_agent_readiness.py
+++ b/scripts/docmeta/tests/test_generate_agent_readiness.py
@@ -113,6 +113,41 @@ class TestGenerateAgentReadiness(unittest.TestCase):
             target.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(source, target)
 
+    def _copy_discovery_capability(self) -> None:
+        source_root = Path(gen.REPO_ROOT).resolve()
+        required_paths = list(
+            dict.fromkeys(
+                [
+                    *gen.DISCOVERY_REQUIRED_FILES,
+                    "repo.meta.yaml",
+                    "agent-policy.yaml",
+                    "docs/policies/agent-reading-protocol.md",
+                    "README.md",
+                    "docs/index.md",
+                    "docs/tasks/README.md",
+                    "docs/roadmap.md",
+                    "scripts/docmeta/generate_task_index.py",
+                    ".github/workflows/task-index.yml",
+                    ".wgx/generated-artifacts.yml",
+                ]
+            )
+        )
+        for rel_path in required_paths:
+            source = (source_root / rel_path).resolve()
+            try:
+                source.relative_to(source_root)
+            except ValueError as exc:
+                raise AssertionError(
+                    f"discovery fixture dependency escapes repository root: {rel_path}"
+                ) from exc
+            if not source.is_file():
+                raise AssertionError(
+                    f"discovery fixture dependency is missing or not a file: {rel_path}"
+                )
+            target = self.root / rel_path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, target)
+
     def _init_git_repo(self) -> None:
         subprocess_kwargs = {
             "cwd": self.root,
@@ -168,9 +203,7 @@ class TestGenerateAgentReadiness(unittest.TestCase):
         self.assertIn("dry_run_runner", report)
 
     def test_all_hard_capabilities_present_yields_pass(self):
-        for rel_path in gen.DISCOVERY_REQUIRED_FILES:
-            self._touch(rel_path)
-        self._touch("agent-policy.yaml")
+        self._copy_discovery_capability()
         self._touch("scripts/agent/check_agent_preflight.py")
         self._touch("scripts/agent/tests/test_check_agent_preflight.py")
         self._touch(".github/workflows/agent-safety-preflight.yml")
@@ -222,8 +255,7 @@ class TestGenerateAgentReadiness(unittest.TestCase):
         self.assertRegex(report, r"\| run_evidence_lite \| (pass|partial|open|fail) \|")
 
     def test_discovery_is_repo_capability_and_external_dependencies_are_explicit(self):
-        for rel_path in gen.DISCOVERY_REQUIRED_FILES:
-            self._touch(rel_path)
+        self._copy_discovery_capability()
 
         results = gen.evaluate_capabilities(self.root)
         status = self._status_map(results)
@@ -233,6 +265,41 @@ class TestGenerateAgentReadiness(unittest.TestCase):
         self.assertIn("## External Operator Dependencies", report)
         self.assertIn("`workspace` / `workspace`", report)
         self.assertNotIn("discover` / `discover`", report)
+
+    def test_discovery_placeholders_fail_functional_smoke(self):
+        for rel_path in gen.DISCOVERY_REQUIRED_FILES:
+            self._touch(
+                rel_path, "{}\n" if rel_path.endswith(".json") else "# placeholder\n"
+            )
+
+        result = next(
+            item
+            for item in gen.evaluate_capabilities(self.root)
+            if item.id == "discover"
+        )
+
+        self.assertEqual(result.status, "fail")
+        self.assertIn("functional discovery smoke", result.missing)
+
+    def test_invalid_discovery_contract_fails_readiness(self):
+        self._copy_discovery_capability()
+        contract_path = self.root / "agent-contract.json"
+        contract = json.loads(contract_path.read_text(encoding="utf-8"))
+        contract["reading_order"] = ["repo.meta.yaml"]
+        contract_path.write_text(
+            json.dumps(contract, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        result = next(
+            item
+            for item in gen.evaluate_capabilities(self.root)
+            if item.id == "discover"
+        )
+
+        self.assertEqual(result.status, "fail")
+        self.assertIn("functional discovery smoke", result.missing)
+        self.assertIn("AGENT_CONTRACT", result.rationale)
 
     def test_missing_discovery_is_hard_gap(self):
         results = gen.evaluate_capabilities(self.root)


### PR DESCRIPTION
## Problem
Die Agentgrenzen waren auf mehrere YAML- und Markdownflächen verteilt. `just check` konnte schreiben beziehungsweise Fehler weichschalten, und die Readiness vermischte Repo-Fähigkeiten mit externer Ausführung.

## Architekturentscheidung
- `agent-contract.json` ist die einzige strikte Maschinenquelle für Agentpfade, Checks, Generatoren und Rollen.
- Das Weltgewebe-Repo bleibt `repo_contract_authority`.
- Grabowski bleibt `external_operator_execution` für Workspace, Lease, Schreiben, Review, Veröffentlichung, Recovery und Cleanup.
- `repo_generic_write_mode` ist ausdrücklich `rejected`.

## Änderungen
- versionierter JSON-Contract plus Schema und fail-closed Validator
- exakte Kompatibilitätsprojektionen für `repo.meta.yaml` und `agent-policy.yaml`
- progressive Einstiegskarte und verbindliche Lesereihenfolge
- schreibfreier, fail-closed `just check` samt rekursivem Sicherheitstest
- Readiness-Dimensionen mit `plan_ready`, funktionalem Discovery-Smoke und getrennten externen Operatorabhängigkeiten
- Generatorziele ausschließlich unter `docs/_generated/`; `secrets/` und `snapshots/` ausgeschlossen
- Autoritätsdateien `agent-contract.json` und `.wgx/generated-artifacts.yml` ausdrücklich bewacht
- Erweiterung des bestehenden Agent-Safety-Workflows statt eines zweiten Workflows
- dokumentierter Migrations- und Rückbaupfad

## Sicherheitsgrenzen
- keine freie Shell-Autorität durch Validierungsprofile
- keine direkten Agent-Edits an generierten Zielen
- Generatorregistry fest auf `.wgx/generated-artifacts.yml` gebunden
- doppelte YAML-Schlüssel, absolute Pfade, Traversal, doppelte Artefakte, leere argv-Elemente und nicht erlaubte Generatorziele werden abgelehnt
- keine Produkt-, Runtime- oder Infrastrukturänderung

## Finale Bindung
- Base: `1c7708fdd4af2353c70b2e60c185ae4d63a4adea`
- Head: `7fd76b8c8110f0931ee03bfc95c50c47cce66b9e`
- GitHub-Diff SHA-256: `ab673daedea3bf553917c4bd32cbca35295e0e198029bc41160c582007ced46d`
- Diff: https://gist.github.com/alexdermohr/6b62c0384d499205cd1ecefc02f6ba85
- Der Rebase auf aktuellen `main` war konfliktfrei; die dazwischenliegenden Deploy-Reconciler-Dateien sind vollständig pfaddisjunkt.

## Tests und Evidenz
- 191 Agent-Tests: grün
- 36 Entrypoint-/Readiness-Tests: grün
- Contract-Validatoren, Handoff-Freshness und Python-Kompilierung: grün
- Repo-, Relations-, Generated-, Coverage- und Search-Goldset-Guards: grün
- Markdownlint: grün
- `just check`: Exitcode 0; Repository-Fingerprint `c89e9b22…` vor und nach dem Lauf identisch
- deterministischer Korrektheitsreview: PASS
- adversarialer Sicherheitsreview mit gefährlichen Vertragsmutationen: PASS

## Restarbeit
- Legacy-`validation_commands`, alte Minimalparser und doppelte Preflightflächen werden erst nach belegter Consumer-Parität zurückgebaut.
- PyYAML ist versionsgebunden, aber noch nicht paket-hashgebunden; dies bleibt Supply-Chain-Folgehärtung.
- Die Grabowski-`operation.*`-Schicht folgt außerhalb dieses Repos.

## Nichtziel
Kein generischer Repo-Write-Operator und kein autonomes Policy-Umschreiben.

Closes #1482

<!-- weltgewebe-risk: R3 -->