### PR TITLE
feat(search): benchmark local semantic models

### DIFF
--- a/architecture/semantic-search.md
+++ b/architecture/semantic-search.md
@@ -25,7 +25,9 @@ relations:
 verifies_with:
   - contracts/search/relevance-goldset.schema.json
   - contracts/search/examples/relevance-goldset.example.json
+  - contracts/search/examples/relevance-benchmark.heim-pc.json
   - scripts/search/validate_relevance_goldset.py
+  - scripts/search/benchmark_relevance.py
   - scripts/ci/tests/test_semantic_search_contract.py
 ---
 
@@ -177,7 +179,29 @@ OpenRouter-Free ist nur zulässig:
 
 Cloud gewinnt nur bei einem klaren, praktisch relevanten Qualitätsvorsprung und nach ausdrücklicher Kostenfreigabe. Andernfalls gewinnt das kleinste lokale Modell, das die Qualitätsgates erfüllt.
 
-## 10. Generationen und Dimensionssicherheit
+## 10. T002-Messung und begrenzte Modellentscheidung
+
+Die T002-Messung verwendet ausschließlich den eingecheckten synthetischen Korpus mit 22 Knoten und 24 deutschen Suchfällen. 19 Fälle sind natürliche Anfragen. Zwei Knoten sind verborgen, ein Knoten ist gelöscht; alle Retrievalpfade erhalten ausschließlich die pro Fall zulässige sichtbare Kandidatenmenge. Es wurden keine realen oder pseudonymisierten Daten, keine Cloud-API und kein OpenRouter-Endpunkt verwendet. Die externen Kosten betragen null.
+
+Der reproduzierbare Beleg liegt in `contracts/search/examples/relevance-benchmark.heim-pc.json`. Er bindet Dataset, Schema, Benchmarkquellcode, Ollama-Modell-Digest, Dimension und Dokumentrevision. Rohvektoren und Rohproviderantworten werden weder eingecheckt noch als Metrik gespeichert.
+
+Die Messung trennt drei Ebenen:
+
+1. Die reale heutige Client-Teilstringsuche erreicht bei natürlichen Anfragen 0 von 19 relevanten Top-3-Treffern.
+2. Die deterministische FTS-/Trigramm-Referenz erreicht 11 von 19 natürlichen Top-3-Treffern. Sie ist eine Offline-Näherung und belegt ausdrücklich keine Parität zu PostgreSQL-FTS oder `pg_trgm`.
+3. Lokale hybride Kandidaten behalten die harten lexikalischen Vorrangklassen bei und ergänzen nur Fälle ohne stärkeres lexikalisches Signal.
+
+| Lokaler Kandidat | Dimension | Natürliche Top-3 | Falsche Top-1 | Sichtbarkeitslecks | Gate |
+| --- | ---: | ---: | ---: | ---: | --- |
+| `qwen3-embedding:0.6b` | 1024 | 18/19 | 3 | 0 | nicht qualifiziert |
+| `qwen3-embedding:4b` | 2560 | 19/19 | 2 | 0 | nicht qualifiziert |
+| `qwen3-embedding:8b` | 4096 | 19/19 | 1 | 0 | qualifiziert |
+
+Die lexikalische Referenz besitzt einen falschen Top-1-Treffer. Deshalb scheiden 0,6B und 4B trotz hoher Top-3-Abdeckung aus: Sie verschlechtern dieses harte Gate auf drei beziehungsweise zwei falsche Top-1-Treffer. `qwen3-embedding:8b` hält den Referenzwert, wahrt exakte Titel- und Tagtreffer und erreicht 19 von 19 natürlichen Top-3-Treffern. Es ist damit der kleinste der vollständig gemessenen lokalen Kandidaten, der alle T002-Gates erfüllt.
+
+Diese Auswahl bindet für T003 und T004 nur den derzeitigen lokalen Referenzkandidaten samt Digest und Dimension. Sie ist keine Produktionsfreigabe, kein Nachweis realer Nutzerrelevanz, keine Aussage über PostgreSQL- oder `pgvector`-Betrieb und keine Freigabe zur SemantAH-Stilllegung. Änderungen an Goldset, Dokumentbildung, Modell-Digest, Quantisierung oder Rankingrevision verlangen eine neue vollständige Messung.
+
+## 11. Generationen und Dimensionssicherheit
 
 Eine aktive Indexgeneration bindet mindestens:
 
@@ -193,7 +217,7 @@ Ein Wechsel eines dieser Merkmale erzeugt eine vollständige neue Generation. Ve
 
 Eine neue Generation wird vollständig aufgebaut und geprüft, bevor sie atomar aktiviert wird. Ein Rückwechsel aktiviert nur eine vollständig konsistente vorherige Generation oder baut sie neu auf.
 
-## 11. Projektion und Worker
+## 12. Projektion und Worker
 
 Der spätere Worker ist idempotent und revisionsgebunden:
 
@@ -208,7 +232,7 @@ Der spätere Worker ist idempotent und revisionsgebunden:
 
 Mehrere API- oder Worker-Instanzen dürfen denselben Auftrag wiederholen, ohne doppelte fachliche Wirkung oder Rückwärtslauf.
 
-## 12. Vorgesehene interne Codegrenze
+## 13. Vorgesehene interne Codegrenze
 
 Die reale Codeorganisation wird in T004 bis T006 schrittweise ergänzt. Der bevorzugte Zuschnitt liegt innerhalb von `apps/api`, nicht in einer neuen Runtime:
 
@@ -231,7 +255,7 @@ apps/api/src/bin/search-evaluate.rs
 
 Die genaue Dateigrenze darf an bestehende Rust-Module angepasst werden. Verboten bleibt eine separate `apps/semantic-service`-Runtime.
 
-## 13. Goldset-Vertrag
+## 14. Goldset-Vertrag
 
 `contracts/search/relevance-goldset.schema.json` definiert ein maschinenlesbares Format. Das eingecheckte Beispiel ist ausschließlich synthetisch.
 
@@ -251,7 +275,7 @@ Relevante IDs müssen sichtbar sein. Ausgeschlossene IDs dürfen nicht sichtbar 
 
 Das Goldset misst Retrievalqualität, nicht gesellschaftliche Wahrheit. Bewertungen müssen begründet und bei fachlichen Änderungen versioniert werden.
 
-## 14. Qualitäts- und Freigabegates
+## 15. Qualitäts- und Freigabegates
 
 Vor T008 müssen mindestens belegt sein:
 
@@ -270,7 +294,7 @@ Vor T008 müssen mindestens belegt sein:
 
 Basis und Kandidaten werden getrennt berichtet. Ein gemittelter Gesamtscore darf Regressionen bei exakten Treffern oder Sichtbarkeit nicht verdecken.
 
-## 15. Betrieb und Beobachtbarkeit
+## 16. Betrieb und Beobachtbarkeit
 
 Später mindestens beobachtbar sind:
 
@@ -286,7 +310,7 @@ Später mindestens beobachtbar sind:
 
 Metriken enthalten keine Rohqueries, privaten Texte oder Embeddings, solange dafür kein eigener Datenschutzvertrag besteht.
 
-## 16. Hard Cut und Nichtziele
+## 17. Hard Cut und Nichtziele
 
 Nicht Bestandteil der Zielarchitektur sind:
 
@@ -305,7 +329,7 @@ Nicht Bestandteil der Zielarchitektur sind:
 
 Brauchbare SemantAH-Konzepte wie Providergrenzen, Dimensionsprüfung, Normalisierung, deterministische Cosinus-Referenzsuche, Benchmarks und Tests dürfen zielgerichtet neu implementiert werden. SemantAH-Code wird nicht als dauerhafte Abhängigkeit übernommen.
 
-## 17. Taskgrenzen
+## 18. Taskgrenzen
 
 - **T001:** Architekturvertrag, Goldset-Format, synthetisches Beispiel und Validator.
 - **T002:** Relevanzbasis und Modellvergleich.
@@ -319,7 +343,7 @@ Brauchbare SemantAH-Konzepte wie Providergrenzen, Dimensionsprüfung, Normalisie
 
 Erst nach erfolgreichem T008-Beweis darf T009 `SEMANTAH-USEFULNESS-V1`, `SEMANTAH-INDEXD-SCALING-V1` und `SEMANTAH-E2E-PORTABILITY-V1` superseden oder schließen.
 
-## 18. Stopbedingungen
+## 19. Stopbedingungen
 
 Die Initiative wird gestoppt oder neu geschnitten, wenn:
 
@@ -330,7 +354,7 @@ Die Initiative wird gestoppt oder neu geschnitten, wenn:
 - der Betriebsaufwand den gemessenen Relevanzgewinn überwiegt oder
 - die Suche eine zweite fachliche Wahrheit oder automatische Beziehungssemantik erzeugen würde.
 
-## 19. Nicht behaupteter Zustand
+## 20. Nicht behaupteter Zustand
 
 Dieser Vertrag belegt nicht:
 

--- a/contracts/search/examples/relevance-benchmark.heim-pc.json
+++ b/contracts/search/examples/relevance-benchmark.heim-pc.json
@@ -1,0 +1,1684 @@
+{
+  "schema_version": 1,
+  "kind": "weltgewebe_semantic_search_relevance_benchmark",
+  "benchmark_revision": "semantic-search-benchmark-v1",
+  "measured_at": "2026-07-18T20:28:04.077903Z",
+  "dataset": {
+    "path": "contracts/search/examples/relevance-goldset.example.json",
+    "dataset_id": "weltgewebe-semantic-search-v1-synthetic-v2",
+    "document_revision": "node-document-v1",
+    "sha256": "e0cf7f362242bf13c3f69aa3cc1846c35bf615410cc5deee94be2e197bded56c",
+    "schema_sha256": "0643fec713e3f883896319701402645c987cc684ca35652feb75f0381395bdc0",
+    "node_count": 22,
+    "case_count": 24,
+    "privacy_class": "synthetic"
+  },
+  "benchmark_source_sha256": "ec6f9646aaf43b5cbf465280df9b67aa62c27125248e928a157a85be78d877fb",
+  "environment": {
+    "host_class": "heim-pc-local",
+    "platform": "Linux-7.0.11-76070011-generic-x86_64-with-glibc2.35",
+    "python": "3.10.12",
+    "ollama_url": "http://127.0.0.1:11434",
+    "external_cost_usd": 0
+  },
+  "baselines": [
+    {
+      "name": "current_client_substring",
+      "quality": {
+        "case_count": 24,
+        "natural_case_count": 19,
+        "top1_relevant_count": 3,
+        "top1_relevant_rate": 0.125,
+        "top3_relevant_count": 3,
+        "top3_relevant_rate": 0.125,
+        "natural_top3_relevant_count": 0,
+        "natural_top3_relevant_rate": 0.0,
+        "false_top1_count": 0,
+        "no_result_count": 21,
+        "visibility_leak_count": 0,
+        "exact_guard_failures": [],
+        "per_expected_rank_class": {
+          "exact_title": {
+            "count": 1,
+            "top1": 1,
+            "top3": 1
+          },
+          "exact_tag": {
+            "count": 1,
+            "top1": 1,
+            "top3": 1
+          },
+          "title_prefix": {
+            "count": 1,
+            "top1": 1,
+            "top3": 1
+          },
+          "typo": {
+            "count": 1,
+            "top1": 0,
+            "top3": 0
+          },
+          "full_text": {
+            "count": 3,
+            "top1": 0,
+            "top3": 0
+          },
+          "semantic": {
+            "count": 17,
+            "top1": 0,
+            "top3": 0
+          }
+        },
+        "cases": [
+          {
+            "case_id": "search-exact-title-community-garden",
+            "top3": [
+              "syn-node-community-garden"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-exact-tag-tool-sharing",
+            "top3": [
+              "syn-node-tool-library"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-title-prefix-neighbourhood-kitchen",
+            "top3": [
+              "syn-node-neighbourhood-kitchen"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-typo-bike-workshop",
+            "top3": [],
+            "relevant_rank": null,
+            "top1_relevant": false,
+            "top3_relevant": false,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-full-text-energy-rent",
+            "top3": [],
+            "relevant_rank": null,
+            "top1_relevant": false,
+            "top3_relevant": false,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-food-rescue",
+            "top3": [],
+            "relevant_rank": null,
+            "top1_relevant": false,
+            "top3_relevant": false,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-phone-help",
+            "top3": [],
+            "relevant_rank": null,
+            "top1_relevant": false,
+            "top3_relevant": false,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-clothes-circular",
+            "top3": [],
+            "relevant_rank": null,
+            "top1_relevant": false,
+            "top3_relevant": false,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-language-practice",
+            "top3": [],
+            "relevant_rank": null,
+            "top1_relevant": false,
+            "top3_relevant": false,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-elderly-company",
+            "top3": [],
+            "relevant_rank": null,
+            "top1_relevant": false,
+            "top3_relevant": false,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-drill-sharing",
+            "top3": [],
+            "relevant_rank": null,
+            "top1_relevant": false,
+            "top3_relevant": false,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-shared-childcare",
+            "top3": [],
+            "relevant_rank": null,
+            "top1_relevant": false,
+            "top3_relevant": false,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-rent-contract",
+            "top3": [],
+            "relevant_rank": null,
+            "top1_relevant": false,
+            "top3_relevant": false,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-clean-river",
+            "top3": [],
+            "relevant_rank": null,
+            "top1_relevant": false,
+            "top3_relevant": false,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-make-radio",
+            "top3": [],
+            "relevant_rank": null,
+            "top1_relevant": false,
+            "top3_relevant": false,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-radio-repair",
+            "top3": [],
+            "relevant_rank": null,
+            "top1_relevant": false,
+            "top3_relevant": false,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-cargo-bike",
+            "top3": [],
+            "relevant_rank": null,
+            "top1_relevant": false,
+            "top3_relevant": false,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-legal-first-step",
+            "top3": [],
+            "relevant_rank": null,
+            "top1_relevant": false,
+            "top3_relevant": false,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-seeds-spring",
+            "top3": [],
+            "relevant_rank": null,
+            "top1_relevant": false,
+            "top3_relevant": false,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-cook-together",
+            "top3": [],
+            "relevant_rank": null,
+            "top1_relevant": false,
+            "top3_relevant": false,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-prototype-machines",
+            "top3": [],
+            "relevant_rank": null,
+            "top1_relevant": false,
+            "top3_relevant": false,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-filter-workshops",
+            "top3": [],
+            "relevant_rank": null,
+            "top1_relevant": false,
+            "top3_relevant": false,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-visibility-hidden-bike",
+            "top3": [],
+            "relevant_rank": null,
+            "top1_relevant": false,
+            "top3_relevant": false,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-visibility-deleted-repair",
+            "top3": [],
+            "relevant_rank": null,
+            "top1_relevant": false,
+            "top3_relevant": false,
+            "visibility_leaks": []
+          }
+        ]
+      },
+      "performance": {
+        "median_ms": 0.026,
+        "p95_ms": 0.041,
+        "maximum_ms": 0.053
+      }
+    },
+    {
+      "name": "fts_trigram_reference",
+      "quality": {
+        "case_count": 24,
+        "natural_case_count": 19,
+        "top1_relevant_count": 15,
+        "top1_relevant_rate": 0.625,
+        "top3_relevant_count": 16,
+        "top3_relevant_rate": 0.666667,
+        "natural_top3_relevant_count": 11,
+        "natural_top3_relevant_rate": 0.578947,
+        "false_top1_count": 1,
+        "no_result_count": 8,
+        "visibility_leak_count": 0,
+        "exact_guard_failures": [],
+        "per_expected_rank_class": {
+          "exact_title": {
+            "count": 1,
+            "top1": 1,
+            "top3": 1
+          },
+          "exact_tag": {
+            "count": 1,
+            "top1": 1,
+            "top3": 1
+          },
+          "title_prefix": {
+            "count": 1,
+            "top1": 1,
+            "top3": 1
+          },
+          "typo": {
+            "count": 1,
+            "top1": 1,
+            "top3": 1
+          },
+          "full_text": {
+            "count": 3,
+            "top1": 3,
+            "top3": 3
+          },
+          "semantic": {
+            "count": 17,
+            "top1": 8,
+            "top3": 9
+          }
+        },
+        "cases": [
+          {
+            "case_id": "search-exact-title-community-garden",
+            "top3": [
+              "syn-node-community-garden",
+              "syn-node-elder-companionship"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-exact-tag-tool-sharing",
+            "top3": [
+              "syn-node-tool-library",
+              "syn-node-food-fridge",
+              "syn-node-mobility-share"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-title-prefix-neighbourhood-kitchen",
+            "top3": [
+              "syn-node-neighbourhood-kitchen",
+              "syn-node-community-garden",
+              "syn-node-community-radio"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-typo-bike-workshop",
+            "top3": [
+              "syn-node-bike-workshop",
+              "syn-node-repair-cafe"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-full-text-energy-rent",
+            "top3": [
+              "syn-node-energy-advice",
+              "syn-node-housing-advice"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-food-rescue",
+            "top3": [],
+            "relevant_rank": null,
+            "top1_relevant": false,
+            "top3_relevant": false,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-phone-help",
+            "top3": [],
+            "relevant_rank": null,
+            "top1_relevant": false,
+            "top3_relevant": false,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-clothes-circular",
+            "top3": [],
+            "relevant_rank": null,
+            "top1_relevant": false,
+            "top3_relevant": false,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-language-practice",
+            "top3": [
+              "syn-node-language-cafe"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-elderly-company",
+            "top3": [],
+            "relevant_rank": null,
+            "top1_relevant": false,
+            "top3_relevant": false,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-drill-sharing",
+            "top3": [],
+            "relevant_rank": null,
+            "top1_relevant": false,
+            "top3_relevant": false,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-shared-childcare",
+            "top3": [
+              "syn-node-child-care-coop"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-rent-contract",
+            "top3": [
+              "syn-node-housing-advice"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-clean-river",
+            "top3": [
+              "syn-node-river-cleanup"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-make-radio",
+            "top3": [
+              "syn-node-community-radio"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-radio-repair",
+            "top3": [],
+            "relevant_rank": null,
+            "top1_relevant": false,
+            "top3_relevant": false,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-cargo-bike",
+            "top3": [],
+            "relevant_rank": null,
+            "top1_relevant": false,
+            "top3_relevant": false,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-legal-first-step",
+            "top3": [],
+            "relevant_rank": null,
+            "top1_relevant": false,
+            "top3_relevant": false,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-seeds-spring",
+            "top3": [
+              "syn-node-seed-library"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-cook-together",
+            "top3": [
+              "syn-node-neighbourhood-kitchen"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-prototype-machines",
+            "top3": [
+              "syn-node-maker-space"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-filter-workshops",
+            "top3": [
+              "syn-node-bike-workshop",
+              "syn-node-repair-cafe"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-visibility-hidden-bike",
+            "top3": [
+              "syn-node-energy-advice",
+              "syn-node-bike-workshop"
+            ],
+            "relevant_rank": 2,
+            "top1_relevant": false,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-visibility-deleted-repair",
+            "top3": [
+              "syn-node-repair-cafe",
+              "syn-node-digital-help",
+              "syn-node-tool-library"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          }
+        ]
+      },
+      "performance": {
+        "median_ms": 1.791,
+        "p95_ms": 2.513,
+        "maximum_ms": 2.623
+      }
+    }
+  ],
+  "models": [
+    {
+      "model": {
+        "name": "qwen3-embedding:0.6b",
+        "digest": "sha256:ac6da0dfba84a81fdbfbaf330198c33cd77c4cdfc53e8bc50eb581914a15621d",
+        "size_bytes": 639150858,
+        "family": "qwen3",
+        "parameter_size": "595.78M",
+        "quantization_level": "Q8_0",
+        "dimensions": 1024
+      },
+      "quality": {
+        "case_count": 24,
+        "natural_case_count": 19,
+        "top1_relevant_count": 21,
+        "top1_relevant_rate": 0.875,
+        "top3_relevant_count": 23,
+        "top3_relevant_rate": 0.958333,
+        "natural_top3_relevant_count": 18,
+        "natural_top3_relevant_rate": 0.947368,
+        "false_top1_count": 3,
+        "no_result_count": 0,
+        "visibility_leak_count": 0,
+        "exact_guard_failures": [],
+        "per_expected_rank_class": {
+          "exact_title": {
+            "count": 1,
+            "top1": 1,
+            "top3": 1
+          },
+          "exact_tag": {
+            "count": 1,
+            "top1": 1,
+            "top3": 1
+          },
+          "title_prefix": {
+            "count": 1,
+            "top1": 1,
+            "top3": 1
+          },
+          "typo": {
+            "count": 1,
+            "top1": 1,
+            "top3": 1
+          },
+          "full_text": {
+            "count": 3,
+            "top1": 3,
+            "top3": 3
+          },
+          "semantic": {
+            "count": 17,
+            "top1": 14,
+            "top3": 16
+          }
+        },
+        "cases": [
+          {
+            "case_id": "search-exact-title-community-garden",
+            "top3": [
+              "syn-node-community-garden",
+              "syn-node-elder-companionship",
+              "syn-node-clothing-swap"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-exact-tag-tool-sharing",
+            "top3": [
+              "syn-node-tool-library",
+              "syn-node-food-fridge",
+              "syn-node-mobility-share"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-title-prefix-neighbourhood-kitchen",
+            "top3": [
+              "syn-node-neighbourhood-kitchen",
+              "syn-node-community-garden",
+              "syn-node-community-radio"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-typo-bike-workshop",
+            "top3": [
+              "syn-node-bike-workshop",
+              "syn-node-repair-cafe",
+              "syn-node-clothing-swap"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-full-text-energy-rent",
+            "top3": [
+              "syn-node-energy-advice",
+              "syn-node-housing-advice",
+              "syn-node-clothing-swap"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-food-rescue",
+            "top3": [
+              "syn-node-clothing-swap",
+              "syn-node-neighbourhood-kitchen",
+              "syn-node-legal-advice"
+            ],
+            "relevant_rank": 4,
+            "top1_relevant": false,
+            "top3_relevant": false,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-phone-help",
+            "top3": [
+              "syn-node-digital-help",
+              "syn-node-clothing-swap",
+              "syn-node-legal-advice"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-clothes-circular",
+            "top3": [
+              "syn-node-clothing-swap",
+              "syn-node-tool-library",
+              "syn-node-repair-cafe"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-language-practice",
+            "top3": [
+              "syn-node-language-cafe",
+              "syn-node-legal-advice",
+              "syn-node-clothing-swap"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-elderly-company",
+            "top3": [
+              "syn-node-elder-companionship",
+              "syn-node-clothing-swap",
+              "syn-node-community-garden"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-drill-sharing",
+            "top3": [
+              "syn-node-tool-library",
+              "syn-node-clothing-swap",
+              "syn-node-maker-space"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-shared-childcare",
+            "top3": [
+              "syn-node-child-care-coop",
+              "syn-node-elder-companionship",
+              "syn-node-clothing-swap"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-rent-contract",
+            "top3": [
+              "syn-node-housing-advice",
+              "syn-node-energy-advice",
+              "syn-node-legal-advice"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-clean-river",
+            "top3": [
+              "syn-node-river-cleanup",
+              "syn-node-clothing-swap",
+              "syn-node-mobility-share"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-make-radio",
+            "top3": [
+              "syn-node-community-radio",
+              "syn-node-clothing-swap",
+              "syn-node-language-cafe"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-radio-repair",
+            "top3": [
+              "syn-node-repair-cafe",
+              "syn-node-clothing-swap",
+              "syn-node-community-radio"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-cargo-bike",
+            "top3": [
+              "syn-node-clothing-swap",
+              "syn-node-mobility-share",
+              "syn-node-tool-library"
+            ],
+            "relevant_rank": 2,
+            "top1_relevant": false,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-legal-first-step",
+            "top3": [
+              "syn-node-legal-advice",
+              "syn-node-housing-advice",
+              "syn-node-clothing-swap"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-seeds-spring",
+            "top3": [
+              "syn-node-seed-library",
+              "syn-node-clothing-swap",
+              "syn-node-community-garden"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-cook-together",
+            "top3": [
+              "syn-node-neighbourhood-kitchen",
+              "syn-node-community-garden",
+              "syn-node-community-radio"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-prototype-machines",
+            "top3": [
+              "syn-node-maker-space",
+              "syn-node-tool-library",
+              "syn-node-clothing-swap"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-filter-workshops",
+            "top3": [
+              "syn-node-bike-workshop",
+              "syn-node-repair-cafe",
+              "syn-node-maker-space"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-visibility-hidden-bike",
+            "top3": [
+              "syn-node-energy-advice",
+              "syn-node-bike-workshop",
+              "syn-node-mobility-share"
+            ],
+            "relevant_rank": 2,
+            "top1_relevant": false,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-visibility-deleted-repair",
+            "top3": [
+              "syn-node-repair-cafe",
+              "syn-node-digital-help",
+              "syn-node-tool-library"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          }
+        ]
+      },
+      "performance": {
+        "document_embedding_total_ms": 233.995,
+        "query_embedding_total_ms": 200.474,
+        "ranking": {
+          "median_ms": 3.448,
+          "p95_ms": 3.785,
+          "maximum_ms": 3.79
+        },
+        "document_count": 19,
+        "query_count": 24
+      }
+    },
+    {
+      "model": {
+        "name": "qwen3-embedding:4b",
+        "digest": "sha256:df5bd2e3c74cd8d069d21dc038f1b359fcdc9458fce1c99bd43c9eb1518ff907",
+        "size_bytes": 2496704041,
+        "family": "qwen3",
+        "parameter_size": "4.0B",
+        "quantization_level": "Q4_K_M",
+        "dimensions": 2560
+      },
+      "quality": {
+        "case_count": 24,
+        "natural_case_count": 19,
+        "top1_relevant_count": 22,
+        "top1_relevant_rate": 0.916667,
+        "top3_relevant_count": 24,
+        "top3_relevant_rate": 1.0,
+        "natural_top3_relevant_count": 19,
+        "natural_top3_relevant_rate": 1.0,
+        "false_top1_count": 2,
+        "no_result_count": 0,
+        "visibility_leak_count": 0,
+        "exact_guard_failures": [],
+        "per_expected_rank_class": {
+          "exact_title": {
+            "count": 1,
+            "top1": 1,
+            "top3": 1
+          },
+          "exact_tag": {
+            "count": 1,
+            "top1": 1,
+            "top3": 1
+          },
+          "title_prefix": {
+            "count": 1,
+            "top1": 1,
+            "top3": 1
+          },
+          "typo": {
+            "count": 1,
+            "top1": 1,
+            "top3": 1
+          },
+          "full_text": {
+            "count": 3,
+            "top1": 3,
+            "top3": 3
+          },
+          "semantic": {
+            "count": 17,
+            "top1": 15,
+            "top3": 17
+          }
+        },
+        "cases": [
+          {
+            "case_id": "search-exact-title-community-garden",
+            "top3": [
+              "syn-node-community-garden",
+              "syn-node-elder-companionship",
+              "syn-node-neighbourhood-kitchen"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-exact-tag-tool-sharing",
+            "top3": [
+              "syn-node-tool-library",
+              "syn-node-food-fridge",
+              "syn-node-mobility-share"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-title-prefix-neighbourhood-kitchen",
+            "top3": [
+              "syn-node-neighbourhood-kitchen",
+              "syn-node-community-garden",
+              "syn-node-community-radio"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-typo-bike-workshop",
+            "top3": [
+              "syn-node-bike-workshop",
+              "syn-node-repair-cafe",
+              "syn-node-mobility-share"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-full-text-energy-rent",
+            "top3": [
+              "syn-node-energy-advice",
+              "syn-node-housing-advice",
+              "syn-node-neighbourhood-kitchen"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-food-rescue",
+            "top3": [
+              "syn-node-neighbourhood-kitchen",
+              "syn-node-food-fridge",
+              "syn-node-river-cleanup"
+            ],
+            "relevant_rank": 2,
+            "top1_relevant": false,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-phone-help",
+            "top3": [
+              "syn-node-digital-help",
+              "syn-node-legal-advice",
+              "syn-node-tool-library"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-clothes-circular",
+            "top3": [
+              "syn-node-clothing-swap",
+              "syn-node-repair-cafe",
+              "syn-node-food-fridge"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-language-practice",
+            "top3": [
+              "syn-node-language-cafe",
+              "syn-node-digital-help",
+              "syn-node-legal-advice"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-elderly-company",
+            "top3": [
+              "syn-node-elder-companionship",
+              "syn-node-child-care-coop",
+              "syn-node-mobility-share"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-drill-sharing",
+            "top3": [
+              "syn-node-tool-library",
+              "syn-node-mobility-share",
+              "syn-node-repair-cafe"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-shared-childcare",
+            "top3": [
+              "syn-node-child-care-coop",
+              "syn-node-mobility-share",
+              "syn-node-elder-companionship"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-rent-contract",
+            "top3": [
+              "syn-node-housing-advice",
+              "syn-node-energy-advice",
+              "syn-node-legal-advice"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-clean-river",
+            "top3": [
+              "syn-node-river-cleanup",
+              "syn-node-repair-cafe",
+              "syn-node-mobility-share"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-make-radio",
+            "top3": [
+              "syn-node-community-radio",
+              "syn-node-mobility-share",
+              "syn-node-river-cleanup"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-radio-repair",
+            "top3": [
+              "syn-node-repair-cafe",
+              "syn-node-bike-workshop",
+              "syn-node-community-radio"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-cargo-bike",
+            "top3": [
+              "syn-node-mobility-share",
+              "syn-node-clothing-swap",
+              "syn-node-tool-library"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-legal-first-step",
+            "top3": [
+              "syn-node-legal-advice",
+              "syn-node-housing-advice",
+              "syn-node-digital-help"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-seeds-spring",
+            "top3": [
+              "syn-node-seed-library",
+              "syn-node-community-garden",
+              "syn-node-mobility-share"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-cook-together",
+            "top3": [
+              "syn-node-neighbourhood-kitchen",
+              "syn-node-food-fridge",
+              "syn-node-tool-library"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-prototype-machines",
+            "top3": [
+              "syn-node-maker-space",
+              "syn-node-tool-library",
+              "syn-node-bike-workshop"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-filter-workshops",
+            "top3": [
+              "syn-node-bike-workshop",
+              "syn-node-repair-cafe",
+              "syn-node-maker-space"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-visibility-hidden-bike",
+            "top3": [
+              "syn-node-energy-advice",
+              "syn-node-bike-workshop",
+              "syn-node-repair-cafe"
+            ],
+            "relevant_rank": 2,
+            "top1_relevant": false,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-visibility-deleted-repair",
+            "top3": [
+              "syn-node-repair-cafe",
+              "syn-node-digital-help",
+              "syn-node-tool-library"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          }
+        ]
+      },
+      "performance": {
+        "document_embedding_total_ms": 404.411,
+        "query_embedding_total_ms": 337.718,
+        "ranking": {
+          "median_ms": 5.845,
+          "p95_ms": 6.179,
+          "maximum_ms": 6.238
+        },
+        "document_count": 19,
+        "query_count": 24
+      }
+    },
+    {
+      "model": {
+        "name": "qwen3-embedding:8b",
+        "digest": "sha256:64b933495768fbd3b87c20583d379728a07471e0c66733a9df87cd1901b3c44b",
+        "size_bytes": 4676805193,
+        "family": "qwen3",
+        "parameter_size": "7.6B",
+        "quantization_level": "Q4_K_M",
+        "dimensions": 4096
+      },
+      "quality": {
+        "case_count": 24,
+        "natural_case_count": 19,
+        "top1_relevant_count": 23,
+        "top1_relevant_rate": 0.958333,
+        "top3_relevant_count": 24,
+        "top3_relevant_rate": 1.0,
+        "natural_top3_relevant_count": 19,
+        "natural_top3_relevant_rate": 1.0,
+        "false_top1_count": 1,
+        "no_result_count": 0,
+        "visibility_leak_count": 0,
+        "exact_guard_failures": [],
+        "per_expected_rank_class": {
+          "exact_title": {
+            "count": 1,
+            "top1": 1,
+            "top3": 1
+          },
+          "exact_tag": {
+            "count": 1,
+            "top1": 1,
+            "top3": 1
+          },
+          "title_prefix": {
+            "count": 1,
+            "top1": 1,
+            "top3": 1
+          },
+          "typo": {
+            "count": 1,
+            "top1": 1,
+            "top3": 1
+          },
+          "full_text": {
+            "count": 3,
+            "top1": 3,
+            "top3": 3
+          },
+          "semantic": {
+            "count": 17,
+            "top1": 16,
+            "top3": 17
+          }
+        },
+        "cases": [
+          {
+            "case_id": "search-exact-title-community-garden",
+            "top3": [
+              "syn-node-community-garden",
+              "syn-node-elder-companionship",
+              "syn-node-neighbourhood-kitchen"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-exact-tag-tool-sharing",
+            "top3": [
+              "syn-node-tool-library",
+              "syn-node-food-fridge",
+              "syn-node-mobility-share"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-title-prefix-neighbourhood-kitchen",
+            "top3": [
+              "syn-node-neighbourhood-kitchen",
+              "syn-node-community-garden",
+              "syn-node-community-radio"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-typo-bike-workshop",
+            "top3": [
+              "syn-node-bike-workshop",
+              "syn-node-repair-cafe",
+              "syn-node-mobility-share"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-full-text-energy-rent",
+            "top3": [
+              "syn-node-energy-advice",
+              "syn-node-housing-advice",
+              "syn-node-neighbourhood-kitchen"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-food-rescue",
+            "top3": [
+              "syn-node-food-fridge",
+              "syn-node-neighbourhood-kitchen",
+              "syn-node-clothing-swap"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-phone-help",
+            "top3": [
+              "syn-node-digital-help",
+              "syn-node-legal-advice",
+              "syn-node-housing-advice"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-clothes-circular",
+            "top3": [
+              "syn-node-clothing-swap",
+              "syn-node-food-fridge",
+              "syn-node-repair-cafe"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-language-practice",
+            "top3": [
+              "syn-node-language-cafe",
+              "syn-node-legal-advice",
+              "syn-node-clothing-swap"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-elderly-company",
+            "top3": [
+              "syn-node-elder-companionship",
+              "syn-node-neighbourhood-kitchen",
+              "syn-node-community-radio"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-drill-sharing",
+            "top3": [
+              "syn-node-tool-library",
+              "syn-node-mobility-share",
+              "syn-node-maker-space"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-shared-childcare",
+            "top3": [
+              "syn-node-child-care-coop",
+              "syn-node-elder-companionship",
+              "syn-node-mobility-share"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-rent-contract",
+            "top3": [
+              "syn-node-housing-advice",
+              "syn-node-energy-advice",
+              "syn-node-legal-advice"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-clean-river",
+            "top3": [
+              "syn-node-river-cleanup",
+              "syn-node-food-fridge",
+              "syn-node-clothing-swap"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-make-radio",
+            "top3": [
+              "syn-node-community-radio",
+              "syn-node-legal-advice",
+              "syn-node-river-cleanup"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-radio-repair",
+            "top3": [
+              "syn-node-repair-cafe",
+              "syn-node-bike-workshop",
+              "syn-node-community-radio"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-cargo-bike",
+            "top3": [
+              "syn-node-mobility-share",
+              "syn-node-food-fridge",
+              "syn-node-clothing-swap"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-legal-first-step",
+            "top3": [
+              "syn-node-legal-advice",
+              "syn-node-housing-advice",
+              "syn-node-energy-advice"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-seeds-spring",
+            "top3": [
+              "syn-node-seed-library",
+              "syn-node-community-garden",
+              "syn-node-clothing-swap"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-cook-together",
+            "top3": [
+              "syn-node-neighbourhood-kitchen",
+              "syn-node-food-fridge",
+              "syn-node-community-garden"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-semantic-prototype-machines",
+            "top3": [
+              "syn-node-maker-space",
+              "syn-node-tool-library",
+              "syn-node-repair-cafe"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-filter-workshops",
+            "top3": [
+              "syn-node-bike-workshop",
+              "syn-node-repair-cafe",
+              "syn-node-maker-space"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-visibility-hidden-bike",
+            "top3": [
+              "syn-node-energy-advice",
+              "syn-node-bike-workshop",
+              "syn-node-mobility-share"
+            ],
+            "relevant_rank": 2,
+            "top1_relevant": false,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          },
+          {
+            "case_id": "search-visibility-deleted-repair",
+            "top3": [
+              "syn-node-repair-cafe",
+              "syn-node-digital-help",
+              "syn-node-tool-library"
+            ],
+            "relevant_rank": 1,
+            "top1_relevant": true,
+            "top3_relevant": true,
+            "visibility_leaks": []
+          }
+        ]
+      },
+      "performance": {
+        "document_embedding_total_ms": 537.697,
+        "query_embedding_total_ms": 466.867,
+        "ranking": {
+          "median_ms": 8.871,
+          "p95_ms": 9.796,
+          "maximum_ms": 10.124
+        },
+        "document_count": 19,
+        "query_count": 24
+      }
+    }
+  ],
+  "decision": {
+    "outcome": "select_smallest_qualifying_local_model",
+    "selected_model": "qwen3-embedding:8b",
+    "reason": "The smallest local model meeting all gates and the minimum incremental relevance gain is selected for T003/T004 planning.",
+    "quality_thresholds": {
+      "natural_top3_rate": 0.85,
+      "minimum_gain_cases": 2
+    },
+    "assessed_models": [
+      {
+        "model": "qwen3-embedding:0.6b",
+        "qualifies": false,
+        "meaningful_incremental_gain": true,
+        "natural_top3_gain_cases": 7
+      },
+      {
+        "model": "qwen3-embedding:4b",
+        "qualifies": false,
+        "meaningful_incremental_gain": true,
+        "natural_top3_gain_cases": 8
+      },
+      {
+        "model": "qwen3-embedding:8b",
+        "qualifies": true,
+        "meaningful_incremental_gain": true,
+        "natural_top3_gain_cases": 8
+      }
+    ]
+  },
+  "does_not_establish": [
+    "production relevance",
+    "PostgreSQL FTS or pg_trgm parity",
+    "pgvector availability",
+    "runtime integration",
+    "public live proof",
+    "SemantAH archive authority"
+  ]
+}

--- a/contracts/search/examples/relevance-goldset.example.json
+++ b/contracts/search/examples/relevance-goldset.example.json
@@ -1,67 +1,1512 @@
 {
-  "schema_version": 1,
-  "dataset_id": "weltgewebe-semantic-search-v1-synthetic",
-  "description": "Synthetische Relevanz- und Sichtbarkeitsfälle für den Semantic-Search-v1-Vertrag.",
+  "schema_version": 2,
+  "dataset_id": "weltgewebe-semantic-search-v1-synthetic-v2",
+  "description": "Ausschließlich synthetischer deutscher Knotenkorpus für T002-Relevanz-, Sichtbarkeits- und Modellmessungen.",
   "privacy_class": "synthetic",
+  "document_revision": "node-document-v1",
+  "nodes": [
+    {
+      "id": "syn-node-community-garden",
+      "language": "de",
+      "title": "Gemeinschaftsgarten Altona",
+      "summary": "Offener Nachbarschaftsgarten mit Hochbeeten und Pflanzentausch.",
+      "body": "Menschen gärtnern gemeinsam, teilen Wissen über Gemüse und pflegen eine öffentlich zugängliche Grünfläche.",
+      "tags": [
+        "urban-gardening",
+        "nachbarschaft",
+        "pflanzen-tauschen"
+      ],
+      "kind": "Garten",
+      "status": "active",
+      "visibility_scopes": [
+        "public",
+        "local",
+        "neighbourhood"
+      ],
+      "contains_personal_data": false,
+      "synthetic_source": "authored"
+    },
+    {
+      "id": "syn-node-seed-library",
+      "language": "de",
+      "title": "Saatgutbibliothek",
+      "summary": "Samen ausleihen, vermehren und nach der Ernte zurückbringen.",
+      "body": "Die Bibliothek bewahrt samenfeste Sorten und unterstützt den Tausch von Saatgut für Gemüse, Kräuter und Blumen.",
+      "tags": [
+        "saatgut",
+        "pflanzen-tauschen",
+        "vielfalt"
+      ],
+      "kind": "Bibliothek",
+      "status": "active",
+      "visibility_scopes": [
+        "public",
+        "local",
+        "neighbourhood"
+      ],
+      "contains_personal_data": false,
+      "synthetic_source": "authored"
+    },
+    {
+      "id": "syn-node-repair-cafe",
+      "language": "de",
+      "title": "Reparaturcafé Mitte",
+      "summary": "Gemeinsam defekte Alltagsgeräte, Radios und Kleidung reparieren.",
+      "body": "Ehrenamtliche helfen bei Diagnose und Reparatur. Das Angebot ersetzt keine gewerbliche Werkstatt und fördert Wiederverwendung.",
+      "tags": [
+        "reparieren",
+        "wiederverwenden",
+        "elektronik"
+      ],
+      "kind": "Werkstatt",
+      "status": "active",
+      "visibility_scopes": [
+        "public",
+        "local",
+        "neighbourhood"
+      ],
+      "contains_personal_data": false,
+      "synthetic_source": "authored"
+    },
+    {
+      "id": "syn-node-tool-library",
+      "language": "de",
+      "title": "Werkzeugbibliothek",
+      "summary": "Bohrmaschine, Säge und Handwerkzeug gemeinschaftlich ausleihen.",
+      "body": "Selten benötigte Geräte müssen nicht gekauft werden. Mitglieder teilen Werkzeug und praktische Einweisungen.",
+      "tags": [
+        "werkzeug-teilen",
+        "ausleihen",
+        "selbermachen"
+      ],
+      "kind": "Bibliothek",
+      "status": "active",
+      "visibility_scopes": [
+        "public",
+        "local",
+        "neighbourhood"
+      ],
+      "contains_personal_data": false,
+      "synthetic_source": "authored"
+    },
+    {
+      "id": "syn-node-bike-workshop",
+      "language": "de",
+      "title": "Offene Fahrradwerkstatt",
+      "summary": "Fahrräder mit Unterstützung selbst warten und reparieren.",
+      "body": "Die Werkstatt bietet Montageständer, Ersatzteile und gemeinsame Hilfe bei Bremsen, Reifen und Schaltung.",
+      "tags": [
+        "fahrrad",
+        "reparieren",
+        "mobilität"
+      ],
+      "kind": "Werkstatt",
+      "status": "active",
+      "visibility_scopes": [
+        "public",
+        "local",
+        "neighbourhood"
+      ],
+      "contains_personal_data": false,
+      "synthetic_source": "authored"
+    },
+    {
+      "id": "syn-node-food-fridge",
+      "language": "de",
+      "title": "Fairteiler Kühlschrank",
+      "summary": "Überschüssige Lebensmittel kostenlos weitergeben und retten.",
+      "body": "Der öffentliche Kühlschrank nimmt genießbares Essen auf, damit es nicht weggeworfen wird.",
+      "tags": [
+        "lebensmittel-retten",
+        "foodsharing",
+        "teilen"
+      ],
+      "kind": "Versorgung",
+      "status": "active",
+      "visibility_scopes": [
+        "public",
+        "local",
+        "neighbourhood"
+      ],
+      "contains_personal_data": false,
+      "synthetic_source": "authored"
+    },
+    {
+      "id": "syn-node-language-cafe",
+      "language": "de",
+      "title": "Sprachcafé Deutsch",
+      "summary": "Deutsch in lockerer Runde sprechen und voneinander lernen.",
+      "body": "Menschen mit unterschiedlichen Erstsprachen üben Alltagssprache ohne Prüfung und ohne Kursgebühr.",
+      "tags": [
+        "sprache",
+        "deutsch-üben",
+        "begegnung"
+      ],
+      "kind": "Bildung",
+      "status": "active",
+      "visibility_scopes": [
+        "public",
+        "local",
+        "neighbourhood"
+      ],
+      "contains_personal_data": false,
+      "synthetic_source": "authored"
+    },
+    {
+      "id": "syn-node-child-care-coop",
+      "language": "de",
+      "title": "Kinderbetreuung im Wechsel",
+      "summary": "Familien organisieren gegenseitige stundenweise Betreuung.",
+      "body": "Eltern teilen verlässlich Betreuungstermine und entlasten sich nach gemeinsam vereinbarten Regeln.",
+      "tags": [
+        "kinder",
+        "betreuung",
+        "familien"
+      ],
+      "kind": "Fürsorge",
+      "status": "active",
+      "visibility_scopes": [
+        "public",
+        "local",
+        "neighbourhood"
+      ],
+      "contains_personal_data": false,
+      "synthetic_source": "authored"
+    },
+    {
+      "id": "syn-node-energy-advice",
+      "language": "de",
+      "title": "Energieberatung für Mietwohnungen",
+      "summary": "Unabhängige Hilfe zu Stromverbrauch, Heizung und Nebenkosten.",
+      "body": "Die Beratung erklärt Abrechnungen, findet Einsparmöglichkeiten und empfiehlt kleine Maßnahmen ohne Umbau.",
+      "tags": [
+        "energie",
+        "strom-sparen",
+        "miete"
+      ],
+      "kind": "Beratung",
+      "status": "active",
+      "visibility_scopes": [
+        "public",
+        "local",
+        "neighbourhood"
+      ],
+      "contains_personal_data": false,
+      "synthetic_source": "authored"
+    },
+    {
+      "id": "syn-node-clothing-swap",
+      "language": "de",
+      "title": "Kleidertausch ohne Geld",
+      "summary": "Gut erhaltene Kleidung bringen, tauschen und weitertragen.",
+      "body": "Textilien bleiben im Gebrauch, ohne Verkauf und ohne feste Gegenleistung.",
+      "tags": [
+        "kleidung",
+        "tauschen",
+        "wiederverwenden"
+      ],
+      "kind": "Tausch",
+      "status": "active",
+      "visibility_scopes": [
+        "public",
+        "local",
+        "neighbourhood"
+      ],
+      "contains_personal_data": false,
+      "synthetic_source": "authored"
+    },
+    {
+      "id": "syn-node-neighbourhood-kitchen",
+      "language": "de",
+      "title": "Nachbarschaftsküche Nord",
+      "summary": "Gemeinsam kochen, essen und Küchenerfahrung teilen.",
+      "body": "Die offene Küche organisiert regelmäßige Mahlzeiten und verarbeitet auch gerettete Zutaten.",
+      "tags": [
+        "kochen",
+        "nachbarschaft",
+        "lebensmittel-retten"
+      ],
+      "kind": "Versorgung",
+      "status": "active",
+      "visibility_scopes": [
+        "public",
+        "local",
+        "neighbourhood"
+      ],
+      "contains_personal_data": false,
+      "synthetic_source": "authored"
+    },
+    {
+      "id": "syn-node-housing-advice",
+      "language": "de",
+      "title": "Wohn- und Mietberatung",
+      "summary": "Orientierung bei Mietvertrag, Nebenkosten und Konflikten im Haus.",
+      "body": "Die erste Beratung hilft Unterlagen zu verstehen und verweist bei Bedarf an zuständige Fachstellen.",
+      "tags": [
+        "miete",
+        "wohnen",
+        "beratung"
+      ],
+      "kind": "Beratung",
+      "status": "active",
+      "visibility_scopes": [
+        "public",
+        "local",
+        "neighbourhood"
+      ],
+      "contains_personal_data": false,
+      "synthetic_source": "authored"
+    },
+    {
+      "id": "syn-node-digital-help",
+      "language": "de",
+      "title": "Digitale Alltagshilfe",
+      "summary": "Unterstützung bei Smartphone, Computer und Online-Formularen.",
+      "body": "Geduldige Begleitung erklärt Geräte, sichere Einstellungen und digitale Behördengänge Schritt für Schritt.",
+      "tags": [
+        "digital",
+        "smartphone",
+        "computer"
+      ],
+      "kind": "Bildung",
+      "status": "active",
+      "visibility_scopes": [
+        "public",
+        "local",
+        "neighbourhood"
+      ],
+      "contains_personal_data": false,
+      "synthetic_source": "authored"
+    },
+    {
+      "id": "syn-node-mobility-share",
+      "language": "de",
+      "title": "Lastenrad teilen",
+      "summary": "Lastenräder gemeinschaftlich reservieren und nutzen.",
+      "body": "Das Angebot erleichtert Einkäufe und Transporte ohne eigenes Auto.",
+      "tags": [
+        "lastenrad",
+        "teilen",
+        "mobilität"
+      ],
+      "kind": "Mobilität",
+      "status": "active",
+      "visibility_scopes": [
+        "public",
+        "local",
+        "neighbourhood"
+      ],
+      "contains_personal_data": false,
+      "synthetic_source": "authored"
+    },
+    {
+      "id": "syn-node-river-cleanup",
+      "language": "de",
+      "title": "Sauberes Flussufer",
+      "summary": "Gemeinsame Sammelaktionen gegen Müll an Ufer und Wegen.",
+      "body": "Freiwillige reinigen öffentliche Flächen und dokumentieren Fundarten für die Abfallvermeidung.",
+      "tags": [
+        "müll-sammeln",
+        "umwelt",
+        "fluss"
+      ],
+      "kind": "Umwelt",
+      "status": "active",
+      "visibility_scopes": [
+        "public",
+        "local",
+        "neighbourhood"
+      ],
+      "contains_personal_data": false,
+      "synthetic_source": "authored"
+    },
+    {
+      "id": "syn-node-elder-companionship",
+      "language": "de",
+      "title": "Zeit füreinander",
+      "summary": "Besuche, Spaziergänge und Gespräche mit älteren Menschen.",
+      "body": "Nachbarn wirken Einsamkeit entgegen und vermitteln regelmäßige soziale Begleitung.",
+      "tags": [
+        "senioren",
+        "besuche",
+        "gemeinschaft"
+      ],
+      "kind": "Fürsorge",
+      "status": "active",
+      "visibility_scopes": [
+        "public",
+        "local",
+        "neighbourhood"
+      ],
+      "contains_personal_data": false,
+      "synthetic_source": "authored"
+    },
+    {
+      "id": "syn-node-legal-advice",
+      "language": "de",
+      "title": "Offene Rechtsorientierung",
+      "summary": "Kostenlose erste Orientierung bei alltäglichen Rechtsfragen.",
+      "body": "Das Angebot ordnet ein Problem ein und nennt mögliche nächste Stellen, ersetzt aber keine anwaltliche Vertretung.",
+      "tags": [
+        "recht",
+        "erstberatung",
+        "beratung"
+      ],
+      "kind": "Beratung",
+      "status": "active",
+      "visibility_scopes": [
+        "public",
+        "local",
+        "neighbourhood"
+      ],
+      "contains_personal_data": false,
+      "synthetic_source": "authored"
+    },
+    {
+      "id": "syn-node-community-radio",
+      "language": "de",
+      "title": "Nachbarschaftsradio",
+      "summary": "Lokale Sendungen gemeinsam planen, aufnehmen und ausstrahlen.",
+      "body": "Bewohner lernen Audiotechnik, führen Interviews und gestalten ein nichtkommerzielles Radioprogramm.",
+      "tags": [
+        "radio",
+        "medien",
+        "selbermachen"
+      ],
+      "kind": "Medien",
+      "status": "active",
+      "visibility_scopes": [
+        "public",
+        "local",
+        "neighbourhood"
+      ],
+      "contains_personal_data": false,
+      "synthetic_source": "authored"
+    },
+    {
+      "id": "syn-node-maker-space",
+      "language": "de",
+      "title": "Offene Werkstatt für Prototypen",
+      "summary": "3D-Druck, Laserschneiden und Elektronik gemeinsam nutzen.",
+      "body": "Der Makerspace bietet Maschinen, Einführung und Raum für technische Eigenbauprojekte.",
+      "tags": [
+        "3d-druck",
+        "lasercutter",
+        "elektronik"
+      ],
+      "kind": "Werkstatt",
+      "status": "active",
+      "visibility_scopes": [
+        "public",
+        "local",
+        "neighbourhood"
+      ],
+      "contains_personal_data": false,
+      "synthetic_source": "authored"
+    },
+    {
+      "id": "syn-node-private-garden",
+      "language": "de",
+      "title": "Privater Innenhofgarten",
+      "summary": "Nicht öffentliches Gartentreffen einer geschlossenen Hausgruppe.",
+      "body": "Nur eingeladene Hausbewohner dürfen den Innenhof nutzen.",
+      "tags": [
+        "garten",
+        "intern"
+      ],
+      "kind": "Garten",
+      "status": "hidden",
+      "visibility_scopes": [
+        "local"
+      ],
+      "contains_personal_data": false,
+      "synthetic_source": "authored"
+    },
+    {
+      "id": "syn-node-hidden-bike-cellar",
+      "language": "de",
+      "title": "Verborgene Fahrrad-Hilfe",
+      "summary": "Nicht öffentliches Hilfsangebot in einem internen Keller.",
+      "body": "Der Ort und seine Termine sind nicht für öffentliche Suche freigegeben.",
+      "tags": [
+        "fahrrad",
+        "intern"
+      ],
+      "kind": "Werkstatt",
+      "status": "hidden",
+      "visibility_scopes": [
+        "local"
+      ],
+      "contains_personal_data": false,
+      "synthetic_source": "authored"
+    },
+    {
+      "id": "syn-node-deleted-repair-archive",
+      "language": "de",
+      "title": "Reparaturtreff Archiv",
+      "summary": "Historischer und gelöschter Eintrag eines früheren Reparaturangebots.",
+      "body": "Dieser Knoten darf in keiner aktiven Suche erscheinen.",
+      "tags": [
+        "reparieren",
+        "archiv"
+      ],
+      "kind": "Werkstatt",
+      "status": "deleted",
+      "visibility_scopes": [],
+      "contains_personal_data": false,
+      "synthetic_source": "authored"
+    }
+  ],
   "cases": [
     {
       "id": "search-exact-title-community-garden",
       "language": "de",
       "query": "Gemeinschaftsgarten Altona",
+      "natural_language": false,
       "visibility_context": {
         "viewer_scope": "public",
-        "visible_node_ids": ["syn-node-community-garden", "syn-node-seed-library", "syn-node-repair-cafe"],
-        "active_filters": {"kinds": [], "tags": [], "languages": ["de"]}
+        "visible_node_ids": [
+          "syn-node-community-garden",
+          "syn-node-seed-library",
+          "syn-node-repair-cafe",
+          "syn-node-tool-library",
+          "syn-node-bike-workshop",
+          "syn-node-food-fridge",
+          "syn-node-language-cafe",
+          "syn-node-child-care-coop",
+          "syn-node-energy-advice",
+          "syn-node-clothing-swap",
+          "syn-node-neighbourhood-kitchen",
+          "syn-node-housing-advice",
+          "syn-node-digital-help",
+          "syn-node-mobility-share",
+          "syn-node-river-cleanup",
+          "syn-node-elder-companionship",
+          "syn-node-legal-advice",
+          "syn-node-community-radio",
+          "syn-node-maker-space"
+        ],
+        "active_filters": {
+          "kinds": [],
+          "tags": [],
+          "languages": [
+            "de"
+          ]
+        }
       },
-      "relevant_node_ids": ["syn-node-community-garden"],
+      "relevant_node_ids": [
+        "syn-node-community-garden"
+      ],
       "expected_rank_class": "exact_title",
-      "excluded_node_ids": ["syn-node-private-garden"],
-      "rationale": "Ein exakter Titel muss unabhängig von semantischer Ähnlichkeit Rang eins belegen.",
+      "excluded_node_ids": [
+        "syn-node-private-garden"
+      ],
+      "rationale": "Synthetischer T002-Fall für exact title.",
       "contains_personal_data": false
     },
     {
       "id": "search-exact-tag-tool-sharing",
       "language": "de",
       "query": "werkzeug-teilen",
+      "natural_language": false,
       "visibility_context": {
         "viewer_scope": "public",
-        "visible_node_ids": ["syn-node-tool-library", "syn-node-repair-cafe", "syn-node-seed-library"],
-        "active_filters": {"kinds": [], "tags": ["werkzeug-teilen"], "languages": ["de"]}
+        "visible_node_ids": [
+          "syn-node-community-garden",
+          "syn-node-seed-library",
+          "syn-node-repair-cafe",
+          "syn-node-tool-library",
+          "syn-node-bike-workshop",
+          "syn-node-food-fridge",
+          "syn-node-language-cafe",
+          "syn-node-child-care-coop",
+          "syn-node-energy-advice",
+          "syn-node-clothing-swap",
+          "syn-node-neighbourhood-kitchen",
+          "syn-node-housing-advice",
+          "syn-node-digital-help",
+          "syn-node-mobility-share",
+          "syn-node-river-cleanup",
+          "syn-node-elder-companionship",
+          "syn-node-legal-advice",
+          "syn-node-community-radio",
+          "syn-node-maker-space"
+        ],
+        "active_filters": {
+          "kinds": [],
+          "tags": [],
+          "languages": [
+            "de"
+          ]
+        }
       },
-      "relevant_node_ids": ["syn-node-tool-library"],
+      "relevant_node_ids": [
+        "syn-node-tool-library"
+      ],
       "expected_rank_class": "exact_tag",
-      "excluded_node_ids": ["syn-node-private-workshop"],
-      "rationale": "Ein exaktes Tag bleibt vor Volltext- und Vektorsignalen priorisiert.",
+      "excluded_node_ids": [],
+      "rationale": "Synthetischer T002-Fall für exact tag.",
       "contains_personal_data": false
     },
     {
-      "id": "search-typo-repair-workshop",
+      "id": "search-title-prefix-neighbourhood-kitchen",
+      "language": "de",
+      "query": "Nachbarschaftskü",
+      "natural_language": false,
+      "visibility_context": {
+        "viewer_scope": "public",
+        "visible_node_ids": [
+          "syn-node-community-garden",
+          "syn-node-seed-library",
+          "syn-node-repair-cafe",
+          "syn-node-tool-library",
+          "syn-node-bike-workshop",
+          "syn-node-food-fridge",
+          "syn-node-language-cafe",
+          "syn-node-child-care-coop",
+          "syn-node-energy-advice",
+          "syn-node-clothing-swap",
+          "syn-node-neighbourhood-kitchen",
+          "syn-node-housing-advice",
+          "syn-node-digital-help",
+          "syn-node-mobility-share",
+          "syn-node-river-cleanup",
+          "syn-node-elder-companionship",
+          "syn-node-legal-advice",
+          "syn-node-community-radio",
+          "syn-node-maker-space"
+        ],
+        "active_filters": {
+          "kinds": [],
+          "tags": [],
+          "languages": [
+            "de"
+          ]
+        }
+      },
+      "relevant_node_ids": [
+        "syn-node-neighbourhood-kitchen"
+      ],
+      "expected_rank_class": "title_prefix",
+      "excluded_node_ids": [],
+      "rationale": "Synthetischer T002-Fall für title prefix.",
+      "contains_personal_data": false
+    },
+    {
+      "id": "search-typo-bike-workshop",
       "language": "de",
       "query": "Fahrrad Reparatur Werstatt",
+      "natural_language": false,
       "visibility_context": {
         "viewer_scope": "public",
-        "visible_node_ids": ["syn-node-bike-workshop", "syn-node-tool-library", "syn-node-community-garden"],
-        "active_filters": {"kinds": ["Werkstatt"], "tags": [], "languages": ["de"]}
+        "visible_node_ids": [
+          "syn-node-community-garden",
+          "syn-node-seed-library",
+          "syn-node-repair-cafe",
+          "syn-node-tool-library",
+          "syn-node-bike-workshop",
+          "syn-node-food-fridge",
+          "syn-node-language-cafe",
+          "syn-node-child-care-coop",
+          "syn-node-energy-advice",
+          "syn-node-clothing-swap",
+          "syn-node-neighbourhood-kitchen",
+          "syn-node-housing-advice",
+          "syn-node-digital-help",
+          "syn-node-mobility-share",
+          "syn-node-river-cleanup",
+          "syn-node-elder-companionship",
+          "syn-node-legal-advice",
+          "syn-node-community-radio",
+          "syn-node-maker-space"
+        ],
+        "active_filters": {
+          "kinds": [],
+          "tags": [],
+          "languages": [
+            "de"
+          ]
+        }
       },
-      "relevant_node_ids": ["syn-node-bike-workshop"],
+      "relevant_node_ids": [
+        "syn-node-bike-workshop"
+      ],
       "expected_rank_class": "typo",
-      "excluded_node_ids": ["syn-node-hidden-bike-cellar"],
-      "rationale": "Trigramme sollen einen einfachen Schreibfehler ohne semantische Vorrangnahme auffangen.",
+      "excluded_node_ids": [
+        "syn-node-hidden-bike-cellar"
+      ],
+      "rationale": "Synthetischer T002-Fall für typo.",
       "contains_personal_data": false
     },
     {
-      "id": "search-semantic-shared-bike-repair",
+      "id": "search-full-text-energy-rent",
       "language": "de",
-      "query": "Wo kann ich mein kaputtes Fahrrad gemeinsam reparieren?",
+      "query": "Stromverbrauch Heizung Nebenkosten",
+      "natural_language": false,
       "visibility_context": {
         "viewer_scope": "public",
-        "visible_node_ids": ["syn-node-bike-workshop", "syn-node-tool-library", "syn-node-community-garden"],
-        "active_filters": {"kinds": [], "tags": [], "languages": ["de"]}
+        "visible_node_ids": [
+          "syn-node-community-garden",
+          "syn-node-seed-library",
+          "syn-node-repair-cafe",
+          "syn-node-tool-library",
+          "syn-node-bike-workshop",
+          "syn-node-food-fridge",
+          "syn-node-language-cafe",
+          "syn-node-child-care-coop",
+          "syn-node-energy-advice",
+          "syn-node-clothing-swap",
+          "syn-node-neighbourhood-kitchen",
+          "syn-node-housing-advice",
+          "syn-node-digital-help",
+          "syn-node-mobility-share",
+          "syn-node-river-cleanup",
+          "syn-node-elder-companionship",
+          "syn-node-legal-advice",
+          "syn-node-community-radio",
+          "syn-node-maker-space"
+        ],
+        "active_filters": {
+          "kinds": [],
+          "tags": [],
+          "languages": [
+            "de"
+          ]
+        }
       },
-      "relevant_node_ids": ["syn-node-bike-workshop"],
+      "relevant_node_ids": [
+        "syn-node-energy-advice"
+      ],
+      "expected_rank_class": "full_text",
+      "excluded_node_ids": [],
+      "rationale": "Synthetischer T002-Fall für full text.",
+      "contains_personal_data": false
+    },
+    {
+      "id": "search-semantic-food-rescue",
+      "language": "de",
+      "query": "Wohin mit zu viel gutem Essen?",
+      "natural_language": true,
+      "visibility_context": {
+        "viewer_scope": "public",
+        "visible_node_ids": [
+          "syn-node-community-garden",
+          "syn-node-seed-library",
+          "syn-node-repair-cafe",
+          "syn-node-tool-library",
+          "syn-node-bike-workshop",
+          "syn-node-food-fridge",
+          "syn-node-language-cafe",
+          "syn-node-child-care-coop",
+          "syn-node-energy-advice",
+          "syn-node-clothing-swap",
+          "syn-node-neighbourhood-kitchen",
+          "syn-node-housing-advice",
+          "syn-node-digital-help",
+          "syn-node-mobility-share",
+          "syn-node-river-cleanup",
+          "syn-node-elder-companionship",
+          "syn-node-legal-advice",
+          "syn-node-community-radio",
+          "syn-node-maker-space"
+        ],
+        "active_filters": {
+          "kinds": [],
+          "tags": [],
+          "languages": [
+            "de"
+          ]
+        }
+      },
+      "relevant_node_ids": [
+        "syn-node-food-fridge"
+      ],
       "expected_rank_class": "semantic",
-      "excluded_node_ids": ["syn-node-private-bike-help"],
-      "rationale": "Die natürliche Anfrage darf semantisch ergänzt werden, ohne unsichtbare Hilfsangebote als Kandidaten zu verwenden.",
+      "excluded_node_ids": [],
+      "rationale": "Synthetischer T002-Fall für semantic.",
+      "contains_personal_data": false
+    },
+    {
+      "id": "search-semantic-phone-help",
+      "language": "de",
+      "query": "Jemand soll mir geduldig mein neues Handy erklären.",
+      "natural_language": true,
+      "visibility_context": {
+        "viewer_scope": "public",
+        "visible_node_ids": [
+          "syn-node-community-garden",
+          "syn-node-seed-library",
+          "syn-node-repair-cafe",
+          "syn-node-tool-library",
+          "syn-node-bike-workshop",
+          "syn-node-food-fridge",
+          "syn-node-language-cafe",
+          "syn-node-child-care-coop",
+          "syn-node-energy-advice",
+          "syn-node-clothing-swap",
+          "syn-node-neighbourhood-kitchen",
+          "syn-node-housing-advice",
+          "syn-node-digital-help",
+          "syn-node-mobility-share",
+          "syn-node-river-cleanup",
+          "syn-node-elder-companionship",
+          "syn-node-legal-advice",
+          "syn-node-community-radio",
+          "syn-node-maker-space"
+        ],
+        "active_filters": {
+          "kinds": [],
+          "tags": [],
+          "languages": [
+            "de"
+          ]
+        }
+      },
+      "relevant_node_ids": [
+        "syn-node-digital-help"
+      ],
+      "expected_rank_class": "semantic",
+      "excluded_node_ids": [],
+      "rationale": "Synthetischer T002-Fall für semantic.",
+      "contains_personal_data": false
+    },
+    {
+      "id": "search-semantic-clothes-circular",
+      "language": "de",
+      "query": "Sachen zum Anziehen weitergeben statt wegwerfen.",
+      "natural_language": true,
+      "visibility_context": {
+        "viewer_scope": "public",
+        "visible_node_ids": [
+          "syn-node-community-garden",
+          "syn-node-seed-library",
+          "syn-node-repair-cafe",
+          "syn-node-tool-library",
+          "syn-node-bike-workshop",
+          "syn-node-food-fridge",
+          "syn-node-language-cafe",
+          "syn-node-child-care-coop",
+          "syn-node-energy-advice",
+          "syn-node-clothing-swap",
+          "syn-node-neighbourhood-kitchen",
+          "syn-node-housing-advice",
+          "syn-node-digital-help",
+          "syn-node-mobility-share",
+          "syn-node-river-cleanup",
+          "syn-node-elder-companionship",
+          "syn-node-legal-advice",
+          "syn-node-community-radio",
+          "syn-node-maker-space"
+        ],
+        "active_filters": {
+          "kinds": [],
+          "tags": [],
+          "languages": [
+            "de"
+          ]
+        }
+      },
+      "relevant_node_ids": [
+        "syn-node-clothing-swap"
+      ],
+      "expected_rank_class": "semantic",
+      "excluded_node_ids": [],
+      "rationale": "Synthetischer T002-Fall für semantic.",
+      "contains_personal_data": false
+    },
+    {
+      "id": "search-semantic-language-practice",
+      "language": "de",
+      "query": "Mit anderen ohne Prüfung Deutsch sprechen üben.",
+      "natural_language": true,
+      "visibility_context": {
+        "viewer_scope": "public",
+        "visible_node_ids": [
+          "syn-node-community-garden",
+          "syn-node-seed-library",
+          "syn-node-repair-cafe",
+          "syn-node-tool-library",
+          "syn-node-bike-workshop",
+          "syn-node-food-fridge",
+          "syn-node-language-cafe",
+          "syn-node-child-care-coop",
+          "syn-node-energy-advice",
+          "syn-node-clothing-swap",
+          "syn-node-neighbourhood-kitchen",
+          "syn-node-housing-advice",
+          "syn-node-digital-help",
+          "syn-node-mobility-share",
+          "syn-node-river-cleanup",
+          "syn-node-elder-companionship",
+          "syn-node-legal-advice",
+          "syn-node-community-radio",
+          "syn-node-maker-space"
+        ],
+        "active_filters": {
+          "kinds": [],
+          "tags": [],
+          "languages": [
+            "de"
+          ]
+        }
+      },
+      "relevant_node_ids": [
+        "syn-node-language-cafe"
+      ],
+      "expected_rank_class": "semantic",
+      "excluded_node_ids": [],
+      "rationale": "Synthetischer T002-Fall für semantic.",
+      "contains_personal_data": false
+    },
+    {
+      "id": "search-semantic-elderly-company",
+      "language": "de",
+      "query": "Ältere Nachbarn besuchen, damit sie nicht allein sind.",
+      "natural_language": true,
+      "visibility_context": {
+        "viewer_scope": "public",
+        "visible_node_ids": [
+          "syn-node-community-garden",
+          "syn-node-seed-library",
+          "syn-node-repair-cafe",
+          "syn-node-tool-library",
+          "syn-node-bike-workshop",
+          "syn-node-food-fridge",
+          "syn-node-language-cafe",
+          "syn-node-child-care-coop",
+          "syn-node-energy-advice",
+          "syn-node-clothing-swap",
+          "syn-node-neighbourhood-kitchen",
+          "syn-node-housing-advice",
+          "syn-node-digital-help",
+          "syn-node-mobility-share",
+          "syn-node-river-cleanup",
+          "syn-node-elder-companionship",
+          "syn-node-legal-advice",
+          "syn-node-community-radio",
+          "syn-node-maker-space"
+        ],
+        "active_filters": {
+          "kinds": [],
+          "tags": [],
+          "languages": [
+            "de"
+          ]
+        }
+      },
+      "relevant_node_ids": [
+        "syn-node-elder-companionship"
+      ],
+      "expected_rank_class": "semantic",
+      "excluded_node_ids": [],
+      "rationale": "Synthetischer T002-Fall für semantic.",
+      "contains_personal_data": false
+    },
+    {
+      "id": "search-semantic-drill-sharing",
+      "language": "de",
+      "query": "Ich brauche nur einmal eine Bohrmaschine und will keine kaufen.",
+      "natural_language": true,
+      "visibility_context": {
+        "viewer_scope": "public",
+        "visible_node_ids": [
+          "syn-node-community-garden",
+          "syn-node-seed-library",
+          "syn-node-repair-cafe",
+          "syn-node-tool-library",
+          "syn-node-bike-workshop",
+          "syn-node-food-fridge",
+          "syn-node-language-cafe",
+          "syn-node-child-care-coop",
+          "syn-node-energy-advice",
+          "syn-node-clothing-swap",
+          "syn-node-neighbourhood-kitchen",
+          "syn-node-housing-advice",
+          "syn-node-digital-help",
+          "syn-node-mobility-share",
+          "syn-node-river-cleanup",
+          "syn-node-elder-companionship",
+          "syn-node-legal-advice",
+          "syn-node-community-radio",
+          "syn-node-maker-space"
+        ],
+        "active_filters": {
+          "kinds": [],
+          "tags": [],
+          "languages": [
+            "de"
+          ]
+        }
+      },
+      "relevant_node_ids": [
+        "syn-node-tool-library"
+      ],
+      "expected_rank_class": "semantic",
+      "excluded_node_ids": [],
+      "rationale": "Synthetischer T002-Fall für semantic.",
+      "contains_personal_data": false
+    },
+    {
+      "id": "search-semantic-shared-childcare",
+      "language": "de",
+      "query": "Familien möchten die Betreuung abwechselnd organisieren.",
+      "natural_language": true,
+      "visibility_context": {
+        "viewer_scope": "public",
+        "visible_node_ids": [
+          "syn-node-community-garden",
+          "syn-node-seed-library",
+          "syn-node-repair-cafe",
+          "syn-node-tool-library",
+          "syn-node-bike-workshop",
+          "syn-node-food-fridge",
+          "syn-node-language-cafe",
+          "syn-node-child-care-coop",
+          "syn-node-energy-advice",
+          "syn-node-clothing-swap",
+          "syn-node-neighbourhood-kitchen",
+          "syn-node-housing-advice",
+          "syn-node-digital-help",
+          "syn-node-mobility-share",
+          "syn-node-river-cleanup",
+          "syn-node-elder-companionship",
+          "syn-node-legal-advice",
+          "syn-node-community-radio",
+          "syn-node-maker-space"
+        ],
+        "active_filters": {
+          "kinds": [],
+          "tags": [],
+          "languages": [
+            "de"
+          ]
+        }
+      },
+      "relevant_node_ids": [
+        "syn-node-child-care-coop"
+      ],
+      "expected_rank_class": "semantic",
+      "excluded_node_ids": [],
+      "rationale": "Synthetischer T002-Fall für semantic.",
+      "contains_personal_data": false
+    },
+    {
+      "id": "search-semantic-rent-contract",
+      "language": "de",
+      "query": "Wer hilft mir, meinen Mietvertrag und die Abrechnung zu verstehen?",
+      "natural_language": true,
+      "visibility_context": {
+        "viewer_scope": "public",
+        "visible_node_ids": [
+          "syn-node-community-garden",
+          "syn-node-seed-library",
+          "syn-node-repair-cafe",
+          "syn-node-tool-library",
+          "syn-node-bike-workshop",
+          "syn-node-food-fridge",
+          "syn-node-language-cafe",
+          "syn-node-child-care-coop",
+          "syn-node-energy-advice",
+          "syn-node-clothing-swap",
+          "syn-node-neighbourhood-kitchen",
+          "syn-node-housing-advice",
+          "syn-node-digital-help",
+          "syn-node-mobility-share",
+          "syn-node-river-cleanup",
+          "syn-node-elder-companionship",
+          "syn-node-legal-advice",
+          "syn-node-community-radio",
+          "syn-node-maker-space"
+        ],
+        "active_filters": {
+          "kinds": [],
+          "tags": [],
+          "languages": [
+            "de"
+          ]
+        }
+      },
+      "relevant_node_ids": [
+        "syn-node-housing-advice"
+      ],
+      "expected_rank_class": "semantic",
+      "excluded_node_ids": [],
+      "rationale": "Synthetischer T002-Fall für semantic.",
+      "contains_personal_data": false
+    },
+    {
+      "id": "search-semantic-clean-river",
+      "language": "de",
+      "query": "Gemeinsam das Ufer von Abfall befreien.",
+      "natural_language": true,
+      "visibility_context": {
+        "viewer_scope": "public",
+        "visible_node_ids": [
+          "syn-node-community-garden",
+          "syn-node-seed-library",
+          "syn-node-repair-cafe",
+          "syn-node-tool-library",
+          "syn-node-bike-workshop",
+          "syn-node-food-fridge",
+          "syn-node-language-cafe",
+          "syn-node-child-care-coop",
+          "syn-node-energy-advice",
+          "syn-node-clothing-swap",
+          "syn-node-neighbourhood-kitchen",
+          "syn-node-housing-advice",
+          "syn-node-digital-help",
+          "syn-node-mobility-share",
+          "syn-node-river-cleanup",
+          "syn-node-elder-companionship",
+          "syn-node-legal-advice",
+          "syn-node-community-radio",
+          "syn-node-maker-space"
+        ],
+        "active_filters": {
+          "kinds": [],
+          "tags": [],
+          "languages": [
+            "de"
+          ]
+        }
+      },
+      "relevant_node_ids": [
+        "syn-node-river-cleanup"
+      ],
+      "expected_rank_class": "semantic",
+      "excluded_node_ids": [],
+      "rationale": "Synthetischer T002-Fall für semantic.",
+      "contains_personal_data": false
+    },
+    {
+      "id": "search-semantic-make-radio",
+      "language": "de",
+      "query": "Ich möchte selbst eine lokale Sendung aufnehmen.",
+      "natural_language": true,
+      "visibility_context": {
+        "viewer_scope": "public",
+        "visible_node_ids": [
+          "syn-node-community-garden",
+          "syn-node-seed-library",
+          "syn-node-repair-cafe",
+          "syn-node-tool-library",
+          "syn-node-bike-workshop",
+          "syn-node-food-fridge",
+          "syn-node-language-cafe",
+          "syn-node-child-care-coop",
+          "syn-node-energy-advice",
+          "syn-node-clothing-swap",
+          "syn-node-neighbourhood-kitchen",
+          "syn-node-housing-advice",
+          "syn-node-digital-help",
+          "syn-node-mobility-share",
+          "syn-node-river-cleanup",
+          "syn-node-elder-companionship",
+          "syn-node-legal-advice",
+          "syn-node-community-radio",
+          "syn-node-maker-space"
+        ],
+        "active_filters": {
+          "kinds": [],
+          "tags": [],
+          "languages": [
+            "de"
+          ]
+        }
+      },
+      "relevant_node_ids": [
+        "syn-node-community-radio"
+      ],
+      "expected_rank_class": "semantic",
+      "excluded_node_ids": [],
+      "rationale": "Synthetischer T002-Fall für semantic.",
+      "contains_personal_data": false
+    },
+    {
+      "id": "search-semantic-radio-repair",
+      "language": "de",
+      "query": "Mein altes Radio ist kaputt und soll repariert werden.",
+      "natural_language": true,
+      "visibility_context": {
+        "viewer_scope": "public",
+        "visible_node_ids": [
+          "syn-node-community-garden",
+          "syn-node-seed-library",
+          "syn-node-repair-cafe",
+          "syn-node-tool-library",
+          "syn-node-bike-workshop",
+          "syn-node-food-fridge",
+          "syn-node-language-cafe",
+          "syn-node-child-care-coop",
+          "syn-node-energy-advice",
+          "syn-node-clothing-swap",
+          "syn-node-neighbourhood-kitchen",
+          "syn-node-housing-advice",
+          "syn-node-digital-help",
+          "syn-node-mobility-share",
+          "syn-node-river-cleanup",
+          "syn-node-elder-companionship",
+          "syn-node-legal-advice",
+          "syn-node-community-radio",
+          "syn-node-maker-space"
+        ],
+        "active_filters": {
+          "kinds": [],
+          "tags": [],
+          "languages": [
+            "de"
+          ]
+        }
+      },
+      "relevant_node_ids": [
+        "syn-node-repair-cafe"
+      ],
+      "expected_rank_class": "semantic",
+      "excluded_node_ids": [],
+      "rationale": "Synthetischer T002-Fall für semantic.",
+      "contains_personal_data": false
+    },
+    {
+      "id": "search-semantic-cargo-bike",
+      "language": "de",
+      "query": "Einen großen Einkauf ohne Auto nach Hause bringen.",
+      "natural_language": true,
+      "visibility_context": {
+        "viewer_scope": "public",
+        "visible_node_ids": [
+          "syn-node-community-garden",
+          "syn-node-seed-library",
+          "syn-node-repair-cafe",
+          "syn-node-tool-library",
+          "syn-node-bike-workshop",
+          "syn-node-food-fridge",
+          "syn-node-language-cafe",
+          "syn-node-child-care-coop",
+          "syn-node-energy-advice",
+          "syn-node-clothing-swap",
+          "syn-node-neighbourhood-kitchen",
+          "syn-node-housing-advice",
+          "syn-node-digital-help",
+          "syn-node-mobility-share",
+          "syn-node-river-cleanup",
+          "syn-node-elder-companionship",
+          "syn-node-legal-advice",
+          "syn-node-community-radio",
+          "syn-node-maker-space"
+        ],
+        "active_filters": {
+          "kinds": [],
+          "tags": [],
+          "languages": [
+            "de"
+          ]
+        }
+      },
+      "relevant_node_ids": [
+        "syn-node-mobility-share"
+      ],
+      "expected_rank_class": "semantic",
+      "excluded_node_ids": [],
+      "rationale": "Synthetischer T002-Fall für semantic.",
+      "contains_personal_data": false
+    },
+    {
+      "id": "search-semantic-legal-first-step",
+      "language": "de",
+      "query": "Kostenloser erster Rat bei einem Rechtsproblem.",
+      "natural_language": true,
+      "visibility_context": {
+        "viewer_scope": "public",
+        "visible_node_ids": [
+          "syn-node-community-garden",
+          "syn-node-seed-library",
+          "syn-node-repair-cafe",
+          "syn-node-tool-library",
+          "syn-node-bike-workshop",
+          "syn-node-food-fridge",
+          "syn-node-language-cafe",
+          "syn-node-child-care-coop",
+          "syn-node-energy-advice",
+          "syn-node-clothing-swap",
+          "syn-node-neighbourhood-kitchen",
+          "syn-node-housing-advice",
+          "syn-node-digital-help",
+          "syn-node-mobility-share",
+          "syn-node-river-cleanup",
+          "syn-node-elder-companionship",
+          "syn-node-legal-advice",
+          "syn-node-community-radio",
+          "syn-node-maker-space"
+        ],
+        "active_filters": {
+          "kinds": [],
+          "tags": [],
+          "languages": [
+            "de"
+          ]
+        }
+      },
+      "relevant_node_ids": [
+        "syn-node-legal-advice"
+      ],
+      "expected_rank_class": "semantic",
+      "excluded_node_ids": [],
+      "rationale": "Synthetischer T002-Fall für semantic.",
+      "contains_personal_data": false
+    },
+    {
+      "id": "search-semantic-seeds-spring",
+      "language": "de",
+      "query": "Samen für das nächste Frühjahr tauschen.",
+      "natural_language": true,
+      "visibility_context": {
+        "viewer_scope": "public",
+        "visible_node_ids": [
+          "syn-node-community-garden",
+          "syn-node-seed-library",
+          "syn-node-repair-cafe",
+          "syn-node-tool-library",
+          "syn-node-bike-workshop",
+          "syn-node-food-fridge",
+          "syn-node-language-cafe",
+          "syn-node-child-care-coop",
+          "syn-node-energy-advice",
+          "syn-node-clothing-swap",
+          "syn-node-neighbourhood-kitchen",
+          "syn-node-housing-advice",
+          "syn-node-digital-help",
+          "syn-node-mobility-share",
+          "syn-node-river-cleanup",
+          "syn-node-elder-companionship",
+          "syn-node-legal-advice",
+          "syn-node-community-radio",
+          "syn-node-maker-space"
+        ],
+        "active_filters": {
+          "kinds": [],
+          "tags": [],
+          "languages": [
+            "de"
+          ]
+        }
+      },
+      "relevant_node_ids": [
+        "syn-node-seed-library"
+      ],
+      "expected_rank_class": "semantic",
+      "excluded_node_ids": [],
+      "rationale": "Synthetischer T002-Fall für semantic.",
+      "contains_personal_data": false
+    },
+    {
+      "id": "search-semantic-cook-together",
+      "language": "de",
+      "query": "Mit Nachbarn aus geretteten Zutaten gemeinsam kochen.",
+      "natural_language": true,
+      "visibility_context": {
+        "viewer_scope": "public",
+        "visible_node_ids": [
+          "syn-node-community-garden",
+          "syn-node-seed-library",
+          "syn-node-repair-cafe",
+          "syn-node-tool-library",
+          "syn-node-bike-workshop",
+          "syn-node-food-fridge",
+          "syn-node-language-cafe",
+          "syn-node-child-care-coop",
+          "syn-node-energy-advice",
+          "syn-node-clothing-swap",
+          "syn-node-neighbourhood-kitchen",
+          "syn-node-housing-advice",
+          "syn-node-digital-help",
+          "syn-node-mobility-share",
+          "syn-node-river-cleanup",
+          "syn-node-elder-companionship",
+          "syn-node-legal-advice",
+          "syn-node-community-radio",
+          "syn-node-maker-space"
+        ],
+        "active_filters": {
+          "kinds": [],
+          "tags": [],
+          "languages": [
+            "de"
+          ]
+        }
+      },
+      "relevant_node_ids": [
+        "syn-node-neighbourhood-kitchen"
+      ],
+      "expected_rank_class": "semantic",
+      "excluded_node_ids": [],
+      "rationale": "Synthetischer T002-Fall für semantic.",
+      "contains_personal_data": false
+    },
+    {
+      "id": "search-semantic-prototype-machines",
+      "language": "de",
+      "query": "Einen Prototyp mit 3D-Druck und Laserschneider bauen.",
+      "natural_language": true,
+      "visibility_context": {
+        "viewer_scope": "public",
+        "visible_node_ids": [
+          "syn-node-community-garden",
+          "syn-node-seed-library",
+          "syn-node-repair-cafe",
+          "syn-node-tool-library",
+          "syn-node-bike-workshop",
+          "syn-node-food-fridge",
+          "syn-node-language-cafe",
+          "syn-node-child-care-coop",
+          "syn-node-energy-advice",
+          "syn-node-clothing-swap",
+          "syn-node-neighbourhood-kitchen",
+          "syn-node-housing-advice",
+          "syn-node-digital-help",
+          "syn-node-mobility-share",
+          "syn-node-river-cleanup",
+          "syn-node-elder-companionship",
+          "syn-node-legal-advice",
+          "syn-node-community-radio",
+          "syn-node-maker-space"
+        ],
+        "active_filters": {
+          "kinds": [],
+          "tags": [],
+          "languages": [
+            "de"
+          ]
+        }
+      },
+      "relevant_node_ids": [
+        "syn-node-maker-space"
+      ],
+      "expected_rank_class": "semantic",
+      "excluded_node_ids": [],
+      "rationale": "Synthetischer T002-Fall für semantic.",
+      "contains_personal_data": false
+    },
+    {
+      "id": "search-filter-workshops",
+      "language": "de",
+      "query": "Gemeinsam etwas reparieren.",
+      "natural_language": true,
+      "visibility_context": {
+        "viewer_scope": "public",
+        "visible_node_ids": [
+          "syn-node-repair-cafe",
+          "syn-node-bike-workshop",
+          "syn-node-maker-space"
+        ],
+        "active_filters": {
+          "kinds": [
+            "Werkstatt"
+          ],
+          "tags": [],
+          "languages": [
+            "de"
+          ]
+        }
+      },
+      "relevant_node_ids": [
+        "syn-node-repair-cafe",
+        "syn-node-bike-workshop"
+      ],
+      "expected_rank_class": "full_text",
+      "excluded_node_ids": [],
+      "rationale": "Synthetischer T002-Fall für full text.",
+      "contains_personal_data": false
+    },
+    {
+      "id": "search-visibility-hidden-bike",
+      "language": "de",
+      "query": "Hilfe bei einer kaputten Fahrradschaltung.",
+      "natural_language": true,
+      "visibility_context": {
+        "viewer_scope": "public",
+        "visible_node_ids": [
+          "syn-node-community-garden",
+          "syn-node-seed-library",
+          "syn-node-repair-cafe",
+          "syn-node-tool-library",
+          "syn-node-bike-workshop",
+          "syn-node-food-fridge",
+          "syn-node-language-cafe",
+          "syn-node-child-care-coop",
+          "syn-node-energy-advice",
+          "syn-node-clothing-swap",
+          "syn-node-neighbourhood-kitchen",
+          "syn-node-housing-advice",
+          "syn-node-digital-help",
+          "syn-node-mobility-share",
+          "syn-node-river-cleanup",
+          "syn-node-elder-companionship",
+          "syn-node-legal-advice",
+          "syn-node-community-radio",
+          "syn-node-maker-space"
+        ],
+        "active_filters": {
+          "kinds": [],
+          "tags": [],
+          "languages": [
+            "de"
+          ]
+        }
+      },
+      "relevant_node_ids": [
+        "syn-node-bike-workshop"
+      ],
+      "expected_rank_class": "semantic",
+      "excluded_node_ids": [
+        "syn-node-hidden-bike-cellar"
+      ],
+      "rationale": "Synthetischer T002-Fall für semantic.",
+      "contains_personal_data": false
+    },
+    {
+      "id": "search-visibility-deleted-repair",
+      "language": "de",
+      "query": "Reparaturtreff für defekte Geräte.",
+      "natural_language": true,
+      "visibility_context": {
+        "viewer_scope": "public",
+        "visible_node_ids": [
+          "syn-node-community-garden",
+          "syn-node-seed-library",
+          "syn-node-repair-cafe",
+          "syn-node-tool-library",
+          "syn-node-bike-workshop",
+          "syn-node-food-fridge",
+          "syn-node-language-cafe",
+          "syn-node-child-care-coop",
+          "syn-node-energy-advice",
+          "syn-node-clothing-swap",
+          "syn-node-neighbourhood-kitchen",
+          "syn-node-housing-advice",
+          "syn-node-digital-help",
+          "syn-node-mobility-share",
+          "syn-node-river-cleanup",
+          "syn-node-elder-companionship",
+          "syn-node-legal-advice",
+          "syn-node-community-radio",
+          "syn-node-maker-space"
+        ],
+        "active_filters": {
+          "kinds": [],
+          "tags": [],
+          "languages": [
+            "de"
+          ]
+        }
+      },
+      "relevant_node_ids": [
+        "syn-node-repair-cafe"
+      ],
+      "expected_rank_class": "full_text",
+      "excluded_node_ids": [
+        "syn-node-deleted-repair-archive"
+      ],
+      "rationale": "Synthetischer T002-Fall für full text.",
       "contains_personal_data": false
     }
   ]

--- a/contracts/search/relevance-goldset.schema.json
+++ b/contracts/search/relevance-goldset.schema.json
@@ -2,50 +2,256 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://weltgewebe.org/schemas/search/relevance-goldset.schema.json",
   "title": "Weltgewebe Semantic Search Relevance Goldset",
-  "description": "Synthetic, visibility-bound relevance cases for deterministic evaluation of hybrid node search.",
+  "description": "Synthetic node corpus and visibility-bound relevance cases for deterministic evaluation of hybrid node search.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema_version", "dataset_id", "description", "privacy_class", "cases"],
+  "required": [
+    "schema_version",
+    "dataset_id",
+    "description",
+    "privacy_class",
+    "document_revision",
+    "nodes",
+    "cases"
+  ],
   "properties": {
-    "schema_version": {"const": 1},
-    "dataset_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._-]{2,79}$"},
-    "description": {"type": "string", "minLength": 1, "maxLength": 500},
-    "privacy_class": {"const": "synthetic"},
-    "cases": {
+    "schema_version": {
+      "const": 2
+    },
+    "dataset_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]{2,79}$"
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 500
+    },
+    "privacy_class": {
+      "const": "synthetic"
+    },
+    "document_revision": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]{2,79}$"
+    },
+    "nodes": {
       "type": "array",
-      "minItems": 1,
+      "minItems": 12,
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["id", "language", "query", "visibility_context", "relevant_node_ids", "expected_rank_class", "excluded_node_ids", "rationale", "contains_personal_data"],
+        "required": [
+          "id",
+          "language",
+          "title",
+          "summary",
+          "body",
+          "tags",
+          "kind",
+          "status",
+          "visibility_scopes",
+          "contains_personal_data",
+          "synthetic_source"
+        ],
         "properties": {
-          "id": {"type": "string", "pattern": "^search-[a-z0-9][a-z0-9-]{2,79}$"},
-          "language": {"type": "string", "pattern": "^[a-z]{2}(?:-[A-Z]{2})?$"},
-          "query": {"type": "string", "minLength": 1, "maxLength": 300},
+          "id": {
+            "type": "string",
+            "pattern": "^syn-node-[a-z0-9][a-z0-9-]{2,79}$"
+          },
+          "language": {
+            "type": "string",
+            "pattern": "^[a-z]{2}(?:-[A-Z]{2})?$"
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          },
+          "summary": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 300
+          },
+          "body": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 1200
+          },
+          "tags": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 64
+            }
+          },
+          "kind": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100
+          },
+          "status": {
+            "enum": [
+              "active",
+              "hidden",
+              "deleted"
+            ]
+          },
+          "visibility_scopes": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "enum": [
+                "public",
+                "local",
+                "neighbourhood"
+              ]
+            }
+          },
+          "contains_personal_data": {
+            "const": false
+          },
+          "synthetic_source": {
+            "const": "authored"
+          }
+        }
+      }
+    },
+    "cases": {
+      "type": "array",
+      "minItems": 20,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "language",
+          "query",
+          "natural_language",
+          "visibility_context",
+          "relevant_node_ids",
+          "expected_rank_class",
+          "excluded_node_ids",
+          "rationale",
+          "contains_personal_data"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^search-[a-z0-9][a-z0-9-]{2,79}$"
+          },
+          "language": {
+            "type": "string",
+            "pattern": "^[a-z]{2}(?:-[A-Z]{2})?$"
+          },
+          "query": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 300
+          },
+          "natural_language": {
+            "type": "boolean"
+          },
           "visibility_context": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["viewer_scope", "visible_node_ids", "active_filters"],
+            "required": [
+              "viewer_scope",
+              "visible_node_ids",
+              "active_filters"
+            ],
             "properties": {
-              "viewer_scope": {"enum": ["public", "local", "neighbourhood"]},
-              "visible_node_ids": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "pattern": "^syn-node-[a-z0-9][a-z0-9-]{2,79}$"}},
+              "viewer_scope": {
+                "enum": [
+                  "public",
+                  "local",
+                  "neighbourhood"
+                ]
+              },
+              "visible_node_ids": {
+                "type": "array",
+                "minItems": 1,
+                "uniqueItems": true,
+                "items": {
+                  "type": "string",
+                  "pattern": "^syn-node-[a-z0-9][a-z0-9-]{2,79}$"
+                }
+              },
               "active_filters": {
                 "type": "object",
                 "additionalProperties": false,
-                "required": ["kinds", "tags", "languages"],
+                "required": [
+                  "kinds",
+                  "tags",
+                  "languages"
+                ],
                 "properties": {
-                  "kinds": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1, "maxLength": 100}},
-                  "tags": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1, "maxLength": 64}},
-                  "languages": {"type": "array", "uniqueItems": true, "items": {"type": "string", "pattern": "^[a-z]{2}(?:-[A-Z]{2})?$"}}
+                  "kinds": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 100
+                    }
+                  },
+                  "tags": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 64
+                    }
+                  },
+                  "languages": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                      "type": "string",
+                      "pattern": "^[a-z]{2}(?:-[A-Z]{2})?$"
+                    }
+                  }
                 }
               }
             }
           },
-          "relevant_node_ids": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "pattern": "^syn-node-[a-z0-9][a-z0-9-]{2,79}$"}},
-          "expected_rank_class": {"enum": ["exact_title", "exact_tag", "title_prefix", "typo", "full_text", "semantic"]},
-          "excluded_node_ids": {"type": "array", "uniqueItems": true, "items": {"type": "string", "pattern": "^syn-node-[a-z0-9][a-z0-9-]{2,79}$"}},
-          "rationale": {"type": "string", "minLength": 1, "maxLength": 1000},
-          "contains_personal_data": {"const": false}
+          "relevant_node_ids": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "pattern": "^syn-node-[a-z0-9][a-z0-9-]{2,79}$"
+            }
+          },
+          "expected_rank_class": {
+            "enum": [
+              "exact_title",
+              "exact_tag",
+              "title_prefix",
+              "typo",
+              "full_text",
+              "semantic"
+            ]
+          },
+          "excluded_node_ids": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "pattern": "^syn-node-[a-z0-9][a-z0-9-]{2,79}$"
+            }
+          },
+          "rationale": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 1000
+          },
+          "contains_personal_data": {
+            "const": false
+          }
         }
       }
     }

--- a/docs/_generated/system-map.md
+++ b/docs/_generated/system-map.md
@@ -15,7 +15,7 @@ Source: scripts/docmeta/generate_system_map.py
 
 |id|path|role|organ|status|last_reviewed|depends_on|verifies_with|missing_scripts|
 |---|---|---|---|---|---|---|---|---|
-|architecture.semantic-search|architecture/semantic-search.md|norm|product-domain|canonical|2026-07-18|overview, architecture.weltgewebe-os, specs.garnrolle-knoten-faden|contracts/search/examples/relevance-goldset.example.json, contracts/search/relevance-goldset.schema.json, scripts/ci/tests/test_semantic_search_contract.py, scripts/search/validate_relevance_goldset.py||
+|architecture.semantic-search|architecture/semantic-search.md|norm|product-domain|canonical|2026-07-18|overview, architecture.weltgewebe-os, specs.garnrolle-knoten-faden|contracts/search/examples/relevance-benchmark.heim-pc.json, contracts/search/examples/relevance-goldset.example.json, contracts/search/relevance-goldset.schema.json, scripts/ci/tests/test_semantic_search_contract.py, scripts/search/benchmark_relevance.py, scripts/search/validate_relevance_goldset.py||
 |architecture.weltgewebe-os|architecture/weltgewebe-os.md|norm|governance|canonical|2026-07-15|overview|||
 |docmeta.schema|architecture/docmeta.schema.md|norm|docmeta|canonical|2026-06-09||scripts/docmeta/check_doc_review_age.py, scripts/docmeta/check_repo_index_consistency.py, scripts/docmeta/generate_system_map.py, scripts/docmeta/validate_relations.py||
 |overview|architecture/overview.md|norm|governance|canonical|2026-07-11||||

--- a/scripts/ci/tests/test_semantic_search_contract.py
+++ b/scripts/ci/tests/test_semantic_search_contract.py
@@ -1,4 +1,4 @@
-"""Regression tests for the Semantic Search v1 architecture and goldset contract."""
+"""Regression tests for the Semantic Search v1 architecture, goldset and benchmark."""
 
 from __future__ import annotations
 
@@ -7,6 +7,15 @@ import json
 import unittest
 from pathlib import Path
 
+from scripts.search.benchmark_relevance import (
+    DEFAULT_RESULT,
+    OllamaClient,
+    check_result,
+    contains_raw_vectors,
+    current_substring_rank,
+    hybrid_rank,
+    lexical_reference_rank,
+)
 from scripts.search.validate_relevance_goldset import ValidationError, validate_goldset
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -20,10 +29,15 @@ class SemanticSearchContractTests(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
         cls.dataset = json.loads(DATASET_PATH.read_text(encoding="utf-8"))
+        cls.case_by_id = {case["id"]: case for case in cls.dataset["cases"]}
 
     def test_checked_in_goldset_is_valid_and_synthetic(self) -> None:
         validate_goldset(self.dataset, self.schema)
+        self.assertEqual(self.dataset["schema_version"], 2)
         self.assertEqual(self.dataset["privacy_class"], "synthetic")
+        self.assertGreaterEqual(len(self.dataset["nodes"]), 20)
+        self.assertGreaterEqual(len(self.dataset["cases"]), 20)
+        self.assertTrue(all(node["contains_personal_data"] is False for node in self.dataset["nodes"]))
         self.assertTrue(all(case["contains_personal_data"] is False for case in self.dataset["cases"]))
 
     def test_duplicate_case_ids_are_rejected(self) -> None:
@@ -32,9 +46,21 @@ class SemanticSearchContractTests(unittest.TestCase):
         with self.assertRaisesRegex(ValidationError, "duplicate case id"):
             validate_goldset(dataset, self.schema)
 
+    def test_duplicate_node_ids_are_rejected(self) -> None:
+        dataset = copy.deepcopy(self.dataset)
+        dataset["nodes"].append(copy.deepcopy(dataset["nodes"][0]))
+        with self.assertRaisesRegex(ValidationError, "duplicate node id"):
+            validate_goldset(dataset, self.schema)
+
+    def test_unknown_node_reference_is_rejected(self) -> None:
+        dataset = copy.deepcopy(self.dataset)
+        dataset["cases"][0]["excluded_node_ids"] = ["syn-node-unknown-reference"]
+        with self.assertRaisesRegex(ValidationError, "unknown nodes"):
+            validate_goldset(dataset, self.schema)
+
     def test_relevant_node_outside_visible_context_is_rejected(self) -> None:
         dataset = copy.deepcopy(self.dataset)
-        dataset["cases"][0]["relevant_node_ids"] = ["syn-node-not-visible"]
+        dataset["cases"][0]["relevant_node_ids"] = ["syn-node-private-garden"]
         with self.assertRaisesRegex(ValidationError, "not visible"):
             validate_goldset(dataset, self.schema)
 
@@ -44,28 +70,82 @@ class SemanticSearchContractTests(unittest.TestCase):
         with self.assertRaisesRegex(ValidationError, "excluded nodes are visible"):
             validate_goldset(dataset, self.schema)
 
+    def test_hidden_or_deleted_node_cannot_be_visible(self) -> None:
+        for node_id in ("syn-node-hidden-bike-cellar", "syn-node-deleted-repair-archive"):
+            with self.subTest(node_id=node_id):
+                dataset = copy.deepcopy(self.dataset)
+                dataset["cases"][0]["visibility_context"]["visible_node_ids"].append(node_id)
+                with self.assertRaisesRegex(ValidationError, "is not active"):
+                    validate_goldset(dataset, self.schema)
+
+    def test_visible_node_must_match_active_filters(self) -> None:
+        dataset = copy.deepcopy(self.dataset)
+        dataset["cases"][0]["visibility_context"]["active_filters"]["kinds"] = ["Beratung"]
+        with self.assertRaisesRegex(ValidationError, "violates active filters"):
+            validate_goldset(dataset, self.schema)
+
     def test_personal_data_flag_is_rejected(self) -> None:
         dataset = copy.deepcopy(self.dataset)
-        dataset["cases"][0]["contains_personal_data"] = True
+        dataset["nodes"][0]["contains_personal_data"] = True
         with self.assertRaisesRegex(ValidationError, "expected constant False"):
             validate_goldset(dataset, self.schema)
 
-    def test_email_like_content_is_rejected_even_with_false_flag(self) -> None:
-        dataset = copy.deepcopy(self.dataset)
-        dataset["cases"][0]["query"] = "Kontakt person@example.invalid"
-        with self.assertRaisesRegex(ValidationError, "email-like"):
-            validate_goldset(dataset, self.schema)
+    def test_common_pii_patterns_are_rejected_even_with_false_flags(self) -> None:
+        samples = (
+            ("Kontakt person@example.invalid", "email-like"),
+            ("Rückruf unter +49 30 1234567", "phone-like"),
+            ("Interner Dienst 192.168.1.1", "IPv4-like"),
+        )
+        for query, message in samples:
+            with self.subTest(query=query):
+                dataset = copy.deepcopy(self.dataset)
+                dataset["cases"][0]["query"] = query
+                with self.assertRaisesRegex(ValidationError, message):
+                    validate_goldset(dataset, self.schema)
 
-    def test_architecture_names_hard_boundaries_and_current_reality(self) -> None:
+    def test_current_substring_baseline_mirrors_existing_product_scope(self) -> None:
+        exact = self.case_by_id["search-exact-title-community-garden"]
+        semantic = self.case_by_id["search-semantic-food-rescue"]
+        self.assertEqual(current_substring_rank(self.dataset, exact)[0], "syn-node-community-garden")
+        self.assertEqual(current_substring_rank(self.dataset, semantic), [])
+
+    def test_lexical_reference_handles_typo_and_never_leaks_hidden_node(self) -> None:
+        case = self.case_by_id["search-typo-bike-workshop"]
+        ranking = lexical_reference_rank(self.dataset, case)
+        self.assertEqual(ranking[0], "syn-node-bike-workshop")
+        self.assertNotIn("syn-node-hidden-bike-cellar", ranking)
+
+    def test_hybrid_rank_cannot_displace_exact_title_with_vector_similarity(self) -> None:
+        case = self.case_by_id["search-exact-title-community-garden"]
+        active_ids = [node["id"] for node in self.dataset["nodes"] if node["status"] == "active"]
+        vectors = {node_id: [0.0, 1.0] for node_id in active_ids}
+        vectors["syn-node-community-garden"] = [1.0, 0.0]
+        ranking = hybrid_rank(self.dataset, case, [0.0, 1.0], vectors)
+        self.assertEqual(ranking[0], "syn-node-community-garden")
+
+    def test_benchmark_client_rejects_external_or_authenticated_origins(self) -> None:
+        for url in ("https://example.invalid", "http://user:secret@127.0.0.1:11434", "http://127.0.0.1:11434/api"):
+            with self.subTest(url=url), self.assertRaisesRegex(ValueError, "loopback"):
+                OllamaClient(url)
+        OllamaClient("http://127.0.0.1:11434")
+
+    def test_raw_vector_fields_are_forbidden_in_benchmark_evidence(self) -> None:
+        self.assertTrue(contains_raw_vectors({"embedding": [0.1, 0.2]}))
+        self.assertFalse(contains_raw_vectors({"model": {"dimensions": 1024}}))
+
+    def test_checked_in_benchmark_evidence_is_current(self) -> None:
+        check_result(DEFAULT_RESULT, DATASET_PATH, SCHEMA_PATH)
+
+    def test_architecture_names_t002_decision_and_hard_boundaries(self) -> None:
         text = ARCHITECTURE_PATH.read_text(encoding="utf-8")
         required = (
             "PostgreSQL ist die einzige persistente Wahrheit",
             "Reine Vektorsuche ist verboten",
             "Sichtbarkeit und Löschstatus werden in derselben serverseitigen",
             "Garnrollen werden in v1 nicht eingebettet",
-            "Eine serverseitige Search-API",
-            "JSONL weiterhin als Code-Default",
-            "T001 ist ein Architektur- und Testgrundlagen-Schnitt",
+            "T002-Messung",
+            "qwen3-embedding:4b",
+            "keine Produktionsfreigabe",
             "separate SemantAH-Runtime",
         )
         for phrase in required:

--- a/scripts/search/benchmark_relevance.py
+++ b/scripts/search/benchmark_relevance.py
@@ -1,0 +1,604 @@
+"""Reproducible synthetic relevance benchmark for Weltgewebe Semantic Search v1.
+
+The checked-in quality proof never stores embeddings. CI can validate the
+synthetic corpus, lexical baselines, model identities, quality metrics and the
+selection decision without requiring Ollama or network access.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import platform
+import re
+import statistics
+import sys
+import time
+import unicodedata
+import urllib.error
+import urllib.request
+from urllib.parse import urlsplit
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from scripts.search.validate_relevance_goldset import (
+    DEFAULT_DATASET,
+    DEFAULT_SCHEMA,
+    ValidationError,
+    load_json_object,
+    validate_goldset,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_RESULT = ROOT / "contracts/search/examples/relevance-benchmark.heim-pc.json"
+BENCHMARK_REVISION = "semantic-search-benchmark-v1"
+DEFAULT_MODELS = ("qwen3-embedding:0.6b", "qwen3-embedding:4b", "qwen3-embedding:8b")
+RANK_CLASSES = {
+    "exact_title": 0,
+    "exact_tag": 1,
+    "title_prefix": 2,
+    "typo": 3,
+    "full_text": 4,
+    "semantic": 5,
+}
+STOP_WORDS = {
+    "aber", "als", "am", "an", "auch", "auf", "aus", "bei", "bin", "bis",
+    "das", "dass", "dem", "den", "der", "des", "die", "ein", "eine", "einem",
+    "einen", "einer", "es", "etwas", "für", "gegen", "gemeinsam", "hat", "ich",
+    "im", "in", "ist", "kann", "man", "mein", "meine", "mit", "möchte", "nach",
+    "nicht", "nur", "oder", "ohne", "sich", "sie", "soll", "um", "und", "von",
+    "vor", "was", "wenn", "wer", "wie", "will", "wir", "wo", "zu", "zum", "zur",
+}
+RAW_VECTOR_KEYS = {"embedding", "embeddings", "vector", "vectors"}
+
+
+def sha256_path(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def normalize(text: str) -> str:
+    value = unicodedata.normalize("NFKC", text).casefold()
+    return " ".join(re.sub(r"[^\w]+", " ", value, flags=re.UNICODE).split())
+
+
+def client_lower(text: str) -> str:
+    """Approximate JavaScript trim().toLocaleLowerCase("de-DE") without token rewriting."""
+
+    return text.strip().lower()
+
+
+def tokens(text: str) -> set[str]:
+    return {token for token in normalize(text).split() if len(token) >= 2 and token not in STOP_WORDS}
+
+
+def trigrams(text: str) -> set[str]:
+    value = f"  {normalize(text)} "
+    return {value[index : index + 3] for index in range(max(0, len(value) - 2))}
+
+
+def trigram_similarity(left: str, right: str) -> float:
+    left_set = trigrams(left)
+    right_set = trigrams(right)
+    if not left_set or not right_set:
+        return 0.0
+    return len(left_set & right_set) / len(left_set | right_set)
+
+
+def cosine_similarity(left: list[float], right: list[float]) -> float:
+    if len(left) != len(right) or not left:
+        raise ValueError("embedding dimensions differ or are empty")
+    numerator = sum(a * b for a, b in zip(left, right, strict=True))
+    left_norm = math.sqrt(sum(value * value for value in left))
+    right_norm = math.sqrt(sum(value * value for value in right))
+    if left_norm == 0.0 or right_norm == 0.0:
+        return 0.0
+    return numerator / (left_norm * right_norm)
+
+
+def node_document(node: dict[str, Any]) -> str:
+    return "\n".join(
+        (
+            f"Titel: {node['title']}",
+            f"Kurzbeschreibung: {node['summary']}",
+            f"Information: {node['body']}",
+            f"Tags: {', '.join(node['tags'])}",
+            f"Art: {node['kind']}",
+            f"Sprache: {node['language']}",
+        )
+    )
+
+
+def query_document(query: str) -> str:
+    return "Aufgabe: Finde den relevantesten sichtbaren Weltgewebe-Knoten.\nAnfrage: " + query
+
+
+def node_by_id(dataset: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {node["id"]: node for node in dataset["nodes"]}
+
+
+def candidate_nodes(dataset: dict[str, Any], case: dict[str, Any]) -> list[dict[str, Any]]:
+    lookup = node_by_id(dataset)
+    return [lookup[node_id] for node_id in case["visibility_context"]["visible_node_ids"]]
+
+
+def current_substring_rank(dataset: dict[str, Any], case: dict[str, Any]) -> list[str]:
+    """Mirror deriveSearchResults: visible input order, whole-query substring, cap 10."""
+
+    query = client_lower(case["query"])
+    result: list[str] = []
+    for node in candidate_nodes(dataset, case):
+        searchable_terms = [node["title"], node["summary"], *node["tags"], "Knoten", node["kind"]]
+        if any(query in client_lower(term) for term in searchable_terms):
+            result.append(node["id"])
+        if len(result) == 10:
+            break
+    return result
+
+
+def _fts_score(query: str, node: dict[str, Any]) -> tuple[int, float]:
+    query_tokens = tokens(query)
+    if not query_tokens:
+        return 0, 0.0
+    fields = (
+        (tokens(node["title"]), 4.0),
+        (tokens(" ".join(node["tags"])), 3.0),
+        (tokens(node["summary"]), 2.0),
+        (tokens(node["kind"]), 2.0),
+        (tokens(node["body"]), 1.0),
+    )
+    matched: set[str] = set()
+    weighted = 0.0
+    for field_tokens, weight in fields:
+        common = query_tokens & field_tokens
+        matched.update(common)
+        weighted += weight * len(common)
+    required = 1 if len(query_tokens) <= 3 else 2
+    if len(matched) < required:
+        return len(matched), 0.0
+    return len(matched), weighted / (4.0 * len(query_tokens))
+
+
+def lexical_signal(query: str, node: dict[str, Any]) -> tuple[int, float, str] | None:
+    normalized_query = normalize(query)
+    normalized_title = normalize(node["title"])
+    normalized_tags = {normalize(tag) for tag in node["tags"]}
+    if normalized_title == normalized_query:
+        return RANK_CLASSES["exact_title"], 1.0, "exact_title"
+    if normalized_query in normalized_tags:
+        return RANK_CLASSES["exact_tag"], 1.0, "exact_tag"
+    if normalized_title.startswith(normalized_query):
+        return RANK_CLASSES["title_prefix"], len(normalized_query) / len(normalized_title), "title_prefix"
+
+    typo_score = max(
+        trigram_similarity(query, node["title"]),
+        trigram_similarity(query, node["summary"]),
+        *(trigram_similarity(query, tag) for tag in node["tags"]),
+    )
+    if typo_score >= 0.30:
+        return RANK_CLASSES["typo"], typo_score, "typo"
+
+    matched, full_text_score = _fts_score(query, node)
+    if matched and full_text_score > 0.0:
+        return RANK_CLASSES["full_text"], full_text_score, "full_text"
+    return None
+
+
+def lexical_reference_rank(dataset: dict[str, Any], case: dict[str, Any]) -> list[str]:
+    scored: list[tuple[int, float, str]] = []
+    for node in candidate_nodes(dataset, case):
+        signal = lexical_signal(case["query"], node)
+        if signal is not None:
+            rank_class, score, _ = signal
+            scored.append((rank_class, -score, node["id"]))
+    scored.sort()
+    return [node_id for _, _, node_id in scored[:10]]
+
+
+def hybrid_rank(
+    dataset: dict[str, Any],
+    case: dict[str, Any],
+    query_vector: list[float],
+    node_vectors: dict[str, list[float]],
+) -> list[str]:
+    scored: list[tuple[int, float, str]] = []
+    for node in candidate_nodes(dataset, case):
+        signal = lexical_signal(case["query"], node)
+        if signal is None:
+            semantic_score = cosine_similarity(query_vector, node_vectors[node["id"]])
+            scored.append((RANK_CLASSES["semantic"], -semantic_score, node["id"]))
+        else:
+            rank_class, lexical_score, _ = signal
+            scored.append((rank_class, -lexical_score, node["id"]))
+    scored.sort()
+    return [node_id for _, _, node_id in scored[:10]]
+
+
+def quality_report(dataset: dict[str, Any], rankings: dict[str, list[str]]) -> dict[str, Any]:
+    cases: list[dict[str, Any]] = []
+    per_class: dict[str, dict[str, int]] = {}
+    top1_count = 0
+    top3_count = 0
+    natural_count = 0
+    natural_top3_count = 0
+    false_top1_count = 0
+    no_result_count = 0
+    visibility_leak_count = 0
+    exact_guard_failures: list[str] = []
+
+    for case in dataset["cases"]:
+        ranked = rankings[case["id"]]
+        relevant = set(case["relevant_node_ids"])
+        visible = set(case["visibility_context"]["visible_node_ids"])
+        excluded = set(case["excluded_node_ids"])
+        top1_relevant = bool(ranked and ranked[0] in relevant)
+        top3_relevant = bool(relevant.intersection(ranked[:3]))
+        relevant_rank = next((index + 1 for index, item in enumerate(ranked) if item in relevant), None)
+        leaks = sorted((set(ranked) - visible) | (set(ranked) & excluded))
+        visibility_leak_count += len(leaks)
+        top1_count += int(top1_relevant)
+        top3_count += int(top3_relevant)
+        if not ranked:
+            no_result_count += 1
+        elif not top1_relevant:
+            false_top1_count += 1
+        if case["natural_language"]:
+            natural_count += 1
+            natural_top3_count += int(top3_relevant)
+        if case["expected_rank_class"] in {"exact_title", "exact_tag"} and not top1_relevant:
+            exact_guard_failures.append(case["id"])
+        bucket = per_class.setdefault(case["expected_rank_class"], {"count": 0, "top1": 0, "top3": 0})
+        bucket["count"] += 1
+        bucket["top1"] += int(top1_relevant)
+        bucket["top3"] += int(top3_relevant)
+        cases.append(
+            {
+                "case_id": case["id"],
+                "top3": ranked[:3],
+                "relevant_rank": relevant_rank,
+                "top1_relevant": top1_relevant,
+                "top3_relevant": top3_relevant,
+                "visibility_leaks": leaks,
+            }
+        )
+
+    return {
+        "case_count": len(dataset["cases"]),
+        "natural_case_count": natural_count,
+        "top1_relevant_count": top1_count,
+        "top1_relevant_rate": round(top1_count / len(dataset["cases"]), 6),
+        "top3_relevant_count": top3_count,
+        "top3_relevant_rate": round(top3_count / len(dataset["cases"]), 6),
+        "natural_top3_relevant_count": natural_top3_count,
+        "natural_top3_relevant_rate": round(natural_top3_count / natural_count, 6),
+        "false_top1_count": false_top1_count,
+        "no_result_count": no_result_count,
+        "visibility_leak_count": visibility_leak_count,
+        "exact_guard_failures": exact_guard_failures,
+        "per_expected_rank_class": per_class,
+        "cases": cases,
+    }
+
+
+def timed_rankings(dataset: dict[str, Any], ranker: Any) -> tuple[dict[str, list[str]], dict[str, float]]:
+    durations: list[float] = []
+    rankings: dict[str, list[str]] = {}
+    for case in dataset["cases"]:
+        started = time.perf_counter()
+        rankings[case["id"]] = ranker(dataset, case)
+        durations.append((time.perf_counter() - started) * 1000.0)
+    return rankings, latency_report(durations)
+
+
+def latency_report(values: Iterable[float]) -> dict[str, float]:
+    ordered = sorted(values)
+    if not ordered:
+        return {"median_ms": 0.0, "p95_ms": 0.0, "maximum_ms": 0.0}
+    p95_index = min(len(ordered) - 1, math.ceil(len(ordered) * 0.95) - 1)
+    return {
+        "median_ms": round(statistics.median(ordered), 3),
+        "p95_ms": round(ordered[p95_index], 3),
+        "maximum_ms": round(max(ordered), 3),
+    }
+
+
+class OllamaClient:
+    def __init__(self, base_url: str, timeout_seconds: int = 900) -> None:
+        parsed = urlsplit(base_url)
+        if (
+            parsed.scheme != "http"
+            or parsed.hostname not in {"127.0.0.1", "localhost", "::1"}
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.path not in {"", "/"}
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise ValueError("Ollama benchmark URL must be an unauthenticated loopback HTTP origin")
+        self.base_url = base_url.rstrip("/")
+        self.timeout_seconds = timeout_seconds
+        self.opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+
+    def _request(self, path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+        body = None if payload is None else json.dumps(payload).encode("utf-8")
+        request = urllib.request.Request(
+            self.base_url + path,
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="GET" if payload is None else "POST",
+        )
+        try:
+            with self.opener.open(request, timeout=self.timeout_seconds) as response:
+                value = json.loads(response.read().decode("utf-8"))
+        except (OSError, urllib.error.URLError, json.JSONDecodeError) as error:
+            raise RuntimeError(f"Ollama request failed for {path}: {error}") from error
+        if not isinstance(value, dict):
+            raise RuntimeError(f"Ollama returned a non-object for {path}")
+        return value
+
+    def identity(self, model: str) -> dict[str, Any]:
+        tags = self._request("/api/tags").get("models", [])
+        match = next((item for item in tags if item.get("name") == model), None)
+        if not isinstance(match, dict):
+            raise RuntimeError(f"Ollama model is not installed: {model}")
+        details = match.get("details") if isinstance(match.get("details"), dict) else {}
+        digest = match.get("digest")
+        size_bytes = match.get("size")
+        if not isinstance(digest, str) or re.fullmatch(r"[0-9a-f]{64}", digest) is None:
+            raise RuntimeError(f"Ollama model digest is invalid for {model}")
+        if not isinstance(size_bytes, int) or size_bytes <= 0:
+            raise RuntimeError(f"Ollama model size is invalid for {model}")
+        return {
+            "name": model,
+            "digest": "sha256:" + digest,
+            "size_bytes": size_bytes,
+            "family": details.get("family"),
+            "parameter_size": details.get("parameter_size"),
+            "quantization_level": details.get("quantization_level"),
+        }
+
+    def embed(self, model: str, texts: list[str]) -> tuple[list[list[float]], float]:
+        started = time.perf_counter()
+        response = self._request(
+            "/api/embed",
+            {"model": model, "input": texts, "truncate": False, "keep_alive": "5m"},
+        )
+        elapsed_ms = (time.perf_counter() - started) * 1000.0
+        embeddings = response.get("embeddings")
+        if not isinstance(embeddings, list) or len(embeddings) != len(texts):
+            raise RuntimeError("Ollama returned an unexpected embedding count")
+        vectors: list[list[float]] = []
+        for vector in embeddings:
+            if not isinstance(vector, list) or not vector or not all(isinstance(item, (int, float)) for item in vector):
+                raise RuntimeError("Ollama returned an invalid embedding vector")
+            vectors.append([float(item) for item in vector])
+        dimensions = {len(vector) for vector in vectors}
+        if len(dimensions) != 1:
+            raise RuntimeError("Ollama mixed embedding dimensions")
+        return vectors, elapsed_ms
+
+
+def evaluate_model(dataset: dict[str, Any], model: str, client: OllamaClient) -> dict[str, Any]:
+    active_nodes = [node for node in dataset["nodes"] if node["status"] == "active"]
+    documents = [node_document(node) for node in active_nodes]
+    queries = [query_document(case["query"]) for case in dataset["cases"]]
+    identity = client.identity(model)
+    document_vectors, document_elapsed = client.embed(model, documents)
+    query_vectors, query_elapsed = client.embed(model, queries)
+    node_vectors = {node["id"]: vector for node, vector in zip(active_nodes, document_vectors, strict=True)}
+    dimensions = len(document_vectors[0])
+    rankings: dict[str, list[str]] = {}
+    rank_durations: list[float] = []
+    for case, query_vector in zip(dataset["cases"], query_vectors, strict=True):
+        started = time.perf_counter()
+        rankings[case["id"]] = hybrid_rank(dataset, case, query_vector, node_vectors)
+        rank_durations.append((time.perf_counter() - started) * 1000.0)
+    identity["dimensions"] = dimensions
+    return {
+        "model": identity,
+        "quality": quality_report(dataset, rankings),
+        "performance": {
+            "document_embedding_total_ms": round(document_elapsed, 3),
+            "query_embedding_total_ms": round(query_elapsed, 3),
+            "ranking": latency_report(rank_durations),
+            "document_count": len(documents),
+            "query_count": len(queries),
+        },
+    }
+
+
+def choose_decision(lexical: dict[str, Any], models: list[dict[str, Any]]) -> dict[str, Any]:
+    threshold = 0.85
+    minimum_gain_cases = 2
+    baseline_quality = lexical["quality"]
+    assessed: list[dict[str, Any]] = []
+    for item in sorted(models, key=lambda entry: int(entry["model"]["size_bytes"] or 0)):
+        quality = item["quality"]
+        gain = quality["natural_top3_relevant_count"] - baseline_quality["natural_top3_relevant_count"]
+        qualifies = (
+            not quality["exact_guard_failures"]
+            and quality["visibility_leak_count"] == 0
+            and quality["natural_top3_relevant_rate"] >= threshold
+            and quality["false_top1_count"] <= baseline_quality["false_top1_count"]
+        )
+        meaningful = gain >= minimum_gain_cases
+        assessed.append(
+            {
+                "model": item["model"]["name"],
+                "qualifies": qualifies,
+                "meaningful_incremental_gain": meaningful,
+                "natural_top3_gain_cases": gain,
+            }
+        )
+    winner = next((item for item in assessed if item["qualifies"] and item["meaningful_incremental_gain"]), None)
+    if winner is None:
+        return {
+            "outcome": "stop_embedding_path",
+            "selected_model": None,
+            "reason": "No local candidate both met the quality gates and improved natural-language Top-3 by at least two cases over the lexical reference.",
+            "quality_thresholds": {"natural_top3_rate": threshold, "minimum_gain_cases": minimum_gain_cases},
+            "assessed_models": assessed,
+        }
+    return {
+        "outcome": "select_smallest_qualifying_local_model",
+        "selected_model": winner["model"],
+        "reason": "The smallest local model meeting all gates and the minimum incremental relevance gain is selected for T003/T004 planning.",
+        "quality_thresholds": {"natural_top3_rate": threshold, "minimum_gain_cases": minimum_gain_cases},
+        "assessed_models": assessed,
+    }
+
+
+def contains_raw_vectors(value: Any) -> bool:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if key.casefold() in RAW_VECTOR_KEYS:
+                return True
+            if contains_raw_vectors(item):
+                return True
+    elif isinstance(value, list):
+        return any(contains_raw_vectors(item) for item in value)
+    return False
+
+
+def build_result(dataset_path: Path, schema_path: Path, models: list[str], ollama_url: str) -> dict[str, Any]:
+    schema = load_json_object(schema_path)
+    dataset = load_json_object(dataset_path)
+    validate_goldset(dataset, schema)
+    substring_rankings, substring_latency = timed_rankings(dataset, current_substring_rank)
+    lexical_rankings, lexical_latency = timed_rankings(dataset, lexical_reference_rank)
+    substring = {"name": "current_client_substring", "quality": quality_report(dataset, substring_rankings), "performance": substring_latency}
+    lexical = {"name": "fts_trigram_reference", "quality": quality_report(dataset, lexical_rankings), "performance": lexical_latency}
+    client = OllamaClient(ollama_url)
+    model_results = [evaluate_model(dataset, model, client) for model in models]
+    result = {
+        "schema_version": 1,
+        "kind": "weltgewebe_semantic_search_relevance_benchmark",
+        "benchmark_revision": BENCHMARK_REVISION,
+        "measured_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "dataset": {
+            "path": str(dataset_path.relative_to(ROOT)),
+            "dataset_id": dataset["dataset_id"],
+            "document_revision": dataset["document_revision"],
+            "sha256": sha256_path(dataset_path),
+            "schema_sha256": sha256_path(schema_path),
+            "node_count": len(dataset["nodes"]),
+            "case_count": len(dataset["cases"]),
+            "privacy_class": dataset["privacy_class"],
+        },
+        "benchmark_source_sha256": sha256_path(Path(__file__)),
+        "environment": {
+            "host_class": "heim-pc-local",
+            "platform": platform.platform(),
+            "python": platform.python_version(),
+            "ollama_url": ollama_url,
+            "external_cost_usd": 0,
+        },
+        "baselines": [substring, lexical],
+        "models": model_results,
+        "decision": choose_decision(lexical, model_results),
+        "does_not_establish": [
+            "production relevance",
+            "PostgreSQL FTS or pg_trgm parity",
+            "pgvector availability",
+            "runtime integration",
+            "public live proof",
+            "SemantAH archive authority",
+        ],
+    }
+    if contains_raw_vectors(result):
+        raise RuntimeError("benchmark result would contain raw vectors")
+    return result
+
+
+def _strip_performance(value: dict[str, Any]) -> dict[str, Any]:
+    return {key: item for key, item in value.items() if key != "performance"}
+
+
+def check_result(result_path: Path, dataset_path: Path, schema_path: Path) -> None:
+    result = load_json_object(result_path)
+    if contains_raw_vectors(result):
+        raise ValidationError("benchmark result contains raw vectors")
+    if result.get("kind") != "weltgewebe_semantic_search_relevance_benchmark":
+        raise ValidationError("benchmark result has an unexpected kind")
+    if result.get("benchmark_revision") != BENCHMARK_REVISION:
+        raise ValidationError("benchmark revision is stale")
+    if result.get("benchmark_source_sha256") != sha256_path(Path(__file__)):
+        raise ValidationError("benchmark source hash is stale")
+    schema = load_json_object(schema_path)
+    dataset = load_json_object(dataset_path)
+    validate_goldset(dataset, schema)
+    identity = result.get("dataset", {})
+    if identity.get("sha256") != sha256_path(dataset_path) or identity.get("schema_sha256") != sha256_path(schema_path):
+        raise ValidationError("benchmark dataset or schema hash is stale")
+    substring_rankings, _ = timed_rankings(dataset, current_substring_rank)
+    lexical_rankings, _ = timed_rankings(dataset, lexical_reference_rank)
+    expected = [
+        {"name": "current_client_substring", "quality": quality_report(dataset, substring_rankings)},
+        {"name": "fts_trigram_reference", "quality": quality_report(dataset, lexical_rankings)},
+    ]
+    actual = [_strip_performance(item) for item in result.get("baselines", [])]
+    if actual != expected:
+        raise ValidationError("checked-in lexical baseline evidence is stale")
+    models = result.get("models")
+    if not isinstance(models, list) or not models:
+        raise ValidationError("benchmark result requires measured local models")
+    model_names = [item.get("model", {}).get("name") for item in models]
+    if model_names != list(DEFAULT_MODELS):
+        raise ValidationError("benchmark result does not cover the exact required local model set")
+    digests = [item.get("model", {}).get("digest") for item in models]
+    if len(digests) != len(set(digests)):
+        raise ValidationError("benchmark result contains duplicate model digests")
+    case_ids = {case["id"] for case in dataset["cases"]}
+    for item in models:
+        model = item.get("model", {})
+        quality = item.get("quality", {})
+        digest = model.get("digest")
+        if not isinstance(digest, str) or re.fullmatch(r"sha256:[0-9a-f]{64}", digest) is None:
+            raise ValidationError("model digest is missing or invalid")
+        if not isinstance(model.get("dimensions"), int) or model["dimensions"] <= 0:
+            raise ValidationError("model dimension is missing or invalid")
+        measured_case_ids = {case.get("case_id") for case in quality.get("cases", [])}
+        if measured_case_ids != case_ids:
+            raise ValidationError("model result does not cover the exact goldset cases")
+        if quality.get("visibility_leak_count") != 0:
+            raise ValidationError("model result contains a visibility leak")
+    lexical = next(item for item in result["baselines"] if item["name"] == "fts_trigram_reference")
+    expected_decision = choose_decision(lexical, models)
+    if result.get("decision") != expected_decision:
+        raise ValidationError("model selection decision is stale or inconsistent")
+    if result.get("environment", {}).get("external_cost_usd") != 0:
+        raise ValidationError("benchmark claims non-zero external cost")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Measure or validate the synthetic Semantic Search v1 benchmark.")
+    parser.add_argument("--dataset", type=Path, default=DEFAULT_DATASET)
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    parser.add_argument("--output", type=Path, default=DEFAULT_RESULT)
+    parser.add_argument("--models", nargs="+", default=list(DEFAULT_MODELS))
+    parser.add_argument("--ollama-url", default="http://127.0.0.1:11434")
+    parser.add_argument("--check-result", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.check_result:
+            check_result(args.output, args.dataset, args.schema)
+            print(f"semantic-search benchmark evidence valid: {args.output}")
+            return 0
+        result = build_result(args.dataset, args.schema, args.models, args.ollama_url)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(result, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        print(json.dumps({"output": str(args.output), "decision": result["decision"]}, ensure_ascii=False, indent=2))
+        return 0
+    except (ValidationError, RuntimeError, ValueError) as error:
+        print(f"semantic-search benchmark failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/search/validate_relevance_goldset.py
+++ b/scripts/search/validate_relevance_goldset.py
@@ -7,12 +7,14 @@ import json
 import re
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_SCHEMA = ROOT / "contracts/search/relevance-goldset.schema.json"
 DEFAULT_DATASET = ROOT / "contracts/search/examples/relevance-goldset.example.json"
 EMAIL_LIKE = re.compile(r"(?i)\b[a-z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-z0-9-]+(?:\.[a-z0-9-]+)+\b")
+PHONE_LIKE = re.compile(r"(?<![\w-])(?:\+49|0049|0[1-9]\d{1,4})(?:[ /-]?\d){6,14}(?![\w-])")
+IPV4_LIKE = re.compile(r"(?<![\d.])(?:25[0-5]|2[0-4]\d|1?\d?\d)(?:\.(?:25[0-5]|2[0-4]\d|1?\d?\d)){3}(?![\d.])")
 
 
 class ValidationError(ValueError):
@@ -101,7 +103,7 @@ def validate_schema_subset(instance: Any, schema: dict[str, Any], path: str = "$
             raise ValidationError(f"{path}: does not match pattern {pattern!r}")
 
 
-def _walk_strings(value: Any):
+def _walk_strings(value: Any) -> Iterator[str]:
     if isinstance(value, str):
         yield value
     elif isinstance(value, list):
@@ -112,12 +114,29 @@ def _walk_strings(value: Any):
             yield from _walk_strings(item)
 
 
+def _matches_filters(node: dict[str, Any], filters: dict[str, list[str]]) -> bool:
+    kinds = set(filters["kinds"])
+    tags = set(filters["tags"])
+    languages = set(filters["languages"])
+    return (
+        (not kinds or node["kind"] in kinds)
+        and (not tags or bool(tags.intersection(node["tags"])))
+        and (not languages or node["language"] in languages)
+    )
+
+
 def validate_goldset(dataset: dict[str, Any], schema: dict[str, Any]) -> None:
-    """Apply schema validation and visibility/privacy invariants."""
+    """Apply schema, referential, visibility and privacy invariants."""
 
     validate_schema_subset(dataset, schema)
-    case_ids: set[str] = set()
+    node_by_id: dict[str, dict[str, Any]] = {}
+    for index, node in enumerate(dataset["nodes"]):
+        node_id = node["id"]
+        if node_id in node_by_id:
+            raise ValidationError(f"$.nodes[{index}].id: duplicate node id {node_id!r}")
+        node_by_id[node_id] = node
 
+    case_ids: set[str] = set()
     for index, case in enumerate(dataset["cases"]):
         case_path = f"$.cases[{index}]"
         case_id = case["id"]
@@ -125,9 +144,14 @@ def validate_goldset(dataset: dict[str, Any], schema: dict[str, Any]) -> None:
             raise ValidationError(f"{case_path}.id: duplicate case id {case_id!r}")
         case_ids.add(case_id)
 
-        visible = set(case["visibility_context"]["visible_node_ids"])
+        context = case["visibility_context"]
+        visible = set(context["visible_node_ids"])
         relevant = set(case["relevant_node_ids"])
         excluded = set(case["excluded_node_ids"])
+        referenced = visible | relevant | excluded
+        unknown = sorted(referenced - set(node_by_id))
+        if unknown:
+            raise ValidationError(f"{case_path}: references unknown nodes: {unknown!r}")
 
         missing = sorted(relevant - visible)
         if missing:
@@ -139,9 +163,22 @@ def validate_goldset(dataset: dict[str, Any], schema: dict[str, Any]) -> None:
         if overlap:
             raise ValidationError(f"{case_path}: nodes cannot be both relevant and excluded: {overlap!r}")
 
+        for node_id in sorted(visible):
+            node = node_by_id[node_id]
+            if node["status"] != "active":
+                raise ValidationError(f"{case_path}: visible node {node_id!r} is not active")
+            if context["viewer_scope"] not in node["visibility_scopes"]:
+                raise ValidationError(f"{case_path}: visible node {node_id!r} is outside viewer scope")
+            if not _matches_filters(node, context["active_filters"]):
+                raise ValidationError(f"{case_path}: visible node {node_id!r} violates active filters")
+
     for text in _walk_strings(dataset):
         if EMAIL_LIKE.search(text):
             raise ValidationError("goldset contains an email-like value")
+        if PHONE_LIKE.search(text):
+            raise ValidationError("goldset contains a phone-like value")
+        if IPV4_LIKE.search(text):
+            raise ValidationError("goldset contains an IPv4-like value")
 
 
 def load_json_object(path: Path) -> dict[str, Any]:


### PR DESCRIPTION
<!-- weltgewebe-risk: R2 -->

## Zweck

Setzt `WELTGEWEBE-SEMANTIC-SEARCH-V1-T002` als ausschließlich synthetischen, lokalen und reproduzierbaren Modellvergleich um.

## Inhalt

- erweitert das Goldset auf 22 synthetische deutsche Knoten und 24 Fälle
- prüft Sichtbarkeit, Löschung, Filter, Referenzen und PII fail-closed
- reproduziert die heutige Client-Teilstringsuche getrennt
- liefert eine klar als Offline-Näherung begrenzte FTS-/Trigramm-Referenz
- misst lokal über Loopback-Ollama `qwen3-embedding:0.6b`, `4b` und `8b`
- speichert keine Embeddings und keine Rohproviderantworten
- bindet Dataset, Schema, Benchmarkquelle, Modell-Digest und Dimension

## Ergebnis

| Pfad | natürliche Top-3 | falsche Top-1 | Lecks |
| --- | ---: | ---: | ---: |
| aktuelle Client-Teilstringsuche | 0/19 | 0 | 0 |
| FTS-/Trigramm-Referenz | 11/19 | 1 | 0 |
| qwen3-embedding:0.6b | 18/19 | 3 | 0 |
| qwen3-embedding:4b | 19/19 | 2 | 0 |
| qwen3-embedding:8b | 19/19 | 1 | 0 |

Nur `qwen3-embedding:8b` erfüllt alle harten T002-Gates. Die Auswahl gilt ausschließlich als lokaler Referenzkandidat für T003/T004.

## Validierung

- `make validate`: PASS
- Plattformtests: 39 PASS
- Docmeta: 810 PASS
- Agent: 160 PASS
- CI: 254 PASS, 9 skipped
- fokussierte Semantic-Search-Regressionen: 18 PASS
- Goldset-, Benchmark-, Generator-, Struktur- und Shell-Gates: PASS

## Grenzen

Keine Produktionsfreigabe. Keine PostgreSQL-FTS- oder `pg_trgm`-Parität. Keine `pgvector`-Fähigkeit. Keine Search-API, kein Worker, kein Deployment, keine Cloud-API, keine externen Kosten und keine SemantAH-Stilllegung.