### PR TITLE
Knotenaktionen in Reiter „Bearbeiten“ verschieben

### DIFF
--- a/apps/web/src/lib/components/panels/NodePanel.svelte
+++ b/apps/web/src/lib/components/panels/NodePanel.svelte
@@ -25,7 +25,9 @@
     domainChanged: DomainChanged;
   }>();
 
-  let activeTab = "uebersicht";
+  type NodeTab = "uebersicht" | "verlauf" | "bearbeiten";
+  let activeTab: NodeTab = "uebersicht";
+  let tabs: NodeTab[] = ["uebersicht", "verlauf"];
   let editing = false;
   let saving = false;
   let deleting = false;
@@ -84,8 +86,15 @@
     $authStore.authenticated &&
     ($authStore.role === "weber" || $authStore.role === "admin");
 
-  const tabs = ["uebersicht", "verlauf"];
-  function setTab(tab: string) {
+  $: tabs = canMutate
+    ? ["uebersicht", "verlauf", "bearbeiten"]
+    : ["uebersicht", "verlauf"];
+  $: if (!canMutate) {
+    if (activeTab === "bearbeiten") activeTab = "uebersicht";
+    if (editing) editing = false;
+  }
+
+  function setTab(tab: NodeTab) {
     activeTab = tab;
   }
 
@@ -195,6 +204,7 @@
       } as NodeDetails);
       conflictNode = null;
       editing = false;
+      activeTab = "uebersicht";
       dispatch("domainChanged", { kind: "node", id, action: "updated" });
     } catch (error) {
       if (
@@ -359,6 +369,18 @@
         id="tab-verlauf"
         tabindex={activeTab === "verlauf" ? 0 : -1}>Verlauf</button
       >
+      {#if canMutate}
+        <button
+          class:active={activeTab === "bearbeiten"}
+          on:click={() => setTab("bearbeiten")}
+          on:keydown={handleKeydown}
+          role="tab"
+          aria-selected={activeTab === "bearbeiten"}
+          aria-controls="panel-bearbeiten"
+          id="tab-bearbeiten"
+          tabindex={activeTab === "bearbeiten" ? 0 : -1}>Bearbeiten</button
+        >
+      {/if}
     </div>
 
     <div class="tab-content">
@@ -411,7 +433,7 @@
             {/if}
           {/if}
         </div>
-      {:else}
+      {:else if activeTab === "verlauf"}
         <div id="panel-verlauf" role="tabpanel" aria-labelledby="tab-verlauf">
           {#if isLoadingDetails}<p class="ghost">Lade Verlauf…</p>
           {:else if nodeDetails?.history?.length}<ul class="timeline">
@@ -434,29 +456,33 @@
             </ul>
           {:else}<p class="ghost">Noch kein Verlauf.</p>{/if}
         </div>
+      {:else if canMutate}
+        <div
+          class="mutation-actions"
+          id="panel-bearbeiten"
+          role="tabpanel"
+          aria-labelledby="tab-bearbeiten"
+        >
+          {#if mutationError}<p class="error" role="alert">
+              {mutationError}
+            </p>{/if}
+          <button type="button" class="secondary" on:click={beginEdit}
+            >Bearbeiten</button
+          >
+          <button
+            type="button"
+            class="danger"
+            on:click={removeNode}
+            disabled={deleting}
+            >{deleting ? "Löscht…" : "Knoten löschen"}</button
+          >
+          <p class="collective-note">
+            Knoten gehören zum gemeinsamen Gewebe und können von allen Webern
+            gepflegt werden.
+          </p>
+        </div>
       {/if}
     </div>
-
-    {#if canMutate}
-      <div class="mutation-actions" aria-label="Knoten bearbeiten">
-        {#if mutationError}<p class="error" role="alert">
-            {mutationError}
-          </p>{/if}
-        <button type="button" class="secondary" on:click={beginEdit}
-          >Bearbeiten</button
-        >
-        <button
-          type="button"
-          class="danger"
-          on:click={removeNode}
-          disabled={deleting}>{deleting ? "Löscht…" : "Knoten löschen"}</button
-        >
-        <p class="collective-note">
-          Knoten gehören zum gemeinsamen Gewebe und können von allen Webern
-          gepflegt werden.
-        </p>
-      </div>
-    {/if}
   {/if}
 </div>
 
@@ -482,11 +508,13 @@
   .long-info {
     white-space: pre-wrap;
   }
-  .participants,
-  .mutation-actions {
+  .participants {
     margin-top: 1rem;
     padding-top: 1rem;
     border-top: 1px solid var(--panel-border);
+  }
+  .mutation-actions {
+    padding-top: 0.25rem;
   }
   .participants p,
   .collective-note {

--- a/apps/web/tests/map-interaction.spec.ts
+++ b/apps/web/tests/map-interaction.spec.ts
@@ -287,19 +287,22 @@ test.describe("Map Interaction & Context Panel", () => {
     await expect(verlaufTab).toHaveAttribute("aria-selected", "true");
     await expect(panel.locator("#panel-verlauf")).toBeVisible();
 
-    // End remains on the last productive tab.
+    // Press End -> Should move to the final "Bearbeiten" tab.
     await page.keyboard.press("End");
-    await expect(verlaufTab).toBeFocused();
+    const bearbeitenTab = panel.getByRole("tab", { name: "Bearbeiten" });
+    await expect(bearbeitenTab).toBeFocused();
+    await expect(bearbeitenTab).toHaveAttribute("aria-selected", "true");
+    await expect(panel.locator("#panel-bearbeiten")).toBeVisible();
 
     // Press Home -> Should move back to "Übersicht"
     await page.keyboard.press("Home");
     await expect(uebersichtTab).toBeFocused();
     await expect(uebersichtTab).toHaveAttribute("aria-selected", "true");
 
-    // Press ArrowLeft -> Should wrap around to "Verlauf"
+    // Press ArrowLeft -> Should wrap around to "Bearbeiten"
     await page.keyboard.press("ArrowLeft");
-    await expect(verlaufTab).toBeFocused();
-    await expect(verlaufTab).toHaveAttribute("aria-selected", "true");
+    await expect(bearbeitenTab).toBeFocused();
+    await expect(bearbeitenTab).toHaveAttribute("aria-selected", "true");
   });
 
   test("AccountPanel keyboard navigation allows arrow keys, Home, and End", async ({

--- a/apps/web/tests/node-mutations.spec.ts
+++ b/apps/web/tests/node-mutations.spec.ts
@@ -33,7 +33,13 @@ test.describe("Knoten bearbeiten und löschen", () => {
     await page.goto("/map");
 
     const panel = await openFirstNode(page);
-    await panel.getByRole("button", { name: "Bearbeiten" }).click();
+    await expect(
+      panel.getByRole("button", { name: "Bearbeiten", exact: true }),
+    ).toHaveCount(0);
+    await panel.getByRole("tab", { name: "Bearbeiten" }).click();
+    await panel
+      .getByRole("button", { name: "Bearbeiten", exact: true })
+      .click();
     await panel.getByLabel("Titel").fill("Gemeinsam gepflegter Knoten");
     await panel
       .getByLabel("Kurzbeschreibung")
@@ -58,6 +64,11 @@ test.describe("Knoten bearbeiten und löschen", () => {
     ).toBeVisible();
     const markerCountBeforeDelete = await page.locator(".map-marker").count();
 
+    await expect(panel.getByRole("tab", { name: "Übersicht" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    await panel.getByRole("tab", { name: "Bearbeiten" }).click();
     page.once("dialog", async (dialog) => {
       expect(dialog.type()).toBe("confirm");
       expect(dialog.message()).toContain("Knoten wirklich löschen");
@@ -89,9 +100,10 @@ test.describe("Knoten bearbeiten und löschen", () => {
     await page.goto("/map");
 
     const panel = await openFirstNode(page);
-    await expect(panel.getByRole("button", { name: "Bearbeiten" })).toHaveCount(
-      0,
-    );
+    await expect(panel.getByRole("tab", { name: "Bearbeiten" })).toHaveCount(0);
+    await expect(
+      panel.getByRole("button", { name: "Bearbeiten", exact: true }),
+    ).toHaveCount(0);
     await expect(
       panel.getByRole("button", { name: "Knoten löschen" }),
     ).toHaveCount(0);
@@ -146,7 +158,10 @@ test.describe("Knoten bearbeiten und löschen", () => {
 
     await page.goto("/map");
     const panel = await openFirstNode(page);
-    await panel.getByRole("button", { name: "Bearbeiten" }).click();
+    await panel.getByRole("tab", { name: "Bearbeiten" }).click();
+    await panel
+      .getByRole("button", { name: "Bearbeiten", exact: true })
+      .click();
     await panel.getByLabel("Titel").fill("Mein Konflikt");
     await panel.getByRole("button", { name: "Änderungen speichern" }).click();
 


### PR DESCRIPTION
## Änderung

- ergänzt im Knotenpanel den eigenen Reiter **Bearbeiten**
- verschiebt **Bearbeiten** und **Knoten löschen** aus der Übersicht in diesen Reiter
- hält den Reiter für Gäste verborgen
- bindet den neuen Reiter vollständig in Pfeiltasten-, Home- und End-Navigation ein
- kehrt nach erfolgreichem Speichern zur Übersicht zurück
- schließt ein offenes Bearbeitungsformular bei Verlust der Berechtigung
- entfernt die nun redundante innere Trennlinie

## Prüfung

- `pnpm --dir apps/web check`
- `pnpm --dir apps/web test -- tests/map-interaction.spec.ts tests/node-mutations.spec.ts`
- `pnpm --dir apps/web test:ci` — vollständiger Lauf mit 157 Browserprüfungen
- `git diff --check`

Alle lokalen Prüfungen erfolgreich. Aktueller Head: `7ccb135b3d1c213d81ebd866f9c3715c81a6c1b1`.

<!-- weltgewebe-risk: R2 -->
