### PR TITLE
Knotenbearbeitung: Fokusführung und Tab-Semantik härten

### DIFF
--- a/apps/web/src/lib/components/panels/NodePanel.svelte
+++ b/apps/web/src/lib/components/panels/NodePanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { createEventDispatcher, onDestroy } from "svelte";
+  import { createEventDispatcher, onDestroy, tick } from "svelte";
   import { selection } from "$lib/stores/uiView";
   import { authStore } from "$lib/auth/store";
   import {
@@ -28,6 +28,9 @@
   type NodeTab = "uebersicht" | "verlauf" | "bearbeiten";
   let activeTab: NodeTab = "uebersicht";
   let tabs: NodeTab[] = ["uebersicht", "verlauf"];
+  let overviewTab: HTMLButtonElement | null = null;
+  let editTab: HTMLButtonElement | null = null;
+  let titleInput: HTMLInputElement | null = null;
   let editing = false;
   let saving = false;
   let deleting = false;
@@ -90,8 +93,17 @@
     ? ["uebersicht", "verlauf", "bearbeiten"]
     : ["uebersicht", "verlauf"];
   $: if (!canMutate) {
+    const shouldRestoreFocus = activeTab === "bearbeiten" || editing;
     if (activeTab === "bearbeiten") activeTab = "uebersicht";
     if (editing) editing = false;
+    if (shouldRestoreFocus) void focusAfterRender(() => overviewTab);
+  }
+
+  async function focusAfterRender(
+    resolveTarget: () => HTMLElement | null,
+  ): Promise<void> {
+    await tick();
+    resolveTarget()?.focus();
   }
 
   function setTab(tab: NodeTab) {
@@ -133,6 +145,12 @@
     mutationError = "";
     conflictNode = null;
     editing = true;
+    void focusAfterRender(() => titleInput);
+  }
+
+  function cancelEdit() {
+    editing = false;
+    void focusAfterRender(() => editTab);
   }
 
   function mutationMessage(error: unknown): string {
@@ -205,6 +223,7 @@
       conflictNode = null;
       editing = false;
       activeTab = "uebersicht";
+      void focusAfterRender(() => overviewTab);
       dispatch("domainChanged", { kind: "node", id, action: "updated" });
     } catch (error) {
       if (
@@ -270,7 +289,12 @@
     <form class="edit-form" on:submit|preventDefault={saveNode}>
       <label>
         Titel
-        <input bind:value={formTitle} maxlength="200" required />
+        <input
+          bind:this={titleInput}
+          bind:value={formTitle}
+          maxlength="200"
+          required
+        />
       </label>
       <label>
         Knotenart
@@ -339,7 +363,7 @@
         <button
           type="button"
           class="secondary"
-          on:click={() => (editing = false)}
+          on:click={cancelEdit}
           disabled={saving}>Abbrechen</button
         >
         <button type="submit" class="primary" disabled={saving}
@@ -357,6 +381,7 @@
         aria-selected={activeTab === "uebersicht"}
         aria-controls="panel-uebersicht"
         id="tab-uebersicht"
+        bind:this={overviewTab}
         tabindex={activeTab === "uebersicht" ? 0 : -1}>Übersicht</button
       >
       <button
@@ -378,6 +403,7 @@
           aria-selected={activeTab === "bearbeiten"}
           aria-controls="panel-bearbeiten"
           id="tab-bearbeiten"
+          bind:this={editTab}
           tabindex={activeTab === "bearbeiten" ? 0 : -1}>Bearbeiten</button
         >
       {/if}
@@ -390,6 +416,7 @@
           id="panel-uebersicht"
           role="tabpanel"
           aria-labelledby="tab-uebersicht"
+          tabindex="0"
         >
           {#if isLoadingDetails}<p class="ghost">Lade Details…</p>
           {:else}
@@ -434,7 +461,12 @@
           {/if}
         </div>
       {:else if activeTab === "verlauf"}
-        <div id="panel-verlauf" role="tabpanel" aria-labelledby="tab-verlauf">
+        <div
+          id="panel-verlauf"
+          role="tabpanel"
+          aria-labelledby="tab-verlauf"
+          tabindex="0"
+        >
           {#if isLoadingDetails}<p class="ghost">Lade Verlauf…</p>
           {:else if nodeDetails?.history?.length}<ul class="timeline">
               {#each nodeDetails.history as event}<li>
@@ -456,7 +488,7 @@
             </ul>
           {:else}<p class="ghost">Noch kein Verlauf.</p>{/if}
         </div>
-      {:else if canMutate}
+      {:else if activeTab === "bearbeiten" && canMutate}
         <div
           class="mutation-actions"
           id="panel-bearbeiten"

--- a/apps/web/tests/map-interaction.spec.ts
+++ b/apps/web/tests/map-interaction.spec.ts
@@ -277,6 +277,15 @@ test.describe("Map Interaction & Context Panel", () => {
     await uebersichtTab.focus();
     await expect(uebersichtTab).toBeFocused();
     await expect(uebersichtTab).toHaveAttribute("aria-selected", "true");
+    await expect(uebersichtTab).toHaveAttribute(
+      "aria-controls",
+      "panel-uebersicht",
+    );
+    await expect(uebersichtTab).toHaveAttribute("tabindex", "0");
+    await expect(panel.locator("#panel-uebersicht")).toHaveAttribute(
+      "tabindex",
+      "0",
+    );
 
     // Press ArrowRight -> Should move to "Verlauf"
     await page.keyboard.press("ArrowRight");
@@ -285,13 +294,26 @@ test.describe("Map Interaction & Context Panel", () => {
     });
     await expect(verlaufTab).toBeFocused();
     await expect(verlaufTab).toHaveAttribute("aria-selected", "true");
+    await expect(verlaufTab).toHaveAttribute("aria-controls", "panel-verlauf");
+    await expect(verlaufTab).toHaveAttribute("tabindex", "0");
+    await expect(uebersichtTab).toHaveAttribute("tabindex", "-1");
     await expect(panel.locator("#panel-verlauf")).toBeVisible();
+    await expect(panel.locator("#panel-verlauf")).toHaveAttribute(
+      "tabindex",
+      "0",
+    );
 
     // Press End -> Should move to the final "Bearbeiten" tab.
     await page.keyboard.press("End");
     const bearbeitenTab = panel.getByRole("tab", { name: "Bearbeiten" });
     await expect(bearbeitenTab).toBeFocused();
     await expect(bearbeitenTab).toHaveAttribute("aria-selected", "true");
+    await expect(bearbeitenTab).toHaveAttribute(
+      "aria-controls",
+      "panel-bearbeiten",
+    );
+    await expect(bearbeitenTab).toHaveAttribute("tabindex", "0");
+    await expect(verlaufTab).toHaveAttribute("tabindex", "-1");
     await expect(panel.locator("#panel-bearbeiten")).toBeVisible();
 
     // Press Home -> Should move back to "Übersicht"

--- a/apps/web/tests/node-mutations.spec.ts
+++ b/apps/web/tests/node-mutations.spec.ts
@@ -40,6 +40,13 @@ test.describe("Knoten bearbeiten und löschen", () => {
     await panel
       .getByRole("button", { name: "Bearbeiten", exact: true })
       .click();
+    await expect(panel.getByLabel("Titel")).toBeFocused();
+    await panel.getByRole("button", { name: "Abbrechen" }).click();
+    await expect(panel.getByRole("tab", { name: "Bearbeiten" })).toBeFocused();
+    await panel
+      .getByRole("button", { name: "Bearbeiten", exact: true })
+      .click();
+    await expect(panel.getByLabel("Titel")).toBeFocused();
     await panel.getByLabel("Titel").fill("Gemeinsam gepflegter Knoten");
     await panel
       .getByLabel("Kurzbeschreibung")
@@ -68,6 +75,7 @@ test.describe("Knoten bearbeiten und löschen", () => {
       "aria-selected",
       "true",
     );
+    await expect(panel.getByRole("tab", { name: "Übersicht" })).toBeFocused();
     await panel.getByRole("tab", { name: "Bearbeiten" }).click();
     page.once("dialog", async (dialog) => {
       expect(dialog.type()).toBe("confirm");
@@ -107,6 +115,18 @@ test.describe("Knoten bearbeiten und löschen", () => {
     await expect(
       panel.getByRole("button", { name: "Knoten löschen" }),
     ).toHaveCount(0);
+
+    const uebersichtTab = panel.getByRole("tab", { name: "Übersicht" });
+    const verlaufTab = panel.getByRole("tab", { name: "Verlauf" });
+    await uebersichtTab.focus();
+    await page.keyboard.press("ArrowLeft");
+    await expect(verlaufTab).toBeFocused();
+    await expect(verlaufTab).toHaveAttribute("aria-selected", "true");
+    await expect(verlaufTab).toHaveAttribute("tabindex", "0");
+    await expect(uebersichtTab).toHaveAttribute("tabindex", "-1");
+    await page.keyboard.press("ArrowRight");
+    await expect(uebersichtTab).toBeFocused();
+    await expect(uebersichtTab).toHaveAttribute("aria-selected", "true");
   });
 
   test("bewahrt den Entwurf bei 412 und speichert nach bewusstem Vergleich erneut", async ({


### PR DESCRIPTION
## Kontext

Folge-PR zu #1507. Der Reiter **Bearbeiten** ist bereits in `main`; dieser Patch behebt die im unabhängigen Barrierefreiheitsreview gefundenen Fokus- und Semantiklücken.

<!-- weltgewebe-risk: R2 -->

## Änderung

- fokussiert beim Öffnen des Formulars das Titelfeld
- führt den Fokus nach Abbrechen zurück zum Reiter **Bearbeiten**
- führt den Fokus nach erfolgreichem Speichern zurück zu **Übersicht**
- stellt bei Verlust der Bearbeitungsrechte den Fokus auf **Übersicht** wieder her
- macht textlastige Tabpanels per Tastatur erreichbar
- bindet das Bearbeiten-Panel ausdrücklich an den aktiven Reiter
- stärkt Tests für `aria-controls`, roving `tabindex`, Gastnavigation und Fokusübergänge
- bewahrt die Integration des inzwischen gemergten Reiters **Gespräch**

## Prüfung

- `pnpm --dir apps/web check`
- `pnpm --dir apps/web test -- tests/map-interaction.spec.ts tests/node-mutations.spec.ts`
- GitHub-CI einschließlich Web E2E, CodeQL, GitOps- und HA-Nachweisen grün

Head: `50d13c9f17736b2c8fba34f728a0131e5a004a3c`.