### PR TITLE
perf(web): delta-update map search highlights

### DIFF
--- a/apps/web/src/lib/map/overlay/nodes.test.ts
+++ b/apps/web/src/lib/map/overlay/nodes.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { diffSearchMatchIds } from "./nodes";
+
+describe("diffSearchMatchIds", () => {
+  it("returns only the changed search-match ids", () => {
+    expect(
+      diffSearchMatchIds(new Set(["keep", "remove"]), new Set(["keep", "add"])),
+    ).toEqual({
+      added: ["add"],
+      removed: ["remove"],
+    });
+  });
+
+  it("returns an empty delta for unchanged matches", () => {
+    expect(
+      diffSearchMatchIds(new Set(["a", "b"]), new Set(["a", "b"])),
+    ).toEqual({
+      added: [],
+      removed: [],
+    });
+  });
+});

--- a/apps/web/src/lib/map/overlay/nodes.ts
+++ b/apps/web/src/lib/map/overlay/nodes.ts
@@ -13,6 +13,23 @@ function hasRenderablePosition(item: MapEntityViewModel): boolean {
   );
 }
 
+export function diffSearchMatchIds(
+  previous: ReadonlySet<string>,
+  next: ReadonlySet<string>,
+): { added: string[]; removed: string[] } {
+  const added: string[] = [];
+  const removed: string[] = [];
+
+  for (const id of next) {
+    if (!previous.has(id)) added.push(id);
+  }
+  for (const id of previous) {
+    if (!next.has(id)) removed.push(id);
+  }
+
+  return { added, removed };
+}
+
 export class NodesOverlay {
   private activeMarkers = new Map<
     string,
@@ -23,6 +40,7 @@ export class NodesOverlay {
       cleanup: () => void;
     }
   >();
+  private searchMatchIds = new Set<string>();
 
   constructor(private map: MapLibreMap) {}
 
@@ -32,11 +50,7 @@ export class NodesOverlay {
     return type === "garnrolle" ? "account" : "node";
   }
 
-  public async update(
-    points: MapEntityViewModel[],
-    showNodes: boolean,
-    searchMatchIds: Set<string> = new Set(),
-  ) {
+  public async update(points: MapEntityViewModel[], showNodes: boolean) {
     if (!this.map) return;
     const maplibregl = await import("maplibre-gl");
 
@@ -97,14 +111,6 @@ export class NodesOverlay {
           element.setAttribute("aria-label", item.title);
         }
         element.dataset.testid = `marker-${item.type}-${item.id}`;
-
-        if (searchMatchIds.has(item.id)) {
-          element.classList.add("search-highlight");
-          element.dataset.searchMatch = "true";
-        } else {
-          element.classList.remove("search-highlight");
-          delete element.dataset.searchMatch;
-        }
       } else {
         // Create new
         const element = document.createElement("button");
@@ -153,7 +159,7 @@ export class NodesOverlay {
         element.setAttribute("aria-label", item.title);
         element.title = item.title;
 
-        if (searchMatchIds.has(item.id)) {
+        if (this.searchMatchIds.has(item.id)) {
           element.classList.add("search-highlight");
           element.dataset.searchMatch = "true";
         }
@@ -178,6 +184,31 @@ export class NodesOverlay {
     }
   }
 
+  private setSearchMatch(id: string, highlighted: boolean) {
+    const entry = this.activeMarkers.get(id);
+    if (!entry) return;
+
+    if (highlighted) {
+      entry.element.classList.add("search-highlight");
+      entry.element.dataset.searchMatch = "true";
+    } else {
+      entry.element.classList.remove("search-highlight");
+      delete entry.element.dataset.searchMatch;
+    }
+  }
+
+  public updateSearchMatches(nextSearchMatchIds: ReadonlySet<string>) {
+    const { added, removed } = diffSearchMatchIds(
+      this.searchMatchIds,
+      nextSearchMatchIds,
+    );
+
+    for (const id of removed) this.setSearchMatch(id, false);
+    for (const id of added) this.setSearchMatch(id, true);
+
+    this.searchMatchIds = new Set(nextSearchMatchIds);
+  }
+
   public getActiveMarker(id: string) {
     return this.activeMarkers.get(id);
   }
@@ -185,5 +216,6 @@ export class NodesOverlay {
   public destroy() {
     this.activeMarkers.forEach(({ cleanup }) => cleanup());
     this.activeMarkers.clear();
+    this.searchMatchIds.clear();
   }
 }

--- a/apps/web/src/lib/stores/mapView.test.ts
+++ b/apps/web/src/lib/stores/mapView.test.ts
@@ -141,6 +141,38 @@ describe("mapView presentation helpers", () => {
     expect(deriveSearchMatchIds(results).has("node-1")).toBe(true);
   });
 
+  it("stops scanning once the ten-result search limit is satisfied", () => {
+    const matches: MapEntityViewModel[] = Array.from(
+      { length: 10 },
+      (_, index) => ({
+        type: "node",
+        id: `node-${index}`,
+        title: `Needle ${index}`,
+        kind: "Werkstatt",
+        tags: [],
+        created_at: "2025-01-01T00:00:00Z",
+        lat: 53.5 + index * 0.001,
+        lon: 10 + index * 0.001,
+      }),
+    );
+    const sentinel = {
+      ...matches[0],
+      id: "must-not-be-scanned",
+      title: "placeholder",
+    };
+    Object.defineProperty(sentinel, "title", {
+      get() {
+        throw new Error("search scanned beyond its ten-result limit");
+      },
+    });
+
+    const results = deriveSearchResults([...matches, sentinel], "needle", true);
+    expect(results).toHaveLength(10);
+    expect(results.map((item) => item.id)).toEqual(
+      matches.map((item) => item.id),
+    );
+  });
+
   it("finds Garnrollen by semantic type, plural and profile tags", () => {
     const scene = sceneFrom(
       [],

--- a/apps/web/src/lib/stores/mapView.ts
+++ b/apps/web/src/lib/stores/mapView.ts
@@ -121,25 +121,28 @@ export function deriveSearchResults(
     return [];
   }
   const q = query.trim().toLocaleLowerCase("de-DE");
-  return visibleMarkers
-    .filter((marker) => {
-      const semanticTerms =
-        marker.type === "node"
-          ? ["Knoten", marker.kind]
-          : ["Garnrolle", "Garnrollen"];
-      const searchableTerms = [
-        marker.title,
-        marker.summary,
-        ...(marker.tags ?? []),
-        ...semanticTerms,
-      ];
-      return searchableTerms.some(
-        (term) =>
-          typeof term === "string" &&
-          term.toLocaleLowerCase("de-DE").includes(q),
-      );
-    })
-    .slice(0, 10);
+  const results: MapEntityViewModel[] = [];
+  for (const marker of visibleMarkers) {
+    const semanticTerms =
+      marker.type === "node"
+        ? ["Knoten", marker.kind]
+        : ["Garnrolle", "Garnrollen"];
+    const searchableTerms = [
+      marker.title,
+      marker.summary,
+      ...(marker.tags ?? []),
+      ...semanticTerms,
+    ];
+    const matches = searchableTerms.some(
+      (term) =>
+        typeof term === "string" && term.toLocaleLowerCase("de-DE").includes(q),
+    );
+    if (!matches) continue;
+
+    results.push(marker);
+    if (results.length === 10) break;
+  }
+  return results;
 }
 
 /** Ids of the current search matches, for marker highlighting. */

--- a/apps/web/src/routes/map/+page.svelte
+++ b/apps/web/src/routes/map/+page.svelte
@@ -292,18 +292,20 @@
     );
   }
 
-  // Reactive update for markers and search highlight strictly handled in overlay update
+  // Marker data and search highlighting have separate update paths. Filtering or
+  // scene changes may touch the full marker set; search changes only toggle the
+  // small delta between the previous and next (maximum ten) search matches.
   $: if (nodesOverlay && filteredMarkersData && $view) {
     (async () => {
-      await nodesOverlay.update(
-        filteredMarkersData,
-        $view.showNodes,
-        searchMatchIds,
-      );
+      await nodesOverlay.update(filteredMarkersData, $view.showNodes);
     })();
   }
 
-  // Search content changes only require a marker refresh. ResizeObserver already
+  $: if (nodesOverlay) {
+    nodesOverlay.updateSearchMatches(searchMatchIds);
+  }
+
+  // Search content changes only require indicator and highlight refreshes. ResizeObserver already
   // reports intrinsic overlay-size changes, so it must not be recycled per key.
   $: if (map) {
     filteredResults;


### PR DESCRIPTION
<!-- weltgewebe-risk: R2 -->

## Wirkung
- Trennt vollständige Marker-Datenupdates von reinen Suchhervorhebungen.
- Eine Suchänderung verarbeitet nur noch die Differenz aus alten und neuen Treffer-IDs statt alle sichtbaren Marker; die Ergebnisliste ist auf 10 begrenzt.
- Die Suchauswertung bricht nach dem zehnten Treffer ab, statt erst die gesamte sichtbare Marker-Liste zu filtern.

## Verifikation
- `pnpm --dir apps/web run test:unit`: 22 Dateien, 167 Tests grün.
- `pnpm --dir apps/web run check:ci`: 0 Fehler, 0 Warnungen.
- `pnpm --dir apps/web run lint`: grün.
- `pnpm --dir apps/web run build`: grün; Route-Budget `/map` 78.903 B JS gzip / 16.756 B CSS gzip.
- `tests/ui-search.spec.ts`: langlebiger Grabowski-Testtask mit Exit-Code 0.
- `git diff --check`: grün.

## Abgrenzung
Dieser Slice behebt den belegten O(N)-Suchhervorhebungs-Hotpath. Die größeren Architekturthemen DOM-Marker-Skalierung und viewport-/BBOX-basierter Karten-Datenvertrag bleiben getrennt als Bureau-Kandidaten erfasst und werden nicht durch ein voreiliges globales Limit- oder Rendering-Rewrite vermischt.