### PR TITLE
fix(web): clarify map fan surfaces

### DIFF
--- a/apps/web/src/lib/components/GovernanceFan.svelte
+++ b/apps/web/src/lib/components/GovernanceFan.svelte
@@ -84,8 +84,7 @@
     aria-controls="governance-fan-actions"
     on:click={handleTrigger}
   >
-    <span aria-hidden="true">⌘</span>
-    <span>Gemeinsam</span>
+    <span>Mitentscheiden</span>
   </button>
 
   <div
@@ -180,13 +179,8 @@
     position: absolute;
     top: calc(100% + 10px);
     left: 50%;
-    width: min(var(--governance-fan-menu-width), calc(100vw - 24px));
-    padding: 0.65rem;
-    border: 1px solid var(--panel-border);
-    border-radius: 18px;
-    background: rgba(15, 17, 21, 0.92);
-    box-shadow: var(--shadow);
-    backdrop-filter: blur(var(--map-lens-blur));
+    width: max-content;
+    max-width: min(var(--governance-fan-menu-width), calc(100vw - 24px));
     display: flex;
     flex-wrap: wrap;
     align-items: flex-start;
@@ -206,9 +200,12 @@
   .governance-menu.open {
     opacity: 1;
     visibility: visible;
-    pointer-events: auto;
     transform: translateX(-50%) translateY(0) scale(1);
     transition-delay: 0s;
+  }
+
+  .governance-menu :global(.fan-action) {
+    pointer-events: auto;
   }
 
   .governance-slot--outer-left,
@@ -239,14 +236,13 @@
 
   @media (max-width: 520px) {
     .governance-menu {
-      width: min(304px, calc(100vw - 16px));
+      max-width: min(304px, calc(100vw - 16px));
       gap: 0.35rem;
     }
   }
 
   @media (prefers-reduced-transparency: reduce) {
-    .governance-trigger,
-    .governance-menu {
+    .governance-trigger {
       background: var(--panel-solid);
       backdrop-filter: none;
     }

--- a/apps/web/src/lib/components/ToolFanMenu.svelte
+++ b/apps/web/src/lib/components/ToolFanMenu.svelte
@@ -27,6 +27,7 @@
   id="tool-fan-actions"
   class="fan-panel"
   class:open
+  class:root={branch === TOOL_FAN_BRANCH.root}
   role="group"
   aria-label={branch === TOOL_FAN_BRANCH.root
     ? "Werkzeugfächer"
@@ -166,6 +167,24 @@
     transition-delay: 0s;
   }
 
+  .fan-panel.root {
+    width: max-content;
+    max-width: min(var(--tool-fan-menu-width), calc(100vw - 24px));
+    padding: 0;
+    border: 0;
+    background: transparent;
+    box-shadow: none;
+    backdrop-filter: none;
+  }
+
+  .fan-panel.root.open {
+    pointer-events: none;
+  }
+
+  .fan-panel.root :global(.fan-action) {
+    pointer-events: auto;
+  }
+
   .fan-row {
     display: flex;
     align-items: flex-end;
@@ -252,6 +271,12 @@
       padding: 0.6rem;
     }
 
+    .fan-panel.root {
+      width: max-content;
+      max-width: min(304px, calc(100vw - 16px));
+      padding: 0;
+    }
+
     .fan-row {
       gap: 0.35rem;
     }
@@ -270,7 +295,7 @@
   }
 
   @media (prefers-reduced-transparency: reduce) {
-    .fan-panel {
+    .fan-panel:not(.root) {
       background: var(--panel-solid);
       backdrop-filter: none;
     }

--- a/apps/web/tests/map-fan-surface-clarity.spec.ts
+++ b/apps/web/tests/map-fan-surface-clarity.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from "@playwright/test";
+import { mockApiResponses } from "./fixtures/mockApi";
+
+async function fanSurface(
+  page: import("@playwright/test").Page,
+  selector: string,
+) {
+  return page.locator(selector).evaluate((element) => {
+    const style = getComputedStyle(element);
+    return {
+      backgroundColor: style.backgroundColor,
+      borderTopWidth: style.borderTopWidth,
+      boxShadow: style.boxShadow,
+      backdropFilter: style.backdropFilter,
+      pointerEvents: style.pointerEvents,
+    };
+  });
+}
+
+test.describe("Map fan surface clarity", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockApiResponses(page, {
+      auth: { authenticated: true, account_id: "e2e-weber", role: "weber" },
+    });
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.goto("/map");
+    await page.waitForSelector('[data-testid="tool-fan"]', { timeout: 10000 });
+  });
+
+  test("root fans expose only their action pills without opaque carrier panels", async ({
+    page,
+  }) => {
+    await page.getByTestId("tool-fan-trigger").click();
+    await expect(page.getByTestId("tool-fan")).toHaveAttribute(
+      "data-expanded",
+      "true",
+    );
+
+    expect(await fanSurface(page, "#tool-fan-actions")).toEqual({
+      backgroundColor: "rgba(0, 0, 0, 0)",
+      borderTopWidth: "0px",
+      boxShadow: "none",
+      backdropFilter: "none",
+      pointerEvents: "none",
+    });
+    await expect(page.getByTestId("tool-fan-find")).toHaveCSS(
+      "pointer-events",
+      "auto",
+    );
+
+    await page.getByTestId("governance-fan-trigger").click();
+    const governanceTrigger = page.getByTestId("governance-fan-trigger");
+    await expect(governanceTrigger).toContainText("Mitentscheiden");
+    await expect(governanceTrigger).not.toContainText("Gemeinsam");
+    await expect(governanceTrigger).toHaveAccessibleName(
+      "Gemeinsame Entscheidungen schließen",
+    );
+
+    expect(await fanSurface(page, "#governance-fan-actions")).toEqual({
+      backgroundColor: "rgba(0, 0, 0, 0)",
+      borderTopWidth: "0px",
+      boxShadow: "none",
+      backdropFilter: "none",
+      pointerEvents: "none",
+    });
+    await expect(page.getByTestId("governance-fan-all")).toHaveCSS(
+      "pointer-events",
+      "auto",
+    );
+  });
+
+  test("the explanatory weaving branch keeps a readable panel surface", async ({
+    page,
+  }) => {
+    await page.getByTestId("tool-fan-trigger").click();
+    await page.getByTestId("tool-fan-weave").click();
+
+    const surface = await fanSurface(page, "#tool-fan-actions");
+    expect(surface.backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
+    expect(surface.borderTopWidth).not.toBe("0px");
+    expect(surface.pointerEvents).toBe("auto");
+  });
+});


### PR DESCRIPTION
<!-- weltgewebe-risk: R2 -->

## Ziel

Die großen opaken Trägerflächen unter den Root-Fächern von `Werkzeuge` und Governance entfernen, ohne Lesbarkeit oder Interaktion der einzelnen Aktionen zu verlieren. Den sichtbaren Governance-Einstieg von `Gemeinsam` auf `Mitentscheiden` umstellen und das missverständliche Command-Symbol entfernen.

## Nicht-Ziele

- keine Neuordnung der fünf Governance-Aktionen
- keine Änderung der kanonischen Root-Begriffe `Finden`, `Karteninhalt`, `Weben`
- keine Änderung an Berechtigungen oder Governance-Fachlogik
- keine vollständige Neugestaltung der Fächer

## Zu bewahrende Invarianten

- Die Karte bleibt primärer räumlicher Kontext.
- `Werkzeuge` und Governance bleiben getrennte Fächer und gegenseitig exklusiv.
- Einzelne `FanAction`-Knöpfe bleiben sichtbar, fokussierbar und klickbar.
- Transparente Wrapper blockieren keine Karteninteraktion.
- Die erklärende zweite Ebene `Weben` behält eine lesbare Panel-Fläche.

## Fehlerszenarien und Rückfallweg

Mögliche Regressionen sind unsichtbare Pointer-Blockaden, nicht klickbare Aktionsknöpfe oder unlesbare Weben-Inhalte. Die fokussierten Playwright-Tests prüfen diese Zustände. Rückfallweg ist ein Revert des einzelnen Commits `1026682dcdf7012b0d08356241672b254d0ce4db`.

## Prüfungen

- `make validate-guards` — grün
- `pnpm lint` — grün
- `pnpm check:ci` — 0 Fehler, 0 Warnungen
- `pnpm run build:e2e` — grün, Performance-Budget grün
- fokussierte Playwright-Suite `map-fan-surface-clarity.spec.ts`, `tool-fan-layout.spec.ts`, `governance.spec.ts`, `map-controls-offset.spec.ts` — Exit 0

Baseline-Hinweis: Ein vollständiger unveränderter Playwright-Baseline-Lauf konnte wegen eines nicht gestarteten Preview-Webservers im persistenten Test-Task nicht als global grün belegt werden (`ERR_CONNECTION_REFUSED`). Der unveränderte E2E-Build war grün. Für den Patch wurde anschließend ein separat gestarteter Preview-Server per Readback bestätigt und die vier direkt relevanten Browser-Suites liefen mit Exit 0.

## Reviewevidenz

Head- und diffgebundener Self-Review: kein Blocker. Besonderes Augenmerk auf Pointer-Events, Narrow-Viewport-Wrapping, Accessibility und Erhalt der Weben-Fläche. Ein externer Provider-Review wurde nicht gestartet, weil der vorhandene Agentenpfad eine positive Kostenfreigabe verlangt und für diese Arbeit die Null-Kosten-Regel gilt.

## Veröffentlichung und Liveprüfung

Nach Merge den exakten `main`-Commit und die Produktionsversion read-only abgleichen; anschließend die beiden Root-Fächer auf der Kartenoberfläche prüfen.