### PR TITLE
ci(review): make review-evidence gate converge after cancellation

### DIFF
--- a/.github/workflows/review-evidence.yml
+++ b/.github/workflows/review-evidence.yml
@@ -28,6 +28,10 @@ concurrency:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   GH_API_VERSION: "2022-11-28"
+  # Stable branch-protection context. Keep distinct from the cancellable workflow
+  # job name `Review evidence evaluator`; otherwise a CANCELLED check-run can
+  # block a later exact-head terminal commit status with the same required name.
+  REVIEW_EVIDENCE_CONTEXT: "Review evidence gate"
 
 jobs:
   review-evidence:
@@ -139,7 +143,7 @@ jobs:
           gh api --method POST -H "${api_header}" \
             "repos/${REPOSITORY}/statuses/${head_sha}" \
             -f state=pending \
-            -f context='Review evidence gate' \
+            -f context="${REVIEW_EVIDENCE_CONTEXT}" \
             -f description='Exact diff and review evidence are being verified.' \
             -f target_url="${GITHUB_SERVER_URL}/${REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
             >/dev/null
@@ -322,7 +326,7 @@ jobs:
               -H "X-GitHub-Api-Version: ${GH_API_VERSION}" \
               "repos/${REPOSITORY}/statuses/${HEAD_SHA}" \
               -f state="${state}" \
-              -f context='Review evidence gate' \
+              -f context="${REVIEW_EVIDENCE_CONTEXT}" \
               -f description="${description}" \
               -f target_url="${GITHUB_SERVER_URL}/${REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
               >/dev/null; then

--- a/.github/workflows/review-evidence.yml
+++ b/.github/workflows/review-evidence.yml
@@ -31,7 +31,9 @@ env:
 
 jobs:
   review-evidence:
-    name: Review evidence gate
+    # Keep the workflow check-run name distinct from the required commit-status context.
+    # A cancelled concurrency run must never shadow a later exact-head terminal status.
+    name: Review evidence evaluator
     if: >-
       (
         github.event_name != 'issue_comment' ||

--- a/scripts/ci/tests/test_canonical_truth_contract.py
+++ b/scripts/ci/tests/test_canonical_truth_contract.py
@@ -35,10 +35,13 @@ class CanonicalTruthContractTests(unittest.TestCase):
             "Review evidence gate": ROOT / ".github/workflows/review-evidence.yml",
         }
         self.assertEqual(set(data["required_checks"]), set(producers))
-        for name, workflow_path in producers.items():
-            workflow = workflow_path.read_text(encoding="utf-8")
-            self.assertIn(f"name: {name}", workflow)
+        required_merge_workflow = producers["Required merge gate"].read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("name: Required merge gate", required_merge_workflow)
         review_workflow = producers["Review evidence gate"].read_text(encoding="utf-8")
+        self.assertNotIn("\n    name: Review evidence gate\n", review_workflow)
+        self.assertIn("name: Review evidence evaluator", review_workflow)
         self.assertGreaterEqual(
             review_workflow.count("context='Review evidence gate'"),
             2,

--- a/scripts/ci/tests/test_canonical_truth_contract.py
+++ b/scripts/ci/tests/test_canonical_truth_contract.py
@@ -7,6 +7,8 @@ import re
 import unittest
 from pathlib import Path
 
+import yaml
+
 ROOT = Path(__file__).resolve().parents[3]
 
 
@@ -31,21 +33,56 @@ class CanonicalTruthContractTests(unittest.TestCase):
             ["Required merge gate", "Review evidence gate"],
         )
         producers = {
-            "Required merge gate": ROOT / ".github/workflows/ci.yml",
-            "Review evidence gate": ROOT / ".github/workflows/review-evidence.yml",
+            "Required merge gate": {
+                "kind": "check_run",
+                "workflow": ROOT / ".github/workflows/ci.yml",
+            },
+            "Review evidence gate": {
+                "kind": "commit_status",
+                "workflow": ROOT / ".github/workflows/review-evidence.yml",
+            },
         }
         self.assertEqual(set(data["required_checks"]), set(producers))
-        required_merge_workflow = producers["Required merge gate"].read_text(
-            encoding="utf-8"
-        )
+
+        required_merge = producers["Required merge gate"]
+        self.assertEqual(required_merge["kind"], "check_run")
+        required_merge_workflow = required_merge["workflow"].read_text(encoding="utf-8")
         self.assertIn("name: Required merge gate", required_merge_workflow)
-        review_workflow = producers["Review evidence gate"].read_text(encoding="utf-8")
-        self.assertNotIn("\n    name: Review evidence gate\n", review_workflow)
-        self.assertIn("name: Review evidence evaluator", review_workflow)
-        self.assertGreaterEqual(
-            review_workflow.count("context='Review evidence gate'"),
-            2,
+
+        review = producers["Review evidence gate"]
+        self.assertEqual(review["kind"], "commit_status")
+        review_workflow = review["workflow"].read_text(encoding="utf-8")
+        review_data = yaml.safe_load(review_workflow)
+        review_job = review_data["jobs"]["review-evidence"]
+        required_context = review_data["env"]["REVIEW_EVIDENCE_CONTEXT"]
+        self.assertEqual(review_job["name"], "Review evidence evaluator")
+        self.assertEqual(required_context, "Review evidence gate")
+        self.assertNotEqual(review_job["name"], required_context)
+
+        evaluate_step = next(
+            step
+            for step in review_job["steps"]
+            if step.get("name") == "Resolve PR and evaluate exact review evidence"
         )
+        publish_step = next(
+            step
+            for step in review_job["steps"]
+            if step.get("name") == "Publish exact-head gate status"
+        )
+        self.assertIn('statuses/${head_sha}', evaluate_step["run"])
+        self.assertIn('-f state=pending', evaluate_step["run"])
+        self.assertIn('-f context="${REVIEW_EVIDENCE_CONTEXT}"', evaluate_step["run"])
+        self.assertEqual(
+            publish_step["env"]["HEAD_SHA"],
+            "${{ steps.evaluate.outputs.head_sha }}",
+        )
+        self.assertIn('statuses/${HEAD_SHA}', publish_step["run"])
+        self.assertIn('-f state="${state}"', publish_step["run"])
+        self.assertIn("state=success", publish_step["run"])
+        self.assertIn("state=failure", publish_step["run"])
+        self.assertIn('-f context="${REVIEW_EVIDENCE_CONTEXT}"', publish_step["run"])
+        self.assertNotIn("context='Review evidence evaluator'", review_workflow)
+        self.assertNotIn('context="Review evidence evaluator"', review_workflow)
         self.assertIn("ref: main", review_workflow)
         self.assertIn("fetch-depth: 1", review_workflow)
         self.assertIn("persist-credentials: false", review_workflow)

--- a/scripts/quality/tests/test_review_governance.py
+++ b/scripts/quality/tests/test_review_governance.py
@@ -9,6 +9,8 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+import yaml
+
 from scripts.quality.review_governance import (
     Bundle,
     DiffStats,
@@ -1041,6 +1043,8 @@ class WorkflowContractTests(unittest.TestCase):
         self.workflow = (
             self.repo_root / ".github/workflows/review-evidence.yml"
         ).read_text(encoding="utf-8")
+        self.workflow_data = yaml.safe_load(self.workflow)
+        self.review_job = self.workflow_data["jobs"]["review-evidence"]
 
     def test_privileged_workflow_executes_only_literal_main_code(self) -> None:
         self.assertIn("pull_request_target:", self.workflow)
@@ -1109,27 +1113,48 @@ class WorkflowContractTests(unittest.TestCase):
                 encoding="utf-8"
             )
         )
-        self.assertIn("Review evidence gate", required["required_checks"])
-        self.assertGreaterEqual(
-            self.workflow.count("context='Review evidence gate'"), 2
-        )
-        self.assertIn("name: Review evidence evaluator", self.workflow)
-        self.assertNotIn("\n    name: Review evidence gate\n", self.workflow)
-        self.assertIn("cancel-in-progress: true", self.workflow)
+        required_context = self.workflow_data["env"]["REVIEW_EVIDENCE_CONTEXT"]
+        self.assertIn(required_context, required["required_checks"])
+        self.assertEqual(required_context, "Review evidence gate")
+        self.assertEqual(self.review_job["name"], "Review evidence evaluator")
+        self.assertNotEqual(self.review_job["name"], required_context)
+        self.assertTrue(self.workflow_data["concurrency"]["cancel-in-progress"])
 
-    def test_cancelled_workflow_check_cannot_share_required_status_name(self) -> None:
-        # GitHub exposes workflow job check-runs and commit statuses in the same
-        # required-check namespace.  Keeping these names distinct means a cancelled
-        # evaluator run cannot shadow the later exact-head terminal status.
-        job_name = re.search(
-            r"(?m)^  review-evidence:\n    (?:#.*\n    )*name: (.+)$",
-            self.workflow,
+        evaluate_step = next(
+            step
+            for step in self.review_job["steps"]
+            if step.get("name") == "Resolve PR and evaluate exact review evidence"
         )
-        self.assertIsNotNone(job_name)
-        self.assertNotEqual(job_name.group(1), "Review evidence gate")
-        self.assertGreaterEqual(
-            self.workflow.count("context='Review evidence gate'"), 2
+        publish_step = next(
+            step
+            for step in self.review_job["steps"]
+            if step.get("name") == "Publish exact-head gate status"
         )
+        self.assertIn('statuses/${head_sha}', evaluate_step["run"])
+        self.assertIn('-f state=pending', evaluate_step["run"])
+        self.assertIn('-f context="${REVIEW_EVIDENCE_CONTEXT}"', evaluate_step["run"])
+        self.assertEqual(
+            publish_step["env"]["HEAD_SHA"],
+            "${{ steps.evaluate.outputs.head_sha }}",
+        )
+        self.assertIn('statuses/${HEAD_SHA}', publish_step["run"])
+        self.assertIn('-f state="${state}"', publish_step["run"])
+        self.assertIn("state=success", publish_step["run"])
+        self.assertIn("state=failure", publish_step["run"])
+        self.assertIn('-f context="${REVIEW_EVIDENCE_CONTEXT}"', publish_step["run"])
+        self.assertNotIn("context='Review evidence evaluator'", self.workflow)
+        self.assertNotIn('context="Review evidence evaluator"', self.workflow)
+
+    def test_cancellable_review_job_name_is_distinct_from_required_status_context(
+        self,
+    ) -> None:
+        # GitHub requires both a check run and a commit status when both share a
+        # configured required-check name. Keep the cancellable evaluator job name
+        # distinct from the explicit required commit-status context.
+        required_context = self.workflow_data["env"]["REVIEW_EVIDENCE_CONTEXT"]
+        self.assertEqual(self.review_job["name"], "Review evidence evaluator")
+        self.assertEqual(required_context, "Review evidence gate")
+        self.assertNotEqual(self.review_job["name"], required_context)
 
     def test_pr_template_contains_single_risk_marker(self) -> None:
         template = (self.repo_root / ".github/PULL_REQUEST_TEMPLATE.md").read_text(

--- a/scripts/quality/tests/test_review_governance.py
+++ b/scripts/quality/tests/test_review_governance.py
@@ -1113,6 +1113,23 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertGreaterEqual(
             self.workflow.count("context='Review evidence gate'"), 2
         )
+        self.assertIn("name: Review evidence evaluator", self.workflow)
+        self.assertNotIn("\n    name: Review evidence gate\n", self.workflow)
+        self.assertIn("cancel-in-progress: true", self.workflow)
+
+    def test_cancelled_workflow_check_cannot_share_required_status_name(self) -> None:
+        # GitHub exposes workflow job check-runs and commit statuses in the same
+        # required-check namespace.  Keeping these names distinct means a cancelled
+        # evaluator run cannot shadow the later exact-head terminal status.
+        job_name = re.search(
+            r"(?m)^  review-evidence:\n    (?:#.*\n    )*name: (.+)$",
+            self.workflow,
+        )
+        self.assertIsNotNone(job_name)
+        self.assertNotEqual(job_name.group(1), "Review evidence gate")
+        self.assertGreaterEqual(
+            self.workflow.count("context='Review evidence gate'"), 2
+        )
 
     def test_pr_template_contains_single_risk_marker(self) -> None:
         template = (self.repo_root / ".github/PULL_REQUEST_TEMPLATE.md").read_text(


### PR DESCRIPTION
<!-- weltgewebe-risk: R3 -->

## Ziel

Verhindert, dass ein abgebrochener, gleichnamiger Workflow-Check `Review evidence gate` einen späteren exakt an den PR-Head gebundenen erfolgreichen Commit-Status überschattet.

## Umsetzung

- Workflow-Job heißt nun `Review evidence evaluator`.
- Der verpflichtende Kontext `Review evidence gate` wird weiterhin ausschließlich explizit als exakt-head-gebundener Commit-Status veröffentlicht.
- `cancel-in-progress: true` bleibt erhalten, damit redundante Auswertungen weiter begrenzt werden.
- Vertrags- und Regressionstests sichern die Namensentkopplung und den kanonischen Required-Check-Vertrag.

## Sicherheit

Die privilegierte `pull_request_target`-Grenze bleibt unverändert: ausgeführt wird nur Code von `main`; PR-Code wird nicht ausgecheckt oder ausgeführt. Base/Head/Diff-Bindung, Trusted-Association-Prüfung sowie Fork-/Dependabot-Recheck-Pfad bleiben unverändert.

## Tests

- `python3 -m unittest scripts.quality.tests.test_review_governance scripts.ci.tests.test_canonical_truth_contract` (54 Tests, PASS)
- `git diff --check` (PASS)

Bureau: `OPERATOR-INTEGRATION-LOOP-V1-T008`