### PR TITLE
fix(web): tighten map UI density

### DIFF
--- a/apps/web/src/lib/components/GovernanceFan.svelte
+++ b/apps/web/src/lib/components/GovernanceFan.svelte
@@ -224,6 +224,10 @@
   }
 
   @media (max-width: 900px) {
+    .governance-menu {
+      max-width: min(292px, calc(100vw - 24px));
+    }
+
     .governance-menu :global(.fan-action) {
       min-width: 0;
       width: 92px;
@@ -232,11 +236,18 @@
       white-space: normal;
       text-align: left;
     }
+
+    .governance-slot--outer-left,
+    .governance-slot--outer-right,
+    .governance-slot--inner-left,
+    .governance-slot--inner-right {
+      transform: none;
+    }
   }
 
   @media (max-width: 520px) {
     .governance-menu {
-      max-width: min(304px, calc(100vw - 16px));
+      max-width: min(288px, calc(100vw - 16px));
       gap: 0.35rem;
     }
   }

--- a/apps/web/src/lib/components/ToolFanMenu.svelte
+++ b/apps/web/src/lib/components/ToolFanMenu.svelte
@@ -182,6 +182,9 @@
   }
 
   .fan-panel.root :global(.fan-action) {
+    min-width: 104px;
+    min-height: 44px;
+    padding-inline: 0.7rem;
     pointer-events: auto;
   }
 
@@ -281,7 +284,7 @@
       gap: 0.35rem;
     }
 
-    .fan-row--root :global(.fan-action) {
+    .fan-panel.root :global(.fan-action) {
       min-width: 0;
       width: 92px;
       padding-inline: 0.55rem;

--- a/apps/web/src/lib/styles/tokens.css
+++ b/apps/web/src/lib/styles/tokens.css
@@ -16,7 +16,7 @@
   --shadow: 0 6px 24px rgba(0, 0, 0, 0.35);
   /* Layout-Defaults: Die Karte reserviert keinen dauerhaften unteren Balken. */
   --toolbar-offset: 52px;
-  --context-panel-width: 400px;
+  --context-panel-width: clamp(320px, 30vw, 400px);
   --tool-fan-size: 52px;
   --tool-fan-collapsed-width: 116px;
   --tool-fan-edge: 16px;

--- a/apps/web/tests/map-controls-offset.spec.ts
+++ b/apps/web/tests/map-controls-offset.spec.ts
@@ -174,6 +174,18 @@ test.describe("MapLibre control placement", () => {
     expect(lensBox!.x + lensBox!.width).toBeLessThanOrEqual(panelBox!.x);
   });
 
+  test("tablet-width desktop context panel uses a bounded adaptive width", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1024, height: 800 });
+    await page.locator(".map-marker").first().click();
+
+    const panelBox = await page.getByTestId("context-panel").boundingBox();
+    expect(panelBox).not.toBeNull();
+    expect(panelBox!.width).toBeGreaterThanOrEqual(319);
+    expect(panelBox!.width).toBeLessThanOrEqual(321);
+  });
+
   test("mobile focus sheet moves both corner controls above the sheet", async ({
     page,
   }) => {

--- a/apps/web/tests/map-fan-surface-clarity.spec.ts
+++ b/apps/web/tests/map-fan-surface-clarity.spec.ts
@@ -70,6 +70,51 @@ test.describe("Map fan surface clarity", () => {
     );
   });
 
+  test("root tool actions stay compact without shrinking below touch-target size", async ({
+    page,
+  }) => {
+    await page.getByTestId("tool-fan-trigger").click();
+
+    for (const testId of [
+      "tool-fan-find",
+      "tool-fan-map-content",
+      "tool-fan-weave",
+    ]) {
+      const box = await page.getByTestId(testId).boundingBox();
+      expect(box).not.toBeNull();
+      expect(box!.height).toBeGreaterThanOrEqual(44);
+    }
+
+    const findBox = await page.getByTestId("tool-fan-find").boundingBox();
+    expect(findBox).not.toBeNull();
+    expect(findBox!.width).toBeLessThanOrEqual(106);
+  });
+
+  test("five governance actions wrap as a balanced 3 plus 2 layout on tablet widths", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 900, height: 800 });
+    await page.getByTestId("governance-fan-trigger").click();
+
+    const boxes = await Promise.all(
+      [
+        "governance-fan-all",
+        "governance-fan-open",
+        "governance-fan-vetoes",
+        "governance-fan-conversations",
+        "governance-fan-voting",
+      ].map((testId) => page.getByTestId(testId).boundingBox()),
+    );
+    expect(boxes.every(Boolean)).toBe(true);
+
+    const rowCounts = new Map<number, number>();
+    for (const box of boxes) {
+      const row = Math.round(box!.y);
+      rowCounts.set(row, (rowCounts.get(row) ?? 0) + 1);
+    }
+    expect([...rowCounts.values()].sort((a, b) => b - a)).toEqual([3, 2]);
+  });
+
   test("the explanatory weaving branch keeps a readable panel surface", async ({
     page,
   }) => {


### PR DESCRIPTION
<!-- weltgewebe-risk: R2 -->

## Was ändert sich

- Werkzeugaktionen im Hauptfächer werden kompakter, behalten aber mindestens 44 px Touchhöhe.
- Fünf Mitentscheiden-Aktionen brechen auf Tabletbreite ausgewogen als 3+2 um statt 4+1.
- Das rechte Kontext-/Garnrollenpanel nutzt auf kleineren Desktopbreiten eine adaptive Breite von 320–400 px statt pauschal 400 px.
- Mobile 320-px-Ansicht bleibt innerhalb des Viewports.

## Warum

Mehr sichtbare Karte, weniger visuelle Masse und ein ruhigeres responsives Layout, ohne Funktionen oder Berechtigungen zu verändern.

## Prüfung

- `git diff --check`
- `pnpm lint`
- `pnpm check:ci`
- `pnpm run build:e2e`
- Playwright, seriell: `map-fan-surface-clarity.spec.ts`, `map-controls-offset.spec.ts`, `tool-fan-layout.spec.ts`, `governance.spec.ts`

Lokaler Pre-Commit-Diff SHA-256: `d1b9f44e600c0698c4fe2b23416991b5b095e6fe453a6e7e2bbf821c46a42afe`

Hinweis: Zwei zunächst rote Browserläufe wurden als Preview-Infrastrukturfehler eingegrenzt. Ein verwaister Vite-Preview-Prozess belegte den alten Testport; gegen einen frischen isolierten Port liefen sowohl die fünf gezielten Regressionen als auch alle vier betroffenen Browser-Suiten grün.