### PR TITLE
fix(web): keep governance fan labels readable

### DIFF
--- a/apps/web/src/lib/components/GovernanceFan.svelte
+++ b/apps/web/src/lib/components/GovernanceFan.svelte
@@ -252,6 +252,12 @@
       text-align: left;
     }
 
+    .governance-menu :global(.fan-label) {
+      overflow-wrap: anywhere;
+      hyphens: auto;
+      text-overflow: clip;
+    }
+
     .governance-slot--outer-left,
     .governance-slot--outer-right,
     .governance-slot--inner-left,

--- a/apps/web/tests/map-fan-surface-clarity.spec.ts
+++ b/apps/web/tests/map-fan-surface-clarity.spec.ts
@@ -1,6 +1,31 @@
 import { test, expect } from "@playwright/test";
 import { mockApiResponses } from "./fixtures/mockApi";
 
+const GOVERNANCE_ACTIONS = [
+  "governance-fan-all",
+  "governance-fan-open",
+  "governance-fan-vetoes",
+  "governance-fan-conversations",
+  "governance-fan-voting",
+] as const;
+
+type Box = { x: number; y: number; width: number; height: number };
+
+function horizontalCenter(boxes: Box[]): number {
+  const left = Math.min(...boxes.map((box) => box.x));
+  const right = Math.max(...boxes.map((box) => box.x + box.width));
+  return (left + right) / 2;
+}
+
+function boxesOverlap(a: Box, b: Box): boolean {
+  return (
+    a.x < b.x + b.width &&
+    a.x + a.width > b.x &&
+    a.y < b.y + b.height &&
+    a.y + a.height > b.y
+  );
+}
+
 async function fanSurface(
   page: import("@playwright/test").Page,
   selector: string,
@@ -91,44 +116,58 @@ test.describe("Map fan surface clarity", () => {
   });
 
   for (const viewportWidth of [900, 520, 320] as const) {
-    test(`five governance actions form an ordered 3 plus 2 layout at ${viewportWidth}px`, async ({
+    test(`five governance actions form a centered non-overlapping 3 plus 2 layout at ${viewportWidth}px`, async ({
       page,
     }) => {
       await page.setViewportSize({ width: viewportWidth, height: 800 });
       await page.getByTestId("governance-fan-trigger").click();
 
+      const actions = page.locator("#governance-fan-actions .fan-action");
+      await expect(actions).toHaveCount(5);
+
       const boxes = await Promise.all(
-        [
-          "governance-fan-all",
-          "governance-fan-open",
-          "governance-fan-vetoes",
-          "governance-fan-conversations",
-          "governance-fan-voting",
-        ].map((testId) => page.getByTestId(testId).boundingBox()),
+        GOVERNANCE_ACTIONS.map((testId) =>
+          page.getByTestId(testId).boundingBox(),
+        ),
       );
       expect(boxes.every(Boolean)).toBe(true);
 
       const positionedBoxes = boxes.map((box) => box!);
-      const rows: Array<{ y: number; count: number }> = [];
-      const rowTolerancePx = 4;
+      const topRow = positionedBoxes.slice(0, 3);
+      const bottomRow = positionedBoxes.slice(3);
+      const rowTolerancePx = 2;
 
-      for (const box of [...positionedBoxes].sort((a, b) => a.y - b.y)) {
-        const matchingRow = rows.find(
-          (row) => Math.abs(row.y - box.y) <= rowTolerancePx,
-        );
-        if (matchingRow) {
-          matchingRow.count += 1;
-        } else {
-          rows.push({ y: box.y, count: 1 });
+      const topYs = topRow.map((box) => box.y);
+      const bottomYs = bottomRow.map((box) => box.y);
+      expect(Math.max(...topYs) - Math.min(...topYs)).toBeLessThanOrEqual(
+        rowTolerancePx,
+      );
+      expect(Math.max(...bottomYs) - Math.min(...bottomYs)).toBeLessThanOrEqual(
+        rowTolerancePx,
+      );
+      expect(Math.min(...bottomYs)).toBeGreaterThan(Math.max(...topYs));
+      expect(
+        Math.abs(horizontalCenter(topRow) - horizontalCenter(bottomRow)),
+      ).toBeLessThanOrEqual(rowTolerancePx);
+
+      for (
+        let leftIndex = 0;
+        leftIndex < positionedBoxes.length;
+        leftIndex += 1
+      ) {
+        for (
+          let rightIndex = leftIndex + 1;
+          rightIndex < positionedBoxes.length;
+          rightIndex += 1
+        ) {
+          expect(
+            boxesOverlap(
+              positionedBoxes[leftIndex],
+              positionedBoxes[rightIndex],
+            ),
+            `${GOVERNANCE_ACTIONS[leftIndex]} overlaps ${GOVERNANCE_ACTIONS[rightIndex]}`,
+          ).toBe(false);
         }
-      }
-
-      expect(rows.map((row) => row.count)).toEqual([3, 2]);
-      for (const box of positionedBoxes.slice(0, 3)) {
-        expect(Math.abs(box.y - rows[0].y)).toBeLessThanOrEqual(rowTolerancePx);
-      }
-      for (const box of positionedBoxes.slice(3)) {
-        expect(Math.abs(box.y - rows[1].y)).toBeLessThanOrEqual(rowTolerancePx);
       }
 
       const menuBox = await page
@@ -140,6 +179,21 @@ test.describe("Map fan surface clarity", () => {
       for (const box of positionedBoxes) {
         expect(box.x).toBeGreaterThanOrEqual(0);
         expect(box.x + box.width).toBeLessThanOrEqual(viewportWidth);
+      }
+
+      for (const testId of [
+        "governance-fan-open",
+        "governance-fan-voting",
+      ] as const) {
+        const label = page.getByTestId(testId).locator(".fan-label");
+        const clipping = await label.evaluate((element) => ({
+          horizontal: element.scrollWidth > element.clientWidth + 1,
+          vertical: element.scrollHeight > element.clientHeight + 1,
+        }));
+        expect(clipping, `${testId} label is clipped`).toEqual({
+          horizontal: false,
+          vertical: false,
+        });
       }
     });
   }


### PR DESCRIPTION
Follow-up zu #1521.

- hält den bestehenden zentrierten 3+2-Governance-Fächer bewusst bei genau fünf festen Aktionen
- ersetzt generisches Row-Clustering durch direkte semantische 3+2-Assertions
- prüft horizontale Zentrierung, paarweise Überlappungsfreiheit und Viewport-Grenzen bei 900/520/320 px
- prüft lange Labels auf tatsächliches Clipping
- behebt dabei den gefundenen Produktfehler: „Offene Anträge“ wurde bei 320 und 520 px horizontal abgeschnitten; Governance-Labels dürfen nun innerhalb der bestehenden 3+2-Struktur sauber umbrechen

Validierung:
- git diff --check
- pnpm lint
- pnpm check:ci
- pnpm run build:e2e
- Playwright seriell: map-fan-surface-clarity, map-controls-offset, tool-fan-layout, governance

<!-- weltgewebe-risk: R2 -->