### PR TITLE
ci(actions): migrate remaining Node 20 pins to Node 24

### DIFF
--- a/.github/workflows/api-smoke.yml
+++ b/.github/workflows/api-smoke.yml
@@ -74,7 +74,7 @@ jobs:
           rustc --version
           cargo --version
       - name: Cache cargo target
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # tag: v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # tag: v6.1.0
         with:
           path: target
           key: ${{ runner.os }}-cargo-target-${{ hashFiles('**/Cargo.lock','**/Cargo.toml') }}
@@ -96,7 +96,7 @@ jobs:
             2>&1 | tee /tmp/build-logs/cargo-build.log
       - name: Upload cargo build log
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: cargo-build-log
           path: /tmp/build-logs/cargo-build.log
@@ -230,7 +230,7 @@ jobs:
           fi
       - name: Upload API log
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: api-log
           path: /tmp/api.log

--- a/.github/workflows/auth-passkey-register-proof.yml
+++ b/.github/workflows/auth-passkey-register-proof.yml
@@ -162,7 +162,7 @@ jobs:
         working-directory: apps/web
 
       - name: Cache Playwright browsers
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # tag: v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # tag: v6.1.0
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
@@ -182,7 +182,7 @@ jobs:
 
       - name: Upload proof summary
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: auth-passkey-register-proof-summary
           path: build/proofs/auth-passkey-register/
@@ -191,7 +191,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: auth-passkey-register-proof-report
           path: apps/web/playwright-report/
@@ -200,7 +200,7 @@ jobs:
 
       - name: Upload Playwright traces and test results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: auth-passkey-register-proof-traces
           path: apps/web/test-results/

--- a/.github/workflows/auth-session-persistence-proof.yml
+++ b/.github/workflows/auth-session-persistence-proof.yml
@@ -160,7 +160,7 @@ jobs:
         working-directory: apps/web
 
       - name: Cache Playwright browsers
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # tag: v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # tag: v6.1.0
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
@@ -180,7 +180,7 @@ jobs:
 
       - name: Upload proof summary
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: auth-session-persistence-proof-summary
           path: build/proofs/auth-session-persistence/
@@ -189,7 +189,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: auth-session-persistence-proof-report
           path: apps/web/playwright-report-session/
@@ -198,7 +198,7 @@ jobs:
 
       - name: Upload Playwright traces and test results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: auth-session-persistence-proof-traces
           path: apps/web/test-results/

--- a/.github/workflows/basemap-runtime-proof.yml
+++ b/.github/workflows/basemap-runtime-proof.yml
@@ -268,7 +268,7 @@ jobs:
 
       - name: Upload proof evidence
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: basemap-range-delivery-proof-evidence
           path: |
@@ -460,7 +460,7 @@ jobs:
 
       - name: Upload proof evidence
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: basemap-pmtiles-content-proof-evidence
           path: |
@@ -476,7 +476,7 @@ jobs:
 
       - name: Upload reusable visual proof input artefact
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: basemap-visual-proof-input
           path: |
@@ -629,7 +629,7 @@ jobs:
 
       - name: Upload Schleswig-Holstein proof evidence
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: basemap-schleswig-holstein-content-proof-evidence
           path: |
@@ -735,7 +735,7 @@ jobs:
 
       - name: Upload visual proof screenshot and summary
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: basemap-visual-proof-screenshot
           path: |
@@ -746,7 +746,7 @@ jobs:
 
       - name: Upload visual proof trace and test results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: basemap-visual-proof-trace
           path: |
@@ -756,7 +756,7 @@ jobs:
 
       - name: Upload Playwright HTML report
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: basemap-visual-proof-report
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,7 +273,7 @@ jobs:
           CARGO_TERM_COLOR: always
 
       - name: Cache Cargo artifacts
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # tag: v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # tag: v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -410,7 +410,7 @@ jobs:
         run: pnpm test:unit
 
       - name: Cache Playwright browser binaries
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # tag: v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # tag: v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-ms-playwright-${{ hashFiles('apps/web/pnpm-lock.yaml') }}
@@ -440,7 +440,7 @@ jobs:
 
       - name: Upload Playwright report
         if: ${{ always() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: playwright-report-${{ github.run_id }}-${{ github.job }}
           path: apps/web/playwright-report
@@ -528,7 +528,7 @@ jobs:
           fi
 
       - name: Markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@b4c9feab76d8025d1e83c653fa3990936df0e6c8 # tag: v16
+        uses: DavidAnson/markdownlint-cli2-action@6bf21b07787794f89a243495939cd651942aeabe # tag: v24.1.0
         with:
           globs: |
             **/*.md
@@ -537,7 +537,7 @@ jobs:
             !**/.git/**
 
       - name: Cache lychee responses
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # tag: v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # tag: v6.1.0
         with:
           path: .lycheecache
           key: ${{ runner.os }}-lychee-${{ hashFiles('**/*.md', '.lychee.toml') }}

--- a/.github/workflows/cost-report.yml
+++ b/.github/workflows/cost-report.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           python-version-file: '.python-version'
       - run: python tools/py/cost/report.py
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: cost-report
           path: docs/reports/cost-report.md

--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -36,7 +36,7 @@ jobs:
             -c ajv-formats
 
       - name: Upload Snapshot
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: deploy.snapshot.json
           path: artifacts/deploy.snapshot.json

--- a/.github/workflows/docs-guard.yml
+++ b/.github/workflows/docs-guard.yml
@@ -148,7 +148,7 @@ jobs:
 
       - name: upload-generated-diagnostics
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: generated-diagnostics
           path: |

--- a/.github/workflows/domain-scale.yml
+++ b/.github/workflows/domain-scale.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Upload PostgreSQL plan evidence
         if: ${{ always() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: domain-scale-${{ github.run_id }}
           path: |

--- a/.github/workflows/heavy.yml
+++ b/.github/workflows/heavy.yml
@@ -71,7 +71,7 @@ jobs:
         run: pnpm test
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: playwright-report
           path: apps/web/playwright-report

--- a/.github/workflows/kubernetes-platform.yml
+++ b/.github/workflows/kubernetes-platform.yml
@@ -96,7 +96,7 @@ jobs:
           --source-commit "$GITHUB_SHA"
       - name: Collect failure diagnostics
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: kubernetes-platform-failure-${{ github.run_id }}-${{ github.run_attempt }}
           path: .cache/weltgewebe-platform/failures/
@@ -124,7 +124,7 @@ jobs:
           --cluster "$CLUSTER_NAME"
       - name: Upload HA recovery receipt
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: kubernetes-ha-recovery-${{ github.run_id }}-${{ github.run_attempt }}
           path: .cache/weltgewebe-platform/receipts/*-ha-recovery.json
@@ -132,7 +132,7 @@ jobs:
           retention-days: 14
       - name: Collect HA failure diagnostics
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: kubernetes-ha-failure-${{ github.run_id }}-${{ github.run_attempt }}
           path: .cache/weltgewebe-platform/failures/

--- a/.github/workflows/production-live-contract.yml
+++ b/.github/workflows/production-live-contract.yml
@@ -121,7 +121,7 @@ jobs:
             "$BASE_SHA" "$HEAD_SHA" "$digest" "$bytes" \
             > review-diff-manifest.txt
       - name: Upload exact review diff
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: review-diff-pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
           path: |
@@ -165,7 +165,7 @@ jobs:
             --output production-live-receipt.json
       - name: Upload production receipt
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: production-live-${{ steps.target.outputs.commit }}
           path: production-live-receipt.json

--- a/.github/workflows/python-tooling.yml
+++ b/.github/workflows/python-tooling.yml
@@ -68,7 +68,7 @@ jobs:
           version: ${{ steps.uv-version.outputs.uv_version }}
 
       - name: Cache uv downloads
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # tag: v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # tag: v6.1.0
         with:
           path: ~/.cache/uv
           key: uv-${{ runner.os }}-${{ hashFiles('**/pyproject.toml', '**/requirements*.txt', '**/uv.lock') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # tag: v7.0.1
-      - uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # tag: v2
+      - uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # tag: v3.0.2
         with:
           generate_release_notes: true

--- a/.github/workflows/review-evidence.yml
+++ b/.github/workflows/review-evidence.yml
@@ -293,7 +293,7 @@ jobs:
 
       - name: Upload downloadable diff and review bundle
         if: ${{ always() && steps.evaluate.outputs.pr_number != '' }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: wg-review-pr-${{ steps.evaluate.outputs.pr_number }}-${{ steps.evaluate.outputs.head_sha }}
           path: ${{ steps.evaluate.outputs.output_dir }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -70,7 +70,7 @@ jobs:
         run: cargo audit --json | tee cargo-audit-report.json
       - name: Upload audit report
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: cargo-audit-report
           path: cargo-audit-report.json
@@ -115,7 +115,7 @@ jobs:
         run: cargo deny --format json check | tee cargo-deny-report.json
       - name: Upload cargo-deny report
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: cargo-deny-report
           path: cargo-deny-report.json
@@ -140,7 +140,7 @@ jobs:
           output-file: sbom.spdx.json
       - name: Upload SBOM artifact
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: sbom-spdx
           path: sbom.spdx.json

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -78,7 +78,7 @@ jobs:
         run: pnpm --filter weltgewebe-web test:ci
       - name: Upload HTML report (always)
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: playwright-report
           path: |
@@ -93,7 +93,7 @@ jobs:
           echo "npx playwright show-report apps/web/playwright-report"
       - name: Upload traces (on failure)
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: playwright-traces
           path: apps/web/test-results/**/*.zip

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -80,7 +80,7 @@ jobs:
           echo "PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION" >> $GITHUB_ENV
 
       - name: Cache Playwright browsers
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # tag: v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # tag: v6.1.0
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
@@ -117,7 +117,7 @@ jobs:
           fi
       - name: Upload Playwright report artifact
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: playwright-report
           path: apps/web/playwright-report


### PR DESCRIPTION
WELTGEWEBE-OS-V1-T021 schließt die verbliebenen direkten Node-20-Runtimepfade in Weltgewebes GitHub-Actions-Konfiguration.

Änderungen:
- `actions/upload-artifact`: v4 / Node 20 → v7.0.1 / Node 24, SHA `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`
- `actions/cache`: v4 / Node 20 → v6.1.0 / Node 24, SHA `55cc8345863c7cc4c66a329aec7e433d2d1c52a9`
- `DavidAnson/markdownlint-cli2-action`: v16 / Node 20 → v24.1.0 / Node 24, SHA `6bf21b07787794f89a243495939cd651942aeabe`
- `softprops/action-gh-release`: v2 / Node 20 → v3.0.2 / Node 24, SHA `3d0d9888cb7fd7b750713d6e236d1fcb99157228`

Scope:
- 18 Workflowdateien
- 43 Pin-Vorkommen
- ausschließlich vollständige Commit-SHAs und zugehörige Versionskommentare geändert
- keine Änderungen an Berechtigungen, Triggern, Environment-Bindungen, Secrets oder Projektskripten

Belege:
- aktueller main-CI-Lauf `29870543813` meldete Node-20-Warnungen für `actions/cache`, `markdownlint-cli2-action` und `upload-artifact`
- repo-weiter Upstream-Metadaten-Audit aller 18 einzigartigen direkten Action-Pins: nach dem Patch 0× `node20`, 0× unlesbar; übrige Actions sind `node24` oder `composite`
- alle vier neuen SHAs gegen die offiziellen Upstream-Tags und `action.yml`/`action.yaml` verifiziert
- verwendete Inputs bleiben in den neuen Action-Versionen unterstützt

Lokale Prüfungen:
- `git diff --check`: grün
- 18 geänderte YAML-Dateien parsebar und `yamllint --strict`: grün
- Review-Governance-Tests: 45/45 grün
- Node-24-Readiness-Scanner-Tests: 12/12 grün
- vollständiges lokales `make ci-validate` läuft bis zu einem umgebungsbedingten Fehler: Host-Python ist 3.10 und besitzt kein `tomllib`, während das Repository `.python-version` = 3.12 verlangt. GitHub-CI ist daher die autoritative Vollprüfung.

Separater Befund, nicht Teil dieses PRs: Die vier gepinnten wiederverwendbaren externen Workflows enthalten intern Floating Tags bzw. einen `@main`-Aufruf. Das wird als eigener Bureau-Folgetask behandelt, weil die Korrektur `metarepo`/`wgx` betrifft.

<!-- weltgewebe-risk: R3 -->