### PR TITLE
feat(api): add semantic search projection worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3313,6 +3313,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "unicode-normalization",
  "url",
  "uuid",
  "webauthn-rs",

--- a/apps/api/Cargo.toml
+++ b/apps/api/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "weltgewebe-api"
+default-run = "weltgewebe-api"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.85.0"

--- a/apps/api/Cargo.toml
+++ b/apps/api/Cargo.toml
@@ -19,7 +19,7 @@ prometheus = "0.14.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sqlx = { version = "0.8.1", default-features = false, features = ["runtime-tokio", "postgres", "chrono", "migrate", "macros", "uuid"] }
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "io-util", "time"] }
 tower = "0.5"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
@@ -39,6 +39,7 @@ tower-http = { version = "0.7.0", features = ["request-id", "util"] }
 webauthn-rs = { version = "0.5", features = ["danger-allow-state-serialisation"] }
 url = "2"
 serde_jcs = "0.1"
+unicode-normalization = "0.1"
 
 [features]
 # Enables test-helper APIs (e.g. token introspection) used by integration tests.

--- a/apps/api/migrations/20260721000001_semantic_search_projection_worker.down.sql
+++ b/apps/api/migrations/20260721000001_semantic_search_projection_worker.down.sql
@@ -1,0 +1,8 @@
+DROP TRIGGER IF EXISTS search_track_domain_nodes ON domain_nodes;
+DROP FUNCTION IF EXISTS weltgewebe_search_track_domain_node();
+DROP FUNCTION IF EXISTS weltgewebe_search_enqueue_node(TEXT, TEXT);
+DROP FUNCTION IF EXISTS weltgewebe_activate_search_generation(TEXT);
+DROP TABLE IF EXISTS search_projection_jobs;
+DROP TABLE IF EXISTS search_node_projections;
+DROP TABLE IF EXISTS search_node_versions;
+DROP TABLE IF EXISTS search_index_generations;

--- a/apps/api/migrations/20260721000001_semantic_search_projection_worker.up.sql
+++ b/apps/api/migrations/20260721000001_semantic_search_projection_worker.up.sql
@@ -1,0 +1,173 @@
+-- WELTGEWEBE-SEMANTIC-SEARCH-V1-T005
+-- PostgreSQL remains canonical.  These tables are a fully regenerable, internal
+-- search projection and work ledger; this migration adds neither an HTTP search
+-- route nor an embedding provider.
+
+CREATE TABLE search_index_generations (
+    generation_id TEXT PRIMARY KEY CHECK (btrim(generation_id) <> ''),
+    provider TEXT NOT NULL CHECK (btrim(provider) <> ''),
+    model_id TEXT NOT NULL CHECK (btrim(model_id) <> ''),
+    model_revision TEXT NOT NULL CHECK (btrim(model_revision) <> ''),
+    runtime_identity TEXT NOT NULL CHECK (btrim(runtime_identity) <> ''),
+    dimension INTEGER NOT NULL CHECK (dimension > 0 AND dimension <= 8192),
+    document_revision TEXT NOT NULL CHECK (btrim(document_revision) <> ''),
+    normalization_revision TEXT NOT NULL CHECK (btrim(normalization_revision) <> ''),
+    ranking_revision TEXT NOT NULL CHECK (btrim(ranking_revision) <> ''),
+    state TEXT NOT NULL DEFAULT 'building' CHECK (state IN ('building', 'ready', 'active', 'retired', 'failed')),
+    expected_nodes BIGINT NOT NULL DEFAULT 0 CHECK (expected_nodes >= 0),
+    completed_nodes BIGINT NOT NULL DEFAULT 0 CHECK (completed_nodes >= 0),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    activated_at TIMESTAMPTZ,
+    CHECK ((state = 'active') = (activated_at IS NOT NULL))
+);
+CREATE UNIQUE INDEX search_index_generations_one_active ON search_index_generations ((state)) WHERE state = 'active';
+CREATE UNIQUE INDEX search_index_generations_one_ready ON search_index_generations ((state)) WHERE state = 'ready';
+
+CREATE TABLE search_node_versions (
+    node_id TEXT PRIMARY KEY,
+    source_version BIGINT NOT NULL CHECK (source_version >= 1),
+    source_revision TEXT NOT NULL CHECK (btrim(source_revision) <> ''),
+    deleted_at TIMESTAMPTZ
+);
+
+CREATE TABLE search_node_projections (
+    generation_id TEXT NOT NULL REFERENCES search_index_generations(generation_id) ON DELETE CASCADE,
+    node_id TEXT NOT NULL,
+    source_version BIGINT NOT NULL CHECK (source_version >= 1),
+    source_revision TEXT NOT NULL CHECK (btrim(source_revision) <> ''),
+    content_sha256 TEXT NOT NULL CHECK (content_sha256 ~ '^[0-9a-f]{64}$'),
+    title TEXT NOT NULL CHECK (btrim(title) <> ''),
+    tags TEXT[] NOT NULL DEFAULT '{}',
+    searchable_text TEXT NOT NULL CHECK (btrim(searchable_text) <> ''),
+    language TEXT NOT NULL CHECK (btrim(language) <> ''),
+    kind TEXT NOT NULL CHECK (btrim(kind) <> ''),
+    status TEXT NOT NULL CHECK (status IN ('active', 'hidden')),
+    visibility_scopes TEXT[] NOT NULL DEFAULT '{}',
+    semantic_state TEXT NOT NULL CHECK (semantic_state IN ('pending', 'ready', 'unavailable')),
+    embedding DOUBLE PRECISION[],
+    indexed_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    PRIMARY KEY (generation_id, node_id)
+);
+CREATE INDEX search_node_projections_eligible ON search_node_projections (generation_id, status, node_id);
+
+CREATE TABLE search_projection_jobs (
+    id BIGSERIAL PRIMARY KEY,
+    generation_id TEXT NOT NULL REFERENCES search_index_generations(generation_id) ON DELETE CASCADE,
+    node_id TEXT NOT NULL,
+    source_version BIGINT NOT NULL CHECK (source_version >= 1),
+    source_revision TEXT NOT NULL CHECK (btrim(source_revision) <> ''),
+    operation TEXT NOT NULL CHECK (operation IN ('upsert', 'delete')),
+    state TEXT NOT NULL DEFAULT 'pending' CHECK (state IN ('pending', 'claimed', 'retry', 'done', 'stale', 'failed')),
+    attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+    available_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    claimed_by TEXT,
+    claim_until TIMESTAMPTZ,
+    last_error_code TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    completed_at TIMESTAMPTZ,
+    UNIQUE (generation_id, node_id, source_version, operation),
+    CHECK ((state = 'claimed') = (claimed_by IS NOT NULL AND claim_until IS NOT NULL))
+);
+CREATE INDEX search_projection_jobs_claimable ON search_projection_jobs (available_at, id)
+    WHERE state IN ('pending', 'retry', 'claimed');
+
+CREATE OR REPLACE FUNCTION weltgewebe_search_enqueue_node(p_node_id TEXT, p_operation TEXT)
+RETURNS VOID LANGUAGE plpgsql AS $$
+DECLARE current_version BIGINT; current_revision TEXT;
+BEGIN
+    SELECT source_version, source_revision INTO current_version, current_revision
+      FROM search_node_versions WHERE node_id = p_node_id;
+    IF current_version IS NULL THEN RETURN; END IF;
+    INSERT INTO search_projection_jobs (generation_id, node_id, source_version, source_revision, operation)
+    SELECT generation_id, p_node_id, current_version, current_revision, p_operation
+      FROM search_index_generations WHERE state IN ('building', 'ready', 'active')
+    ON CONFLICT DO NOTHING;
+END; $$;
+
+CREATE OR REPLACE FUNCTION weltgewebe_search_track_domain_node()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+DECLARE next_version BIGINT; revision TEXT; node_identifier TEXT;
+BEGIN
+    -- Location, address and arbitrary JSON payload keys are not part of the
+    -- fail-closed search document.  They must not create projection or
+    -- embedding work.  Deletion and every field consumed by SearchDocument
+    -- remain revisioned.
+    IF TG_OP = 'UPDATE'
+       AND OLD.kind IS NOT DISTINCT FROM NEW.kind
+       AND OLD.title IS NOT DISTINCT FROM NEW.title
+       AND (OLD.payload -> 'summary') IS NOT DISTINCT FROM (NEW.payload -> 'summary')
+       AND (OLD.payload -> 'info') IS NOT DISTINCT FROM (NEW.payload -> 'info')
+       AND (OLD.payload -> 'tags') IS NOT DISTINCT FROM (NEW.payload -> 'tags')
+       AND (OLD.payload -> 'language') IS NOT DISTINCT FROM (NEW.payload -> 'language')
+       AND (OLD.payload -> 'search_visibility') IS NOT DISTINCT FROM (NEW.payload -> 'search_visibility')
+    THEN
+        RETURN NEW;
+    END IF;
+    -- Domain mutations take a shared transaction lock. Generation creation
+    -- and activation take the matching exclusive lock, so a mutation either
+    -- commits before their snapshot/gate or is ordered strictly after it.
+    PERFORM pg_advisory_xact_lock_shared(hashtextextended('weltgewebe.search.generation.activation', 0));
+    node_identifier := CASE WHEN TG_OP = 'DELETE' THEN OLD.id ELSE NEW.id END;
+    INSERT INTO search_node_versions (node_id, source_version, source_revision, deleted_at)
+    VALUES (node_identifier, 1, 'node-1', CASE WHEN TG_OP = 'DELETE' THEN clock_timestamp() ELSE NULL END)
+    ON CONFLICT (node_id) DO UPDATE SET
+      source_version = search_node_versions.source_version + 1,
+      source_revision = 'node-' || (search_node_versions.source_version + 1)::TEXT,
+      deleted_at = EXCLUDED.deleted_at
+    RETURNING source_version, source_revision INTO next_version, revision;
+    PERFORM weltgewebe_search_enqueue_node(node_identifier, CASE WHEN TG_OP = 'DELETE' THEN 'delete' ELSE 'upsert' END);
+    RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+END; $$;
+CREATE TRIGGER search_track_domain_nodes AFTER INSERT OR UPDATE OR DELETE ON domain_nodes
+FOR EACH ROW EXECUTE FUNCTION weltgewebe_search_track_domain_node();
+
+-- Atomically switches only a fully completed generation.  The old active
+-- generation is retained for an explicit operator rollback via the same gate.
+CREATE OR REPLACE FUNCTION weltgewebe_activate_search_generation(p_generation_id TEXT)
+RETURNS VOID LANGUAGE plpgsql AS $$
+DECLARE target search_index_generations%ROWTYPE;
+BEGIN
+    PERFORM pg_advisory_xact_lock(hashtextextended('weltgewebe.search.generation.activation', 0));
+    SELECT * INTO target FROM search_index_generations WHERE generation_id = p_generation_id FOR UPDATE;
+    IF NOT FOUND THEN RAISE EXCEPTION 'unknown search generation' USING ERRCODE = '23503'; END IF;
+    IF target.state NOT IN ('building', 'ready', 'active')
+       OR target.completed_nodes <> target.expected_nodes
+       OR EXISTS (
+           SELECT 1 FROM search_node_versions v
+           WHERE v.deleted_at IS NULL
+             AND NOT EXISTS (
+                 SELECT 1 FROM search_node_projections p
+                 WHERE p.generation_id = p_generation_id
+                   AND p.node_id = v.node_id
+                   AND p.source_version = v.source_version
+                   AND p.source_revision = v.source_revision
+                   AND p.semantic_state = 'ready'
+                   AND cardinality(p.embedding) = target.dimension
+             )
+       )
+       OR EXISTS (
+           SELECT 1 FROM search_projection_jobs j
+           WHERE j.generation_id = p_generation_id
+             AND j.state NOT IN ('done', 'stale')
+       )
+       OR EXISTS (
+           SELECT 1
+           FROM search_node_versions v
+           JOIN search_node_projections p
+             ON p.generation_id = p_generation_id
+            AND p.node_id = v.node_id
+           WHERE v.deleted_at IS NOT NULL
+       )
+    THEN
+      RAISE EXCEPTION 'generation is not complete and ready' USING ERRCODE = '23514';
+    END IF;
+    IF target.state = 'active' THEN RETURN; END IF;
+    -- A complete building generation may activate directly.  This permits a
+    -- new rebuild while the current active+ready pair remains rollback-safe.
+    -- The advisory lock makes the retirement/swap atomic to every caller.
+    UPDATE search_index_generations SET state = 'building' WHERE generation_id = p_generation_id;
+    UPDATE search_index_generations SET state = 'retired', activated_at = NULL
+      WHERE state = 'ready';
+    UPDATE search_index_generations SET state = 'ready', activated_at = NULL WHERE state = 'active';
+    UPDATE search_index_generations SET state = 'active', activated_at = clock_timestamp() WHERE generation_id = p_generation_id;
+END; $$;

--- a/apps/api/src/bin/search-backfill.rs
+++ b/apps/api/src/bin/search-backfill.rs
@@ -1,0 +1,67 @@
+//! Bounded, resumable internal T005 projection backfill.  It has no HTTP role.
+
+use std::env;
+
+use sqlx::postgres::PgPoolOptions;
+use weltgewebe_api::{
+    search::{GenerationSpec, OllamaEmbeddingProvider, ProcessOutcome, ProjectionWorker},
+    telemetry::{BuildInfo, Metrics},
+};
+
+fn required(name: &str) -> anyhow::Result<String> {
+    env::var(name).map_err(|_| anyhow::anyhow!("{name} is required"))
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let database_url = required("DATABASE_URL")?;
+    let generation_id = required("WELTGEWEBE_SEARCH_GENERATION_ID")?;
+    let max_jobs: usize = env::var("WELTGEWEBE_SEARCH_BACKFILL_MAX_JOBS")
+        .unwrap_or_else(|_| "100".to_string())
+        .parse()?;
+    if max_jobs == 0 || max_jobs > 10_000 {
+        anyhow::bail!("WELTGEWEBE_SEARCH_BACKFILL_MAX_JOBS must be 1..=10000");
+    }
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&database_url)
+        .await?;
+    let provider = OllamaEmbeddingProvider::new(
+        &required("WELTGEWEBE_SEARCH_OLLAMA_URL")?,
+        required("WELTGEWEBE_SEARCH_MODEL_ID")?,
+        required("WELTGEWEBE_SEARCH_MODEL_REVISION")?,
+        required("WELTGEWEBE_SEARCH_RUNTIME_IDENTITY")?,
+    )
+    .map_err(|error| anyhow::anyhow!("invalid local Ollama provider: {}", error.code()))?;
+    let worker = ProjectionWorker::new_with_provider(
+        pool,
+        format!("backfill:{}", std::process::id()),
+        Metrics::try_new(BuildInfo::collect())?,
+        std::sync::Arc::new(provider),
+    )?;
+    let provider_name = required("WELTGEWEBE_SEARCH_PROVIDER")?;
+    let model_id = required("WELTGEWEBE_SEARCH_MODEL_ID")?;
+    let model_revision = required("WELTGEWEBE_SEARCH_MODEL_REVISION")?;
+    let runtime_identity = required("WELTGEWEBE_SEARCH_RUNTIME_IDENTITY")?;
+    worker
+        .start_generation(GenerationSpec {
+            generation_id: &generation_id,
+            provider: &provider_name,
+            model_id: &model_id,
+            model_revision: &model_revision,
+            runtime_identity: &runtime_identity,
+            dimension: required("WELTGEWEBE_SEARCH_DIMENSION")?.parse()?,
+        })
+        .await?;
+    let mut completed = 0usize;
+    while completed < max_jobs {
+        match worker.claim_and_process_one().await? {
+            ProcessOutcome::Empty => break,
+            _ => completed += 1,
+        }
+    }
+    // Deliberately no auto-activation: an operator invokes the atomic database
+    // gate only after examining the bounded run's aggregate state.
+    println!("search backfill processed {completed} jobs; generation remains unactivated");
+    Ok(())
+}

--- a/apps/api/src/lib.rs
+++ b/apps/api/src/lib.rs
@@ -8,6 +8,7 @@ pub mod mailer;
 pub mod middleware;
 pub mod outbox;
 pub mod routes;
+pub mod search;
 pub mod state;
 pub mod telemetry;
 pub mod utils;

--- a/apps/api/src/search.rs
+++ b/apps/api/src/search.rs
@@ -1,0 +1,1232 @@
+//! T005's internal, PostgreSQL-backed search projection worker.
+//!
+//! It deliberately has no HTTP surface.  Domain rows remain canonical; this
+//! module only claims leased work and writes a regenerable projection.
+
+use std::{sync::Arc, time::Duration};
+
+use anyhow::Context;
+use async_trait::async_trait;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use sqlx::{PgPool, Row};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpStream,
+    time::timeout,
+};
+use unicode_normalization::UnicodeNormalization;
+
+use crate::telemetry::Metrics;
+
+pub const DOCUMENT_REVISION: &str = "weltgewebe-node-document-v1";
+pub const NORMALIZATION_REVISION: &str = "weltgewebe-search-normalization-v1";
+pub const RANKING_REVISION: &str = "weltgewebe-hybrid-ranking-v2";
+// Five minutes exceeds the provider boundary's bounded worst-case request budget
+// while keeping abandoned claims recoverable without a heartbeat.
+const CLAIM_SECONDS: i32 = 300;
+const MAX_PROVIDER_ATTEMPTS: i32 = 8;
+const OLLAMA_RESPONSE_LIMIT: usize = 1_048_576;
+const OLLAMA_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Clone, Debug)]
+pub struct GenerationSpec<'a> {
+    pub generation_id: &'a str,
+    pub provider: &'a str,
+    pub model_id: &'a str,
+    pub model_revision: &'a str,
+    pub runtime_identity: &'a str,
+    pub dimension: i32,
+}
+
+impl GenerationSpec<'_> {
+    pub fn derived_id(&self) -> String {
+        let mut digest = Sha256::new();
+        for field in [
+            self.provider,
+            self.model_id,
+            self.model_revision,
+            self.runtime_identity,
+            &self.dimension.to_string(),
+            DOCUMENT_REVISION,
+            NORMALIZATION_REVISION,
+            RANKING_REVISION,
+        ] {
+            digest.update(field.as_bytes());
+            digest.update([0]);
+        }
+        format!("search-gen-{}", hex::encode(digest.finalize()))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ProcessOutcome {
+    Processed,
+    Stale,
+    PendingProvider,
+    Failed,
+    Deleted,
+    LeaseLost,
+    Empty,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProjectionStatusSnapshot {
+    pub pending_jobs: i64,
+    pub claimed_jobs: i64,
+    pub retry_jobs: i64,
+    pub done_jobs: i64,
+    pub stale_jobs: i64,
+    pub failed_jobs: i64,
+    pub active_generation_id: Option<String>,
+    pub active_generation_identity: Option<String>,
+    pub rebuild_expected_nodes: Option<i64>,
+    pub rebuild_completed_nodes: Option<i64>,
+    pub last_successful_projection_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum EmbeddingProviderError {
+    #[error("embedding provider unavailable")]
+    Unavailable,
+    #[error("embedding provider identity mismatch")]
+    IdentityMismatch,
+    #[error("embedding provider returned malformed data")]
+    MalformedResponse,
+    #[error("embedding provider returned wrong dimension")]
+    WrongDimension,
+    #[error("embedding provider returned invalid vector")]
+    InvalidVector,
+    #[error("embedding provider is unsupported")]
+    Unsupported,
+    #[error("embedding provider failed")]
+    Failed,
+}
+
+impl EmbeddingProviderError {
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::Unavailable => "provider_unavailable",
+            Self::IdentityMismatch => "provider_identity_mismatch",
+            Self::MalformedResponse => "provider_malformed_response",
+            Self::WrongDimension => "provider_wrong_dimension",
+            Self::InvalidVector => "provider_invalid_vector",
+            Self::Unsupported => "provider_unsupported",
+            Self::Failed => "provider_failed",
+        }
+    }
+}
+
+/// Private boundary for T005's worker. Implementations must not log the
+/// document or vector; the worker records only bounded outcome labels.
+#[async_trait]
+pub trait EmbeddingProvider: Send + Sync {
+    async fn embed(
+        &self,
+        document: &str,
+        dimension: usize,
+    ) -> Result<Vec<f64>, EmbeddingProviderError>;
+}
+
+/// T004-compatible local Ollama boundary.  It accepts only a literal loopback
+/// HTTP origin and checks the model/runtime identity on both sides of embedding.
+pub struct OllamaEmbeddingProvider {
+    base_url: url::Url,
+    model_id: String,
+    model_revision: String,
+    runtime_identity: String,
+}
+
+impl OllamaEmbeddingProvider {
+    pub fn new(
+        base_url: &str,
+        model_id: String,
+        model_revision: String,
+        runtime_identity: String,
+    ) -> Result<Self, EmbeddingProviderError> {
+        let base_url =
+            url::Url::parse(base_url).map_err(|_| EmbeddingProviderError::Unsupported)?;
+        let loopback = matches!(base_url.host_str(), Some("127.0.0.1") | Some("::1"));
+        if base_url.scheme() != "http"
+            || !loopback
+            || base_url.username() != ""
+            || base_url.password().is_some()
+            || base_url.query().is_some()
+            || base_url.fragment().is_some()
+            || base_url.path() != "/"
+        {
+            return Err(EmbeddingProviderError::Unsupported);
+        }
+        Ok(Self {
+            base_url,
+            model_id,
+            model_revision,
+            runtime_identity,
+        })
+    }
+
+    async fn object(
+        &self,
+        path: &str,
+        body: Option<Value>,
+    ) -> Result<Value, EmbeddingProviderError> {
+        let host = self
+            .base_url
+            .host_str()
+            .ok_or(EmbeddingProviderError::Unsupported)?;
+        let port = self
+            .base_url
+            .port_or_known_default()
+            .ok_or(EmbeddingProviderError::Unsupported)?;
+        let payload = body
+            .map(|body| serde_json::to_vec(&body).map_err(|_| EmbeddingProviderError::Failed))
+            .transpose()?;
+        let host_header = http_host_header(host, port);
+        let request = match &payload {
+            Some(payload) => format!("POST /{path} HTTP/1.1\r\nHost: {host_header}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n", payload.len()).into_bytes(),
+            None => format!("GET /{path} HTTP/1.1\r\nHost: {host_header}\r\nConnection: close\r\n\r\n").into_bytes(),
+        };
+        let mut stream = timeout(OLLAMA_TIMEOUT, TcpStream::connect((host, port)))
+            .await
+            .map_err(|_| EmbeddingProviderError::Unavailable)?
+            .map_err(|_| EmbeddingProviderError::Unavailable)?;
+        timeout(OLLAMA_TIMEOUT, async {
+            stream.write_all(&request).await?;
+            if let Some(payload) = &payload {
+                stream.write_all(payload).await?;
+            }
+            stream.flush().await
+        })
+        .await
+        .map_err(|_| EmbeddingProviderError::Unavailable)?
+        .map_err(|_| EmbeddingProviderError::Unavailable)?;
+        let mut bytes = Vec::new();
+        timeout(OLLAMA_TIMEOUT, async {
+            let mut part = [0_u8; 8192];
+            loop {
+                let read = stream
+                    .read(&mut part)
+                    .await
+                    .map_err(|_| EmbeddingProviderError::Unavailable)?;
+                if read == 0 {
+                    match http_response_complete(&bytes)? {
+                        true => break,
+                        false if http_response_is_close_delimited(&bytes)? => break,
+                        false => return Err(EmbeddingProviderError::Unavailable),
+                    }
+                }
+                if bytes.len() + read > OLLAMA_RESPONSE_LIMIT + 16_384 {
+                    return Err(EmbeddingProviderError::MalformedResponse);
+                }
+                bytes.extend_from_slice(&part[..read]);
+                if http_response_complete(&bytes)? {
+                    break;
+                }
+            }
+            Ok::<(), EmbeddingProviderError>(())
+        })
+        .await
+        .map_err(|_| EmbeddingProviderError::Unavailable)??;
+        let split = bytes
+            .windows(4)
+            .position(|window| window == b"\r\n\r\n")
+            .ok_or(EmbeddingProviderError::MalformedResponse)?;
+        let header = std::str::from_utf8(&bytes[..split])
+            .map_err(|_| EmbeddingProviderError::MalformedResponse)?;
+        let status = header
+            .split_whitespace()
+            .nth(1)
+            .ok_or(EmbeddingProviderError::MalformedResponse)?
+            .parse::<u16>()
+            .map_err(|_| EmbeddingProviderError::MalformedResponse)?;
+        if status == 408 || status == 429 || (500..600).contains(&status) {
+            return Err(EmbeddingProviderError::Unavailable);
+        }
+        if !(200..300).contains(&status) {
+            return Err(EmbeddingProviderError::Failed);
+        }
+        let body = &bytes[split + 4..];
+        let header_lower = header.to_ascii_lowercase();
+        let decoded;
+        let body = if header_lower.lines().any(|line| {
+            line.strip_prefix("transfer-encoding:")
+                .is_some_and(|value| value.split(',').any(|coding| coding.trim() == "chunked"))
+        }) {
+            decoded = decode_chunked_body(body)?;
+            decoded.as_slice()
+        } else {
+            body
+        };
+        if body.len() > OLLAMA_RESPONSE_LIMIT {
+            return Err(EmbeddingProviderError::MalformedResponse);
+        }
+        serde_json::from_slice(body).map_err(|_| EmbeddingProviderError::MalformedResponse)
+    }
+
+    async fn verify_identity(&self) -> Result<(), EmbeddingProviderError> {
+        let tags = self.object("api/tags", None).await?;
+        let digest = tags
+            .get("models")
+            .and_then(Value::as_array)
+            .and_then(|models| {
+                models
+                    .iter()
+                    .find(|m| m.get("name").and_then(Value::as_str) == Some(self.model_id.as_str()))
+            })
+            .and_then(|model| model.get("digest"))
+            .and_then(Value::as_str)
+            .ok_or(EmbeddingProviderError::IdentityMismatch)?;
+        if digest != self.model_revision {
+            return Err(EmbeddingProviderError::IdentityMismatch);
+        }
+        let version_response = self.object("api/version", None).await?;
+        let version = version_response
+            .get("version")
+            .and_then(Value::as_str)
+            .filter(|v| !v.is_empty())
+            .ok_or(EmbeddingProviderError::IdentityMismatch)?;
+        let observed = format!(
+            "ollama:{version}@{}",
+            self.base_url.as_str().trim_end_matches('/')
+        );
+        if observed != self.runtime_identity {
+            return Err(EmbeddingProviderError::IdentityMismatch);
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl EmbeddingProvider for OllamaEmbeddingProvider {
+    async fn embed(
+        &self,
+        document: &str,
+        dimension: usize,
+    ) -> Result<Vec<f64>, EmbeddingProviderError> {
+        self.verify_identity().await?;
+        let response = self
+            .object(
+                "api/embed",
+                Some(serde_json::json!({"model": self.model_id, "input": document})),
+            )
+            .await?;
+        let vectors = response
+            .get("embeddings")
+            .and_then(Value::as_array)
+            .filter(|v| v.len() == 1)
+            .ok_or(EmbeddingProviderError::MalformedResponse)?;
+        let vector = vectors[0]
+            .as_array()
+            .ok_or(EmbeddingProviderError::MalformedResponse)?;
+        if vector.len() != dimension {
+            return Err(EmbeddingProviderError::WrongDimension);
+        }
+        let vector = vector
+            .iter()
+            .map(|v| v.as_f64().ok_or(EmbeddingProviderError::InvalidVector))
+            .collect::<Result<Vec<_>, _>>()?;
+        let norm = vector.iter().map(|v| v * v).sum::<f64>();
+        if !norm.is_finite() || norm <= 0.0 || vector.iter().any(|v| !v.is_finite()) {
+            return Err(EmbeddingProviderError::InvalidVector);
+        }
+        self.verify_identity().await?;
+        Ok(vector)
+    }
+}
+
+fn http_host_header(host: &str, port: u16) -> String {
+    if host.contains(':') {
+        format!("[{host}]:{port}")
+    } else {
+        format!("{host}:{port}")
+    }
+}
+
+fn http_framing(header_lower: &str) -> Result<(bool, Option<usize>), EmbeddingProviderError> {
+    let chunked = header_lower.lines().any(|line| {
+        line.strip_prefix("transfer-encoding:")
+            .is_some_and(|value| value.split(',').any(|coding| coding.trim() == "chunked"))
+    });
+    let mut content_length = None;
+    for line in header_lower.lines() {
+        let Some(value) = line.strip_prefix("content-length:") else {
+            continue;
+        };
+        let parsed = value
+            .trim()
+            .parse::<usize>()
+            .map_err(|_| EmbeddingProviderError::MalformedResponse)?;
+        if parsed > OLLAMA_RESPONSE_LIMIT {
+            return Err(EmbeddingProviderError::MalformedResponse);
+        }
+        if content_length.is_some_and(|previous| previous != parsed) {
+            return Err(EmbeddingProviderError::MalformedResponse);
+        }
+        content_length = Some(parsed);
+    }
+    if chunked && content_length.is_some() {
+        return Err(EmbeddingProviderError::MalformedResponse);
+    }
+    Ok((chunked, content_length))
+}
+
+fn http_response_is_close_delimited(bytes: &[u8]) -> Result<bool, EmbeddingProviderError> {
+    let Some(split) = bytes.windows(4).position(|window| window == b"\r\n\r\n") else {
+        return Ok(false);
+    };
+    let header = std::str::from_utf8(&bytes[..split])
+        .map_err(|_| EmbeddingProviderError::MalformedResponse)?
+        .to_ascii_lowercase();
+    let (chunked, content_length) = http_framing(&header)?;
+    Ok(!chunked && content_length.is_none())
+}
+
+fn http_response_complete(bytes: &[u8]) -> Result<bool, EmbeddingProviderError> {
+    let Some(split) = bytes.windows(4).position(|window| window == b"\r\n\r\n") else {
+        return Ok(false);
+    };
+    let header = std::str::from_utf8(&bytes[..split])
+        .map_err(|_| EmbeddingProviderError::MalformedResponse)?;
+    let header_lower = header.to_ascii_lowercase();
+    let body = &bytes[split + 4..];
+    let (chunked, content_length) = http_framing(&header_lower)?;
+    if chunked {
+        return chunked_body_complete(body);
+    }
+    if let Some(length) = content_length {
+        return Ok(body.len() >= length);
+    }
+    Ok(false)
+}
+
+fn chunked_body_complete(mut input: &[u8]) -> Result<bool, EmbeddingProviderError> {
+    loop {
+        let Some(line_end) = input.windows(2).position(|window| window == b"\r\n") else {
+            return Ok(false);
+        };
+        let size_line = std::str::from_utf8(&input[..line_end])
+            .map_err(|_| EmbeddingProviderError::MalformedResponse)?;
+        let size_token = size_line.split(';').next().unwrap_or_default().trim();
+        let size = usize::from_str_radix(size_token, 16)
+            .map_err(|_| EmbeddingProviderError::MalformedResponse)?;
+        input = &input[line_end + 2..];
+        if size == 0 {
+            return Ok(
+                input.starts_with(b"\r\n") || input.windows(4).any(|window| window == b"\r\n\r\n")
+            );
+        }
+        if size > OLLAMA_RESPONSE_LIMIT {
+            return Err(EmbeddingProviderError::MalformedResponse);
+        }
+        if input.len() < size + 2 {
+            return Ok(false);
+        }
+        if &input[size..size + 2] != b"\r\n" {
+            return Err(EmbeddingProviderError::MalformedResponse);
+        }
+        input = &input[size + 2..];
+    }
+}
+
+fn decode_chunked_body(mut input: &[u8]) -> Result<Vec<u8>, EmbeddingProviderError> {
+    let mut output = Vec::new();
+    loop {
+        let line_end = input
+            .windows(2)
+            .position(|window| window == b"\r\n")
+            .ok_or(EmbeddingProviderError::MalformedResponse)?;
+        let size_line = std::str::from_utf8(&input[..line_end])
+            .map_err(|_| EmbeddingProviderError::MalformedResponse)?;
+        let size_token = size_line.split(';').next().unwrap_or_default().trim();
+        let size = usize::from_str_radix(size_token, 16)
+            .map_err(|_| EmbeddingProviderError::MalformedResponse)?;
+        input = &input[line_end + 2..];
+        if size == 0 {
+            return Ok(output);
+        }
+        if size > OLLAMA_RESPONSE_LIMIT.saturating_sub(output.len())
+            || input.len() < size + 2
+            || &input[size..size + 2] != b"\r\n"
+        {
+            return Err(EmbeddingProviderError::MalformedResponse);
+        }
+        output.extend_from_slice(&input[..size]);
+        input = &input[size + 2..];
+    }
+}
+
+struct UnavailableEmbeddingProvider;
+
+#[async_trait]
+impl EmbeddingProvider for UnavailableEmbeddingProvider {
+    async fn embed(
+        &self,
+        _document: &str,
+        _dimension: usize,
+    ) -> Result<Vec<f64>, EmbeddingProviderError> {
+        Err(EmbeddingProviderError::Unavailable)
+    }
+}
+
+#[derive(Clone)]
+pub struct ProjectionWorker {
+    pool: PgPool,
+    worker_id: String,
+    metrics: Metrics,
+    provider: Arc<dyn EmbeddingProvider>,
+}
+
+impl ProjectionWorker {
+    pub fn new(pool: PgPool, worker_id: String, metrics: Metrics) -> anyhow::Result<Self> {
+        Self::new_with_provider(
+            pool,
+            worker_id,
+            metrics,
+            Arc::new(UnavailableEmbeddingProvider),
+        )
+    }
+
+    pub fn new_with_provider(
+        pool: PgPool,
+        worker_id: String,
+        metrics: Metrics,
+        provider: Arc<dyn EmbeddingProvider>,
+    ) -> anyhow::Result<Self> {
+        if worker_id.trim().is_empty() {
+            anyhow::bail!("search worker id must not be empty");
+        }
+        Ok(Self {
+            pool,
+            worker_id,
+            metrics,
+            provider,
+        })
+    }
+
+    /// Starts a bounded rebuild generation.  No activation occurs here.
+    pub async fn start_generation(&self, spec: GenerationSpec<'_>) -> anyhow::Result<i64> {
+        if spec.provider != "local:ollama" {
+            anyhow::bail!("unsupported search embedding provider");
+        }
+        if spec.dimension <= 0 || spec.dimension > 8192 {
+            anyhow::bail!("search generation identity is invalid");
+        }
+        let mut tx = self.pool.begin().await?;
+        // Match the trigger's shared transaction lock. This makes the initial
+        // generation snapshot linearizable with relevant domain mutations: a
+        // mutation is ordered wholly before this seed or, after commit, sees
+        // the new generation and enqueues its own current revision.
+        sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended('weltgewebe.search.generation.activation', 0))")
+            .execute(&mut *tx)
+            .await?;
+        // A migration starts tracking future mutations.  This idempotent seed
+        // makes legacy rows resumable without treating a missing revision as a
+        // public/visible value.
+        sqlx::query(
+            "INSERT INTO search_node_versions (node_id,source_version,source_revision) \
+            SELECT id,1,'node-1' FROM domain_nodes ON CONFLICT (node_id) DO NOTHING",
+        )
+        .execute(&mut *tx)
+        .await?;
+        let identity = sqlx::query("INSERT INTO search_index_generations (generation_id, provider, model_id, model_revision, runtime_identity, dimension, document_revision, normalization_revision, ranking_revision, state, expected_nodes) \
+                     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,'building',(SELECT count(*) FROM domain_nodes)) \
+                     ON CONFLICT (generation_id) DO UPDATE SET generation_id=EXCLUDED.generation_id \
+                     WHERE search_index_generations.provider=EXCLUDED.provider \
+                       AND search_index_generations.model_id=EXCLUDED.model_id \
+                       AND search_index_generations.model_revision=EXCLUDED.model_revision \
+                       AND search_index_generations.runtime_identity=EXCLUDED.runtime_identity \
+                       AND search_index_generations.dimension=EXCLUDED.dimension \
+                       AND search_index_generations.document_revision=EXCLUDED.document_revision \
+                       AND search_index_generations.normalization_revision=EXCLUDED.normalization_revision \
+                       AND search_index_generations.ranking_revision=EXCLUDED.ranking_revision \
+                     RETURNING generation_id")
+            .bind(spec.generation_id).bind(spec.provider).bind(spec.model_id).bind(spec.model_revision).bind(spec.runtime_identity)
+            .bind(spec.dimension).bind(DOCUMENT_REVISION).bind(NORMALIZATION_REVISION).bind(RANKING_REVISION)
+            .fetch_optional(&mut *tx).await?;
+        if identity.is_none() {
+            anyhow::bail!("search generation identity mismatch");
+        }
+        // A previous bounded outage may have exhausted retries. Re-running the
+        // same exact generation is the explicit catch-up action: only outage-
+        // exhausted jobs are rearmed; permanent contract failures stay failed.
+        sqlx::query("UPDATE search_projection_jobs SET state='pending', attempt_count=0, available_at=NOW(), claimed_by=NULL, claim_until=NULL, completed_at=NULL, last_error_code=NULL WHERE generation_id=$1 AND state='failed' AND last_error_code='provider_unavailable_exhausted'")
+            .bind(spec.generation_id).execute(&mut *tx).await?;
+        let inserted = sqlx::query("INSERT INTO search_projection_jobs (generation_id,node_id,source_version,source_revision,operation) \
+            SELECT $1, v.node_id,v.source_version,v.source_revision,'upsert' FROM search_node_versions v JOIN domain_nodes n ON n.id=v.node_id \
+            ON CONFLICT DO NOTHING")
+            .bind(spec.generation_id).execute(&mut *tx).await?.rows_affected() as i64;
+        tx.commit().await?;
+        // Defense-in-depth reconciliation after releasing the exclusive
+        // generation lock. The lock establishes the race-free ordering; this
+        // idempotent pass repairs legacy or externally seeded version rows.
+        let reconciled = sqlx::query("INSERT INTO search_projection_jobs (generation_id,node_id,source_version,source_revision,operation) \
+            SELECT $1, v.node_id,v.source_version,v.source_revision,'upsert' FROM search_node_versions v JOIN domain_nodes n ON n.id=v.node_id \
+            ON CONFLICT DO NOTHING")
+            .bind(spec.generation_id)
+            .execute(&self.pool)
+            .await?
+            .rows_affected() as i64;
+        Ok(inserted + reconciled)
+    }
+
+    pub async fn claim_and_process_one(&self) -> anyhow::Result<ProcessOutcome> {
+        let job = sqlx::query("WITH picked AS (SELECT id FROM search_projection_jobs \
+            WHERE (state IN ('pending','retry') AND available_at <= NOW()) OR (state='claimed' AND claim_until <= NOW()) \
+            ORDER BY available_at,id FOR UPDATE SKIP LOCKED LIMIT 1) \
+            UPDATE search_projection_jobs j SET state='claimed', claimed_by=$1, claim_until=NOW()+make_interval(secs=>$2), attempt_count=j.attempt_count+1 \
+            FROM picked WHERE j.id=picked.id RETURNING j.id,j.generation_id,j.node_id,j.source_version,j.source_revision,j.operation,j.attempt_count")
+            .bind(&self.worker_id).bind(CLAIM_SECONDS).fetch_optional(&self.pool).await?;
+        let Some(job) = job else {
+            return Ok(ProcessOutcome::Empty);
+        };
+        let id: i64 = job.get("id");
+        let generation: String = job.get("generation_id");
+        let node_id: String = job.get("node_id");
+        let version: i64 = job.get("source_version");
+        let revision: String = job.get("source_revision");
+        let operation: String = job.get("operation");
+        let attempts: i32 = job.get("attempt_count");
+        let result = if operation == "delete" {
+            self.delete_if_current(id, attempts, &generation, &node_id, version, &revision)
+                .await?
+        } else {
+            self.upsert_if_current(id, attempts, &generation, &node_id, version, &revision)
+                .await?
+        };
+        let outcome = match result {
+            Ok(outcome) => outcome,
+            Err(code) => {
+                if !self.finish(id, attempts, "failed", Some(code)).await? {
+                    self.metrics.search_projection_outcome("lease_lost");
+                    return Ok(ProcessOutcome::LeaseLost);
+                }
+                self.metrics.search_projection_outcome("failed");
+                return Ok(ProcessOutcome::Failed);
+            }
+        };
+        let final_outcome = match outcome {
+            ProcessOutcome::LeaseLost => ProcessOutcome::LeaseLost,
+            ProcessOutcome::PendingProvider if attempts >= MAX_PROVIDER_ATTEMPTS => {
+                if self
+                    .finish(
+                        id,
+                        attempts,
+                        "failed",
+                        Some("provider_unavailable_exhausted"),
+                    )
+                    .await?
+                {
+                    ProcessOutcome::Failed
+                } else {
+                    ProcessOutcome::LeaseLost
+                }
+            }
+            ProcessOutcome::PendingProvider => {
+                if self.retry(id, attempts, "provider_unavailable").await? {
+                    ProcessOutcome::PendingProvider
+                } else {
+                    ProcessOutcome::LeaseLost
+                }
+            }
+            ProcessOutcome::Stale => {
+                if self
+                    .finish(id, attempts, "stale", Some("stale_revision"))
+                    .await?
+                {
+                    ProcessOutcome::Stale
+                } else {
+                    ProcessOutcome::LeaseLost
+                }
+            }
+            other => {
+                if self.finish(id, attempts, "done", None).await? {
+                    other
+                } else {
+                    ProcessOutcome::LeaseLost
+                }
+            }
+        };
+        self.metrics.search_projection_outcome(match final_outcome {
+            ProcessOutcome::Processed => "processed",
+            ProcessOutcome::Stale => "stale",
+            ProcessOutcome::PendingProvider => "pending",
+            ProcessOutcome::Deleted => "deleted",
+            ProcessOutcome::Failed => "failed",
+            ProcessOutcome::LeaseLost => "lease_lost",
+            ProcessOutcome::Empty => "empty",
+        });
+        Ok(final_outcome)
+    }
+
+    /// Read-only operational view: no document text, tags, or vectors escape.
+    pub async fn status_snapshot(&self) -> anyhow::Result<ProjectionStatusSnapshot> {
+        let row = sqlx::query("SELECT count(*) FILTER (WHERE state='pending') AS pending, count(*) FILTER (WHERE state='claimed') AS claimed, count(*) FILTER (WHERE state='retry') AS retry, count(*) FILTER (WHERE state='done') AS done, count(*) FILTER (WHERE state='stale') AS stale, count(*) FILTER (WHERE state='failed') AS failed FROM search_projection_jobs")
+            .fetch_one(&self.pool).await?;
+        let generation = sqlx::query("SELECT generation_id,provider,model_id,model_revision,runtime_identity,dimension,document_revision,normalization_revision,ranking_revision,expected_nodes,completed_nodes,activated_at FROM search_index_generations WHERE state='active'")
+            .fetch_optional(&self.pool).await?;
+        Ok(ProjectionStatusSnapshot {
+            pending_jobs: row.get::<i64, _>("pending"),
+            claimed_jobs: row.get::<i64, _>("claimed"),
+            retry_jobs: row.get::<i64, _>("retry"),
+            done_jobs: row.get::<i64, _>("done"),
+            stale_jobs: row.get::<i64, _>("stale"),
+            failed_jobs: row.get::<i64, _>("failed"),
+            active_generation_id: generation.as_ref().map(|row| row.get("generation_id")),
+            active_generation_identity: generation.as_ref().map(|row| {
+                format!(
+                    "{}:{}:{}:{}:{}:{}:{}:{}",
+                    row.get::<String, _>("provider"),
+                    row.get::<String, _>("model_id"),
+                    row.get::<String, _>("model_revision"),
+                    row.get::<String, _>("runtime_identity"),
+                    row.get::<i32, _>("dimension"),
+                    row.get::<String, _>("document_revision"),
+                    row.get::<String, _>("normalization_revision"),
+                    row.get::<String, _>("ranking_revision")
+                )
+            }),
+            rebuild_expected_nodes: generation.as_ref().map(|row| row.get("expected_nodes")),
+            rebuild_completed_nodes: generation.as_ref().map(|row| row.get("completed_nodes")),
+            last_successful_projection_at: generation
+                .as_ref()
+                .and_then(|row| row.try_get("activated_at").ok()),
+        })
+    }
+
+    /// Deterministic digest over projection identity and metadata, deliberately
+    /// excluding `searchable_text`, tags, and raw embeddings.
+    /// Deterministic digest over projection identity and metadata, deliberately
+    /// excluding `searchable_text`, tags, raw embeddings, timestamps, and the
+    /// generation id itself. Empty rebuilds still bind the full identity.
+    pub async fn integrity_digest(&self, generation_id: &str) -> anyhow::Result<String> {
+        let generation = sqlx::query("SELECT provider,model_id,model_revision,runtime_identity,dimension,document_revision,normalization_revision,ranking_revision FROM search_index_generations WHERE generation_id=$1")
+            .bind(generation_id)
+            .fetch_optional(&self.pool)
+            .await?
+            .context("unknown search generation")?;
+        let rows = sqlx::query("SELECT node_id,source_version,source_revision,content_sha256,language,kind,status,visibility_scopes,semantic_state FROM search_node_projections WHERE generation_id=$1 ORDER BY node_id")
+            .bind(generation_id).fetch_all(&self.pool).await?;
+        let mut digest = Sha256::new();
+        for value in [
+            generation.get::<String, _>("provider"),
+            generation.get::<String, _>("model_id"),
+            generation.get::<String, _>("model_revision"),
+            generation.get::<String, _>("runtime_identity"),
+            generation.get::<i32, _>("dimension").to_string(),
+            generation.get::<String, _>("document_revision"),
+            generation.get::<String, _>("normalization_revision"),
+            generation.get::<String, _>("ranking_revision"),
+        ] {
+            digest.update(value.as_bytes());
+            digest.update([0]);
+        }
+        for row in rows {
+            for value in [
+                row.get::<String, _>("node_id"),
+                row.get::<i64, _>("source_version").to_string(),
+                row.get::<String, _>("source_revision"),
+                row.get::<String, _>("content_sha256"),
+                row.get::<String, _>("language"),
+                row.get::<String, _>("kind"),
+                row.get::<String, _>("status"),
+                row.get::<Vec<String>, _>("visibility_scopes")
+                    .join("\u{1f}"),
+                row.get::<String, _>("semantic_state"),
+            ] {
+                digest.update(value.as_bytes());
+                digest.update([0]);
+            }
+        }
+        Ok(hex::encode(digest.finalize()))
+    }
+
+    async fn claim_is_current(&self, id: i64, attempts: i32) -> anyhow::Result<bool> {
+        Ok(sqlx::query_scalar(
+            "SELECT EXISTS (SELECT 1 FROM search_projection_jobs WHERE id=$1 AND state='claimed' AND claimed_by=$2 AND attempt_count=$3 AND claim_until > NOW())",
+        )
+        .bind(id)
+        .bind(&self.worker_id)
+        .bind(attempts)
+        .fetch_one(&self.pool)
+        .await?)
+    }
+
+    async fn delete_if_current(
+        &self,
+        job_id: i64,
+        attempts: i32,
+        generation: &str,
+        node: &str,
+        version: i64,
+        revision: &str,
+    ) -> anyhow::Result<Result<ProcessOutcome, &'static str>> {
+        // The claim row and canonical tombstone are locked and checked inside
+        // the mutating statement. attempt_count is the fencing token, so a
+        // reclaimed lease cannot be reused even when a worker id is recycled.
+        let row = sqlx::query(
+            "WITH lease AS (SELECT 1 FROM search_projection_jobs WHERE id=$5 AND generation_id=$4 AND node_id=$1 AND source_version=$2 AND source_revision=$3 AND operation='delete' AND state='claimed' AND claimed_by=$6 AND attempt_count=$7 AND claim_until > NOW() FOR UPDATE), current AS (SELECT 1 FROM search_node_versions WHERE node_id=$1 AND source_version=$2 AND source_revision=$3 AND deleted_at IS NOT NULL FOR UPDATE), deleted AS (DELETE FROM search_node_projections p USING current, lease, search_index_generations g WHERE p.node_id=$1 AND p.generation_id=$4 AND g.generation_id=p.generation_id AND g.state IN ('building','ready','active') RETURNING 1) SELECT EXISTS (SELECT 1 FROM lease) AS lease_current, EXISTS (SELECT 1 FROM current) AS tombstone_current",
+        )
+        .bind(node)
+        .bind(version)
+        .bind(revision)
+        .bind(generation)
+        .bind(job_id)
+        .bind(&self.worker_id)
+        .bind(attempts)
+        .fetch_one(&self.pool)
+        .await?;
+        let lease_current: bool = row.get("lease_current");
+        let tombstone_current: bool = row.get("tombstone_current");
+        Ok(Ok(if !lease_current {
+            ProcessOutcome::LeaseLost
+        } else if tombstone_current {
+            ProcessOutcome::Deleted
+        } else {
+            ProcessOutcome::Stale
+        }))
+    }
+
+    async fn upsert_if_current(
+        &self,
+        job_id: i64,
+        attempts: i32,
+        generation: &str,
+        node: &str,
+        version: i64,
+        revision: &str,
+    ) -> anyhow::Result<Result<ProcessOutcome, &'static str>> {
+        let row = sqlx::query("SELECT n.kind,n.title,n.payload::text,g.dimension FROM domain_nodes n JOIN search_node_versions v ON v.node_id=n.id JOIN search_index_generations g ON g.generation_id=$2 JOIN search_projection_jobs j ON j.id=$5 WHERE n.id=$1 AND v.source_version=$3 AND v.source_revision=$4 AND v.deleted_at IS NULL AND j.generation_id=$2 AND j.node_id=$1 AND j.source_version=$3 AND j.source_revision=$4 AND j.operation='upsert' AND j.state='claimed' AND j.claimed_by=$6 AND j.attempt_count=$7 AND j.claim_until > NOW()")
+            .bind(node).bind(generation).bind(version).bind(revision).bind(job_id).bind(&self.worker_id).bind(attempts).fetch_optional(&self.pool).await?;
+        let Some(row) = row else {
+            return Ok(Ok(if self.claim_is_current(job_id, attempts).await? {
+                ProcessOutcome::Stale
+            } else {
+                ProcessOutcome::LeaseLost
+            }));
+        };
+        let document = match SearchDocument::from_row(
+            node,
+            &row.get::<String, _>("kind"),
+            &row.get::<String, _>("title"),
+            &row.get::<String, _>("payload"),
+        ) {
+            Ok(document) => document,
+            Err(_) => return Ok(Err("document_invalid")),
+        };
+        let dimension: i32 = row.get("dimension");
+        let embedding = match self
+            .provider
+            .embed(&document.text, dimension as usize)
+            .await
+        {
+            Ok(vector)
+                if vector.len() == dimension as usize
+                    && vector.iter().all(|v| v.is_finite())
+                    && vector.iter().map(|v| v * v).sum::<f64>() > 0.0 =>
+            {
+                vector
+            }
+            Ok(vector) if vector.len() != dimension as usize => {
+                return Ok(Err("provider_wrong_dimension"))
+            }
+            Ok(_) => return Ok(Err("provider_invalid_vector")),
+            Err(EmbeddingProviderError::Unavailable) => {
+                return Ok(Ok(ProcessOutcome::PendingProvider))
+            }
+            Err(error) => return Ok(Err(error.code())),
+        };
+        // This INSERT is itself revision fenced. Its affected-row semantics
+        // classify a concurrent canonical mutation as Stale, closing TOCTOU.
+        let written = sqlx::query("INSERT INTO search_node_projections (generation_id,node_id,source_version,source_revision,content_sha256,title,tags,searchable_text,language,kind,status,visibility_scopes,semantic_state,embedding) \
+            SELECT $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,'ready',$13 \
+            FROM (SELECT v.node_id FROM search_node_versions v JOIN domain_nodes n ON n.id=v.node_id JOIN search_index_generations g ON g.generation_id=$1 JOIN search_projection_jobs j ON j.id=$14 WHERE n.id=$2 AND v.source_version=$3 AND v.source_revision=$4 AND v.deleted_at IS NULL AND g.state IN ('building','ready','active') AND j.generation_id=$1 AND j.node_id=$2 AND j.source_version=$3 AND j.source_revision=$4 AND j.operation='upsert' AND j.state='claimed' AND j.claimed_by=$15 AND j.attempt_count=$16 AND j.claim_until > NOW() FOR UPDATE OF v,j) current \
+            ON CONFLICT (generation_id,node_id) DO UPDATE SET source_version=EXCLUDED.source_version,source_revision=EXCLUDED.source_revision,content_sha256=EXCLUDED.content_sha256,title=EXCLUDED.title,tags=EXCLUDED.tags,searchable_text=EXCLUDED.searchable_text,language=EXCLUDED.language,kind=EXCLUDED.kind,status=EXCLUDED.status,visibility_scopes=EXCLUDED.visibility_scopes,semantic_state='ready',embedding=EXCLUDED.embedding,indexed_at=clock_timestamp() \
+            WHERE search_node_projections.source_version <= EXCLUDED.source_version")
+            .bind(generation).bind(node).bind(version).bind(revision).bind(document.hash()).bind(&document.title).bind(&document.tags).bind(&document.text).bind(&document.language).bind(&document.kind).bind(&document.status).bind(&document.scopes).bind(embedding).bind(job_id).bind(&self.worker_id).bind(attempts).execute(&self.pool).await?.rows_affected();
+        Ok(Ok(if written == 1 {
+            ProcessOutcome::Processed
+        } else if self.claim_is_current(job_id, attempts).await? {
+            ProcessOutcome::Stale
+        } else {
+            ProcessOutcome::LeaseLost
+        }))
+    }
+
+    async fn finish(
+        &self,
+        id: i64,
+        attempts: i32,
+        state: &str,
+        code: Option<&str>,
+    ) -> anyhow::Result<bool> {
+        let finished = sqlx::query("UPDATE search_projection_jobs SET state=$2,claimed_by=NULL,claim_until=NULL,completed_at=NOW(),last_error_code=$3 WHERE id=$1 AND state='claimed' AND claimed_by=$4 AND attempt_count=$5 AND claim_until > NOW()")
+            .bind(id).bind(state).bind(code).bind(&self.worker_id).bind(attempts).execute(&self.pool).await?.rows_affected() == 1;
+        if !finished {
+            return Ok(false);
+        }
+        sqlx::query("UPDATE search_index_generations g SET expected_nodes=(SELECT count(*) FROM search_projection_jobs j WHERE j.generation_id=g.generation_id), completed_nodes=(SELECT count(*) FROM search_projection_jobs j WHERE j.generation_id=g.generation_id AND j.state IN ('done','stale')), state=CASE WHEN g.state='building' AND NOT EXISTS (SELECT 1 FROM search_index_generations r WHERE r.state='ready' AND r.generation_id<>g.generation_id) AND NOT EXISTS (SELECT 1 FROM search_projection_jobs j WHERE j.generation_id=g.generation_id AND j.state NOT IN ('done','stale')) AND NOT EXISTS (SELECT 1 FROM search_node_versions v WHERE v.deleted_at IS NULL AND NOT EXISTS (SELECT 1 FROM search_node_projections p WHERE p.generation_id=g.generation_id AND p.node_id=v.node_id AND p.source_version=v.source_version AND p.source_revision=v.source_revision AND p.semantic_state='ready' AND cardinality(p.embedding)=g.dimension)) AND NOT EXISTS (SELECT 1 FROM search_node_versions v JOIN search_node_projections p ON p.generation_id=g.generation_id AND p.node_id=v.node_id WHERE v.deleted_at IS NOT NULL) THEN 'ready' ELSE g.state END WHERE g.generation_id=(SELECT generation_id FROM search_projection_jobs WHERE id=$1)")
+            .bind(id).execute(&self.pool).await?;
+        Ok(true)
+    }
+
+    async fn retry(&self, id: i64, attempts: i32, code: &str) -> anyhow::Result<bool> {
+        let secs = (2_i32.pow(attempts.clamp(1, 7) as u32)).min(300);
+        Ok(sqlx::query("UPDATE search_projection_jobs SET state='retry',claimed_by=NULL,claim_until=NULL,available_at=NOW()+make_interval(secs=>$2),last_error_code=$3 WHERE id=$1 AND state='claimed' AND claimed_by=$4 AND attempt_count=$5 AND claim_until > NOW()")
+            .bind(id).bind(secs).bind(code).bind(&self.worker_id).bind(attempts).execute(&self.pool).await?.rows_affected() == 1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        http_host_header, http_response_complete, EmbeddingProvider, EmbeddingProviderError,
+        OllamaEmbeddingProvider, SearchDocument,
+    };
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpListener,
+    };
+
+    #[test]
+    fn document_excludes_address_and_fails_closed_visibility() {
+        let private = SearchDocument::from_row(
+            "node-1",
+            "Werkstatt",
+            "Fahrradhilfe",
+            r#"{"summary":"Reparatur","address":"secret lane 9","tags":["Rad"]}"#,
+        )
+        .expect("document");
+        assert_eq!(private.status, "hidden");
+        assert!(private.scopes.is_empty());
+        assert!(!private.text.contains("secret lane 9"));
+
+        let public = SearchDocument::from_row(
+            "node-1",
+            "Werkstatt",
+            "Fahrradhilfe",
+            r#"{"search_visibility":"public","summary":"Reparatur","tags":["Rad"]}"#,
+        )
+        .expect("document");
+        assert_eq!(public.status, "active");
+        assert_eq!(public.scopes, ["public"]);
+    }
+
+    #[test]
+    fn document_rejects_blank_projection_required_fields() {
+        assert!(SearchDocument::from_row("node", "Kind", "   ", "{}").is_err());
+        assert!(SearchDocument::from_row("node", "   ", "Titel", "{}").is_err());
+    }
+
+    #[test]
+    fn document_hash_changes_for_indexed_content_not_unindexed_payload() {
+        let first = SearchDocument::from_row("node", "Kind", "Titel", r#"{"address":"a"}"#)
+            .expect("document");
+        let same = SearchDocument::from_row("node", "Kind", "Titel", r#"{"address":"b"}"#)
+            .expect("document");
+        let changed = SearchDocument::from_row("node", "Kind", "Titel", r#"{"summary":"neu"}"#)
+            .expect("document");
+        assert_eq!(first.hash(), same.hash());
+        assert_ne!(first.hash(), changed.hash());
+    }
+
+    #[test]
+    fn ollama_ipv6_loopback_uses_bracketed_host_header() {
+        assert_eq!(http_host_header("::1", 11434), "[::1]:11434");
+        assert_eq!(http_host_header("127.0.0.1", 11434), "127.0.0.1:11434");
+    }
+
+    #[test]
+    fn ollama_invalid_or_conflicting_content_length_is_permanent_format_error() {
+        for response in [
+            b"HTTP/1.1 200 OK\r\nContent-Length: abc\r\n\r\n{}".as_slice(),
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nContent-Length: 3\r\n\r\n{}".as_slice(),
+            b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nContent-Length: 2\r\n\r\n0\r\n\r\n"
+                .as_slice(),
+        ] {
+            assert!(matches!(
+                http_response_complete(response),
+                Err(EmbeddingProviderError::MalformedResponse)
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn ollama_truncated_framed_response_is_temporary_unavailability() {
+        let listener = match TcpListener::bind("127.0.0.1:0").await {
+            Ok(listener) => listener,
+            Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => return,
+            Err(error) => panic!("bind loopback: {error}"),
+        };
+        let port = listener.local_addr().expect("address").port();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept");
+            let mut request = [0_u8; 4096];
+            let _ = stream.read(&mut request).await.expect("read request");
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 64\r\nConnection: close\r\n\r\n{\"models\":[")
+                .await
+                .expect("partial response");
+        });
+        let provider = OllamaEmbeddingProvider::new(
+            &format!("http://127.0.0.1:{port}/"),
+            "test-model".into(),
+            "sha256:exact".into(),
+            format!("ollama:test-runtime@http://127.0.0.1:{port}"),
+        )
+        .expect("provider");
+        assert!(matches!(
+            provider.object("api/tags", None).await,
+            Err(EmbeddingProviderError::Unavailable)
+        ));
+        server.await.expect("server");
+    }
+
+    #[tokio::test]
+    async fn ollama_408_and_429_are_temporary_unavailability() {
+        for status in [408_u16, 429_u16] {
+            let listener = match TcpListener::bind("127.0.0.1:0").await {
+                Ok(listener) => listener,
+                Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => return,
+                Err(error) => panic!("bind loopback: {error}"),
+            };
+            let port = listener.local_addr().expect("address").port();
+            let server = tokio::spawn(async move {
+                let (mut stream, _) = listener.accept().await.expect("accept");
+                let mut request = [0_u8; 4096];
+                let _ = stream.read(&mut request).await.expect("read request");
+                stream
+                    .write_all(
+                        format!(
+                            "HTTP/1.1 {status} Temporary\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                        )
+                        .as_bytes(),
+                    )
+                    .await
+                    .expect("temporary response");
+            });
+            let provider = OllamaEmbeddingProvider::new(
+                &format!("http://127.0.0.1:{port}/"),
+                "test-model".into(),
+                "sha256:exact".into(),
+                format!("ollama:test-runtime@http://127.0.0.1:{port}"),
+            )
+            .expect("provider");
+            assert!(matches!(
+                provider.object("api/tags", None).await,
+                Err(EmbeddingProviderError::Unavailable)
+            ));
+            server.await.expect("server");
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "requires explicit T005 live Ollama identity environment"]
+    async fn ollama_boundary_embeds_against_explicit_live_loopback() {
+        let url = std::env::var("T005_LIVE_OLLAMA_URL").expect("T005_LIVE_OLLAMA_URL");
+        let model_id = std::env::var("T005_LIVE_OLLAMA_MODEL_ID").expect("model id");
+        let model_revision =
+            std::env::var("T005_LIVE_OLLAMA_MODEL_REVISION").expect("model revision");
+        let runtime_identity =
+            std::env::var("T005_LIVE_OLLAMA_RUNTIME_IDENTITY").expect("runtime identity");
+        let dimension: usize = std::env::var("T005_LIVE_OLLAMA_DIMENSION")
+            .expect("dimension")
+            .parse()
+            .expect("numeric dimension");
+        let provider =
+            OllamaEmbeddingProvider::new(&url, model_id, model_revision, runtime_identity)
+                .expect("live local provider");
+        provider
+            .object("api/tags", None)
+            .await
+            .expect("live local tags");
+        provider
+            .object("api/version", None)
+            .await
+            .expect("live local version");
+        provider
+            .verify_identity()
+            .await
+            .expect("live local identity");
+        let vector = provider
+            .embed("T005 local provider contract proof", dimension)
+            .await
+            .expect("live local embedding");
+        assert_eq!(vector.len(), dimension);
+        assert!(vector.iter().all(|value| value.is_finite()));
+    }
+
+    #[tokio::test]
+    async fn ollama_boundary_uses_only_mocked_loopback_and_rechecks_identity() {
+        let listener = match TcpListener::bind("127.0.0.1:0").await {
+            Ok(listener) => listener,
+            Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => return,
+            Err(error) => panic!("bind loopback: {error}"),
+        };
+        let port = listener.local_addr().expect("address").port();
+        let server = tokio::spawn(async move {
+            for _ in 0..5 {
+                let (mut stream, _) = listener.accept().await.expect("accept");
+                let mut request = [0_u8; 4096];
+                let count = stream.read(&mut request).await.expect("read request");
+                let request = std::str::from_utf8(&request[..count]).expect("request utf8");
+                let (body, chunked) = if request.starts_with("GET /api/tags ") {
+                    (
+                        r#"{"models":[{"name":"test-model","digest":"sha256:exact"}]}"#,
+                        false,
+                    )
+                } else if request.starts_with("GET /api/version ") {
+                    (r#"{"version":"test-runtime"}"#, false)
+                } else if request.starts_with("POST /api/embed ") {
+                    (r#"{"embeddings":[[0.25,0.5]]}"#, true)
+                } else {
+                    panic!("unexpected request: {request}");
+                };
+                let response = if chunked {
+                    format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n{:X}\r\n{}\r\n0\r\n\r\n",
+                        body.len(), body
+                    )
+                } else {
+                    format!("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}", body.len(), body)
+                };
+                stream
+                    .write_all(response.as_bytes())
+                    .await
+                    .expect("response");
+            }
+        });
+        let origin = format!("http://127.0.0.1:{port}/");
+        let provider = OllamaEmbeddingProvider::new(
+            &origin,
+            "test-model".into(),
+            "sha256:exact".into(),
+            format!("ollama:test-runtime@http://127.0.0.1:{port}"),
+        )
+        .expect("provider");
+        assert_eq!(
+            provider.embed("only a test", 2).await.expect("embedding"),
+            vec![0.25, 0.5]
+        );
+        server.await.expect("server");
+        assert!(matches!(
+            OllamaEmbeddingProvider::new(
+                "https://127.0.0.1:11434/",
+                "m".into(),
+                "r".into(),
+                "x".into()
+            ),
+            Err(EmbeddingProviderError::Unsupported)
+        ));
+        assert!(matches!(
+            OllamaEmbeddingProvider::new(
+                "http://example.invalid/",
+                "m".into(),
+                "r".into(),
+                "x".into()
+            ),
+            Err(EmbeddingProviderError::Unsupported)
+        ));
+    }
+}
+
+#[derive(Debug)]
+struct SearchDocument {
+    title: String,
+    tags: Vec<String>,
+    summary: String,
+    info: String,
+    text: String,
+    language: String,
+    kind: String,
+    status: String,
+    scopes: Vec<String>,
+}
+impl SearchDocument {
+    fn from_row(node_id: &str, kind: &str, title: &str, payload: &str) -> anyhow::Result<Self> {
+        let payload: Value =
+            serde_json::from_str(payload).context("domain node payload is not JSON")?;
+        let tags = payload
+            .get("tags")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(Value::as_str)
+            .map(normalize)
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<_>>();
+        let mut tags = tags;
+        tags.sort();
+        tags.dedup();
+        let summary = normalize(payload.get("summary").and_then(Value::as_str).unwrap_or(""));
+        let info = normalize(payload.get("info").and_then(Value::as_str).unwrap_or(""));
+        let language = normalize(
+            payload
+                .get("language")
+                .and_then(Value::as_str)
+                .filter(|v| !v.trim().is_empty())
+                .unwrap_or("und"),
+        );
+        // Visibility is fail-closed: legacy/missing values are hidden. No address
+        // or arbitrary payload key is ever incorporated into the document.
+        let public = payload.get("search_visibility").and_then(Value::as_str) == Some("public");
+        let title = normalize(title);
+        let kind = normalize(kind);
+        // Projection columns enforce non-blank title/kind individually. Reject
+        // invalid legacy domain rows before embedding or SQL mutation so the
+        // leased job can terminate fail-closed as document_invalid.
+        if title.is_empty() || kind.is_empty() {
+            anyhow::bail!("search document for {node_id} has blank required fields");
+        }
+        let tag_text = tags.join(" ");
+        let text = [
+            title.as_str(),
+            kind.as_str(),
+            summary.as_str(),
+            info.as_str(),
+            tag_text.as_str(),
+        ]
+        .join("\n");
+        if text.trim().is_empty() {
+            anyhow::bail!("search document for {node_id} is empty");
+        }
+        Ok(Self {
+            title,
+            tags,
+            summary,
+            info,
+            text,
+            language,
+            kind,
+            status: if public { "active" } else { "hidden" }.to_owned(),
+            scopes: if public {
+                vec!["public".to_owned()]
+            } else {
+                vec![]
+            },
+        })
+    }
+    fn hash(&self) -> String {
+        let mut h = Sha256::new();
+        let tags = self.tags.join("\u{1f}");
+        for (label, value) in [
+            ("document_revision", DOCUMENT_REVISION),
+            ("normalization_revision", NORMALIZATION_REVISION),
+            ("title", self.title.as_str()),
+            ("summary", self.summary.as_str()),
+            ("info", self.info.as_str()),
+            ("tags", tags.as_str()),
+            ("language", self.language.as_str()),
+            ("kind", self.kind.as_str()),
+        ] {
+            h.update(label.as_bytes());
+            h.update([0]);
+            h.update(value.as_bytes());
+            h.update([0]);
+        }
+        hex::encode(h.finalize())
+    }
+}
+
+fn normalize(value: &str) -> String {
+    value.nfkc().collect::<String>().trim().to_owned()
+}

--- a/apps/api/src/search.rs
+++ b/apps/api/src/search.rs
@@ -859,13 +859,24 @@ impl ProjectionWorker {
         state: &str,
         code: Option<&str>,
     ) -> anyhow::Result<bool> {
+        let mut tx = self.pool.begin().await?;
+        // Generation completion is a state transition, so serialize it with
+        // generation start/activation and relevant domain mutations. Keeping
+        // the fenced job finish and generation reconciliation in one
+        // transaction also prevents a ready-index conflict from committing the
+        // job while leaving its generation counters stale.
+        sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended('weltgewebe.search.generation.activation', 0))")
+            .execute(&mut *tx)
+            .await?;
         let finished = sqlx::query("UPDATE search_projection_jobs SET state=$2,claimed_by=NULL,claim_until=NULL,completed_at=NOW(),last_error_code=$3 WHERE id=$1 AND state='claimed' AND claimed_by=$4 AND attempt_count=$5 AND claim_until > NOW()")
-            .bind(id).bind(state).bind(code).bind(&self.worker_id).bind(attempts).execute(&self.pool).await?.rows_affected() == 1;
+            .bind(id).bind(state).bind(code).bind(&self.worker_id).bind(attempts).execute(&mut *tx).await?.rows_affected() == 1;
         if !finished {
+            tx.rollback().await?;
             return Ok(false);
         }
         sqlx::query("UPDATE search_index_generations g SET expected_nodes=(SELECT count(*) FROM search_projection_jobs j WHERE j.generation_id=g.generation_id), completed_nodes=(SELECT count(*) FROM search_projection_jobs j WHERE j.generation_id=g.generation_id AND j.state IN ('done','stale')), state=CASE WHEN g.state='building' AND NOT EXISTS (SELECT 1 FROM search_index_generations r WHERE r.state='ready' AND r.generation_id<>g.generation_id) AND NOT EXISTS (SELECT 1 FROM search_projection_jobs j WHERE j.generation_id=g.generation_id AND j.state NOT IN ('done','stale')) AND NOT EXISTS (SELECT 1 FROM search_node_versions v WHERE v.deleted_at IS NULL AND NOT EXISTS (SELECT 1 FROM search_node_projections p WHERE p.generation_id=g.generation_id AND p.node_id=v.node_id AND p.source_version=v.source_version AND p.source_revision=v.source_revision AND p.semantic_state='ready' AND cardinality(p.embedding)=g.dimension)) AND NOT EXISTS (SELECT 1 FROM search_node_versions v JOIN search_node_projections p ON p.generation_id=g.generation_id AND p.node_id=v.node_id WHERE v.deleted_at IS NOT NULL) THEN 'ready' ELSE g.state END WHERE g.generation_id=(SELECT generation_id FROM search_projection_jobs WHERE id=$1)")
-            .bind(id).execute(&self.pool).await?;
+            .bind(id).execute(&mut *tx).await?;
+        tx.commit().await?;
         Ok(true)
     }
 

--- a/apps/api/src/telemetry/mod.rs
+++ b/apps/api/src/telemetry/mod.rs
@@ -66,6 +66,7 @@ struct MetricsInner {
     pub http_requests_total: IntCounterVec,
     pub nodes_cache_count: IntGauge,
     pub edges_cache_count: IntGauge,
+    pub search_projection_jobs_total: IntCounterVec,
 }
 
 impl Metrics {
@@ -83,11 +84,20 @@ impl Metrics {
         let edges_count_opts = Opts::new("edges_cache_count", "Number of edges in memory cache");
         let edges_cache_count = IntGauge::with_opts(edges_count_opts)?;
 
+        let search_projection_jobs_total = IntCounterVec::new(
+            Opts::new(
+                "search_projection_jobs_total",
+                "Projection worker outcomes without node, text, query, or vector labels",
+            ),
+            &["outcome"],
+        )?;
+
         let registry = Registry::new();
         registry.register(Box::new(http_requests_total.clone()))?;
         registry.register(Box::new(build_info_metric.clone()))?;
         registry.register(Box::new(nodes_cache_count.clone()))?;
         registry.register(Box::new(edges_cache_count.clone()))?;
+        registry.register(Box::new(search_projection_jobs_total.clone()))?;
 
         build_info_metric
             .with_label_values(&[
@@ -103,6 +113,7 @@ impl Metrics {
                 http_requests_total,
                 nodes_cache_count,
                 edges_cache_count,
+                search_projection_jobs_total,
             }),
         })
     }
@@ -117,6 +128,15 @@ impl Metrics {
 
     pub fn http_requests_total(&self) -> &IntCounterVec {
         &self.inner.http_requests_total
+    }
+
+    /// Outcome labels are from a fixed enum; callers must never attach node
+    /// identifiers, source text, queries, provider responses, or vectors.
+    pub fn search_projection_outcome(&self, outcome: &str) {
+        self.inner
+            .search_projection_jobs_total
+            .with_label_values(&[outcome])
+            .inc();
     }
 
     pub fn render(&self) -> Result<Vec<u8>, prometheus::Error> {

--- a/apps/api/tests/db_semantic_search_foundation.rs
+++ b/apps/api/tests/db_semantic_search_foundation.rs
@@ -61,6 +61,16 @@ async fn run_migrations(pool: &sqlx::PgPool) {
 }
 
 async fn apply_t003_contract(pool: &sqlx::PgPool) {
+    // This target proves the historical T003 foundation in isolation. The
+    // production migrator now also contains the later T005 projection schema,
+    // so unwind only that Search migration in this disposable database before
+    // applying the deliberately non-production T003 proof contract.
+    sqlx::raw_sql(include_str!(
+        "../migrations/20260721000001_semantic_search_projection_worker.down.sql"
+    ))
+    .execute(pool)
+    .await
+    .expect("unwind T005 search migration for isolated T003 proof");
     sqlx::raw_sql(include_str!(
         "../../../contracts/search/postgres-foundation.up.sql"
     ))

--- a/apps/api/tests/db_semantic_search_projection_worker.rs
+++ b/apps/api/tests/db_semantic_search_projection_worker.rs
@@ -1,0 +1,1184 @@
+//! Direct disposable-PostgreSQL proof for T005's leased projection worker.
+//!
+//! Run with `T005_DATABASE_URL`; it never starts the API or exposes search.
+
+use std::{
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
+
+use async_trait::async_trait;
+use sqlx::{postgres::PgPoolOptions, PgPool};
+use tokio::{
+    sync::Notify,
+    time::{sleep, Duration},
+};
+use weltgewebe_api::{
+    search::{
+        EmbeddingProvider, EmbeddingProviderError, GenerationSpec, ProcessOutcome, ProjectionWorker,
+    },
+    telemetry::{BuildInfo, Metrics},
+};
+
+async fn pool() -> PgPool {
+    let url = std::env::var("T005_DATABASE_URL")
+        .expect("T005_DATABASE_URL must point to a direct disposable PostgreSQL database");
+    assert!(
+        !url.contains(":6432/"),
+        "T005 must not use PgBouncer because claims require direct PostgreSQL locking"
+    );
+    PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&url)
+        .await
+        .expect("connect T005 PostgreSQL")
+}
+
+async fn migrate(pool: &PgPool) {
+    let migrations = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("migrations");
+    sqlx::migrate::Migrator::new(migrations)
+        .await
+        .expect("load migrations")
+        .run(pool)
+        .await
+        .expect("run migrations")
+}
+
+async fn reset_search_state(pool: &PgPool) {
+    // Tests in this target share one disposable database serially. Remove test
+    // domain rows first (which may fire triggers), then clear all derived state.
+    sqlx::query("DELETE FROM domain_nodes WHERE id LIKE 't005-%'")
+        .execute(pool)
+        .await
+        .expect("remove prior T005 test nodes");
+    sqlx::query("TRUNCATE search_projection_jobs, search_node_projections, search_node_versions, search_index_generations RESTART IDENTITY CASCADE")
+        .execute(pool)
+        .await
+        .expect("reset T005 projection state");
+}
+
+struct FakeProvider {
+    unavailable: AtomicBool,
+}
+
+#[async_trait]
+impl EmbeddingProvider for FakeProvider {
+    async fn embed(
+        &self,
+        _document: &str,
+        dimension: usize,
+    ) -> Result<Vec<f64>, EmbeddingProviderError> {
+        if self.unavailable.load(Ordering::SeqCst) {
+            Err(EmbeddingProviderError::Unavailable)
+        } else {
+            Ok(vec![0.25; dimension])
+        }
+    }
+}
+
+struct BlockingProvider {
+    entered: Arc<Notify>,
+    release: Arc<Notify>,
+}
+
+#[async_trait]
+impl EmbeddingProvider for BlockingProvider {
+    async fn embed(
+        &self,
+        _document: &str,
+        dimension: usize,
+    ) -> Result<Vec<f64>, EmbeddingProviderError> {
+        self.entered.notify_one();
+        self.release.notified().await;
+        Ok(vec![0.5; dimension])
+    }
+}
+
+struct PermanentFailureProvider;
+
+#[async_trait]
+impl EmbeddingProvider for PermanentFailureProvider {
+    async fn embed(
+        &self,
+        _document: &str,
+        _dimension: usize,
+    ) -> Result<Vec<f64>, EmbeddingProviderError> {
+        Err(EmbeddingProviderError::InvalidVector)
+    }
+}
+
+fn worker(pool: PgPool, id: &str, provider: Arc<FakeProvider>) -> ProjectionWorker {
+    ProjectionWorker::new_with_provider(
+        pool,
+        id.to_owned(),
+        Metrics::try_new(BuildInfo::collect()).expect("metrics"),
+        provider,
+    )
+    .expect("worker")
+}
+
+#[tokio::test]
+#[ignore = "requires T005_DATABASE_URL pointing to direct disposable PostgreSQL"]
+async fn worker_is_revision_bound_leased_resumable_and_deletion_propagates() {
+    let pool = pool().await;
+    migrate(&pool).await;
+    reset_search_state(&pool).await;
+    let node = "t005-worker-node";
+    sqlx::query("INSERT INTO domain_nodes (id,kind,title,payload) VALUES ($1,'Werkstatt','Fahrradhilfe',$2::jsonb)")
+        .bind(node)
+        .bind(r#"{"summary":"Reparatur","address":"must not index","search_visibility":"public"}"#)
+        .execute(&pool).await.expect("insert node");
+    let provider = Arc::new(FakeProvider {
+        unavailable: AtomicBool::new(false),
+    });
+    let first = worker(pool.clone(), "t005-a", provider.clone());
+    first
+        .start_generation(GenerationSpec {
+            generation_id: "t005-generation",
+            provider: "local:ollama",
+            model_id: "test",
+            model_revision: "test",
+            runtime_identity: "ollama:test@http://127.0.0.1:11434",
+            dimension: 4,
+        })
+        .await
+        .expect("start");
+    assert_eq!(
+        first.claim_and_process_one().await.expect("process"),
+        ProcessOutcome::Processed
+    );
+    let projection: (i64, String, String, String) = sqlx::query_as("SELECT source_version,status,semantic_state,searchable_text FROM search_node_projections WHERE generation_id='t005-generation' AND node_id=$1")
+        .bind(node).fetch_one(&pool).await.expect("projection");
+    assert_eq!(projection.0, 1);
+    assert_eq!(projection.1, "active");
+    assert_eq!(projection.2, "ready");
+    assert!(!projection.3.contains("must not index"));
+
+    // A stale result is terminal and cannot overwrite revision two.
+    sqlx::query("UPDATE domain_nodes SET title='Neue Fahrradhilfe' WHERE id=$1")
+        .bind(node)
+        .execute(&pool)
+        .await
+        .expect("update node");
+    let second = worker(pool.clone(), "t005-b", provider);
+    assert_eq!(
+        second
+            .claim_and_process_one()
+            .await
+            .expect("process current"),
+        ProcessOutcome::Processed
+    );
+    let version: i64 = sqlx::query_scalar("SELECT source_version FROM search_node_projections WHERE generation_id='t005-generation' AND node_id=$1")
+        .bind(node).fetch_one(&pool).await.expect("current projection");
+    assert_eq!(version, 2);
+    sqlx::query("INSERT INTO search_projection_jobs (generation_id,node_id,source_version,source_revision,operation) VALUES ('t005-generation',$1,1,'node-1','delete')")
+        .bind(node).execute(&pool).await.expect("stale job");
+    assert_eq!(
+        second.claim_and_process_one().await.expect("process stale"),
+        ProcessOutcome::Stale
+    );
+
+    sqlx::query("DELETE FROM domain_nodes WHERE id=$1")
+        .bind(node)
+        .execute(&pool)
+        .await
+        .expect("delete node");
+    assert_eq!(
+        first
+            .claim_and_process_one()
+            .await
+            .expect("process deletion"),
+        ProcessOutcome::Deleted
+    );
+    let remaining: i64 =
+        sqlx::query_scalar("SELECT count(*) FROM search_node_projections WHERE node_id=$1")
+            .bind(node)
+            .fetch_one(&pool)
+            .await
+            .expect("remaining projection count");
+    assert_eq!(remaining, 0);
+}
+
+#[tokio::test]
+#[ignore = "requires T005_DATABASE_URL pointing to direct disposable PostgreSQL"]
+async fn worker_hardening_proves_races_trigger_identity_outage_and_activation() {
+    let pool = pool().await;
+    migrate(&pool).await;
+    reset_search_state(&pool).await;
+    let node = "t005-hardening-node";
+    let generation = "t005-hardening-generation";
+    sqlx::query("INSERT INTO domain_nodes (id,kind,title,lat,lon,payload) VALUES ($1,'Werkstatt','Alt',1,2,$2::jsonb)")
+        .bind(node).bind(r#"{"summary":"S","search_visibility":"public","address":"private","other":"a"}"#)
+        .execute(&pool).await.expect("insert");
+    let provider = Arc::new(FakeProvider {
+        unavailable: AtomicBool::new(true),
+    });
+    let a = worker(pool.clone(), "t005-hardening-a", provider.clone());
+    let b = worker(pool.clone(), "t005-hardening-b", provider.clone());
+    a.start_generation(GenerationSpec {
+        generation_id: generation,
+        provider: "local:ollama",
+        model_id: "m",
+        model_revision: "r",
+        runtime_identity: "ollama:test@http://127.0.0.1:11434",
+        dimension: 3,
+    })
+    .await
+    .expect("start");
+    // A provider outage leaves a leased item retryable; it does not alter the canonical node.
+    assert_eq!(
+        a.claim_and_process_one().await.expect("outage"),
+        ProcessOutcome::PendingProvider
+    );
+    let state: String =
+        sqlx::query_scalar("SELECT state FROM search_projection_jobs WHERE generation_id=$1")
+            .bind(generation)
+            .fetch_one(&pool)
+            .await
+            .expect("retry state");
+    assert_eq!(state, "retry");
+    let canonical: String = sqlx::query_scalar("SELECT title FROM domain_nodes WHERE id=$1")
+        .bind(node)
+        .fetch_one(&pool)
+        .await
+        .expect("canonical row");
+    assert_eq!(canonical, "Alt");
+    // The same generation id is a complete immutable identity, including ranking revision.
+    assert!(a
+        .start_generation(GenerationSpec {
+            generation_id: generation,
+            provider: "local:ollama",
+            model_id: "other",
+            model_revision: "r",
+            runtime_identity: "ollama:test@http://127.0.0.1:11434",
+            dimension: 3
+        })
+        .await
+        .is_err());
+    sqlx::query("UPDATE search_index_generations SET ranking_revision='different-ranking' WHERE generation_id=$1")
+        .bind(generation)
+        .execute(&pool)
+        .await
+        .expect("simulate incompatible stored generation identity");
+    assert!(a
+        .start_generation(GenerationSpec {
+            generation_id: generation,
+            provider: "local:ollama",
+            model_id: "m",
+            model_revision: "r",
+            runtime_identity: "ollama:test@http://127.0.0.1:11434",
+            dimension: 3
+        })
+        .await
+        .is_err());
+    sqlx::query("UPDATE search_index_generations SET ranking_revision='weltgewebe-hybrid-ranking-v2' WHERE generation_id=$1")
+        .bind(generation)
+        .execute(&pool)
+        .await
+        .expect("restore test identity");
+    // Incomplete/provider-pending generations cannot be atomically activated.
+    assert!(
+        sqlx::query("SELECT weltgewebe_activate_search_generation($1)")
+            .bind(generation)
+            .execute(&pool)
+            .await
+            .is_err()
+    );
+
+    // An irrelevant position or unknown JSON update does not version/enqueue; title does.
+    let before: i64 =
+        sqlx::query_scalar("SELECT source_version FROM search_node_versions WHERE node_id=$1")
+            .bind(node)
+            .fetch_one(&pool)
+            .await
+            .expect("version");
+    let jobs_before: i64 =
+        sqlx::query_scalar("SELECT count(*) FROM search_projection_jobs WHERE generation_id=$1")
+            .bind(generation)
+            .fetch_one(&pool)
+            .await
+            .expect("jobs");
+    sqlx::query("UPDATE domain_nodes SET lat=3, lon=4, payload=payload || '{\"address\":\"changed\",\"other\":\"b\"}'::jsonb WHERE id=$1").bind(node).execute(&pool).await.expect("irrelevant update");
+    assert_eq!(
+        sqlx::query_scalar::<_, i64>(
+            "SELECT source_version FROM search_node_versions WHERE node_id=$1"
+        )
+        .bind(node)
+        .fetch_one(&pool)
+        .await
+        .expect("unchanged version"),
+        before
+    );
+    assert_eq!(
+        sqlx::query_scalar::<_, i64>(
+            "SELECT count(*) FROM search_projection_jobs WHERE generation_id=$1"
+        )
+        .bind(generation)
+        .fetch_one(&pool)
+        .await
+        .expect("no new job"),
+        jobs_before
+    );
+
+    // Make the retry immediately claimable and recover idempotently with the provider restored.
+    provider.unavailable.store(false, Ordering::SeqCst);
+    sqlx::query("UPDATE search_projection_jobs SET available_at=NOW() WHERE generation_id=$1 AND state='retry'").bind(generation).execute(&pool).await.expect("release retry");
+    assert_eq!(
+        b.claim_and_process_one().await.expect("recovery"),
+        ProcessOutcome::Processed
+    );
+    // Two independent instances race for one new job; SKIP LOCKED gives it to
+    // exactly one claimant rather than duplicating a provider call/write.
+    sqlx::query("UPDATE domain_nodes SET title='Mitte' WHERE id=$1")
+        .bind(node)
+        .execute(&pool)
+        .await
+        .expect("create one claimable job");
+    let (a_claim, b_claim) = tokio::join!(a.claim_and_process_one(), b.claim_and_process_one());
+    let a_claim = a_claim.expect("first claimant");
+    let b_claim = b_claim.expect("second claimant");
+    assert!(
+        (a_claim == ProcessOutcome::Processed && b_claim == ProcessOutcome::Empty)
+            || (a_claim == ProcessOutcome::Empty && b_claim == ProcessOutcome::Processed),
+        "exactly one worker must claim the leased job"
+    );
+
+    // Insert old jobs after a newer canonical update: final mutating SQL fences both stale upsert and stale delete.
+    sqlx::query("UPDATE domain_nodes SET title='Neu' WHERE id=$1")
+        .bind(node)
+        .execute(&pool)
+        .await
+        .expect("relevant update");
+    sqlx::query("UPDATE search_projection_jobs SET state='pending', claimed_by=NULL, claim_until=NULL, available_at=TIMESTAMPTZ '1970-01-01' WHERE generation_id=$1 AND node_id=$2 AND source_version=$3 AND operation='upsert'")
+        .bind(generation).bind(node).bind(before).execute(&pool).await.expect("requeue stale upsert");
+    assert_eq!(
+        a.claim_and_process_one()
+            .await
+            .expect("stale upsert outcome"),
+        ProcessOutcome::Stale
+    );
+    sqlx::query("INSERT INTO search_projection_jobs (generation_id,node_id,source_version,source_revision,operation,available_at) VALUES ($1,$2,$3,$4,'delete',TIMESTAMPTZ '1970-01-01') ON CONFLICT DO NOTHING")
+        .bind(generation).bind(node).bind(before).bind("node-1").execute(&pool).await.expect("stale delete");
+    sqlx::query("UPDATE search_projection_jobs SET state='stale', completed_at=NOW() WHERE generation_id=$1 AND node_id=$2 AND source_version=$3 AND operation='upsert'")
+        .bind(generation).bind(node).bind(before + 2).execute(&pool).await.expect("keep newer job out of this race proof");
+    assert_eq!(
+        b.claim_and_process_one()
+            .await
+            .expect("stale delete outcome"),
+        ProcessOutcome::Stale
+    );
+    let projection_title: String = sqlx::query_scalar(
+        "SELECT title FROM search_node_projections WHERE generation_id=$1 AND node_id=$2",
+    )
+    .bind(generation)
+    .bind(node)
+    .fetch_one(&pool)
+    .await
+    .expect("stale delete did not remove projection");
+    assert_eq!(projection_title, "Mitte");
+}
+
+#[tokio::test]
+#[ignore = "requires T005_DATABASE_URL pointing to direct disposable PostgreSQL"]
+async fn provider_failures_are_bounded_fail_closed_and_explicitly_recoverable() {
+    let pool = pool().await;
+    migrate(&pool).await;
+    reset_search_state(&pool).await;
+    let node = "t005-provider-node";
+    let generation = "t005-provider-generation";
+    sqlx::query("INSERT INTO domain_nodes (id,kind,title,payload) VALUES ($1,'Werkstatt','Provider',$2::jsonb)")
+        .bind(node)
+        .bind(r#"{"search_visibility":"public"}"#)
+        .execute(&pool)
+        .await
+        .expect("insert provider node");
+
+    let unavailable = Arc::new(FakeProvider {
+        unavailable: AtomicBool::new(true),
+    });
+    let retrying = worker(pool.clone(), "t005-provider-retry", unavailable.clone());
+    retrying
+        .start_generation(GenerationSpec {
+            generation_id: generation,
+            provider: "local:ollama",
+            model_id: "m",
+            model_revision: "r",
+            runtime_identity: "ollama:test@http://127.0.0.1:11434",
+            dimension: 3,
+        })
+        .await
+        .expect("start retry generation");
+
+    for attempt in 1..=8 {
+        let outcome = retrying
+            .claim_and_process_one()
+            .await
+            .expect("provider outage attempt");
+        if attempt < 8 {
+            assert_eq!(outcome, ProcessOutcome::PendingProvider);
+            sqlx::query("UPDATE search_projection_jobs SET available_at=TIMESTAMPTZ '1970-01-01' WHERE generation_id=$1 AND state='retry'")
+                .bind(generation)
+                .execute(&pool)
+                .await
+                .expect("make retry claimable");
+        } else {
+            assert_eq!(outcome, ProcessOutcome::Failed);
+        }
+    }
+    let exhausted: (String, i32, Option<String>) = sqlx::query_as(
+        "SELECT state,attempt_count,last_error_code FROM search_projection_jobs WHERE generation_id=$1",
+    )
+    .bind(generation)
+    .fetch_one(&pool)
+    .await
+    .expect("exhausted job");
+    assert_eq!(exhausted.0, "failed");
+    assert_eq!(exhausted.1, 8);
+    assert_eq!(
+        exhausted.2.as_deref(),
+        Some("provider_unavailable_exhausted")
+    );
+
+    unavailable.unavailable.store(false, Ordering::SeqCst);
+    retrying
+        .start_generation(GenerationSpec {
+            generation_id: generation,
+            provider: "local:ollama",
+            model_id: "m",
+            model_revision: "r",
+            runtime_identity: "ollama:test@http://127.0.0.1:11434",
+            dimension: 3,
+        })
+        .await
+        .expect("explicit catch-up rearm");
+    assert_eq!(
+        retrying
+            .claim_and_process_one()
+            .await
+            .expect("catch-up projection"),
+        ProcessOutcome::Processed
+    );
+
+    let permanent_generation = "t005-provider-permanent";
+    let permanent = ProjectionWorker::new_with_provider(
+        pool.clone(),
+        "t005-provider-permanent-worker".to_owned(),
+        Metrics::try_new(BuildInfo::collect()).expect("metrics"),
+        Arc::new(PermanentFailureProvider),
+    )
+    .expect("permanent worker");
+    permanent
+        .start_generation(GenerationSpec {
+            generation_id: permanent_generation,
+            provider: "local:ollama",
+            model_id: "m",
+            model_revision: "r",
+            runtime_identity: "ollama:test@http://127.0.0.1:11434",
+            dimension: 3,
+        })
+        .await
+        .expect("start permanent failure generation");
+    assert_eq!(
+        permanent
+            .claim_and_process_one()
+            .await
+            .expect("permanent provider failure"),
+        ProcessOutcome::Failed
+    );
+    let permanent_state: (String, i32, Option<String>) = sqlx::query_as(
+        "SELECT state,attempt_count,last_error_code FROM search_projection_jobs WHERE generation_id=$1",
+    )
+    .bind(permanent_generation)
+    .fetch_one(&pool)
+    .await
+    .expect("permanent failed job");
+    assert_eq!(permanent_state.0, "failed");
+    assert_eq!(permanent_state.1, 1);
+    assert_eq!(
+        permanent_state.2.as_deref(),
+        Some("provider_invalid_vector")
+    );
+    permanent
+        .start_generation(GenerationSpec {
+            generation_id: permanent_generation,
+            provider: "local:ollama",
+            model_id: "m",
+            model_revision: "r",
+            runtime_identity: "ollama:test@http://127.0.0.1:11434",
+            dimension: 3,
+        })
+        .await
+        .expect("idempotent permanent generation restart");
+    let still_failed: String =
+        sqlx::query_scalar("SELECT state FROM search_projection_jobs WHERE generation_id=$1")
+            .bind(permanent_generation)
+            .fetch_one(&pool)
+            .await
+            .expect("permanent failure stays failed");
+    assert_eq!(still_failed, "failed");
+}
+
+#[tokio::test]
+#[ignore = "requires T005_DATABASE_URL pointing to direct disposable PostgreSQL"]
+async fn rollback_candidate_stays_current_and_retired_generation_cannot_reactivate() {
+    let pool = pool().await;
+    migrate(&pool).await;
+    reset_search_state(&pool).await;
+    let node = "t005-rollback-node";
+    sqlx::query(
+        "INSERT INTO domain_nodes (id,kind,title,payload) VALUES ($1,'Werkstatt','A',$2::jsonb)",
+    )
+    .bind(node)
+    .bind(r#"{"summary":"sichtbar","search_visibility":"public"}"#)
+    .execute(&pool)
+    .await
+    .expect("insert rollback node");
+    let provider = Arc::new(FakeProvider {
+        unavailable: AtomicBool::new(false),
+    });
+    let worker = worker(pool.clone(), "t005-rollback", provider);
+    let spec = |generation_id| GenerationSpec {
+        generation_id,
+        provider: "local:ollama",
+        model_id: "m",
+        model_revision: "r",
+        runtime_identity: "ollama:test@http://127.0.0.1:11434",
+        dimension: 3,
+    };
+
+    worker
+        .start_generation(spec("t005-gen-a"))
+        .await
+        .expect("gen A");
+    assert_eq!(
+        worker.claim_and_process_one().await.expect("A project"),
+        ProcessOutcome::Processed
+    );
+    sqlx::query("SELECT weltgewebe_activate_search_generation('t005-gen-a')")
+        .execute(&pool)
+        .await
+        .expect("activate A");
+
+    worker
+        .start_generation(spec("t005-gen-b"))
+        .await
+        .expect("gen B");
+    assert_eq!(
+        worker.claim_and_process_one().await.expect("B project"),
+        ProcessOutcome::Processed
+    );
+    sqlx::query("SELECT weltgewebe_activate_search_generation('t005-gen-b')")
+        .execute(&pool)
+        .await
+        .expect("activate B");
+    let states: Vec<(String, String)> = sqlx::query_as(
+        "SELECT generation_id,state FROM search_index_generations WHERE generation_id IN ('t005-gen-a','t005-gen-b') ORDER BY generation_id",
+    )
+    .fetch_all(&pool).await.expect("A/B states");
+    assert_eq!(
+        states,
+        vec![
+            ("t005-gen-a".into(), "ready".into()),
+            ("t005-gen-b".into(), "active".into())
+        ]
+    );
+
+    sqlx::query("UPDATE domain_nodes SET title='Aktuell' WHERE id=$1")
+        .bind(node)
+        .execute(&pool)
+        .await
+        .expect("mutate canonical node");
+    assert_eq!(
+        worker
+            .claim_and_process_one()
+            .await
+            .expect("first catch-up"),
+        ProcessOutcome::Processed
+    );
+    assert_eq!(
+        worker
+            .claim_and_process_one()
+            .await
+            .expect("second catch-up"),
+        ProcessOutcome::Processed
+    );
+    let versions: Vec<(String, i64)> = sqlx::query_as(
+        "SELECT generation_id,source_version FROM search_node_projections WHERE node_id=$1 AND generation_id IN ('t005-gen-a','t005-gen-b') ORDER BY generation_id",
+    )
+    .bind(node).fetch_all(&pool).await.expect("caught-up versions");
+    assert_eq!(
+        versions,
+        vec![("t005-gen-a".into(), 2), ("t005-gen-b".into(), 2)]
+    );
+
+    sqlx::query("UPDATE domain_nodes SET payload=jsonb_set(payload,'{search_visibility}','\"hidden\"'::jsonb) WHERE id=$1")
+        .bind(node).execute(&pool).await.expect("withdraw visibility");
+    assert_eq!(
+        worker
+            .claim_and_process_one()
+            .await
+            .expect("first visibility catch-up"),
+        ProcessOutcome::Processed
+    );
+    assert_eq!(
+        worker
+            .claim_and_process_one()
+            .await
+            .expect("second visibility catch-up"),
+        ProcessOutcome::Processed
+    );
+    let visibility: Vec<(String, String, Vec<String>)> = sqlx::query_as(
+        "SELECT generation_id,status,visibility_scopes FROM search_node_projections WHERE node_id=$1 AND generation_id IN ('t005-gen-a','t005-gen-b') ORDER BY generation_id",
+    )
+    .bind(node).fetch_all(&pool).await.expect("visibility projections");
+    assert_eq!(visibility.len(), 2);
+    assert!(visibility
+        .iter()
+        .all(|(_, status, scopes)| status == "hidden" && scopes.is_empty()));
+
+    sqlx::query("SELECT weltgewebe_activate_search_generation('t005-gen-a')")
+        .execute(&pool)
+        .await
+        .expect("rollback A");
+    let rolled_back: Vec<(String, String)> = sqlx::query_as(
+        "SELECT generation_id,state FROM search_index_generations WHERE generation_id IN ('t005-gen-a','t005-gen-b') ORDER BY generation_id",
+    )
+    .fetch_all(&pool).await.expect("rollback states");
+    assert_eq!(
+        rolled_back,
+        vec![
+            ("t005-gen-a".into(), "active".into()),
+            ("t005-gen-b".into(), "ready".into())
+        ]
+    );
+
+    worker
+        .start_generation(spec("t005-gen-c"))
+        .await
+        .expect("gen C");
+    assert_eq!(
+        worker.claim_and_process_one().await.expect("C project"),
+        ProcessOutcome::Processed
+    );
+    sqlx::query("SELECT weltgewebe_activate_search_generation('t005-gen-c')")
+        .execute(&pool)
+        .await
+        .expect("activate C");
+    let fallback_states: Vec<(String, String)> = sqlx::query_as(
+        "SELECT generation_id,state FROM search_index_generations WHERE generation_id IN ('t005-gen-a','t005-gen-b','t005-gen-c') ORDER BY generation_id",
+    )
+    .fetch_all(&pool)
+    .await
+    .expect("post-C generation states");
+    assert_eq!(
+        fallback_states,
+        vec![
+            ("t005-gen-a".into(), "ready".into()),
+            ("t005-gen-b".into(), "retired".into()),
+            ("t005-gen-c".into(), "active".into()),
+        ]
+    );
+    assert!(
+        sqlx::query("SELECT weltgewebe_activate_search_generation('t005-gen-b')")
+            .execute(&pool)
+            .await
+            .is_err()
+    );
+
+    sqlx::query("DELETE FROM domain_nodes WHERE id=$1")
+        .bind(node)
+        .execute(&pool)
+        .await
+        .expect("delete canonical node");
+    assert!(
+        sqlx::query("SELECT weltgewebe_activate_search_generation('t005-gen-a')")
+            .execute(&pool)
+            .await
+            .is_err(),
+        "ready rollback target must not activate while delete jobs are pending"
+    );
+    assert_eq!(
+        worker.claim_and_process_one().await.expect("delete active"),
+        ProcessOutcome::Deleted
+    );
+    assert_eq!(
+        worker.claim_and_process_one().await.expect("delete ready"),
+        ProcessOutcome::Deleted
+    );
+    let live_rollback_projections: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM search_node_projections p JOIN search_index_generations g USING (generation_id) WHERE p.node_id=$1 AND g.state IN ('active','ready')",
+    )
+    .bind(node).fetch_one(&pool).await.expect("active/ready deletion count");
+    assert_eq!(live_rollback_projections, 0);
+    sqlx::query("SELECT weltgewebe_activate_search_generation('t005-gen-a')")
+        .execute(&pool)
+        .await
+        .expect("rollback is safe after all delete jobs complete");
+}
+
+#[tokio::test]
+#[ignore = "requires T005_DATABASE_URL pointing to direct disposable PostgreSQL"]
+async fn identical_rebuilds_have_the_same_logical_integrity_digest() {
+    let pool = pool().await;
+    migrate(&pool).await;
+    reset_search_state(&pool).await;
+    let node = "t005-digest-node";
+    sqlx::query("INSERT INTO domain_nodes (id,kind,title,payload) VALUES ($1,'Werkstatt','Digest',$2::jsonb)")
+        .bind(node)
+        .bind(r#"{"summary":"gleich","tags":["b","a"],"language":"de","search_visibility":"public"}"#)
+        .execute(&pool).await.expect("insert digest node");
+    let provider = Arc::new(FakeProvider {
+        unavailable: AtomicBool::new(false),
+    });
+    let worker = worker(pool.clone(), "t005-digest", provider);
+    for generation_id in ["t005-digest-a", "t005-digest-b"] {
+        worker
+            .start_generation(GenerationSpec {
+                generation_id,
+                provider: "local:ollama",
+                model_id: "m",
+                model_revision: "r",
+                runtime_identity: "ollama:test@http://127.0.0.1:11434",
+                dimension: 3,
+            })
+            .await
+            .expect("start digest generation");
+    }
+    assert_eq!(
+        worker.claim_and_process_one().await.expect("digest first"),
+        ProcessOutcome::Processed
+    );
+    assert_eq!(
+        worker.claim_and_process_one().await.expect("digest second"),
+        ProcessOutcome::Processed
+    );
+    let first = worker
+        .integrity_digest("t005-digest-a")
+        .await
+        .expect("first digest");
+    let second = worker
+        .integrity_digest("t005-digest-b")
+        .await
+        .expect("second digest");
+    assert_eq!(first, second);
+    assert_eq!(first.len(), 64);
+}
+
+#[tokio::test]
+#[ignore = "requires T005_DATABASE_URL pointing to direct disposable PostgreSQL"]
+async fn generation_start_and_activation_serialize_with_domain_mutations() {
+    let pool = pool().await;
+    migrate(&pool).await;
+    reset_search_state(&pool).await;
+    let node = "t005-generation-race-node";
+    let generation = "t005-generation-race";
+    sqlx::query(
+        "INSERT INTO domain_nodes (id,kind,title,payload) VALUES ($1,'Werkstatt','A',$2::jsonb)",
+    )
+    .bind(node)
+    .bind(r#"{"search_visibility":"public"}"#)
+    .execute(&pool)
+    .await
+    .expect("insert race node");
+
+    // Mutation reaches the trigger first and therefore holds the shared
+    // generation lock until commit. Generation start must wait, then seed the
+    // committed current revision rather than an older snapshot.
+    let mut mutation = pool.begin().await.expect("begin pre-start mutation");
+    sqlx::query("UPDATE domain_nodes SET title='B' WHERE id=$1")
+        .bind(node)
+        .execute(&mut *mutation)
+        .await
+        .expect("mutate before generation start");
+    let worker = Arc::new(worker(
+        pool.clone(),
+        "t005-generation-race-worker",
+        Arc::new(FakeProvider {
+            unavailable: AtomicBool::new(false),
+        }),
+    ));
+    let starter = worker.clone();
+    let start = tokio::spawn(async move {
+        starter
+            .start_generation(GenerationSpec {
+                generation_id: generation,
+                provider: "local:ollama",
+                model_id: "m",
+                model_revision: "r",
+                runtime_identity: "ollama:test@http://127.0.0.1:11434",
+                dimension: 3,
+            })
+            .await
+    });
+    sleep(Duration::from_millis(50)).await;
+    assert!(
+        !start.is_finished(),
+        "generation start bypassed mutation lock"
+    );
+    mutation.commit().await.expect("commit pre-start mutation");
+    start
+        .await
+        .expect("start task join")
+        .expect("start generation after mutation");
+    let seeded_version: i64 = sqlx::query_scalar(
+        "SELECT max(source_version) FROM search_projection_jobs WHERE generation_id=$1 AND node_id=$2",
+    )
+    .bind(generation)
+    .bind(node)
+    .fetch_one(&pool)
+    .await
+    .expect("seeded job version");
+    assert_eq!(seeded_version, 2);
+    assert_eq!(
+        worker
+            .claim_and_process_one()
+            .await
+            .expect("project seeded revision"),
+        ProcessOutcome::Processed
+    );
+
+    // A mutation whose trigger already holds the shared lock must commit before
+    // activation can take the exclusive lock. Activation then sees the pending
+    // current-revision job and rejects the stale target.
+    let mut before_activation = pool.begin().await.expect("begin activation mutation");
+    sqlx::query("UPDATE domain_nodes SET title='C' WHERE id=$1")
+        .bind(node)
+        .execute(&mut *before_activation)
+        .await
+        .expect("mutate before activation");
+    let activation_pool = pool.clone();
+    let activation = tokio::spawn(async move {
+        sqlx::query("SELECT weltgewebe_activate_search_generation($1)")
+            .bind(generation)
+            .execute(&activation_pool)
+            .await
+    });
+    sleep(Duration::from_millis(50)).await;
+    assert!(
+        !activation.is_finished(),
+        "activation bypassed mutation lock"
+    );
+    before_activation
+        .commit()
+        .await
+        .expect("commit activation mutation");
+    assert!(
+        activation.await.expect("activation task join").is_err(),
+        "activation must reject the newly pending revision"
+    );
+    assert_eq!(
+        worker
+            .claim_and_process_one()
+            .await
+            .expect("project activation revision"),
+        ProcessOutcome::Processed
+    );
+    sqlx::query("SELECT weltgewebe_activate_search_generation($1)")
+        .bind(generation)
+        .execute(&pool)
+        .await
+        .expect("activate after catch-up");
+
+    // The opposite ordering is explicit too: while an exclusive generation
+    // operation owns the lock, a relevant mutation cannot finish its trigger.
+    // Once released, the mutation proceeds and must enqueue the new revision.
+    let mut generation_gate = pool.begin().await.expect("begin exclusive generation gate");
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended('weltgewebe.search.generation.activation', 0))")
+        .execute(&mut *generation_gate)
+        .await
+        .expect("take exclusive generation gate");
+    let mutation_pool = pool.clone();
+    let after_activation = tokio::spawn(async move {
+        sqlx::query("UPDATE domain_nodes SET title='D' WHERE id=$1")
+            .bind(node)
+            .execute(&mutation_pool)
+            .await
+    });
+    sleep(Duration::from_millis(50)).await;
+    assert!(
+        !after_activation.is_finished(),
+        "domain mutation bypassed exclusive generation lock"
+    );
+    generation_gate
+        .commit()
+        .await
+        .expect("release exclusive generation gate");
+    after_activation
+        .await
+        .expect("post-activation mutation join")
+        .expect("post-activation mutation");
+    let pending_version: i64 = sqlx::query_scalar(
+        "SELECT max(source_version) FROM search_projection_jobs WHERE generation_id=$1 AND node_id=$2 AND state='pending'",
+    )
+    .bind(generation)
+    .bind(node)
+    .fetch_one(&pool)
+    .await
+    .expect("post-activation pending version");
+    assert_eq!(pending_version, 4);
+}
+
+#[tokio::test]
+#[ignore = "requires T005_DATABASE_URL pointing to direct disposable PostgreSQL"]
+async fn reclaimed_lease_fences_the_old_worker_before_projection_mutation() {
+    let pool = pool().await;
+    migrate(&pool).await;
+    reset_search_state(&pool).await;
+    let node = "t005-lease-fence-node";
+    let generation = "t005-lease-fence-generation";
+    sqlx::query("INSERT INTO domain_nodes (id,kind,title,payload) VALUES ($1,'Werkstatt','Lease',$2::jsonb)")
+        .bind(node)
+        .bind(r#"{"search_visibility":"public"}"#)
+        .execute(&pool)
+        .await
+        .expect("insert lease node");
+
+    let entered = Arc::new(Notify::new());
+    let release = Arc::new(Notify::new());
+    let slow = ProjectionWorker::new_with_provider(
+        pool.clone(),
+        "t005-lease-slow".to_owned(),
+        Metrics::try_new(BuildInfo::collect()).expect("metrics"),
+        Arc::new(BlockingProvider {
+            entered: entered.clone(),
+            release: release.clone(),
+        }),
+    )
+    .expect("slow worker");
+    slow.start_generation(GenerationSpec {
+        generation_id: generation,
+        provider: "local:ollama",
+        model_id: "m",
+        model_revision: "r",
+        runtime_identity: "ollama:test@http://127.0.0.1:11434",
+        dimension: 3,
+    })
+    .await
+    .expect("start lease generation");
+
+    let slow_task = tokio::spawn(async move { slow.claim_and_process_one().await });
+    entered.notified().await;
+    sqlx::query("UPDATE search_projection_jobs SET claim_until=NOW()-INTERVAL '1 second' WHERE generation_id=$1 AND state='claimed'")
+        .bind(generation)
+        .execute(&pool)
+        .await
+        .expect("expire first claim");
+
+    let fast = worker(
+        pool.clone(),
+        "t005-lease-fast",
+        Arc::new(FakeProvider {
+            unavailable: AtomicBool::new(false),
+        }),
+    );
+    assert_eq!(
+        fast.claim_and_process_one().await.expect("reclaimed job"),
+        ProcessOutcome::Processed
+    );
+    release.notify_one();
+    assert_eq!(
+        slow_task
+            .await
+            .expect("slow task join")
+            .expect("slow result"),
+        ProcessOutcome::LeaseLost
+    );
+    let job: (String, i32) = sqlx::query_as(
+        "SELECT state,attempt_count FROM search_projection_jobs WHERE generation_id=$1",
+    )
+    .bind(generation)
+    .fetch_one(&pool)
+    .await
+    .expect("lease job state");
+    assert_eq!(job, ("done".into(), 2));
+    let projection_count: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM search_node_projections WHERE generation_id=$1 AND node_id=$2",
+    )
+    .bind(generation)
+    .bind(node)
+    .fetch_one(&pool)
+    .await
+    .expect("lease projection count");
+    assert_eq!(projection_count, 1);
+}
+
+#[tokio::test]
+#[ignore = "requires T005_DATABASE_URL pointing to direct disposable PostgreSQL"]
+async fn empty_integrity_digest_binds_generation_identity_but_not_generation_id() {
+    let pool = pool().await;
+    migrate(&pool).await;
+    reset_search_state(&pool).await;
+    let provider = Arc::new(FakeProvider {
+        unavailable: AtomicBool::new(false),
+    });
+    let worker = worker(pool, "t005-empty-digest", provider);
+    for (generation_id, revision) in [
+        ("t005-empty-a", "r1"),
+        ("t005-empty-b", "r2"),
+        ("t005-empty-c", "r1"),
+    ] {
+        worker
+            .start_generation(GenerationSpec {
+                generation_id,
+                provider: "local:ollama",
+                model_id: "m",
+                model_revision: revision,
+                runtime_identity: "ollama:test@http://127.0.0.1:11434",
+                dimension: 3,
+            })
+            .await
+            .expect("start empty digest generation");
+    }
+    let first = worker
+        .integrity_digest("t005-empty-a")
+        .await
+        .expect("digest A");
+    let changed = worker
+        .integrity_digest("t005-empty-b")
+        .await
+        .expect("digest B");
+    let same = worker
+        .integrity_digest("t005-empty-c")
+        .await
+        .expect("digest C");
+    assert_eq!(first, same);
+    assert_ne!(first, changed);
+}
+
+#[tokio::test]
+#[ignore = "requires T005_DATABASE_URL pointing to direct disposable PostgreSQL"]
+async fn invalid_projection_document_fails_terminally_without_lease_cycle() {
+    let pool = pool().await;
+    migrate(&pool).await;
+    reset_search_state(&pool).await;
+    let node = "t005-invalid-document-node";
+    let generation = "t005-invalid-document-generation";
+    sqlx::query(
+        "INSERT INTO domain_nodes (id,kind,title,payload) VALUES ($1,'Werkstatt','   ',$2::jsonb)",
+    )
+    .bind(node)
+    .bind(r#"{"search_visibility":"public"}"#)
+    .execute(&pool)
+    .await
+    .expect("insert invalid projection document");
+    let worker = worker(
+        pool.clone(),
+        "t005-invalid-document-worker",
+        Arc::new(FakeProvider {
+            unavailable: AtomicBool::new(false),
+        }),
+    );
+    worker
+        .start_generation(GenerationSpec {
+            generation_id: generation,
+            provider: "local:ollama",
+            model_id: "m",
+            model_revision: "r",
+            runtime_identity: "ollama:test@http://127.0.0.1:11434",
+            dimension: 3,
+        })
+        .await
+        .expect("start invalid document generation");
+    assert_eq!(
+        worker
+            .claim_and_process_one()
+            .await
+            .expect("process invalid document"),
+        ProcessOutcome::Failed
+    );
+    let failed: (String, i32, Option<String>) = sqlx::query_as(
+        "SELECT state,attempt_count,last_error_code FROM search_projection_jobs WHERE generation_id=$1 AND node_id=$2",
+    )
+    .bind(generation)
+    .bind(node)
+    .fetch_one(&pool)
+    .await
+    .expect("invalid document job state");
+    assert_eq!(failed.0, "failed");
+    assert_eq!(failed.1, 1);
+    assert_eq!(failed.2.as_deref(), Some("document_invalid"));
+    assert_eq!(
+        worker
+            .claim_and_process_one()
+            .await
+            .expect("no invalid document reclaim"),
+        ProcessOutcome::Empty
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires T005_DATABASE_URL plus explicit live Ollama identity environment"]
+async fn search_backfill_binary_projects_with_live_local_provider_without_activation() {
+    if std::env::var("T005_RUN_LIVE_OLLAMA_E2E").as_deref() != Ok("1") {
+        return;
+    }
+    let pool = pool().await;
+    migrate(&pool).await;
+    reset_search_state(&pool).await;
+    let node = "t005-backfill-e2e-node";
+    let generation = "t005-backfill-e2e-generation";
+    sqlx::query("INSERT INTO domain_nodes (id,kind,title,payload) VALUES ($1,'Werkstatt','Backfill E2E',$2::jsonb)")
+        .bind(node)
+        .bind(r#"{"summary":"lokaler Providerpfad","search_visibility":"public"}"#)
+        .execute(&pool)
+        .await
+        .expect("insert E2E node");
+
+    let database_url = std::env::var("T005_DATABASE_URL").expect("T005_DATABASE_URL");
+    let ollama_url = std::env::var("T005_LIVE_OLLAMA_URL").expect("T005_LIVE_OLLAMA_URL");
+    let model_id = std::env::var("T005_LIVE_OLLAMA_MODEL_ID").expect("model id");
+    let model_revision = std::env::var("T005_LIVE_OLLAMA_MODEL_REVISION").expect("model revision");
+    let runtime_identity =
+        std::env::var("T005_LIVE_OLLAMA_RUNTIME_IDENTITY").expect("runtime identity");
+    let dimension = std::env::var("T005_LIVE_OLLAMA_DIMENSION").expect("dimension");
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_search-backfill"))
+        .env("DATABASE_URL", &database_url)
+        .env("WELTGEWEBE_SEARCH_GENERATION_ID", generation)
+        .env("WELTGEWEBE_SEARCH_BACKFILL_MAX_JOBS", "10")
+        .env("WELTGEWEBE_SEARCH_OLLAMA_URL", &ollama_url)
+        .env("WELTGEWEBE_SEARCH_PROVIDER", "local:ollama")
+        .env("WELTGEWEBE_SEARCH_MODEL_ID", &model_id)
+        .env("WELTGEWEBE_SEARCH_MODEL_REVISION", &model_revision)
+        .env("WELTGEWEBE_SEARCH_RUNTIME_IDENTITY", &runtime_identity)
+        .env("WELTGEWEBE_SEARCH_DIMENSION", &dimension)
+        .output()
+        .expect("run search-backfill binary");
+    assert!(
+        output.status.success(),
+        "search-backfill failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("utf8 backfill stdout");
+    assert!(stdout.contains("search backfill processed 1 jobs; generation remains unactivated"));
+    assert!(!stdout.contains("Backfill E2E"));
+    assert!(!stdout.contains("lokaler Providerpfad"));
+
+    let projection: (i64, String, String) = sqlx::query_as(
+        "SELECT source_version,semantic_state,status FROM search_node_projections WHERE generation_id=$1 AND node_id=$2",
+    )
+    .bind(generation)
+    .bind(node)
+    .fetch_one(&pool)
+    .await
+    .expect("E2E projection");
+    assert_eq!(projection.0, 1);
+    assert_eq!(projection.1, "ready");
+    assert_eq!(projection.2, "active");
+    let generation_state: String =
+        sqlx::query_scalar("SELECT state FROM search_index_generations WHERE generation_id=$1")
+            .bind(generation)
+            .fetch_one(&pool)
+            .await
+            .expect("E2E generation state");
+    assert_eq!(generation_state, "ready");
+    let active_count: i64 =
+        sqlx::query_scalar("SELECT count(*) FROM search_index_generations WHERE state='active'")
+            .fetch_one(&pool)
+            .await
+            .expect("active generation count");
+    assert_eq!(active_count, 0);
+}

--- a/apps/api/tests/db_semantic_search_projection_worker.rs
+++ b/apps/api/tests/db_semantic_search_projection_worker.rs
@@ -13,7 +13,7 @@ use std::{
 use async_trait::async_trait;
 use sqlx::{postgres::PgPoolOptions, PgPool};
 use tokio::{
-    sync::Notify,
+    sync::{Barrier, Notify},
     time::{sleep, Duration},
 };
 use weltgewebe_api::{
@@ -93,6 +93,22 @@ impl EmbeddingProvider for BlockingProvider {
     ) -> Result<Vec<f64>, EmbeddingProviderError> {
         self.entered.notify_one();
         self.release.notified().await;
+        Ok(vec![0.5; dimension])
+    }
+}
+
+struct BarrierProvider {
+    barrier: Arc<Barrier>,
+}
+
+#[async_trait]
+impl EmbeddingProvider for BarrierProvider {
+    async fn embed(
+        &self,
+        _document: &str,
+        dimension: usize,
+    ) -> Result<Vec<f64>, EmbeddingProviderError> {
+        self.barrier.wait().await;
         Ok(vec![0.5; dimension])
     }
 }
@@ -919,6 +935,106 @@ async fn generation_start_and_activation_serialize_with_domain_mutations() {
     .await
     .expect("post-activation pending version");
     assert_eq!(pending_version, 4);
+}
+
+#[tokio::test]
+#[ignore = "requires T005_DATABASE_URL pointing to direct disposable PostgreSQL"]
+async fn concurrent_generation_finishes_serialize_ready_transition_and_keep_counters_current() {
+    let pool = pool().await;
+    migrate(&pool).await;
+    reset_search_state(&pool).await;
+    let node = "t005-concurrent-ready-node";
+    sqlx::query("INSERT INTO domain_nodes (id,kind,title,payload) VALUES ($1,'Werkstatt','Ready Race',$2::jsonb)")
+        .bind(node)
+        .bind(r#"{"search_visibility":"public"}"#)
+        .execute(&pool)
+        .await
+        .expect("insert concurrent ready node");
+
+    let barrier = Arc::new(Barrier::new(2));
+    let provider = Arc::new(BarrierProvider {
+        barrier: barrier.clone(),
+    });
+    let worker_a = Arc::new(
+        ProjectionWorker::new_with_provider(
+            pool.clone(),
+            "t005-ready-race-a".to_owned(),
+            Metrics::try_new(BuildInfo::collect()).expect("metrics a"),
+            provider.clone(),
+        )
+        .expect("worker a"),
+    );
+    let worker_b = Arc::new(
+        ProjectionWorker::new_with_provider(
+            pool.clone(),
+            "t005-ready-race-b".to_owned(),
+            Metrics::try_new(BuildInfo::collect()).expect("metrics b"),
+            provider,
+        )
+        .expect("worker b"),
+    );
+
+    for generation_id in ["t005-ready-race-gen-a", "t005-ready-race-gen-b"] {
+        worker_a
+            .start_generation(GenerationSpec {
+                generation_id,
+                provider: "local:ollama",
+                model_id: "m",
+                model_revision: "r",
+                runtime_identity: "ollama:test@http://127.0.0.1:11434",
+                dimension: 3,
+            })
+            .await
+            .expect("start concurrent generation");
+    }
+
+    let first_worker = worker_a.clone();
+    let second_worker = worker_b.clone();
+    let (first, second) = tokio::join!(
+        async move { first_worker.claim_and_process_one().await },
+        async move { second_worker.claim_and_process_one().await }
+    );
+    assert_eq!(
+        first.expect("first concurrent finish"),
+        ProcessOutcome::Processed
+    );
+    assert_eq!(
+        second.expect("second concurrent finish"),
+        ProcessOutcome::Processed
+    );
+
+    let generations: Vec<(String, String, i64, i64)> = sqlx::query_as(
+        "SELECT generation_id,state,expected_nodes,completed_nodes FROM search_index_generations WHERE generation_id IN ('t005-ready-race-gen-a','t005-ready-race-gen-b') ORDER BY generation_id",
+    )
+    .fetch_all(&pool)
+    .await
+    .expect("concurrent generation states");
+    assert_eq!(generations.len(), 2);
+    assert_eq!(generations.iter().filter(|row| row.1 == "ready").count(), 1);
+    assert_eq!(
+        generations.iter().filter(|row| row.1 == "building").count(),
+        1
+    );
+    assert!(generations.iter().all(|row| row.2 == 1 && row.3 == 1));
+
+    let building: String = generations
+        .iter()
+        .find(|row| row.1 == "building")
+        .expect("one complete building generation")
+        .0
+        .clone();
+    sqlx::query("SELECT weltgewebe_activate_search_generation($1)")
+        .bind(&building)
+        .execute(&pool)
+        .await
+        .expect("complete building generation remains directly activatable");
+    let active: String = sqlx::query_scalar(
+        "SELECT generation_id FROM search_index_generations WHERE state='active'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("active generation after concurrent finish");
+    assert_eq!(active, building);
 }
 
 #[tokio::test]

--- a/scripts/ci/run-postgres-integration-proofs.sh
+++ b/scripts/ci/run-postgres-integration-proofs.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 : "${DATABASE_URL:?DATABASE_URL must point at a disposable PostgreSQL database}"
 export PG_DIRECT_URL="${PG_DIRECT_URL:-$DATABASE_URL}"
+export T005_DATABASE_URL="${T005_DATABASE_URL:-$PG_DIRECT_URL}"
 export AUTH_PG_003_FIXTURE_MUTATION=1
 
 load_t003_connection() {
@@ -98,6 +99,7 @@ for target in \
   db_session_store_persistence \
   db_webauthn_user_id_backfill_audit \
   db_semantic_search_foundation \
+  db_semantic_search_projection_worker \
   sqlx_postgres_direct_session_crud; do
   printf '=== PostgreSQL proof: %s ===\n' "$target"
   reset_database


### PR DESCRIPTION
<!-- weltgewebe-risk: R3 -->

## Problem
T005 benötigt einen revisionsgebundenen, fehlertoleranten PostgreSQL-Projektionspfad und einen real nutzbaren lokalen Backfill. Der bisherige Worker-/Backfill-Stand hatte keinen funktionsfähigen realen Providerpfad, keine reale PostgreSQL-Race-Evidenz und unvollständige Retry-/Generation-/Rollback-Grenzen.

## Architekturentscheidung
- PostgreSQL bleibt kanonisch und alleiniger Projektionsspeicher.
- Interne Generationen binden Provider, Modell-ID/-Revision, Runtime-Identität, Dimension sowie Dokument-, Normalisierungs- und Rankingrevision.
- Lokaler Provider ist ausschließlich `local:ollama` über Literal-Loopback; kein Proxy, Cloudprovider oder externer Vektorindex.
- Backfill ist begrenzt und resumierbar und aktiviert Generationen ausdrücklich nicht automatisch.

## Race-, Retry- und Generation-Vertrag
- Revisions- und Lease-Fencing bis in die mutierende SQL-Anweisung; `attempt_count` ist Fencing-Token.
- `FOR UPDATE SKIP LOCKED` für Multi-Instance-Claims.
- Advisory-Lock serialisiert relevante Domain-Mutationen mit Generationsstart und Aktivierung.
- Nur echte temporäre Provider-/Transportfehler sind retryfähig; 408/429/5xx und Transportabbrüche degradieren, Vertrags-/Identitäts-/Dimensions-/Formatfehler scheitern permanent.
- Provider-Retries sind auf acht Versuche begrenzt; expliziter erneuter Start derselben exakten Generation rearmt nur wegen Provider-Nichtverfügbarkeit ausgeschöpfte Jobs.
- Aktivierung verlangt keine offenen Jobs, vollständige aktuelle Projektionen und keine Tombstone-Projektionen.
- Retired Generationen sind nicht direkt reaktivierbar; Rollback erfolgt nur über eine vollständig nachgezogene `ready`-Generation.
- Löschung und Sichtbarkeitsentzug werden für aktive und rollbackfähige Generationen nachgezogen.

## Datenschutzgrenze
- Keine Dokumenttexte, Rohvektoren oder Providerantworten in Logs, Metriken oder Backfill-Ausgabe.
- Adresse und irrelevante Payload-Felder werden nicht in das Suchdokument aufgenommen und erzeugen keine Projektionsarbeit.
- Unbekannte oder fehlende Suchsichtbarkeit bleibt fail-closed verborgen.

## Testevidenz
Auf dem finalen Patch-Digest `98916aada86d778611b085bb0474bcda69a6a34375ee1e9a9d72ef5ed5f6fdf0` grün:
- `cargo fmt --check`
- `git diff --check`
- `cargo check --locked -p weltgewebe-api`
- vollständige `cargo test --locked -p weltgewebe-api`
- 63 Semantic-Search-Python-Tests
- Shell-Syntax des PostgreSQL-Proof-Scripts
- vollständiger kanonischer PostgreSQL-16- plus JetStream-Proof
- echte Multi-Instance-, Race-, Lease-, stale UPSERT/DELETE-, Retry-, Rollback-, Delete-, Digest- und Invalid-Document-Fälle
- echter Ollama-0.12.6-Pfad mit `qwen3-embedding:4b`
- echter `search-backfill`-Binary gegen Wegwerf-PostgreSQL und lokalen Ollama-Provider ohne Aktivierung
- unabhängiger head-/diff-gebundener Review: PASS

## Nichtziele
- keine Produktionsaktivierung oder Deployment-Änderung
- keine Search-API
- kein ANN/HNSW
- kein externer Vektorindex
- keine SemantAH-Abhängigkeit

Bewusste Grenze: Die Projektion behandelt ausschließlich explizites `search_visibility == "public"` als sichtbar und bleibt sonst fail-closed. Die exakte autoritative fachliche Sichtbarkeitsabbildung wird separat im Bureau nachgeführt.