### PR TITLE
ci(kubernetes): harden proof artifact evidence

### DIFF
--- a/.github/workflows/kubernetes-platform.yml
+++ b/.github/workflows/kubernetes-platform.yml
@@ -94,12 +94,22 @@ jobs:
           --cluster "$CLUSTER_NAME"
           --mode gitops
           --source-commit "$GITHUB_SHA"
+      - name: Stage failure diagnostics
+        if: failure()
+        run: |
+          set -euo pipefail
+          source=.cache/weltgewebe-platform/failures
+          target=build/kubernetes-platform/failures
+          if [[ -d "$source" ]]; then
+            mkdir -p "$target"
+            cp -a "$source"/. "$target"/
+          fi
       - name: Collect failure diagnostics
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: kubernetes-platform-failure-${{ github.run_id }}-${{ github.run_attempt }}
-          path: .cache/weltgewebe-platform/failures/
+          path: build/kubernetes-platform/failures/
           if-no-files-found: ignore
           retention-days: 7
 
@@ -122,20 +132,35 @@ jobs:
         run: >-
           python scripts/platform/ha_reference.py proof
           --cluster "$CLUSTER_NAME"
+      - name: Stage HA recovery receipt
+        run: |
+          set -euo pipefail
+          mkdir -p build/kubernetes-platform/ha-recovery
+          cp -- .cache/weltgewebe-platform/receipts/*-ha-recovery.json \
+            build/kubernetes-platform/ha-recovery/
       - name: Upload HA recovery receipt
-        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: kubernetes-ha-recovery-${{ github.run_id }}-${{ github.run_attempt }}
-          path: .cache/weltgewebe-platform/receipts/*-ha-recovery.json
-          if-no-files-found: ignore
+          path: build/kubernetes-platform/ha-recovery/*.json
+          if-no-files-found: error
           retention-days: 14
+      - name: Stage HA failure diagnostics
+        if: failure()
+        run: |
+          set -euo pipefail
+          source=.cache/weltgewebe-platform/failures
+          target=build/kubernetes-platform/failures
+          if [[ -d "$source" ]]; then
+            mkdir -p "$target"
+            cp -a "$source"/. "$target"/
+          fi
       - name: Collect HA failure diagnostics
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: kubernetes-ha-failure-${{ github.run_id }}-${{ github.run_attempt }}
-          path: .cache/weltgewebe-platform/failures/
+          path: build/kubernetes-platform/failures/
           if-no-files-found: ignore
           retention-days: 14
       - name: Reconcile owned HA proof resources

--- a/.github/workflows/production-live-contract.yml
+++ b/.github/workflows/production-live-contract.yml
@@ -121,7 +121,7 @@ jobs:
             "$BASE_SHA" "$HEAD_SHA" "$digest" "$bytes" \
             > review-diff-manifest.txt
       - name: Upload exact review diff
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: review-diff-pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
           path: |
@@ -165,7 +165,7 @@ jobs:
             --output production-live-receipt.json
       - name: Upload production receipt
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: production-live-${{ steps.target.outputs.commit }}
           path: production-live-receipt.json

--- a/scripts/ci/tests/test_kubernetes_platform_contract.py
+++ b/scripts/ci/tests/test_kubernetes_platform_contract.py
@@ -44,6 +44,57 @@ class KubernetesPlatformContractTests(unittest.TestCase):
         result = self.validator.validate(render=False)
         self.assertEqual(result["status"], "pass")
 
+    def test_kubernetes_artifact_uploads_stage_hidden_evidence(self) -> None:
+        workflow_path = ROOT / ".github/workflows/kubernetes-platform.yml"
+        workflow = yaml.safe_load(workflow_path.read_text())
+
+        def named_steps(job_name: str) -> dict[str, dict]:
+            return {
+                step["name"]: step
+                for step in workflow["jobs"][job_name]["steps"]
+                if "name" in step
+            }
+
+        gitops = named_steps("kind-gitops-proof")
+        stage_failure = gitops["Stage failure diagnostics"]
+        upload_failure = gitops["Collect failure diagnostics"]
+        self.assertEqual(stage_failure["if"], "failure()")
+        self.assertIn("source=.cache/weltgewebe-platform/failures", stage_failure["run"])
+        self.assertIn("target=build/kubernetes-platform/failures", stage_failure["run"])
+        self.assertEqual(upload_failure["with"]["path"], "build/kubernetes-platform/failures/")
+        self.assertEqual(upload_failure["with"]["if-no-files-found"], "ignore")
+
+        ha = named_steps("kind-ha-recovery-proof")
+        stage_receipt = ha["Stage HA recovery receipt"]
+        upload_receipt = ha["Upload HA recovery receipt"]
+        self.assertNotIn("if", stage_receipt)
+        self.assertIn(
+            ".cache/weltgewebe-platform/receipts/*-ha-recovery.json",
+            stage_receipt["run"],
+        )
+        self.assertIn("build/kubernetes-platform/ha-recovery/", stage_receipt["run"])
+        self.assertNotIn("if", upload_receipt)
+        self.assertEqual(
+            upload_receipt["with"]["path"],
+            "build/kubernetes-platform/ha-recovery/*.json",
+        )
+        self.assertEqual(upload_receipt["with"]["if-no-files-found"], "error")
+
+        stage_ha_failure = ha["Stage HA failure diagnostics"]
+        upload_ha_failure = ha["Collect HA failure diagnostics"]
+        self.assertEqual(stage_ha_failure["if"], "failure()")
+        self.assertIn("source=.cache/weltgewebe-platform/failures", stage_ha_failure["run"])
+        self.assertEqual(
+            upload_ha_failure["with"]["path"],
+            "build/kubernetes-platform/failures/",
+        )
+        self.assertEqual(upload_ha_failure["with"]["if-no-files-found"], "ignore")
+
+        for job_name in ("kind-gitops-proof", "kind-ha-recovery-proof"):
+            for step in workflow["jobs"][job_name]["steps"]:
+                if str(step.get("uses", "")).startswith("actions/upload-artifact@"):
+                    self.assertNotIn(".cache/", str((step.get("with") or {}).get("path", "")))
+
     def test_ci_proof_binds_pull_requests_to_checked_out_merge_state(self) -> None:
         workflow_path = ROOT / ".github/workflows/kubernetes-platform.yml"
         workflow_text = workflow_path.read_text()


### PR DESCRIPTION
Diese Änderung härtet die nach PR #1528 aufgefallene Artefakt-Evidenzlogik gezielt, ohne die Action-Pins erneut zu verändern.

Änderungen:
- Kubernetes-Failure-Diagnostics werden vor dem Upload aus dem versteckten `.cache/...`-Pfad nach `build/kubernetes-platform/failures/` gespiegelt. Damit werden sie von `actions/upload-artifact@v7.0.1` nicht mehr wegen `include-hidden-files: false` still ausgeschlossen.
- Der HA-Recovery-Receipt wird nach erfolgreichem Proof nach `build/kubernetes-platform/ha-recovery/` gestaged und mit `if-no-files-found: error` fail-closed hochgeladen.
- Failure-Diagnostics bleiben bewusst best-effort (`if-no-files-found: ignore`), damit fehlende Diagnoseausgabe nicht den ursprünglichen Proof-Fehler überdeckt.
- Die zwei bestehenden `upload-artifact`-Pins im Production-Live-Contract erhalten nur den fehlenden Kommentar `# tag: v7.0.1`.
- Neuer Regressionstest bindet Staging-Pfade und fail-closed Receipt-Vertrag.

Nicht umgesetzt, weil bereits korrekt oder nicht sinnvoll:
- Review-Diff, Production-Receipt und Review-Evidence sind bereits fail-closed und haben 30 Tage Retention.
- Playwright-Cache-Keys sind bereits an Playwright-Version bzw. `pnpm-lock.yaml` gebunden.
- `actions/cache@v6.1.0` markiert `save-always` upstream selbst als deprecated und nicht wie beabsichtigt funktionierend.
- Keine pauschale `include-hidden-files: true`-Freigabe, um versehentlichen Upload sensibler Punktdateien zu vermeiden.

Lokale Prüfungen:
- `git diff --check`: grün
- `yamllint --strict`: grün
- `python3 scripts/platform/validate_platform.py`: PASS
- Kubernetes-Platform-Contract: 40/40 grün
- Review-Governance: 45/45 grün

<!-- weltgewebe-risk: R3 -->