### PR TITLE
fix(security): keep Prometheus metrics private at public edge

### DIFF
--- a/docs/_generated/backlinks.md
+++ b/docs/_generated/backlinks.md
@@ -519,6 +519,7 @@ Generated automatically. Do not edit.
 
 - [relates_to] docs/deploy/README.md
 - [relates_to] docs/deploy/merge-to-live.md
+- [relates_to] docs/deploy/public-metrics-boundary.md
 - [relates_to] docs/deploy/vps-http-smoke.md
 - [relates_to] docs/runbooks/weltgewebe-ddns-runtime-verification.md
 
@@ -1132,6 +1133,7 @@ Generated automatically. Do not edit.
 
 ## infra/caddy/Caddyfile.vps
 
+- [relates_to] docs/deploy/public-metrics-boundary.md
 - [relates_to] docs/deploy/vps-http-smoke.md
 
 ## infra/compose/compose.prod.override.yml
@@ -1143,6 +1145,10 @@ Generated automatically. Do not edit.
 - [relates_to] docs/deploy/vps-http-route-smoke.md
 - [relates_to] docs/deploy/vps-http-smoke.md
 - [relates_to] docs/deploy/vps-migration-safe-runtime-smoke.md
+
+## infra/compose/monitoring/prometheus.yml
+
+- [relates_to] docs/deploy/public-metrics-boundary.md
 
 ## platform/README.md
 

--- a/docs/_generated/doc-index.md
+++ b/docs/_generated/doc-index.md
@@ -47,6 +47,7 @@ Generated automatically. Do not edit.
 | deploy.heimserver.deployment | Heimserver Deployment | reference | deprecated | docs/deploy/heimserver.deployment.md |
 | deploy.heimserver.integration | Heimserver Integration | reference | deprecated | docs/deploy/heimserver.integration.md |
 | deploy.public-app-base-url | Public APP_BASE_URL Contract | reference | active | docs/deploy/public-app-base-url.md |
+| deploy.public-metrics-boundary | Public Metrics Boundary | reference | active | docs/deploy/public-metrics-boundary.md |
 | deploy.secondary-domain-web-surfaces | Sekundäre Domain-Webflächen | reference | active | docs/deploy/secondary-domain-web-surfaces.md |
 | deploy.security | Deploy Security | architecture | active | docs/deploy/security.md |
 | deploy.vps | VPS-Deployment | reference | active | docs/deploy/vps.md |

--- a/docs/_generated/relates-to-audit.md
+++ b/docs/_generated/relates-to-audit.md
@@ -14,9 +14,9 @@ Generated automatically. Do not edit.
 
 | Metrik | Wert |
 | --- | --- |
-| Relationen gesamt | 642 |
+| Relationen gesamt | 645 |
 | — depends_on | 25 |
-| — relates_to | 600 |
+| — relates_to | 603 |
 | — supersedes | 12 |
 | — verifies | 5 |
 | relates_to Anteil | 93% |
@@ -31,7 +31,7 @@ _Keine Lücken erkannt._
 
 > Zusammenhängende Gruppen im relates_to-Graphen.
 
-**Cluster 1** (256 Dokumente):
+**Cluster 1** (258 Dokumente):
 
 - `.github/workflows/api.yml`
 - `.github/workflows/basemap-runtime-proof.yml`
@@ -117,6 +117,7 @@ _Keine Lücken erkannt._
 - `docs/deploy/heimserver.integration.md`
 - `docs/deploy/merge-to-live.md`
 - `docs/deploy/public-app-base-url.md`
+- `docs/deploy/public-metrics-boundary.md`
 - `docs/deploy/secondary-domain-web-surfaces.md`
 - `docs/deploy/security.md`
 - `docs/deploy/vps-db-initialization-boundary.md`
@@ -247,6 +248,7 @@ _Keine Lücken erkannt._
 - `infra/caddy/Caddyfile.vps`
 - `infra/compose/compose.prod.override.yml`
 - `infra/compose/compose.vps.override.yml`
+- `infra/compose/monitoring/prometheus.yml`
 - `platform/README.md`
 - `repo.meta.yaml`
 - `runbooks/README.md`

--- a/docs/_generated/relations-analysis.md
+++ b/docs/_generated/relations-analysis.md
@@ -14,12 +14,12 @@ Generated automatically. Do not edit.
 
 | Metrik | Wert |
 | --- | --- |
-| Dokumente gesamt | 183 |
-| Dokumente mit ausgehenden Relationen | 182 |
+| Dokumente gesamt | 184 |
+| Dokumente mit ausgehenden Relationen | 183 |
 | Dokumente als Ziel referenziert | 138 |
-| Relationen gesamt | 642 |
+| Relationen gesamt | 645 |
 | — depends_on | 25 |
-| — relates_to | 600 |
+| — relates_to | 603 |
 | — supersedes | 12 |
 | — verifies | 5 |
 | Isolierte Dokumente | 0 |

--- a/docs/deploy/public-metrics-boundary.md
+++ b/docs/deploy/public-metrics-boundary.md
@@ -1,19 +1,21 @@
 # Public metrics boundary
 
-The API exposes Prometheus metrics on its internal `/metrics` route. The documented
-Prometheus scraper reaches the API directly through `host.docker.internal:8080`,
-using Prometheus' default `/metrics` path. This internal scrape path does not
-require public Internet exposure.
+The API exposes Prometheus metrics on its internal `/metrics` route. A reference
+Prometheus configuration in `infra/compose/monitoring/prometheus.yml` targets
+`host.docker.internal:8080`, so that reference path does not require public
+Internet exposure. The current optional local observability Compose profile does
+not mount that configuration; this document therefore does not claim a healthy
+or production Prometheus scrape path.
 
-The production VPS edge therefore keeps operational metrics private:
+The production VPS edge keeps operational metrics private:
 
 - `https://weltgewebe.net/api/metrics` and descendants return HTTP `404`;
 - `https://api.weltgewebe.net/metrics` and descendants return HTTP `404`.
 
 `infra/caddy/Caddyfile.vps` enforces this boundary before the generic API reverse
-proxy routes. The API's internal `/metrics` route remains unchanged so the
-Prometheus scrape contract in `infra/compose/monitoring/prometheus.yml` continues
-to work.
+proxy routes. The API's own `/metrics` route remains unchanged. This preserves the
+possibility of an internal scrape without treating the public edge as a scrape
+target; internal scraper health must be verified separately.
 
 After a production deployment, verify the public boundary with read-only requests:
 
@@ -23,4 +25,5 @@ curl -sS -o /dev/null -w '%{http_code}\n' https://api.weltgewebe.net/metrics
 ```
 
 Both requests must return `404`. A successful public `404` verifies only the edge
-access boundary; it does not prove that the internal Prometheus scraper is healthy.
+access boundary; it does not prove that an internal Prometheus scraper is configured
+or healthy.

--- a/docs/deploy/public-metrics-boundary.md
+++ b/docs/deploy/public-metrics-boundary.md
@@ -1,0 +1,26 @@
+# Public metrics boundary
+
+The API exposes Prometheus metrics on its internal `/metrics` route. The documented
+Prometheus scraper reaches the API directly through `host.docker.internal:8080`,
+using Prometheus' default `/metrics` path. This internal scrape path does not
+require public Internet exposure.
+
+The production VPS edge therefore keeps operational metrics private:
+
+- `https://weltgewebe.net/api/metrics` and descendants return HTTP `404`;
+- `https://api.weltgewebe.net/metrics` and descendants return HTTP `404`.
+
+`infra/caddy/Caddyfile.vps` enforces this boundary before the generic API reverse
+proxy routes. The API's internal `/metrics` route remains unchanged so the
+Prometheus scrape contract in `infra/compose/monitoring/prometheus.yml` continues
+to work.
+
+After a production deployment, verify the public boundary with read-only requests:
+
+```bash
+curl -sS -o /dev/null -w '%{http_code}\n' https://weltgewebe.net/api/metrics
+curl -sS -o /dev/null -w '%{http_code}\n' https://api.weltgewebe.net/metrics
+```
+
+Both requests must return `404`. A successful public `404` verifies only the edge
+access boundary; it does not prove that the internal Prometheus scraper is healthy.

--- a/docs/deploy/public-metrics-boundary.md
+++ b/docs/deploy/public-metrics-boundary.md
@@ -1,3 +1,17 @@
+---
+id: deploy.public-metrics-boundary
+title: Public Metrics Boundary
+doc_type: reference
+status: active
+summary: Public/private boundary for Prometheus metrics at the production VPS edge.
+relations:
+  - type: relates_to
+    target: docs/deploy/vps.md
+  - type: relates_to
+    target: infra/caddy/Caddyfile.vps
+  - type: relates_to
+    target: infra/compose/monitoring/prometheus.yml
+---
 # Public metrics boundary
 
 The API exposes Prometheus metrics on its internal `/metrics` route. A reference

--- a/docs/deploy/public-metrics-boundary.md
+++ b/docs/deploy/public-metrics-boundary.md
@@ -31,7 +31,8 @@ proxy routes. The API's own `/metrics` route remains unchanged. This preserves t
 possibility of an internal scrape without treating the public edge as a scrape
 target; internal scraper health must be verified separately.
 
-After a production deployment, verify the public boundary with read-only requests:
+After a production deployment, the canonical read-only public readiness checker
+verifies both public metrics routes automatically. They can also be checked directly:
 
 ```bash
 curl -sS -o /dev/null -w '%{http_code}\n' https://weltgewebe.net/api/metrics

--- a/docs/deploy/vps.md
+++ b/docs/deploy/vps.md
@@ -383,8 +383,10 @@ IPv6-DNS-Erwartung geprüft:
 
 Der Check liest keine Runtime-Secrets und verändert keinen Serverzustand. Er
 prüft DNS-A-Records, HTTP-zu-HTTPS-Redirect, Root-/`www`-HTTPS, `/map`,
-`api.weltgewebe.net/health/ready`, `/_app/version.json`, lokale Basemap-Style-,
-Glyph- und PMTiles-Auslieferung. Ein PASS ist ein Public-HTTP(S)-/Basemap-Receipt,
+`api.weltgewebe.net/health/ready`, die privaten öffentlichen Metrics-Grenzen
+`/api/metrics` und `api.weltgewebe.net/metrics` auf HTTP `404`, `/_app/version.json`,
+lokale Basemap-Style-, Glyph- und PMTiles-Auslieferung. Ein PASS ist ein
+Public-HTTP(S)-/Basemap-Receipt,
 aber kein Beweis für IPv6, Mail/SMTP oder Public Login. Der
 Credential-Source-Cutover wird über den ausgewählten `ENV_FILE`-Pfad und die
 Dateimetadaten der Runtime-Secret-Quelle belegt, nicht über den HTTP(S)-Check

--- a/infra/caddy/Caddyfile.vps
+++ b/infra/caddy/Caddyfile.vps
@@ -1,7 +1,7 @@
 (app_common) {
 	encode zstd gzip
 
-	# Prometheus scrapes the API internally on port 8080. Do not expose
+	# The API exposes metrics on its internal service port 8080. Do not expose
 	# operational metrics through the public application edge.
 	handle /api/metrics {
 		respond 404

--- a/infra/caddy/Caddyfile.vps
+++ b/infra/caddy/Caddyfile.vps
@@ -1,6 +1,15 @@
 (app_common) {
 	encode zstd gzip
 
+	# Prometheus scrapes the API internally on port 8080. Do not expose
+	# operational metrics through the public application edge.
+	handle /api/metrics {
+		respond 404
+	}
+	handle /api/metrics/* {
+		respond 404
+	}
+
 	handle_path /api/* {
 		reverse_proxy api:8080 {
 			# Caddy owns the client-IP chain. Never pass a public client's
@@ -100,6 +109,15 @@
 
 (api_common) {
 	encode zstd gzip
+
+	# The public API hostname is not a Prometheus scrape target.
+	handle /metrics {
+		respond 404
+	}
+	handle /metrics/* {
+		respond 404
+	}
+
 	handle /health/proxy {
 		respond 200
 	}
@@ -122,6 +140,13 @@
 http://weltgewebe.net, http://www.weltgewebe.net {
 	handle /health/proxy {
 		respond 200
+	}
+
+	handle /api/metrics {
+		respond 404
+	}
+	handle /api/metrics/* {
+		respond 404
 	}
 
 	handle_path /api/* {

--- a/scripts/ci/tests/test_public_live_readiness.py
+++ b/scripts/ci/tests/test_public_live_readiness.py
@@ -118,6 +118,8 @@ class PublicLiveReadinessTest(unittest.TestCase):
                 "https-root:www.weltgewebe.net",
                 "map-route",
                 "api-ready",
+                "metrics-private:app",
+                "metrics-private:api",
                 "version-json",
                 "basemap-style",
                 "glyph-range",
@@ -178,6 +180,30 @@ class PublicLiveReadinessTest(unittest.TestCase):
 
         self.assertFalse(api_result.ok)
         self.assertEqual(api_result.data["missing"], ["nats"])
+
+    def test_public_metrics_routes_must_return_404(self) -> None:
+        fake = FakeWorld()
+
+        def exposed_fetcher(url: str, headers: Mapping[str, str] | None, timeout: float):
+            if url in {
+                "https://weltgewebe.net/api/metrics",
+                "https://api.weltgewebe.net/metrics",
+            }:
+                return fake.module.FetchResult(url, 200, {"Content-Type": "text/plain"}, b"secret_metric 1")
+            return fake.fetcher(url, headers, timeout)
+
+        checker = fake.module.PublicLiveChecker(
+            resolver=fake.resolver,
+            fetcher=exposed_fetcher,
+        )
+        metrics_results = [
+            result for result in checker.run() if result.name.startswith("metrics-private:")
+        ]
+
+        self.assertEqual(len(metrics_results), 2)
+        self.assertTrue(all(not result.ok for result in metrics_results))
+        self.assertTrue(all(result.data["status"] == 200 for result in metrics_results))
+        self.assertTrue(all("body" not in result.data for result in metrics_results))
 
     def test_basemap_style_requires_revalidating_cache_policy(self) -> None:
         fake = FakeWorld()

--- a/scripts/ci/tests/test_vps_http_route_smoke_docs.py
+++ b/scripts/ci/tests/test_vps_http_route_smoke_docs.py
@@ -115,10 +115,14 @@ class VpsHttpRouteSmokeDocsTest(unittest.TestCase):
             self.repo / "infra" / "compose" / "monitoring" / "prometheus.yml"
         ).read_text(encoding="utf-8")
 
-        self.assertEqual(production.count("handle /api/metrics {"), 2)
-        self.assertEqual(production.count("handle /api/metrics/* {"), 2)
-        self.assertEqual(production.count("handle /metrics {"), 1)
-        self.assertEqual(production.count("handle /metrics/* {"), 1)
+        self.assertEqual(
+            production.count("handle /api/metrics {\n\t\trespond 404\n\t}"), 2
+        )
+        self.assertEqual(
+            production.count("handle /api/metrics/* {\n\t\trespond 404\n\t}"), 2
+        )
+        self.assertEqual(production.count("handle /metrics {\n\t\trespond 404\n\t}"), 1)
+        self.assertEqual(production.count("handle /metrics/* {\n\t\trespond 404\n\t}"), 1)
 
         app_snippet = production.split("(api_common)", maxsplit=1)[0]
         api_snippet = production.split("(api_common)", maxsplit=1)[1].split(

--- a/scripts/ci/tests/test_vps_http_route_smoke_docs.py
+++ b/scripts/ci/tests/test_vps_http_route_smoke_docs.py
@@ -109,6 +109,31 @@ class VpsHttpRouteSmokeDocsTest(unittest.TestCase):
         self.assertNotIn("try_files {path} {path}.html /index.html", production)
         self.assertIn("Unknown paths must remain real 404 responses", production)
 
+    def test_production_caddyfile_keeps_prometheus_metrics_private(self) -> None:
+        production = (self.repo / "infra" / "caddy" / "Caddyfile.vps").read_text(encoding="utf-8")
+        prometheus = (
+            self.repo / "infra" / "compose" / "monitoring" / "prometheus.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertEqual(production.count("handle /api/metrics {"), 2)
+        self.assertEqual(production.count("handle /api/metrics/* {"), 2)
+        self.assertEqual(production.count("handle /metrics {"), 1)
+        self.assertEqual(production.count("handle /metrics/* {"), 1)
+
+        app_snippet = production.split("(api_common)", maxsplit=1)[0]
+        api_snippet = production.split("(api_common)", maxsplit=1)[1].split(
+            "# HTTP sites", maxsplit=1
+        )[0]
+        self.assertLess(
+            app_snippet.index("handle /api/metrics {"),
+            app_snippet.index("handle_path /api/*"),
+        )
+        self.assertLess(
+            api_snippet.index("handle /metrics {"),
+            api_snippet.index("reverse_proxy api:8080"),
+        )
+        self.assertIn("host.docker.internal:8080", prometheus)
+
     def test_production_caddyfile_canonicalizes_only_existing_trailing_slash_routes(self) -> None:
         production = (self.repo / "infra" / "caddy" / "Caddyfile.vps").read_text(encoding="utf-8")
 

--- a/scripts/ci/tests/test_vps_http_route_smoke_docs.py
+++ b/scripts/ci/tests/test_vps_http_route_smoke_docs.py
@@ -111,10 +111,6 @@ class VpsHttpRouteSmokeDocsTest(unittest.TestCase):
 
     def test_production_caddyfile_keeps_prometheus_metrics_private(self) -> None:
         production = (self.repo / "infra" / "caddy" / "Caddyfile.vps").read_text(encoding="utf-8")
-        prometheus = (
-            self.repo / "infra" / "compose" / "monitoring" / "prometheus.yml"
-        ).read_text(encoding="utf-8")
-
         self.assertEqual(
             production.count("handle /api/metrics {\n\t\trespond 404\n\t}"), 2
         )
@@ -136,7 +132,6 @@ class VpsHttpRouteSmokeDocsTest(unittest.TestCase):
             api_snippet.index("handle /metrics {"),
             api_snippet.index("reverse_proxy api:8080"),
         )
-        self.assertIn("host.docker.internal:8080", prometheus)
 
     def test_production_caddyfile_canonicalizes_only_existing_trailing_slash_routes(self) -> None:
         production = (self.repo / "infra" / "caddy" / "Caddyfile.vps").read_text(encoding="utf-8")

--- a/scripts/ops/check_public_live_readiness.py
+++ b/scripts/ops/check_public_live_readiness.py
@@ -187,6 +187,14 @@ class PublicLiveChecker:
             self.check_https_root(self.www_domain),
             self.check_map_route(),
             self.check_api_ready(),
+            self.check_public_metrics_private(
+                "metrics-private:app",
+                f"https://{self.domain}/api/metrics",
+            ),
+            self.check_public_metrics_private(
+                "metrics-private:api",
+                f"https://{self.api_domain}/metrics",
+            ),
             self.check_version_json(),
             self.check_basemap_style(),
             self.check_glyph_range(),
@@ -288,6 +296,20 @@ class PublicLiveChecker:
                 return pass_result("api-ready", "API ready endpoint reports database/nats/policy true", status=result.status)
             return fail_result("api-ready", "API ready endpoint has failed checks", missing=missing, checks=checks)
         return fail_result("api-ready", "API ready endpoint did not report ok", status=result.status, payload=payload)
+
+    def check_public_metrics_private(self, name: str, url: str) -> CheckResult:
+        try:
+            result = self.fetcher(url, None, self.timeout)
+        except Exception as exc:
+            return fail_result(name, str(exc), url=url)
+        if result.status == 404:
+            return pass_result(name, "Public metrics route is not exposed", status=result.status, url=url)
+        return fail_result(
+            name,
+            "Public metrics route is exposed or does not fail closed",
+            status=result.status,
+            url=url,
+        )
 
     def check_version_json(self) -> CheckResult:
         url = f"https://{self.domain}/_app/version.json"


### PR DESCRIPTION
<!-- weltgewebe-risk: R3 -->

## Summary
- return 404 for public `/api/metrics` and `/api/metrics/*` on `weltgewebe.net`
- return 404 for public `/metrics` and `/metrics/*` on `api.weltgewebe.net`
- keep the documented internal Prometheus target `host.docker.internal:8080` unchanged
- add regression coverage for the VPS Caddy routing contract
- document the production public/private metrics boundary and post-deploy checks

## Evidence
- live pre-fix: `https://weltgewebe.net/api/metrics` -> 200
- live pre-fix: `https://api.weltgewebe.net/metrics` -> 200
- `caddy validate --config infra/caddy/Caddyfile.vps` -> valid
- adapted Caddy routes place metric-specific 404 handlers before generic API reverse proxies
- `python3 -m unittest scripts.ci.tests.test_vps_http_route_smoke_docs` -> 10 tests OK
- `just ci` -> success on final head `ca9a528e385b656b51133fa3a4314bb520a0f7b5`

## Risk
R3: production edge routing and deploy-contract change. The API metrics endpoint itself remains unchanged for the internal scraper; only public Caddy ingress is narrowed.