### PR TITLE
docs: fix auth report lifecycle metadata

### DIFF
--- a/docs/_generated/report-lifecycle-inventory.md
+++ b/docs/_generated/report-lifecycle-inventory.md
@@ -51,10 +51,10 @@ Primary references are exact path matches in canonical documentation surfaces. D
 | --- | --- | --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | --- | --- |
 | docs/reports/agent-readiness-audit.md | documentation | active |  |  |  |  |  | 2 | 4 | 1 | lifecycle, owner_task, review_after, lifecycle_state |  |
 | docs/reports/auth-persistence-direct-proof-diagnose-audit.md | report | deprecated | superseded | audit | OPT-API-002 |  | docs/reports/optimierungsstatus.md | 0 | 5 | 4 | review_after |  |
-| docs/reports/auth-persistence-next-step.md | report | deprecated | superseded | decision-prep | OPT-API-002 |  | docs/reports/optimierungsstatus.md | 6 | 6 | 4 | review_after |  |
-| docs/reports/auth-persistence-readiness.md | report | deprecated | superseded | decision-prep | OPT-API-002 |  | docs/reports/auth-persistence-next-step.md | 4 | 6 | 3 | review_after |  |
+| docs/reports/auth-persistence-next-step.md | report | deprecated | superseded | decision-prep | OPT-API-002 |  | docs/reports/optimierungsstatus.md | 5 | 6 | 4 | review_after |  |
+| docs/reports/auth-persistence-readiness.md | report | deprecated | superseded | decision-prep | OPT-API-002 |  | docs/reports/optimierungsstatus.md | 4 | 6 | 3 | review_after |  |
 | docs/reports/auth-persistence-runtime-proof.md | report | deprecated | superseded | proof | OPT-API-002 |  | docs/reports/optimierungsstatus.md | 4 | 5 | 6 | review_after |  |
-| docs/reports/auth-persistence-runtime-target-reconciliation.md | report | active | active | audit | OPT-API-002 | 2026-07-17 |  | 1 | 4 | 5 |  |  |
+| docs/reports/auth-persistence-runtime-target-reconciliation.md | report | active | active | audit | OPT-API-002 | 2026-08-22 |  | 1 | 4 | 5 |  |  |
 | docs/reports/auth-pg-002-controlled-preflight.md | report | active | active | planning | AUTH-PG-002 | 2026-09-30 |  | 1 | 4 | 2 |  |  |
 | docs/reports/auth-pg-002-cutover-plan.md | report | active | active | planning | AUTH-PG-002 | 2026-09-30 |  | 7 | 4 | 4 |  |  |
 | docs/reports/auth-pg-002-passkey-db-store.md | report | active | active | proof | AUTH-PG-002 | 2026-09-30 |  | 3 | 4 | 3 |  |  |
@@ -185,7 +185,6 @@ Primary references are exact path matches in canonical documentation surfaces. D
   - `docs/blueprints/auth-persistence-runtime-proof.md`
   - `docs/proofs/sqlx-pgbouncer-session-crud-proof.md`
   - `docs/reports/auth-persistence-direct-proof-diagnose-audit.md`
-  - `docs/reports/auth-persistence-readiness.md`
   - `docs/reports/auth-persistence-runtime-proof.md`
   - `docs/reports/passkey-register-verify-prep.md`
 

--- a/docs/_generated/report-lifecycle.md
+++ b/docs/_generated/report-lifecycle.md
@@ -43,7 +43,7 @@ This overview is descriptive only. It surfaces lifecycle metadata and validator 
 
 | Report | status | lifecycle | owner_task | review_after | findings |
 | --- | --- | --- | --- | --- | --- |
-| docs/reports/auth-persistence-runtime-target-reconciliation.md | active | audit | OPT-API-002 | 2026-07-17 |  |
+| docs/reports/auth-persistence-runtime-target-reconciliation.md | active | audit | OPT-API-002 | 2026-08-22 |  |
 | docs/reports/auth-pg-002-controlled-preflight.md | active | planning | AUTH-PG-002 | 2026-09-30 |  |
 | docs/reports/auth-pg-002-cutover-plan.md | active | planning | AUTH-PG-002 | 2026-09-30 |  |
 | docs/reports/auth-pg-002-passkey-db-store.md | active | proof | AUTH-PG-002 | 2026-09-30 |  |

--- a/docs/reports/auth-persistence-readiness.md
+++ b/docs/reports/auth-persistence-readiness.md
@@ -6,7 +6,7 @@ status: deprecated
 lifecycle_state: superseded
 lifecycle: decision-prep
 owner_task: OPT-API-002
-superseded_by: docs/reports/auth-persistence-next-step.md
+superseded_by: docs/reports/optimierungsstatus.md
 created: 2026-04-28
 lang: de
 summary: >
@@ -35,10 +35,10 @@ relations:
 - **Lifecycle-State:** superseded
 - **Lifecycle:** decision-prep
 - **Owner-Task:** OPT-API-002
-- **Superseded by:** `docs/reports/auth-persistence-next-step.md`
-- **Bewertung:** Historische Readiness-Diagnose. Der Bericht wurde durch den
-  konkreteren Next-Step-Report abgelöst und enthält mittlerweile überholte
-  Aussagen zum Fehlen von Migrationen. Keine aktuelle Umsetzungsquelle.
+- **Superseded by:** `docs/reports/optimierungsstatus.md`
+- **Bewertung:** Historische Readiness-Diagnose. Der Bericht wurde durch den aktuellen Optimierungsstatus abgelöst und enthält
+  mittlerweile überholte Aussagen zum Fehlen von Migrationen. Keine aktuelle
+  Umsetzungsquelle.
 
 ---
 

--- a/docs/reports/auth-persistence-runtime-target-reconciliation.md
+++ b/docs/reports/auth-persistence-runtime-target-reconciliation.md
@@ -6,7 +6,7 @@ status: active
 lifecycle_state: active
 lifecycle: audit
 owner_task: OPT-API-002
-review_after: 2026-07-17
+review_after: 2026-08-22
 created: 2026-05-13
 lang: de
 summary: >
@@ -49,7 +49,7 @@ relations:
 - **Lifecycle-State:** active
 - **Lifecycle:** audit
 - **Owner-Task:** OPT-API-002
-- **Review after:** 2026-07-17
+- **Review after:** 2026-08-22
 - **Bewertung:** Weiterhin aktiver Architekturabgleich zur Produktionsentscheidung
   direkter PostgreSQL-Pfad vs. PgBouncer-Dev-/Spezialpfad. Keine neue
   Runtime-Aussage in diesem PR.


### PR DESCRIPTION
<!-- weltgewebe-risk: R3 -->

## Zweck
Korrigiert zwei noch auf aktuellem `main` bestehende Lifecycle-Fehler in den Auth-Persistenz-Reports und regeneriert die abhängigen Report-Lifecycle-Artefakte aus einem sauberen Git-Zustand.

## Änderungen
- `auth-persistence-runtime-target-reconciliation.md`: `review_after` von 2026-07-17 auf 2026-08-22
- `auth-persistence-readiness.md`: direkte Supersession auf `docs/reports/optimierungsstatus.md`
- `docs/_generated/report-lifecycle-inventory.md`: vollständig neu generiert
- `docs/_generated/report-lifecycle.md`: abhängige Lifecycle-Zusammenfassung aktualisiert

## Verifikation
- `python3 -m unittest scripts.docmeta.tests.test_generate_report_lifecycle_inventory`: 34/34 grün
- Inventory-Neugenerierung idempotent
- `scripts/docmeta/generated-files-guard.sh`: grün
- zuvor berichtete fremde Referenzdeltas bei Cost/Basemap/Domain-Audits auf aktuellem `main` nicht reproduzierbar

Kein `review_after: N/A`, da dafür keine belegte Schema-Unterstützung vorliegt.