### PR TITLE
fix(t018): decode nullable governance conversation node

### DIFF
--- a/apps/api/src/routes/conversations.rs
+++ b/apps/api/src/routes/conversations.rs
@@ -39,7 +39,7 @@ const MESSAGE_RATE_LIMIT_PER_MINUTE: i64 = 10;
 
 type ConversationRow = (
     String,
-    String,
+    Option<String>,
     String,
     String,
     DateTime<Utc>,
@@ -62,7 +62,7 @@ type MessageRow = (
 pub struct ConversationView {
     pub id: String,
     pub conversation_type: String,
-    pub node_id: String,
+    pub node_id: Option<String>,
     pub visibility: String,
     pub created_at: String,
     pub updated_at: String,
@@ -878,6 +878,28 @@ mod tests {
         ));
         assert!(!conversation_is_writable("governance_proposal", None));
         assert!(!conversation_is_writable("unknown", Some("canonical")));
+    }
+
+    #[test]
+    fn conversation_view_accepts_governance_target_without_node() {
+        let created_at = DateTime::parse_from_rfc3339("2026-07-22T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let updated_at = DateTime::parse_from_rfc3339("2026-07-22T12:00:01Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let view = conversation_from_row((
+            Uuid::new_v4().to_string(),
+            None,
+            "governance_proposal".to_string(),
+            "public".to_string(),
+            created_at,
+            updated_at,
+            None,
+        ));
+
+        assert_eq!(view.conversation_type, "governance_proposal");
+        assert_eq!(view.node_id, None);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

T018 makes `domain_conversations.node_id` nullable for `governance_proposal` targets, while the generic conversation read path still decoded `node_id` into `String`. Reading a governance conversation through the generic GET path could therefore fail on SQL NULL decoding.

## Fix

- decode `ConversationRow.node_id` as `Option<String>`
- expose `ConversationView.node_id` as `Option<String>`; existing node conversations still serialize their value as a string, governance targets serialize `null`
- add a regression test for converting a governance conversation row without a node id

## Verification

- `cargo test --locked --manifest-path apps/api/Cargo.toml routes::conversations::tests` — PASS (4/4)
- `cargo test --locked --manifest-path apps/api/Cargo.toml --test db_governance_conversation_target --no-run` — PASS
- `git diff --check HEAD^..HEAD` — PASS

Base parent checked at `6c2416791daf09869fe51f5f8e0dd3e2dc8864df`; fix head `92ff3afe81ee50c62067cc8aec19cc1a8a9d42ed`.