### PR TITLE
security: harden local postgres root filesystem

### DIFF
--- a/platform/infrastructure/local-data/postgres.yaml
+++ b/platform/infrastructure/local-data/postgres.yaml
@@ -78,6 +78,7 @@ spec:
             capabilities:
               drop: ["ALL"]
             privileged: false
+            readOnlyRootFilesystem: true
           volumeMounts:
             - name: data
               mountPath: /var/lib/postgresql/data


### PR DESCRIPTION
T045 Trivy real-risk remediation.

- adds `readOnlyRootFilesystem: true` to the local PostgreSQL container
- exact pinned Postgres 16 image was proven ready with a read-only rootfs and the existing writable data/run/tmp mount model
- rendered `local-data` Trivy result reduces KSV-0014 from 1 to 0 with no new rule
- canonical `scripts/platform/validate_platform.py --render` passes all 11 render targets

The broader T045 Trivy triage found that 15/21 raw source rule IDs disappear on canonical Kustomize renders; this PR intentionally fixes only the remaining demonstrated HIGH runtime hardening gap.

<!-- weltgewebe-risk: R1 -->