### PR TITLE
fix: reuse validated gateway probe during HA rollout checks

### DIFF
--- a/scripts/ci/tests/test_kubernetes_ha_contract.py
+++ b/scripts/ci/tests/test_kubernetes_ha_contract.py
@@ -1200,6 +1200,22 @@ spec:
         self.assertIn("timed out", sample["stderr"])
         self.assertIn("duration_seconds", sample)
 
+    def test_gateway_availability_sample_rejects_unexpected_json_shape(self) -> None:
+        completed = mock.Mock(
+            returncode=0,
+            stdout=json.dumps(42),
+            stderr="",
+        )
+        with mock.patch.object(
+            self.ha.subprocess, "run", return_value=completed
+        ):
+            sample = self.ha.gateway_projection_sample(
+                "kind-worker", "10.0.0.10", 80, "marker"
+            )
+        self.assertFalse(sample["available"])
+        self.assertIsNone(sample["response_items"])
+        self.assertEqual(sample["response_shape"], "int")
+
     def test_error_budget_is_measured_from_upgrade_and_rollback(self) -> None:
         budget = self.ha.compute_error_budget(
             {

--- a/scripts/platform/ha_reference.py
+++ b/scripts/platform/ha_reference.py
@@ -1335,10 +1335,14 @@ def projection_sample_url(node: str, url: str, marker: str) -> dict[str, Any]:
     except json.JSONDecodeError as error:
         sample["json_error"] = str(error)
         return sample
+    if not isinstance(payload, list):
+        sample["response_items"] = None
+        sample["response_shape"] = type(payload).__name__
+        return sample
     sample["available"] = any(
         isinstance(item, dict) and item.get("id") == marker for item in payload
     )
-    sample["response_items"] = len(payload) if isinstance(payload, list) else None
+    sample["response_items"] = len(payload)
     return sample
 
 


### PR DESCRIPTION
<!-- weltgewebe-risk: R3 -->

## Kontext

Behebt WELTGEWEBE-OS-V1-T039, entdeckt im Failure-Injection-/Recovery-Audit WELTGEWEBE-OS-V1-T022.

## Root Cause

Der HA-Proof validierte zunächst einen funktionierenden Gateway-Probe-Endpunkt, verwarf diesen aber für API-Upgrade und Rollback wieder und kombinierte Node/Adresse erneut. Dadurch konnten Availability-Samples einen unpassenden Probe-Pfad messen, obwohl alle drei API-Replikas erfolgreich ersetzt wurden.

Der Fix bindet Upgrade und Rollback an exakt den zuvor validierten Gateway-Probe-Endpunkt und erweitert Ausfall-Diagnostik um Curl-Returncode/Stderr/Dauer sowie Deployment-, Pod- und EndpointSlice-Zustand beim ersten Ausfallsample.

## Verifikation auf Head 066983b028748bf7e711c120c5f38fa1e46ed10e

- `python3 -m unittest scripts.ci.tests.test_kubernetes_ha_contract` — PASS
- `python3 -m unittest scripts.ci.tests.test_kubernetes_platform_contract` — PASS
- `python3 scripts/platform/validate_platform.py` — PASS
- `git diff --check` — PASS
- vollständiger `scripts/platform/ha_reference.py proof --cluster t039-final-066983b0` — terminal Exit 0 und `{"status":"pass"}`
- Upgrade: 117 Samples, 0 Fehler, 0 s beobachtete Nichtverfügbarkeit, 3/3 Replikas ersetzt
- Rollback: 121 Samples, 0 Fehler, 0 s beobachtete Nichtverfügbarkeit, 3/3 Replikas ersetzt
- PostgreSQL-Failover, JetStream, WAL/Backup und Blank-Cluster-PITR/Restore erfolgreich durchlaufen
- Recovery-Receipt SHA-256: `c62247be112224a1ee229b361d40fac870083b6e0937e4bb4bd0852613d2f5cf`
- Cleanup-Readback: eigene kind-Cluster, Object-Store-Container und Volume entfernt

## Abgrenzung

Der separate Kapazitätsfall „Deployment bei gleichzeitigem Zonenausfall“ wird nicht durch diesen Patch gelöst und wurde im T022-Audit als eigener Bureau-Candidate Event 974 dedupliziert aufgenommen.

Der nach Proof hinzugekommene Main-Commit e14944fb149c0b66b8a1ca4e1e1b26a8603c5067 ändert ausschließlich `platform/infrastructure/local-data/postgres.yaml`; der HA-Proof verwendet `platform/infrastructure/ha-data` und ist davon nicht betroffen.