### PR TITLE
fix: accept forwarded external review evidence

### DIFF
--- a/.github/workflows/review-evidence.yml
+++ b/.github/workflows/review-evidence.yml
@@ -46,7 +46,9 @@ jobs:
           contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
           (
             contains(github.event.comment.body, '<!-- weltgewebe-review-evidence') ||
+            contains(github.event.comment.body, '<!-- weltgewebe-forwarded-review') ||
             contains(github.event.changes.body.from, '<!-- weltgewebe-review-evidence') ||
+            contains(github.event.changes.body.from, '<!-- weltgewebe-forwarded-review') ||
             startsWith(github.event.comment.body, '/review-evidence recheck')
           )
         )

--- a/docs/process/merge-quality-gate.md
+++ b/docs/process/merge-quality-gate.md
@@ -45,10 +45,12 @@ Der Normalfall soll ohne manuelle Hasharbeit auskommen:
    als PR-Kommentare attestieren.
    Alternativ darf ein in der Attester-Liste autorisierter Maintainer einen von
    außen eingeholten und an den Operator weitergereichten vollständigen Reviewbericht
-   mit `weltgewebe-forwarded-review` attestieren. Dieser vereinfachte Beleg muss den
-   aktuellen `head_sha`, Prüferidentität, Reviewachse, Urteil und den Status der
-   Befundauflösung enthalten; der Gate-Code berechnet den Berichtshash selbst. Ein
-   Head-Wechsel macht den Beleg automatisch ungültig.
+   mit `weltgewebe-forwarded-review` attestieren. Dieser vereinfachte Beleg muss
+   `base_sha`, `head_sha` und `diff_sha256` sowie Prüferidentität, Reviewachse,
+   Urteil und den Status der Befundauflösung enthalten; der Gate-Code berechnet
+   den Berichtshash selbst. Ein Basis-, Head- oder Diff-Wechsel macht den Beleg
+   automatisch ungültig. Die Hashfelder kann der Operator aus dem aktuellen
+   Reviewpaket übernehmen; der Nutzer muss sie nicht manuell berechnen.
 
 Bei jedem Push werden alte Freigaben nur dann weitergezählt, wenn GitHub sie
 ausdrücklich an den neuen Head bindet. Für R2 und R3 bleiben frühere Berichte

--- a/docs/process/merge-quality-gate.md
+++ b/docs/process/merge-quality-gate.md
@@ -43,6 +43,12 @@ Der Normalfall soll ohne manuelle Hasharbeit auskommen:
 3. **R2/R3 – Produktlogik oder sicherheitsrelevante Änderung:** Das automatisch
    erzeugte Reviewpaket verwenden und die vollständigen hashgebundenen Berichte
    als PR-Kommentare attestieren.
+   Alternativ darf ein in der Attester-Liste autorisierter Maintainer einen von
+   außen eingeholten und an den Operator weitergereichten vollständigen Reviewbericht
+   mit `weltgewebe-forwarded-review` attestieren. Dieser vereinfachte Beleg muss den
+   aktuellen `head_sha`, Prüferidentität, Reviewachse, Urteil und den Status der
+   Befundauflösung enthalten; der Gate-Code berechnet den Berichtshash selbst. Ein
+   Head-Wechsel macht den Beleg automatisch ungültig.
 
 Bei jedem Push werden alte Freigaben nur dann weitergezählt, wenn GitHub sie
 ausdrücklich an den neuen Head bindet. Für R2 und R3 bleiben frühere Berichte

--- a/scripts/quality/review_governance.py
+++ b/scripts/quality/review_governance.py
@@ -788,6 +788,7 @@ def _evidence_blocks(
             report_text = _normalized_report_text(body[: match.start()])
             report_bytes = report_text.encode("utf-8")
             record = dict(record)
+            record["_payload_keys"] = tuple(record.keys())
             record["_comment_index"] = comment_index
             record["_block_index"] = block_index
             record["_comment_evidence_block_count"] = len(starts)
@@ -831,6 +832,7 @@ def _forwarded_evidence_blocks(
             report_text = _normalized_report_text(body[: match.start()])
             report_bytes = report_text.encode("utf-8")
             record = dict(record)
+            record["_payload_keys"] = tuple(record.keys())
             record["_comment_index"] = comment_index
             record["_block_index"] = block_index
             record["_comment_evidence_block_count"] = len(starts)
@@ -947,6 +949,15 @@ def evaluate_evidence(
 
     records, evidence_parse_failures, oversized_evidence = _evidence_blocks(comments)
     forwarded_records, forwarded_parse_failures, forwarded_oversized = _forwarded_evidence_blocks(comments)
+    total_blocks_by_comment = {
+        index: len(EVIDENCE_START_RE.findall(str(comment.get("body") or "")))
+        + len(FORWARDED_EVIDENCE_START_RE.findall(str(comment.get("body") or "")))
+        for index, comment in enumerate(comments)
+    }
+    for record in [*records, *forwarded_records]:
+        record["_comment_evidence_block_count"] = total_blocks_by_comment.get(
+            int(record.get("_comment_index", -1)), 0
+        )
     exact: list[dict[str, Any]] = []
     stale = 0
     unauthorized = 0
@@ -973,8 +984,12 @@ def evaluate_evidence(
             "verdict",
             "findings_resolved",
         }
-        external_fields = {key for key in record if not key.startswith("_")}
-        if external_fields != required_fields:
+        payload_keys = record.get("_payload_keys", ())
+        if (
+            not isinstance(payload_keys, tuple)
+            or any(str(key).startswith("_") for key in payload_keys)
+            or set(payload_keys) != required_fields
+        ):
             malformed += 1
             continue
         schema_version = record.get("schema_version")
@@ -1034,17 +1049,32 @@ def evaluate_evidence(
             continue
         required_fields = {
             "schema_version",
+            "base_sha",
             "head_sha",
+            "diff_sha256",
             "reviewer",
             "review_axis",
             "verdict",
             "findings_resolved",
         }
-        external_fields = {key for key in record if not key.startswith("_")}
-        if external_fields != required_fields:
+        payload_keys = record.get("_payload_keys", ())
+        if (
+            not isinstance(payload_keys, tuple)
+            or any(str(key).startswith("_") for key in payload_keys)
+            or set(payload_keys) != required_fields
+        ):
             malformed += 1
             continue
-        if record.get("schema_version") != SCHEMA_VERSION or record.get("head_sha") != bundle.head_sha:
+        schema_version = record.get("schema_version")
+        if not isinstance(schema_version, int) or isinstance(schema_version, bool):
+            malformed += 1
+            continue
+        if (
+            schema_version != SCHEMA_VERSION
+            or record.get("base_sha") != bundle.base_sha
+            or record.get("head_sha") != bundle.head_sha
+            or record.get("diff_sha256") != bundle.diff_sha256
+        ):
             stale += 1
             continue
         reviewer_value = record.get("reviewer")

--- a/scripts/quality/review_governance.py
+++ b/scripts/quality/review_governance.py
@@ -58,6 +58,7 @@ ALLOWED_AXES = HIGH_RISK_AXES | {
 }
 RISK_RE = re.compile(r"<!--\s*weltgewebe-risk:\s*(R[0-3])\s*-->", re.IGNORECASE)
 EVIDENCE_START_RE = re.compile(r"<!--\s*weltgewebe-review-evidence\b", re.IGNORECASE)
+FORWARDED_EVIDENCE_START_RE = re.compile(r"<!--\s*weltgewebe-forwarded-review\b", re.IGNORECASE)
 
 
 class GovernanceError(RuntimeError):
@@ -808,6 +809,43 @@ def _evidence_blocks(
     return evidence, parse_failures, oversized_payloads
 
 
+def _forwarded_evidence_blocks(
+    comments: Sequence[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], int, int]:
+    evidence: list[dict[str, Any]] = []
+    parse_failures = 0
+    oversized_payloads = 0
+    for comment_index, comment in enumerate(comments):
+        body = comment.get("body") or ""
+        if not isinstance(body, str):
+            continue
+        starts = list(FORWARDED_EVIDENCE_START_RE.finditer(body))
+        for block_index, match in enumerate(starts):
+            record, failure = _decode_evidence_payload(body, match.end())
+            if failure is not None:
+                parse_failures += 1
+                if failure == "oversized":
+                    oversized_payloads += 1
+                continue
+            assert record is not None
+            report_text = _normalized_report_text(body[: match.start()])
+            report_bytes = report_text.encode("utf-8")
+            record = dict(record)
+            record["_comment_index"] = comment_index
+            record["_block_index"] = block_index
+            record["_comment_evidence_block_count"] = len(starts)
+            record["_report_text_bytes"] = len(report_bytes)
+            record["_report_text_sha256"] = _sha256(report_bytes)
+            record["_author_association"] = str(comment.get("author_association") or "").upper()
+            user = comment.get("user") or {}
+            record["_comment_author"] = user.get("login") if isinstance(user, dict) else None
+            record["_comment_url"] = comment.get("html_url")
+            record["_comment_id"] = _numeric_id(comment.get("id"))
+            record["_updated_at"] = comment.get("updated_at") or comment.get("created_at") or ""
+            evidence.append(record)
+    return evidence, parse_failures, oversized_payloads
+
+
 def _native_review_evidence(
     *,
     reviews: Sequence[dict[str, Any]],
@@ -908,10 +946,12 @@ def evaluate_evidence(
             reasons.append(detail)
 
     records, evidence_parse_failures, oversized_evidence = _evidence_blocks(comments)
+    forwarded_records, forwarded_parse_failures, forwarded_oversized = _forwarded_evidence_blocks(comments)
     exact: list[dict[str, Any]] = []
     stale = 0
     unauthorized = 0
-    malformed = evidence_parse_failures
+    malformed = evidence_parse_failures + forwarded_parse_failures
+    oversized_evidence += forwarded_oversized
     for record in records:
         comment_author = str(record.get("_comment_author") or "").strip()
         if (
@@ -982,6 +1022,54 @@ def evaluate_evidence(
         record["report_sha256"] = report_sha256
         record["review_axis"] = axis
         record["verdict"] = verdict
+        exact.append(record)
+
+    for record in forwarded_records:
+        comment_author = str(record.get("_comment_author") or "").strip()
+        if (
+            record.get("_author_association") not in AUTHORIZED_ASSOCIATIONS
+            or comment_author.casefold() not in normalized_attesters
+        ):
+            unauthorized += 1
+            continue
+        required_fields = {
+            "schema_version",
+            "head_sha",
+            "reviewer",
+            "review_axis",
+            "verdict",
+            "findings_resolved",
+        }
+        external_fields = {key for key in record if not key.startswith("_")}
+        if external_fields != required_fields:
+            malformed += 1
+            continue
+        if record.get("schema_version") != SCHEMA_VERSION or record.get("head_sha") != bundle.head_sha:
+            stale += 1
+            continue
+        reviewer_value = record.get("reviewer")
+        reviewer_raw = reviewer_value if isinstance(reviewer_value, str) else ""
+        reviewer = unicodedata.normalize("NFC", reviewer_raw.strip())
+        axis = str(record.get("review_axis") or "").strip().lower()
+        verdict = str(record.get("verdict") or "").strip().upper()
+        if (
+            not reviewer
+            or reviewer_raw != reviewer_raw.strip()
+            or len(reviewer) > 120
+            or any(unicodedata.category(char).startswith("C") for char in reviewer)
+            or record.get("_report_text_bytes", 0) < MIN_REVIEW_REPORT_BYTES
+            or record.get("_comment_evidence_block_count") != 1
+            or axis not in ALLOWED_AXES
+            or verdict not in {"PASS", "BLOCKED", "FAIL"}
+            or not isinstance(record.get("findings_resolved"), bool)
+        ):
+            malformed += 1
+            continue
+        record["reviewer"] = reviewer
+        record["report_sha256"] = record["_report_text_sha256"]
+        record["review_axis"] = axis
+        record["verdict"] = verdict
+        record["_forwarded"] = True
         exact.append(record)
 
     latest: dict[tuple[str, str], dict[str, Any]] = {}
@@ -1080,7 +1168,7 @@ def evaluate_evidence(
 
     accepted_summary = [
         {
-            "kind": "attested-report",
+            "kind": "forwarded-external-review" if record.get("_forwarded") else "attested-report",
             "reviewer": record["reviewer"],
             "report_sha256": record["report_sha256"],
             "review_axis": record["review_axis"],

--- a/scripts/quality/tests/test_review_governance.py
+++ b/scripts/quality/tests/test_review_governance.py
@@ -70,6 +70,34 @@ def _comment(
     }
 
 
+def _forwarded_comment(
+    bundle: Bundle, *, reviewer: str, axis: str, author: str = "alex", comment_id: int = 1
+) -> dict:
+    report = (
+        f"Extern eingeholter Reviewbericht von {reviewer} zur Achse {axis}. "
+        "Der vorgelegte Diff wurde vollständig geprüft, einschließlich Korrektheit, "
+        "Regressionen und relevanter Fehlerszenarien. Alle benannten Befunde wurden "
+        "nachgearbeitet; es verbleiben keine bekannten Mergeblocker."
+    )
+    payload = {
+        "schema_version": 1,
+        "head_sha": bundle.head_sha,
+        "reviewer": reviewer,
+        "review_axis": axis,
+        "verdict": "PASS",
+        "findings_resolved": True,
+    }
+    return {
+        "id": comment_id,
+        "body": report + "\n<!-- weltgewebe-forwarded-review\n" + json.dumps(payload) + "\n-->",
+        "author_association": "OWNER",
+        "user": {"login": author},
+        "html_url": "https://example.invalid/forwarded-review",
+        "created_at": "2026-07-22T12:00:00Z",
+        "updated_at": "2026-07-22T12:00:00Z",
+    }
+
+
 ALLOWED_ATTESTERS = frozenset({"alex"})
 
 
@@ -1163,6 +1191,30 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertEqual(template.count("<!-- weltgewebe-risk: R? -->"), 1)
         self.assertIn("R3 = auth, privacy, security", template)
 
+
+
+class ForwardedExternalReviewTests(unittest.TestCase):
+    def test_owner_forwarded_external_reviews_count_for_r2(self) -> None:
+        bundle = _bundle(paths=("apps/web/src/app.ts",), changed_lines=20)
+        comments = [
+            _forwarded_comment(bundle, reviewer="External LLM A", axis="correctness", comment_id=11),
+            _forwarded_comment(bundle, reviewer="External LLM B", axis="testing", comment_id=12),
+        ]
+        result = _evaluate(bundle=bundle, risk_class="R2", comments=comments)
+        self.assertTrue(result["pass"], result["reasons"])
+        self.assertEqual(result["accepted_review_count"], 2)
+        self.assertEqual(
+            {item["kind"] for item in result["accepted_reviews"]},
+            {"forwarded-external-review"},
+        )
+
+    def test_forwarded_review_is_stale_after_head_change(self) -> None:
+        bundle = _bundle(paths=("apps/web/src/app.ts",), changed_lines=20)
+        comment = _forwarded_comment(bundle, reviewer="External LLM A", axis="correctness")
+        changed = Bundle(**{**bundle.__dict__, "head_sha": "f" * 40})
+        result = _evaluate(bundle=changed, risk_class="R2", comments=[comment])
+        self.assertFalse(result["pass"])
+        self.assertEqual(result["stale_evidence_count"], 1)
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/quality/tests/test_review_governance.py
+++ b/scripts/quality/tests/test_review_governance.py
@@ -1194,7 +1194,6 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("R3 = auth, privacy, security", template)
 
 
-
 class ForwardedExternalReviewTests(unittest.TestCase):
     def test_owner_forwarded_external_reviews_count_for_r2(self) -> None:
         bundle = _bundle(paths=("apps/web/src/app.ts",), changed_lines=20)
@@ -1244,6 +1243,33 @@ class ForwardedExternalReviewTests(unittest.TestCase):
         result = _evaluate(bundle=bundle, risk_class="R2", comments=[native])
         self.assertFalse(result["pass"])
         self.assertGreaterEqual(result["malformed_evidence_count"], 2)
+
+    def test_forwarded_review_rejects_boolean_schema_version(self) -> None:
+        bundle = _bundle(paths=("apps/web/src/app.ts",), changed_lines=20)
+        comment = _forwarded_comment(bundle, reviewer="External LLM A", axis="correctness")
+        comment["body"] = comment["body"].replace(
+            '"schema_version": 1',
+            '"schema_version": true',
+        )
+        result = _evaluate(bundle=bundle, risk_class="R2", comments=[comment])
+        self.assertFalse(result["pass"])
+        self.assertEqual(result["malformed_evidence_count"], 1)
+
+    def test_forwarded_blocking_verdict_does_not_count(self) -> None:
+        bundle = _bundle(paths=("apps/web/src/app.ts",), changed_lines=20)
+        comment = _forwarded_comment(bundle, reviewer="External LLM A", axis="correctness")
+        comment["body"] = comment["body"].replace(
+            '"verdict": "PASS"',
+            '"verdict": "BLOCKED"',
+        ).replace(
+            '"findings_resolved": true',
+            '"findings_resolved": false',
+        )
+        result = _evaluate(bundle=bundle, risk_class="R2", comments=[comment])
+        self.assertFalse(result["pass"])
+        self.assertEqual(result["accepted_review_count"], 0)
+        self.assertTrue(any("blocking verdicts" in reason for reason in result["reasons"]))
+
     def test_forwarded_review_is_stale_after_head_change(self) -> None:
         bundle = _bundle(paths=("apps/web/src/app.ts",), changed_lines=20)
         comment = _forwarded_comment(bundle, reviewer="External LLM A", axis="correctness")

--- a/scripts/quality/tests/test_review_governance.py
+++ b/scripts/quality/tests/test_review_governance.py
@@ -81,7 +81,9 @@ def _forwarded_comment(
     )
     payload = {
         "schema_version": 1,
+        "base_sha": bundle.base_sha,
         "head_sha": bundle.head_sha,
+        "diff_sha256": bundle.diff_sha256,
         "reviewer": reviewer,
         "review_axis": axis,
         "verdict": "PASS",
@@ -1208,6 +1210,40 @@ class ForwardedExternalReviewTests(unittest.TestCase):
             {"forwarded-external-review"},
         )
 
+
+    def test_forwarded_review_is_stale_after_base_or_diff_change(self) -> None:
+        bundle = _bundle(paths=("apps/web/src/app.ts",), changed_lines=20)
+        comment = _forwarded_comment(bundle, reviewer="External LLM A", axis="correctness")
+        changed_base = Bundle(**{**bundle.__dict__, "base_sha": "e" * 40})
+        changed_diff = Bundle(**{**bundle.__dict__, "diff_sha256": "f" * 64})
+        self.assertEqual(
+            _evaluate(bundle=changed_base, risk_class="R2", comments=[comment])["stale_evidence_count"],
+            1,
+        )
+        self.assertEqual(
+            _evaluate(bundle=changed_diff, risk_class="R2", comments=[comment])["stale_evidence_count"],
+            1,
+        )
+
+    def test_forwarded_review_rejects_internal_prefixed_payload_keys(self) -> None:
+        bundle = _bundle(paths=("apps/web/src/app.ts",), changed_lines=20)
+        comment = _forwarded_comment(bundle, reviewer="External LLM A", axis="correctness")
+        comment["body"] = comment["body"].replace(
+            '"findings_resolved": true',
+            '"findings_resolved": true, "_forwarded": true',
+        )
+        result = _evaluate(bundle=bundle, risk_class="R2", comments=[comment])
+        self.assertFalse(result["pass"])
+        self.assertEqual(result["malformed_evidence_count"], 1)
+
+    def test_mixed_native_and_forwarded_blocks_in_one_comment_are_rejected(self) -> None:
+        bundle = _bundle(paths=("apps/web/src/app.ts",), changed_lines=20)
+        native = _comment(_record(bundle, reviewer="Reviewer A", axis="correctness", risk="R2"))
+        forwarded = _forwarded_comment(bundle, reviewer="Reviewer B", axis="testing")
+        native["body"] += "\n" + forwarded["body"]
+        result = _evaluate(bundle=bundle, risk_class="R2", comments=[native])
+        self.assertFalse(result["pass"])
+        self.assertGreaterEqual(result["malformed_evidence_count"], 2)
     def test_forwarded_review_is_stale_after_head_change(self) -> None:
         bundle = _bundle(paths=("apps/web/src/app.ts",), changed_lines=20)
         comment = _forwarded_comment(bundle, reviewer="External LLM A", axis="correctness")


### PR DESCRIPTION
## Zweck
Lockert das Review Evidence Gate gezielt: Von einem autorisierten Maintainer weitergereichte externe LLM-Reviews können als externe Reviews zählen, ohne dass der vollständige Hash-Beleg manuell gebaut werden muss.

<!-- weltgewebe-risk: R3 -->

## Sicherheitsgrenzen
- nur autorisierte Attester (OWNER/MEMBER/COLLABORATOR + Attester-Liste)
- explizite Bindung an den aktuellen `head_sha`
- Reviewbericht muss mindestens 120 Byte enthalten
- weiterhin zwei unterschiedliche Prüfer, Berichte und Reviewachsen für R2/R3
- R3 verlangt weiterhin mindestens eine Hochrisikoachse
- Head-Wechsel macht weitergereichte Reviews stale

## Tests
- `python3 -m unittest scripts.quality.tests.test_review_governance` → 47/47 PASS
- `git diff --check` → PASS