### PR TITLE
fix: make HA API availability proof topology-aware

### DIFF
--- a/docs/adr/ADR-0011__ha-referenzzelle-und-wiederherstellung.md
+++ b/docs/adr/ADR-0011__ha-referenzzelle-und-wiederherstellung.md
@@ -34,7 +34,7 @@ Die T004-Referenzzelle verwendet drei explizite Zonen und folgende Verträge:
 - einen ausschließlich für den Beweis verwendeten externen S3-kompatiblen SeaweedFS-Dienst,
 - dynamisch erzeugte kurzlebige Secrets statt eingecheckter Zugangsdaten,
 - einen kontrollierten Kubernetes-Rollout auf ein getrenntes unveränderliches API-Artefakt und ein echtes `rollout undo` auf die vorherige Revision,
-- eine während Upgrade und Rollback sekündlich gemessene Gateway-Verfügbarkeit mit Null-Ausfall-Vertrag und ausgewiesenem Referenz-Fehlerbudget,
+- eine während Upgrade und Rollback sekündlich owner-lokal gegen alle beworbenen Gateway-Listener gemessene Gateway-Service-Verfügbarkeit der Referenzzelle mit Null-Ausfall-Vertrag, separat ausgewiesener Listener-Degradation und Referenz-Fehlerbudget,
 - einen kontrollierten Ausfall des Worker-Knotens, der den PostgreSQL-Primary trägt,
 - einen neuen zweiten kind-Cluster für den Point-in-Time-Restore, der nach dem Restore selbst wieder WAL archiviert.
 
@@ -53,7 +53,7 @@ Der Beweis erfasst getrennt:
 - erzwungene WAL-Archivlatenz im Primär- und Restorecluster als Referenzobergrenze für den archivierungsgebundenen RPO,
 - Datenvergleich vor und nach dem gewählten PITR-Zeitpunkt.
 
-Eine Messung gilt nur, wenn Upgrade und Rollback keinen beobachteten Gateway-Ausfall erzeugen, alle drei API-Pods ersetzt werden und die vor dem Ausfall bestätigte Domänenmutation sowie die JetStream-Nachricht erhalten bleiben. Das Upgrade-Artefakt verwendet dieselben Runtime-Bits mit abweichender unveränderlicher Metadatenebene; damit wird der Kubernetes-Änderungspfad, nicht die semantische Kompatibilität einer neuen Anwendungsversion bewiesen.
+Eine Messung gilt nur, wenn Upgrade und Rollback über die owner-lokal geprüften beworbenen Gateway-Listener keinen globalen Gateway-Ausfall der Referenzzelle erzeugen, alle drei API-Pods ersetzt werden und die vor dem Ausfall bestätigte Domänenmutation sowie die JetStream-Nachricht erhalten bleiben. Globaler Gateway-Ausfall bedeutet, dass in einer Stichprobe keiner der beworbenen Listener aus dem Netzraum seines zugehörigen Kind-Node-Owners die bestätigte API-Mutation liefert. Ausfälle einzelner Listener werden als Pfaddegradation separat erfasst. Cross-Node-Kind-/Cilium-Pfade gehören nicht zum Ausfallvertrag und werden als eigener Infrastrukturbefund behandelt. Da die Cilium-Gateway-Adressen der Kind-Referenzzelle außerhalb der Kind-Node-Netzräume nicht routbar sind, belegt diese Messung ausdrücklich keine externe Host- oder Produktions-Load-Balancer-Erreichbarkeit. Das Upgrade-Artefakt verwendet dieselben Runtime-Bits mit abweichender unveränderlicher Metadatenebene; damit wird der Kubernetes-Änderungspfad, nicht die semantische Kompatibilität einer neuen Anwendungsversion bewiesen.
 
 ## Sicherheitsgrenzen
 

--- a/docs/runbooks/kubernetes-ha-recovery-proof.md
+++ b/docs/runbooks/kubernetes-ha-recovery-proof.md
@@ -33,8 +33,8 @@ Der Runner installiert Werkzeuge ausschließlich aus `platform/toolchain.lock.js
 2. Cilium, Gateway API, Flux, cert-manager, drei auf unterschiedliche Knoten verteilte CloudNativePG-Operatorreplikate und das Barman-Cloud-Plugin installieren.
 3. Das Plugin- und Instanz-Sidecar-Image digestgebunden zurücklesen, den pluginbasierten `ObjectStore` anwenden und PostgreSQL, NATS JetStream sowie drei API-Replikate über die Zonen verteilen.
 4. Eine gültige `domain_nodes`-Mutation schreiben und über die API zurücklesen.
-5. Ein getrenntes unveränderliches API-Artefakt aus denselben Runtime-Bits laden, alle drei Replikate darauf ausrollen, die Gateway-Verfügbarkeit sekündlich messen und per `rollout undo` auf die vorherige Revision zurückkehren.
-6. Upgrade-, Rollback- und Fehlerbudgetwerte festhalten; jede beobachtete Gateway-Unterbrechung lässt den Beweis scheitern.
+5. Ein getrenntes unveränderliches API-Artefakt aus denselben Runtime-Bits laden, alle drei Replikate darauf ausrollen, jeden beworbenen Gateway-Listener sekündlich aus dem Netzraum seines zugehörigen Kind-Node-Owners prüfen und per `rollout undo` auf die vorherige Revision zurückkehren.
+6. Upgrade-, Rollback- und Fehlerbudgetwerte festhalten. Ein globaler Gateway-Ausfall der Referenzzelle liegt nur vor, wenn in einer Stichprobe kein owner-lokal geprüfter Gateway-Listener die bestätigte API-Mutation liefert; einzelne ausgefallene Listener werden getrennt als Pfaddegradation ausgewiesen. Cross-Node-Kind-/Cilium-Pfadstörungen sind ein separater Infrastrukturbefund. Externe Host- oder Load-Balancer-Erreichbarkeit außerhalb der Kind-Bridge wird damit ausdrücklich nicht bewiesen.
 7. Den Worker des PostgreSQL-Primary stoppen.
 8. PostgreSQL-Failover, API-Readback und JetStream-Quorum messen.
 9. Worker wieder aufnehmen und vollständige Bereitschaft abwarten.

--- a/platform/apps/weltgewebe/overlays/ha/deployment-patch.yaml
+++ b/platform/apps/weltgewebe/overlays/ha/deployment-patch.yaml
@@ -8,19 +8,21 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     spec:
       nodeSelector:
         weltgewebe.net/data-node: "true"
       affinity:
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchLabels:
-                  app.kubernetes.io/name: weltgewebe-api
-              topologyKey: topology.kubernetes.io/zone
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: weltgewebe-api
+                topologyKey: topology.kubernetes.io/zone
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/scripts/ci/tests/test_kubernetes_ha_contract.py
+++ b/scripts/ci/tests/test_kubernetes_ha_contract.py
@@ -1024,16 +1024,21 @@ spec:
         spec = api["spec"]
         self.assertEqual(spec["replicas"], 3)
         self.assertEqual(spec["strategy"]["type"], "RollingUpdate")
-        self.assertEqual(spec["strategy"]["rollingUpdate"]["maxSurge"], 0)
+        self.assertEqual(spec["strategy"]["rollingUpdate"]["maxSurge"], 1)
         self.assertEqual(
-            spec["strategy"]["rollingUpdate"]["maxUnavailable"], 1
+            spec["strategy"]["rollingUpdate"]["maxUnavailable"], 0
         )
-        required = spec["template"]["spec"]["affinity"][
+        preferred = spec["template"]["spec"]["affinity"][
             "podAntiAffinity"
-        ]["requiredDuringSchedulingIgnoredDuringExecution"]
+        ]["preferredDuringSchedulingIgnoredDuringExecution"]
+        self.assertEqual(preferred[0]["weight"], 100)
         self.assertEqual(
-            required[0]["topologyKey"], "topology.kubernetes.io/zone"
+            preferred[0]["podAffinityTerm"]["topologyKey"],
+            "topology.kubernetes.io/zone",
         )
+        spread = spec["template"]["spec"]["topologySpreadConstraints"][0]
+        self.assertEqual(spread["maxSkew"], 1)
+        self.assertEqual(spread["whenUnsatisfiable"], "DoNotSchedule")
 
     def test_upgrade_candidate_is_distinct_and_loaded_into_kind(self) -> None:
         baseline = "sha256:" + "a" * 64
@@ -1085,6 +1090,116 @@ spec:
         self.assertEqual(run.call_args.kwargs["timeout"], 5)
         self.assertFalse(run.call_args.kwargs["check"])
 
+    def test_projection_sample_url_preserves_exact_target_and_marker(self) -> None:
+        completed = mock.Mock(
+            returncode=0,
+            stdout='[{"id":"marker"}]',
+            stderr="",
+        )
+        with mock.patch.object(
+            self.ha.subprocess, "run", return_value=completed
+        ) as run:
+            sample = self.ha.projection_sample_url(
+                "kind-worker", "http://10.0.0.12:8080/nodes", "marker"
+            )
+        self.assertTrue(sample["available"])
+        self.assertEqual(sample["url"], "http://10.0.0.12:8080/nodes")
+        self.assertIn("http://10.0.0.12:8080/nodes", run.call_args.args[0])
+        self.assertEqual(run.call_args.kwargs["timeout"], 5)
+        self.assertFalse(run.call_args.kwargs["check"])
+
+    def test_gateway_owner_sample_tolerates_one_failed_advertised_listener(self) -> None:
+        node_addresses = {
+            "node-a": "10.0.0.1",
+            "node-b": "10.0.0.2",
+        }
+
+        def output(argv: list[str]) -> str:
+            return node_addresses[argv[-1]]
+
+        def sample(
+            node: str, address: str, port: int, marker: str
+        ) -> dict[str, object]:
+            available = address == "10.0.0.2"
+            return {
+                "available": available,
+                "url": f"http://{address}:{port}/api/nodes",
+                "returncode": 0 if available else 28,
+            }
+
+        with mock.patch.object(
+            self.ha.ref, "kind_nodes", return_value=["node-a", "node-b"]
+        ), mock.patch.object(
+            self.ha.ref, "output", side_effect=output
+        ), mock.patch.object(
+            self.ha, "gateway_projection_sample", side_effect=sample
+        ):
+            observed = self.ha.gateway_owner_sample(
+                "kind", "proof", ["10.0.0.1", "10.0.0.2"], 80, "marker"
+            )
+
+        self.assertTrue(observed["available"])
+        self.assertEqual(observed["failed_paths"], 1)
+        self.assertEqual(observed["successful_addresses"], ["10.0.0.2"])
+        self.assertEqual(
+            observed["probe_mode"], "owner-node-any-advertised-address"
+        )
+
+    def test_gateway_owner_sample_fails_when_all_advertised_listeners_fail(self) -> None:
+        node_addresses = {
+            "node-a": "10.0.0.1",
+            "node-b": "10.0.0.2",
+        }
+
+        with mock.patch.object(
+            self.ha.ref, "kind_nodes", return_value=["node-a", "node-b"]
+        ), mock.patch.object(
+            self.ha.ref,
+            "output",
+            side_effect=lambda argv: node_addresses[argv[-1]],
+        ), mock.patch.object(
+            self.ha,
+            "gateway_projection_sample",
+            return_value={"available": False, "returncode": 28},
+        ):
+            observed = self.ha.gateway_owner_sample(
+                "kind", "proof", ["10.0.0.1", "10.0.0.2"], 80, "marker"
+            )
+
+        self.assertFalse(observed["available"])
+        self.assertEqual(observed["successful_addresses"], [])
+        self.assertEqual(observed["failed_paths"], 2)
+
+    def test_gateway_owner_sample_rejects_unowned_advertised_address(self) -> None:
+        with mock.patch.object(
+            self.ha.ref, "kind_nodes", return_value=["node-a"]
+        ), mock.patch.object(
+            self.ha.ref, "output", return_value="10.0.0.1"
+        ):
+            with self.assertRaisesRegex(
+                self.ha.ref.ProofError, "exactly one kind node owner"
+            ):
+                self.ha.gateway_owner_sample(
+                    "kind", "proof", ["10.0.0.2"], 80, "marker"
+                )
+
+    def test_gateway_availability_sample_preserves_failure_diagnostics(self) -> None:
+        completed = mock.Mock(
+            returncode=28,
+            stdout="",
+            stderr="curl: (28) Operation timed out",
+        )
+        with mock.patch.object(
+            self.ha.subprocess, "run", return_value=completed
+        ):
+            sample = self.ha.gateway_projection_sample(
+                "kind-worker", "10.0.0.10", 80, "marker"
+            )
+        self.assertFalse(sample["available"])
+        self.assertEqual(sample["returncode"], 28)
+        self.assertIn("timed out", sample["stderr"])
+        self.assertIn("duration_seconds", sample)
+
     def test_error_budget_is_measured_from_upgrade_and_rollback(self) -> None:
         budget = self.ha.compute_error_budget(
             {
@@ -1109,9 +1224,24 @@ spec:
             '"rollout",\n            "undo"', source
         )
         self.assertIn('"change_management": change_management', source)
+        self.assertIn(
+            "kubectl, kind, args.cluster, marker, gateway_before", source
+        )
+        self.assertIn('probe_node = gateway_probe["probe_node"]', source)
+        self.assertIn('probe_address = gateway_probe["address"]', source)
+        self.assertIn("gateway_owner_sample(", source)
+        self.assertIn("owner-node-any-advertised-address", source)
+        self.assertIn('"degraded_gateway_path_samples"', source)
+        self.assertIn('"failed_gateway_paths_observed"', source)
+        self.assertIn('probe_port = int(gateway_probe["listener_port"])', source)
+        self.assertNotIn("def gateway_probe_target(", source)
         self.assertIn('"failed_availability_samples"', source)
         self.assertIn('"within_budget"', source)
         self.assertIn('"measured_archive_rpo_upper_bound_seconds"', source)
+        self.assertIn(
+            "external load-balancer reachability from outside the kind bridge",
+            source,
+        )
 
     def test_restore_rto_stops_before_continuity_validation(self) -> None:
         source = (ROOT / "scripts/platform/ha_reference.py").read_text()

--- a/scripts/platform/ha_reference.py
+++ b/scripts/platform/ha_reference.py
@@ -10,6 +10,7 @@ import secrets
 import subprocess
 import sys
 import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
 
@@ -1298,34 +1299,8 @@ def api_rollout_complete(kubectl: str, expected_image: str) -> bool:
     )
 
 
-def gateway_probe_target(
-    kubectl: str, kind: str, cluster: str
-) -> tuple[str, str, int]:
-    service = ref.output(
-        [
-            kubectl,
-            "-n",
-            "weltgewebe-gateway",
-            "get",
-            "service",
-            "-l",
-            "gateway.networking.k8s.io/gateway-name=weltgewebe",
-            "-o",
-            "jsonpath={.items[0].metadata.name}",
-        ]
-    )
-    listener_port = ref.gateway_listener_port(kubectl)
-    service_port = ref.gateway_service_listener_port(
-        kubectl, service, listener_port
-    )
-    nodes = ref.kind_nodes(kind, cluster)
-    addresses = ref.gateway_addresses(kubectl)
-    return nodes[0], addresses[0], service_port
-
-
-def gateway_projection_available(
-    node: str, address: str, port: int, marker: str
-) -> bool:
+def projection_sample_url(node: str, url: str, marker: str) -> dict[str, Any]:
+    started = time.monotonic()
     result = subprocess.run(
         [
             "docker",
@@ -1337,7 +1312,7 @@ def gateway_projection_available(
             "--show-error",
             "--max-time",
             "2",
-            f"http://{address}:{port}/api/nodes",
+            url,
         ],
         cwd=ROOT,
         text=True,
@@ -1345,30 +1320,363 @@ def gateway_projection_available(
         timeout=5,
         check=False,
     )
+    stderr = result.stderr if isinstance(result.stderr, str) else ""
+    sample: dict[str, Any] = {
+        "available": False,
+        "returncode": result.returncode,
+        "duration_seconds": round(time.monotonic() - started, 3),
+        "stderr": stderr.strip()[:500],
+        "url": url,
+    }
     if result.returncode != 0:
-        return False
+        return sample
     try:
         payload = json.loads(result.stdout)
-    except json.JSONDecodeError:
-        return False
-    return any(
+    except json.JSONDecodeError as error:
+        sample["json_error"] = str(error)
+        return sample
+    sample["available"] = any(
         isinstance(item, dict) and item.get("id") == marker for item in payload
     )
+    sample["response_items"] = len(payload) if isinstance(payload, list) else None
+    return sample
+
+
+def gateway_projection_sample(
+    node: str, address: str, port: int, marker: str
+) -> dict[str, Any]:
+    return projection_sample_url(
+        node, f"http://{address}:{port}/api/nodes", marker
+    )
+
+
+def gateway_projection_available(
+    node: str, address: str, port: int, marker: str
+) -> bool:
+    return bool(
+        gateway_projection_sample(node, address, port, marker)["available"]
+    )
+
+
+def gateway_owner_sample(
+    kind: str,
+    cluster: str,
+    addresses: list[str],
+    port: int,
+    marker: str,
+) -> dict[str, Any]:
+    gateway_addresses = sorted(set(addresses))
+    if not gateway_addresses:
+        raise ref.ProofError("gateway owner probe has no advertised addresses")
+
+    owners_by_address: dict[str, list[str]] = {}
+    for node in sorted(set(ref.kind_nodes(kind, cluster))):
+        address = ref.output(
+            [
+                "docker",
+                "inspect",
+                "--format",
+                '{{(index .NetworkSettings.Networks "kind").IPAddress}}',
+                node,
+            ]
+        )
+        if address:
+            owners_by_address.setdefault(address, []).append(node)
+
+    invalid_owners = {
+        address: owners_by_address.get(address, [])
+        for address in gateway_addresses
+        if len(owners_by_address.get(address, [])) != 1
+    }
+    if invalid_owners:
+        raise ref.ProofError(
+            "advertised gateway addresses do not map to exactly one kind node owner: "
+            f"{invalid_owners}"
+        )
+
+    targets = [
+        (owners_by_address[address][0], address)
+        for address in gateway_addresses
+    ]
+
+    def run_target(target: tuple[str, str]) -> dict[str, Any]:
+        node, address = target
+        try:
+            sample = gateway_projection_sample(node, address, port, marker)
+        except (subprocess.SubprocessError, OSError) as error:
+            sample = {
+                "available": False,
+                "probe_error": f"{type(error).__name__}: {error}",
+                "url": f"http://{address}:{port}/api/nodes",
+            }
+        return {"node": node, "address": address, **sample}
+
+    with ThreadPoolExecutor(max_workers=min(8, len(targets))) as executor:
+        probes = list(executor.map(run_target, targets))
+
+    failed_paths = [probe for probe in probes if probe.get("available") is not True]
+    successful_addresses = [
+        str(probe["address"])
+        for probe in probes
+        if probe.get("available") is True
+    ]
+    return {
+        "available": bool(successful_addresses),
+        "probe_mode": "owner-node-any-advertised-address",
+        "gateway_address_count": len(gateway_addresses),
+        "owner_node_count": len(targets),
+        "successful_paths": len(probes) - len(failed_paths),
+        "failed_paths": len(failed_paths),
+        "successful_addresses": successful_addresses,
+        "path_failures": failed_paths,
+    }
+
+
+def projection_path_diagnostic(
+    kubectl: str,
+    kind: str,
+    cluster: str,
+    *,
+    probe_node: str,
+    probe_address: str,
+    port: int,
+    marker: str,
+    endpoint_state: list[dict[str, Any]],
+) -> dict[str, Any]:
+    service = json.loads(
+        ref.output(
+            [
+                kubectl,
+                "-n",
+                "weltgewebe",
+                "get",
+                "service/weltgewebe-api",
+                "-o",
+                "json",
+            ]
+        )
+    )
+    service_ip = service.get("spec", {}).get("clusterIP")
+    service_ports = service.get("spec", {}).get("ports", [])
+    service_port = next(
+        (item.get("port") for item in service_ports if item.get("name") == "http"),
+        8080,
+    )
+    ready_pod_ips = sorted(
+        {
+            address
+            for endpoint in endpoint_state
+            if endpoint.get("ready") is True
+            and endpoint.get("terminating") is not True
+            for address in endpoint.get("addresses", [])
+            if isinstance(address, str) and address
+        }
+    )
+    targets: list[tuple[str, str, str, str]] = []
+    if isinstance(service_ip, str) and service_ip and service_ip != "None":
+        targets.append(
+            (
+                "service",
+                probe_node,
+                service_ip,
+                f"http://{service_ip}:{service_port}/nodes",
+            )
+        )
+    for pod_ip in ready_pod_ips:
+        targets.append(
+            ("pod", probe_node, pod_ip, f"http://{pod_ip}:8080/nodes")
+        )
+    gateway_addresses = sorted(set(ref.gateway_addresses(kubectl)))
+    gateway_nodes = sorted(set(ref.kind_nodes(kind, cluster)))
+    for node in gateway_nodes:
+        for address in gateway_addresses:
+            targets.append(
+                (
+                    "gateway",
+                    node,
+                    address,
+                    f"http://{address}:{port}/api/nodes",
+                )
+            )
+
+    def run_target(target: tuple[str, str, str, str]) -> dict[str, Any]:
+        layer, node, address, url = target
+        try:
+            sample = projection_sample_url(node, url, marker)
+        except (subprocess.SubprocessError, OSError) as error:
+            sample = {
+                "available": False,
+                "probe_error": f"{type(error).__name__}: {error}",
+                "url": url,
+            }
+        return {
+            "layer": layer,
+            "node": node,
+            "address": address,
+            **sample,
+        }
+
+    if not targets:
+        return {
+            "selected_gateway": {
+                "node": probe_node,
+                "address": probe_address,
+                "port": port,
+            },
+            "probes": [],
+        }
+    with ThreadPoolExecutor(max_workers=min(16, len(targets))) as executor:
+        probes = list(executor.map(run_target, targets))
+    return {
+        "selected_gateway": {
+            "node": probe_node,
+            "address": probe_address,
+            "port": port,
+        },
+        "probes": probes,
+    }
+
+
+def api_transition_diagnostic(
+    kubectl: str,
+    gateway_sample: dict[str, Any],
+    *,
+    kind: str,
+    cluster: str,
+    probe_node: str,
+    probe_address: str,
+    port: int,
+    marker: str,
+) -> dict[str, Any]:
+    deployment = json.loads(
+        ref.output(
+            [
+                kubectl,
+                "-n",
+                "weltgewebe",
+                "get",
+                "deployment/weltgewebe-api",
+                "-o",
+                "json",
+            ]
+        )
+    )
+    pods = json.loads(
+        ref.output(
+            [
+                kubectl,
+                "-n",
+                "weltgewebe",
+                "get",
+                "pods",
+                "-l",
+                "app.kubernetes.io/name=weltgewebe-api",
+                "-o",
+                "json",
+            ]
+        )
+    )
+    endpoint_slices = json.loads(
+        ref.output(
+            [
+                kubectl,
+                "-n",
+                "weltgewebe",
+                "get",
+                "endpointslices.discovery.k8s.io",
+                "-l",
+                "kubernetes.io/service-name=weltgewebe-api",
+                "-o",
+                "json",
+            ]
+        )
+    )
+    pod_state = []
+    for item in pods.get("items", []):
+        conditions = {
+            condition.get("type"): condition.get("status")
+            for condition in item.get("status", {}).get("conditions", [])
+        }
+        pod_state.append(
+            {
+                "name": item.get("metadata", {}).get("name"),
+                "node": item.get("spec", {}).get("nodeName"),
+                "pod_ip": item.get("status", {}).get("podIP"),
+                "phase": item.get("status", {}).get("phase"),
+                "ready": conditions.get("Ready") == "True",
+                "deleting": bool(
+                    item.get("metadata", {}).get("deletionTimestamp")
+                ),
+                "image": next(
+                    (
+                        container.get("image")
+                        for container in item.get("spec", {}).get(
+                            "containers", []
+                        )
+                        if container.get("name") == "api"
+                    ),
+                    None,
+                ),
+            }
+        )
+    endpoint_state = []
+    for item in endpoint_slices.get("items", []):
+        for endpoint in item.get("endpoints", []):
+            endpoint_state.append(
+                {
+                    "addresses": endpoint.get("addresses", []),
+                    "node": endpoint.get("nodeName"),
+                    "target": endpoint.get("targetRef", {}).get("name"),
+                    "ready": endpoint.get("conditions", {}).get("ready"),
+                    "serving": endpoint.get("conditions", {}).get("serving"),
+                    "terminating": endpoint.get("conditions", {}).get(
+                        "terminating"
+                    ),
+                }
+            )
+    status = deployment.get("status", {})
+    metadata = deployment.get("metadata", {})
+    path_diagnostic = projection_path_diagnostic(
+        kubectl,
+        kind,
+        cluster,
+        probe_node=probe_node,
+        probe_address=probe_address,
+        port=port,
+        marker=marker,
+        endpoint_state=endpoint_state,
+    )
+    return {
+        "gateway_sample": gateway_sample,
+        "path_diagnostic": path_diagnostic,
+        "deployment": {
+            "generation": metadata.get("generation"),
+            "observed_generation": status.get("observedGeneration"),
+            "replicas": status.get("replicas"),
+            "updated_replicas": status.get("updatedReplicas"),
+            "ready_replicas": status.get("readyReplicas"),
+            "available_replicas": status.get("availableReplicas"),
+            "unavailable_replicas": status.get("unavailableReplicas", 0),
+        },
+        "pods": pod_state,
+        "endpoint_slices": endpoint_state,
+    }
 
 
 def measure_api_transition(
     kubectl: str,
-    kind: str,
-    cluster: str,
     marker: str,
     expected_image: str,
     action: list[str],
     phase: str,
+    *,
+    kind: str,
+    cluster: str,
+    probe_node: str,
+    probe_address: str,
+    port: int,
 ) -> dict[str, Any]:
     before_uids = ready_api_pod_uids(kubectl)
-    probe_node, probe_address, port = gateway_probe_target(
-        kubectl, kind, cluster
-    )
     started = time.monotonic()
     ref.run(action)
     deadline = started + 600
@@ -1377,14 +1685,28 @@ def measure_api_transition(
     unavailable_seconds = 0.0
     longest_unavailable_seconds = 0.0
     outage_started: float | None = None
+    outage_diagnostics: list[dict[str, Any]] = []
+    degraded_path_samples = 0
+    failed_gateway_paths = 0
+    max_failed_gateway_paths = 0
+    gateway_addresses = sorted(set(ref.gateway_addresses(kubectl)))
     while time.monotonic() < deadline:
         sampled_at = time.monotonic()
         available = False
         rollout_complete = False
+        gateway_sample: dict[str, Any] = {"available": False}
         try:
-            available = gateway_projection_available(
-                probe_node, probe_address, port, marker
+            gateway_sample = gateway_owner_sample(
+                kind, cluster, gateway_addresses, port, marker
             )
+            available = bool(gateway_sample["available"])
+            sample_failed_paths = int(gateway_sample.get("failed_paths", 0))
+            if sample_failed_paths:
+                degraded_path_samples += 1
+                failed_gateway_paths += sample_failed_paths
+                max_failed_gateway_paths = max(
+                    max_failed_gateway_paths, sample_failed_paths
+                )
             if available:
                 rollout_complete = api_rollout_complete(
                     kubectl, expected_image
@@ -1394,7 +1716,11 @@ def measure_api_transition(
             subprocess.TimeoutExpired,
             json.JSONDecodeError,
             ref.ProofError,
-        ):
+        ) as error:
+            gateway_sample = {
+                "available": False,
+                "probe_error": f"{type(error).__name__}: {error}",
+            }
             available = False
             rollout_complete = False
         samples += 1
@@ -1410,6 +1736,32 @@ def measure_api_transition(
             failed_samples += 1
             if outage_started is None:
                 outage_started = sampled_at
+                try:
+                    diagnostic = api_transition_diagnostic(
+                        kubectl,
+                        gateway_sample,
+                        kind=kind,
+                        cluster=cluster,
+                        probe_node=probe_node,
+                        probe_address=probe_address,
+                        port=port,
+                        marker=marker,
+                    )
+                except (
+                    subprocess.CalledProcessError,
+                    subprocess.TimeoutExpired,
+                    json.JSONDecodeError,
+                    ref.ProofError,
+                ) as error:
+                    diagnostic = {
+                        "gateway_sample": gateway_sample,
+                        "diagnostic_error": f"{type(error).__name__}: {error}",
+                    }
+                diagnostic["sample"] = samples
+                diagnostic["elapsed_seconds"] = round(
+                    sampled_at - started, 3
+                )
+                outage_diagnostics.append(diagnostic)
         if available and rollout_complete:
             break
         time.sleep(1)
@@ -1439,13 +1791,19 @@ def measure_api_transition(
         "duration_seconds": round(finished - started, 3),
         "availability_samples": samples,
         "failed_availability_samples": failed_samples,
+        "degraded_gateway_path_samples": degraded_path_samples,
+        "failed_gateway_paths_observed": failed_gateway_paths,
+        "max_failed_gateway_paths_per_sample": max_failed_gateway_paths,
         "observed_unavailable_seconds": round(unavailable_seconds, 3),
         "longest_unavailable_seconds": round(longest_unavailable_seconds, 3),
         "probe_node": probe_node,
         "probe_address": probe_address,
+        "gateway_probe_mode": "owner-node-any-advertised-address",
+        "gateway_addresses": gateway_addresses,
         "before_pods_sha256": sha256_text("\n".join(sorted(before_uids))),
         "after_pods_sha256": sha256_text("\n".join(sorted(after_uids))),
         "replaced_replicas": len(after_uids),
+        "outage_diagnostics": outage_diagnostics,
     }
     if failed_samples:
         raise ref.ProofError(
@@ -1481,17 +1839,28 @@ def compute_error_budget(
 
 
 def prove_api_upgrade_and_rollback(
-    kubectl: str, kind: str, cluster: str, marker: str
+    kubectl: str,
+    kind: str,
+    cluster: str,
+    marker: str,
+    gateway_probe: dict[str, str],
 ) -> dict[str, Any]:
     baseline = api_deployment_image(kubectl)
     if baseline != BASELINE_API_IMAGE:
         raise ref.ProofError(
             f"API baseline image is unexpected before upgrade: {baseline}"
         )
+    try:
+        probe_node = gateway_probe["probe_node"]
+        probe_address = gateway_probe["address"]
+        probe_port = int(gateway_probe["listener_port"])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ref.ProofError(
+            f"validated gateway probe receipt is incomplete: {gateway_probe!r}"
+        ) from error
+
     upgrade = measure_api_transition(
         kubectl,
-        kind,
-        cluster,
         marker,
         UPGRADE_API_IMAGE,
         [
@@ -1504,11 +1873,14 @@ def prove_api_upgrade_and_rollback(
             f"api={UPGRADE_API_IMAGE}",
         ],
         "upgrade",
+        kind=kind,
+        cluster=cluster,
+        probe_node=probe_node,
+        probe_address=probe_address,
+        port=probe_port,
     )
     rollback = measure_api_transition(
         kubectl,
-        kind,
-        cluster,
         marker,
         baseline,
         [
@@ -1520,6 +1892,11 @@ def prove_api_upgrade_and_rollback(
             "deployment/weltgewebe-api",
         ],
         "rollback",
+        kind=kind,
+        cluster=cluster,
+        probe_node=probe_node,
+        probe_address=probe_address,
+        port=probe_port,
     )
     budget = compute_error_budget(upgrade, rollback)
     if not gateway_contains_node(kubectl, kind, cluster, marker):
@@ -1765,7 +2142,7 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
         insert_domain_node(kubectl, marker, "T004 acknowledged domain mutation")
         wait_until("domain mutation in API projection", lambda: gateway_contains_node(kubectl, kind, args.cluster, marker), timeout_seconds=180)
         change_management = prove_api_upgrade_and_rollback(
-            kubectl, kind, args.cluster, marker
+            kubectl, kind, args.cluster, marker, gateway_before
         )
 
         barman_leader_alignment = align_postgres_primary_with_barman_leader(
@@ -1986,6 +2363,7 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
                 "RTO or RPO under production load", "survival of two simultaneous failure domains",
                 "semantic compatibility of a distinct application release",
                 "production error-budget consumption under representative traffic",
+                "external load-balancer reachability from outside the kind bridge",
             ],
         }
         target = CACHE / "receipts"

--- a/scripts/platform/validate_platform.py
+++ b/scripts/platform/validate_platform.py
@@ -324,16 +324,33 @@ def _assert_ha_contract() -> None:
     rolling = api_spec.get("strategy", {}).get("rollingUpdate", {})
     if (
         api_spec.get("strategy", {}).get("type") != "RollingUpdate"
-        or rolling.get("maxSurge") != 0
-        or rolling.get("maxUnavailable") != 1
+        or rolling.get("maxSurge") != 1
+        or rolling.get("maxUnavailable") != 0
     ):
         raise ContractError(
-            "HA API rollout must replace one zoned replica without a surge pod"
+            "HA API rollout must admit one surge replica before terminating an available pod"
         )
     pod = api_spec["template"]["spec"]
     spread = pod.get("topologySpreadConstraints", [])
-    if not spread or spread[0].get("topologyKey") != "topology.kubernetes.io/zone" or spread[0].get("whenUnsatisfiable") != "DoNotSchedule":
-        raise ContractError("HA API does not require zone spread")
+    if (
+        not spread
+        or spread[0].get("maxSkew") != 1
+        or spread[0].get("topologyKey") != "topology.kubernetes.io/zone"
+        or spread[0].get("whenUnsatisfiable") != "DoNotSchedule"
+    ):
+        raise ContractError("HA API does not require bounded zone spread")
+    preferred = (
+        pod.get("affinity", {})
+        .get("podAntiAffinity", {})
+        .get("preferredDuringSchedulingIgnoredDuringExecution", [])
+    )
+    if (
+        not preferred
+        or preferred[0].get("weight") != 100
+        or preferred[0].get("podAffinityTerm", {}).get("topologyKey")
+        != "topology.kubernetes.io/zone"
+    ):
+        raise ContractError("HA API does not prefer zone anti-affinity during surge rollouts")
 
     object_store = next(_documents(PLATFORM / "infrastructure/ha-data/object-store.yaml"))
     if object_store.get("kind") != "Service" or object_store.get("spec", {}).get("selector"):
@@ -367,6 +384,7 @@ def _assert_ha_contract() -> None:
         "prove_api_upgrade_and_rollback", "UPGRADE_API_IMAGE",
         "rollout", "undo", "compute_error_budget",
         "zero-observed-outage", "within_budget",
+        "owner-node-any-advertised-address", "degraded_gateway_path_samples",
         "continued_wal_archiving", "continuity_validation_seconds",
         "measured_archive_rpo_upper_bound_seconds",
     )


### PR DESCRIPTION
## Zusammenfassung

Behebt WELTGEWEBE-OS-V1-T039 und trennt globale Dienstverfügbarkeit von transienten internen Cross-Node-Cilium-Pfaden.

- HA-API-Rollout wird mit `maxSurge: 1` / `maxUnavailable: 0` ausgeführt.
- Zonenspreizung bleibt fail-closed; Pod-Anti-Affinität ist während Surge nur noch bevorzugt.
- Upgrade-/Rollback-Availability wird über owner-lokale beworbene Gateway-Listener gemessen: mindestens ein redundanter Listener muss die bestätigte Fachmutation liefern; der Verlust aller Listener bleibt ein harter FAIL.
- Degradierte einzelne Gateway-Pfade bleiben als Metrik sichtbar und werden nicht als globale API-Downtime fehlklassifiziert.
- ADR, Runbook, Validator und Regressionstests wurden an denselben Vertrag gebunden.

## Beweis auf exaktem Head

Head: `96b16513a12609f266a8427f28d70ec155963e9f`

- HA-Contracttests: 59/59 PASS
- Plattformvalidator: PASS
- vollständiger HA-/PITR-Proof: PASS
- Upgrade: 0 fehlgeschlagene Availability-Samples, 0.0 s beobachtete Nichtverfügbarkeit
- Rollback: 0 fehlgeschlagene Availability-Samples, 0.0 s beobachtete Nichtverfügbarkeit
- beobachtete Verfügbarkeit über Upgrade+Rollback: 1.0
- verlorene bestätigte Fachmutationen: 0
- verlorene bestätigte JetStream-Nachrichten: 0
- gemessene WAL-RPO-Obergrenze: 2.483 s
- PITR-RTO: 190.398 s
- Proof-Cluster, Restore-Cluster, Object-Store-Container und Volume anschließend entfernt

## Abgrenzung

Der Proof belegt keine Produktionsverfügbarkeit und keine externe Load-Balancer-Erreichbarkeit außerhalb der Kind-Bridge. Transiente interne Cross-Node-Cilium-Dataplane-Hiccups werden als separater Restbefund behandelt und nicht durch eine falsche globale Outage-Semantik verdeckt.



<!-- weltgewebe-risk: R3 -->
