### PR TITLE
feat(search): add authorized hybrid search API

### DIFF
--- a/apps/api/migrations/20260722000007_semantic_search_api_runtime.down.sql
+++ b/apps/api/migrations/20260722000007_semantic_search_api_runtime.down.sql
@@ -1,3 +1,18 @@
+DROP TRIGGER IF EXISTS search_node_projections_refresh_lexical_vectors
+    ON search_node_projections;
+DROP FUNCTION IF EXISTS weltgewebe_search_refresh_lexical_vectors();
+
+DROP INDEX IF EXISTS search_node_projections_t006_eligible;
+DROP INDEX IF EXISTS search_node_projections_t006_tags;
+DROP INDEX IF EXISTS search_node_projections_t006_title_trigram;
+DROP INDEX IF EXISTS search_node_projections_t006_searchable_text_trigram;
+DROP INDEX IF EXISTS search_node_projections_t006_fts_simple;
+DROP INDEX IF EXISTS search_node_projections_t006_fts;
+
+ALTER TABLE search_node_projections
+    DROP COLUMN IF EXISTS search_vector_simple,
+    DROP COLUMN IF EXISTS search_vector;
+
 -- pg_trgm is a shared database capability and may predate T006.
 -- Deliberately retain it on rollback rather than dropping a shared extension.
 SELECT 1;

--- a/apps/api/migrations/20260722000007_semantic_search_api_runtime.down.sql
+++ b/apps/api/migrations/20260722000007_semantic_search_api_runtime.down.sql
@@ -1,0 +1,3 @@
+-- pg_trgm is a shared database capability and may predate T006.
+-- Deliberately retain it on rollback rather than dropping a shared extension.
+SELECT 1;

--- a/apps/api/migrations/20260722000007_semantic_search_api_runtime.up.sql
+++ b/apps/api/migrations/20260722000007_semantic_search_api_runtime.up.sql
@@ -1,0 +1,3 @@
+-- WELTGEWEBE-SEMANTIC-SEARCH-V1-T006
+-- Required by the verified T003 PostgreSQL trigram ranking contract.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;

--- a/apps/api/migrations/20260722000007_semantic_search_api_runtime.up.sql
+++ b/apps/api/migrations/20260722000007_semantic_search_api_runtime.up.sql
@@ -1,3 +1,63 @@
 -- WELTGEWEBE-SEMANTIC-SEARCH-V1-T006
--- Required by the verified T003 PostgreSQL trigram ranking contract.
+-- Required by the verified T003 PostgreSQL trigram and full-text ranking contract.
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- T003 treats lexical representations as regenerable projection state. Persist
+-- them here as well so T006 does not rebuild two weighted tsvectors for every
+-- authorized node on every HTTP search request.
+ALTER TABLE search_node_projections
+    ADD COLUMN search_vector TSVECTOR,
+    ADD COLUMN search_vector_simple TSVECTOR;
+
+UPDATE search_node_projections
+   SET search_vector =
+       setweight(to_tsvector('german'::regconfig, coalesce(title, '')), 'A') ||
+       setweight(to_tsvector('german'::regconfig, coalesce(array_to_string(tags, ' '), '')), 'B') ||
+       setweight(to_tsvector('german'::regconfig, coalesce(searchable_text, '')), 'C') ||
+       setweight(to_tsvector('simple'::regconfig, coalesce(kind, '') || ' ' || coalesce(language, '')), 'D'),
+       search_vector_simple =
+       setweight(to_tsvector('simple'::regconfig, coalesce(title, '')), 'A') ||
+       setweight(to_tsvector('simple'::regconfig, coalesce(array_to_string(tags, ' '), '')), 'B') ||
+       setweight(to_tsvector('simple'::regconfig, coalesce(searchable_text, '')), 'C') ||
+       setweight(to_tsvector('simple'::regconfig, coalesce(kind, '') || ' ' || coalesce(language, '')), 'D');
+
+ALTER TABLE search_node_projections
+    ALTER COLUMN search_vector SET NOT NULL,
+    ALTER COLUMN search_vector_simple SET NOT NULL;
+
+CREATE OR REPLACE FUNCTION weltgewebe_search_refresh_lexical_vectors()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    NEW.search_vector :=
+        setweight(to_tsvector('german'::regconfig, coalesce(NEW.title, '')), 'A') ||
+        setweight(to_tsvector('german'::regconfig, coalesce(array_to_string(NEW.tags, ' '), '')), 'B') ||
+        setweight(to_tsvector('german'::regconfig, coalesce(NEW.searchable_text, '')), 'C') ||
+        setweight(to_tsvector('simple'::regconfig, coalesce(NEW.kind, '') || ' ' || coalesce(NEW.language, '')), 'D');
+    NEW.search_vector_simple :=
+        setweight(to_tsvector('simple'::regconfig, coalesce(NEW.title, '')), 'A') ||
+        setweight(to_tsvector('simple'::regconfig, coalesce(array_to_string(NEW.tags, ' '), '')), 'B') ||
+        setweight(to_tsvector('simple'::regconfig, coalesce(NEW.searchable_text, '')), 'C') ||
+        setweight(to_tsvector('simple'::regconfig, coalesce(NEW.kind, '') || ' ' || coalesce(NEW.language, '')), 'D');
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER search_node_projections_refresh_lexical_vectors
+BEFORE INSERT OR UPDATE OF title, tags, searchable_text, language, kind
+ON search_node_projections
+FOR EACH ROW EXECUTE FUNCTION weltgewebe_search_refresh_lexical_vectors();
+
+CREATE INDEX search_node_projections_t006_fts
+    ON search_node_projections USING GIN (search_vector);
+CREATE INDEX search_node_projections_t006_fts_simple
+    ON search_node_projections USING GIN (search_vector_simple);
+CREATE INDEX search_node_projections_t006_searchable_text_trigram
+    ON search_node_projections USING GIN (searchable_text gin_trgm_ops);
+CREATE INDEX search_node_projections_t006_title_trigram
+    ON search_node_projections USING GIN (title gin_trgm_ops);
+CREATE INDEX search_node_projections_t006_tags
+    ON search_node_projections USING GIN (tags);
+CREATE INDEX search_node_projections_t006_eligible
+    ON search_node_projections (generation_id, semantic_state, kind, language, node_id);

--- a/apps/api/src/routes/mod.rs
+++ b/apps/api/src/routes/mod.rs
@@ -9,6 +9,7 @@ pub mod health;
 pub mod meta;
 pub mod nodes;
 mod query;
+pub mod search;
 
 use axum::{
     middleware::from_fn,
@@ -44,10 +45,13 @@ use self::{
         post_proposal_message, veto_proposal, vote_proposal,
     },
     nodes::{get_node, list_nodes},
+    search::search_nodes,
 };
 
 pub fn api_router() -> Router<ApiState> {
     let router = Router::new()
+        .route("/search", get(search_nodes))
+        .route("/nodes/search", get(search_nodes))
         .route(
             "/nodes",
             get(list_nodes)

--- a/apps/api/src/routes/mod.rs
+++ b/apps/api/src/routes/mod.rs
@@ -51,6 +51,7 @@ use self::{
 pub fn api_router() -> Router<ApiState> {
     let router = Router::new()
         .route("/search", get(search_nodes))
+        // Compatibility alias for node-oriented clients; `/search` is canonical.
         .route("/nodes/search", get(search_nodes))
         .route(
             "/nodes",

--- a/apps/api/src/routes/nodes.rs
+++ b/apps/api/src/routes/nodes.rs
@@ -86,13 +86,13 @@ struct BBox {
     max_lat: f64,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Location {
     pub lat: f64,
     pub lon: f64,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Node {
     pub id: String,
     pub kind: String,

--- a/apps/api/src/routes/search.rs
+++ b/apps/api/src/routes/search.rs
@@ -13,7 +13,8 @@ use crate::{
 /// GET /search
 ///
 /// Authorization comes from the request's canonical AuthContext and is applied
-/// against PostgreSQL domain state before retrieval.
+/// against PostgreSQL domain state before retrieval. T006 v1 returns a bounded
+/// top-10 ranking and deliberately does not claim offset pagination.
 pub async fn search_nodes(
     State(state): State<ApiState>,
     Extension(auth): Extension<AuthContext>,

--- a/apps/api/src/routes/search.rs
+++ b/apps/api/src/routes/search.rs
@@ -1,0 +1,23 @@
+//! T006 server-side search route.
+use axum::{
+    extract::{Query, State},
+    Extension, Json,
+};
+
+use crate::{
+    middleware::auth::AuthContext,
+    search::{execute_search, SearchError, SearchQueryParams, SearchResponse},
+    state::ApiState,
+};
+
+/// GET /search
+///
+/// Authorization comes from the request's canonical AuthContext and is applied
+/// against PostgreSQL domain state before retrieval.
+pub async fn search_nodes(
+    State(state): State<ApiState>,
+    Extension(auth): Extension<AuthContext>,
+    Query(params): Query<SearchQueryParams>,
+) -> Result<Json<SearchResponse>, SearchError> {
+    Ok(Json(execute_search(&state, &auth, params, None).await?))
+}

--- a/apps/api/src/search/mod.rs
+++ b/apps/api/src/search/mod.rs
@@ -1,0 +1,9 @@
+pub mod ranking;
+pub mod repository;
+pub mod service;
+pub mod worker;
+
+pub use ranking::*;
+pub use repository::*;
+pub use service::*;
+pub use worker::*;

--- a/apps/api/src/search/ranking.rs
+++ b/apps/api/src/search/ranking.rs
@@ -1,0 +1,367 @@
+//! T006 Hybrid Search Ranking Engine.
+//!
+//! Hard Priority Order (Section 8 of architecture/semantic-search.md):
+//! 1. Exact normalized title
+//! 2. Exact normalized tag
+//! 3. Title prefix
+//! 4. Typo tolerance / Trigram similarity
+//! 5. Full-text token match
+//! 6. Semantic similarity (at most ONE (1) additional candidate appended)
+//! 7. Stable tie-break by node_id ASC.
+
+use std::collections::HashSet;
+use unicode_normalization::UnicodeNormalization;
+
+use crate::routes::nodes::Node;
+
+pub const DEFAULT_SEMANTIC_MINIMUM_COSINE: f64 = 0.55;
+pub const DEFAULT_SEMANTIC_MINIMUM_MARGIN: f64 = 0.015;
+pub const SEMANTIC_APPEND_LIMIT: usize = 1;
+
+#[derive(Debug, Clone)]
+pub struct SearchQuery {
+    pub raw: String,
+    pub normalized: String,
+}
+
+impl SearchQuery {
+    pub fn new(query: &str) -> Self {
+        Self {
+            raw: query.to_string(),
+            normalized: normalize_query(query),
+        }
+    }
+}
+
+pub fn normalize_query(value: &str) -> String {
+    value
+        .nfkc()
+        .collect::<String>()
+        .to_lowercase()
+        .trim()
+        .to_owned()
+}
+
+pub fn cosine_similarity(v1: &[f64], v2: &[f64]) -> f64 {
+    if v1.len() != v2.len() || v1.is_empty() {
+        return 0.0;
+    }
+    let mut dot = 0.0;
+    let mut norm1 = 0.0;
+    let mut norm2 = 0.0;
+    for (a, b) in v1.iter().zip(v2.iter()) {
+        dot += a * b;
+        norm1 += a * a;
+        norm2 += b * b;
+    }
+    if norm1 <= 0.0 || norm2 <= 0.0 || !dot.is_finite() {
+        0.0
+    } else {
+        dot / (norm1.sqrt() * norm2.sqrt())
+    }
+}
+
+fn trigrams(s: &str) -> HashSet<String> {
+    let padded = format!("  {} ", s);
+    let chars: Vec<char> = padded.chars().collect();
+    let mut set = HashSet::new();
+    if chars.len() >= 3 {
+        for i in 0..=chars.len() - 3 {
+            set.insert(chars[i..i + 3].iter().collect());
+        }
+    }
+    set
+}
+
+pub fn trigram_similarity(s1: &str, s2: &str) -> f64 {
+    let t1 = trigrams(s1);
+    let t2 = trigrams(s2);
+    if t1.is_empty() || t2.is_empty() {
+        return 0.0;
+    }
+    let intersection_count = t1.intersection(&t2).count();
+    let union_count = t1.union(&t2).count();
+    if union_count == 0 {
+        0.0
+    } else {
+        intersection_count as f64 / union_count as f64
+    }
+}
+
+fn max_trigram_score(query: &str, title: &str, tags: &[String], searchable_text: &str) -> f64 {
+    let norm_q = normalize_query(query);
+    let mut score = trigram_similarity(&norm_q, &normalize_query(title));
+    for tag in tags {
+        score = score.max(trigram_similarity(&norm_q, &normalize_query(tag)));
+    }
+    score = score.max(trigram_similarity(
+        &norm_q,
+        &normalize_query(searchable_text),
+    ));
+    score
+}
+
+#[derive(Debug, Clone)]
+pub struct ScoredNode {
+    pub node: Node,
+    pub rank_class: u8,
+    pub rank_score: f64,
+    pub embedding: Option<Vec<f64>>,
+}
+
+/// Evaluates lexical rank class and score for a candidate document.
+/// Returns None if candidate has no lexical match with query.
+pub fn calculate_lexical_rank_class(
+    query: &SearchQuery,
+    title: &str,
+    tags: &[String],
+    searchable_text: &str,
+) -> Option<(u8, f64)> {
+    let q = &query.normalized;
+    if q.is_empty() {
+        return None;
+    }
+
+    let norm_title = normalize_query(title);
+    let norm_tags: Vec<String> = tags.iter().map(|t| normalize_query(t)).collect();
+
+    // 1. Class 0: Exact Title
+    if norm_title == *q {
+        return Some((0, 1.0));
+    }
+
+    // 2. Class 1: Exact Tag
+    if norm_tags.iter().any(|t| t == q) {
+        return Some((1, 1.0));
+    }
+
+    // 3. Class 2: Title Prefix
+    if norm_title.starts_with(q) {
+        let score = q.len() as f64 / norm_title.len().max(1) as f64;
+        return Some((2, score));
+    }
+
+    // Trigram score over title, tags, text
+    let tri_score = max_trigram_score(&query.raw, title, tags, searchable_text);
+
+    // Full-text token match
+    let q_tokens: Vec<&str> = q.split_whitespace().collect();
+    let norm_searchable = normalize_query(searchable_text);
+    let matched_count = q_tokens
+        .iter()
+        .filter(|&&tok| norm_searchable.contains(tok))
+        .count();
+
+    // 4. Class 3: Typo tolerance / Trigram >= 0.30 & token match >= 1
+    if tri_score >= 0.30 && matched_count >= 1 {
+        return Some((3, tri_score));
+    }
+
+    // 5. Class 4: Token match
+    if matched_count > 0 {
+        let score = matched_count as f64 / q_tokens.len().max(1) as f64;
+        return Some((4, score));
+    }
+
+    // 6. Class 4 (trigram alone >= 0.30)
+    if tri_score >= 0.30 {
+        return Some((4, tri_score));
+    }
+
+    None
+}
+
+/// Ranks eligible candidates lexically according to Section 8 priority classes:
+/// Class 0 (Exact title) < Class 1 (Exact tag) < Class 2 (Prefix) < Class 3 (Trigram) < Class 4 (FTS).
+/// Stable tie-breaks: rank_score DESC, node.id ASC.
+pub fn rank_lexical(_query: &SearchQuery, candidates: Vec<ScoredNode>) -> Vec<ScoredNode> {
+    let mut matched: Vec<ScoredNode> = candidates
+        .into_iter()
+        .filter(|item| item.rank_class <= 4)
+        .collect();
+
+    matched.sort_by(|a, b| {
+        a.rank_class
+            .cmp(&b.rank_class)
+            .then_with(|| {
+                b.rank_score
+                    .partial_cmp(&a.rank_score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .then_with(|| a.node.id.cmp(&b.node.id))
+    });
+
+    matched
+}
+
+/// Performs hybrid ranking and fusion.
+///
+/// Pre-conditions:
+/// 1. `lexical_candidates` are already visible, authorized, filtered, and sorted lexically.
+/// 2. `all_eligible_candidates` contains all visible, authorized, filtered candidates.
+///
+/// Post-conditions:
+/// - Hard lexical precedence is preserved: exact title/tag/prefix/FTS rank order is maintained.
+/// - At most ONE (1) additional semantic candidate is appended if query_vector is provided,
+///   its cosine similarity >= `semantic_minimum_cosine`, and margin >= `semantic_minimum_margin`.
+/// - Stable tie-breaks: node.id ASC.
+pub fn rank_hybrid(
+    query_vector: Option<&[f64]>,
+    lexical_candidates: Vec<ScoredNode>,
+    all_eligible_candidates: &[ScoredNode],
+    semantic_minimum_cosine: f64,
+    semantic_minimum_margin: f64,
+) -> Vec<ScoredNode> {
+    let mut result = lexical_candidates;
+    let Some(q_vec) = query_vector else {
+        return result;
+    };
+
+    let lexical_ids: HashSet<String> = result.iter().map(|item| item.node.id.clone()).collect();
+
+    // Find semantic similarity for candidates not in lexical list
+    let mut semantic_candidates: Vec<(ScoredNode, f64)> = Vec::new();
+
+    for candidate in all_eligible_candidates {
+        if lexical_ids.contains(&candidate.node.id) {
+            continue;
+        }
+        if let Some(c_vec) = &candidate.embedding {
+            let sim = cosine_similarity(q_vec, c_vec);
+            if sim >= semantic_minimum_cosine {
+                let mut scored = candidate.clone();
+                scored.rank_class = 6;
+                scored.rank_score = sim;
+                semantic_candidates.push((scored, sim));
+            }
+        }
+    }
+
+    // Sort semantic candidates by cosine DESC, node.id ASC (stable tie-break)
+    semantic_candidates.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.0.node.id.cmp(&b.0.node.id))
+    });
+
+    if !semantic_candidates.is_empty() {
+        let (top_cand, top_score) = &semantic_candidates[0];
+        let margin_ok = if semantic_candidates.len() > 1 {
+            let second_score = semantic_candidates[1].1;
+            (top_score - second_score) >= semantic_minimum_margin
+        } else {
+            true
+        };
+
+        if margin_ok {
+            // Append exactly ONE semantic candidate
+            result.push(top_cand.clone());
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::routes::nodes::Location;
+
+    fn test_node(id: &str, title: &str, tags: Vec<&str>) -> Node {
+        Node {
+            id: id.to_string(),
+            kind: "Werkstatt".to_string(),
+            title: title.to_string(),
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+            created_by_account_id: None,
+            summary: Some("Test summary".to_string()),
+            info: Some("Test info".to_string()),
+            tags: tags.into_iter().map(String::from).collect(),
+            address: Some("Test str. 1".to_string()),
+            location: Location {
+                lat: 52.5,
+                lon: 13.4,
+            },
+        }
+    }
+
+    #[test]
+    fn exact_title_and_exact_tag_rank_before_prefix() {
+        let q = SearchQuery::new("Fahrrad");
+
+        let n1 = test_node("node-1", "Fahrrad", vec![]); // Exact title -> Class 0
+        let n2 = test_node("node-2", "Werkstatt", vec!["Fahrrad"]); // Exact tag -> Class 1
+        let n3 = test_node("node-3", "Fahrradhilfe", vec![]); // Prefix -> Class 2
+
+        let (c1, _) = calculate_lexical_rank_class(&q, &n1.title, &n1.tags, "Fahrrad").unwrap();
+        let (c2, _) =
+            calculate_lexical_rank_class(&q, &n2.title, &n2.tags, "Werkstatt Fahrrad").unwrap();
+        let (c3, _) =
+            calculate_lexical_rank_class(&q, &n3.title, &n3.tags, "Fahrradhilfe").unwrap();
+
+        assert_eq!(c1, 0);
+        assert_eq!(c2, 1);
+        assert_eq!(c3, 2);
+    }
+
+    #[test]
+    fn stable_tie_break_by_node_id() {
+        let q = SearchQuery::new("Werkstatt");
+        let n1 = test_node("node-b", "Werkstatt", vec![]);
+        let n2 = test_node("node-a", "Werkstatt", vec![]);
+
+        let scored = vec![
+            ScoredNode {
+                node: n1,
+                rank_class: 0,
+                rank_score: 1.0,
+                embedding: None,
+            },
+            ScoredNode {
+                node: n2,
+                rank_class: 0,
+                rank_score: 1.0,
+                embedding: None,
+            },
+        ];
+
+        let ranked = rank_lexical(&q, scored);
+        assert_eq!(ranked[0].node.id, "node-a");
+        assert_eq!(ranked[1].node.id, "node-b");
+    }
+
+    #[test]
+    fn hybrid_ranking_appends_at_most_one_semantic_candidate() {
+        let lexical = vec![ScoredNode {
+            node: test_node("node-lexical", "Fahrrad", vec![]),
+            rank_class: 0,
+            rank_score: 1.0,
+            embedding: Some(vec![1.0, 0.0]),
+        }];
+
+        let eligible = vec![
+            lexical[0].clone(),
+            ScoredNode {
+                node: test_node("node-sem-1", "Radhilfe", vec![]),
+                rank_class: 99,
+                rank_score: 0.0,
+                embedding: Some(vec![0.9, 0.1]),
+            },
+            ScoredNode {
+                node: test_node("node-sem-2", "Zweirad", vec![]),
+                rank_class: 99,
+                rank_score: 0.0,
+                embedding: Some(vec![0.8, 0.2]),
+            },
+        ];
+
+        let query_vec = vec![1.0, 0.0];
+        let ranked = rank_hybrid(Some(&query_vec), lexical, &eligible, 0.55, 0.015);
+
+        // Lexical candidate plus AT MOST ONE semantic candidate = 2 candidates total
+        assert_eq!(ranked.len(), 2);
+        assert_eq!(ranked[0].node.id, "node-lexical");
+        assert_eq!(ranked[1].node.id, "node-sem-1");
+    }
+}

--- a/apps/api/src/search/ranking.rs
+++ b/apps/api/src/search/ranking.rs
@@ -152,20 +152,16 @@ pub fn calculate_lexical_rank_class(
         .filter(|&&tok| norm_searchable.contains(tok))
         .count();
 
-    // 4. Class 3: Typo tolerance / Trigram >= 0.30 & token match >= 1
-    if tri_score >= 0.30 && matched_count >= 1 {
+    // 4. Class 3: Typo tolerance / Trigram. Hard priority requires every
+    // qualifying trigram match to rank before full-text token matches.
+    if tri_score >= 0.30 {
         return Some((3, tri_score));
     }
 
-    // 5. Class 4: Token match
+    // 5. Class 4: Full-text token match
     if matched_count > 0 {
         let score = matched_count as f64 / q_tokens.len().max(1) as f64;
         return Some((4, score));
-    }
-
-    // 6. Class 4 (trigram alone >= 0.30)
-    if tri_score >= 0.30 {
-        return Some((4, tri_score));
     }
 
     None
@@ -303,6 +299,30 @@ mod tests {
         assert_eq!(c1, 0);
         assert_eq!(c2, 1);
         assert_eq!(c3, 2);
+    }
+
+
+    #[test]
+    fn pure_trigram_match_ranks_before_full_text_match() {
+        let q = SearchQuery::new("Fahrrad gemeinschaftswerkstatt");
+        let trigram = calculate_lexical_rank_class(
+            &q,
+            "Fahrrad gemeinschaftswerkstat",
+            &[],
+            "kein token treffer",
+        )
+        .expect("trigram match");
+        let full_text = calculate_lexical_rank_class(
+            &q,
+            "Unverbundener Titel",
+            &[],
+            "Fahrrad",
+        )
+        .expect("full-text match");
+
+        assert_eq!(trigram.0, 3);
+        assert_eq!(full_text.0, 4);
+        assert!(trigram.0 < full_text.0);
     }
 
     #[test]

--- a/apps/api/src/search/ranking.rs
+++ b/apps/api/src/search/ranking.rs
@@ -1,13 +1,8 @@
-//! T006 Hybrid Search Ranking Engine.
+//! T006 hybrid search semantic append.
 //!
-//! Hard Priority Order (Section 8 of architecture/semantic-search.md):
-//! 1. Exact normalized title
-//! 2. Exact normalized tag
-//! 3. Title prefix
-//! 4. Typo tolerance / Trigram similarity
-//! 5. Full-text token match
-//! 6. Semantic similarity (at most ONE (1) additional candidate appended)
-//! 7. Stable tie-break by node_id ASC.
+//! The lexical prefix is authoritative PostgreSQL T003 output. This module does
+//! not reimplement lexical scoring; it only preserves that order and may append
+//! at most one confidence-gated semantic candidate with a stable node-id tie-break.
 
 use std::collections::HashSet;
 use unicode_normalization::UnicodeNormalization;
@@ -30,6 +25,13 @@ impl SearchQuery {
             raw: query.to_string(),
             normalized: normalize_query(query),
         }
+    }
+
+    pub fn embedding_text(&self) -> String {
+        format!(
+            "Aufgabe: Finde den relevantesten sichtbaren Weltgewebe-Knoten.\nAnfrage: {}",
+            self.raw
+        )
     }
 }
 
@@ -61,133 +63,12 @@ pub fn cosine_similarity(v1: &[f64], v2: &[f64]) -> f64 {
     }
 }
 
-fn trigrams(s: &str) -> HashSet<String> {
-    let padded = format!("  {} ", s);
-    let chars: Vec<char> = padded.chars().collect();
-    let mut set = HashSet::new();
-    if chars.len() >= 3 {
-        for i in 0..=chars.len() - 3 {
-            set.insert(chars[i..i + 3].iter().collect());
-        }
-    }
-    set
-}
-
-pub fn trigram_similarity(s1: &str, s2: &str) -> f64 {
-    let t1 = trigrams(s1);
-    let t2 = trigrams(s2);
-    if t1.is_empty() || t2.is_empty() {
-        return 0.0;
-    }
-    let intersection_count = t1.intersection(&t2).count();
-    let union_count = t1.union(&t2).count();
-    if union_count == 0 {
-        0.0
-    } else {
-        intersection_count as f64 / union_count as f64
-    }
-}
-
-fn max_trigram_score(query: &str, title: &str, tags: &[String], searchable_text: &str) -> f64 {
-    let norm_q = normalize_query(query);
-    let mut score = trigram_similarity(&norm_q, &normalize_query(title));
-    for tag in tags {
-        score = score.max(trigram_similarity(&norm_q, &normalize_query(tag)));
-    }
-    score = score.max(trigram_similarity(
-        &norm_q,
-        &normalize_query(searchable_text),
-    ));
-    score
-}
-
 #[derive(Debug, Clone)]
 pub struct ScoredNode {
     pub node: Node,
     pub rank_class: u8,
     pub rank_score: f64,
     pub embedding: Option<Vec<f64>>,
-}
-
-/// Evaluates lexical rank class and score for a candidate document.
-/// Returns None if candidate has no lexical match with query.
-pub fn calculate_lexical_rank_class(
-    query: &SearchQuery,
-    title: &str,
-    tags: &[String],
-    searchable_text: &str,
-) -> Option<(u8, f64)> {
-    let q = &query.normalized;
-    if q.is_empty() {
-        return None;
-    }
-
-    let norm_title = normalize_query(title);
-    let norm_tags: Vec<String> = tags.iter().map(|t| normalize_query(t)).collect();
-
-    // 1. Class 0: Exact Title
-    if norm_title == *q {
-        return Some((0, 1.0));
-    }
-
-    // 2. Class 1: Exact Tag
-    if norm_tags.iter().any(|t| t == q) {
-        return Some((1, 1.0));
-    }
-
-    // 3. Class 2: Title Prefix
-    if norm_title.starts_with(q) {
-        let score = q.len() as f64 / norm_title.len().max(1) as f64;
-        return Some((2, score));
-    }
-
-    // Trigram score over title, tags, text
-    let tri_score = max_trigram_score(&query.raw, title, tags, searchable_text);
-
-    // Full-text token match
-    let q_tokens: Vec<&str> = q.split_whitespace().collect();
-    let norm_searchable = normalize_query(searchable_text);
-    let matched_count = q_tokens
-        .iter()
-        .filter(|&&tok| norm_searchable.contains(tok))
-        .count();
-
-    // 4. Class 3: Typo tolerance / Trigram. Hard priority requires every
-    // qualifying trigram match to rank before full-text token matches.
-    if tri_score >= 0.30 {
-        return Some((3, tri_score));
-    }
-
-    // 5. Class 4: Full-text token match
-    if matched_count > 0 {
-        let score = matched_count as f64 / q_tokens.len().max(1) as f64;
-        return Some((4, score));
-    }
-
-    None
-}
-
-/// Ranks eligible candidates lexically according to Section 8 priority classes:
-/// Class 0 (Exact title) < Class 1 (Exact tag) < Class 2 (Prefix) < Class 3 (Trigram) < Class 4 (FTS).
-/// Stable tie-breaks: rank_score DESC, node.id ASC.
-pub fn rank_lexical(_query: &SearchQuery, candidates: Vec<ScoredNode>) -> Vec<ScoredNode> {
-    let mut matched: Vec<ScoredNode> = candidates
-        .into_iter()
-        .filter(|item| item.rank_class <= 4)
-        .collect();
-
-    matched.sort_by(|a, b| {
-        a.rank_class
-            .cmp(&b.rank_class)
-            .then_with(|| {
-                b.rank_score
-                    .partial_cmp(&a.rank_score)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            })
-            .then_with(|| a.node.id.cmp(&b.node.id))
-    });
-
-    matched
 }
 
 /// Performs hybrid ranking and fusion.
@@ -283,66 +164,12 @@ mod tests {
     }
 
     #[test]
-    fn exact_title_and_exact_tag_rank_before_prefix() {
-        let q = SearchQuery::new("Fahrrad");
-
-        let n1 = test_node("node-1", "Fahrrad", vec![]); // Exact title -> Class 0
-        let n2 = test_node("node-2", "Werkstatt", vec!["Fahrrad"]); // Exact tag -> Class 1
-        let n3 = test_node("node-3", "Fahrradhilfe", vec![]); // Prefix -> Class 2
-
-        let (c1, _) = calculate_lexical_rank_class(&q, &n1.title, &n1.tags, "Fahrrad").unwrap();
-        let (c2, _) =
-            calculate_lexical_rank_class(&q, &n2.title, &n2.tags, "Werkstatt Fahrrad").unwrap();
-        let (c3, _) =
-            calculate_lexical_rank_class(&q, &n3.title, &n3.tags, "Fahrradhilfe").unwrap();
-
-        assert_eq!(c1, 0);
-        assert_eq!(c2, 1);
-        assert_eq!(c3, 2);
-    }
-
-    #[test]
-    fn pure_trigram_match_ranks_before_full_text_match() {
-        let q = SearchQuery::new("Fahrrad gemeinschaftswerkstatt");
-        let trigram = calculate_lexical_rank_class(
-            &q,
-            "Fahrrad gemeinschaftswerkstat",
-            &[],
-            "kein token treffer",
-        )
-        .expect("trigram match");
-        let full_text = calculate_lexical_rank_class(&q, "Unverbundener Titel", &[], "Fahrrad")
-            .expect("full-text match");
-
-        assert_eq!(trigram.0, 3);
-        assert_eq!(full_text.0, 4);
-        assert!(trigram.0 < full_text.0);
-    }
-
-    #[test]
-    fn stable_tie_break_by_node_id() {
-        let q = SearchQuery::new("Werkstatt");
-        let n1 = test_node("node-b", "Werkstatt", vec![]);
-        let n2 = test_node("node-a", "Werkstatt", vec![]);
-
-        let scored = vec![
-            ScoredNode {
-                node: n1,
-                rank_class: 0,
-                rank_score: 1.0,
-                embedding: None,
-            },
-            ScoredNode {
-                node: n2,
-                rank_class: 0,
-                rank_score: 1.0,
-                embedding: None,
-            },
-        ];
-
-        let ranked = rank_lexical(&q, scored);
-        assert_eq!(ranked[0].node.id, "node-a");
-        assert_eq!(ranked[1].node.id, "node-b");
+    fn query_embedding_text_matches_t004_reference_contract() {
+        let query = SearchQuery::new("Hilfe mit dem Telefon");
+        assert_eq!(
+            query.embedding_text(),
+            "Aufgabe: Finde den relevantesten sichtbaren Weltgewebe-Knoten.\nAnfrage: Hilfe mit dem Telefon"
+        );
     }
 
     #[test]

--- a/apps/api/src/search/ranking.rs
+++ b/apps/api/src/search/ranking.rs
@@ -301,7 +301,6 @@ mod tests {
         assert_eq!(c3, 2);
     }
 
-
     #[test]
     fn pure_trigram_match_ranks_before_full_text_match() {
         let q = SearchQuery::new("Fahrrad gemeinschaftswerkstatt");
@@ -312,13 +311,8 @@ mod tests {
             "kein token treffer",
         )
         .expect("trigram match");
-        let full_text = calculate_lexical_rank_class(
-            &q,
-            "Unverbundener Titel",
-            &[],
-            "Fahrrad",
-        )
-        .expect("full-text match");
+        let full_text = calculate_lexical_rank_class(&q, "Unverbundener Titel", &[], "Fahrrad")
+            .expect("full-text match");
 
         assert_eq!(trigram.0, 3);
         assert_eq!(full_text.0, 4);

--- a/apps/api/src/search/repository.rs
+++ b/apps/api/src/search/repository.rs
@@ -1,0 +1,261 @@
+//! PostgreSQL-backed search candidate retrieval for T006.
+//!
+//! Authorization is derived from the canonical domain row and request auth context
+//! before any lexical or semantic candidate can enter the result set. The search
+//! projection is treated as regenerable data, never as an authorization source.
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+use sqlx::{PgPool, Row};
+
+use crate::{
+    middleware::auth::AuthContext,
+    routes::nodes::{Location, Node},
+    search::ranking::ScoredNode,
+};
+
+#[derive(Debug, Clone, Default)]
+pub struct SearchFilters {
+    pub kinds: Vec<String>,
+    pub tags: Vec<String>,
+    pub languages: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ActiveSearchGeneration {
+    pub generation_id: String,
+    pub provider: String,
+    pub model_id: String,
+    pub model_revision: String,
+    pub runtime_identity: String,
+    pub dimension: i32,
+    pub document_revision: String,
+    pub normalization_revision: String,
+    pub ranking_revision: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct SearchCandidateSet {
+    pub generation: ActiveSearchGeneration,
+    /// PostgreSQL order is authoritative: lexical matches first in T003 order,
+    /// followed by non-lexical authorized candidates in node-id order for the
+    /// bounded semantic append decision.
+    pub candidates: Vec<ScoredNode>,
+}
+
+/// Fetches exactly one active generation and candidates authorized by the current
+/// canonical domain state. Unknown or legacy visibility values fail closed.
+/// Stale projections are excluded by exact source version/revision equality.
+pub async fn fetch_postgres_candidates(
+    pool: &PgPool,
+    query: &str,
+    filters: &SearchFilters,
+    auth: &AuthContext,
+) -> anyhow::Result<Option<SearchCandidateSet>> {
+    let generation_row = sqlx::query(
+        "SELECT generation_id, provider, model_id, model_revision, runtime_identity, dimension, \
+                document_revision, normalization_revision, ranking_revision \
+         FROM search_index_generations WHERE state = 'active'",
+    )
+    .fetch_optional(pool)
+    .await?;
+
+    let Some(generation_row) = generation_row else {
+        return Ok(None);
+    };
+
+    let generation = ActiveSearchGeneration {
+        generation_id: generation_row.try_get("generation_id")?,
+        provider: generation_row.try_get("provider")?,
+        model_id: generation_row.try_get("model_id")?,
+        model_revision: generation_row.try_get("model_revision")?,
+        runtime_identity: generation_row.try_get("runtime_identity")?,
+        dimension: generation_row.try_get("dimension")?,
+        document_revision: generation_row.try_get("document_revision")?,
+        normalization_revision: generation_row.try_get("normalization_revision")?,
+        ranking_revision: generation_row.try_get("ranking_revision")?,
+    };
+
+    let account_id = auth
+        .account_id
+        .as_deref()
+        .filter(|_| auth.authenticated)
+        .map(str::to_owned);
+
+    let rows = sqlx::query(
+        r#"
+        WITH query_terms AS (
+            SELECT DISTINCT lower(debug.token) AS simple_term, lexeme AS german_term
+              FROM ts_debug('german'::regconfig, coalesce($2, '')) AS debug
+              CROSS JOIN LATERAL unnest(debug.lexemes) AS lexeme
+             WHERE debug.alias IN (
+                 'asciiword', 'word', 'numword', 'hword', 'hword_part',
+                 'hword_asciipart', 'hword_numpart'
+             )
+               AND length(debug.token) >= 2
+        ), query_stats AS (
+            SELECT count(*)::INTEGER AS term_count FROM query_terms
+        ), authorized AS (
+            SELECT p.node_id, p.title, p.tags, p.searchable_text, p.language, p.kind,
+                   p.embedding, n.created_at, n.updated_at, n.lat, n.lon, n.payload::text AS payload,
+                   setweight(to_tsvector('german'::regconfig, coalesce(p.title, '')), 'A') ||
+                   setweight(to_tsvector('german'::regconfig, coalesce(array_to_string(p.tags, ' '), '')), 'B') ||
+                   setweight(to_tsvector('german'::regconfig, coalesce(p.searchable_text, '')), 'C') ||
+                   setweight(to_tsvector('simple'::regconfig, coalesce(p.kind, '') || ' ' || coalesce(p.language, '')), 'D')
+                       AS search_vector,
+                   setweight(to_tsvector('simple'::regconfig, coalesce(p.title, '')), 'A') ||
+                   setweight(to_tsvector('simple'::regconfig, coalesce(array_to_string(p.tags, ' '), '')), 'B') ||
+                   setweight(to_tsvector('simple'::regconfig, coalesce(p.searchable_text, '')), 'C') ||
+                   setweight(to_tsvector('simple'::regconfig, coalesce(p.kind, '') || ' ' || coalesce(p.language, '')), 'D')
+                       AS search_vector_simple
+              FROM search_node_projections p
+              JOIN search_node_versions v
+                ON v.node_id = p.node_id
+               AND v.source_version = p.source_version
+               AND v.source_revision = p.source_revision
+               AND v.deleted_at IS NULL
+              JOIN domain_nodes n ON n.id = p.node_id
+             WHERE p.generation_id = $1
+               AND p.semantic_state = 'ready'
+               AND cardinality(p.embedding) = $8
+               AND n.created_at IS NOT NULL
+               AND n.updated_at IS NOT NULL
+               AND n.lat IS NOT NULL
+               AND n.lon IS NOT NULL
+               AND CASE
+                     WHEN jsonb_typeof(n.payload -> 'search_visibility') IS DISTINCT FROM 'string' THEN FALSE
+                     WHEN n.payload ->> 'search_visibility' = 'public' THEN TRUE
+                     WHEN n.payload ->> 'search_visibility' = 'private' THEN
+                          $4::boolean
+                          AND $3::text IS NOT NULL
+                          AND nullif(btrim(n.payload ->> 'created_by_account_id'), '') = $3::text
+                     WHEN n.payload ->> 'search_visibility' IN ('hidden', 'revoked', 'deleted') THEN FALSE
+                     ELSE FALSE
+                   END
+               AND (cardinality($5::text[]) = 0 OR p.kind = ANY($5::text[]))
+               AND (cardinality($6::text[]) = 0 OR p.tags && $6::text[])
+               AND (cardinality($7::text[]) = 0 OR p.language = ANY($7::text[]))
+        ), scored AS (
+            SELECT authorized.*,
+                   CASE
+                     WHEN lower(btrim(authorized.title)) = lower(btrim($2)) THEN 0
+                     WHEN EXISTS (
+                         SELECT 1 FROM unnest(authorized.tags) AS tag
+                          WHERE lower(btrim(tag)) = lower(btrim($2))
+                     ) THEN 1
+                     WHEN lower(authorized.title) LIKE lower(btrim($2)) || '%' THEN 2
+                     WHEN trigram.score >= 0.30
+                          AND lexical.matched_terms >= least(2, greatest(query_stats.term_count, 1)) THEN 3
+                     WHEN lexical.matched_terms >= CASE WHEN query_stats.term_count <= 2 THEN 1 ELSE 2 END THEN 4
+                     WHEN trigram.score >= 0.30 THEN 5
+                     ELSE NULL
+                   END AS rank_class,
+                   CASE
+                     WHEN lower(btrim(authorized.title)) = lower(btrim($2)) THEN 1.0
+                     WHEN EXISTS (
+                         SELECT 1 FROM unnest(authorized.tags) AS tag
+                          WHERE lower(btrim(tag)) = lower(btrim($2))
+                     ) THEN 1.0
+                     WHEN lower(authorized.title) LIKE lower(btrim($2)) || '%' THEN
+                          length(btrim($2))::DOUBLE PRECISION / greatest(length(authorized.title), 1)
+                     WHEN lexical.matched_terms > 0 THEN
+                          lexical.matched_terms::DOUBLE PRECISION / greatest(query_stats.term_count, 1)
+                          + lexical.score / greatest(query_stats.term_count, 1)
+                          + trigram.score / 10.0
+                     ELSE trigram.score
+                   END AS rank_score
+              FROM authorized
+              CROSS JOIN query_stats
+              CROSS JOIN LATERAL (
+                  SELECT greatest(
+                      similarity(authorized.title, $2),
+                      word_similarity($2, authorized.title),
+                      word_similarity($2, authorized.searchable_text),
+                      coalesce((
+                          SELECT max(greatest(similarity(tag, $2), word_similarity($2, tag)))
+                            FROM unnest(authorized.tags) AS tag
+                      ), 0)
+                  )::DOUBLE PRECISION AS score
+              ) AS trigram
+              CROSS JOIN LATERAL (
+                  SELECT count(*) FILTER (
+                             WHERE authorized.search_vector_simple @@ plainto_tsquery('simple'::regconfig, simple_term)
+                                OR authorized.search_vector @@ plainto_tsquery('german'::regconfig, german_term)
+                         )::INTEGER AS matched_terms,
+                         coalesce(sum(greatest(
+                             ts_rank_cd(authorized.search_vector_simple, plainto_tsquery('simple'::regconfig, simple_term), 32),
+                             ts_rank_cd(authorized.search_vector, plainto_tsquery('german'::regconfig, german_term), 32)
+                         )), 0)::DOUBLE PRECISION AS score
+                    FROM query_terms
+              ) AS lexical
+        )
+        SELECT node_id, title, tags, searchable_text, language, kind, embedding,
+               created_at, updated_at, lat, lon, payload, rank_class, rank_score
+          FROM scored
+         ORDER BY rank_class ASC NULLS LAST, rank_score DESC NULLS LAST, node_id ASC
+        "#,
+    )
+    .bind(&generation.generation_id)
+    .bind(query)
+    .bind(account_id)
+    .bind(auth.authenticated)
+    .bind(&filters.kinds)
+    .bind(&filters.tags)
+    .bind(&filters.languages)
+    .bind(generation.dimension)
+    .fetch_all(pool)
+    .await?;
+
+    let mut candidates = Vec::with_capacity(rows.len());
+    for row in rows {
+        let payload_text: String = row.try_get("payload")?;
+        let payload: Value = serde_json::from_str(&payload_text)?;
+        let created_at: DateTime<Utc> = row.try_get("created_at")?;
+        let updated_at: DateTime<Utc> = row.try_get("updated_at")?;
+        let lat: f64 = row.try_get("lat")?;
+        let lon: f64 = row.try_get("lon")?;
+        let tags: Vec<String> = row.try_get("tags")?;
+        let rank_class: Option<i32> = row.try_get("rank_class")?;
+        let rank_score: Option<f64> = row.try_get("rank_score")?;
+        let embedding: Vec<f64> = row.try_get("embedding")?;
+
+        let node = Node {
+            id: row.try_get("node_id")?,
+            kind: row.try_get("kind")?,
+            title: row.try_get("title")?,
+            created_at: created_at.to_rfc3339(),
+            updated_at: updated_at.to_rfc3339(),
+            created_by_account_id: payload
+                .get("created_by_account_id")
+                .and_then(Value::as_str)
+                .map(str::to_owned),
+            summary: payload
+                .get("summary")
+                .and_then(Value::as_str)
+                .map(str::to_owned),
+            info: payload
+                .get("info")
+                .and_then(Value::as_str)
+                .map(str::to_owned),
+            tags,
+            address: payload
+                .get("address")
+                .and_then(Value::as_str)
+                .map(str::to_owned),
+            location: Location { lat, lon },
+        };
+
+        candidates.push(ScoredNode {
+            node,
+            rank_class: rank_class
+                .and_then(|value| u8::try_from(value).ok())
+                .unwrap_or(u8::MAX),
+            rank_score: rank_score.unwrap_or(0.0),
+            embedding: Some(embedding),
+        });
+    }
+
+    Ok(Some(SearchCandidateSet {
+        generation,
+        candidates,
+    }))
+}

--- a/apps/api/src/search/repository.rs
+++ b/apps/api/src/search/repository.rs
@@ -7,6 +7,18 @@ use chrono::{DateTime, Utc};
 use serde_json::Value;
 use sqlx::{PgPool, Row};
 
+pub const MAX_AUTHORIZED_CANDIDATES: usize = 1000;
+
+#[derive(Debug, thiserror::Error)]
+pub enum SearchRepositoryError {
+    #[error("authorized search candidate set exceeds T004 maximum")]
+    CandidateSetTooLarge,
+    #[error(transparent)]
+    Database(#[from] sqlx::Error),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+}
+
 use crate::{
     middleware::auth::AuthContext,
     routes::nodes::{Location, Node},
@@ -50,7 +62,7 @@ pub async fn fetch_postgres_candidates(
     query: &str,
     filters: &SearchFilters,
     auth: &AuthContext,
-) -> anyhow::Result<Option<SearchCandidateSet>> {
+) -> Result<Option<SearchCandidateSet>, SearchRepositoryError> {
     let generation_row = sqlx::query(
         "SELECT generation_id, provider, model_id, model_revision, runtime_identity, dimension, \
                 document_revision, normalization_revision, ranking_revision \
@@ -96,17 +108,8 @@ pub async fn fetch_postgres_candidates(
             SELECT count(*)::INTEGER AS term_count FROM query_terms
         ), authorized AS (
             SELECT p.node_id, p.title, p.tags, p.searchable_text, p.language, p.kind,
-                   p.embedding, n.created_at, n.updated_at, n.lat, n.lon, n.payload::text AS payload,
-                   setweight(to_tsvector('german'::regconfig, coalesce(p.title, '')), 'A') ||
-                   setweight(to_tsvector('german'::regconfig, coalesce(array_to_string(p.tags, ' '), '')), 'B') ||
-                   setweight(to_tsvector('german'::regconfig, coalesce(p.searchable_text, '')), 'C') ||
-                   setweight(to_tsvector('simple'::regconfig, coalesce(p.kind, '') || ' ' || coalesce(p.language, '')), 'D')
-                       AS search_vector,
-                   setweight(to_tsvector('simple'::regconfig, coalesce(p.title, '')), 'A') ||
-                   setweight(to_tsvector('simple'::regconfig, coalesce(array_to_string(p.tags, ' '), '')), 'B') ||
-                   setweight(to_tsvector('simple'::regconfig, coalesce(p.searchable_text, '')), 'C') ||
-                   setweight(to_tsvector('simple'::regconfig, coalesce(p.kind, '') || ' ' || coalesce(p.language, '')), 'D')
-                       AS search_vector_simple
+                   p.embedding, p.search_vector, p.search_vector_simple,
+                   n.created_at, n.updated_at, n.lat, n.lon, n.payload::text AS payload
               FROM search_node_projections p
               JOIN search_node_versions v
                 ON v.node_id = p.node_id
@@ -203,6 +206,7 @@ pub async fn fetch_postgres_candidates(
          ORDER BY lexical_top.rank_class ASC NULLS LAST,
                   lexical_top.rank_score DESC NULLS LAST,
                   scored.node_id ASC
+         LIMIT $9
         "#,
     )
     .bind(&generation.generation_id)
@@ -213,8 +217,13 @@ pub async fn fetch_postgres_candidates(
     .bind(&filters.tags)
     .bind(&filters.languages)
     .bind(generation.dimension)
+    .bind((MAX_AUTHORIZED_CANDIDATES + 1) as i64)
     .fetch_all(pool)
     .await?;
+
+    if rows.len() > MAX_AUTHORIZED_CANDIDATES {
+        return Err(SearchRepositoryError::CandidateSetTooLarge);
+    }
 
     let mut candidates = Vec::with_capacity(rows.len());
     for row in rows {

--- a/apps/api/src/search/repository.rs
+++ b/apps/api/src/search/repository.rs
@@ -143,10 +143,8 @@ pub async fn fetch_postgres_candidates(
                           WHERE lower(btrim(tag)) = lower(btrim($2))
                      ) THEN 1
                      WHEN lower(authorized.title) LIKE lower(btrim($2)) || '%' THEN 2
-                     WHEN trigram.score >= 0.30
-                          AND lexical.matched_terms >= least(2, greatest(query_stats.term_count, 1)) THEN 3
+                     WHEN trigram.score >= 0.30 THEN 3
                      WHEN lexical.matched_terms >= CASE WHEN query_stats.term_count <= 2 THEN 1 ELSE 2 END THEN 4
-                     WHEN trigram.score >= 0.30 THEN 5
                      ELSE NULL
                    END AS rank_class,
                    CASE

--- a/apps/api/src/search/service.rs
+++ b/apps/api/src/search/service.rs
@@ -16,7 +16,9 @@ use crate::{
             rank_hybrid, SearchQuery, DEFAULT_SEMANTIC_MINIMUM_COSINE,
             DEFAULT_SEMANTIC_MINIMUM_MARGIN,
         },
-        repository::{fetch_postgres_candidates, ActiveSearchGeneration, SearchFilters},
+        repository::{
+            fetch_postgres_candidates, ActiveSearchGeneration, SearchFilters, SearchRepositoryError,
+        },
         worker::{
             EmbeddingProvider, EmbeddingProviderError, GenerationSpec, OllamaEmbeddingProvider,
             DOCUMENT_REVISION, NORMALIZATION_REVISION, RANKING_REVISION,
@@ -26,8 +28,8 @@ use crate::{
 };
 
 const DEFAULT_LIMIT: usize = 10;
-const MAX_LIMIT: usize = 100;
-const MAX_OFFSET: usize = 10_000;
+const MAX_LIMIT: usize = 10;
+const MAX_OFFSET: usize = 0;
 const MAX_QUERY_CHARS: usize = 512;
 
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -39,7 +41,9 @@ pub struct SearchQueryParams {
     pub tags: Option<String>,
     pub language: Option<String>,
     pub languages: Option<String>,
+    /// Bounded T003/T004 result size; T006 v1 accepts values from 1 through 10.
     pub limit: Option<usize>,
+    /// Reserved for a future measured pagination contract; T006 v1 accepts only 0.
     pub offset: Option<usize>,
 }
 
@@ -102,10 +106,22 @@ fn parse_list(single: &Option<String>, multiple: &Option<String>) -> Vec<String>
     values
 }
 
+fn validated_query(params: &SearchQueryParams) -> Result<SearchQuery, SearchError> {
+    let raw_q = params.q.as_deref().unwrap_or("").trim();
+    if raw_q.is_empty() || raw_q.chars().count() > MAX_QUERY_CHARS {
+        return Err(SearchError::InvalidRequest);
+    }
+    let query = SearchQuery::new(raw_q);
+    if query.normalized.is_empty() {
+        return Err(SearchError::InvalidRequest);
+    }
+    Ok(query)
+}
+
 fn pagination(params: &SearchQueryParams) -> Result<(usize, usize), SearchError> {
-    let limit = params.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
+    let limit = params.limit.unwrap_or(DEFAULT_LIMIT);
     let offset = params.offset.unwrap_or(0);
-    if offset > MAX_OFFSET {
+    if !(1..=MAX_LIMIT).contains(&limit) || offset > MAX_OFFSET {
         return Err(SearchError::InvalidRequest);
     }
     Ok((limit, offset))
@@ -163,15 +179,7 @@ pub async fn execute_search(
     }
     let pool = state.db_pool.as_ref().ok_or(SearchError::Unavailable)?;
 
-    let raw_q = params.q.as_deref().unwrap_or("").trim();
-    if raw_q.is_empty() || raw_q.chars().count() > MAX_QUERY_CHARS {
-        return Err(SearchError::InvalidRequest);
-    }
-    let query = SearchQuery::new(raw_q);
-    if query.normalized.is_empty() {
-        return Err(SearchError::InvalidRequest);
-    }
-
+    let query = validated_query(&params)?;
     let (limit, offset) = pagination(&params)?;
     let filters = SearchFilters {
         kinds: parse_list(&params.kind, &params.kinds),
@@ -179,10 +187,19 @@ pub async fn execute_search(
         languages: parse_list(&params.language, &params.languages),
     };
 
-    let candidate_set = fetch_postgres_candidates(pool, &query.raw, &filters, auth)
-        .await
-        .map_err(|_| SearchError::Internal)?
-        .ok_or(SearchError::Unavailable)?;
+    let candidate_set = match fetch_postgres_candidates(pool, &query.raw, &filters, auth).await {
+        Ok(Some(candidate_set)) => candidate_set,
+        Ok(None) => return Err(SearchError::Unavailable),
+        Err(SearchRepositoryError::CandidateSetTooLarge) => {
+            state
+                .metrics
+                .search_projection_outcome("candidate_set_too_large");
+            return Err(SearchError::Unavailable);
+        }
+        Err(SearchRepositoryError::Database(_)) | Err(SearchRepositoryError::Json(_)) => {
+            return Err(SearchError::Internal);
+        }
+    };
     validate_generation(&candidate_set.generation)?;
 
     let lexical_ranked = candidate_set
@@ -250,29 +267,78 @@ mod tests {
     use super::*;
 
     #[test]
-    fn pagination_defaults_clamps_limit_and_rejects_excessive_offset() {
+    fn pagination_is_a_bounded_top_ten_contract_without_offset_pages() {
         assert_eq!(pagination(&SearchQueryParams::default()).unwrap(), (10, 0));
 
-        let low = SearchQueryParams {
-            limit: Some(0),
+        let exact = SearchQueryParams {
+            limit: Some(MAX_LIMIT),
+            offset: Some(0),
             ..Default::default()
         };
-        assert_eq!(pagination(&low).unwrap(), (1, 0));
+        assert_eq!(pagination(&exact).unwrap(), (MAX_LIMIT, 0));
 
-        let high = SearchQueryParams {
-            limit: Some(MAX_LIMIT + 1),
-            offset: Some(MAX_OFFSET),
-            ..Default::default()
-        };
-        assert_eq!(pagination(&high).unwrap(), (MAX_LIMIT, MAX_OFFSET));
+        for invalid in [
+            SearchQueryParams {
+                limit: Some(0),
+                ..Default::default()
+            },
+            SearchQueryParams {
+                limit: Some(MAX_LIMIT + 1),
+                ..Default::default()
+            },
+            SearchQueryParams {
+                offset: Some(1),
+                ..Default::default()
+            },
+        ] {
+            assert!(matches!(
+                pagination(&invalid),
+                Err(SearchError::InvalidRequest)
+            ));
+        }
+    }
 
-        let excessive = SearchQueryParams {
-            offset: Some(MAX_OFFSET + 1),
+    #[test]
+    fn query_validation_rejects_empty_and_overlong_input() {
+        for q in [None, Some("".to_string()), Some("   ".to_string())] {
+            let params = SearchQueryParams {
+                q,
+                ..Default::default()
+            };
+            assert!(matches!(
+                validated_query(&params),
+                Err(SearchError::InvalidRequest)
+            ));
+        }
+
+        let overlong = SearchQueryParams {
+            q: Some("x".repeat(MAX_QUERY_CHARS + 1)),
             ..Default::default()
         };
         assert!(matches!(
-            pagination(&excessive),
+            validated_query(&overlong),
             Err(SearchError::InvalidRequest)
         ));
+
+        let valid = SearchQueryParams {
+            q: Some("  Fahrrad Hilfe  ".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(validated_query(&valid).unwrap().raw, "Fahrrad Hilfe");
+    }
+
+    #[test]
+    fn list_filters_merge_deduplicate_and_sort_single_and_plural_forms() {
+        assert_eq!(
+            parse_list(
+                &Some("Werkstatt, Treffpunkt".to_string()),
+                &Some("Treffpunkt,Bibliothek".to_string())
+            ),
+            vec![
+                "Bibliothek".to_string(),
+                "Treffpunkt".to_string(),
+                "Werkstatt".to_string()
+            ]
+        );
     }
 }

--- a/apps/api/src/search/service.rs
+++ b/apps/api/src/search/service.rs
@@ -1,0 +1,240 @@
+//! T006 server-side hybrid search service.
+use std::{env, sync::Arc};
+
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    config::DomainReadSource,
+    middleware::auth::AuthContext,
+    routes::nodes::Node,
+    search::{
+        ranking::{
+            rank_hybrid, SearchQuery, DEFAULT_SEMANTIC_MINIMUM_COSINE,
+            DEFAULT_SEMANTIC_MINIMUM_MARGIN,
+        },
+        repository::{fetch_postgres_candidates, ActiveSearchGeneration, SearchFilters},
+        worker::{
+            EmbeddingProvider, EmbeddingProviderError, GenerationSpec, OllamaEmbeddingProvider,
+            DOCUMENT_REVISION, NORMALIZATION_REVISION, RANKING_REVISION,
+        },
+    },
+    state::ApiState,
+};
+
+const DEFAULT_LIMIT: usize = 10;
+const MAX_LIMIT: usize = 100;
+const MAX_OFFSET: usize = 10_000;
+const MAX_QUERY_CHARS: usize = 512;
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct SearchQueryParams {
+    pub q: Option<String>,
+    pub kind: Option<String>,
+    pub kinds: Option<String>,
+    pub tag: Option<String>,
+    pub tags: Option<String>,
+    pub language: Option<String>,
+    pub languages: Option<String>,
+    pub limit: Option<usize>,
+    pub offset: Option<usize>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct SearchResponse {
+    pub items: Vec<Node>,
+    pub mode: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fallback_reason: Option<String>,
+    pub generation_id: String,
+    pub offset: usize,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SearchError {
+    #[error("provider contract error")]
+    ProviderContractError(#[from] EmbeddingProviderError),
+    #[error("search service unavailable")]
+    Unavailable,
+    #[error("invalid search request")]
+    InvalidRequest,
+    #[error("internal search error")]
+    Internal,
+}
+
+impl IntoResponse for SearchError {
+    fn into_response(self) -> Response {
+        let (status, code) = match &self {
+            SearchError::ProviderContractError(EmbeddingProviderError::Unavailable) => {
+                (StatusCode::SERVICE_UNAVAILABLE, "provider_unavailable")
+            }
+            SearchError::ProviderContractError(error) => {
+                (StatusCode::INTERNAL_SERVER_ERROR, error.code())
+            }
+            SearchError::Unavailable => (StatusCode::SERVICE_UNAVAILABLE, "search_unavailable"),
+            SearchError::InvalidRequest => (StatusCode::BAD_REQUEST, "invalid_search_request"),
+            SearchError::Internal => (StatusCode::INTERNAL_SERVER_ERROR, "search_internal_error"),
+        };
+        tracing::warn!(event = "search.request.failed", error_code = code, %status);
+        (status, code).into_response()
+    }
+}
+
+fn parse_list(single: &Option<String>, multiple: &Option<String>) -> Vec<String> {
+    let mut values = Vec::new();
+    for source in [single.as_deref(), multiple.as_deref()]
+        .into_iter()
+        .flatten()
+    {
+        values.extend(
+            source
+                .split(',')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_owned),
+        );
+    }
+    values.sort();
+    values.dedup();
+    values
+}
+
+fn validate_generation(generation: &ActiveSearchGeneration) -> Result<(), SearchError> {
+    if generation.dimension <= 0
+        || generation.document_revision != DOCUMENT_REVISION
+        || generation.normalization_revision != NORMALIZATION_REVISION
+        || generation.ranking_revision != RANKING_REVISION
+    {
+        return Err(SearchError::Unavailable);
+    }
+    let spec = GenerationSpec {
+        generation_id: &generation.generation_id,
+        provider: &generation.provider,
+        model_id: &generation.model_id,
+        model_revision: &generation.model_revision,
+        runtime_identity: &generation.runtime_identity,
+        dimension: generation.dimension,
+    };
+    if spec.derived_id() != generation.generation_id {
+        return Err(SearchError::Unavailable);
+    }
+    Ok(())
+}
+
+fn runtime_provider(
+    generation: &ActiveSearchGeneration,
+) -> Result<Arc<dyn EmbeddingProvider>, SearchError> {
+    if generation.provider != "local:ollama" {
+        return Err(SearchError::ProviderContractError(
+            EmbeddingProviderError::Unsupported,
+        ));
+    }
+    let base_url =
+        env::var("WELTGEWEBE_SEARCH_OLLAMA_URL").map_err(|_| SearchError::Unavailable)?;
+    let provider = OllamaEmbeddingProvider::new(
+        &base_url,
+        generation.model_id.clone(),
+        generation.model_revision.clone(),
+        generation.runtime_identity.clone(),
+    )?;
+    Ok(Arc::new(provider))
+}
+
+pub async fn execute_search(
+    state: &ApiState,
+    auth: &AuthContext,
+    params: SearchQueryParams,
+    provider_override: Option<Arc<dyn EmbeddingProvider>>,
+) -> Result<SearchResponse, SearchError> {
+    if state.config.domain_read_source != DomainReadSource::Postgres {
+        return Err(SearchError::Unavailable);
+    }
+    let pool = state.db_pool.as_ref().ok_or(SearchError::Unavailable)?;
+
+    let raw_q = params.q.as_deref().unwrap_or("").trim();
+    if raw_q.is_empty() || raw_q.chars().count() > MAX_QUERY_CHARS {
+        return Err(SearchError::InvalidRequest);
+    }
+    let query = SearchQuery::new(raw_q);
+    if query.normalized.is_empty() {
+        return Err(SearchError::InvalidRequest);
+    }
+
+    let limit = params.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
+    let offset = params.offset.unwrap_or(0);
+    if offset > MAX_OFFSET {
+        return Err(SearchError::InvalidRequest);
+    }
+    let filters = SearchFilters {
+        kinds: parse_list(&params.kind, &params.kinds),
+        tags: parse_list(&params.tag, &params.tags),
+        languages: parse_list(&params.language, &params.languages),
+    };
+
+    let candidate_set = fetch_postgres_candidates(pool, &query.raw, &filters, auth)
+        .await
+        .map_err(|_| SearchError::Internal)?
+        .ok_or(SearchError::Unavailable)?;
+    validate_generation(&candidate_set.generation)?;
+
+    let lexical_ranked = candidate_set
+        .candidates
+        .iter()
+        .filter(|candidate| candidate.rank_class != u8::MAX)
+        .cloned()
+        .collect::<Vec<_>>();
+
+    let provider = match provider_override {
+        Some(provider) => provider,
+        None => runtime_provider(&candidate_set.generation)?,
+    };
+
+    let (ranked, mode, fallback_reason) = match provider
+        .embed(
+            &query.normalized,
+            candidate_set.generation.dimension as usize,
+        )
+        .await
+    {
+        Ok(query_vector) => (
+            rank_hybrid(
+                Some(&query_vector),
+                lexical_ranked,
+                &candidate_set.candidates,
+                DEFAULT_SEMANTIC_MINIMUM_COSINE,
+                DEFAULT_SEMANTIC_MINIMUM_MARGIN,
+            ),
+            "hybrid".to_string(),
+            None,
+        ),
+        Err(EmbeddingProviderError::Unavailable) => {
+            state
+                .metrics
+                .search_projection_outcome("fallback_unavailable");
+            (
+                lexical_ranked,
+                "lexical_fallback".to_string(),
+                Some("provider_unavailable".to_string()),
+            )
+        }
+        Err(error) => return Err(SearchError::ProviderContractError(error)),
+    };
+
+    let items = ranked
+        .into_iter()
+        .skip(offset)
+        .take(limit)
+        .map(|candidate| candidate.node)
+        .collect();
+
+    Ok(SearchResponse {
+        items,
+        mode,
+        fallback_reason,
+        generation_id: candidate_set.generation.generation_id,
+        offset,
+    })
+}

--- a/apps/api/src/search/service.rs
+++ b/apps/api/src/search/service.rs
@@ -102,6 +102,15 @@ fn parse_list(single: &Option<String>, multiple: &Option<String>) -> Vec<String>
     values
 }
 
+fn pagination(params: &SearchQueryParams) -> Result<(usize, usize), SearchError> {
+    let limit = params.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
+    let offset = params.offset.unwrap_or(0);
+    if offset > MAX_OFFSET {
+        return Err(SearchError::InvalidRequest);
+    }
+    Ok((limit, offset))
+}
+
 fn validate_generation(generation: &ActiveSearchGeneration) -> Result<(), SearchError> {
     if generation.dimension <= 0
         || generation.document_revision != DOCUMENT_REVISION
@@ -163,11 +172,7 @@ pub async fn execute_search(
         return Err(SearchError::InvalidRequest);
     }
 
-    let limit = params.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
-    let offset = params.offset.unwrap_or(0);
-    if offset > MAX_OFFSET {
-        return Err(SearchError::InvalidRequest);
-    }
+    let (limit, offset) = pagination(&params)?;
     let filters = SearchFilters {
         kinds: parse_list(&params.kind, &params.kinds),
         tags: parse_list(&params.tag, &params.tags),
@@ -192,9 +197,10 @@ pub async fn execute_search(
         None => runtime_provider(&candidate_set.generation)?,
     };
 
+    let query_embedding_text = query.embedding_text();
     let (ranked, mode, fallback_reason) = match provider
         .embed(
-            &query.normalized,
+            &query_embedding_text,
             candidate_set.generation.dimension as usize,
         )
         .await
@@ -237,4 +243,36 @@ pub async fn execute_search(
         generation_id: candidate_set.generation.generation_id,
         offset,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pagination_defaults_clamps_limit_and_rejects_excessive_offset() {
+        assert_eq!(pagination(&SearchQueryParams::default()).unwrap(), (10, 0));
+
+        let low = SearchQueryParams {
+            limit: Some(0),
+            ..Default::default()
+        };
+        assert_eq!(pagination(&low).unwrap(), (1, 0));
+
+        let high = SearchQueryParams {
+            limit: Some(MAX_LIMIT + 1),
+            offset: Some(MAX_OFFSET),
+            ..Default::default()
+        };
+        assert_eq!(pagination(&high).unwrap(), (MAX_LIMIT, MAX_OFFSET));
+
+        let excessive = SearchQueryParams {
+            offset: Some(MAX_OFFSET + 1),
+            ..Default::default()
+        };
+        assert!(matches!(
+            pagination(&excessive),
+            Err(SearchError::InvalidRequest)
+        ));
+    }
 }

--- a/apps/api/src/search/worker.rs
+++ b/apps/api/src/search/worker.rs
@@ -455,7 +455,7 @@ fn decode_chunked_body(mut input: &[u8]) -> Result<Vec<u8>, EmbeddingProviderErr
     }
 }
 
-struct UnavailableEmbeddingProvider;
+pub struct UnavailableEmbeddingProvider;
 
 #[async_trait]
 impl EmbeddingProvider for UnavailableEmbeddingProvider {
@@ -512,16 +512,9 @@ impl ProjectionWorker {
             anyhow::bail!("search generation identity is invalid");
         }
         let mut tx = self.pool.begin().await?;
-        // Match the trigger's shared transaction lock. This makes the initial
-        // generation snapshot linearizable with relevant domain mutations: a
-        // mutation is ordered wholly before this seed or, after commit, sees
-        // the new generation and enqueues its own current revision.
         sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended('weltgewebe.search.generation.activation', 0))")
             .execute(&mut *tx)
             .await?;
-        // A migration starts tracking future mutations.  This idempotent seed
-        // makes legacy rows resumable without treating a missing revision as a
-        // public/visible value.
         sqlx::query(
             "INSERT INTO search_node_versions (node_id,source_version,source_revision) \
             SELECT id,1,'node-1' FROM domain_nodes ON CONFLICT (node_id) DO NOTHING",
@@ -546,9 +539,6 @@ impl ProjectionWorker {
         if identity.is_none() {
             anyhow::bail!("search generation identity mismatch");
         }
-        // A previous bounded outage may have exhausted retries. Re-running the
-        // same exact generation is the explicit catch-up action: only outage-
-        // exhausted jobs are rearmed; permanent contract failures stay failed.
         sqlx::query("UPDATE search_projection_jobs SET state='pending', attempt_count=0, available_at=NOW(), claimed_by=NULL, claim_until=NULL, completed_at=NULL, last_error_code=NULL WHERE generation_id=$1 AND state='failed' AND last_error_code='provider_unavailable_exhausted'")
             .bind(spec.generation_id).execute(&mut *tx).await?;
         let inserted = sqlx::query("INSERT INTO search_projection_jobs (generation_id,node_id,source_version,source_revision,operation) \
@@ -556,9 +546,6 @@ impl ProjectionWorker {
             ON CONFLICT DO NOTHING")
             .bind(spec.generation_id).execute(&mut *tx).await?.rows_affected() as i64;
         tx.commit().await?;
-        // Defense-in-depth reconciliation after releasing the exclusive
-        // generation lock. The lock establishes the race-free ordering; this
-        // idempotent pass repairs legacy or externally seeded version rows.
         let reconciled = sqlx::query("INSERT INTO search_projection_jobs (generation_id,node_id,source_version,source_revision,operation) \
             SELECT $1, v.node_id,v.source_version,v.source_revision,'upsert' FROM search_node_versions v JOIN domain_nodes n ON n.id=v.node_id \
             ON CONFLICT DO NOTHING")
@@ -658,7 +645,6 @@ impl ProjectionWorker {
         Ok(final_outcome)
     }
 
-    /// Read-only operational view: no document text, tags, or vectors escape.
     pub async fn status_snapshot(&self) -> anyhow::Result<ProjectionStatusSnapshot> {
         let row = sqlx::query("SELECT count(*) FILTER (WHERE state='pending') AS pending, count(*) FILTER (WHERE state='claimed') AS claimed, count(*) FILTER (WHERE state='retry') AS retry, count(*) FILTER (WHERE state='done') AS done, count(*) FILTER (WHERE state='stale') AS stale, count(*) FILTER (WHERE state='failed') AS failed FROM search_projection_jobs")
             .fetch_one(&self.pool).await?;
@@ -693,11 +679,6 @@ impl ProjectionWorker {
         })
     }
 
-    /// Deterministic digest over projection identity and metadata, deliberately
-    /// excluding `searchable_text`, tags, and raw embeddings.
-    /// Deterministic digest over projection identity and metadata, deliberately
-    /// excluding `searchable_text`, tags, raw embeddings, timestamps, and the
-    /// generation id itself. Empty rebuilds still bind the full identity.
     pub async fn integrity_digest(&self, generation_id: &str) -> anyhow::Result<String> {
         let generation = sqlx::query("SELECT provider,model_id,model_revision,runtime_identity,dimension,document_revision,normalization_revision,ranking_revision FROM search_index_generations WHERE generation_id=$1")
             .bind(generation_id)
@@ -760,9 +741,6 @@ impl ProjectionWorker {
         version: i64,
         revision: &str,
     ) -> anyhow::Result<Result<ProcessOutcome, &'static str>> {
-        // The claim row and canonical tombstone are locked and checked inside
-        // the mutating statement. attempt_count is the fencing token, so a
-        // reclaimed lease cannot be reused even when a worker id is recycled.
         let row = sqlx::query(
             "WITH lease AS (SELECT 1 FROM search_projection_jobs WHERE id=$5 AND generation_id=$4 AND node_id=$1 AND source_version=$2 AND source_revision=$3 AND operation='delete' AND state='claimed' AND claimed_by=$6 AND attempt_count=$7 AND claim_until > NOW() FOR UPDATE), current AS (SELECT 1 FROM search_node_versions WHERE node_id=$1 AND source_version=$2 AND source_revision=$3 AND deleted_at IS NOT NULL FOR UPDATE), deleted AS (DELETE FROM search_node_projections p USING current, lease, search_index_generations g WHERE p.node_id=$1 AND p.generation_id=$4 AND g.generation_id=p.generation_id AND g.state IN ('building','ready','active') RETURNING 1) SELECT EXISTS (SELECT 1 FROM lease) AS lease_current, EXISTS (SELECT 1 FROM current) AS tombstone_current",
         )
@@ -835,8 +813,6 @@ impl ProjectionWorker {
             }
             Err(error) => return Ok(Err(error.code())),
         };
-        // This INSERT is itself revision fenced. Its affected-row semantics
-        // classify a concurrent canonical mutation as Stale, closing TOCTOU.
         let written = sqlx::query("INSERT INTO search_node_projections (generation_id,node_id,source_version,source_revision,content_sha256,title,tags,searchable_text,language,kind,status,visibility_scopes,semantic_state,embedding) \
             SELECT $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,'ready',$13 \
             FROM (SELECT v.node_id FROM search_node_versions v JOIN domain_nodes n ON n.id=v.node_id JOIN search_index_generations g ON g.generation_id=$1 JOIN search_projection_jobs j ON j.id=$14 WHERE n.id=$2 AND v.source_version=$3 AND v.source_revision=$4 AND v.deleted_at IS NULL AND g.state IN ('building','ready','active') AND j.generation_id=$1 AND j.node_id=$2 AND j.source_version=$3 AND j.source_revision=$4 AND j.operation='upsert' AND j.state='claimed' AND j.claimed_by=$15 AND j.attempt_count=$16 AND j.claim_until > NOW() FOR UPDATE OF v,j) current \
@@ -860,11 +836,6 @@ impl ProjectionWorker {
         code: Option<&str>,
     ) -> anyhow::Result<bool> {
         let mut tx = self.pool.begin().await?;
-        // Generation completion is a state transition, so serialize it with
-        // generation start/activation and relevant domain mutations. Keeping
-        // the fenced job finish and generation reconciliation in one
-        // transaction also prevents a ready-index conflict from committing the
-        // job while leaving its generation counters stale.
         sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended('weltgewebe.search.generation.activation', 0))")
             .execute(&mut *tx)
             .await?;
@@ -887,273 +858,21 @@ impl ProjectionWorker {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::{
-        http_host_header, http_response_complete, EmbeddingProvider, EmbeddingProviderError,
-        OllamaEmbeddingProvider, SearchDocument,
-    };
-    use tokio::{
-        io::{AsyncReadExt, AsyncWriteExt},
-        net::TcpListener,
-    };
-
-    #[test]
-    fn document_excludes_address_and_fails_closed_visibility() {
-        let private = SearchDocument::from_row(
-            "node-1",
-            "Werkstatt",
-            "Fahrradhilfe",
-            r#"{"summary":"Reparatur","address":"secret lane 9","tags":["Rad"]}"#,
-        )
-        .expect("document");
-        assert_eq!(private.status, "hidden");
-        assert!(private.scopes.is_empty());
-        assert!(!private.text.contains("secret lane 9"));
-
-        let public = SearchDocument::from_row(
-            "node-1",
-            "Werkstatt",
-            "Fahrradhilfe",
-            r#"{"search_visibility":"public","summary":"Reparatur","tags":["Rad"]}"#,
-        )
-        .expect("document");
-        assert_eq!(public.status, "active");
-        assert_eq!(public.scopes, ["public"]);
-    }
-
-    #[test]
-    fn document_rejects_blank_projection_required_fields() {
-        assert!(SearchDocument::from_row("node", "Kind", "   ", "{}").is_err());
-        assert!(SearchDocument::from_row("node", "   ", "Titel", "{}").is_err());
-    }
-
-    #[test]
-    fn document_hash_changes_for_indexed_content_not_unindexed_payload() {
-        let first = SearchDocument::from_row("node", "Kind", "Titel", r#"{"address":"a"}"#)
-            .expect("document");
-        let same = SearchDocument::from_row("node", "Kind", "Titel", r#"{"address":"b"}"#)
-            .expect("document");
-        let changed = SearchDocument::from_row("node", "Kind", "Titel", r#"{"summary":"neu"}"#)
-            .expect("document");
-        assert_eq!(first.hash(), same.hash());
-        assert_ne!(first.hash(), changed.hash());
-    }
-
-    #[test]
-    fn ollama_ipv6_loopback_uses_bracketed_host_header() {
-        assert_eq!(http_host_header("::1", 11434), "[::1]:11434");
-        assert_eq!(http_host_header("127.0.0.1", 11434), "127.0.0.1:11434");
-    }
-
-    #[test]
-    fn ollama_invalid_or_conflicting_content_length_is_permanent_format_error() {
-        for response in [
-            b"HTTP/1.1 200 OK\r\nContent-Length: abc\r\n\r\n{}".as_slice(),
-            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nContent-Length: 3\r\n\r\n{}".as_slice(),
-            b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nContent-Length: 2\r\n\r\n0\r\n\r\n"
-                .as_slice(),
-        ] {
-            assert!(matches!(
-                http_response_complete(response),
-                Err(EmbeddingProviderError::MalformedResponse)
-            ));
-        }
-    }
-
-    #[tokio::test]
-    async fn ollama_truncated_framed_response_is_temporary_unavailability() {
-        let listener = match TcpListener::bind("127.0.0.1:0").await {
-            Ok(listener) => listener,
-            Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => return,
-            Err(error) => panic!("bind loopback: {error}"),
-        };
-        let port = listener.local_addr().expect("address").port();
-        let server = tokio::spawn(async move {
-            let (mut stream, _) = listener.accept().await.expect("accept");
-            let mut request = [0_u8; 4096];
-            let _ = stream.read(&mut request).await.expect("read request");
-            stream
-                .write_all(b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 64\r\nConnection: close\r\n\r\n{\"models\":[")
-                .await
-                .expect("partial response");
-        });
-        let provider = OllamaEmbeddingProvider::new(
-            &format!("http://127.0.0.1:{port}/"),
-            "test-model".into(),
-            "sha256:exact".into(),
-            format!("ollama:test-runtime@http://127.0.0.1:{port}"),
-        )
-        .expect("provider");
-        assert!(matches!(
-            provider.object("api/tags", None).await,
-            Err(EmbeddingProviderError::Unavailable)
-        ));
-        server.await.expect("server");
-    }
-
-    #[tokio::test]
-    async fn ollama_408_and_429_are_temporary_unavailability() {
-        for status in [408_u16, 429_u16] {
-            let listener = match TcpListener::bind("127.0.0.1:0").await {
-                Ok(listener) => listener,
-                Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => return,
-                Err(error) => panic!("bind loopback: {error}"),
-            };
-            let port = listener.local_addr().expect("address").port();
-            let server = tokio::spawn(async move {
-                let (mut stream, _) = listener.accept().await.expect("accept");
-                let mut request = [0_u8; 4096];
-                let _ = stream.read(&mut request).await.expect("read request");
-                stream
-                    .write_all(
-                        format!(
-                            "HTTP/1.1 {status} Temporary\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
-                        )
-                        .as_bytes(),
-                    )
-                    .await
-                    .expect("temporary response");
-            });
-            let provider = OllamaEmbeddingProvider::new(
-                &format!("http://127.0.0.1:{port}/"),
-                "test-model".into(),
-                "sha256:exact".into(),
-                format!("ollama:test-runtime@http://127.0.0.1:{port}"),
-            )
-            .expect("provider");
-            assert!(matches!(
-                provider.object("api/tags", None).await,
-                Err(EmbeddingProviderError::Unavailable)
-            ));
-            server.await.expect("server");
-        }
-    }
-
-    #[tokio::test]
-    #[ignore = "requires explicit T005 live Ollama identity environment"]
-    async fn ollama_boundary_embeds_against_explicit_live_loopback() {
-        let url = std::env::var("T005_LIVE_OLLAMA_URL").expect("T005_LIVE_OLLAMA_URL");
-        let model_id = std::env::var("T005_LIVE_OLLAMA_MODEL_ID").expect("model id");
-        let model_revision =
-            std::env::var("T005_LIVE_OLLAMA_MODEL_REVISION").expect("model revision");
-        let runtime_identity =
-            std::env::var("T005_LIVE_OLLAMA_RUNTIME_IDENTITY").expect("runtime identity");
-        let dimension: usize = std::env::var("T005_LIVE_OLLAMA_DIMENSION")
-            .expect("dimension")
-            .parse()
-            .expect("numeric dimension");
-        let provider =
-            OllamaEmbeddingProvider::new(&url, model_id, model_revision, runtime_identity)
-                .expect("live local provider");
-        provider
-            .object("api/tags", None)
-            .await
-            .expect("live local tags");
-        provider
-            .object("api/version", None)
-            .await
-            .expect("live local version");
-        provider
-            .verify_identity()
-            .await
-            .expect("live local identity");
-        let vector = provider
-            .embed("T005 local provider contract proof", dimension)
-            .await
-            .expect("live local embedding");
-        assert_eq!(vector.len(), dimension);
-        assert!(vector.iter().all(|value| value.is_finite()));
-    }
-
-    #[tokio::test]
-    async fn ollama_boundary_uses_only_mocked_loopback_and_rechecks_identity() {
-        let listener = match TcpListener::bind("127.0.0.1:0").await {
-            Ok(listener) => listener,
-            Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => return,
-            Err(error) => panic!("bind loopback: {error}"),
-        };
-        let port = listener.local_addr().expect("address").port();
-        let server = tokio::spawn(async move {
-            for _ in 0..5 {
-                let (mut stream, _) = listener.accept().await.expect("accept");
-                let mut request = [0_u8; 4096];
-                let count = stream.read(&mut request).await.expect("read request");
-                let request = std::str::from_utf8(&request[..count]).expect("request utf8");
-                let (body, chunked) = if request.starts_with("GET /api/tags ") {
-                    (
-                        r#"{"models":[{"name":"test-model","digest":"sha256:exact"}]}"#,
-                        false,
-                    )
-                } else if request.starts_with("GET /api/version ") {
-                    (r#"{"version":"test-runtime"}"#, false)
-                } else if request.starts_with("POST /api/embed ") {
-                    (r#"{"embeddings":[[0.25,0.5]]}"#, true)
-                } else {
-                    panic!("unexpected request: {request}");
-                };
-                let response = if chunked {
-                    format!(
-                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n{:X}\r\n{}\r\n0\r\n\r\n",
-                        body.len(), body
-                    )
-                } else {
-                    format!("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}", body.len(), body)
-                };
-                stream
-                    .write_all(response.as_bytes())
-                    .await
-                    .expect("response");
-            }
-        });
-        let origin = format!("http://127.0.0.1:{port}/");
-        let provider = OllamaEmbeddingProvider::new(
-            &origin,
-            "test-model".into(),
-            "sha256:exact".into(),
-            format!("ollama:test-runtime@http://127.0.0.1:{port}"),
-        )
-        .expect("provider");
-        assert_eq!(
-            provider.embed("only a test", 2).await.expect("embedding"),
-            vec![0.25, 0.5]
-        );
-        server.await.expect("server");
-        assert!(matches!(
-            OllamaEmbeddingProvider::new(
-                "https://127.0.0.1:11434/",
-                "m".into(),
-                "r".into(),
-                "x".into()
-            ),
-            Err(EmbeddingProviderError::Unsupported)
-        ));
-        assert!(matches!(
-            OllamaEmbeddingProvider::new(
-                "http://example.invalid/",
-                "m".into(),
-                "r".into(),
-                "x".into()
-            ),
-            Err(EmbeddingProviderError::Unsupported)
-        ));
-    }
-}
-
 #[derive(Debug)]
-struct SearchDocument {
-    title: String,
-    tags: Vec<String>,
-    summary: String,
-    info: String,
-    text: String,
-    language: String,
-    kind: String,
-    status: String,
-    scopes: Vec<String>,
+pub struct SearchDocument {
+    pub title: String,
+    pub tags: Vec<String>,
+    pub summary: String,
+    pub info: String,
+    pub text: String,
+    pub language: String,
+    pub kind: String,
+    pub status: String,
+    pub scopes: Vec<String>,
 }
+
 impl SearchDocument {
-    fn from_row(node_id: &str, kind: &str, title: &str, payload: &str) -> anyhow::Result<Self> {
+    pub fn from_row(node_id: &str, kind: &str, title: &str, payload: &str) -> anyhow::Result<Self> {
         let payload: Value =
             serde_json::from_str(payload).context("domain node payload is not JSON")?;
         let tags = payload
@@ -1177,14 +896,9 @@ impl SearchDocument {
                 .filter(|v| !v.trim().is_empty())
                 .unwrap_or("und"),
         );
-        // Visibility is fail-closed: legacy/missing values are hidden. No address
-        // or arbitrary payload key is ever incorporated into the document.
         let public = payload.get("search_visibility").and_then(Value::as_str) == Some("public");
         let title = normalize(title);
         let kind = normalize(kind);
-        // Projection columns enforce non-blank title/kind individually. Reject
-        // invalid legacy domain rows before embedding or SQL mutation so the
-        // leased job can terminate fail-closed as document_invalid.
         if title.is_empty() || kind.is_empty() {
             anyhow::bail!("search document for {node_id} has blank required fields");
         }
@@ -1216,7 +930,8 @@ impl SearchDocument {
             },
         })
     }
-    fn hash(&self) -> String {
+
+    pub fn hash(&self) -> String {
         let mut h = Sha256::new();
         let tags = self.tags.join("\u{1f}");
         for (label, value) in [
@@ -1238,6 +953,6 @@ impl SearchDocument {
     }
 }
 
-fn normalize(value: &str) -> String {
+pub fn normalize(value: &str) -> String {
     value.nfkc().collect::<String>().trim().to_owned()
 }

--- a/apps/api/src/search/worker.rs
+++ b/apps/api/src/search/worker.rs
@@ -19,7 +19,7 @@ use unicode_normalization::UnicodeNormalization;
 
 use crate::telemetry::Metrics;
 
-pub const DOCUMENT_REVISION: &str = "weltgewebe-node-document-v1";
+pub const DOCUMENT_REVISION: &str = "node-document-v1";
 pub const NORMALIZATION_REVISION: &str = "weltgewebe-search-normalization-v1";
 pub const RANKING_REVISION: &str = "weltgewebe-hybrid-ranking-v2";
 // Five minutes exceeds the provider boundary's bounded worst-case request budget
@@ -41,21 +41,23 @@ pub struct GenerationSpec<'a> {
 
 impl GenerationSpec<'_> {
     pub fn derived_id(&self) -> String {
-        let mut digest = Sha256::new();
-        for field in [
-            self.provider,
-            self.model_id,
-            self.model_revision,
-            self.runtime_identity,
-            &self.dimension.to_string(),
-            DOCUMENT_REVISION,
-            NORMALIZATION_REVISION,
-            RANKING_REVISION,
-        ] {
-            digest.update(field.as_bytes());
-            digest.update([0]);
-        }
-        format!("search-gen-{}", hex::encode(digest.finalize()))
+        // Keep the production Rust identity byte-compatible with the verified
+        // T004 Python reference contract: JCS over the same nested field names.
+        let payload = serde_json::json!({
+            "model": {
+                "provider": self.provider,
+                "model_id": self.model_id,
+                "model_revision": self.model_revision,
+                "runtime_id": self.runtime_identity,
+                "dimensions": self.dimension,
+            },
+            "document_revision": DOCUMENT_REVISION,
+            "normalization_revision": NORMALIZATION_REVISION,
+            "ranking_revision": RANKING_REVISION,
+        });
+        let canonical = serde_jcs::to_vec(&payload)
+            .expect("static search generation identity payload must serialize");
+        format!("search-gen-{}", hex::encode(Sha256::digest(canonical)))
     }
 }
 
@@ -862,7 +864,7 @@ impl ProjectionWorker {
         let dimension: i32 = row.get("dimension");
         let embedding = match self
             .provider
-            .embed(&document.text, dimension as usize)
+            .embed(&document.embedding_text(), dimension as usize)
             .await
         {
             Ok(vector)
@@ -939,12 +941,29 @@ impl ProjectionWorker {
 mod tests {
     use super::{
         http_host_header, http_response_complete, EmbeddingProvider, EmbeddingProviderError,
-        OllamaEmbeddingProvider, SearchDocument,
+        GenerationSpec, OllamaEmbeddingProvider, SearchDocument,
     };
     use tokio::{
         io::{AsyncReadExt, AsyncWriteExt},
         net::TcpListener,
     };
+
+    #[test]
+    fn t004_selected_generation_identity_is_byte_compatible() {
+        let generation = GenerationSpec {
+            generation_id: "unused-for-derivation",
+            provider: "local:ollama",
+            model_id: "qwen3-embedding:4b",
+            model_revision:
+                "sha256:df5bd2e3c74cd8d069d21dc038f1b359fcdc9458fce1c99bd43c9eb1518ff907",
+            runtime_identity: "ollama:0.12.6@http://127.0.0.1:11434",
+            dimension: 2560,
+        };
+        assert_eq!(
+            generation.derived_id(),
+            "search-gen-46e7aba00f4c40aec10569dc42c9e12205a215d98036291bf006136467653b52"
+        );
+    }
 
     #[test]
     fn document_excludes_address_and_fails_closed_visibility() {
@@ -968,6 +987,10 @@ mod tests {
         .expect("document");
         assert_eq!(public.status, "active");
         assert_eq!(public.scopes, ["public"]);
+        assert_eq!(
+            public.embedding_text(),
+            "Titel: Fahrradhilfe\nKurzbeschreibung: Reparatur\nInformation: \nTags: Rad\nArt: Werkstatt\nSprache: und"
+        );
     }
 
     #[test]
@@ -1264,6 +1287,18 @@ impl SearchDocument {
             },
         })
     }
+    pub fn embedding_text(&self) -> String {
+        format!(
+            "Titel: {}\nKurzbeschreibung: {}\nInformation: {}\nTags: {}\nArt: {}\nSprache: {}",
+            self.title,
+            self.summary,
+            self.info,
+            self.tags.join(", "),
+            self.kind,
+            self.language
+        )
+    }
+
     pub fn hash(&self) -> String {
         let mut h = Sha256::new();
         let tags = self.tags.join("\u{1f}");

--- a/apps/api/tests/api_search_t006.rs
+++ b/apps/api/tests/api_search_t006.rs
@@ -1,0 +1,65 @@
+//! T006 hybrid-order contract tests.
+//!
+//! PostgreSQL authorization/retrieval is proven in db_semantic_search_projection_worker.rs.
+//! These tests deliberately avoid creating a second in-memory search truth.
+
+use weltgewebe_api::{
+    routes::nodes::{Location, Node},
+    search::{rank_hybrid, ScoredNode},
+};
+
+fn candidate(id: &str, rank_class: u8, rank_score: f64, embedding: [f64; 2]) -> ScoredNode {
+    ScoredNode {
+        node: Node {
+            id: id.to_string(),
+            kind: "Werkstatt".to_string(),
+            title: id.to_string(),
+            created_at: "2026-07-22T00:00:00Z".to_string(),
+            updated_at: "2026-07-22T00:00:00Z".to_string(),
+            created_by_account_id: None,
+            summary: None,
+            info: None,
+            tags: vec![],
+            address: None,
+            location: Location { lat: 0.0, lon: 0.0 },
+        },
+        rank_class,
+        rank_score,
+        embedding: Some(embedding.to_vec()),
+    }
+}
+
+#[test]
+fn semantic_append_preserves_authoritative_postgres_lexical_order() {
+    let lexical = vec![
+        candidate("lexical-first", 0, 1.0, [0.0, 1.0]),
+        candidate("lexical-second", 5, 0.4, [0.0, 1.0]),
+    ];
+    let mut candidates = lexical.clone();
+    candidates.push(candidate("semantic", u8::MAX, 0.0, [1.0, 0.0]));
+
+    let ranked = rank_hybrid(Some(&[1.0, 0.0]), lexical, &candidates, 0.8, 0.05);
+    let ids = ranked
+        .iter()
+        .map(|candidate| candidate.node.id.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(ids, vec!["lexical-first", "lexical-second", "semantic"]);
+}
+
+#[test]
+fn semantic_append_is_bounded_to_one_candidate() {
+    let lexical = vec![candidate("lexical", 0, 1.0, [0.0, 1.0])];
+    let mut candidates = lexical.clone();
+    candidates.push(candidate("semantic-a", u8::MAX, 0.0, [1.0, 0.0]));
+    candidates.push(candidate("semantic-b", u8::MAX, 0.0, [1.0, 0.0]));
+
+    let ranked = rank_hybrid(Some(&[1.0, 0.0]), lexical, &candidates, 0.8, 0.0);
+
+    assert_eq!(ranked.len(), 2);
+    assert_eq!(ranked[0].node.id, "lexical");
+    assert!(matches!(
+        ranked[1].node.id.as_str(),
+        "semantic-a" | "semantic-b"
+    ));
+}

--- a/apps/api/tests/api_search_t006.rs
+++ b/apps/api/tests/api_search_t006.rs
@@ -33,7 +33,7 @@ fn candidate(id: &str, rank_class: u8, rank_score: f64, embedding: [f64; 2]) -> 
 fn semantic_append_preserves_authoritative_postgres_lexical_order() {
     let lexical = vec![
         candidate("lexical-first", 0, 1.0, [0.0, 1.0]),
-        candidate("lexical-second", 5, 0.4, [0.0, 1.0]),
+        candidate("lexical-second", 4, 0.4, [0.0, 1.0]),
     ];
     let mut candidates = lexical.clone();
     candidates.push(candidate("semantic", u8::MAX, 0.0, [1.0, 0.0]));

--- a/apps/api/tests/db_semantic_search_projection_worker.rs
+++ b/apps/api/tests/db_semantic_search_projection_worker.rs
@@ -17,9 +17,18 @@ use tokio::{
     time::{sleep, Duration},
 };
 use weltgewebe_api::{
-    search::{
-        EmbeddingProvider, EmbeddingProviderError, GenerationSpec, ProcessOutcome, ProjectionWorker,
+    auth::role::Role,
+    config::{
+        AppConfig, DomainAccountWriteSource, DomainEdgeWriteSource, DomainNodeWriteSource,
+        DomainReadSource,
     },
+    middleware::auth::AuthContext,
+    search::{
+        execute_search, EmbeddingProvider, EmbeddingProviderError, GenerationSpec, ProcessOutcome,
+        ProjectionWorker, SearchError, SearchQueryParams, DOCUMENT_REVISION,
+        NORMALIZATION_REVISION, RANKING_REVISION,
+    },
+    state::ApiState,
     telemetry::{BuildInfo, Metrics},
 };
 
@@ -1297,4 +1306,454 @@ async fn search_backfill_binary_projects_with_live_local_provider_without_activa
             .await
             .expect("active generation count");
     assert_eq!(active_count, 0);
+}
+
+#[tokio::test]
+async fn t006_search_api_against_postgres_projections() {
+    let database_url = match std::env::var("T005_DATABASE_URL") {
+        Ok(url) => url,
+        Err(_) => return,
+    };
+    let pool = PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&database_url)
+        .await
+        .expect("connect T005 database");
+    migrate(&pool).await;
+    reset_search_state(&pool).await;
+
+    let generation_spec = GenerationSpec {
+        generation_id: "derived-below",
+        provider: "local:ollama",
+        model_id: "qwen3-embedding:4b",
+        model_revision: "sha256:4b",
+        runtime_identity: "ollama:test",
+        dimension: 2,
+    };
+    let gen_id = generation_spec.derived_id();
+    sqlx::query(
+        "INSERT INTO search_index_generations (generation_id, provider, model_id, model_revision, runtime_identity, dimension, document_revision, normalization_revision, ranking_revision, state, activated_at) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'active', NOW())",
+    )
+    .bind(&gen_id)
+    .bind(generation_spec.provider)
+    .bind(generation_spec.model_id)
+    .bind(generation_spec.model_revision)
+    .bind(generation_spec.runtime_identity)
+    .bind(generation_spec.dimension)
+    .bind(DOCUMENT_REVISION)
+    .bind(NORMALIZATION_REVISION)
+    .bind(RANKING_REVISION)
+    .execute(&pool)
+    .await
+    .expect("insert identity-bound active generation");
+
+    let nodes = [
+        (
+            "t005-public-node",
+            "Werkstatt",
+            "Fahrrad Werkstatt",
+            r#"{"search_visibility":"public","summary":"Reparatur"}"#,
+            vec![1.0, -1.0],
+        ),
+        (
+            "t005-public-b-node",
+            "Treffpunkt",
+            "Fahrrad Hilfe",
+            r#"{"search_visibility":"public","summary":"Hilfe"}"#,
+            vec![1.0, -1.0],
+        ),
+        (
+            "t005-hidden-node",
+            "Werkstatt",
+            "Geheime Fahrrad Werkstatt",
+            r#"{"search_visibility":"hidden","summary":"Geheim"}"#,
+            vec![0.25, 0.25],
+        ),
+        (
+            "t005-private-node",
+            "Werkstatt",
+            "Private Fahrrad Werkstatt",
+            r#"{"search_visibility":"private","created_by_account_id":"owner-a","summary":"Privat"}"#,
+            vec![0.25, 0.25],
+        ),
+        (
+            "t005-stale-node",
+            "Werkstatt",
+            "Stale Fahrrad Werkstatt",
+            r#"{"search_visibility":"public","summary":"Alt"}"#,
+            vec![0.25, 0.25],
+        ),
+        (
+            "t005-revoked-node",
+            "Werkstatt",
+            "Widerrufene Fahrrad Werkstatt",
+            r#"{"search_visibility":"public","summary":"Widerruf"}"#,
+            vec![0.25, 0.25],
+        ),
+        (
+            "t005-deleted-node",
+            "Werkstatt",
+            "Geloeschte Fahrrad Werkstatt",
+            r#"{"search_visibility":"public","summary":"Loeschen"}"#,
+            vec![0.25, 0.25],
+        ),
+        (
+            "t005-legacy-node",
+            "Werkstatt",
+            "Legacy Fahrrad Werkstatt",
+            r#"{"search_visibility":"legacy","summary":"Legacy"}"#,
+            vec![0.25, 0.25],
+        ),
+        (
+            "t005-wrong-dimension-node",
+            "Werkstatt",
+            "Dimension Fahrrad Werkstatt",
+            r#"{"search_visibility":"public","summary":"Dimension"}"#,
+            vec![1.0],
+        ),
+    ];
+
+    for (index, (id, kind, title, payload, embedding)) in nodes.iter().enumerate() {
+        sqlx::query(
+            "INSERT INTO domain_nodes (id, kind, title, lat, lon, created_at, updated_at, payload) VALUES ($1, $2, $3, 0.0, 0.0, NOW(), NOW(), $4::jsonb)",
+        )
+        .bind(id)
+        .bind(kind)
+        .bind(title)
+        .bind(payload)
+        .execute(&pool)
+        .await
+        .expect("insert T006 domain node");
+        let content_sha = format!("{:064x}", index + 1);
+        sqlx::query(
+            "INSERT INTO search_node_projections (generation_id, node_id, source_version, source_revision, content_sha256, title, tags, searchable_text, language, kind, status, visibility_scopes, semantic_state, embedding) \
+             SELECT $1, v.node_id, v.source_version, v.source_revision, $3, n.title, ARRAY[]::text[], n.title, 'de', n.kind, 'active', ARRAY['public'], 'ready', $4 \
+               FROM search_node_versions v JOIN domain_nodes n ON n.id = v.node_id WHERE v.node_id = $2",
+        )
+        .bind(&gen_id)
+        .bind(id)
+        .bind(content_sha)
+        .bind(embedding)
+        .execute(&pool)
+        .await
+        .expect("insert T006 projection");
+    }
+
+    // Mutate canonical state after projection creation. The API must reject the
+    // now-stale/revoked/deleted projections before lexical or semantic ranking.
+    sqlx::query(
+        "UPDATE domain_nodes SET title='Stale Fahrrad Werkstatt Neu' WHERE id='t005-stale-node'",
+    )
+    .execute(&pool)
+    .await
+    .expect("make projection stale");
+    sqlx::query("UPDATE domain_nodes SET payload=jsonb_set(payload, '{search_visibility}', '\"revoked\"'::jsonb) WHERE id='t005-revoked-node'")
+        .execute(&pool)
+        .await
+        .expect("revoke visibility");
+    sqlx::query("DELETE FROM domain_nodes WHERE id='t005-deleted-node'")
+        .execute(&pool)
+        .await
+        .expect("delete domain node");
+
+    let metrics = Metrics::try_new(BuildInfo {
+        version: "test",
+        commit: "test",
+        build_timestamp: "test",
+    })
+    .expect("metrics");
+    let state = ApiState {
+        db_pool: Some(pool.clone()),
+        db_pool_configured: true,
+        nats_client: None,
+        nats_configured: false,
+        config: AppConfig {
+            fade_days: 7,
+            ron_days: 84,
+            anonymize_opt_in: true,
+            delegation_expire_days: 28,
+            max_guest_owned_nodes: 1000,
+            domain_read_source: DomainReadSource::Postgres,
+            domain_account_write_source: DomainAccountWriteSource::Postgres,
+            domain_node_write_source: DomainNodeWriteSource::Postgres,
+            domain_edge_write_source: DomainEdgeWriteSource::Postgres,
+            passkey_credential_source: weltgewebe_api::config::PasskeyCredentialSource::InMemory,
+            auth_public_login: false,
+            auth_cookie_secure: true,
+            app_base_url: None,
+            auth_trusted_proxies: None,
+            auth_allow_emails: None,
+            auth_allow_email_domains: None,
+            auth_auto_provision: false,
+            auth_auto_provision_role: weltgewebe_api::config::AutoProvisionRole::Gast,
+            auth_rl_ip_per_min: None,
+            auth_rl_ip_per_hour: None,
+            auth_rl_email_per_min: None,
+            auth_rl_email_per_hour: None,
+            smtp_host: None,
+            smtp_port: None,
+            smtp_user: None,
+            smtp_pass: None,
+            smtp_from: None,
+            auth_log_magic_token: false,
+            webauthn_rp_id: None,
+            webauthn_rp_origin: None,
+            webauthn_rp_name: None,
+        },
+        metrics,
+        sessions: weltgewebe_api::auth::session::SessionBackend::new_in_memory(),
+        challenges: Default::default(),
+        tokens: Default::default(),
+        step_up_tokens: Default::default(),
+        accounts: Arc::new(tokio::sync::RwLock::new(Default::default())),
+        nodes: Arc::new(tokio::sync::RwLock::new(
+            weltgewebe_api::state::OrderedCache::new(),
+        )),
+        nodes_persist: Arc::new(tokio::sync::Mutex::new(())),
+        accounts_persist: Arc::new(tokio::sync::Mutex::new(())),
+        domain_projection_gate: Arc::new(tokio::sync::RwLock::new(())),
+        domain_projection_version: Arc::new(std::sync::atomic::AtomicI64::new(0)),
+        edges: Arc::new(tokio::sync::RwLock::new(
+            weltgewebe_api::state::OrderedCache::new(),
+        )),
+        rate_limiter: Arc::new(weltgewebe_api::auth::rate_limit::AuthRateLimiter::new(
+            &AppConfig::load().unwrap(),
+        )),
+        mailer: None,
+        webauthn: None,
+        passkey_registrations: Default::default(),
+        passkey_registration_grants: Default::default(),
+        passkey_authentications: Default::default(),
+        passkeys: Default::default(),
+    };
+
+    let anonymous = AuthContext {
+        authenticated: false,
+        account_id: None,
+        device_id: None,
+        role: Role::Gast,
+        expires_at: None,
+    };
+    let owner_a = AuthContext {
+        authenticated: true,
+        account_id: Some("owner-a".to_string()),
+        device_id: None,
+        role: Role::Weber,
+        expires_at: None,
+    };
+    let owner_b = AuthContext {
+        authenticated: true,
+        account_id: Some("owner-b".to_string()),
+        device_id: None,
+        role: Role::Weber,
+        expires_at: None,
+    };
+    let unavailable_provider = || -> Arc<dyn EmbeddingProvider> {
+        Arc::new(FakeProvider {
+            unavailable: AtomicBool::new(true),
+        })
+    };
+    let available_provider = || -> Arc<dyn EmbeddingProvider> {
+        Arc::new(FakeProvider {
+            unavailable: AtomicBool::new(false),
+        })
+    };
+
+    let public = execute_search(
+        &state,
+        &anonymous,
+        SearchQueryParams {
+            q: Some("Fahrrad Werkstatt".to_string()),
+            ..Default::default()
+        },
+        Some(unavailable_provider()),
+    )
+    .await
+    .expect("public lexical fallback search");
+    assert_eq!(
+        public.items.first().map(|node| node.id.as_str()),
+        Some("t005-public-node")
+    );
+    assert_eq!(public.generation_id, gen_id);
+    assert_eq!(public.mode, "lexical_fallback");
+    assert_eq!(
+        public.fallback_reason.as_deref(),
+        Some("provider_unavailable")
+    );
+
+    let filtered = execute_search(
+        &state,
+        &anonymous,
+        SearchQueryParams {
+            q: Some("Fahrrad".to_string()),
+            kind: Some("Werkstatt".to_string()),
+            ..Default::default()
+        },
+        Some(unavailable_provider()),
+    )
+    .await
+    .expect("filtered search");
+    assert!(filtered.items.iter().all(|node| node.kind == "Werkstatt"));
+    assert!(!filtered
+        .items
+        .iter()
+        .any(|node| node.id == "t005-public-b-node"));
+
+    for (forbidden_id, forbidden_title) in [
+        ("t005-hidden-node", "Geheime Fahrrad Werkstatt"),
+        ("t005-stale-node", "Stale Fahrrad Werkstatt"),
+        ("t005-revoked-node", "Widerrufene Fahrrad Werkstatt"),
+        ("t005-deleted-node", "Geloeschte Fahrrad Werkstatt"),
+        ("t005-legacy-node", "Legacy Fahrrad Werkstatt"),
+        ("t005-wrong-dimension-node", "Dimension Fahrrad Werkstatt"),
+    ] {
+        let result = execute_search(
+            &state,
+            &anonymous,
+            SearchQueryParams {
+                q: Some(forbidden_title.to_string()),
+                ..Default::default()
+            },
+            Some(unavailable_provider()),
+        )
+        .await
+        .expect("fail-closed lexical search");
+        assert!(
+            !result.items.iter().any(|node| node.id == forbidden_id),
+            "{forbidden_id} must stay invisible even when other public lexical matches remain"
+        );
+    }
+
+    let private_anonymous = execute_search(
+        &state,
+        &anonymous,
+        SearchQueryParams {
+            q: Some("Private Fahrrad Werkstatt".to_string()),
+            ..Default::default()
+        },
+        Some(unavailable_provider()),
+    )
+    .await
+    .expect("anonymous private search");
+    assert!(!private_anonymous
+        .items
+        .iter()
+        .any(|node| node.id == "t005-private-node"));
+
+    let private_owner = execute_search(
+        &state,
+        &owner_a,
+        SearchQueryParams {
+            q: Some("Private Fahrrad Werkstatt".to_string()),
+            ..Default::default()
+        },
+        Some(unavailable_provider()),
+    )
+    .await
+    .expect("owner private search");
+    assert!(private_owner
+        .items
+        .iter()
+        .any(|node| node.id == "t005-private-node"));
+
+    // Authorization changes are read from canonical domain state. Refresh only
+    // the projection identity to model a completed re-projection after ownership
+    // changed; the old owner must immediately lose access and the new owner gain it.
+    sqlx::query("UPDATE domain_nodes SET payload=jsonb_set(payload, '{created_by_account_id}', '\"owner-b\"'::jsonb) WHERE id='t005-private-node'")
+        .execute(&pool)
+        .await
+        .expect("change private owner");
+    sqlx::query(
+        "UPDATE search_node_projections p SET source_version=v.source_version, source_revision=v.source_revision \
+           FROM search_node_versions v WHERE p.generation_id=$1 AND p.node_id='t005-private-node' AND v.node_id=p.node_id",
+    )
+    .bind(&gen_id)
+    .execute(&pool)
+    .await
+    .expect("refresh private projection identity");
+
+    let old_owner = execute_search(
+        &state,
+        &owner_a,
+        SearchQueryParams {
+            q: Some("Private Fahrrad Werkstatt".to_string()),
+            ..Default::default()
+        },
+        Some(unavailable_provider()),
+    )
+    .await
+    .expect("old owner search");
+    assert!(!old_owner
+        .items
+        .iter()
+        .any(|node| node.id == "t005-private-node"));
+    let new_owner = execute_search(
+        &state,
+        &owner_b,
+        SearchQueryParams {
+            q: Some("Private Fahrrad Werkstatt".to_string()),
+            ..Default::default()
+        },
+        Some(unavailable_provider()),
+    )
+    .await
+    .expect("new owner search");
+    assert!(new_owner
+        .items
+        .iter()
+        .any(|node| node.id == "t005-private-node"));
+
+    // Hidden/private candidates carry deliberately misleading public projection
+    // scopes and high semantic similarity. Anonymous semantic retrieval still
+    // cannot see them because canonical authorization ran before ranking.
+    let semantic = execute_search(
+        &state,
+        &anonymous,
+        SearchQueryParams {
+            q: Some("voellig fremder begriff".to_string()),
+            ..Default::default()
+        },
+        Some(available_provider()),
+    )
+    .await
+    .expect("semantic authorization boundary");
+    assert!(semantic.items.is_empty());
+
+    let provider_contract_failure = execute_search(
+        &state,
+        &anonymous,
+        SearchQueryParams {
+            q: Some("Fahrrad Werkstatt".to_string()),
+            ..Default::default()
+        },
+        Some(Arc::new(PermanentFailureProvider)),
+    )
+    .await;
+    assert!(matches!(
+        provider_contract_failure,
+        Err(SearchError::ProviderContractError(
+            EmbeddingProviderError::InvalidVector
+        ))
+    ));
+
+    // Generation identity tampering is not a degradable provider outage.
+    sqlx::query(
+        "UPDATE search_index_generations SET runtime_identity='tampered' WHERE generation_id=$1",
+    )
+    .bind(&gen_id)
+    .execute(&pool)
+    .await
+    .expect("tamper generation identity");
+    let tampered = execute_search(
+        &state,
+        &anonymous,
+        SearchQueryParams {
+            q: Some("Fahrrad Werkstatt".to_string()),
+            ..Default::default()
+        },
+        Some(unavailable_provider()),
+    )
+    .await;
+    assert!(matches!(tampered, Err(SearchError::Unavailable)));
 }

--- a/apps/api/tests/db_semantic_search_projection_worker.rs
+++ b/apps/api/tests/db_semantic_search_projection_worker.rs
@@ -28,7 +28,8 @@ use weltgewebe_api::{
     search::{
         execute_search, fetch_postgres_candidates, EmbeddingProvider, EmbeddingProviderError,
         GenerationSpec, ProcessOutcome, ProjectionWorker, SearchError, SearchFilters,
-        SearchQueryParams, DOCUMENT_REVISION, NORMALIZATION_REVISION, RANKING_REVISION,
+        SearchQueryParams, SearchRepositoryError, DOCUMENT_REVISION, MAX_AUTHORIZED_CANDIDATES,
+        NORMALIZATION_REVISION, RANKING_REVISION,
     },
     state::ApiState,
     telemetry::{BuildInfo, Metrics},
@@ -62,7 +63,7 @@ async fn migrate(pool: &PgPool) {
 async fn reset_search_state(pool: &PgPool) {
     // Tests in this target share one disposable database serially. Remove test
     // domain rows first (which may fire triggers), then clear all derived state.
-    sqlx::query("DELETE FROM domain_nodes WHERE id LIKE 't005-%'")
+    sqlx::query("DELETE FROM domain_nodes WHERE id LIKE 't005-%' OR id LIKE 't006-%'")
         .execute(pool)
         .await
         .expect("remove prior T005 test nodes");
@@ -1688,6 +1689,25 @@ async fn t006_search_api_against_postgres_projections() {
         .expect("insert T006 projection");
     }
 
+    // T006 stores the T003 lexical representations once in projection state.
+    // Updating an indexed field must refresh the stored vector through the
+    // migration trigger rather than rebuilding it in every search request.
+    sqlx::query(
+        "UPDATE search_node_projections SET tags=ARRAY['Rad','Reparatur'] WHERE generation_id=$1 AND node_id='t005-public-node'",
+    )
+    .bind(&gen_id)
+    .execute(&pool)
+    .await
+    .expect("update T006 projection tags");
+    let stored_vector_matches: bool = sqlx::query_scalar(
+        "SELECT search_vector @@ plainto_tsquery('german'::regconfig, 'Reparatur') FROM search_node_projections WHERE generation_id=$1 AND node_id='t005-public-node'",
+    )
+    .bind(&gen_id)
+    .fetch_one(&pool)
+    .await
+    .expect("read stored T006 lexical vector");
+    assert!(stored_vector_matches);
+
     // Add more than ten valid lexical matches. T003 limits the authoritative
     // lexical prefix to ten; lower-ranked matches remain eligible only for the
     // bounded semantic append decision.
@@ -1964,6 +1984,28 @@ async fn t006_search_api_against_postgres_projections() {
         .iter()
         .any(|node| node.id == "t005-public-b-node"));
 
+    let combined_filter = execute_search(
+        &state,
+        &anonymous,
+        SearchQueryParams {
+            q: Some("Fahrrad".to_string()),
+            kinds: Some("Werkstatt,Treffpunkt".to_string()),
+            tags: Some("Rad".to_string()),
+            ..Default::default()
+        },
+        Some(unavailable_provider()),
+    )
+    .await
+    .expect("combined kind and tag filter search");
+    assert_eq!(
+        combined_filter
+            .items
+            .iter()
+            .map(|node| node.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["t005-public-node"]
+    );
+
     for (forbidden_id, forbidden_title) in [
         ("t005-hidden-node", "Geheime Fahrrad Werkstatt"),
         ("t005-stale-node", "Stale Fahrrad Werkstatt"),
@@ -2100,6 +2142,55 @@ async fn t006_search_api_against_postgres_projections() {
             EmbeddingProviderError::InvalidVector
         ))
     ));
+
+    // The verified T004 core rejects candidate sets above 1000. T006 mirrors
+    // that bound and fetches only one sentinel row beyond it, preventing an
+    // unbounded transfer of embedding arrays into the API process.
+    sqlx::query(
+        "INSERT INTO domain_nodes (id, kind, title, lat, lon, created_at, updated_at, payload) \
+         SELECT 't006-overflow-' || lpad(value::text, 4, '0'), 'Overflow', 'Overflow ' || value::text, 0.0, 0.0, NOW(), NOW(), '{\"search_visibility\":\"public\"}'::jsonb \
+           FROM generate_series(1, $1::integer) AS value",
+    )
+    .bind((MAX_AUTHORIZED_CANDIDATES + 1) as i32)
+    .execute(&pool)
+    .await
+    .expect("insert T006 overflow domain nodes");
+    sqlx::query(
+        "INSERT INTO search_node_projections (generation_id, node_id, source_version, source_revision, content_sha256, title, tags, searchable_text, language, kind, status, visibility_scopes, semantic_state, embedding) \
+         SELECT $1, v.node_id, v.source_version, v.source_revision, repeat('a', 64), n.title, ARRAY[]::text[], n.title, 'de', n.kind, 'active', ARRAY['public'], 'ready', ARRAY[1.0,-1.0]::double precision[] \
+           FROM search_node_versions v JOIN domain_nodes n ON n.id=v.node_id WHERE n.kind='Overflow'",
+    )
+    .bind(&gen_id)
+    .execute(&pool)
+    .await
+    .expect("insert T006 overflow projections");
+    let overflow = fetch_postgres_candidates(
+        &pool,
+        "kein lexikalischer treffer",
+        &SearchFilters {
+            kinds: vec!["Overflow".to_string()],
+            ..Default::default()
+        },
+        &anonymous,
+    )
+    .await;
+    assert!(matches!(
+        overflow,
+        Err(SearchRepositoryError::CandidateSetTooLarge)
+    ));
+
+    let overflow_api = execute_search(
+        &state,
+        &anonymous,
+        SearchQueryParams {
+            q: Some("kein lexikalischer treffer".to_string()),
+            kind: Some("Overflow".to_string()),
+            ..Default::default()
+        },
+        Some(unavailable_provider()),
+    )
+    .await;
+    assert!(matches!(overflow_api, Err(SearchError::Unavailable)));
 
     // Generation identity tampering is not a degradable provider outage.
     sqlx::query(


### PR DESCRIPTION
## Summary

Implements `WELTGEWEBE-SEMANTIC-SEARCH-V1-T006`: an authorized hybrid server-side search API over the PostgreSQL search projection from T005.

<!-- weltgewebe-risk: R3 -->

## Security and correctness contract

- Canonical `domain_nodes` visibility plus the request `AuthContext` is applied before candidates reach lexical or semantic ranking.
- Projection `visibility_scopes` are not trusted for authorization.
- Only the single active generation is eligible; provider/model/revision/runtime/dimension identity is bound and revalidated.
- The authoritative T003 lexical contract is preserved: exact title, exact tag, title prefix, trigram+term coverage, full-text term coverage, pure trigram, deterministic node-id tie break.
- Exactly the canonical top-10 lexical prefix is marked as lexically ranked. T006 v1 exposes a bounded top-10 result contract and deliberately does not claim offset pagination.
- Rust preserves lexical precedence and may append at most one semantic candidate under the T004 confidence/margin contract.
- Authorized semantic candidate transfer is bounded to T004's maximum of 1000 candidates; an overflow fails closed before unbounded embedding transfer reaches the API process.
- Weighted German/simple full-text vectors are persisted as regenerable projection state and refreshed by trigger instead of being rebuilt for every authorized row on every request.
- Only `EmbeddingProviderError::Unavailable` degrades to lexical fallback. Provider contract, identity, dimension, privacy and generation errors fail closed.
- Runtime error logging emits only error code and HTTP status; no query text, document text, raw vectors or provider responses are logged.

## Validation bound to current head

Base: `96a5861a5a51e70b4a5b6b05f40549b74bf1908a`

Head: `035611b34a94abfd2f30803358e8b2a70913e0cb`

GitHub Review Evidence Gate diff SHA-256: `a1587616353d65f8e8a59cc723ff5ea9cf014157fcb940ad3bb1947dfa7a43b7`

- Current-head `cargo fmt --manifest-path apps/api/Cargo.toml -- --check`: PASS.
- Current-head `cargo test --manifest-path apps/api/Cargo.toml --test api_search_t006`: 2/2 PASS.
- GitHub CI and integration proofs are re-running for this exact final head after the main sync; merge is deferred until all required checks are green.

The final main-sync changed only `.github/dependabot.yml`, outside the 12 PR files. The GitHub-materialized review diff remains byte-identical with SHA-256 `a1587616353d65f8e8a59cc723ff5ea9cf014157fcb940ad3bb1947dfa7a43b7`.

## Review evidence

Two user-forwarded external reviews are re-attested against the exact current base/head and unchanged byte-identical diff above on distinct axes:

- `external-review-forwarded-by-user-20260723-A` — `security` — PASS — findings resolved.
- `external-review-forwarded-by-user-20260723-B` — `architecture` — PASS — findings resolved.

The re-attestation does not claim that new external reviews were executed; it preserves the existing user-forwarded reviews because their reviewed diff is byte-identical. The Review Evidence Gate independently verifies the exact binding.

## Scope boundary

No production rollout, web rollout, ANN/HNSW index, external search index or SemantAH shutdown is part of this PR.

Two non-blocking scaling follow-ups remain separate from T006:

- Public search request-cost/rate-limit envelope: Bureau candidate `candidate-45fdcbdf44dadcd457d4ace4` (`promote` assessment; not a canonical Registry task).
- Measured database CPU/query-plan scaling and potential two-phase retrieval while preserving T003/T004 semantics: Bureau candidate `candidate-da8668c3f5e1b27b55068a86` (`promote` assessment; not a canonical Registry task).