### PR TITLE
audit: close T023–T026 remediation gaps

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -150,7 +150,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_COLOR: always
-      DATABASE_URL: postgres://welt:gewebe@localhost:5432/weltgewebe
+      DATABASE_URL: postgres://welt:gewebe@localhost:5432/weltgewebe_ci_proof
     timeout-minutes: 20
     services:
       postgres:
@@ -158,7 +158,7 @@ jobs:
         env:
           POSTGRES_USER: welt
           POSTGRES_PASSWORD: gewebe
-          POSTGRES_DB: weltgewebe
+          POSTGRES_DB: weltgewebe_ci_proof
         ports:
           - 5432:5432
         options: >-
@@ -198,7 +198,7 @@ jobs:
         run: |
           max_attempts=15
           for attempt in $(seq 1 "$max_attempts"); do
-            if pg_isready -h localhost -p 5432 -U welt -d weltgewebe; then
+            if pg_isready -h localhost -p 5432 -U welt -d weltgewebe_ci_proof; then
               echo "PostgreSQL is ready."
               exit 0
             fi
@@ -219,7 +219,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_COLOR: always
-      DATABASE_URL: postgres://welt:gewebe@localhost:5432/weltgewebe
+      DATABASE_URL: postgres://welt:gewebe@localhost:5432/weltgewebe_ci_proof
     timeout-minutes: 20
     services:
       postgres:
@@ -227,7 +227,7 @@ jobs:
         env:
           POSTGRES_USER: welt
           POSTGRES_PASSWORD: gewebe
-          POSTGRES_DB: weltgewebe
+          POSTGRES_DB: weltgewebe_ci_proof
         ports:
           - 5432:5432
         options: >-
@@ -282,7 +282,7 @@ jobs:
       CARGO_TERM_COLOR: always
       PGUSER: welt
       PGPASSWORD: gewebe
-      PGDATABASE: weltgewebe
+      PGDATABASE: weltgewebe_ci_proof
     timeout-minutes: 20
     services:
       postgres:
@@ -290,7 +290,7 @@ jobs:
         env:
           POSTGRES_USER: welt
           POSTGRES_PASSWORD: gewebe
-          POSTGRES_DB: weltgewebe
+          POSTGRES_DB: weltgewebe_ci_proof
         ports:
           - 5432:5432
         options: >-
@@ -330,7 +330,7 @@ jobs:
         run: |
           max_attempts=15
           for attempt in $(seq 1 "$max_attempts"); do
-            if pg_isready -h localhost -p 5432 -U welt -d weltgewebe; then
+            if pg_isready -h localhost -p 5432 -U welt -d weltgewebe_ci_proof; then
               echo "PostgreSQL is ready."
               exit 0
             fi
@@ -354,7 +354,7 @@ jobs:
       CARGO_TERM_COLOR: always
       PGUSER: welt
       PGPASSWORD: gewebe
-      PGDATABASE: weltgewebe
+      PGDATABASE: weltgewebe_ci_proof
     timeout-minutes: 20
     services:
       postgres:
@@ -362,7 +362,7 @@ jobs:
         env:
           POSTGRES_USER: welt
           POSTGRES_PASSWORD: gewebe
-          POSTGRES_DB: weltgewebe
+          POSTGRES_DB: weltgewebe_ci_proof
         ports:
           - 5432:5432
         options: >-
@@ -402,7 +402,7 @@ jobs:
         run: |
           max_attempts=15
           for attempt in $(seq 1 "$max_attempts"); do
-            if pg_isready -h localhost -p 5432 -U welt -d weltgewebe; then
+            if pg_isready -h localhost -p 5432 -U welt -d weltgewebe_ci_proof; then
               echo "PostgreSQL is ready."
               exit 0
             fi
@@ -426,7 +426,7 @@ jobs:
       CARGO_TERM_COLOR: always
       PGUSER: welt
       PGPASSWORD: gewebe
-      PGDATABASE: weltgewebe
+      PGDATABASE: weltgewebe_ci_proof
     timeout-minutes: 20
     services:
       postgres:
@@ -434,7 +434,7 @@ jobs:
         env:
           POSTGRES_USER: welt
           POSTGRES_PASSWORD: gewebe
-          POSTGRES_DB: weltgewebe
+          POSTGRES_DB: weltgewebe_ci_proof
         ports:
           - 5432:5432
         options: >-
@@ -474,7 +474,7 @@ jobs:
         run: |
           max_attempts=15
           for attempt in $(seq 1 "$max_attempts"); do
-            if pg_isready -h localhost -p 5432 -U welt -d weltgewebe; then
+            if pg_isready -h localhost -p 5432 -U welt -d weltgewebe_ci_proof; then
               echo "PostgreSQL is ready."
               exit 0
             fi
@@ -498,7 +498,7 @@ jobs:
       CARGO_TERM_COLOR: always
       PGUSER: welt
       PGPASSWORD: gewebe
-      PGDATABASE: weltgewebe
+      PGDATABASE: weltgewebe_ci_proof
     timeout-minutes: 20
     services:
       postgres:
@@ -506,7 +506,7 @@ jobs:
         env:
           POSTGRES_USER: welt
           POSTGRES_PASSWORD: gewebe
-          POSTGRES_DB: weltgewebe
+          POSTGRES_DB: weltgewebe_ci_proof
         ports:
           - 5432:5432
         options: >-
@@ -546,7 +546,7 @@ jobs:
         run: |
           max_attempts=15
           for attempt in $(seq 1 "$max_attempts"); do
-            if pg_isready -h localhost -p 5432 -U welt -d weltgewebe; then
+            if pg_isready -h localhost -p 5432 -U welt -d weltgewebe_ci_proof; then
               echo "PostgreSQL is ready."
               exit 0
             fi
@@ -570,7 +570,7 @@ jobs:
       CARGO_TERM_COLOR: always
       PGUSER: welt
       PGPASSWORD: gewebe
-      PGDATABASE: weltgewebe
+      PGDATABASE: weltgewebe_ci_proof
     timeout-minutes: 20
     services:
       postgres:
@@ -578,7 +578,7 @@ jobs:
         env:
           POSTGRES_USER: welt
           POSTGRES_PASSWORD: gewebe
-          POSTGRES_DB: weltgewebe
+          POSTGRES_DB: weltgewebe_ci_proof
         ports:
           - 5432:5432
         options: >-
@@ -618,7 +618,7 @@ jobs:
         run: |
           max_attempts=15
           for attempt in $(seq 1 "$max_attempts"); do
-            if pg_isready -h localhost -p 5432 -U welt -d weltgewebe; then
+            if pg_isready -h localhost -p 5432 -U welt -d weltgewebe_ci_proof; then
               echo "PostgreSQL is ready."
               exit 0
             fi
@@ -656,7 +656,7 @@ jobs:
       CARGO_TERM_COLOR: always
       PGUSER: welt
       PGPASSWORD: gewebe
-      PGDATABASE: weltgewebe
+      PGDATABASE: weltgewebe_ci_proof
     timeout-minutes: 20
     services:
       postgres:
@@ -664,7 +664,7 @@ jobs:
         env:
           POSTGRES_USER: welt
           POSTGRES_PASSWORD: gewebe
-          POSTGRES_DB: weltgewebe
+          POSTGRES_DB: weltgewebe_ci_proof
         ports:
           - 5432:5432
         options: >-
@@ -704,7 +704,7 @@ jobs:
         run: |
           max_attempts=15
           for attempt in $(seq 1 "$max_attempts"); do
-            if pg_isready -h localhost -p 5432 -U welt -d weltgewebe; then
+            if pg_isready -h localhost -p 5432 -U welt -d weltgewebe_ci_proof; then
               echo "PostgreSQL is ready."
               exit 0
             fi

--- a/.github/workflows/auth-passkey-register-proof.yml
+++ b/.github/workflows/auth-passkey-register-proof.yml
@@ -88,7 +88,7 @@ jobs:
       NPM_CONFIG_FUND: "false"
       PUPPETEER_SKIP_DOWNLOAD: "true"
       PLAYWRIGHT_HTML_REPORT_OPEN: never
-      DATABASE_URL: postgres://welt:gewebe@localhost:5432/weltgewebe
+      DATABASE_URL: postgres://welt:gewebe@localhost:5432/weltgewebe_ci_proof
       AUTH_PASSKEY_PROOF_POSTGRES: "1"
       PLAYWRIGHT_JUNIT_OUTPUT_NAME: results.xml
     services:
@@ -97,7 +97,7 @@ jobs:
         env:
           POSTGRES_USER: welt
           POSTGRES_PASSWORD: gewebe
-          POSTGRES_DB: weltgewebe
+          POSTGRES_DB: weltgewebe_ci_proof
         ports:
           - 5432:5432
         options: >-

--- a/.github/workflows/auth-session-persistence-proof.yml
+++ b/.github/workflows/auth-session-persistence-proof.yml
@@ -85,11 +85,11 @@ jobs:
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: weltgewebe
+          POSTGRES_DB: weltgewebe_ci_proof
         ports:
           - 5432:5432
         options: >-
-          --health-cmd "pg_isready -U postgres -d weltgewebe"
+          --health-cmd "pg_isready -U postgres -d weltgewebe_ci_proof"
           --health-interval 5s
           --health-timeout 5s
           --health-retries 20
@@ -101,7 +101,7 @@ jobs:
       PLAYWRIGHT_HTML_REPORT_OPEN: never
       PLAYWRIGHT_HTML_REPORT: playwright-report-session
       PLAYWRIGHT_JUNIT_OUTPUT_NAME: session-results.xml
-      AUTH_SESSION_PROOF_DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5432/weltgewebe
+      AUTH_SESSION_PROOF_DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5432/weltgewebe_ci_proof
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # tag: v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,7 +465,7 @@ jobs:
     env:
       DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5432/weltgewebe_t002_test
       PG_DIRECT_URL: postgres://postgres:postgres@127.0.0.1:5432/weltgewebe_t002_test
-      NATS_URL: nats://127.0.0.1:4222
+      POSTGRES_PROOF_PROVISION_NATS: "1"
       CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # tag: v7.0.1
@@ -477,27 +477,8 @@ jobs:
           toolchain: 1.89.0
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # tag: v2
-      - name: Start isolated JetStream proof service
-        run: |
-          set -euo pipefail
-          docker run --detach --rm \
-            --name weltgewebe-ci-nats \
-            --publish 127.0.0.1:4222:4222 \
-            nats@sha256:b83efabe3e7def1e0a4a31ec6e078999bb17c80363f881df35edc70fcb6bb927 \
-            -js
-          for attempt in {1..30}; do
-            if (echo > /dev/tcp/127.0.0.1/4222) 2>/dev/null; then
-              exit 0
-            fi
-            sleep 1
-          done
-          docker logs weltgewebe-ci-nats
-          exit 1
-      - name: Run PostgreSQL and multi-instance proof suite
+      - name: Run hermetic PostgreSQL and multi-instance proof suite
         run: scripts/ci/run-postgres-integration-proofs.sh
-      - name: Stop isolated JetStream proof service
-        if: ${{ always() }}
-        run: docker stop weltgewebe-ci-nats || true
 
   lint-docs:
     name: Docs & Shell Hygiene

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,7 +465,7 @@ jobs:
     env:
       DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5432/weltgewebe_t002_test
       PG_DIRECT_URL: postgres://postgres:postgres@127.0.0.1:5432/weltgewebe_t002_test
-      NATS_URL: nats://127.0.0.1:4222
+      POSTGRES_PROOF_PROVISION_NATS: "1"
       CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # tag: v7.0.1
@@ -477,27 +477,8 @@ jobs:
           toolchain: 1.89.0
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # tag: v2
-      - name: Start isolated JetStream proof service
-        run: |
-          set -euo pipefail
-          docker run --detach --rm \
-            --name weltgewebe-ci-nats \
-            --publish 127.0.0.1:4222:4222 \
-            nats@sha256:b83efabe3e7def1e0a4a31ec6e078999bb17c80363f881df35edc70fcb6bb927 \
-            -js
-          for attempt in {1..30}; do
-            if (echo > /dev/tcp/127.0.0.1/4222) 2>/dev/null; then
-              exit 0
-            fi
-            sleep 1
-          done
-          docker logs weltgewebe-ci-nats
-          exit 1
       - name: Run PostgreSQL and multi-instance proof suite
         run: scripts/ci/run-postgres-integration-proofs.sh
-      - name: Stop isolated JetStream proof service
-        if: ${{ always() }}
-        run: docker stop weltgewebe-ci-nats || true
 
   lint-docs:
     name: Docs & Shell Hygiene

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,6 +466,7 @@ jobs:
       DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5432/weltgewebe_t002_test
       PG_DIRECT_URL: postgres://postgres:postgres@127.0.0.1:5432/weltgewebe_t002_test
       POSTGRES_PROOF_PROVISION_NATS: "1"
+      POSTGRES_PROOF_ALLOW_RESET: "1"
       CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # tag: v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,7 +465,7 @@ jobs:
     env:
       DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5432/weltgewebe_t002_test
       PG_DIRECT_URL: postgres://postgres:postgres@127.0.0.1:5432/weltgewebe_t002_test
-      POSTGRES_PROOF_PROVISION_NATS: "1"
+      NATS_URL: nats://127.0.0.1:4222
       CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # tag: v7.0.1
@@ -477,8 +477,27 @@ jobs:
           toolchain: 1.89.0
       - name: Cache cargo
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # tag: v2
-      - name: Run hermetic PostgreSQL and multi-instance proof suite
+      - name: Start isolated JetStream proof service
+        run: |
+          set -euo pipefail
+          docker run --detach --rm \
+            --name weltgewebe-ci-nats \
+            --publish 127.0.0.1:4222:4222 \
+            nats@sha256:b83efabe3e7def1e0a4a31ec6e078999bb17c80363f881df35edc70fcb6bb927 \
+            -js
+          for attempt in {1..30}; do
+            if (echo > /dev/tcp/127.0.0.1/4222) 2>/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          docker logs weltgewebe-ci-nats
+          exit 1
+      - name: Run PostgreSQL and multi-instance proof suite
         run: scripts/ci/run-postgres-integration-proofs.sh
+      - name: Stop isolated JetStream proof service
+        if: ${{ always() }}
+        run: docker stop weltgewebe-ci-nats || true
 
   lint-docs:
     name: Docs & Shell Hygiene

--- a/apps/api/migrations/20260721000001_semantic_search_projection_worker.up.sql
+++ b/apps/api/migrations/20260721000001_semantic_search_projection_worker.up.sql
@@ -70,6 +70,7 @@ CREATE TABLE search_projection_jobs (
 );
 CREATE INDEX search_projection_jobs_claimable ON search_projection_jobs (available_at, id)
     WHERE state IN ('pending', 'retry', 'claimed');
+CREATE INDEX search_projection_jobs_generation_state ON search_projection_jobs (generation_id, state);
 
 CREATE OR REPLACE FUNCTION weltgewebe_search_enqueue_node(p_node_id TEXT, p_operation TEXT)
 RETURNS VOID LANGUAGE plpgsql AS $$
@@ -121,6 +122,45 @@ END; $$;
 CREATE TRIGGER search_track_domain_nodes AFTER INSERT OR UPDATE OR DELETE ON domain_nodes
 FOR EACH ROW EXECUTE FUNCTION weltgewebe_search_track_domain_node();
 
+-- Canonical, read-only activation gate shared by worker reconciliation,
+-- operational status, and the actual activation function. Keep all readiness
+-- semantics here so those three surfaces cannot drift independently.
+CREATE OR REPLACE FUNCTION weltgewebe_search_generation_activation_ready(p_generation_id TEXT)
+RETURNS BOOLEAN LANGUAGE sql STABLE AS $$
+SELECT COALESCE((
+    SELECT g.state IN ('building', 'ready', 'active')
+       AND g.completed_nodes = g.expected_nodes
+       AND NOT EXISTS (
+           SELECT 1 FROM search_node_versions v
+           WHERE v.deleted_at IS NULL
+             AND NOT EXISTS (
+                 SELECT 1 FROM search_node_projections p
+                 WHERE p.generation_id = g.generation_id
+                   AND p.node_id = v.node_id
+                   AND p.source_version = v.source_version
+                   AND p.source_revision = v.source_revision
+                   AND p.semantic_state = 'ready'
+                   AND cardinality(p.embedding) = g.dimension
+             )
+       )
+       AND NOT EXISTS (
+           SELECT 1 FROM search_projection_jobs j
+           WHERE j.generation_id = g.generation_id
+             AND j.state NOT IN ('done', 'stale')
+       )
+       AND NOT EXISTS (
+           SELECT 1
+           FROM search_node_versions v
+           JOIN search_node_projections p
+             ON p.generation_id = g.generation_id
+            AND p.node_id = v.node_id
+           WHERE v.deleted_at IS NOT NULL
+       )
+    FROM search_index_generations g
+    WHERE g.generation_id = p_generation_id
+), FALSE);
+$$;
+
 -- Atomically switches only a fully completed generation.  The old active
 -- generation is retained for an explicit operator rollback via the same gate.
 CREATE OR REPLACE FUNCTION weltgewebe_activate_search_generation(p_generation_id TEXT)
@@ -130,35 +170,7 @@ BEGIN
     PERFORM pg_advisory_xact_lock(hashtextextended('weltgewebe.search.generation.activation', 0));
     SELECT * INTO target FROM search_index_generations WHERE generation_id = p_generation_id FOR UPDATE;
     IF NOT FOUND THEN RAISE EXCEPTION 'unknown search generation' USING ERRCODE = '23503'; END IF;
-    IF target.state NOT IN ('building', 'ready', 'active')
-       OR target.completed_nodes <> target.expected_nodes
-       OR EXISTS (
-           SELECT 1 FROM search_node_versions v
-           WHERE v.deleted_at IS NULL
-             AND NOT EXISTS (
-                 SELECT 1 FROM search_node_projections p
-                 WHERE p.generation_id = p_generation_id
-                   AND p.node_id = v.node_id
-                   AND p.source_version = v.source_version
-                   AND p.source_revision = v.source_revision
-                   AND p.semantic_state = 'ready'
-                   AND cardinality(p.embedding) = target.dimension
-             )
-       )
-       OR EXISTS (
-           SELECT 1 FROM search_projection_jobs j
-           WHERE j.generation_id = p_generation_id
-             AND j.state NOT IN ('done', 'stale')
-       )
-       OR EXISTS (
-           SELECT 1
-           FROM search_node_versions v
-           JOIN search_node_projections p
-             ON p.generation_id = p_generation_id
-            AND p.node_id = v.node_id
-           WHERE v.deleted_at IS NOT NULL
-       )
-    THEN
+    IF NOT weltgewebe_search_generation_activation_ready(p_generation_id) THEN
       RAISE EXCEPTION 'generation is not complete and ready' USING ERRCODE = '23514';
     END IF;
     IF target.state = 'active' THEN RETURN; END IF;

--- a/apps/api/src/auth/session.rs
+++ b/apps/api/src/auth/session.rs
@@ -152,6 +152,9 @@ impl SessionBackend {
         }
     }
 
+    /// Build an in-memory backend with the compile-time default lifetime.
+    /// Runtime environment configuration is parsed once at the application
+    /// composition root and injected through `new_in_memory_with_lifetime`.
     pub fn new_in_memory() -> Self {
         Self::new(SessionStore::new())
     }
@@ -200,6 +203,9 @@ impl Default for SessionStore {
 }
 
 impl SessionStore {
+    /// Build a store with `SessionLifetime::default()`. This constructor does
+    /// not read `AUTH_SESSION_TTL_SECONDS`; production startup validates that
+    /// environment value once and injects the resulting lifetime explicitly.
     pub fn new() -> Self {
         Self::with_lifetime(SessionLifetime::default())
     }

--- a/apps/api/src/auth/session.rs
+++ b/apps/api/src/auth/session.rs
@@ -201,9 +201,7 @@ impl Default for SessionStore {
 
 impl SessionStore {
     pub fn new() -> Self {
-        let lifetime = SessionLifetime::from_env()
-            .unwrap_or_else(|error| panic!("invalid {}: {}", SESSION_TTL_ENV, error));
-        Self::with_lifetime(lifetime)
+        Self::with_lifetime(SessionLifetime::default())
     }
 
     pub fn with_lifetime(lifetime: SessionLifetime) -> Self {

--- a/apps/api/src/auth/session_db.rs
+++ b/apps/api/src/auth/session_db.rs
@@ -2,9 +2,7 @@ use async_trait::async_trait;
 use sqlx::{postgres::PgRow, PgPool, Row};
 use uuid::Uuid;
 
-use super::session::{
-    Session, SessionBackendError, SessionLifetime, SessionOps, SessionResult, SESSION_TTL_ENV,
-};
+use super::session::{Session, SessionBackendError, SessionLifetime, SessionOps, SessionResult};
 
 // Trusted static SQL fragment shared by the session queries below. It must
 // never contain configuration or request data; all external values remain
@@ -30,9 +28,7 @@ pub struct DbSessionStore {
 
 impl DbSessionStore {
     pub fn new(pool: PgPool) -> Self {
-        let lifetime = SessionLifetime::from_env()
-            .unwrap_or_else(|error| panic!("invalid {}: {}", SESSION_TTL_ENV, error));
-        Self::with_lifetime(pool, lifetime)
+        Self::with_lifetime(pool, SessionLifetime::default())
     }
 
     pub fn with_lifetime(pool: PgPool, lifetime: SessionLifetime) -> Self {

--- a/apps/api/src/auth/session_db.rs
+++ b/apps/api/src/auth/session_db.rs
@@ -27,6 +27,10 @@ pub struct DbSessionStore {
 }
 
 impl DbSessionStore {
+    /// Build a database-backed store with `SessionLifetime::default()`. This
+    /// constructor is deterministic and does not read runtime environment; the
+    /// application composition root injects validated configuration through
+    /// `with_lifetime`.
     pub fn new(pool: PgPool) -> Self {
         Self::with_lifetime(pool, SessionLifetime::default())
     }

--- a/apps/api/src/lib.rs
+++ b/apps/api/src/lib.rs
@@ -88,6 +88,14 @@ pub async fn run() -> anyhow::Result<()> {
         return Ok(());
     }
 
+    let session_lifetime = crate::auth::session::SessionLifetime::from_env().map_err(|error| {
+        anyhow!(
+            "invalid {}: {}",
+            crate::auth::session::SESSION_TTL_ENV,
+            error
+        )
+    })?;
+
     let (nats_client, nats_configured) = initialise_nats_client().await;
     let federation_router = federation::runtime_router(db_pool.clone())
         .await
@@ -170,9 +178,12 @@ pub async fn run() -> anyhow::Result<()> {
     let sessions = match (db_pool_configured, db_pool.as_ref()) {
         (true, Some(pool)) => {
             tracing::info!("Session store backed by PostgreSQL database");
-            crate::auth::session::SessionBackend::new(crate::auth::session_db::DbSessionStore::new(
-                pool.clone(),
-            ))
+            crate::auth::session::SessionBackend::new(
+                crate::auth::session_db::DbSessionStore::with_lifetime(
+                    pool.clone(),
+                    session_lifetime,
+                ),
+            )
         }
         (true, None) => {
             return Err(anyhow!(
@@ -181,7 +192,7 @@ pub async fn run() -> anyhow::Result<()> {
         }
         (false, _) => {
             tracing::info!("Session store in-memory (database not configured)");
-            crate::auth::session::SessionBackend::new_in_memory()
+            crate::auth::session::SessionBackend::new_in_memory_with_lifetime(session_lifetime)
         }
     };
     let (challenges, tokens, step_up_tokens) = match db_pool.as_ref() {

--- a/apps/api/src/lib.rs
+++ b/apps/api/src/lib.rs
@@ -50,6 +50,16 @@ use tracing_subscriber::{fmt, EnvFilter};
 /// pool by each waiting for a second connection.
 pub(crate) const DATABASE_POOL_MAX_CONNECTIONS: u32 = 5;
 
+fn configured_session_lifetime() -> anyhow::Result<crate::auth::session::SessionLifetime> {
+    crate::auth::session::SessionLifetime::from_env().map_err(|error| {
+        anyhow!(
+            "invalid {}: {}",
+            crate::auth::session::SESSION_TTL_ENV,
+            error
+        )
+    })
+}
+
 pub async fn run() -> anyhow::Result<()> {
     // Load `.env` *before* initialising tracing so a `RUST_LOG` defined there is
     // visible to `EnvFilter::try_from_default_env()` inside `init_tracing`. The
@@ -88,13 +98,7 @@ pub async fn run() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let session_lifetime = crate::auth::session::SessionLifetime::from_env().map_err(|error| {
-        anyhow!(
-            "invalid {}: {}",
-            crate::auth::session::SESSION_TTL_ENV,
-            error
-        )
-    })?;
+    let session_lifetime = configured_session_lifetime()?;
 
     let (nats_client, nats_configured) = initialise_nats_client().await;
     let federation_router = federation::runtime_router(db_pool.clone())
@@ -725,12 +729,23 @@ async fn initialise_nats_client() -> (Option<NatsClient>, bool) {
 #[cfg(test)]
 mod tests {
     use super::{
-        initialise_database_pool, migration_only_requested, record_applied_startup_migration,
-        validate_applied_startup_migrations, validate_migration_only_request,
-        AppliedStartupMigration, StartupMigrationMode,
+        configured_session_lifetime, initialise_database_pool, migration_only_requested,
+        record_applied_startup_migration, validate_applied_startup_migrations,
+        validate_migration_only_request, AppliedStartupMigration, StartupMigrationMode,
     };
     use crate::test_helpers::EnvGuard;
     use serial_test::serial;
+
+    #[test]
+    #[serial]
+    fn invalid_session_ttl_is_a_controlled_startup_configuration_error() {
+        let _guard = EnvGuard::set("AUTH_SESSION_TTL_SECONDS", "not-a-number");
+        let error = configured_session_lifetime()
+            .expect_err("invalid session TTL must fail startup configuration");
+        let message = error.to_string();
+        assert!(message.contains("invalid AUTH_SESSION_TTL_SECONDS"));
+        assert!(message.contains("must be an integer number of seconds"));
+    }
 
     #[tokio::test]
     #[serial]

--- a/apps/api/src/search.rs
+++ b/apps/api/src/search.rs
@@ -72,17 +72,30 @@ pub enum ProcessOutcome {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ProjectionStatusSnapshot {
+    /// Unique canonical nodes that currently exist, independent of revision/job history.
+    pub current_nodes: i64,
+    /// All projection jobs across generations and revisions.
+    pub total_jobs: i64,
+    /// Jobs in terminal states (`done`, `stale`, or `failed`).
+    pub terminal_jobs: i64,
     pub pending_jobs: i64,
     pub claimed_jobs: i64,
     pub retry_jobs: i64,
     pub done_jobs: i64,
     pub stale_jobs: i64,
     pub failed_jobs: i64,
+    /// Generation currently serving semantic search.
     pub active_generation_id: Option<String>,
     pub active_generation_identity: Option<String>,
-    pub rebuild_expected_nodes: Option<i64>,
-    pub rebuild_completed_nodes: Option<i64>,
-    pub last_successful_projection_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub active_generation_activated_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Newest non-active generation still being built or retained as activation candidate.
+    pub rebuild_generation_id: Option<String>,
+    pub rebuild_generation_identity: Option<String>,
+    pub rebuild_generation_state: Option<String>,
+    pub rebuild_total_jobs: Option<i64>,
+    pub rebuild_terminal_jobs: Option<i64>,
+    /// Separate integrity statement mirroring the database activation gate.
+    pub rebuild_activation_ready: Option<bool>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -660,36 +673,75 @@ impl ProjectionWorker {
 
     /// Read-only operational view: no document text, tags, or vectors escape.
     pub async fn status_snapshot(&self) -> anyhow::Result<ProjectionStatusSnapshot> {
-        let row = sqlx::query("SELECT count(*) FILTER (WHERE state='pending') AS pending, count(*) FILTER (WHERE state='claimed') AS claimed, count(*) FILTER (WHERE state='retry') AS retry, count(*) FILTER (WHERE state='done') AS done, count(*) FILTER (WHERE state='stale') AS stale, count(*) FILTER (WHERE state='failed') AS failed FROM search_projection_jobs")
-            .fetch_one(&self.pool).await?;
-        let generation = sqlx::query("SELECT generation_id,provider,model_id,model_revision,runtime_identity,dimension,document_revision,normalization_revision,ranking_revision,expected_nodes,completed_nodes,activated_at FROM search_index_generations WHERE state='active'")
-            .fetch_optional(&self.pool).await?;
+        let row = sqlx::query(
+            "SELECT \
+                (SELECT count(*) FROM domain_nodes) AS current_nodes, \
+                count(*) AS total_jobs, \
+                count(*) FILTER (WHERE state IN ('done','stale','failed')) AS terminal_jobs, \
+                count(*) FILTER (WHERE state='pending') AS pending, \
+                count(*) FILTER (WHERE state='claimed') AS claimed, \
+                count(*) FILTER (WHERE state='retry') AS retry, \
+                count(*) FILTER (WHERE state='done') AS done, \
+                count(*) FILTER (WHERE state='stale') AS stale, \
+                count(*) FILTER (WHERE state='failed') AS failed \
+             FROM search_projection_jobs",
+        )
+        .fetch_one(&self.pool)
+        .await?;
+        let active = sqlx::query(
+            "SELECT generation_id,provider,model_id,model_revision,runtime_identity,dimension,document_revision,normalization_revision,ranking_revision,activated_at \
+             FROM search_index_generations WHERE state='active'",
+        )
+        .fetch_optional(&self.pool)
+        .await?;
+        let rebuild = sqlx::query(
+            "SELECT g.generation_id,g.provider,g.model_id,g.model_revision,g.runtime_identity,g.dimension,g.document_revision,g.normalization_revision,g.ranking_revision,g.state, \
+                (SELECT count(*) FROM search_projection_jobs j WHERE j.generation_id=g.generation_id) AS total_jobs, \
+                (SELECT count(*) FROM search_projection_jobs j WHERE j.generation_id=g.generation_id AND j.state IN ('done','stale','failed')) AS terminal_jobs, \
+                (g.completed_nodes = g.expected_nodes \
+                 AND NOT EXISTS (SELECT 1 FROM search_projection_jobs j WHERE j.generation_id=g.generation_id AND j.state NOT IN ('done','stale')) \
+                 AND NOT EXISTS (SELECT 1 FROM search_node_versions v WHERE v.deleted_at IS NULL AND NOT EXISTS (SELECT 1 FROM search_node_projections p WHERE p.generation_id=g.generation_id AND p.node_id=v.node_id AND p.source_version=v.source_version AND p.source_revision=v.source_revision AND p.semantic_state='ready' AND cardinality(p.embedding)=g.dimension)) \
+                 AND NOT EXISTS (SELECT 1 FROM search_node_versions v JOIN search_node_projections p ON p.generation_id=g.generation_id AND p.node_id=v.node_id WHERE v.deleted_at IS NOT NULL)) AS activation_ready \
+             FROM search_index_generations g \
+             WHERE g.state IN ('building','ready') \
+             ORDER BY g.created_at DESC, g.generation_id DESC LIMIT 1",
+        )
+        .fetch_optional(&self.pool)
+        .await?;
+        let identity = |row: &sqlx::postgres::PgRow| {
+            format!(
+                "{}:{}:{}:{}:{}:{}:{}:{}",
+                row.get::<String, _>("provider"),
+                row.get::<String, _>("model_id"),
+                row.get::<String, _>("model_revision"),
+                row.get::<String, _>("runtime_identity"),
+                row.get::<i32, _>("dimension"),
+                row.get::<String, _>("document_revision"),
+                row.get::<String, _>("normalization_revision"),
+                row.get::<String, _>("ranking_revision")
+            )
+        };
         Ok(ProjectionStatusSnapshot {
+            current_nodes: row.get::<i64, _>("current_nodes"),
+            total_jobs: row.get::<i64, _>("total_jobs"),
+            terminal_jobs: row.get::<i64, _>("terminal_jobs"),
             pending_jobs: row.get::<i64, _>("pending"),
             claimed_jobs: row.get::<i64, _>("claimed"),
             retry_jobs: row.get::<i64, _>("retry"),
             done_jobs: row.get::<i64, _>("done"),
             stale_jobs: row.get::<i64, _>("stale"),
             failed_jobs: row.get::<i64, _>("failed"),
-            active_generation_id: generation.as_ref().map(|row| row.get("generation_id")),
-            active_generation_identity: generation.as_ref().map(|row| {
-                format!(
-                    "{}:{}:{}:{}:{}:{}:{}:{}",
-                    row.get::<String, _>("provider"),
-                    row.get::<String, _>("model_id"),
-                    row.get::<String, _>("model_revision"),
-                    row.get::<String, _>("runtime_identity"),
-                    row.get::<i32, _>("dimension"),
-                    row.get::<String, _>("document_revision"),
-                    row.get::<String, _>("normalization_revision"),
-                    row.get::<String, _>("ranking_revision")
-                )
-            }),
-            rebuild_expected_nodes: generation.as_ref().map(|row| row.get("expected_nodes")),
-            rebuild_completed_nodes: generation.as_ref().map(|row| row.get("completed_nodes")),
-            last_successful_projection_at: generation
+            active_generation_id: active.as_ref().map(|row| row.get("generation_id")),
+            active_generation_identity: active.as_ref().map(&identity),
+            active_generation_activated_at: active
                 .as_ref()
                 .and_then(|row| row.try_get("activated_at").ok()),
+            rebuild_generation_id: rebuild.as_ref().map(|row| row.get("generation_id")),
+            rebuild_generation_identity: rebuild.as_ref().map(&identity),
+            rebuild_generation_state: rebuild.as_ref().map(|row| row.get("state")),
+            rebuild_total_jobs: rebuild.as_ref().map(|row| row.get("total_jobs")),
+            rebuild_terminal_jobs: rebuild.as_ref().map(|row| row.get("terminal_jobs")),
+            rebuild_activation_ready: rebuild.as_ref().map(|row| row.get("activation_ready")),
         })
     }
 

--- a/apps/api/src/search.rs
+++ b/apps/api/src/search.rs
@@ -72,7 +72,7 @@ pub enum ProcessOutcome {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ProjectionStatusSnapshot {
-    /// Unique canonical nodes that currently exist, independent of revision/job history.
+    /// Unique rows currently present in `domain_nodes`; revisions and projection-job history do not inflate this count.
     pub current_nodes: i64,
     /// All projection jobs across generations and revisions.
     pub total_jobs: i64,
@@ -698,10 +698,7 @@ impl ProjectionWorker {
             "SELECT g.generation_id,g.provider,g.model_id,g.model_revision,g.runtime_identity,g.dimension,g.document_revision,g.normalization_revision,g.ranking_revision,g.state, \
                 (SELECT count(*) FROM search_projection_jobs j WHERE j.generation_id=g.generation_id) AS total_jobs, \
                 (SELECT count(*) FROM search_projection_jobs j WHERE j.generation_id=g.generation_id AND j.state IN ('done','stale','failed')) AS terminal_jobs, \
-                (g.completed_nodes = g.expected_nodes \
-                 AND NOT EXISTS (SELECT 1 FROM search_projection_jobs j WHERE j.generation_id=g.generation_id AND j.state NOT IN ('done','stale')) \
-                 AND NOT EXISTS (SELECT 1 FROM search_node_versions v WHERE v.deleted_at IS NULL AND NOT EXISTS (SELECT 1 FROM search_node_projections p WHERE p.generation_id=g.generation_id AND p.node_id=v.node_id AND p.source_version=v.source_version AND p.source_revision=v.source_revision AND p.semantic_state='ready' AND cardinality(p.embedding)=g.dimension)) \
-                 AND NOT EXISTS (SELECT 1 FROM search_node_versions v JOIN search_node_projections p ON p.generation_id=g.generation_id AND p.node_id=v.node_id WHERE v.deleted_at IS NOT NULL)) AS activation_ready \
+                weltgewebe_search_generation_activation_ready(g.generation_id) AS activation_ready \
              FROM search_index_generations g \
              WHERE g.state IN ('building','ready') \
              ORDER BY g.created_at DESC, g.generation_id DESC LIMIT 1",
@@ -926,7 +923,9 @@ impl ProjectionWorker {
             tx.rollback().await?;
             return Ok(false);
         }
-        sqlx::query("UPDATE search_index_generations g SET expected_nodes=(SELECT count(*) FROM search_projection_jobs j WHERE j.generation_id=g.generation_id), completed_nodes=(SELECT count(*) FROM search_projection_jobs j WHERE j.generation_id=g.generation_id AND j.state IN ('done','stale')), state=CASE WHEN g.state='building' AND NOT EXISTS (SELECT 1 FROM search_index_generations r WHERE r.state='ready' AND r.generation_id<>g.generation_id) AND NOT EXISTS (SELECT 1 FROM search_projection_jobs j WHERE j.generation_id=g.generation_id AND j.state NOT IN ('done','stale')) AND NOT EXISTS (SELECT 1 FROM search_node_versions v WHERE v.deleted_at IS NULL AND NOT EXISTS (SELECT 1 FROM search_node_projections p WHERE p.generation_id=g.generation_id AND p.node_id=v.node_id AND p.source_version=v.source_version AND p.source_revision=v.source_revision AND p.semantic_state='ready' AND cardinality(p.embedding)=g.dimension)) AND NOT EXISTS (SELECT 1 FROM search_node_versions v JOIN search_node_projections p ON p.generation_id=g.generation_id AND p.node_id=v.node_id WHERE v.deleted_at IS NOT NULL) THEN 'ready' ELSE g.state END WHERE g.generation_id=(SELECT generation_id FROM search_projection_jobs WHERE id=$1)")
+        sqlx::query("UPDATE search_index_generations g SET expected_nodes=(SELECT count(*) FROM search_projection_jobs j WHERE j.generation_id=g.generation_id), completed_nodes=(SELECT count(*) FROM search_projection_jobs j WHERE j.generation_id=g.generation_id AND j.state IN ('done','stale')) WHERE g.generation_id=(SELECT generation_id FROM search_projection_jobs WHERE id=$1)")
+            .bind(id).execute(&mut *tx).await?;
+        sqlx::query("UPDATE search_index_generations g SET state='ready' WHERE g.generation_id=(SELECT generation_id FROM search_projection_jobs WHERE id=$1) AND g.state='building' AND NOT EXISTS (SELECT 1 FROM search_index_generations r WHERE r.state='ready' AND r.generation_id<>g.generation_id) AND weltgewebe_search_generation_activation_ready(g.generation_id)")
             .bind(id).execute(&mut *tx).await?;
         tx.commit().await?;
         Ok(true)

--- a/apps/api/src/search.rs
+++ b/apps/api/src/search.rs
@@ -672,52 +672,51 @@ impl ProjectionWorker {
     }
 
     /// Read-only operational view: no document text, tags, or vectors escape.
+    /// All fields come from one PostgreSQL statement, so operators never see a
+    /// synthetic snapshot assembled from different committed moments.
     pub async fn status_snapshot(&self) -> anyhow::Result<ProjectionStatusSnapshot> {
         let row = sqlx::query(
-            "SELECT \
-                (SELECT count(*) FROM domain_nodes) AS current_nodes, \
-                count(*) AS total_jobs, \
-                count(*) FILTER (WHERE state IN ('done','stale','failed')) AS terminal_jobs, \
-                count(*) FILTER (WHERE state='pending') AS pending, \
-                count(*) FILTER (WHERE state='claimed') AS claimed, \
-                count(*) FILTER (WHERE state='retry') AS retry, \
-                count(*) FILTER (WHERE state='done') AS done, \
-                count(*) FILTER (WHERE state='stale') AS stale, \
-                count(*) FILTER (WHERE state='failed') AS failed \
-             FROM search_projection_jobs",
+            "WITH job_counts AS ( \
+                SELECT \
+                    (SELECT count(*) FROM domain_nodes) AS current_nodes, \
+                    count(*) AS total_jobs, \
+                    count(*) FILTER (WHERE state IN ('done','stale','failed')) AS terminal_jobs, \
+                    count(*) FILTER (WHERE state='pending') AS pending, \
+                    count(*) FILTER (WHERE state='claimed') AS claimed, \
+                    count(*) FILTER (WHERE state='retry') AS retry, \
+                    count(*) FILTER (WHERE state='done') AS done, \
+                    count(*) FILTER (WHERE state='stale') AS stale, \
+                    count(*) FILTER (WHERE state='failed') AS failed \
+                FROM search_projection_jobs \
+             ), active AS ( \
+                SELECT generation_id,provider,model_id,model_revision,runtime_identity,dimension,document_revision,normalization_revision,ranking_revision,activated_at \
+                FROM search_index_generations WHERE state='active' \
+             ), rebuild AS ( \
+                SELECT g.generation_id,g.provider,g.model_id,g.model_revision,g.runtime_identity,g.dimension,g.document_revision,g.normalization_revision,g.ranking_revision,g.state, \
+                    (SELECT count(*) FROM search_projection_jobs j WHERE j.generation_id=g.generation_id) AS total_jobs, \
+                    (SELECT count(*) FROM search_projection_jobs j WHERE j.generation_id=g.generation_id AND j.state IN ('done','stale','failed')) AS terminal_jobs, \
+                    weltgewebe_search_generation_activation_ready(g.generation_id) AS activation_ready \
+                FROM search_index_generations g \
+                WHERE g.state IN ('building','ready') \
+                ORDER BY CASE WHEN g.state='ready' THEN 0 ELSE 1 END, g.created_at DESC, g.generation_id DESC \
+                LIMIT 1 \
+             ) \
+             SELECT jc.*, \
+                a.generation_id AS active_generation_id, \
+                CASE WHEN a.generation_id IS NULL THEN NULL ELSE concat_ws(':',a.provider,a.model_id,a.model_revision,a.runtime_identity,a.dimension::text,a.document_revision,a.normalization_revision,a.ranking_revision) END AS active_generation_identity, \
+                a.activated_at AS active_generation_activated_at, \
+                r.generation_id AS rebuild_generation_id, \
+                CASE WHEN r.generation_id IS NULL THEN NULL ELSE concat_ws(':',r.provider,r.model_id,r.model_revision,r.runtime_identity,r.dimension::text,r.document_revision,r.normalization_revision,r.ranking_revision) END AS rebuild_generation_identity, \
+                r.state AS rebuild_generation_state, \
+                r.total_jobs AS rebuild_total_jobs, \
+                r.terminal_jobs AS rebuild_terminal_jobs, \
+                r.activation_ready AS rebuild_activation_ready \
+             FROM job_counts jc \
+             LEFT JOIN active a ON TRUE \
+             LEFT JOIN rebuild r ON TRUE",
         )
         .fetch_one(&self.pool)
         .await?;
-        let active = sqlx::query(
-            "SELECT generation_id,provider,model_id,model_revision,runtime_identity,dimension,document_revision,normalization_revision,ranking_revision,activated_at \
-             FROM search_index_generations WHERE state='active'",
-        )
-        .fetch_optional(&self.pool)
-        .await?;
-        let rebuild = sqlx::query(
-            "SELECT g.generation_id,g.provider,g.model_id,g.model_revision,g.runtime_identity,g.dimension,g.document_revision,g.normalization_revision,g.ranking_revision,g.state, \
-                (SELECT count(*) FROM search_projection_jobs j WHERE j.generation_id=g.generation_id) AS total_jobs, \
-                (SELECT count(*) FROM search_projection_jobs j WHERE j.generation_id=g.generation_id AND j.state IN ('done','stale','failed')) AS terminal_jobs, \
-                weltgewebe_search_generation_activation_ready(g.generation_id) AS activation_ready \
-             FROM search_index_generations g \
-             WHERE g.state IN ('building','ready') \
-             ORDER BY g.created_at DESC, g.generation_id DESC LIMIT 1",
-        )
-        .fetch_optional(&self.pool)
-        .await?;
-        let identity = |row: &sqlx::postgres::PgRow| {
-            format!(
-                "{}:{}:{}:{}:{}:{}:{}:{}",
-                row.get::<String, _>("provider"),
-                row.get::<String, _>("model_id"),
-                row.get::<String, _>("model_revision"),
-                row.get::<String, _>("runtime_identity"),
-                row.get::<i32, _>("dimension"),
-                row.get::<String, _>("document_revision"),
-                row.get::<String, _>("normalization_revision"),
-                row.get::<String, _>("ranking_revision")
-            )
-        };
         Ok(ProjectionStatusSnapshot {
             current_nodes: row.get::<i64, _>("current_nodes"),
             total_jobs: row.get::<i64, _>("total_jobs"),
@@ -728,17 +727,15 @@ impl ProjectionWorker {
             done_jobs: row.get::<i64, _>("done"),
             stale_jobs: row.get::<i64, _>("stale"),
             failed_jobs: row.get::<i64, _>("failed"),
-            active_generation_id: active.as_ref().map(|row| row.get("generation_id")),
-            active_generation_identity: active.as_ref().map(identity),
-            active_generation_activated_at: active
-                .as_ref()
-                .and_then(|row| row.try_get("activated_at").ok()),
-            rebuild_generation_id: rebuild.as_ref().map(|row| row.get("generation_id")),
-            rebuild_generation_identity: rebuild.as_ref().map(identity),
-            rebuild_generation_state: rebuild.as_ref().map(|row| row.get("state")),
-            rebuild_total_jobs: rebuild.as_ref().map(|row| row.get("total_jobs")),
-            rebuild_terminal_jobs: rebuild.as_ref().map(|row| row.get("terminal_jobs")),
-            rebuild_activation_ready: rebuild.as_ref().map(|row| row.get("activation_ready")),
+            active_generation_id: row.get("active_generation_id"),
+            active_generation_identity: row.get("active_generation_identity"),
+            active_generation_activated_at: row.get("active_generation_activated_at"),
+            rebuild_generation_id: row.get("rebuild_generation_id"),
+            rebuild_generation_identity: row.get("rebuild_generation_identity"),
+            rebuild_generation_state: row.get("rebuild_generation_state"),
+            rebuild_total_jobs: row.get("rebuild_total_jobs"),
+            rebuild_terminal_jobs: row.get("rebuild_terminal_jobs"),
+            rebuild_activation_ready: row.get("rebuild_activation_ready"),
         })
     }
 

--- a/apps/api/src/search.rs
+++ b/apps/api/src/search.rs
@@ -732,12 +732,12 @@ impl ProjectionWorker {
             stale_jobs: row.get::<i64, _>("stale"),
             failed_jobs: row.get::<i64, _>("failed"),
             active_generation_id: active.as_ref().map(|row| row.get("generation_id")),
-            active_generation_identity: active.as_ref().map(&identity),
+            active_generation_identity: active.as_ref().map(identity),
             active_generation_activated_at: active
                 .as_ref()
                 .and_then(|row| row.try_get("activated_at").ok()),
             rebuild_generation_id: rebuild.as_ref().map(|row| row.get("generation_id")),
-            rebuild_generation_identity: rebuild.as_ref().map(&identity),
+            rebuild_generation_identity: rebuild.as_ref().map(identity),
             rebuild_generation_state: rebuild.as_ref().map(|row| row.get("state")),
             rebuild_total_jobs: rebuild.as_ref().map(|row| row.get("total_jobs")),
             rebuild_terminal_jobs: rebuild.as_ref().map(|row| row.get("terminal_jobs")),

--- a/apps/api/tests/db_auto_provision_write_path.rs
+++ b/apps/api/tests/db_auto_provision_write_path.rs
@@ -14,6 +14,8 @@
 //!     cargo test --locked -p weltgewebe-api --test db_auto_provision_write_path \
 //!     -- --include-ignored --test-threads=1
 
+mod support;
+
 use anyhow::Result;
 use axum::{
     body,
@@ -48,7 +50,7 @@ fn direct_database_url() -> String {
         !url.contains(":6432"),
         "DATABASE_URL must target direct PostgreSQL, not PgBouncer (port 6432)"
     );
-    url
+    support::postgres_proof::validated_direct_disposable_url(url)
 }
 
 async fn connect_pool() -> PgPool {

--- a/apps/api/tests/db_domain_account_write_path.rs
+++ b/apps/api/tests/db_domain_account_write_path.rs
@@ -19,6 +19,8 @@
 //! - DATABASE_URL must point to direct PostgreSQL (not PgBouncer at :6432).
 //! - Fixture rows use a recognizable UUID namespace and are cleaned before/after.
 
+mod support;
+
 use anyhow::{Context, Result};
 use axum::{
     body,
@@ -63,7 +65,7 @@ fn direct_database_url() -> String {
         !url.contains(":6432"),
         "DATABASE_URL must target direct PostgreSQL, not PgBouncer (port 6432)"
     );
-    url
+    support::postgres_proof::validated_direct_disposable_url(url)
 }
 
 async fn connect_pool() -> PgPool {

--- a/apps/api/tests/db_domain_backfill.rs
+++ b/apps/api/tests/db_domain_backfill.rs
@@ -16,6 +16,8 @@
 //! - DATABASE_URL must point to direct PostgreSQL (not PgBouncer at :6432).
 //! - Use --test-threads=1 to avoid row-level conflicts between parallel tests.
 
+mod support;
+
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 use std::{path::PathBuf, str::FromStr};
 use weltgewebe_api::domain_db::NewDomainAccountRow;
@@ -29,7 +31,7 @@ fn direct_database_url() -> String {
         !url.contains(":6432"),
         "DATABASE_URL must target direct PostgreSQL, not PgBouncer (port 6432)"
     );
-    url
+    support::postgres_proof::validated_direct_disposable_url(url)
 }
 
 async fn connect_pool() -> sqlx::PgPool {

--- a/apps/api/tests/db_domain_edge_write_path.rs
+++ b/apps/api/tests/db_domain_edge_write_path.rs
@@ -21,6 +21,8 @@
 //! - Fixture rows use the `edec0000-` id prefix (valid UUID hex) and are
 //!   cleaned before/after.
 
+mod support;
+
 use anyhow::{Context, Result};
 use axum::{
     body,
@@ -62,7 +64,7 @@ fn direct_database_url() -> String {
         !url.contains(":6432"),
         "DATABASE_URL must target direct PostgreSQL, not PgBouncer (port 6432)"
     );
-    url
+    support::postgres_proof::validated_direct_disposable_url(url)
 }
 
 async fn connect_pool() -> PgPool {

--- a/apps/api/tests/db_domain_node_write_path.rs
+++ b/apps/api/tests/db_domain_node_write_path.rs
@@ -18,6 +18,8 @@
 //! - DATABASE_URL must point to direct PostgreSQL (not PgBouncer at :6432).
 //! - Fixture rows use the `writepath-node-` id prefix and are cleaned before/after.
 
+mod support;
+
 use anyhow::{Context, Result};
 use axum::{
     body,
@@ -88,7 +90,7 @@ fn direct_database_url() -> String {
         !url.contains(":6432"),
         "DATABASE_URL must target direct PostgreSQL, not PgBouncer (port 6432)"
     );
-    url
+    support::postgres_proof::validated_direct_disposable_url(url)
 }
 
 struct EnvVarGuard {

--- a/apps/api/tests/db_domain_read_path.rs
+++ b/apps/api/tests/db_domain_read_path.rs
@@ -1,3 +1,5 @@
+mod support;
+
 use std::path::PathBuf;
 
 use serial_test::serial;
@@ -11,6 +13,7 @@ use weltgewebe_api::test_helpers::EnvGuard;
 async fn direct_pool() -> PgPool {
     let url = std::env::var("DATABASE_URL")
         .expect("DATABASE_URL must point at a direct PostgreSQL database");
+    support::postgres_proof::assert_direct_disposable_database_url(&url);
     PgPool::connect(&url).await.expect("connect to PostgreSQL")
 }
 

--- a/apps/api/tests/db_domain_schema_migrations.rs
+++ b/apps/api/tests/db_domain_schema_migrations.rs
@@ -18,6 +18,8 @@
 //! - Tests are ignored by default to keep offline paths green.
 //! - DATABASE_URL must point to direct PostgreSQL (not PgBouncer at :6432).
 
+mod support;
+
 use std::{path::PathBuf, str::FromStr};
 
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
@@ -33,7 +35,7 @@ fn direct_database_url() -> String {
         "DATABASE_URL must target direct PostgreSQL, not PgBouncer (port 6432)"
     );
 
-    url
+    support::postgres_proof::validated_direct_disposable_url(url)
 }
 
 async fn connect_pool() -> sqlx::PgPool {

--- a/apps/api/tests/db_governance.rs
+++ b/apps/api/tests/db_governance.rs
@@ -3,6 +3,8 @@
 //! Run with a direct PostgreSQL connection:
 //! `DATABASE_URL=postgres://... cargo test --locked --test db_governance -- --include-ignored`
 
+mod support;
+
 use std::{path::PathBuf, str::FromStr};
 
 use chrono::{Duration, TimeZone, Utc};
@@ -31,7 +33,7 @@ fn direct_database_url() -> String {
         !url.contains(":6432"),
         "do not use PgBouncer for migration tests"
     );
-    url
+    support::postgres_proof::validated_direct_disposable_url(url)
 }
 
 async fn pool() -> sqlx::PgPool {

--- a/apps/api/tests/db_multi_instance_foundation.rs
+++ b/apps/api/tests/db_multi_instance_foundation.rs
@@ -9,6 +9,8 @@
 //! cargo test --locked -p weltgewebe-api --test db_multi_instance_foundation \
 //!   -- --ignored --test-threads=1
 
+mod support;
+
 use std::{
     net::{IpAddr, Ipv4Addr},
     path::PathBuf,
@@ -55,12 +57,8 @@ const DEVICE_ID: &str = "multi-instance-device-1";
 
 fn database_url() -> String {
     let url = std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "postgres://welt@127.0.0.1:55432/weltgewebe_t002_test".to_string());
-    assert!(
-        url.contains("_test"),
-        "multi-instance proof refuses a database not explicitly named as a test database"
-    );
-    url
+        .expect("DATABASE_URL must point to a direct disposable PostgreSQL database");
+    support::postgres_proof::validated_direct_disposable_url(url)
 }
 
 async fn migrate(pool: &PgPool) {

--- a/apps/api/tests/db_passkey_fk_readiness.rs
+++ b/apps/api/tests/db_passkey_fk_readiness.rs
@@ -9,6 +9,8 @@
 //!     cargo test --locked -p weltgewebe-api \
 //!     --test db_passkey_fk_readiness -- --include-ignored --test-threads=1
 
+mod support;
+
 use std::{path::PathBuf, str::FromStr};
 
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
@@ -23,7 +25,7 @@ fn direct_database_url() -> String {
         !url.contains(":6432"),
         "DATABASE_URL must target direct PostgreSQL, not PgBouncer (port 6432)"
     );
-    url
+    support::postgres_proof::validated_direct_disposable_url(url)
 }
 
 async fn connect_pool() -> sqlx::PgPool {

--- a/apps/api/tests/db_passkey_schema_preflight.rs
+++ b/apps/api/tests/db_passkey_schema_preflight.rs
@@ -32,6 +32,8 @@
 //! - NOT proven here: the home-server runtime schema state, the controlled
 //!   runtime application of this migration, and any production cutover.
 
+mod support;
+
 use std::str::FromStr;
 
 use sqlx::migrate::MigrationType;
@@ -62,7 +64,7 @@ fn direct_database_url() -> String {
         !url.contains(":6432"),
         "DATABASE_URL must target direct PostgreSQL, not PgBouncer (port 6432)"
     );
-    url
+    support::postgres_proof::validated_direct_disposable_url(url)
 }
 
 /// Connects a fresh pool per async test runtime and applies the embedded

--- a/apps/api/tests/db_passkey_store_persistence.rs
+++ b/apps/api/tests/db_passkey_store_persistence.rs
@@ -24,6 +24,8 @@
 //! - DATABASE_URL must point to direct PostgreSQL (not PgBouncer at :6432).
 //! - Fixtures use a recognizable account-id namespace and are cleaned up.
 
+mod support;
+
 use std::{net::SocketAddr, path::PathBuf, str::FromStr, sync::Arc};
 
 use axum::{
@@ -76,7 +78,7 @@ fn direct_database_url() -> String {
         !url.contains(":6432"),
         "DATABASE_URL must target direct PostgreSQL, not PgBouncer (port 6432)"
     );
-    url
+    support::postgres_proof::validated_direct_disposable_url(url)
 }
 
 async fn connect_pool() -> sqlx::PgPool {

--- a/apps/api/tests/db_semantic_search_foundation.rs
+++ b/apps/api/tests/db_semantic_search_foundation.rs
@@ -4,6 +4,8 @@
 //! database. It verifies the migration surface and hard candidate boundaries;
 //! it does not start an API, worker, backfill or production search runtime.
 
+mod support;
+
 use std::path::PathBuf;
 
 use serial_test::serial;
@@ -32,12 +34,14 @@ async fn connect_pool() -> sqlx::PgPool {
         port, 6432,
         "T003 must target direct PostgreSQL, not PgBouncer"
     );
+    let database = required_env("T003_PG_DATABASE");
+    support::postgres_proof::assert_disposable_database_name(&database);
     let options = PgConnectOptions::new()
         .host(&host)
         .port(port)
         .username(&required_env("T003_PG_USER"))
         .password(&required_env("T003_PG_PASSWORD"))
-        .database(&required_env("T003_PG_DATABASE"))
+        .database(&database)
         .ssl_mode(PgSslMode::Disable);
     let probe = PgConnection::connect_with(&options)
         .await

--- a/apps/api/tests/db_semantic_search_projection_worker.rs
+++ b/apps/api/tests/db_semantic_search_projection_worker.rs
@@ -358,6 +358,23 @@ async fn status_snapshot_separates_unique_nodes_job_history_and_activation_readi
         Some(canonical_second_complete)
     );
 
+    sqlx::query("SELECT weltgewebe_activate_search_generation($1)")
+        .bind(generation)
+        .execute(&pool)
+        .await
+        .expect("activate first status generation");
+    let active_only = projection_worker
+        .status_snapshot()
+        .await
+        .expect("active-only status");
+    assert_eq!(
+        active_only.active_generation_id.as_deref(),
+        Some(generation)
+    );
+    assert!(active_only.active_generation_identity.is_some());
+    assert!(active_only.active_generation_activated_at.is_some());
+    assert_eq!(active_only.rebuild_generation_id, None);
+
     let generation_two = "t005-status-semantics-generation-two";
     projection_worker
         .start_generation(GenerationSpec {
@@ -374,6 +391,13 @@ async fn status_snapshot_separates_unique_nodes_job_history_and_activation_readi
         .status_snapshot()
         .await
         .expect("second generation pending status");
+    assert_eq!(
+        second_generation_pending.active_generation_id.as_deref(),
+        Some(generation)
+    );
+    assert!(second_generation_pending
+        .active_generation_activated_at
+        .is_some());
     assert_eq!(
         second_generation_pending.rebuild_generation_id.as_deref(),
         Some(generation_two)

--- a/apps/api/tests/db_semantic_search_projection_worker.rs
+++ b/apps/api/tests/db_semantic_search_projection_worker.rs
@@ -220,6 +220,107 @@ async fn worker_is_revision_bound_leased_resumable_and_deletion_propagates() {
 
 #[tokio::test]
 #[ignore = "requires T005_DATABASE_URL pointing to direct disposable PostgreSQL"]
+async fn status_snapshot_separates_unique_nodes_job_history_and_activation_readiness() {
+    let pool = pool().await;
+    migrate(&pool).await;
+    reset_search_state(&pool).await;
+    let node = "t005-status-semantics-node";
+    let generation = "t005-status-semantics-generation";
+    sqlx::query("INSERT INTO domain_nodes (id,kind,title,payload) VALUES ($1,'Werkstatt','Revision eins',$2::jsonb)")
+        .bind(node)
+        .bind(r#"{"search_visibility":"public"}"#)
+        .execute(&pool)
+        .await
+        .expect("insert status semantics node");
+    let projection_worker = worker(
+        pool.clone(),
+        "t005-status-semantics-worker",
+        Arc::new(FakeProvider {
+            unavailable: AtomicBool::new(false),
+        }),
+    );
+    projection_worker
+        .start_generation(GenerationSpec {
+            generation_id: generation,
+            provider: "local:ollama",
+            model_id: "m",
+            model_revision: "r",
+            runtime_identity: "ollama:test@http://127.0.0.1:11434",
+            dimension: 3,
+        })
+        .await
+        .expect("start status semantics generation");
+
+    let initial = projection_worker
+        .status_snapshot()
+        .await
+        .expect("initial status");
+    assert_eq!(initial.current_nodes, 1);
+    assert_eq!(initial.total_jobs, 1);
+    assert_eq!(initial.terminal_jobs, 0);
+    assert_eq!(initial.rebuild_total_jobs, Some(1));
+    assert_eq!(initial.rebuild_terminal_jobs, Some(0));
+    assert_eq!(initial.rebuild_activation_ready, Some(false));
+
+    assert_eq!(
+        projection_worker
+            .claim_and_process_one()
+            .await
+            .expect("project first revision"),
+        ProcessOutcome::Processed
+    );
+    let first_complete = projection_worker
+        .status_snapshot()
+        .await
+        .expect("first complete status");
+    assert_eq!(first_complete.current_nodes, 1);
+    assert_eq!(first_complete.total_jobs, 1);
+    assert_eq!(first_complete.terminal_jobs, 1);
+    assert_eq!(first_complete.rebuild_activation_ready, Some(true));
+
+    sqlx::query("UPDATE domain_nodes SET title='Revision zwei' WHERE id=$1")
+        .bind(node)
+        .execute(&pool)
+        .await
+        .expect("create second revision");
+    let second_pending = projection_worker
+        .status_snapshot()
+        .await
+        .expect("second revision pending status");
+    assert_eq!(
+        second_pending.current_nodes, 1,
+        "revisions must not inflate unique node count"
+    );
+    assert_eq!(
+        second_pending.total_jobs, 2,
+        "job history must retain both revisions"
+    );
+    assert_eq!(second_pending.terminal_jobs, 1);
+    assert_eq!(second_pending.rebuild_total_jobs, Some(2));
+    assert_eq!(second_pending.rebuild_terminal_jobs, Some(1));
+    assert_eq!(second_pending.rebuild_activation_ready, Some(false));
+
+    assert_eq!(
+        projection_worker
+            .claim_and_process_one()
+            .await
+            .expect("project second revision"),
+        ProcessOutcome::Processed
+    );
+    let second_complete = projection_worker
+        .status_snapshot()
+        .await
+        .expect("second complete status");
+    assert_eq!(second_complete.current_nodes, 1);
+    assert_eq!(second_complete.total_jobs, 2);
+    assert_eq!(second_complete.terminal_jobs, 2);
+    assert_eq!(second_complete.rebuild_total_jobs, Some(2));
+    assert_eq!(second_complete.rebuild_terminal_jobs, Some(2));
+    assert_eq!(second_complete.rebuild_activation_ready, Some(true));
+}
+
+#[tokio::test]
+#[ignore = "requires T005_DATABASE_URL pointing to direct disposable PostgreSQL"]
 async fn worker_hardening_proves_races_trigger_identity_outage_and_activation() {
     let pool = pool().await;
     migrate(&pool).await;

--- a/apps/api/tests/db_semantic_search_projection_worker.rs
+++ b/apps/api/tests/db_semantic_search_projection_worker.rs
@@ -2,6 +2,8 @@
 //!
 //! Run with `T005_DATABASE_URL`; it never starts the API or exposes search.
 
+mod support;
+
 use std::{
     path::PathBuf,
     sync::{
@@ -26,6 +28,7 @@ use weltgewebe_api::{
 async fn pool() -> PgPool {
     let url = std::env::var("T005_DATABASE_URL")
         .expect("T005_DATABASE_URL must point to a direct disposable PostgreSQL database");
+    support::postgres_proof::assert_direct_disposable_database_url(&url);
     assert!(
         !url.contains(":6432/"),
         "T005 must not use PgBouncer because claims require direct PostgreSQL locking"

--- a/apps/api/tests/db_semantic_search_projection_worker.rs
+++ b/apps/api/tests/db_semantic_search_projection_worker.rs
@@ -264,6 +264,13 @@ async fn status_snapshot_separates_unique_nodes_job_history_and_activation_readi
     assert_eq!(initial.rebuild_total_jobs, Some(1));
     assert_eq!(initial.rebuild_terminal_jobs, Some(0));
     assert_eq!(initial.rebuild_activation_ready, Some(false));
+    let canonical_initial: bool =
+        sqlx::query_scalar("SELECT weltgewebe_search_generation_activation_ready($1)")
+            .bind(generation)
+            .fetch_one(&pool)
+            .await
+            .expect("canonical initial readiness");
+    assert_eq!(initial.rebuild_activation_ready, Some(canonical_initial));
 
     assert_eq!(
         projection_worker
@@ -280,6 +287,16 @@ async fn status_snapshot_separates_unique_nodes_job_history_and_activation_readi
     assert_eq!(first_complete.total_jobs, 1);
     assert_eq!(first_complete.terminal_jobs, 1);
     assert_eq!(first_complete.rebuild_activation_ready, Some(true));
+    let canonical_first_complete: bool =
+        sqlx::query_scalar("SELECT weltgewebe_search_generation_activation_ready($1)")
+            .bind(generation)
+            .fetch_one(&pool)
+            .await
+            .expect("canonical first-complete readiness");
+    assert_eq!(
+        first_complete.rebuild_activation_ready,
+        Some(canonical_first_complete)
+    );
 
     sqlx::query("UPDATE domain_nodes SET title='Revision zwei' WHERE id=$1")
         .bind(node)
@@ -302,6 +319,16 @@ async fn status_snapshot_separates_unique_nodes_job_history_and_activation_readi
     assert_eq!(second_pending.rebuild_total_jobs, Some(2));
     assert_eq!(second_pending.rebuild_terminal_jobs, Some(1));
     assert_eq!(second_pending.rebuild_activation_ready, Some(false));
+    let canonical_second_pending: bool =
+        sqlx::query_scalar("SELECT weltgewebe_search_generation_activation_ready($1)")
+            .bind(generation)
+            .fetch_one(&pool)
+            .await
+            .expect("canonical second-pending readiness");
+    assert_eq!(
+        second_pending.rebuild_activation_ready,
+        Some(canonical_second_pending)
+    );
 
     assert_eq!(
         projection_worker
@@ -320,6 +347,99 @@ async fn status_snapshot_separates_unique_nodes_job_history_and_activation_readi
     assert_eq!(second_complete.rebuild_total_jobs, Some(2));
     assert_eq!(second_complete.rebuild_terminal_jobs, Some(2));
     assert_eq!(second_complete.rebuild_activation_ready, Some(true));
+    let canonical_second_complete: bool =
+        sqlx::query_scalar("SELECT weltgewebe_search_generation_activation_ready($1)")
+            .bind(generation)
+            .fetch_one(&pool)
+            .await
+            .expect("canonical second-complete readiness");
+    assert_eq!(
+        second_complete.rebuild_activation_ready,
+        Some(canonical_second_complete)
+    );
+
+    let generation_two = "t005-status-semantics-generation-two";
+    projection_worker
+        .start_generation(GenerationSpec {
+            generation_id: generation_two,
+            provider: "local:ollama",
+            model_id: "m",
+            model_revision: "r2",
+            runtime_identity: "ollama:test@http://127.0.0.1:11434",
+            dimension: 3,
+        })
+        .await
+        .expect("start second status generation");
+    let second_generation_pending = projection_worker
+        .status_snapshot()
+        .await
+        .expect("second generation pending status");
+    assert_eq!(
+        second_generation_pending.rebuild_generation_id.as_deref(),
+        Some(generation_two)
+    );
+    assert_eq!(
+        second_generation_pending.rebuild_activation_ready,
+        Some(false)
+    );
+    assert_eq!(
+        projection_worker
+            .claim_and_process_one()
+            .await
+            .expect("project second generation"),
+        ProcessOutcome::Processed
+    );
+    let second_generation_complete = projection_worker
+        .status_snapshot()
+        .await
+        .expect("second generation complete status");
+    let canonical_generation_two: bool =
+        sqlx::query_scalar("SELECT weltgewebe_search_generation_activation_ready($1)")
+            .bind(generation_two)
+            .fetch_one(&pool)
+            .await
+            .expect("canonical second-generation readiness");
+    assert_eq!(
+        second_generation_complete.rebuild_activation_ready,
+        Some(canonical_generation_two)
+    );
+    assert!(canonical_generation_two);
+
+    sqlx::query("DELETE FROM domain_nodes WHERE id=$1")
+        .bind(node)
+        .execute(&pool)
+        .await
+        .expect("delete status semantics node");
+    let deletion_pending = projection_worker
+        .status_snapshot()
+        .await
+        .expect("deletion pending status");
+    assert_eq!(deletion_pending.current_nodes, 0);
+    assert_eq!(deletion_pending.rebuild_activation_ready, Some(false));
+    for _ in 0..2 {
+        assert_eq!(
+            projection_worker
+                .claim_and_process_one()
+                .await
+                .expect("process retained-generation deletion"),
+            ProcessOutcome::Deleted
+        );
+    }
+    let deletion_complete = projection_worker
+        .status_snapshot()
+        .await
+        .expect("deletion complete status");
+    let canonical_after_delete: bool =
+        sqlx::query_scalar("SELECT weltgewebe_search_generation_activation_ready($1)")
+            .bind(generation_two)
+            .fetch_one(&pool)
+            .await
+            .expect("canonical post-deletion readiness");
+    assert_eq!(
+        deletion_complete.rebuild_activation_ready,
+        Some(canonical_after_delete)
+    );
+    assert!(canonical_after_delete);
 }
 
 #[tokio::test]

--- a/apps/api/tests/db_session_store_persistence.rs
+++ b/apps/api/tests/db_session_store_persistence.rs
@@ -8,6 +8,8 @@
 //! - Tests are ignored by default to keep offline paths green.
 //! - DATABASE_URL must point to direct PostgreSQL (not PgBouncer at :6432).
 
+mod support;
+
 use std::{path::PathBuf, str::FromStr};
 
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
@@ -27,7 +29,7 @@ fn direct_database_url() -> String {
         "DATABASE_URL must target direct PostgreSQL, not PgBouncer (port 6432)"
     );
 
-    url
+    support::postgres_proof::validated_direct_disposable_url(url)
 }
 
 async fn connect_pool() -> sqlx::PgPool {

--- a/apps/api/tests/db_webauthn_user_id_backfill_audit.rs
+++ b/apps/api/tests/db_webauthn_user_id_backfill_audit.rs
@@ -1,6 +1,8 @@
 //! AUTH-PG-003 read-only DB proof.
 //! No backfill, no NOT NULL, no WebAuthn crypto: row/UUID coherence only.
 
+mod support;
+
 use std::{path::PathBuf, str::FromStr};
 
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
@@ -16,7 +18,7 @@ fn direct_database_url() -> String {
         !url.contains(":6432"),
         "DATABASE_URL must target direct PostgreSQL, not PgBouncer (port 6432)"
     );
-    url
+    support::postgres_proof::validated_direct_disposable_url(url)
 }
 
 fn require_fixture_mutation_opt_in() {

--- a/apps/api/tests/sqlx_postgres_direct_session_crud.rs
+++ b/apps/api/tests/sqlx_postgres_direct_session_crud.rs
@@ -32,6 +32,8 @@
 //! - Production `SessionStore` wiring (no `DbSessionStore` in this PR).
 //! - PgBouncer compatibility (see `sqlx_pgbouncer_session_crud.rs` for that path).
 
+mod support;
+
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 use sqlx::Row;
 use std::str::FromStr;
@@ -236,6 +238,7 @@ async fn sqlx_postgres_direct_session_crud() {
              -- point it at direct PostgreSQL (port 5432), e.g. \
              postgres://welt:gewebe@localhost:5432/weltgewebe_proof",
         );
+    support::postgres_proof::assert_direct_disposable_database_url(&direct_url);
 
     // Guard: reject any URL that targets PgBouncer port 6432.
     assert_not_pgbouncer_url(&direct_url);

--- a/apps/api/tests/support/mod.rs
+++ b/apps/api/tests/support/mod.rs
@@ -1,0 +1,1 @@
+pub mod postgres_proof;

--- a/apps/api/tests/support/postgres_proof.rs
+++ b/apps/api/tests/support/postgres_proof.rs
@@ -6,7 +6,7 @@ use url::Url;
 #[derive(Debug, Deserialize)]
 struct PostgresProofContract {
     schema_version: u32,
-    disposable_database_name_markers: Vec<String>,
+    disposable_database_name_segments: Vec<String>,
     pgbouncer_port: u16,
 }
 
@@ -20,8 +20,8 @@ fn contract() -> PostgresProofContract {
         "unsupported postgres proof contract schema"
     );
     assert!(
-        !parsed.disposable_database_name_markers.is_empty(),
-        "postgres proof contract must define disposable database markers"
+        !parsed.disposable_database_name_segments.is_empty(),
+        "postgres proof contract must define disposable database segments"
     );
     parsed
 }
@@ -31,11 +31,14 @@ pub fn assert_disposable_database_name(name: &str) {
     assert!(
         !name.is_empty()
             && contract
-                .disposable_database_name_markers
+                .disposable_database_name_segments
                 .iter()
-                .any(|marker| name.contains(marker)),
-        "PostgreSQL proof refuses non-disposable database name {name:?}; expected one of markers {:?}",
-        contract.disposable_database_name_markers
+                .any(|expected| {
+                    name.split(['_', '-', '.'])
+                        .any(|segment| segment == expected)
+                }),
+        "PostgreSQL proof refuses non-disposable database name {name:?}; expected a delimited name segment from {:?}",
+        contract.disposable_database_name_segments
     );
 }
 

--- a/apps/api/tests/support/postgres_proof.rs
+++ b/apps/api/tests/support/postgres_proof.rs
@@ -64,5 +64,9 @@ pub fn assert_direct_disposable_database_url(raw: &str) {
         "PostgreSQL proof requires direct PostgreSQL, not PgBouncer"
     );
     let database = url.path().trim_start_matches('/');
+    assert!(
+        !database.contains('%'),
+        "PostgreSQL proof database path must not contain percent-encoding"
+    );
     assert_disposable_database_name(database);
 }

--- a/apps/api/tests/support/postgres_proof.rs
+++ b/apps/api/tests/support/postgres_proof.rs
@@ -1,0 +1,65 @@
+#![allow(dead_code)]
+
+use serde::Deserialize;
+use url::Url;
+
+#[derive(Debug, Deserialize)]
+struct PostgresProofContract {
+    schema_version: u32,
+    disposable_database_name_markers: Vec<String>,
+    pgbouncer_port: u16,
+}
+
+fn contract() -> PostgresProofContract {
+    let parsed: PostgresProofContract = serde_json::from_str(include_str!(
+        "../../../../scripts/ci/postgres-proof-contract.json"
+    ))
+    .expect("postgres proof contract JSON must parse");
+    assert_eq!(
+        parsed.schema_version, 1,
+        "unsupported postgres proof contract schema"
+    );
+    assert!(
+        !parsed.disposable_database_name_markers.is_empty(),
+        "postgres proof contract must define disposable database markers"
+    );
+    parsed
+}
+
+pub fn assert_disposable_database_name(name: &str) {
+    let contract = contract();
+    assert!(
+        !name.is_empty()
+            && contract
+                .disposable_database_name_markers
+                .iter()
+                .any(|marker| name.contains(marker)),
+        "PostgreSQL proof refuses non-disposable database name {name:?}; expected one of markers {:?}",
+        contract.disposable_database_name_markers
+    );
+}
+
+pub fn validated_direct_disposable_url(raw: String) -> String {
+    assert_direct_disposable_database_url(&raw);
+    raw
+}
+
+pub fn assert_direct_disposable_database_url(raw: &str) {
+    let contract = contract();
+    let url = Url::parse(raw).expect("PostgreSQL proof URL must parse");
+    assert!(
+        matches!(url.scheme(), "postgres" | "postgresql"),
+        "PostgreSQL proof URL must use postgres/postgresql scheme"
+    );
+    assert!(
+        url.host_str().is_some(),
+        "PostgreSQL proof URL must contain a host"
+    );
+    assert_ne!(
+        url.port().unwrap_or(5432),
+        contract.pgbouncer_port,
+        "PostgreSQL proof requires direct PostgreSQL, not PgBouncer"
+    );
+    let database = url.path().trim_start_matches('/');
+    assert_disposable_database_name(database);
+}

--- a/apps/api/tests/support/postgres_proof.rs
+++ b/apps/api/tests/support/postgres_proof.rs
@@ -30,14 +30,24 @@ pub fn assert_disposable_database_name(name: &str) {
     let contract = contract();
     assert!(
         !name.is_empty()
-            && contract
-                .disposable_database_name_segments
-                .iter()
-                .any(|expected| {
-                    name.split(['_', '-', '.'])
-                        .any(|segment| segment == expected)
-                }),
-        "PostgreSQL proof refuses non-disposable database name {name:?}; expected a delimited name segment from {:?}",
+            && name.chars().all(|character| {
+                character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '.')
+            }),
+        "PostgreSQL proof refuses unsafe disposable database identifier {name:?}"
+    );
+    let final_segment = name
+        .split(['_', '-', '.'])
+        .filter(|segment| !segment.is_empty())
+        .next_back();
+    assert!(
+        name.starts_with("weltgewebe_")
+            && final_segment.is_some_and(|segment| {
+                contract
+                    .disposable_database_name_segments
+                    .iter()
+                    .any(|expected| segment == expected)
+            }),
+        "PostgreSQL proof refuses non-disposable database name {name:?}; expected weltgewebe_ prefix and final delimited segment from {:?}",
         contract.disposable_database_name_segments
     );
 }

--- a/apps/web/static/weltweberei/index.html
+++ b/apps/web/static/weltweberei/index.html
@@ -10,6 +10,7 @@
     />
     <meta name="weltgewebe-surface" content="weltweberei-info-v1" />
     <meta name="robots" content="noindex, nofollow" />
+    <meta http-equiv="content-security-policy" content="script-src 'none'; object-src 'none'; base-uri 'self'" />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>

--- a/apps/web/static/weltweberei/index.html
+++ b/apps/web/static/weltweberei/index.html
@@ -10,7 +10,10 @@
     />
     <meta name="weltgewebe-surface" content="weltweberei-info-v1" />
     <meta name="robots" content="noindex, nofollow" />
-    <meta http-equiv="content-security-policy" content="script-src 'none'; object-src 'none'; base-uri 'self'" />
+    <meta
+      http-equiv="content-security-policy"
+      content="script-src 'none'; object-src 'none'; base-uri 'self'"
+    />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>

--- a/apps/web/svelte.config.js
+++ b/apps/web/svelte.config.js
@@ -7,6 +7,13 @@ const config = {
   preprocess: vitePreprocess(),
 
   kit: {
+    // Hash the prerendered SvelteKit bootstrap scripts instead of allowing all inline JS.
+    csp: {
+      mode: "hash",
+      directives: {
+        "script-src": ["self"],
+      },
+    },
     // Verwende adapter-static, da wir eine SPA bzw. statische Seite bauen:
     adapter: adapter(),
 

--- a/apps/web/svelte.config.js
+++ b/apps/web/svelte.config.js
@@ -12,6 +12,7 @@ const config = {
       mode: "hash",
       directives: {
         "script-src": ["self"],
+        "worker-src": ["self", "blob:"],
       },
     },
     // Verwende adapter-static, da wir eine SPA bzw. statische Seite bauen:

--- a/docs/deploy/CHANGELOG.md
+++ b/docs/deploy/CHANGELOG.md
@@ -824,3 +824,4 @@ erhalten bleibt.
 Der temporäre Legacy-Alias `/auth/login/consume` wurde entfernt. Der Magic-Link-Consume-Pfad läuft nun ausschließlich über `/auth/magic-link/consume`.
 
 **Risiko:** Niedrig.
+- 2026-07-22: Audit remediation T023-T026 hardens Caddy CSP and security-header handling across default, Heim and VPS edge configurations; deployment contract acknowledgement for the coordinated infra/caddy change set.

--- a/docs/deploy/CHANGELOG.md
+++ b/docs/deploy/CHANGELOG.md
@@ -824,4 +824,5 @@ erhalten bleibt.
 Der temporäre Legacy-Alias `/auth/login/consume` wurde entfernt. Der Magic-Link-Consume-Pfad läuft nun ausschließlich über `/auth/magic-link/consume`.
 
 **Risiko:** Niedrig.
+
 - 2026-07-22: Audit remediation T023-T026 hardens Caddy CSP and security-header handling across default, Heim and VPS edge configurations; deployment contract acknowledgement for the coordinated infra/caddy change set.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -181,15 +181,20 @@ Cargo-Paketversion.
 
 ## CSP contract
 
-The production frontend currently contains an inline bootstrap `<script>` (SvelteKit).
-Therefore the served `Content-Security-Policy` must allow that inline script, either via:
+The production frontend uses SvelteKit's hash-mode CSP. SvelteKit writes a document-level CSP meta tag whose
+`script-src` contains the build-generated SHA-256 hashes for the prerendered inline bootstrap scripts.
+`script-src 'unsafe-inline'` is forbidden.
 
-- `script-src 'unsafe-inline'` (pragmatic), or
-- a nonce/hash-based CSP (preferred hardening, follow-up work).
+The static-app Caddy edge deliberately does **not** add `default-src` or `script-src` to its HTTP CSP. Multiple CSP
+policies intersect; an edge policy without the same build-generated hashes would therefore block the legitimate
+hash-authorized SvelteKit bootstrap. Directives that must remain edge-owned, including `frame-ancestors`, plus the
+non-script resource directives remain in the Caddy header.
 
-The static preflight `scripts/preflight/csp_contract_static.sh` parses the Caddyfile and the compiled `index.html` to
-fail deploys early if an inline script is present but the CSP forbids it. This prevents a whitepage without relying on
-a running server.
+The static preflight `scripts/preflight/csp_contract_static.sh` fails closed before deploy. It recursively validates
+**every** compiled HTML artifact, requires exactly one CSP meta policy with `script-src`, rejects `unsafe-inline`, and
+verifies every inline script body against a matching SHA-256 source expression. Because non-HTML active documents do
+not receive a meta CSP, the same guard also rejects scriptable constructs in static SVG artifacts. This keeps the split
+edge/document CSP contract explicit without relying on a running server.
 
 ### Caddyfile Source of Truth
 

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -49,6 +49,7 @@
     # The static CSP preflight validates every HTML artifact and rejects active SVGs.
     X-Frame-Options "DENY"
     Referrer-Policy "no-referrer"
+    X-Content-Type-Options "nosniff"
     # Optional diagnostic header. Deploy can set WELTGEWEBE_BUILD to the canonical
     # build version (matches /_app/version.json#version).
     X-Weltgewebe-Build "{$WELTGEWEBE_BUILD}"

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -33,6 +33,13 @@
     reverse_proxy api:8080
   }
   reverse_proxy /* web:5173
+  @apiResponse path /api/*
+  header @apiResponse Content-Security-Policy "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
+  @frontendResponse {
+    not path /api/*
+  }
+  header @frontendResponse Content-Security-Policy "style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss:; img-src 'self' data: blob:; worker-src 'self' blob:; font-src 'self'; media-src 'self'; manifest-src 'self'; child-src 'self'; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';"
+
   header {
     # Local-sovereign CSP: WebSocket-Schemes bleiben fuer Dev/Proxy erlaubt;
     # externe Tile-/Bildquellen bleiben in diesem Caddy-Pfad bewusst gesperrt.
@@ -40,11 +47,16 @@
     # meta CSP for every served HTML artifact. An edge default-src/script-src would
     # intersect with that policy and block the hash-authorized inline bootstrap.
     # The static CSP preflight validates every HTML artifact and rejects active SVGs.
-    Content-Security-Policy "style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss:; img-src 'self' data: blob:; worker-src 'self' blob:; font-src 'self'; media-src 'self'; manifest-src 'self'; child-src 'self'; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';"
     X-Frame-Options "DENY"
     Referrer-Policy "no-referrer"
     # Optional diagnostic header. Deploy can set WELTGEWEBE_BUILD to the canonical
     # build version (matches /_app/version.json#version).
     X-Weltgewebe-Build "{$WELTGEWEBE_BUILD}"
+  }
+
+  handle_errors {
+    header Content-Security-Policy "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
+    header X-Content-Type-Options "nosniff"
+    respond "request failed" {err.status_code}
   }
 }

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -36,6 +36,10 @@
   header {
     # Local-sovereign CSP: WebSocket-Schemes bleiben fuer Dev/Proxy erlaubt;
     # externe Tile-/Bildquellen bleiben in diesem Caddy-Pfad bewusst gesperrt.
+    # Script execution is intentionally document-owned: SvelteKit emits a hash-bound
+    # meta CSP for every served HTML artifact. An edge default-src/script-src would
+    # intersect with that policy and block the hash-authorized inline bootstrap.
+    # The static CSP preflight validates every HTML artifact and rejects active SVGs.
     Content-Security-Policy "style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss:; img-src 'self' data: blob:; worker-src 'self' blob:; font-src 'self'; media-src 'self'; manifest-src 'self'; child-src 'self'; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';"
     X-Frame-Options "DENY"
     Referrer-Policy "no-referrer"

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -36,7 +36,7 @@
   header {
     # Local-sovereign CSP: WebSocket-Schemes bleiben fuer Dev/Proxy erlaubt;
     # externe Tile-/Bildquellen bleiben in diesem Caddy-Pfad bewusst gesperrt.
-    Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss:; img-src 'self' data: blob:; worker-src 'self' blob:; object-src 'none';"
+    Content-Security-Policy "style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss:; img-src 'self' data: blob:; worker-src 'self' blob:; font-src 'self'; media-src 'self'; manifest-src 'self'; child-src 'self'; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';"
     X-Frame-Options "DENY"
     Referrer-Policy "no-referrer"
     # Optional diagnostic header. Deploy can set WELTGEWEBE_BUILD to the canonical

--- a/infra/caddy/Caddyfile.heim
+++ b/infra/caddy/Caddyfile.heim
@@ -67,6 +67,10 @@ weltgewebe.home.arpa {
 
   header {
     # Security headers (Heim-first specific)
+    # Script execution is intentionally document-owned: SvelteKit emits a hash-bound
+    # meta CSP for every served HTML artifact. An edge default-src/script-src would
+    # intersect with that policy and block the hash-authorized inline bootstrap.
+    # The static CSP preflight validates every HTML artifact and rejects active SVGs.
     Content-Security-Policy "style-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: blob:; worker-src 'self' blob:; font-src 'self'; media-src 'self'; manifest-src 'self'; child-src 'self'; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';"
     X-Frame-Options "DENY"
     Referrer-Policy "no-referrer"

--- a/infra/caddy/Caddyfile.heim
+++ b/infra/caddy/Caddyfile.heim
@@ -65,13 +65,19 @@ weltgewebe.home.arpa {
     file_server
   }
 
+  @apiResponse path /api/*
+  header @apiResponse Content-Security-Policy "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
+  @frontendResponse {
+    not path /api/*
+  }
+  header @frontendResponse Content-Security-Policy "style-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: blob:; worker-src 'self' blob:; font-src 'self'; media-src 'self'; manifest-src 'self'; child-src 'self'; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';"
+
   header {
     # Security headers (Heim-first specific)
     # Script execution is intentionally document-owned: SvelteKit emits a hash-bound
     # meta CSP for every served HTML artifact. An edge default-src/script-src would
     # intersect with that policy and block the hash-authorized inline bootstrap.
     # The static CSP preflight validates every HTML artifact and rejects active SVGs.
-    Content-Security-Policy "style-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: blob:; worker-src 'self' blob:; font-src 'self'; media-src 'self'; manifest-src 'self'; child-src 'self'; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';"
     X-Frame-Options "DENY"
     Referrer-Policy "no-referrer"
     X-Content-Type-Options "nosniff"
@@ -79,5 +85,12 @@ weltgewebe.home.arpa {
     # Optional diagnostic header. Deploy can set WELTGEWEBE_BUILD to the canonical
     # build version (matches /_app/version.json#version).
     X-Weltgewebe-Build "{$WELTGEWEBE_BUILD}"
+  }
+
+
+  handle_errors {
+    header Content-Security-Policy "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
+    header X-Content-Type-Options "nosniff"
+    respond "request failed" {err.status_code}
   }
 }

--- a/infra/caddy/Caddyfile.heim
+++ b/infra/caddy/Caddyfile.heim
@@ -67,7 +67,7 @@ weltgewebe.home.arpa {
 
   header {
     # Security headers (Heim-first specific)
-    Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: blob:; worker-src 'self' blob:; object-src 'none';"
+    Content-Security-Policy "style-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: blob:; worker-src 'self' blob:; font-src 'self'; media-src 'self'; manifest-src 'self'; child-src 'self'; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';"
     X-Frame-Options "DENY"
     Referrer-Policy "no-referrer"
     X-Content-Type-Options "nosniff"

--- a/infra/caddy/Caddyfile.http-smoke
+++ b/infra/caddy/Caddyfile.http-smoke
@@ -3,6 +3,11 @@
 # Pre-cutover Host-header smoke only.
 
 http://weltgewebe.net {
+	header {
+		Content-Security-Policy "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
+		X-Content-Type-Options "nosniff"
+	}
+
 	handle /health/proxy {
 		respond 200
 	}

--- a/infra/caddy/Caddyfile.vps
+++ b/infra/caddy/Caddyfile.vps
@@ -98,7 +98,7 @@
 	}
 
 	header {
-		Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: blob:; worker-src 'self' blob:; object-src 'none';"
+		Content-Security-Policy "style-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: blob:; worker-src 'self' blob:; font-src 'self'; media-src 'self'; manifest-src 'self'; child-src 'self'; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';"
 		X-Frame-Options "DENY"
 		Referrer-Policy "no-referrer"
 		X-Content-Type-Options "nosniff"

--- a/infra/caddy/Caddyfile.vps
+++ b/infra/caddy/Caddyfile.vps
@@ -98,6 +98,10 @@
 	}
 
 	header {
+		# Script execution is intentionally document-owned: SvelteKit emits a hash-bound
+		# meta CSP for every served HTML artifact. An edge default-src/script-src would
+		# intersect with that policy and block the hash-authorized inline bootstrap.
+		# The static CSP preflight validates every HTML artifact and rejects active SVGs.
 		Content-Security-Policy "style-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: blob:; worker-src 'self' blob:; font-src 'self'; media-src 'self'; manifest-src 'self'; child-src 'self'; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';"
 		X-Frame-Options "DENY"
 		Referrer-Policy "no-referrer"

--- a/infra/caddy/Caddyfile.vps
+++ b/infra/caddy/Caddyfile.vps
@@ -97,17 +97,29 @@
 		file_server
 	}
 
+	@nonDocumentResponse path /api/* /health/*
+	header @nonDocumentResponse Content-Security-Policy "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
+	@frontendResponse {
+		not path /api/* /health/*
+	}
+	header @frontendResponse Content-Security-Policy "style-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: blob:; worker-src 'self' blob:; font-src 'self'; media-src 'self'; manifest-src 'self'; child-src 'self'; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';"
+
 	header {
 		# Script execution is intentionally document-owned: SvelteKit emits a hash-bound
 		# meta CSP for every served HTML artifact. An edge default-src/script-src would
 		# intersect with that policy and block the hash-authorized inline bootstrap.
 		# The static CSP preflight validates every HTML artifact and rejects active SVGs.
-		Content-Security-Policy "style-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: blob:; worker-src 'self' blob:; font-src 'self'; media-src 'self'; manifest-src 'self'; child-src 'self'; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';"
 		X-Frame-Options "DENY"
 		Referrer-Policy "no-referrer"
 		X-Content-Type-Options "nosniff"
 		Strict-Transport-Security "max-age=31536000; includeSubDomains"
 		X-Weltgewebe-Build "{$WELTGEWEBE_BUILD}"
+	}
+
+	handle_errors {
+		header Content-Security-Policy "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
+		header X-Content-Type-Options "nosniff"
+		respond "request failed" {err.status_code}
 	}
 }
 
@@ -132,6 +144,7 @@
 		header_up X-Forwarded-For {remote_host}
 	}
 	header {
+		Content-Security-Policy "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
 		X-Frame-Options "DENY"
 		Referrer-Policy "no-referrer"
 		X-Content-Type-Options "nosniff"
@@ -142,6 +155,9 @@
 # HTTP sites are intentionally narrow: they support pre-DNS smoke tests for
 # health/API readiness, but do not serve the full app over plaintext.
 http://weltgewebe.net, http://www.weltgewebe.net {
+	header Content-Security-Policy "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
+	header X-Content-Type-Options "nosniff"
+
 	handle /health/proxy {
 		respond 200
 	}
@@ -166,6 +182,9 @@ http://weltgewebe.net, http://www.weltgewebe.net {
 }
 
 http://api.weltgewebe.net {
+	header Content-Security-Policy "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
+	header X-Content-Type-Options "nosniff"
+
 	handle /health/proxy {
 		respond 200
 	}

--- a/policies/security.yml
+++ b/policies/security.yml
@@ -1,21 +1,29 @@
 ---
 content_security_policy:
-  default-src: "'self'"
-  img-src: "'self' data: blob:"
-  script-src: "'self' 'unsafe-inline'"
+  script-src: "'self' plus build-generated sha256 hashes"
+  script_delivery: sveltekit_prerender_meta
+  script_mode: hash
   style-src: "'self' 'unsafe-inline'"
   connect-src:
     - "'self'"
+  img-src: "'self' data: blob:"
   worker-src: "'self' blob:"
+  font-src: "'self'"
+  media-src: "'self'"
+  manifest-src: "'self'"
+  child-src: "'self'"
+  frame-src: "'self'"
   object-src: "'none'"
+  base-uri: "'self'"
+  form-action: "'self'"
+  frame-ancestors: "'none'"
 csp_exceptions:
-  - directive: "script-src 'unsafe-inline'"
+  - directive: "style-src 'unsafe-inline'"
     status: accepted_residual_risk
     reason: >
-      The current static Svelte build contract still permits inline bootstrap
-      script execution. Removal requires a proven static build without inline
-      scripts. scripts/preflight/csp_contract_static.sh and
-      scripts/guard/security-headers-guard.sh keep this exception explicit.
+      Svelte transitions can create runtime inline style elements. Script execution
+      does not share this exception: prerendered SvelteKit bootstrap scripts are
+      bound to build-generated sha256 hashes in the document CSP meta tag.
 allowed_origins:
   - https://weltgewebe.net
   - https://www.weltgewebe.net
@@ -29,5 +37,6 @@ effective_caddy_contract:
     - infra/caddy/Caddyfile.heim
     - infra/caddy/Caddyfile.prod
   static_app_caddyfiles:
+    - infra/caddy/Caddyfile
     - infra/caddy/Caddyfile.vps
     - infra/caddy/Caddyfile.heim

--- a/scripts/ci/postgres-proof-contract.json
+++ b/scripts/ci/postgres-proof-contract.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "disposable_database_name_markers": [
+  "pgbouncer_port": 6432,
+  "jetstream_image": "nats@sha256:b83efabe3e7def1e0a4a31ec6e078999bb17c80363f881df35edc70fcb6bb927",
+  "disposable_database_name_segments": [
     "test",
     "proof",
     "ci"
-  ],
-  "pgbouncer_port": 6432,
-  "jetstream_image": "nats@sha256:b83efabe3e7def1e0a4a31ec6e078999bb17c80363f881df35edc70fcb6bb927"
+  ]
 }

--- a/scripts/ci/postgres-proof-contract.json
+++ b/scripts/ci/postgres-proof-contract.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "disposable_database_name_markers": [
+    "test",
+    "proof",
+    "ci"
+  ],
+  "pgbouncer_port": 6432,
+  "jetstream_image": "nats@sha256:b83efabe3e7def1e0a4a31ec6e078999bb17c80363f881df35edc70fcb6bb927"
+}

--- a/scripts/ci/run-postgres-integration-proofs.sh
+++ b/scripts/ci/run-postgres-integration-proofs.sh
@@ -1,35 +1,96 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-: "${DATABASE_URL:?DATABASE_URL must point at a disposable PostgreSQL database}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+CONTRACT_FILE="${SCRIPT_DIR}/postgres-proof-contract.json"
+
+: "${DATABASE_URL:?DATABASE_URL must point at a direct disposable PostgreSQL database}"
 export PG_DIRECT_URL="${PG_DIRECT_URL:-$DATABASE_URL}"
 export T005_DATABASE_URL="${T005_DATABASE_URL:-$PG_DIRECT_URL}"
 export AUTH_PG_003_FIXTURE_MUTATION=1
 
-load_t003_connection() {
-  local -a values=()
-  mapfile -d '' -t values < <(
-    python3 - "$PG_DIRECT_URL" << 'PY'
-import sys
-from urllib.parse import unquote, urlsplit
+owned_nats_container=""
+cleanup() {
+  local exit_code=$?
+  trap - EXIT INT TERM
+  if [[ -n "$owned_nats_container" ]]; then
+    docker rm --force "$owned_nats_container" >/dev/null 2>&1 || true
+  fi
+  exit "$exit_code"
+}
+trap cleanup EXIT INT TERM
 
-url = urlsplit(sys.argv[1])
-if url.scheme not in {'postgres', 'postgresql'}:
+contract_value() {
+  local key="$1"
+  python3 - "$CONTRACT_FILE" "$key" <<'PY'
+import json, sys
+contract=json.load(open(sys.argv[1], encoding='utf-8'))
+if contract.get('schema_version') != 1:
+    raise SystemExit('unsupported postgres proof contract schema')
+value=contract.get(sys.argv[2])
+if value is None:
+    raise SystemExit(f'missing postgres proof contract key: {sys.argv[2]}')
+if isinstance(value, (list, dict)):
+    print(json.dumps(value, separators=(',', ':')))
+else:
+    print(value)
+PY
+}
+
+validate_database_url() {
+  local url="$1"
+  python3 - "$CONTRACT_FILE" "$url" <<'PY'
+import json, sys
+from urllib.parse import unquote, urlsplit
+contract=json.load(open(sys.argv[1], encoding='utf-8'))
+if contract.get('schema_version') != 1:
+    raise SystemExit('unsupported postgres proof contract schema')
+markers=contract.get('disposable_database_name_markers') or []
+if not markers:
+    raise SystemExit('postgres proof contract has no disposable database markers')
+url=urlsplit(sys.argv[2])
+if url.scheme not in {'postgres','postgresql'}:
     raise SystemExit(f'unsupported PostgreSQL URL scheme: {url.scheme!r}')
 if not url.hostname:
     raise SystemExit('PostgreSQL URL must contain a host')
-port = url.port or 5432
-if port == 6432:
-    raise SystemExit('T003 proof requires direct PostgreSQL, not PgBouncer')
-values = (
-    url.hostname,
-    str(port),
+port=url.port or 5432
+if port == int(contract['pgbouncer_port']):
+    raise SystemExit('PostgreSQL integration proofs require direct PostgreSQL, not PgBouncer')
+database=unquote(url.path.lstrip('/'))
+if not database or not any(marker in database for marker in markers):
+    raise SystemExit(
+        f'refusing non-disposable database {database!r}; expected a name containing one of {markers!r}'
+    )
+print(database)
+PY
+}
+
+DATABASE_NAME="$(validate_database_url "$DATABASE_URL")"
+PG_DIRECT_DATABASE_NAME="$(validate_database_url "$PG_DIRECT_URL")"
+T005_DATABASE_NAME="$(validate_database_url "$T005_DATABASE_URL")"
+if [[ "$DATABASE_NAME" == "$PG_DIRECT_DATABASE_NAME" && "$DATABASE_NAME" == "$T005_DATABASE_NAME" ]]; then
+  :
+else
+  echo "PostgreSQL proof URLs must target the same disposable database name: DATABASE_URL=${DATABASE_NAME}, PG_DIRECT_URL=${PG_DIRECT_DATABASE_NAME}, T005_DATABASE_URL=${T005_DATABASE_NAME}" >&2
+  exit 1
+fi
+
+load_t003_connection() {
+  local -a values=()
+  mapfile -d '' -t values < <(
+    python3 - "$PG_DIRECT_URL" <<'PY'
+import sys
+from urllib.parse import unquote, urlsplit
+url=urlsplit(sys.argv[1])
+values=(
+    url.hostname or '',
+    str(url.port or 5432),
     unquote(url.username or ''),
     unquote(url.password or ''),
     unquote(url.path.lstrip('/')),
 )
-if not values[2] or not values[4]:
-    raise SystemExit('PostgreSQL URL must contain a user and database')
+if not values[0] or not values[2] or not values[4]:
+    raise SystemExit('PostgreSQL URL must contain host, user and database')
 for value in values:
     sys.stdout.write(value)
     sys.stdout.write('\0')
@@ -45,62 +106,161 @@ PY
   export T003_PG_PASSWORD="${values[3]}"
   export T003_PG_DATABASE="${values[4]}"
 }
-
 load_t003_connection
 
-database_name() {
-  python3 - "$DATABASE_URL" << 'PY'
+postgres_admin_url() {
+  python3 - "$PG_DIRECT_URL" <<'PY'
 import sys
-from urllib.parse import urlsplit
-name=urlsplit(sys.argv[1]).path.lstrip('/')
-if not name or not any(marker in name for marker in ('test', 'proof', 'ci')):
-    raise SystemExit(f"refusing to reset non-disposable database: {name!r}")
-print(name)
+from urllib.parse import urlsplit, urlunsplit
+url=urlsplit(sys.argv[1])
+print(urlunsplit((url.scheme, url.netloc, '/postgres', url.query, url.fragment)))
 PY
+}
+
+preflight_postgres() {
+  local admin
+  admin="$(postgres_admin_url)"
+  if [[ -n "${POSTGRES_RESET_CONTAINER:-}" ]]; then
+    command -v docker >/dev/null 2>&1 || {
+      echo 'PostgreSQL proof container preflight requires docker' >&2
+      return 1
+    }
+    if ! docker exec "$POSTGRES_RESET_CONTAINER" pg_isready -U postgres -d postgres >/dev/null 2>&1; then
+      echo "PostgreSQL proof preflight container is not ready: ${POSTGRES_RESET_CONTAINER}" >&2
+      return 1
+    fi
+    if ! docker exec "$POSTGRES_RESET_CONTAINER" psql -U postgres -d postgres -X --no-psqlrc -v ON_ERROR_STOP=1 -Atqc 'SELECT 1' >/dev/null; then
+      echo "PostgreSQL proof preflight container query failed: ${POSTGRES_RESET_CONTAINER}" >&2
+      return 1
+    fi
+    echo "PostgreSQL proof preflight: isolated container ready; disposable database=${DATABASE_NAME}"
+    return 0
+  fi
+  if ! command -v psql >/dev/null 2>&1; then
+    echo 'PostgreSQL proof preflight requires psql before the first test' >&2
+    return 1
+  fi
+  if ! psql "$admin" -X --no-psqlrc -v ON_ERROR_STOP=1 -Atqc 'SELECT 1' >/dev/null; then
+    echo 'PostgreSQL proof preflight could not reach the direct PostgreSQL admin database' >&2
+    return 1
+  fi
+  echo "PostgreSQL proof preflight: direct server ready; disposable database=${DATABASE_NAME}"
+}
+
+check_jetstream_once() {
+  python3 - "$NATS_URL" <<'PY'
+import json, socket, sys
+from urllib.parse import urlsplit
+url=urlsplit(sys.argv[1])
+if url.scheme != 'nats' or not url.hostname:
+    raise SystemExit('NATS_URL must be a plain nats:// URL for the integration proof')
+with socket.create_connection((url.hostname, url.port or 4222), timeout=2.0) as sock:
+    sock.settimeout(2.0)
+    data=b''
+    while b'\r\n' not in data and len(data) < 65536:
+        chunk=sock.recv(4096)
+        if not chunk:
+            break
+        data += chunk
+line=data.split(b'\r\n',1)[0]
+if not line.startswith(b'INFO '):
+    raise SystemExit(f'NATS readiness expected INFO line, got {line[:80]!r}')
+info=json.loads(line[5:].decode('utf-8'))
+if info.get('jetstream') is not True:
+    raise SystemExit('NATS server is reachable but JetStream is not enabled')
+print('JetStream proof preflight: semantic INFO jetstream=true')
+PY
+}
+
+wait_for_jetstream() {
+  for _ in {1..30}; do
+    if check_jetstream_once; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "JetStream proof preflight failed for ${NATS_URL}" >&2
+  if [[ -n "$owned_nats_container" ]]; then
+    docker logs "$owned_nats_container" >&2 || true
+  fi
+  return 1
+}
+
+provision_jetstream_if_requested() {
+  if [[ "${POSTGRES_PROOF_PROVISION_NATS:-0}" != "1" ]]; then
+    : "${NATS_URL:?NATS_URL is required unless POSTGRES_PROOF_PROVISION_NATS=1}"
+    wait_for_jetstream
+    return
+  fi
+  command -v docker >/dev/null 2>&1 || {
+    echo 'JetStream proof provisioning requires docker' >&2
+    return 1
+  }
+  local image binding port suffix
+  image="$(contract_value jetstream_image)"
+  suffix="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}-$$"
+  owned_nats_container="weltgewebe-ci-nats-${suffix}"
+  docker run --detach --rm \
+    --name "$owned_nats_container" \
+    --publish 127.0.0.1::4222 \
+    "$image" -js >/dev/null
+  binding="$(docker port "$owned_nats_container" 4222/tcp | head -n1)"
+  port="${binding##*:}"
+  if [[ ! "$port" =~ ^[0-9]+$ ]]; then
+    echo "could not resolve dynamically published JetStream port from ${binding!r}" >&2
+    return 1
+  fi
+  export NATS_URL="nats://127.0.0.1:${port}"
+  wait_for_jetstream
 }
 
 reset_database() {
-  local database
-  database="$(database_name)"
+  local admin
+  admin="$(postgres_admin_url)"
   if [[ -n "${POSTGRES_RESET_CONTAINER:-}" ]]; then
-    docker exec "$POSTGRES_RESET_CONTAINER" dropdb -U postgres --if-exists --force "$database" > /dev/null
-    docker exec "$POSTGRES_RESET_CONTAINER" createdb -U postgres "$database"
+    docker exec "$POSTGRES_RESET_CONTAINER" dropdb -U postgres --if-exists --force "$DATABASE_NAME" >/dev/null
+    docker exec "$POSTGRES_RESET_CONTAINER" createdb -U postgres "$DATABASE_NAME"
     return
   fi
-  python3 - "$DATABASE_URL" << 'PY'
-import os
-import subprocess
-import sys
-from urllib.parse import urlsplit, urlunsplit
-url = urlsplit(sys.argv[1])
-database = url.path.lstrip('/')
-admin = urlunsplit((url.scheme, url.netloc, '/postgres', url.query, url.fragment))
-env = dict(os.environ)
-subprocess.run(['psql', admin, '-X', '--no-psqlrc', '-v', 'ON_ERROR_STOP=1', '-c',
-                f'DROP DATABASE IF EXISTS "{database}" WITH (FORCE);'], check=True, env=env)
-subprocess.run(['psql', admin, '-X', '--no-psqlrc', '-v', 'ON_ERROR_STOP=1', '-c',
-                f'CREATE DATABASE "{database}";'], check=True, env=env)
-PY
+  psql "$admin" -X --no-psqlrc -v ON_ERROR_STOP=1 -c \
+    "DROP DATABASE IF EXISTS \"${DATABASE_NAME}\" WITH (FORCE);" >/dev/null
+  psql "$admin" -X --no-psqlrc -v ON_ERROR_STOP=1 -c \
+    "CREATE DATABASE \"${DATABASE_NAME}\";" >/dev/null
 }
 
-for target in \
-  db_auto_provision_write_path \
-  db_domain_account_write_path \
-  db_domain_backfill \
-  db_domain_edge_write_path \
-  db_domain_node_write_path \
-  db_governance \
-  db_multi_instance_foundation \
-  db_domain_read_path \
-  db_domain_schema_migrations \
-  db_passkey_fk_readiness \
-  db_passkey_schema_preflight \
-  db_passkey_store_persistence \
-  db_session_store_persistence \
-  db_webauthn_user_id_backfill_audit \
-  db_semantic_search_foundation \
-  db_semantic_search_projection_worker \
-  sqlx_postgres_direct_session_crud; do
+preflight_postgres
+provision_jetstream_if_requested
+
+if [[ "${POSTGRES_PROOF_PREFLIGHT_ONLY:-0}" == "1" ]]; then
+  echo 'PostgreSQL integration proof preflight-only mode: PASS'
+  exit 0
+fi
+
+targets=(
+  db_auto_provision_write_path
+  db_domain_account_write_path
+  db_domain_backfill
+  db_domain_edge_write_path
+  db_domain_node_write_path
+  db_governance
+  db_multi_instance_foundation
+  db_domain_read_path
+  db_domain_schema_migrations
+  db_passkey_fk_readiness
+  db_passkey_schema_preflight
+  db_passkey_store_persistence
+  db_session_store_persistence
+  db_webauthn_user_id_backfill_audit
+  db_semantic_search_foundation
+  db_semantic_search_projection_worker
+  sqlx_postgres_direct_session_crud
+)
+
+if [[ -n "${POSTGRES_PROOF_TARGETS:-}" ]]; then
+  read -r -a targets <<<"$POSTGRES_PROOF_TARGETS"
+fi
+
+for target in "${targets[@]}"; do
   printf '=== PostgreSQL proof: %s ===\n' "$target"
   reset_database
   cargo test --locked -p weltgewebe-api --test "$target" -- --include-ignored --test-threads=1

--- a/scripts/ci/run-postgres-integration-proofs.sh
+++ b/scripts/ci/run-postgres-integration-proofs.sh
@@ -207,7 +207,7 @@ provision_jetstream_if_requested() {
   binding="$(docker port "$owned_nats_container" 4222/tcp | head -n1)"
   port="${binding##*:}"
   if [[ ! "$port" =~ ^[0-9]+$ ]]; then
-    echo "could not resolve dynamically published JetStream port from ${binding!r}" >&2
+    echo "could not resolve dynamically published JetStream port from ${binding}" >&2
     return 1
   fi
   export NATS_URL="nats://127.0.0.1:${port}"

--- a/scripts/ci/run-postgres-integration-proofs.sh
+++ b/scripts/ci/run-postgres-integration-proofs.sh
@@ -113,7 +113,7 @@ load_t003_connection() {
   local tmp_file
   local -a values=()
   tmp_file="$(mktemp)"
-  if ! python3 - "$PG_DIRECT_URL" > "$tmp_file" << 'PY'
+  if ! python3 - "$PG_DIRECT_URL" > "$tmp_file" << 'PY'; then
 import sys
 from urllib.parse import unquote, urlsplit
 url=urlsplit(sys.argv[1])
@@ -130,7 +130,7 @@ for value in values:
     sys.stdout.write(value)
     sys.stdout.write('\0')
 PY
-  then
+
     rm -f "$tmp_file"
     return 1
   fi

--- a/scripts/ci/run-postgres-integration-proofs.sh
+++ b/scripts/ci/run-postgres-integration-proofs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
 CONTRACT_FILE="${SCRIPT_DIR}/postgres-proof-contract.json"
 
 : "${DATABASE_URL:?DATABASE_URL must point at a direct disposable PostgreSQL database}"
@@ -14,7 +14,7 @@ cleanup() {
   local exit_code=$?
   trap - EXIT INT TERM
   if [[ -n "$owned_nats_container" ]]; then
-    docker rm --force "$owned_nats_container" >/dev/null 2>&1 || true
+    docker rm --force "$owned_nats_container" > /dev/null 2>&1 || true
   fi
   exit "$exit_code"
 }
@@ -22,7 +22,7 @@ trap cleanup EXIT INT TERM
 
 contract_value() {
   local key="$1"
-  python3 - "$CONTRACT_FILE" "$key" <<'PY'
+  python3 - "$CONTRACT_FILE" "$key" << 'PY'
 import json, sys
 contract=json.load(open(sys.argv[1], encoding='utf-8'))
 if contract.get('schema_version') != 1:
@@ -39,7 +39,7 @@ PY
 
 validate_database_url() {
   local url="$1"
-  python3 - "$CONTRACT_FILE" "$url" <<'PY'
+  python3 - "$CONTRACT_FILE" "$url" << 'PY'
 import json, sys
 from urllib.parse import unquote, urlsplit
 contract=json.load(open(sys.argv[1], encoding='utf-8'))
@@ -78,7 +78,7 @@ fi
 load_t003_connection() {
   local -a values=()
   mapfile -d '' -t values < <(
-    python3 - "$PG_DIRECT_URL" <<'PY'
+    python3 - "$PG_DIRECT_URL" << 'PY'
 import sys
 from urllib.parse import unquote, urlsplit
 url=urlsplit(sys.argv[1])
@@ -109,7 +109,7 @@ PY
 load_t003_connection
 
 postgres_admin_url() {
-  python3 - "$PG_DIRECT_URL" <<'PY'
+  python3 - "$PG_DIRECT_URL" << 'PY'
 import sys
 from urllib.parse import urlsplit, urlunsplit
 url=urlsplit(sys.argv[1])
@@ -121,26 +121,26 @@ preflight_postgres() {
   local admin
   admin="$(postgres_admin_url)"
   if [[ -n "${POSTGRES_RESET_CONTAINER:-}" ]]; then
-    command -v docker >/dev/null 2>&1 || {
+    command -v docker > /dev/null 2>&1 || {
       echo 'PostgreSQL proof container preflight requires docker' >&2
       return 1
     }
-    if ! docker exec "$POSTGRES_RESET_CONTAINER" pg_isready -U postgres -d postgres >/dev/null 2>&1; then
+    if ! docker exec "$POSTGRES_RESET_CONTAINER" pg_isready -U postgres -d postgres > /dev/null 2>&1; then
       echo "PostgreSQL proof preflight container is not ready: ${POSTGRES_RESET_CONTAINER}" >&2
       return 1
     fi
-    if ! docker exec "$POSTGRES_RESET_CONTAINER" psql -U postgres -d postgres -X --no-psqlrc -v ON_ERROR_STOP=1 -Atqc 'SELECT 1' >/dev/null; then
+    if ! docker exec "$POSTGRES_RESET_CONTAINER" psql -U postgres -d postgres -X --no-psqlrc -v ON_ERROR_STOP=1 -Atqc 'SELECT 1' > /dev/null; then
       echo "PostgreSQL proof preflight container query failed: ${POSTGRES_RESET_CONTAINER}" >&2
       return 1
     fi
     echo "PostgreSQL proof preflight: isolated container ready; disposable database=${DATABASE_NAME}"
     return 0
   fi
-  if ! command -v psql >/dev/null 2>&1; then
+  if ! command -v psql > /dev/null 2>&1; then
     echo 'PostgreSQL proof preflight requires psql before the first test' >&2
     return 1
   fi
-  if ! psql "$admin" -X --no-psqlrc -v ON_ERROR_STOP=1 -Atqc 'SELECT 1' >/dev/null; then
+  if ! psql "$admin" -X --no-psqlrc -v ON_ERROR_STOP=1 -Atqc 'SELECT 1' > /dev/null; then
     echo 'PostgreSQL proof preflight could not reach the direct PostgreSQL admin database' >&2
     return 1
   fi
@@ -148,7 +148,7 @@ preflight_postgres() {
 }
 
 check_jetstream_once() {
-  python3 - "$NATS_URL" <<'PY'
+  python3 - "$NATS_URL" << 'PY'
 import json, socket, sys
 from urllib.parse import urlsplit
 url=urlsplit(sys.argv[1])
@@ -192,7 +192,7 @@ provision_jetstream_if_requested() {
     wait_for_jetstream
     return
   fi
-  command -v docker >/dev/null 2>&1 || {
+  command -v docker > /dev/null 2>&1 || {
     echo 'JetStream proof provisioning requires docker' >&2
     return 1
   }
@@ -203,7 +203,7 @@ provision_jetstream_if_requested() {
   docker run --detach --rm \
     --name "$owned_nats_container" \
     --publish 127.0.0.1::4222 \
-    "$image" -js >/dev/null
+    "$image" -js > /dev/null
   binding="$(docker port "$owned_nats_container" 4222/tcp | head -n1)"
   port="${binding##*:}"
   if [[ ! "$port" =~ ^[0-9]+$ ]]; then
@@ -218,14 +218,14 @@ reset_database() {
   local admin
   admin="$(postgres_admin_url)"
   if [[ -n "${POSTGRES_RESET_CONTAINER:-}" ]]; then
-    docker exec "$POSTGRES_RESET_CONTAINER" dropdb -U postgres --if-exists --force "$DATABASE_NAME" >/dev/null
+    docker exec "$POSTGRES_RESET_CONTAINER" dropdb -U postgres --if-exists --force "$DATABASE_NAME" > /dev/null
     docker exec "$POSTGRES_RESET_CONTAINER" createdb -U postgres "$DATABASE_NAME"
     return
   fi
   psql "$admin" -X --no-psqlrc -v ON_ERROR_STOP=1 -c \
-    "DROP DATABASE IF EXISTS \"${DATABASE_NAME}\" WITH (FORCE);" >/dev/null
+    "DROP DATABASE IF EXISTS \"${DATABASE_NAME}\" WITH (FORCE);" > /dev/null
   psql "$admin" -X --no-psqlrc -v ON_ERROR_STOP=1 -c \
-    "CREATE DATABASE \"${DATABASE_NAME}\";" >/dev/null
+    "CREATE DATABASE \"${DATABASE_NAME}\";" > /dev/null
 }
 
 preflight_postgres
@@ -257,7 +257,7 @@ targets=(
 )
 
 if [[ -n "${POSTGRES_PROOF_TARGETS:-}" ]]; then
-  read -r -a targets <<<"$POSTGRES_PROOF_TARGETS"
+  read -r -a targets <<< "$POSTGRES_PROOF_TARGETS"
 fi
 
 for target in "${targets[@]}"; do

--- a/scripts/ci/run-postgres-integration-proofs.sh
+++ b/scripts/ci/run-postgres-integration-proofs.sh
@@ -91,7 +91,9 @@ IFS=$'\t' read -r T005_HOST T005_PORT T005_DATABASE_NAME <<< "$(validate_databas
 DATABASE_ENDPOINT="${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}"
 PG_DIRECT_ENDPOINT="${PG_DIRECT_HOST}:${PG_DIRECT_PORT}/${PG_DIRECT_DATABASE_NAME}"
 T005_ENDPOINT="${T005_HOST}:${T005_PORT}/${T005_DATABASE_NAME}"
-if [[ "$DATABASE_ENDPOINT" != "$PG_DIRECT_ENDPOINT" || "$DATABASE_ENDPOINT" != "$T005_ENDPOINT" ]]; then
+if [[ "$DATABASE_ENDPOINT" == "$PG_DIRECT_ENDPOINT" && "$DATABASE_ENDPOINT" == "$T005_ENDPOINT" ]]; then
+  :
+else
   echo "PostgreSQL proof URLs must target the same direct endpoint: DATABASE_URL=${DATABASE_ENDPOINT}, PG_DIRECT_URL=${PG_DIRECT_ENDPOINT}, T005_DATABASE_URL=${T005_ENDPOINT}" >&2
   exit 1
 fi
@@ -145,7 +147,7 @@ validate_reset_container_binding() {
     return 1
   }
   case "$PG_DIRECT_HOST" in
-    localhost|127.0.0.1|::1) ;;
+    localhost | 127.0.0.1 | ::1) ;;
     *)
       echo "POSTGRES_RESET_CONTAINER requires a loopback PG_DIRECT_URL, got host ${PG_DIRECT_HOST}" >&2
       return 1
@@ -295,7 +297,7 @@ reset_database() {
     return 1
   fi
   case "$PG_DIRECT_HOST" in
-    localhost|127.0.0.1|::1) ;;
+    localhost | 127.0.0.1 | ::1) ;;
     *)
       echo "PostgreSQL proof reset refused for non-loopback host ${PG_DIRECT_HOST}; destructive CI proofs must use an isolated local server" >&2
       return 1

--- a/scripts/ci/run-postgres-integration-proofs.sh
+++ b/scripts/ci/run-postgres-integration-proofs.sh
@@ -55,7 +55,7 @@ PY
 validate_database_url() {
   local url="$1"
   python3 - "$CONTRACT_FILE" "$url" << 'PY'
-import json, sys
+import json, re, sys
 from urllib.parse import unquote, urlsplit
 contract=json.load(open(sys.argv[1], encoding='utf-8'))
 if contract.get('schema_version') != 1:
@@ -75,19 +75,30 @@ raw_database=url.path.lstrip('/')
 if '%' in raw_database:
     raise SystemExit('PostgreSQL proof database path must not contain percent-encoding')
 database=unquote(raw_database)
-database_segments={segment for segment in database.replace('-', '_').replace('.', '_').split('_') if segment}
-if not database or not any(segment in database_segments for segment in segments):
+if not re.fullmatch(r'[A-Za-z0-9_.-]+', database):
+    raise SystemExit(f'refusing unsafe disposable database identifier: {database!r}')
+database_segments=[segment for segment in database.replace('-', '_').replace('.', '_').split('_') if segment]
+if not database.startswith('weltgewebe_') or not database_segments or database_segments[-1] not in segments:
     raise SystemExit(
-        f'refusing non-disposable database {database!r}; expected a delimited name segment from {segments!r}'
+        f'refusing non-disposable database {database!r}; expected weltgewebe_ prefix and final delimited segment from {segments!r}'
     )
 host=url.hostname.rstrip('.').lower()
 print(f'{host}\t{port}\t{database}')
 PY
 }
 
-IFS=$'\t' read -r DATABASE_HOST DATABASE_PORT DATABASE_NAME <<< "$(validate_database_url "$DATABASE_URL")"
-IFS=$'\t' read -r PG_DIRECT_HOST PG_DIRECT_PORT PG_DIRECT_DATABASE_NAME <<< "$(validate_database_url "$PG_DIRECT_URL")"
-IFS=$'\t' read -r T005_HOST T005_PORT T005_DATABASE_NAME <<< "$(validate_database_url "$T005_DATABASE_URL")"
+validated_database="$(validate_database_url "$DATABASE_URL")"
+validated_pg_direct="$(validate_database_url "$PG_DIRECT_URL")"
+validated_t005="$(validate_database_url "$T005_DATABASE_URL")"
+IFS=$'\t' read -r DATABASE_HOST DATABASE_PORT DATABASE_NAME <<< "$validated_database"
+IFS=$'\t' read -r PG_DIRECT_HOST PG_DIRECT_PORT PG_DIRECT_DATABASE_NAME <<< "$validated_pg_direct"
+IFS=$'\t' read -r T005_HOST T005_PORT T005_DATABASE_NAME <<< "$validated_t005"
+for endpoint_field in DATABASE_HOST DATABASE_PORT DATABASE_NAME PG_DIRECT_HOST PG_DIRECT_PORT PG_DIRECT_DATABASE_NAME T005_HOST T005_PORT T005_DATABASE_NAME; do
+  if [[ -z "${!endpoint_field}" ]]; then
+    echo "PostgreSQL proof URL validation returned an empty field: ${endpoint_field}" >&2
+    exit 1
+  fi
+done
 DATABASE_ENDPOINT="${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}"
 PG_DIRECT_ENDPOINT="${PG_DIRECT_HOST}:${PG_DIRECT_PORT}/${PG_DIRECT_DATABASE_NAME}"
 T005_ENDPOINT="${T005_HOST}:${T005_PORT}/${T005_DATABASE_NAME}"
@@ -99,9 +110,10 @@ else
 fi
 
 load_t003_connection() {
+  local tmp_file
   local -a values=()
-  mapfile -d '' -t values < <(
-    python3 - "$PG_DIRECT_URL" << 'PY'
+  tmp_file="$(mktemp)"
+  if ! python3 - "$PG_DIRECT_URL" > "$tmp_file" << 'PY'
 import sys
 from urllib.parse import unquote, urlsplit
 url=urlsplit(sys.argv[1])
@@ -118,10 +130,15 @@ for value in values:
     sys.stdout.write(value)
     sys.stdout.write('\0')
 PY
-  )
+  then
+    rm -f "$tmp_file"
+    return 1
+  fi
+  mapfile -d '' -t values < "$tmp_file"
+  rm -f "$tmp_file"
   if ((${#values[@]} != 5)); then
     echo 'failed to derive direct T003 PostgreSQL connection parameters' >&2
-    exit 1
+    return 1
   fi
   export T003_PG_HOST="${values[0]}"
   export T003_PG_PORT="${values[1]}"
@@ -224,18 +241,24 @@ from urllib.parse import urlsplit
 url=urlsplit(sys.argv[1])
 if url.scheme != 'nats' or not url.hostname:
     raise SystemExit('NATS_URL must be a plain nats:// URL for the integration proof')
-with socket.create_connection((url.hostname, url.port or 4222), timeout=2.0) as sock:
-    sock.settimeout(2.0)
-    data=b''
-    while b'\r\n' not in data and len(data) < 65536:
-        chunk=sock.recv(4096)
-        if not chunk:
-            break
-        data += chunk
+try:
+    with socket.create_connection((url.hostname, url.port or 4222), timeout=2.0) as sock:
+        sock.settimeout(2.0)
+        data=b''
+        while b'\r\n' not in data and len(data) < 65536:
+            chunk=sock.recv(4096)
+            if not chunk:
+                break
+            data += chunk
+except OSError:
+    raise SystemExit(1)
 line=data.split(b'\r\n',1)[0]
 if not line.startswith(b'INFO '):
     raise SystemExit(f'NATS readiness expected INFO line, got {line[:80]!r}')
-info=json.loads(line[5:].decode('utf-8'))
+try:
+    info=json.loads(line[5:].decode('utf-8'))
+except (UnicodeDecodeError, json.JSONDecodeError):
+    raise SystemExit('NATS readiness received malformed INFO JSON')
 if info.get('jetstream') is not True:
     raise SystemExit('NATS server is reachable but JetStream is not enabled')
 print('JetStream proof preflight: semantic INFO jetstream=true')
@@ -310,10 +333,16 @@ reset_database() {
     docker exec "$POSTGRES_RESET_CONTAINER" createdb -U postgres "$DATABASE_NAME"
     return
   fi
-  psql "$admin" -X --no-psqlrc -v ON_ERROR_STOP=1 -c \
-    "DROP DATABASE IF EXISTS \"${DATABASE_NAME}\" WITH (FORCE);" > /dev/null
-  psql "$admin" -X --no-psqlrc -v ON_ERROR_STOP=1 -c \
-    "CREATE DATABASE \"${DATABASE_NAME}\";" > /dev/null
+  command -v dropdb > /dev/null 2>&1 || {
+    echo 'PostgreSQL proof reset requires dropdb' >&2
+    return 1
+  }
+  command -v createdb > /dev/null 2>&1 || {
+    echo 'PostgreSQL proof reset requires createdb' >&2
+    return 1
+  }
+  dropdb --maintenance-db="$admin" --if-exists --force "$DATABASE_NAME" > /dev/null
+  createdb --maintenance-db="$admin" "$DATABASE_NAME" > /dev/null
 }
 
 preflight_postgres

--- a/scripts/ci/run-postgres-integration-proofs.sh
+++ b/scripts/ci/run-postgres-integration-proofs.sh
@@ -10,15 +10,30 @@ export T005_DATABASE_URL="${T005_DATABASE_URL:-$PG_DIRECT_URL}"
 export AUTH_PG_003_FIXTURE_MUTATION=1
 
 owned_nats_container=""
-cleanup() {
-  local exit_code=$?
-  trap - EXIT INT TERM
+cleanup_owned_nats() {
   if [[ -n "$owned_nats_container" ]]; then
     docker rm --force "$owned_nats_container" > /dev/null 2>&1 || true
   fi
+}
+cleanup_exit() {
+  local exit_code=$?
+  trap - EXIT INT TERM
+  cleanup_owned_nats
   exit "$exit_code"
 }
-trap cleanup EXIT INT TERM
+cleanup_int() {
+  trap - EXIT INT TERM
+  cleanup_owned_nats
+  exit 130
+}
+cleanup_term() {
+  trap - EXIT INT TERM
+  cleanup_owned_nats
+  exit 143
+}
+trap cleanup_exit EXIT
+trap cleanup_int INT
+trap cleanup_term TERM
 
 contract_value() {
   local key="$1"
@@ -56,23 +71,28 @@ if not url.hostname:
 port=url.port or 5432
 if port == int(contract['pgbouncer_port']):
     raise SystemExit('PostgreSQL integration proofs require direct PostgreSQL, not PgBouncer')
-database=unquote(url.path.lstrip('/'))
+raw_database=url.path.lstrip('/')
+if '%' in raw_database:
+    raise SystemExit('PostgreSQL proof database path must not contain percent-encoding')
+database=unquote(raw_database)
 database_segments={segment for segment in database.replace('-', '_').replace('.', '_').split('_') if segment}
 if not database or not any(segment in database_segments for segment in segments):
     raise SystemExit(
         f'refusing non-disposable database {database!r}; expected a delimited name segment from {segments!r}'
     )
-print(database)
+host=url.hostname.rstrip('.').lower()
+print(f'{host}\t{port}\t{database}')
 PY
 }
 
-DATABASE_NAME="$(validate_database_url "$DATABASE_URL")"
-PG_DIRECT_DATABASE_NAME="$(validate_database_url "$PG_DIRECT_URL")"
-T005_DATABASE_NAME="$(validate_database_url "$T005_DATABASE_URL")"
-if [[ "$DATABASE_NAME" == "$PG_DIRECT_DATABASE_NAME" && "$DATABASE_NAME" == "$T005_DATABASE_NAME" ]]; then
-  :
-else
-  echo "PostgreSQL proof URLs must target the same disposable database name: DATABASE_URL=${DATABASE_NAME}, PG_DIRECT_URL=${PG_DIRECT_DATABASE_NAME}, T005_DATABASE_URL=${T005_DATABASE_NAME}" >&2
+IFS=$'\t' read -r DATABASE_HOST DATABASE_PORT DATABASE_NAME <<< "$(validate_database_url "$DATABASE_URL")"
+IFS=$'\t' read -r PG_DIRECT_HOST PG_DIRECT_PORT PG_DIRECT_DATABASE_NAME <<< "$(validate_database_url "$PG_DIRECT_URL")"
+IFS=$'\t' read -r T005_HOST T005_PORT T005_DATABASE_NAME <<< "$(validate_database_url "$T005_DATABASE_URL")"
+DATABASE_ENDPOINT="${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}"
+PG_DIRECT_ENDPOINT="${PG_DIRECT_HOST}:${PG_DIRECT_PORT}/${PG_DIRECT_DATABASE_NAME}"
+T005_ENDPOINT="${T005_HOST}:${T005_PORT}/${T005_DATABASE_NAME}"
+if [[ "$DATABASE_ENDPOINT" != "$PG_DIRECT_ENDPOINT" || "$DATABASE_ENDPOINT" != "$T005_ENDPOINT" ]]; then
+  echo "PostgreSQL proof URLs must target the same direct endpoint: DATABASE_URL=${DATABASE_ENDPOINT}, PG_DIRECT_URL=${PG_DIRECT_ENDPOINT}, T005_DATABASE_URL=${T005_ENDPOINT}" >&2
   exit 1
 fi
 
@@ -118,10 +138,57 @@ print(urlunsplit((url.scheme, url.netloc, '/postgres', url.query, url.fragment))
 PY
 }
 
+validate_reset_container_binding() {
+  [[ -n "${POSTGRES_RESET_CONTAINER:-}" ]] || return 0
+  command -v docker > /dev/null 2>&1 || {
+    echo 'PostgreSQL proof container binding validation requires docker' >&2
+    return 1
+  }
+  case "$PG_DIRECT_HOST" in
+    localhost|127.0.0.1|::1) ;;
+    *)
+      echo "POSTGRES_RESET_CONTAINER requires a loopback PG_DIRECT_URL, got host ${PG_DIRECT_HOST}" >&2
+      return 1
+      ;;
+  esac
+  local -a bindings=()
+  mapfile -t bindings < <(docker port "$POSTGRES_RESET_CONTAINER" 5432/tcp)
+  if [[ "${#bindings[@]}" -ne 1 ]]; then
+    echo "PostgreSQL reset container must expose exactly one 5432/tcp binding; found ${#bindings[@]}" >&2
+    return 1
+  fi
+  python3 - "${bindings[0]}" "$PG_DIRECT_PORT" << 'PY'
+import ipaddress, sys
+binding=sys.argv[1].strip()
+expected_port=int(sys.argv[2])
+if binding.startswith('['):
+    host, sep, tail=binding[1:].partition(']:')
+    if not sep:
+        raise SystemExit(f'invalid Docker port binding: {binding!r}')
+    port=int(tail)
+else:
+    host, sep, tail=binding.rpartition(':')
+    if not sep:
+        raise SystemExit(f'invalid Docker port binding: {binding!r}')
+    port=int(tail)
+try:
+    loopback=ipaddress.ip_address(host).is_loopback
+except ValueError:
+    loopback=host.lower() == 'localhost'
+if not loopback:
+    raise SystemExit(f'PostgreSQL reset container binding must be loopback-only, got {host!r}')
+if port != expected_port:
+    raise SystemExit(
+        f'PostgreSQL reset container published port {port} does not match PG_DIRECT_URL port {expected_port}'
+    )
+PY
+}
+
 preflight_postgres() {
   local admin
   admin="$(postgres_admin_url)"
   if [[ -n "${POSTGRES_RESET_CONTAINER:-}" ]]; then
+    validate_reset_container_binding
     command -v docker > /dev/null 2>&1 || {
       echo 'PostgreSQL proof container preflight requires docker' >&2
       return 1
@@ -205,7 +272,13 @@ provision_jetstream_if_requested() {
     --name "$owned_nats_container" \
     --publish 127.0.0.1::4222 \
     "$image" -js > /dev/null
-  binding="$(docker port "$owned_nats_container" 4222/tcp | head -n1)"
+  local -a bindings=()
+  mapfile -t bindings < <(docker port "$owned_nats_container" 4222/tcp)
+  if [[ "${#bindings[@]}" -ne 1 ]]; then
+    echo "JetStream proof container must expose exactly one 4222/tcp binding; found ${#bindings[@]}" >&2
+    return 1
+  fi
+  binding="${bindings[0]}"
   port="${binding##*:}"
   if [[ ! "$port" =~ ^[0-9]+$ ]]; then
     echo "could not resolve dynamically published JetStream port from ${binding}" >&2
@@ -217,8 +290,20 @@ provision_jetstream_if_requested() {
 
 reset_database() {
   local admin
+  if [[ "${POSTGRES_PROOF_ALLOW_RESET:-0}" != "1" ]]; then
+    echo 'PostgreSQL proof reset refused: set POSTGRES_PROOF_ALLOW_RESET=1 for destructive disposable-database reset' >&2
+    return 1
+  fi
+  case "$PG_DIRECT_HOST" in
+    localhost|127.0.0.1|::1) ;;
+    *)
+      echo "PostgreSQL proof reset refused for non-loopback host ${PG_DIRECT_HOST}; destructive CI proofs must use an isolated local server" >&2
+      return 1
+      ;;
+  esac
   admin="$(postgres_admin_url)"
   if [[ -n "${POSTGRES_RESET_CONTAINER:-}" ]]; then
+    validate_reset_container_binding
     docker exec "$POSTGRES_RESET_CONTAINER" dropdb -U postgres --if-exists --force "$DATABASE_NAME" > /dev/null
     docker exec "$POSTGRES_RESET_CONTAINER" createdb -U postgres "$DATABASE_NAME"
     return

--- a/scripts/ci/run-postgres-integration-proofs.sh
+++ b/scripts/ci/run-postgres-integration-proofs.sh
@@ -45,9 +45,9 @@ from urllib.parse import unquote, urlsplit
 contract=json.load(open(sys.argv[1], encoding='utf-8'))
 if contract.get('schema_version') != 1:
     raise SystemExit('unsupported postgres proof contract schema')
-markers=contract.get('disposable_database_name_markers') or []
-if not markers:
-    raise SystemExit('postgres proof contract has no disposable database markers')
+segments=contract.get('disposable_database_name_segments') or []
+if not segments:
+    raise SystemExit('postgres proof contract has no disposable database segments')
 url=urlsplit(sys.argv[2])
 if url.scheme not in {'postgres','postgresql'}:
     raise SystemExit(f'unsupported PostgreSQL URL scheme: {url.scheme!r}')
@@ -57,9 +57,10 @@ port=url.port or 5432
 if port == int(contract['pgbouncer_port']):
     raise SystemExit('PostgreSQL integration proofs require direct PostgreSQL, not PgBouncer')
 database=unquote(url.path.lstrip('/'))
-if not database or not any(marker in database for marker in markers):
+database_segments={segment for segment in database.replace('-', '_').replace('.', '_').split('_') if segment}
+if not database or not any(segment in database_segments for segment in segments):
     raise SystemExit(
-        f'refusing non-disposable database {database!r}; expected a name containing one of {markers!r}'
+        f'refusing non-disposable database {database!r}; expected a delimited name segment from {segments!r}'
     )
 print(database)
 PY

--- a/scripts/ci/tests/test_postgres_integration_proof_contract.py
+++ b/scripts/ci/tests/test_postgres_integration_proof_contract.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[3]
+CONTRACT = REPO / "scripts/ci/postgres-proof-contract.json"
+RUNNER = REPO / "scripts/ci/run-postgres-integration-proofs.sh"
+RUST_SUPPORT = REPO / "apps/api/tests/support/postgres_proof.rs"
+CI = REPO / ".github/workflows/ci.yml"
+
+TARGETS = {
+    "db_auto_provision_write_path",
+    "db_domain_account_write_path",
+    "db_domain_backfill",
+    "db_domain_edge_write_path",
+    "db_domain_node_write_path",
+    "db_governance",
+    "db_multi_instance_foundation",
+    "db_domain_read_path",
+    "db_domain_schema_migrations",
+    "db_passkey_fk_readiness",
+    "db_passkey_schema_preflight",
+    "db_passkey_store_persistence",
+    "db_session_store_persistence",
+    "db_webauthn_user_id_backfill_audit",
+    "db_semantic_search_foundation",
+    "db_semantic_search_projection_worker",
+    "sqlx_postgres_direct_session_crud",
+}
+
+
+def test_disposable_database_contract_is_single_source_for_runner_and_rust_tests() -> None:
+    contract = json.loads(CONTRACT.read_text(encoding="utf-8"))
+    assert contract["schema_version"] == 1
+    assert contract["disposable_database_name_markers"] == ["test", "proof", "ci"]
+    assert contract["pgbouncer_port"] == 6432
+    runner = RUNNER.read_text(encoding="utf-8")
+    rust = RUST_SUPPORT.read_text(encoding="utf-8")
+    assert "postgres-proof-contract.json" in runner
+    assert "postgres-proof-contract.json" in rust
+    for target in TARGETS:
+        source = (REPO / "apps/api/tests" / f"{target}.rs").read_text(encoding="utf-8")
+        assert "mod support;" in source
+
+
+def test_runner_preflights_postgres_and_jetstream_before_the_first_target() -> None:
+    runner = RUNNER.read_text(encoding="utf-8")
+    preflight = runner.index("preflight_postgres\nprovision_jetstream_if_requested")
+    loop = runner.index('for target in "${targets[@]}"; do')
+    assert preflight < loop
+    assert "info.get('jetstream') is not True" in runner
+    assert 'trap cleanup EXIT INT TERM' in runner
+    assert 'docker rm --force "$owned_nats_container"' in runner
+    assert 'docker exec "$POSTGRES_RESET_CONTAINER" pg_isready' in runner
+    assert 'docker exec "$POSTGRES_RESET_CONTAINER" psql' in runner
+
+
+def test_ci_delegates_jetstream_lifecycle_to_runner() -> None:
+    workflow = yaml.safe_load(CI.read_text(encoding="utf-8"))
+    job = workflow["jobs"]["postgres-proofs"]
+    assert job["env"]["POSTGRES_PROOF_PROVISION_NATS"] == "1"
+    rendered = json.dumps(job, sort_keys=True)
+    assert "weltgewebe-ci-nats" not in rendered
+    assert "run-postgres-integration-proofs.sh" in rendered

--- a/scripts/ci/tests/test_postgres_integration_proof_contract.py
+++ b/scripts/ci/tests/test_postgres_integration_proof_contract.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
+import subprocess
 
 import yaml
 
@@ -35,7 +37,7 @@ TARGETS = {
 def test_disposable_database_contract_is_single_source_for_runner_and_rust_tests() -> None:
     contract = json.loads(CONTRACT.read_text(encoding="utf-8"))
     assert contract["schema_version"] == 1
-    assert contract["disposable_database_name_markers"] == ["test", "proof", "ci"]
+    assert contract["disposable_database_name_segments"] == ["test", "proof", "ci"]
     assert contract["pgbouncer_port"] == 6432
     runner = RUNNER.read_text(encoding="utf-8")
     rust = RUST_SUPPORT.read_text(encoding="utf-8")
@@ -65,3 +67,32 @@ def test_ci_delegates_jetstream_lifecycle_to_runner() -> None:
     rendered = json.dumps(job, sort_keys=True)
     assert "weltgewebe-ci-nats" not in rendered
     assert "run-postgres-integration-proofs.sh" in rendered
+
+
+def test_runner_rejects_incidental_disposable_name_substrings() -> None:
+    env = os.environ.copy()
+    for database in ("social", "official", "citizen"):
+        url = f"postgres://postgres:postgres@127.0.0.1:5432/{database}"
+        env.update(
+            DATABASE_URL=url,
+            PG_DIRECT_URL=url,
+            T005_DATABASE_URL=url,
+        )
+        completed = subprocess.run(
+            [str(RUNNER)],
+            cwd=REPO,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        assert completed.returncode != 0
+        assert "refusing non-disposable database" in completed.stderr
+
+
+def test_runner_accepts_delimited_disposable_name_segment_before_preflight() -> None:
+    runner = RUNNER.read_text(encoding="utf-8")
+    assert "database_segments={segment for segment in database.replace('-', '_').replace('.', '_').split('_') if segment}" in runner
+    assert "segment in database_segments for segment in segments" in runner
+    assert "weltgewebe_t002_test".split("_")[-1] == "test"

--- a/scripts/ci/tests/test_postgres_integration_proof_contract.py
+++ b/scripts/ci/tests/test_postgres_integration_proof_contract.py
@@ -54,7 +54,9 @@ def test_runner_preflights_postgres_and_jetstream_before_the_first_target() -> N
     loop = runner.index('for target in "${targets[@]}"; do')
     assert preflight < loop
     assert "info.get('jetstream') is not True" in runner
-    assert 'trap cleanup EXIT INT TERM' in runner
+    assert 'trap cleanup_exit EXIT' in runner
+    assert 'trap cleanup_int INT' in runner
+    assert 'trap cleanup_term TERM' in runner
     assert 'docker rm --force "$owned_nats_container"' in runner
     assert 'docker exec "$POSTGRES_RESET_CONTAINER" pg_isready' in runner
     assert 'docker exec "$POSTGRES_RESET_CONTAINER" psql' in runner
@@ -64,6 +66,7 @@ def test_ci_delegates_jetstream_lifecycle_to_runner() -> None:
     workflow = yaml.safe_load(CI.read_text(encoding="utf-8"))
     job = workflow["jobs"]["postgres-proofs"]
     assert job["env"]["POSTGRES_PROOF_PROVISION_NATS"] == "1"
+    assert job["env"]["POSTGRES_PROOF_ALLOW_RESET"] == "1"
     rendered = json.dumps(job, sort_keys=True)
     assert "weltgewebe-ci-nats" not in rendered
     assert "run-postgres-integration-proofs.sh" in rendered
@@ -96,3 +99,51 @@ def test_runner_accepts_delimited_disposable_name_segment_before_preflight() -> 
     assert "database_segments={segment for segment in database.replace('-', '_').replace('.', '_').split('_') if segment}" in runner
     assert "segment in database_segments for segment in segments" in runner
     assert "weltgewebe_t002_test".split("_")[-1] == "test"
+
+def _run_runner_with_urls(database_url: str, direct_url: str, t005_url: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(
+        DATABASE_URL=database_url,
+        PG_DIRECT_URL=direct_url,
+        T005_DATABASE_URL=t005_url,
+        POSTGRES_PROOF_PREFLIGHT_ONLY="1",
+    )
+    return subprocess.run(
+        [str(RUNNER)],
+        cwd=REPO,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def test_runner_rejects_same_database_name_on_different_endpoints_before_preflight() -> None:
+    completed = _run_runner_with_urls(
+        "postgres://postgres:postgres@127.0.0.1:5432/weltgewebe_ci_proof",
+        "postgres://postgres:postgres@127.0.0.1:55432/weltgewebe_ci_proof",
+        "postgres://postgres:postgres@127.0.0.1:5432/weltgewebe_ci_proof",
+    )
+    assert completed.returncode != 0
+    assert "must target the same direct endpoint" in completed.stderr
+
+
+def test_runner_rejects_percent_encoded_database_path_before_preflight() -> None:
+    encoded = "postgres://postgres:postgres@127.0.0.1:5432/weltgewebe%5Fci%5Fproof"
+    completed = _run_runner_with_urls(encoded, encoded, encoded)
+    assert completed.returncode != 0
+    assert "must not contain percent-encoding" in completed.stderr
+
+
+def test_reset_and_container_guards_are_fail_closed() -> None:
+    runner = RUNNER.read_text(encoding="utf-8")
+    assert 'POSTGRES_PROOF_ALLOW_RESET:-0' in runner
+    assert 'reset refused for non-loopback host' in runner
+    assert 'validate_reset_container_binding' in runner
+    assert 'must expose exactly one 5432/tcp binding' in runner
+    assert 'requires a loopback PG_DIRECT_URL' in runner
+    assert 'does not match PG_DIRECT_URL port' in runner
+    assert 'must expose exactly one 4222/tcp binding' in runner
+    rust = RUST_SUPPORT.read_text(encoding="utf-8")
+    assert "must not contain percent-encoding" in rust

--- a/scripts/ci/tests/test_postgres_integration_proof_contract.py
+++ b/scripts/ci/tests/test_postgres_integration_proof_contract.py
@@ -94,11 +94,18 @@ def test_runner_rejects_incidental_disposable_name_substrings() -> None:
         assert "refusing non-disposable database" in completed.stderr
 
 
-def test_runner_accepts_delimited_disposable_name_segment_before_preflight() -> None:
+def test_runner_requires_weltgewebe_prefix_and_final_disposable_segment() -> None:
     runner = RUNNER.read_text(encoding="utf-8")
-    assert "database_segments={segment for segment in database.replace('-', '_').replace('.', '_').split('_') if segment}" in runner
-    assert "segment in database_segments for segment in segments" in runner
-    assert "weltgewebe_t002_test".split("_")[-1] == "test"
+    assert "database.startswith('weltgewebe_')" in runner
+    assert "database_segments[-1] not in segments" in runner
+    for database in ("proof_of_concept", "ci_test_db", "weltgewebe_ci_data"):
+        url = f"postgres://postgres:postgres@127.0.0.1:5432/{database}"
+        completed = _run_runner_with_urls(url, url, url)
+        assert completed.returncode != 0
+        assert "refusing non-disposable database" in completed.stderr
+    for database in ("weltgewebe_proof", "weltgewebe_ci_proof", "weltgewebe_t002_test"):
+        assert database.startswith("weltgewebe_")
+        assert database.replace("-", "_").replace(".", "_").split("_")[-1] in {"test", "proof", "ci"}
 
 def _run_runner_with_urls(database_url: str, direct_url: str, t005_url: str) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
@@ -147,3 +154,47 @@ def test_reset_and_container_guards_are_fail_closed() -> None:
     assert 'must expose exactly one 4222/tcp binding' in runner
     rust = RUST_SUPPORT.read_text(encoding="utf-8")
     assert "must not contain percent-encoding" in rust
+
+
+def test_runner_binds_validator_failures_before_read_and_rejects_unsafe_identifiers() -> None:
+    runner = RUNNER.read_text(encoding="utf-8")
+    assert 'validated_database="$(validate_database_url "$DATABASE_URL")"' in runner
+    assert 'validated_pg_direct="$(validate_database_url "$PG_DIRECT_URL")"' in runner
+    assert 'validated_t005="$(validate_database_url "$T005_DATABASE_URL")"' in runner
+    assert '<<< "$(validate_database_url' not in runner
+    assert "re.fullmatch(r'[A-Za-z0-9_.-]+', database)" in runner
+    unsafe = "postgres://postgres:postgres@127.0.0.1:5432/weltgewebe_ci_proof%22"
+    completed = _run_runner_with_urls(unsafe, unsafe, unsafe)
+    assert completed.returncode != 0
+    assert "percent-encoding" in completed.stderr
+
+
+def test_t003_loader_binds_python_exit_status_and_preserves_nul_records() -> None:
+    runner = RUNNER.read_text(encoding="utf-8")
+    assert 'tmp_file="$(mktemp)"' in runner
+    assert 'if ! python3 - "$PG_DIRECT_URL" > "$tmp_file"' in runner
+    assert "mapfile -d '' -t values < \"$tmp_file\"" in runner
+    assert 'if ((${#values[@]} != 5)); then' in runner
+    assert "mapfile -d '' -t values < <(" not in runner
+
+
+def test_local_reset_uses_postgres_cli_arguments_not_interpolated_sql() -> None:
+    runner = RUNNER.read_text(encoding="utf-8")
+    assert 'dropdb --maintenance-db="$admin" --if-exists --force "$DATABASE_NAME"' in runner
+    assert 'createdb --maintenance-db="$admin" "$DATABASE_NAME"' in runner
+    assert 'DROP DATABASE IF EXISTS' not in runner
+    assert 'CREATE DATABASE \"${DATABASE_NAME}\"' not in runner
+
+
+def test_jetstream_retry_handles_expected_socket_failures_without_tracebacks() -> None:
+    runner = RUNNER.read_text(encoding="utf-8")
+    assert "except OSError:" in runner
+    assert "except (UnicodeDecodeError, json.JSONDecodeError):" in runner
+    assert "raise SystemExit(1)" in runner
+
+
+def test_rust_support_rejects_unsafe_database_identifier_characters() -> None:
+    rust = RUST_SUPPORT.read_text(encoding="utf-8")
+    assert "character.is_ascii_alphanumeric()" in rust
+    assert "matches!(character, '_' | '-' | '.')" in rust
+    assert "unsafe disposable database identifier" in rust

--- a/scripts/ci/tests/test_static_app_caddy_csp_adapted_contract.py
+++ b/scripts/ci/tests/test_static_app_caddy_csp_adapted_contract.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import unittest
+
+REPO = Path(__file__).resolve().parents[3]
+CASES = (
+    ("infra/caddy/Caddyfile", None),
+    ("infra/caddy/Caddyfile.heim", "weltgewebe.home.arpa"),
+    ("infra/caddy/Caddyfile.vps", "weltgewebe.net"),
+)
+
+
+def adapt(relative: str) -> dict:
+    result = subprocess.run(
+        ["caddy", "adapt", "--config", relative, "--adapter", "caddyfile"],
+        cwd=REPO, text=True, capture_output=True, check=False,
+    )
+    if result.returncode != 0:
+        raise AssertionError(result.stdout + result.stderr)
+    return json.loads(result.stdout)
+
+
+def app_routes(config: dict, host: str | None) -> list[dict]:
+    servers = config["apps"]["http"]["servers"]
+    if host is None:
+        return next(iter(servers.values()))["routes"]
+    for server in servers.values():
+        if ":443" not in server.get("listen", []):
+            continue
+        for route in server.get("routes", []):
+            matches = route.get("match", [])
+            if any(host in matcher.get("host", []) for matcher in matches):
+                handles = route.get("handle", [])
+                if len(handles) == 1 and handles[0].get("handler") == "subroute":
+                    return handles[0].get("routes", [])
+    raise AssertionError(f"no HTTPS app route for {host}")
+
+
+def collect_csp(routes: list[dict]) -> list[tuple[object, str]]:
+    found: list[tuple[object, str]] = []
+    for route in routes:
+        for handler in route.get("handle", []):
+            if handler.get("handler") == "headers":
+                values = handler.get("response", {}).get("set", {}).get("Content-Security-Policy", [])
+                found.extend((route.get("match"), value) for value in values)
+            if handler.get("handler") == "subroute":
+                found.extend(collect_csp(handler.get("routes", [])))
+    return found
+
+
+@unittest.skipUnless(shutil.which("caddy"), "caddy binary required")
+class StaticAppCaddyAdaptedCspTest(unittest.TestCase):
+    def test_adapted_app_route_has_only_split_csp_pair(self) -> None:
+        for relative, host in CASES:
+            with self.subTest(caddyfile=relative):
+                policies = collect_csp(app_routes(adapt(relative), host))
+                self.assertEqual(len(policies), 2, policies)
+                strict = [item for item in policies if "default-src 'none'" in item[1]]
+                frontend = [item for item in policies if "default-src 'none'" not in item[1]]
+                self.assertEqual(len(strict), 1, policies)
+                self.assertEqual(len(frontend), 1, policies)
+                self.assertIn("frame-ancestors 'none'", strict[0][1])
+                self.assertNotIn("unsafe-inline", strict[0][1])
+                directives = {part.strip().split()[0] for part in frontend[0][1].split(";") if part.strip()}
+                self.assertNotIn("default-src", directives)
+                self.assertNotIn("script-src", directives)
+                self.assertIn("frame-ancestors", directives)
+                self.assertIn("not", json.dumps(frontend[0][0]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/tests/test_vps_http_smoke_csp_contract.py
+++ b/scripts/ci/tests/test_vps_http_smoke_csp_contract.py
@@ -1,61 +1,92 @@
-"""Coverage for the VPS HTTP smoke Caddy preflight contract."""
+"""Coverage for the route-only VPS HTTP smoke security boundary."""
 
 from __future__ import annotations
 
-import base64
-import hashlib
-import os
+import http.client
 import pathlib
+import shutil
+import socket
 import subprocess
 import tempfile
+import time
 import unittest
 
 
 class VpsHttpSmokeCspContractTest(unittest.TestCase):
-    def test_vps_http_smoke_caddyfile_matches_static_csp_guard_target(self) -> None:
+    def test_route_only_smoke_has_strict_non_app_baseline(self) -> None:
         repo = pathlib.Path(__file__).resolve().parents[3]
-        guard = repo / "scripts" / "preflight" / "csp_contract_static.sh"
-        smoke_caddyfile = repo / "infra" / "caddy" / "Caddyfile.http-smoke"
-
-        with tempfile.TemporaryDirectory() as tmp:
-            root = pathlib.Path(tmp)
-            build_dir = root / "apps" / "web" / "build"
-            build_dir.mkdir(parents=True)
-            inline_script = 'console.log("inline")'
-            digest = base64.b64encode(
-                hashlib.sha256(inline_script.encode("utf-8")).digest()
-            ).decode("ascii")
-            (build_dir / "index.html").write_text(
-                f'<html><head><meta http-equiv="content-security-policy" '
-                f"content=\"script-src 'self' 'sha256-{digest}'\">"
-                f'<script>{inline_script}</script></head></html>',
-                encoding="utf-8",
-            )
-
-            env = os.environ.copy()
-            env.update(
-                {
-                    "ROOT": str(root),
-                    "REQUIRE_FRONTEND": "1",
-                    "CADDYFILE_PATH": str(smoke_caddyfile),
-                    "CADDY_TARGET_SITE": "weltgewebe.net",
-                }
-            )
-
-            result = subprocess.run(
-                ["bash", str(guard)],
-                cwd=repo,
-                env=env,
-                text=True,
-                capture_output=True,
-                check=False,
-            )
-
-        self.assertEqual(
-            result.returncode,
-            0,
-            result.stdout + result.stderr,
+        smoke = (repo / "infra" / "caddy" / "Caddyfile.http-smoke").read_text(
+            encoding="utf-8"
         )
+
+        # This surface deliberately never serves the Svelte app, so it can use a
+        # strict header CSP without conflicting with SvelteKit's hash-authorized
+        # inline bootstrap. It must not be treated as a frontend CSP smoke.
+        self.assertIn("default-src 'none'", smoke)
+        self.assertIn("frame-ancestors 'none'", smoke)
+        self.assertIn('X-Content-Type-Options "nosniff"', smoke)
+        self.assertNotIn("'unsafe-inline'", smoke)
+        self.assertNotIn("file_server", smoke)
+        self.assertIn('respond "dns-free smoke only" 404', smoke)
+
+
+    @unittest.skipUnless(shutil.which("caddy"), "caddy binary required for runtime header proof")
+    def test_route_only_smoke_runtime_emits_strict_csp_headers(self) -> None:
+        repo = pathlib.Path(__file__).resolve().parents[3]
+        source = (repo / "infra" / "caddy" / "Caddyfile.http-smoke").read_text(encoding="utf-8")
+        with socket.socket() as probe:
+            probe.bind(("127.0.0.1", 0))
+            port = probe.getsockname()[1]
+        runtime = "{\n    admin off\n}\n\n" + source.replace(
+            "http://weltgewebe.net", f"http://127.0.0.1:{port}"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            config = pathlib.Path(tmp) / "Caddyfile"
+            config.write_text(runtime, encoding="utf-8")
+            process = subprocess.Popen(
+                ["caddy", "run", "--config", str(config), "--adapter", "caddyfile"],
+                cwd=repo,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            try:
+                deadline = time.monotonic() + 5
+                response = None
+                while time.monotonic() < deadline:
+                    try:
+                        connection = http.client.HTTPConnection("127.0.0.1", port, timeout=1)
+                        connection.request("GET", "/unmatched")
+                        response = connection.getresponse()
+                        break
+                    except OSError:
+                        time.sleep(0.05)
+                if response is None:
+                    stderr = process.stderr.read() if process.stderr else ""
+                    self.fail(f"caddy smoke runtime did not become ready: {stderr}")
+                self.assertEqual(response.status, 404)
+                policy = response.getheader("Content-Security-Policy") or ""
+                self.assertIn("default-src 'none'", policy)
+                self.assertIn("frame-ancestors 'none'", policy)
+                self.assertNotIn("unsafe-inline", policy)
+                self.assertEqual(response.getheader("X-Content-Type-Options"), "nosniff")
+                self.assertTrue((response.getheader("Content-Type") or "").startswith("text/plain"))
+                response.read()
+            finally:
+                process.terminate()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=5)
+
+    def test_production_static_csp_guard_does_not_target_route_only_smoke(self) -> None:
+        repo = pathlib.Path(__file__).resolve().parents[3]
+        workflow = (repo / ".github" / "workflows" / "deploy-check.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("CADDYFILE_PATH=infra/caddy/Caddyfile.heim", workflow)
+        self.assertNotIn("CADDYFILE_PATH=infra/caddy/Caddyfile.http-smoke", workflow)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/tests/test_vps_http_smoke_csp_contract.py
+++ b/scripts/ci/tests/test_vps_http_smoke_csp_contract.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import os
 import pathlib
 import subprocess
@@ -19,8 +21,14 @@ class VpsHttpSmokeCspContractTest(unittest.TestCase):
             root = pathlib.Path(tmp)
             build_dir = root / "apps" / "web" / "build"
             build_dir.mkdir(parents=True)
+            inline_script = 'console.log("inline")'
+            digest = base64.b64encode(
+                hashlib.sha256(inline_script.encode("utf-8")).digest()
+            ).decode("ascii")
             (build_dir / "index.html").write_text(
-                '<html><head><script>console.log("inline")</script></head></html>',
+                f'<html><head><meta http-equiv="content-security-policy" '
+                f"content=\"script-src 'self' 'sha256-{digest}'\">"
+                f'<script>{inline_script}</script></head></html>',
                 encoding="utf-8",
             )
 

--- a/scripts/guard/domain-multi-instance-guard.sh
+++ b/scripts/guard/domain-multi-instance-guard.sh
@@ -34,6 +34,7 @@ LIB='apps/api/src/lib.rs'
 PROOF='apps/api/tests/db_multi_instance_foundation.rs'
 CI='.github/workflows/ci.yml'
 PROOF_RUNNER='scripts/ci/run-postgres-integration-proofs.sh'
+PROOF_CONTRACT='scripts/ci/postgres-proof-contract.json'
 
 for table in auth_ephemeral_state auth_rate_limit_counters domain_outbox \
   domain_event_consumptions domain_projection_state; do
@@ -85,8 +86,9 @@ for marker in 'let state_a =' 'let state_b =' 'let state_c =' \
 done
 
 require_literal "$CI" 'weltgewebe_t002_test' 'isolated CI database'
-require_literal "$CI" 'NATS_URL: nats://127.0.0.1:4222' 'JetStream CI endpoint'
-require_literal "$CI" 'nats@sha256:b83efabe3e7def1e0a4a31ec6e078999bb17c80363f881df35edc70fcb6bb927' 'pinned JetStream CI image'
+require_literal "$CI" 'POSTGRES_PROOF_PROVISION_NATS: "1"' 'JetStream CI provisioning delegation'
+require_literal "$PROOF_RUNNER" 'contract_value jetstream_image' 'JetStream image contract lookup'
+require_literal "$PROOF_CONTRACT" 'nats@sha256:b83efabe3e7def1e0a4a31ec6e078999bb17c80363f881df35edc70fcb6bb927' 'pinned JetStream proof image'
 require_literal "$CI" 'Run PostgreSQL and multi-instance proof suite' 'multi-instance CI job'
 require_literal "$PROOF_RUNNER" 'db_multi_instance_foundation' 'multi-instance proof runner'
 

--- a/scripts/guard/security-headers-guard.sh
+++ b/scripts/guard/security-headers-guard.sh
@@ -62,30 +62,49 @@ for caddy in \
 done
 
 for caddy in \
+  "${REPO_ROOT}/infra/caddy/Caddyfile" \
   "${REPO_ROOT}/infra/caddy/Caddyfile.vps" \
   "${REPO_ROOT}/infra/caddy/Caddyfile.heim"; do
   if [[ ! -f "$caddy" ]]; then
+    fail "static-app Caddyfile missing: $caddy"
     continue
   fi
   if ! grep -Fq "Content-Security-Policy" "$caddy"; then
     fail "$(realpath --relative-to "$REPO_ROOT" "$caddy") missing static-app CSP"
     continue
   fi
+  if grep -Eq "script-src[^;]*'unsafe-inline'" "$caddy"; then
+    fail "$(realpath --relative-to "$REPO_ROOT" "$caddy") must not allow script-src unsafe-inline"
+  fi
   for directive in \
-    "default-src 'self'" \
-    "script-src 'self' 'unsafe-inline'" \
     "style-src 'self' 'unsafe-inline'" \
     "connect-src 'self'" \
     "img-src 'self' data: blob:" \
-    "object-src 'none'"; do
+    "worker-src 'self' blob:" \
+    "font-src 'self'" \
+    "media-src 'self'" \
+    "manifest-src 'self'" \
+    "child-src 'self'" \
+    "frame-src 'self'" \
+    "object-src 'none'" \
+    "base-uri 'self'" \
+    "form-action 'self'" \
+    "frame-ancestors 'none'"; do
     if ! grep -Fq "$directive" "$caddy"; then
       fail "$(realpath --relative-to "$REPO_ROOT" "$caddy") CSP missing directive: $directive"
     fi
   done
 done
 
-if ! grep -Fq "script-src 'unsafe-inline'" "$POLICY_FILE"; then
-  fail "policies/security.yml must record the current script-src unsafe-inline exception"
+if grep -Fq "script-src 'unsafe-inline'" "$POLICY_FILE"; then
+  fail "policies/security.yml must not retain a script-src unsafe-inline exception"
+fi
+if ! grep -Fq "script_mode: hash" "$POLICY_FILE"; then
+  fail "policies/security.yml must record hash-bound script delivery"
+fi
+SVELTE_CONFIG="${REPO_ROOT}/apps/web/svelte.config.js"
+if ! grep -Fq 'mode: "hash"' "$SVELTE_CONFIG" || ! grep -Fq '"script-src": ["self"]' "$SVELTE_CONFIG"; then
+  fail "apps/web/svelte.config.js must enable SvelteKit hash CSP for script-src"
 fi
 
 if [[ "$failures" -ne 0 ]]; then

--- a/scripts/guard/security-headers-guard.sh
+++ b/scripts/guard/security-headers-guard.sh
@@ -76,6 +76,9 @@ for caddy in \
   if grep -Eq "script-src[^;]*'unsafe-inline'" "$caddy"; then
     fail "$(realpath --relative-to "$REPO_ROOT" "$caddy") must not allow script-src unsafe-inline"
   fi
+  if ! grep -Fq "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';" "$caddy"; then
+    fail "$(realpath --relative-to "$REPO_ROOT" "$caddy") missing strict non-document/error CSP baseline"
+  fi
   for directive in \
     "style-src 'self' 'unsafe-inline'" \
     "connect-src 'self'" \

--- a/scripts/preflight/csp_contract_static.sh
+++ b/scripts/preflight/csp_contract_static.sh
@@ -37,7 +37,7 @@ if [[ ! -f "$INDEX_HTML" ]]; then
   exit 1
 fi
 
-python3 - "$ROOT/apps/web/build" << 'PY'
+python3 - "$ROOT/apps/web/build" "$CADDYFILE" << 'PY'
 from __future__ import annotations
 import base64
 import hashlib
@@ -68,7 +68,7 @@ ACTIVE_SCRIPT_TYPES = {"module", "importmap", "speculationrules"}
 
 
 def executable_script_type(raw: str) -> bool:
-    script_type = raw.strip().lower()
+    script_type = raw.split(";", 1)[0].strip().lower()
     return (
         not script_type
         or script_type in ACTIVE_SCRIPT_TYPES
@@ -82,13 +82,25 @@ class DocumentParser(HTMLParser):
         self.csp_meta: list[str] = []
         self.inline_scripts: list[str] = []
         self.executable_script_before_csp = False
+        self.csp_meta_outside_head = False
+        self.active_markup: list[str] = []
+        self._in_head = False
         self._script_inline = False
         self._script_parts: list[str] = []
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
-        values = {key.lower(): (value or "") for key, value in attrs}
         lowered_tag = tag.lower()
+        if lowered_tag == "head":
+            self._in_head = True
+        values = {key.lower(): (value or "") for key, value in attrs}
+        for key, value in values.items():
+            if re.fullmatch(r"on[a-z0-9_-]+", key):
+                self.active_markup.append(f"inline event handler {key}")
+            if value.lstrip().lower().startswith("javascript:"):
+                self.active_markup.append(f"javascript URL in {key}")
         if lowered_tag == "meta" and values.get("http-equiv", "").lower() == "content-security-policy":
+            if not self._in_head:
+                self.csp_meta_outside_head = True
             self.csp_meta.append(values.get("content", ""))
         if lowered_tag == "script":
             executable = executable_script_type(values.get("type", ""))
@@ -102,11 +114,14 @@ class DocumentParser(HTMLParser):
             self._script_parts.append(data)
 
     def handle_endtag(self, tag: str) -> None:
-        if tag.lower() == "script":
+        lowered_tag = tag.lower()
+        if lowered_tag == "script":
             if self._script_inline:
                 self.inline_scripts.append("".join(self._script_parts))
             self._script_inline = False
             self._script_parts = []
+        if lowered_tag == "head":
+            self._in_head = False
 
 
 def directives(policy: str) -> dict[str, list[str]]:
@@ -118,6 +133,24 @@ def directives(policy: str) -> dict[str, list[str]]:
     return result
 
 build = Path(sys.argv[1])
+caddyfile = Path(sys.argv[2])
+caddy_text = caddyfile.read_text(encoding="utf-8")
+frontend_policies = re.findall(
+    r'^\s*header\s+@frontendResponse\s+Content-Security-Policy\s+"([^"]*)"\s*$',
+    caddy_text,
+    flags=re.MULTILINE,
+)
+if len(frontend_policies) != 1:
+    raise SystemExit(
+        f"ERROR: expected exactly one @frontendResponse CSP in {caddyfile}, found {len(frontend_policies)}"
+    )
+frontend_directives = directives(frontend_policies[0])
+for forbidden in ("default-src", "script-src"):
+    if forbidden in frontend_directives:
+        raise SystemExit(
+            f"ERROR: frontend edge CSP in {caddyfile} must delegate {forbidden} to the document policy"
+        )
+
 html_files = sorted(build.rglob("*.html"))
 if not html_files:
     raise SystemExit(f"ERROR: no HTML files found under {build}")
@@ -128,6 +161,10 @@ for path in html_files:
     parser.feed(path.read_text(encoding="utf-8"))
     if len(parser.csp_meta) != 1:
         raise SystemExit(f"ERROR: expected exactly one CSP meta tag in {path}, found {len(parser.csp_meta)}")
+    if parser.csp_meta_outside_head:
+        raise SystemExit(f"ERROR: CSP meta tag must appear inside <head> in {path}")
+    if parser.active_markup:
+        raise SystemExit(f"ERROR: active inline HTML markup is forbidden in {path}: {parser.active_markup[0]}")
     if parser.executable_script_before_csp:
         raise SystemExit(f"ERROR: executable script appears before the CSP meta tag in {path}")
     policy = directives(parser.csp_meta[0])

--- a/scripts/preflight/csp_contract_static.sh
+++ b/scripts/preflight/csp_contract_static.sh
@@ -41,6 +41,7 @@ python3 - "$ROOT/apps/web/build" << 'PY'
 from __future__ import annotations
 import base64
 import hashlib
+import re
 import sys
 from html.parser import HTMLParser
 from pathlib import Path
@@ -104,5 +105,29 @@ for path in html_files:
             raise SystemExit(f"ERROR: inline script hash missing from script-src in {path}: {token}")
     validated += 1
     print(f"csp_contract_static: {path.relative_to(build)} scripts={len(parser.inline_scripts)} hash-bound")
-print(f"csp_contract_static: OK ({validated} HTML artifact(s) validated)")
+
+# The edge CSP intentionally delegates script-src to each HTML document so that
+# SvelteKit can authorize its inline bootstrap with build-generated hashes.
+# Non-HTML active documents therefore need a separate fail-closed rule. Static
+# SVG assets are repository/build artifacts only and must not contain scriptable
+# constructs when served directly by Caddy.
+active_svg = re.compile(
+    r"<\s*script\b|javascript\s*:|\son[a-z0-9_-]+\s*=|"
+    r"<\s*foreignobject\b|<\s*(?:iframe|object|embed)\b",
+    re.IGNORECASE,
+)
+svg_files = sorted(build.rglob("*.svg"))
+for path in svg_files:
+    text = path.read_text(encoding="utf-8")
+    match = active_svg.search(text)
+    if match:
+        raise SystemExit(
+            f"ERROR: active/scriptable SVG content is forbidden in {path}: {match.group(0)!r}"
+        )
+    print(f"csp_contract_static: {path.relative_to(build)} passive-svg")
+
+print(
+    f"csp_contract_static: OK ({validated} HTML artifact(s) validated, "
+    f"{len(svg_files)} passive SVG artifact(s) validated)"
+)
 PY

--- a/scripts/preflight/csp_contract_static.sh
+++ b/scripts/preflight/csp_contract_static.sh
@@ -46,20 +46,55 @@ import sys
 from html.parser import HTMLParser
 from pathlib import Path
 
+JAVASCRIPT_MIME_TYPES = {
+    "application/ecmascript",
+    "application/javascript",
+    "application/x-ecmascript",
+    "application/x-javascript",
+    "text/ecmascript",
+    "text/javascript",
+    "text/javascript1.0",
+    "text/javascript1.1",
+    "text/javascript1.2",
+    "text/javascript1.3",
+    "text/javascript1.4",
+    "text/javascript1.5",
+    "text/jscript",
+    "text/livescript",
+    "text/x-ecmascript",
+    "text/x-javascript",
+}
+ACTIVE_SCRIPT_TYPES = {"module", "importmap", "speculationrules"}
+
+
+def executable_script_type(raw: str) -> bool:
+    script_type = raw.strip().lower()
+    return (
+        not script_type
+        or script_type in ACTIVE_SCRIPT_TYPES
+        or script_type in JAVASCRIPT_MIME_TYPES
+    )
+
+
 class DocumentParser(HTMLParser):
     def __init__(self) -> None:
         super().__init__(convert_charrefs=True)
         self.csp_meta: list[str] = []
         self.inline_scripts: list[str] = []
+        self.executable_script_before_csp = False
         self._script_inline = False
         self._script_parts: list[str] = []
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         values = {key.lower(): (value or "") for key, value in attrs}
-        if tag.lower() == "meta" and values.get("http-equiv", "").lower() == "content-security-policy":
+        lowered_tag = tag.lower()
+        if lowered_tag == "meta" and values.get("http-equiv", "").lower() == "content-security-policy":
             self.csp_meta.append(values.get("content", ""))
-        if tag.lower() == "script":
-            self._script_inline = "src" not in values
+        if lowered_tag == "script":
+            executable = executable_script_type(values.get("type", ""))
+            if executable and not self.csp_meta:
+                self.executable_script_before_csp = True
+            self._script_inline = executable and "src" not in values
             self._script_parts = []
 
     def handle_data(self, data: str) -> None:
@@ -67,8 +102,9 @@ class DocumentParser(HTMLParser):
             self._script_parts.append(data)
 
     def handle_endtag(self, tag: str) -> None:
-        if tag.lower() == "script" and self._script_inline:
-            self.inline_scripts.append("".join(self._script_parts))
+        if tag.lower() == "script":
+            if self._script_inline:
+                self.inline_scripts.append("".join(self._script_parts))
             self._script_inline = False
             self._script_parts = []
 
@@ -92,6 +128,8 @@ for path in html_files:
     parser.feed(path.read_text(encoding="utf-8"))
     if len(parser.csp_meta) != 1:
         raise SystemExit(f"ERROR: expected exactly one CSP meta tag in {path}, found {len(parser.csp_meta)}")
+    if parser.executable_script_before_csp:
+        raise SystemExit(f"ERROR: executable script appears before the CSP meta tag in {path}")
     policy = directives(parser.csp_meta[0])
     script_src = policy.get("script-src")
     if not script_src:

--- a/scripts/preflight/csp_contract_static.sh
+++ b/scripts/preflight/csp_contract_static.sh
@@ -37,7 +37,7 @@ if [[ ! -f "$INDEX_HTML" ]]; then
   exit 1
 fi
 
-python3 - "$ROOT/apps/web/build" <<'PY'
+python3 - "$ROOT/apps/web/build" << 'PY'
 from __future__ import annotations
 import base64
 import hashlib

--- a/scripts/preflight/csp_contract_static.sh
+++ b/scripts/preflight/csp_contract_static.sh
@@ -1,126 +1,108 @@
 #!/usr/bin/env bash
 set -euo pipefail
-
-# This is a STATIC preflight guard. It runs BEFORE docker compose up.
-# It checks if the build artifacts contain an inline script, and if so,
-# verifies that the target Caddyfile's CSP allows it.
-
 ROOT="${ROOT:-/opt/weltgewebe}"
 REQUIRE_FRONTEND="${REQUIRE_FRONTEND:-1}"
-CADDY_TARGET_SITE="${CADDY_TARGET_SITE:-weltgewebe.home.arpa}"
-
-# Caddyfile detection (heuristic: prioritize user explicit env var, then root, then infra)
-if [[ -n "${CADDYFILE_PATH:-}" ]] && [[ -f "$CADDYFILE_PATH" ]]; then
-  CADDYFILE="$CADDYFILE_PATH"
-elif [[ -f "$ROOT/Caddyfile" ]]; then
-  CADDYFILE="$ROOT/Caddyfile"
-elif [[ -f "$ROOT/infra/caddy/Caddyfile.heim" ]]; then
-  CADDYFILE="$ROOT/infra/caddy/Caddyfile.heim"
-elif [[ -f "$ROOT/infra/caddy/Caddyfile.prod" ]]; then
-  CADDYFILE="$ROOT/infra/caddy/Caddyfile.prod"
-elif [[ -f "$ROOT/infra/caddy/Caddyfile" ]]; then
-  CADDYFILE="$ROOT/infra/caddy/Caddyfile"
-else
-  CADDYFILE=""
-fi
 
 if [[ "$REQUIRE_FRONTEND" != "1" ]]; then
   echo "csp_contract_static: Frontend delivery not required, skipping."
   exit 0
 fi
 
+if [[ -n "${CADDYFILE_PATH:-}" ]] && [[ -f "$CADDYFILE_PATH" ]]; then
+  CADDYFILE="$CADDYFILE_PATH"
+elif [[ -f "$ROOT/Caddyfile" ]]; then
+  CADDYFILE="$ROOT/Caddyfile"
+elif [[ -f "$ROOT/infra/caddy/Caddyfile.heim" ]]; then
+  CADDYFILE="$ROOT/infra/caddy/Caddyfile.heim"
+elif [[ -f "$ROOT/infra/caddy/Caddyfile.vps" ]]; then
+  CADDYFILE="$ROOT/infra/caddy/Caddyfile.vps"
+elif [[ -f "$ROOT/infra/caddy/Caddyfile" ]]; then
+  CADDYFILE="$ROOT/infra/caddy/Caddyfile"
+else
+  CADDYFILE=""
+fi
+
 if [[ -z "$CADDYFILE" || ! -f "$CADDYFILE" ]]; then
   echo "ERROR: csp_contract_static could not find the target Caddyfile." >&2
-  echo "       This is a fail-closed check because frontend delivery is required and Caddy is enabled." >&2
+  exit 1
+fi
+if grep -Eq "script-src[^;]*'unsafe-inline'" "$CADDYFILE"; then
+  echo "ERROR: target Caddyfile still allows script-src 'unsafe-inline': $CADDYFILE" >&2
   exit 1
 fi
 
 INDEX_HTML="$ROOT/apps/web/build/index.html"
-
 if [[ ! -f "$INDEX_HTML" ]]; then
   echo "ERROR: csp_contract_static could not find index.html at $INDEX_HTML." >&2
-  echo "       This is a fail-closed check because REQUIRE_FRONTEND=1." >&2
-  echo "       (Note: runtime_contract.sh also enforces this file's existence)." >&2
   exit 1
 fi
 
-# Detect inline script in HTML
-# We must find a <script ...> tag that does NOT contain a src= attribute.
-HAS_INLINE_SCRIPT=0
-# Extract all script tags. grep -o is standard, but the regex needs to be simple.
-# '<script[^>]*>' works in standard grep in many implementations, but to be 100% POSIX safe
-# and handle minified files, we use sed to isolate the script tags by injecting newlines.
-SCRIPT_TAGS=$(sed 's/<script/\n<script/g' "$INDEX_HTML" | grep -io '^<script[^>]*>' || true)
+python3 - "$ROOT/apps/web/build" <<'PY'
+from __future__ import annotations
+import base64
+import hashlib
+import sys
+from html.parser import HTMLParser
+from pathlib import Path
 
-while IFS= read -r tag; do
-  if [[ -z "$tag" ]]; then
-    continue
-  fi
-  # If the script tag does not contain "src=", it's an inline script
-  if ! echo "$tag" | grep -qi "src="; then
-    HAS_INLINE_SCRIPT=1
-    break
-  fi
-done <<< "$SCRIPT_TAGS"
+class DocumentParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.csp_meta: list[str] = []
+        self.inline_scripts: list[str] = []
+        self._script_inline = False
+        self._script_parts: list[str] = []
 
-if [[ "$HAS_INLINE_SCRIPT" == "1" ]]; then
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        values = {key.lower(): (value or "") for key, value in attrs}
+        if tag.lower() == "meta" and values.get("http-equiv", "").lower() == "content-security-policy":
+            self.csp_meta.append(values.get("content", ""))
+        if tag.lower() == "script":
+            self._script_inline = "src" not in values
+            self._script_parts = []
 
-  # Extract the configuration block for the target site.
-  # This uses a simple awk script to count braces and extract only the relevant host block.
-  TARGET_BLOCK=$(awk -v site="$CADDY_TARGET_SITE" '
-    # Match the site name followed by a brace or space
-    $0 ~ site"( *{| *$)" { in_block=1; braces=0 }
-    in_block {
-      print
-      # Count opening and closing braces
-      braces += gsub(/{/, "{") - gsub(/}/, "}")
-      if (braces <= 0 && $0 ~ /}/) { in_block=0 }
-    }
-  ' "$CADDYFILE" || true)
+    def handle_data(self, data: str) -> None:
+        if self._script_inline:
+            self._script_parts.append(data)
 
-  if [[ -z "$TARGET_BLOCK" ]]; then
-    echo "ERROR: csp_contract_static could not find the host block for '$CADDY_TARGET_SITE' in $CADDYFILE." >&2
-    exit 1
-  fi
+    def handle_endtag(self, tag: str) -> None:
+        if tag.lower() == "script" and self._script_inline:
+            self.inline_scripts.append("".join(self._script_parts))
+            self._script_inline = False
+            self._script_parts = []
 
-  # Extract CSP lines from the target block
-  # Assuming standard format: Content-Security-Policy "..."
-  CSP_LINES=$(echo "$TARGET_BLOCK" | grep -i "Content-Security-Policy" || true)
 
-  if [[ -z "$CSP_LINES" ]]; then
-    echo "csp_contract_static: No CSP found for $CADDY_TARGET_SITE in $CADDYFILE, assuming safe (or no CSP)."
-    exit 0
-  fi
+def directives(policy: str) -> dict[str, list[str]]:
+    result: dict[str, list[str]] = {}
+    for raw in policy.split(";"):
+        parts = raw.strip().split()
+        if parts:
+            result[parts[0].lower()] = parts[1:]
+    return result
 
-  # Handle multiple CSP lines: If ANY line satisfies the requirement, we pass.
-  # This prevents false positives in multi-site Caddyfiles without needing a full parser.
-  while IFS= read -r CSP_LINE; do
-    if [[ -z "$CSP_LINE" ]]; then
-      continue
-    fi
+build = Path(sys.argv[1])
+html_files = sorted(build.rglob("*.html"))
+if not html_files:
+    raise SystemExit(f"ERROR: no HTML files found under {build}")
 
-    # Look specifically within the script-src directive
-    if echo "$CSP_LINE" | grep -qi "script-src"; then
-      # Extract just the script-src part (up to the next semicolon or end of string) using sed for portability
-      SCRIPT_SRC=$(echo "$CSP_LINE" | sed -n 's/.*\([sS][cC][rR][iI][pP][tT]-[sS][rR][cC][^;]*\).*/\1/p')
-
-      if echo "$SCRIPT_SRC" | grep -qF "'unsafe-inline'"; then
-        echo "csp_contract_static: OK ('unsafe-inline' present in script-src of $CADDYFILE)"
-        exit 0
-      fi
-
-      if echo "$SCRIPT_SRC" | grep -qE "'nonce-|'sha256-"; then
-        echo "csp_contract_static: OK (nonce/hash present in script-src of $CADDYFILE)"
-        exit 0
-      fi
-    fi
-  done <<< "$CSP_LINES"
-
-  echo "ERROR: Inline <script> detected in INDEX_HTML ($INDEX_HTML), but no matching Content-Security-Policy in CADDYFILE_PATH ($CADDYFILE) allows 'unsafe-inline' or nonce/hash." >&2
-  echo "Found CSP lines:" >&2
-  echo "$CSP_LINES" >&2
-  exit 1
-fi
-
-echo "csp_contract_static: OK (no inline script or valid CSP)"
-exit 0
+validated = 0
+for path in html_files:
+    parser = DocumentParser()
+    parser.feed(path.read_text(encoding="utf-8"))
+    if len(parser.csp_meta) != 1:
+        raise SystemExit(f"ERROR: expected exactly one CSP meta tag in {path}, found {len(parser.csp_meta)}")
+    policy = directives(parser.csp_meta[0])
+    script_src = policy.get("script-src")
+    if not script_src:
+        raise SystemExit(f"ERROR: CSP meta tag has no script-src directive in {path}")
+    if "'unsafe-inline'" in script_src:
+        raise SystemExit(f"ERROR: CSP meta tag still allows script-src 'unsafe-inline' in {path}")
+    for body in parser.inline_scripts:
+        digest = base64.b64encode(hashlib.sha256(body.encode("utf-8")).digest()).decode("ascii")
+        token = f"'sha256-{digest}'"
+        if token not in script_src:
+            raise SystemExit(f"ERROR: inline script hash missing from script-src in {path}: {token}")
+    validated += 1
+    print(f"csp_contract_static: {path.relative_to(build)} scripts={len(parser.inline_scripts)} hash-bound")
+print(f"csp_contract_static: OK ({validated} HTML artifact(s) validated)")
+PY

--- a/scripts/tests/test_csp_contract_static.sh
+++ b/scripts/tests/test_csp_contract_static.sh
@@ -33,6 +33,18 @@ run_test "missing-index" 1
 printf '%s\n' '<meta http-equiv="content-security-policy" content="script-src '\''self'\''"><script src="/app.js"></script>' > "$INDEX_HTML"
 run_test "external-script-strict" 0
 
+mkdir -p "$TEST_DIR/apps/web/build/weltweberei"
+printf '%s\n' '<html><body>secondary static document</body></html>' > "$TEST_DIR/apps/web/build/weltweberei/index.html"
+run_test "secondary-html-without-csp" 1
+printf '%s\n' '<meta http-equiv="content-security-policy" content="script-src '\''none'\''"><main>secondary static document</main>' > "$TEST_DIR/apps/web/build/weltweberei/index.html"
+run_test "secondary-html-strict" 0
+
+printf '%s\n' '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0h1v1z"/></svg>' > "$TEST_DIR/apps/web/build/favicon.svg"
+run_test "passive-svg" 0
+printf '%s\n' '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>' > "$TEST_DIR/apps/web/build/favicon.svg"
+run_test "active-svg-rejected" 1
+printf '%s\n' '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0h1v1z"/></svg>' > "$TEST_DIR/apps/web/build/favicon.svg"
+
 printf '%s\n' '<meta http-equiv="content-security-policy" content="script-src '\''self'\''"><script>console.log("inline")</script>' > "$INDEX_HTML"
 run_test "inline-without-hash" 1
 

--- a/scripts/tests/test_csp_contract_static.sh
+++ b/scripts/tests/test_csp_contract_static.sh
@@ -58,6 +58,15 @@ PY
 printf '%s\n' "<meta http-equiv=\"content-security-policy\" content=\"script-src 'self' 'sha256-$hash'\"><script>console.log(\"inline\")</script>" > "$INDEX_HTML"
 run_test "inline-with-matching-hash" 0
 
+printf '%s\n' "<script>console.log(\"inline\")</script><meta http-equiv=\"content-security-policy\" content=\"script-src 'self' 'sha256-$hash'\">" > "$INDEX_HTML"
+run_test "csp-meta-after-executable-script-rejected" 1
+
+printf '%s\n' '<meta http-equiv="content-security-policy" content="script-src '\''self'\''"><script type="application/json">{"safe":true}</script>' > "$INDEX_HTML"
+run_test "json-data-script-does-not-require-hash" 0
+
+printf '%s\n' '<meta http-equiv="content-security-policy" content="script-src '\''self'\''"><script type="module">console.log("module")</script>' > "$INDEX_HTML"
+run_test "inline-module-without-hash-rejected" 1
+
 printf '%s\n' '<meta http-equiv="content-security-policy" content="script-src '\''self'\'' '\''unsafe-inline'\''"><script>console.log("inline")</script>' > "$INDEX_HTML"
 run_test "inline-unsafe-inline-rejected" 1
 

--- a/scripts/tests/test_csp_contract_static.sh
+++ b/scripts/tests/test_csp_contract_static.sh
@@ -36,7 +36,8 @@ run_test "external-script-strict" 0
 printf '%s\n' '<meta http-equiv="content-security-policy" content="script-src '\''self'\''"><script>console.log("inline")</script>' > "$INDEX_HTML"
 run_test "inline-without-hash" 1
 
-hash=$(python3 - <<'PY'
+hash=$(
+  python3 - << 'PY'
 import base64, hashlib
 body='console.log("inline")'
 print(base64.b64encode(hashlib.sha256(body.encode()).digest()).decode())

--- a/scripts/tests/test_csp_contract_static.sh
+++ b/scripts/tests/test_csp_contract_static.sh
@@ -26,17 +26,17 @@ run_test() {
 export REQUIRE_FRONTEND=0
 run_test "frontend-disabled" 0
 export REQUIRE_FRONTEND=1
-printf '%s\n' 'header { Content-Security-Policy "frame-ancestors '\''none'\'';" }' > "$CADDYFILE_PATH"
+printf '%s\n' 'header @frontendResponse Content-Security-Policy "frame-ancestors '\''none'\'';"' > "$CADDYFILE_PATH"
 rm -f "$INDEX_HTML"
 run_test "missing-index" 1
 
-printf '%s\n' '<meta http-equiv="content-security-policy" content="script-src '\''self'\''"><script src="/app.js"></script>' > "$INDEX_HTML"
+printf '%s\n' '<html><head><meta http-equiv="content-security-policy" content="script-src '\''self'\''"><script src="/app.js"></script></head><body></body></html>' > "$INDEX_HTML"
 run_test "external-script-strict" 0
 
 mkdir -p "$TEST_DIR/apps/web/build/weltweberei"
 printf '%s\n' '<html><body>secondary static document</body></html>' > "$TEST_DIR/apps/web/build/weltweberei/index.html"
 run_test "secondary-html-without-csp" 1
-printf '%s\n' '<meta http-equiv="content-security-policy" content="script-src '\''none'\''"><main>secondary static document</main>' > "$TEST_DIR/apps/web/build/weltweberei/index.html"
+printf '%s\n' '<html><head><meta http-equiv="content-security-policy" content="script-src '\''none'\''"></head><body><main>secondary static document</main></body></html>' > "$TEST_DIR/apps/web/build/weltweberei/index.html"
 run_test "secondary-html-strict" 0
 
 printf '%s\n' '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0h1v1z"/></svg>' > "$TEST_DIR/apps/web/build/favicon.svg"
@@ -45,7 +45,7 @@ printf '%s\n' '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script>
 run_test "active-svg-rejected" 1
 printf '%s\n' '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0h1v1z"/></svg>' > "$TEST_DIR/apps/web/build/favicon.svg"
 
-printf '%s\n' '<meta http-equiv="content-security-policy" content="script-src '\''self'\''"><script>console.log("inline")</script>' > "$INDEX_HTML"
+printf '%s\n' '<html><head><meta http-equiv="content-security-policy" content="script-src '\''self'\''"><script>console.log("inline")</script></head><body></body></html>' > "$INDEX_HTML"
 run_test "inline-without-hash" 1
 
 hash=$(
@@ -55,22 +55,42 @@ body='console.log("inline")'
 print(base64.b64encode(hashlib.sha256(body.encode()).digest()).decode())
 PY
 )
-printf '%s\n' "<meta http-equiv=\"content-security-policy\" content=\"script-src 'self' 'sha256-$hash'\"><script>console.log(\"inline\")</script>" > "$INDEX_HTML"
+printf '%s\n' "<html><head><meta http-equiv=\"content-security-policy\" content=\"script-src 'self' 'sha256-$hash'\"><script>console.log(\"inline\")</script></head><body></body></html>" > "$INDEX_HTML"
 run_test "inline-with-matching-hash" 0
 
-printf '%s\n' "<script>console.log(\"inline\")</script><meta http-equiv=\"content-security-policy\" content=\"script-src 'self' 'sha256-$hash'\">" > "$INDEX_HTML"
+printf '%s\n' "<html><head><script>console.log(\"inline\")</script><meta http-equiv=\"content-security-policy\" content=\"script-src 'self' 'sha256-$hash'\"></head><body></body></html>" > "$INDEX_HTML"
 run_test "csp-meta-after-executable-script-rejected" 1
 
-printf '%s\n' '<meta http-equiv="content-security-policy" content="script-src '\''self'\''"><script type="application/json">{"safe":true}</script>' > "$INDEX_HTML"
+printf '%s\n' '<html><head><meta http-equiv="content-security-policy" content="script-src '\''self'\''"><script type="application/json">{"safe":true}</script></head><body></body></html>' > "$INDEX_HTML"
 run_test "json-data-script-does-not-require-hash" 0
 
-printf '%s\n' '<meta http-equiv="content-security-policy" content="script-src '\''self'\''"><script type="module">console.log("module")</script>' > "$INDEX_HTML"
+printf '%s\n' '<html><head><meta http-equiv="content-security-policy" content="script-src '\''self'\''"><script type="module">console.log("module")</script></head><body></body></html>' > "$INDEX_HTML"
 run_test "inline-module-without-hash-rejected" 1
 
-printf '%s\n' '<meta http-equiv="content-security-policy" content="script-src '\''self'\'' '\''unsafe-inline'\''"><script>console.log("inline")</script>' > "$INDEX_HTML"
+printf '%s\n' '<html><head><meta http-equiv="content-security-policy" content="script-src '\''self'\'' '\''unsafe-inline'\''"><script>console.log("inline")</script></head><body></body></html>' > "$INDEX_HTML"
 run_test "inline-unsafe-inline-rejected" 1
 
 printf '%s\n' 'header { Content-Security-Policy "script-src '\''self'\'' '\''unsafe-inline'\'';" }' > "$CADDYFILE_PATH"
 run_test "edge-unsafe-inline-rejected" 1
+
+printf '%s\n' 'header @frontendResponse Content-Security-Policy "frame-ancestors '\''none'\'';"' > "$CADDYFILE_PATH"
+
+printf '%s\n' '<html><body><meta http-equiv="content-security-policy" content="script-src '\''self'\''"></body></html>' > "$INDEX_HTML"
+run_test "csp-meta-outside-head-rejected" 1
+
+printf '%s\n' '<html><head><meta http-equiv="content-security-policy" content="script-src '\''self'\''"></head><body onclick="alert(1)"></body></html>' > "$INDEX_HTML"
+run_test "inline-event-handler-rejected" 1
+
+printf '%s\n' '<html><head><meta http-equiv="content-security-policy" content="script-src '\''self'\''"></head><body><a href="javascript:alert(1)">x</a></body></html>' > "$INDEX_HTML"
+run_test "javascript-url-rejected" 1
+
+printf '%s\n' '<html><head><meta http-equiv="content-security-policy" content="script-src '\''self'\''"><script type="text/javascript; charset=utf-8">console.log("mime")</script></head><body></body></html>' > "$INDEX_HTML"
+run_test "parameterized-javascript-mime-requires-hash" 1
+
+printf '%s\n' 'header @frontendResponse Content-Security-Policy "default-src '\''self'\''; frame-ancestors '\''none'\'';"' > "$CADDYFILE_PATH"
+run_test "frontend-edge-default-src-rejected" 1
+
+printf '%s\n' 'header @frontendResponse Content-Security-Policy "script-src '\''self'\''; frame-ancestors '\''none'\'';"' > "$CADDYFILE_PATH"
+run_test "frontend-edge-script-src-rejected" 1
 
 echo "All csp_contract_static tests passed"

--- a/scripts/tests/test_csp_contract_static.sh
+++ b/scripts/tests/test_csp_contract_static.sh
@@ -1,104 +1,54 @@
 #!/usr/bin/env bash
 set -euo pipefail
-
-echo "Running tests for csp_contract_static.sh..."
-
 SCRIPT_DIR=$(dirname "$0")
 GUARD_SCRIPT="$SCRIPT_DIR/../preflight/csp_contract_static.sh"
-
 TEST_DIR=$(mktemp -d)
 trap 'rm -rf "$TEST_DIR"' EXIT
-
 mkdir -p "$TEST_DIR/apps/web/build"
-
 export ROOT="$TEST_DIR"
 export CADDYFILE_PATH="$TEST_DIR/Caddyfile"
 INDEX_HTML="$TEST_DIR/apps/web/build/index.html"
 
 run_test() {
-  local name="$1"
-  local expected_exit="$2"
-
-  echo "Test: $name"
-
+  local name="$1" expected_exit="$2"
   set +e
   output=$(bash "$GUARD_SCRIPT" 2>&1)
-  exit_code=$?
+  actual=$?
   set -e
-
-  if [[ "$exit_code" -eq "$expected_exit" ]]; then
-    echo "  -> PASS"
-  else
-    echo "  -> FAIL (expected $expected_exit, got $exit_code)"
-    echo "  Output: $output"
+  if [[ "$actual" -ne "$expected_exit" ]]; then
+    echo "FAIL: $name (expected $expected_exit, got $actual)" >&2
+    echo "$output" >&2
     exit 1
   fi
+  echo "PASS: $name"
 }
 
-# Test 1: REQUIRE_FRONTEND=0 -> pass
 export REQUIRE_FRONTEND=0
-run_test "REQUIRE_FRONTEND=0 skips check" 0
+run_test "frontend-disabled" 0
 export REQUIRE_FRONTEND=1
-
-# Test 2: index.html missing when REQUIRE_FRONTEND=1 -> fail
+printf '%s\n' 'header { Content-Security-Policy "frame-ancestors '\''none'\'';" }' > "$CADDYFILE_PATH"
 rm -f "$INDEX_HTML"
-touch "$CADDYFILE_PATH"
-run_test "Missing index.html with REQUIRE_FRONTEND=1 fails check" 1
+run_test "missing-index" 1
 
-# Test 3: index.html has only external script, CSP lacks unsafe-inline -> pass
-echo '<script type="module" src="/app.js"></script>' > "$INDEX_HTML"
-echo 'Content-Security-Policy "default-src '"'self'"'; script-src '"'self'"';"' > "$CADDYFILE_PATH"
-run_test "External script only, strict CSP passes" 0
+printf '%s\n' '<meta http-equiv="content-security-policy" content="script-src '\''self'\''"><script src="/app.js"></script>' > "$INDEX_HTML"
+run_test "external-script-strict" 0
 
-# Test 4: index.html has inline script, CSP lacks unsafe-inline -> fail
-echo '<script>console.log("inline")</script>' > "$INDEX_HTML"
-echo 'Content-Security-Policy "default-src '"'self'"'; script-src '"'self'"';"' > "$CADDYFILE_PATH"
-run_test "Inline script with strict CSP fails" 1
+printf '%s\n' '<meta http-equiv="content-security-policy" content="script-src '\''self'\''"><script>console.log("inline")</script>' > "$INDEX_HTML"
+run_test "inline-without-hash" 1
 
-export CADDY_TARGET_SITE="weltgewebe.home.arpa"
+hash=$(python3 - <<'PY'
+import base64, hashlib
+body='console.log("inline")'
+print(base64.b64encode(hashlib.sha256(body.encode()).digest()).decode())
+PY
+)
+printf '%s\n' "<meta http-equiv=\"content-security-policy\" content=\"script-src 'self' 'sha256-$hash'\"><script>console.log(\"inline\")</script>" > "$INDEX_HTML"
+run_test "inline-with-matching-hash" 0
 
-# Test 5: index.html has inline script, CSP has unsafe-inline -> pass
-echo '<script>console.log("inline")</script>' > "$INDEX_HTML"
-echo 'weltgewebe.home.arpa { Content-Security-Policy "default-src '"'self'"'; script-src '"'self'"' '"'unsafe-inline'"';"' > "$CADDYFILE_PATH"
-echo '}' >> "$CADDYFILE_PATH"
-run_test "Inline script with unsafe-inline CSP passes" 0
+printf '%s\n' '<meta http-equiv="content-security-policy" content="script-src '\''self'\'' '\''unsafe-inline'\''"><script>console.log("inline")</script>' > "$INDEX_HTML"
+run_test "inline-unsafe-inline-rejected" 1
 
-# Test 6: index.html has inline script, CSP has nonce -> pass
-echo '<script>console.log("inline")</script>' > "$INDEX_HTML"
-echo 'weltgewebe.home.arpa { Content-Security-Policy "default-src '"'self'"'; script-src '"'self'"' '"'nonce-1234'"';"' > "$CADDYFILE_PATH"
-echo '}' >> "$CADDYFILE_PATH"
-run_test "Inline script with nonce CSP passes" 0
+printf '%s\n' 'header { Content-Security-Policy "script-src '\''self'\'' '\''unsafe-inline'\'';" }' > "$CADDYFILE_PATH"
+run_test "edge-unsafe-inline-rejected" 1
 
-# Test 7: Minified HTML with inline script -> fail
-echo '<html><head><title>test</title><script>let x=1;</script></head><body></body></html>' > "$INDEX_HTML"
-echo 'weltgewebe.home.arpa { Content-Security-Policy "default-src '"'self'"'; script-src '"'self'"';"' > "$CADDYFILE_PATH"
-echo '}' >> "$CADDYFILE_PATH"
-run_test "Minified HTML with inline script and strict CSP fails" 1
-
-export CADDY_TARGET_SITE="weltgewebe.home.arpa"
-
-# Test 8: Target host strict, other host lenient -> FAIL
-echo '<script>console.log("inline")</script>' > "$INDEX_HTML"
-cat << EOF > "$CADDYFILE_PATH"
-weltgewebe.home.arpa {
-  Content-Security-Policy "default-src 'self'; script-src 'self';"
-}
-other.host {
-  Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline';"
-}
-EOF
-run_test "Target host strict, other host lenient -> FAIL" 1
-
-# Test 9: Target host lenient, other host strict -> PASS
-echo '<script>console.log("inline")</script>' > "$INDEX_HTML"
-cat << EOF > "$CADDYFILE_PATH"
-other.host {
-  Content-Security-Policy "default-src 'self'; script-src 'self';"
-}
-weltgewebe.home.arpa {
-  Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline';"
-}
-EOF
-run_test "Target host lenient, other host strict -> PASS" 0
-
-echo "All tests passed!"
+echo "All csp_contract_static tests passed"

--- a/scripts/tests/test_domain_multi_instance_guard.sh
+++ b/scripts/tests/test_domain_multi_instance_guard.sh
@@ -18,6 +18,7 @@ FILES=(
   apps/api/tests/db_multi_instance_foundation.rs
   .github/workflows/ci.yml
   scripts/ci/run-postgres-integration-proofs.sh
+  scripts/ci/postgres-proof-contract.json
 )
 
 seed() {

--- a/scripts/tests/test_security_headers_guard.sh
+++ b/scripts/tests/test_security_headers_guard.sh
@@ -38,6 +38,7 @@ write_static_caddy() {
 example.test {
   header {
     Content-Security-Policy "style-src 'self' 'unsafe-inline'; connect-src $connect; img-src 'self' data: blob:; worker-src 'self' blob:; font-src 'self'; media-src 'self'; manifest-src 'self'; child-src 'self'; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';"
+    Content-Security-Policy "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
     Strict-Transport-Security "max-age=31536000; includeSubDomains"
     X-Frame-Options "DENY"
     Referrer-Policy "no-referrer"

--- a/scripts/tests/test_security_headers_guard.sh
+++ b/scripts/tests/test_security_headers_guard.sh
@@ -7,7 +7,7 @@ TEMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TEMP_DIR"' EXIT
 mkdir -p "$TEMP_DIR/policies" "$TEMP_DIR/infra/caddy" "$TEMP_DIR/apps/web"
 
-cat > "$TEMP_DIR/policies/security.yml" <<'YAML'
+cat > "$TEMP_DIR/policies/security.yml" << 'YAML'
 content_security_policy:
   script-src: "'self' plus build-generated sha256 hashes"
   script_mode: hash
@@ -18,7 +18,7 @@ strict_transport_security:
   max_age_seconds: 31536000
 YAML
 
-cat > "$TEMP_DIR/apps/web/svelte.config.js" <<'JS'
+cat > "$TEMP_DIR/apps/web/svelte.config.js" << 'JS'
 export default {
   kit: {
     csp: {
@@ -34,7 +34,7 @@ JS
 write_static_caddy() {
   local file="$1"
   local connect="$2"
-  cat > "$file" <<CADDY
+  cat > "$file" << CADDY
 example.test {
   header {
     Content-Security-Policy "style-src 'self' 'unsafe-inline'; connect-src $connect; img-src 'self' data: blob:; worker-src 'self' blob:; font-src 'self'; media-src 'self'; manifest-src 'self'; child-src 'self'; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';"
@@ -50,7 +50,7 @@ CADDY
 
 write_prod_caddy() {
   local file="$1"
-  cat > "$file" <<'CADDY'
+  cat > "$file" << 'CADDY'
 example.test {
   header {
     Strict-Transport-Security "max-age=31536000; includeSubDomains"

--- a/scripts/tests/test_security_headers_guard.sh
+++ b/scripts/tests/test_security_headers_guard.sh
@@ -1,27 +1,58 @@
 #!/usr/bin/env bash
 set -euo pipefail
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
 REPO_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
 GUARD="$REPO_ROOT/scripts/guard/security-headers-guard.sh"
-
 TEMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TEMP_DIR"' EXIT
+mkdir -p "$TEMP_DIR/policies" "$TEMP_DIR/infra/caddy" "$TEMP_DIR/apps/web"
 
-mkdir -p "$TEMP_DIR/policies" "$TEMP_DIR/infra/caddy"
-cat > "$TEMP_DIR/policies/security.yml" << 'YAML'
+cat > "$TEMP_DIR/policies/security.yml" <<'YAML'
+content_security_policy:
+  script-src: "'self' plus build-generated sha256 hashes"
+  script_mode: hash
+  style-src: "'self' 'unsafe-inline'"
+csp_exceptions:
+  - directive: "style-src 'unsafe-inline'"
 strict_transport_security:
   max_age_seconds: 31536000
-csp_exceptions:
-  - "script-src 'unsafe-inline'"
 YAML
 
-write_caddy() {
+cat > "$TEMP_DIR/apps/web/svelte.config.js" <<'JS'
+export default {
+  kit: {
+    csp: {
+      mode: "hash",
+      directives: {
+        "script-src": ["self"],
+      },
+    },
+  },
+};
+JS
+
+write_static_caddy() {
   local file="$1"
-  cat > "$file" << 'CADDY'
+  local connect="$2"
+  cat > "$file" <<CADDY
 example.test {
   header {
-    Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data: blob:; object-src 'none';"
+    Content-Security-Policy "style-src 'self' 'unsafe-inline'; connect-src $connect; img-src 'self' data: blob:; worker-src 'self' blob:; font-src 'self'; media-src 'self'; manifest-src 'self'; child-src 'self'; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';"
+    Strict-Transport-Security "max-age=31536000; includeSubDomains"
+    X-Frame-Options "DENY"
+    Referrer-Policy "no-referrer"
+    X-Content-Type-Options "nosniff"
+    X-Weltgewebe-Build "{\$WELTGEWEBE_BUILD}"
+  }
+}
+CADDY
+}
+
+write_prod_caddy() {
+  local file="$1"
+  cat > "$file" <<'CADDY'
+example.test {
+  header {
     Strict-Transport-Security "max-age=31536000; includeSubDomains"
     X-Frame-Options "DENY"
     Referrer-Policy "no-referrer"
@@ -32,15 +63,23 @@ example.test {
 CADDY
 }
 
-write_caddy "$TEMP_DIR/infra/caddy/Caddyfile.vps"
-write_caddy "$TEMP_DIR/infra/caddy/Caddyfile.heim"
-write_caddy "$TEMP_DIR/infra/caddy/Caddyfile.prod"
+write_static_caddy "$TEMP_DIR/infra/caddy/Caddyfile" "'self' ws: wss:"
+write_static_caddy "$TEMP_DIR/infra/caddy/Caddyfile.vps" "'self'"
+write_static_caddy "$TEMP_DIR/infra/caddy/Caddyfile.heim" "'self'"
+write_prod_caddy "$TEMP_DIR/infra/caddy/Caddyfile.prod"
 
 REPO_ROOT="$TEMP_DIR" bash "$GUARD" > /dev/null
 
 sed -i '/Strict-Transport-Security/d' "$TEMP_DIR/infra/caddy/Caddyfile.vps"
 if REPO_ROOT="$TEMP_DIR" bash "$GUARD" > /dev/null 2>&1; then
   echo "security headers guard should fail without HSTS" >&2
+  exit 1
+fi
+write_static_caddy "$TEMP_DIR/infra/caddy/Caddyfile.vps" "'self'"
+
+sed -i "s/style-src 'self' 'unsafe-inline';/script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';/" "$TEMP_DIR/infra/caddy/Caddyfile.vps"
+if REPO_ROOT="$TEMP_DIR" bash "$GUARD" > /dev/null 2>&1; then
+  echo "security headers guard should fail with script-src unsafe-inline" >&2
   exit 1
 fi
 


### PR DESCRIPTION
<!-- weltgewebe-risk: R3 -->

Replacement for closed, unmerged PR #1544. This branch is bound to reviewed head a765ec19ebdf05e82aef3faf05b3cf4cacd73470 and includes the original T023–T026 remediation plus review hardening: fail-closed PostgreSQL proof runner error propagation and safer resets, stricter disposable database naming, atomic semantic-search status snapshot, stronger static/edge CSP contracts including adapted Caddy routing checks, and nosniff on the default Caddy path.

Verified locally on this exact head: cargo check --locked -p weltgewebe-api; cargo fmt --check; git diff --check; shfmt and shellcheck for the proof runner; targeted PostgreSQL/CSP contract tests; full PostgreSQL integration proofs against isolated Postgres 16; pnpm web build; CSP preflight against built frontend for default/heim/VPS Caddyfiles.

A broad make validate-tests run reached 817 passing docmeta tests but then stopped in the local Python 3.10 environment because the repository requires Python 3.12/tomllib; this is an environment limitation, not counted as a pass.

Follow-up candidates recorded separately in Bureau intake: run-owned destructive proof database identity, and clearer settled-vs-failed semantic-search progress semantics.