### PR TITLE
fix: restore applied semantic-search migration checksum

### DIFF
--- a/apps/api/migrations/20260721000001_semantic_search_projection_worker.up.sql
+++ b/apps/api/migrations/20260721000001_semantic_search_projection_worker.up.sql
@@ -70,7 +70,6 @@ CREATE TABLE search_projection_jobs (
 );
 CREATE INDEX search_projection_jobs_claimable ON search_projection_jobs (available_at, id)
     WHERE state IN ('pending', 'retry', 'claimed');
-CREATE INDEX search_projection_jobs_generation_state ON search_projection_jobs (generation_id, state);
 
 CREATE OR REPLACE FUNCTION weltgewebe_search_enqueue_node(p_node_id TEXT, p_operation TEXT)
 RETURNS VOID LANGUAGE plpgsql AS $$
@@ -122,45 +121,6 @@ END; $$;
 CREATE TRIGGER search_track_domain_nodes AFTER INSERT OR UPDATE OR DELETE ON domain_nodes
 FOR EACH ROW EXECUTE FUNCTION weltgewebe_search_track_domain_node();
 
--- Canonical, read-only activation gate shared by worker reconciliation,
--- operational status, and the actual activation function. Keep all readiness
--- semantics here so those three surfaces cannot drift independently.
-CREATE OR REPLACE FUNCTION weltgewebe_search_generation_activation_ready(p_generation_id TEXT)
-RETURNS BOOLEAN LANGUAGE sql STABLE AS $$
-SELECT COALESCE((
-    SELECT g.state IN ('building', 'ready', 'active')
-       AND g.completed_nodes = g.expected_nodes
-       AND NOT EXISTS (
-           SELECT 1 FROM search_node_versions v
-           WHERE v.deleted_at IS NULL
-             AND NOT EXISTS (
-                 SELECT 1 FROM search_node_projections p
-                 WHERE p.generation_id = g.generation_id
-                   AND p.node_id = v.node_id
-                   AND p.source_version = v.source_version
-                   AND p.source_revision = v.source_revision
-                   AND p.semantic_state = 'ready'
-                   AND cardinality(p.embedding) = g.dimension
-             )
-       )
-       AND NOT EXISTS (
-           SELECT 1 FROM search_projection_jobs j
-           WHERE j.generation_id = g.generation_id
-             AND j.state NOT IN ('done', 'stale')
-       )
-       AND NOT EXISTS (
-           SELECT 1
-           FROM search_node_versions v
-           JOIN search_node_projections p
-             ON p.generation_id = g.generation_id
-            AND p.node_id = v.node_id
-           WHERE v.deleted_at IS NOT NULL
-       )
-    FROM search_index_generations g
-    WHERE g.generation_id = p_generation_id
-), FALSE);
-$$;
-
 -- Atomically switches only a fully completed generation.  The old active
 -- generation is retained for an explicit operator rollback via the same gate.
 CREATE OR REPLACE FUNCTION weltgewebe_activate_search_generation(p_generation_id TEXT)
@@ -170,7 +130,35 @@ BEGIN
     PERFORM pg_advisory_xact_lock(hashtextextended('weltgewebe.search.generation.activation', 0));
     SELECT * INTO target FROM search_index_generations WHERE generation_id = p_generation_id FOR UPDATE;
     IF NOT FOUND THEN RAISE EXCEPTION 'unknown search generation' USING ERRCODE = '23503'; END IF;
-    IF NOT weltgewebe_search_generation_activation_ready(p_generation_id) THEN
+    IF target.state NOT IN ('building', 'ready', 'active')
+       OR target.completed_nodes <> target.expected_nodes
+       OR EXISTS (
+           SELECT 1 FROM search_node_versions v
+           WHERE v.deleted_at IS NULL
+             AND NOT EXISTS (
+                 SELECT 1 FROM search_node_projections p
+                 WHERE p.generation_id = p_generation_id
+                   AND p.node_id = v.node_id
+                   AND p.source_version = v.source_version
+                   AND p.source_revision = v.source_revision
+                   AND p.semantic_state = 'ready'
+                   AND cardinality(p.embedding) = target.dimension
+             )
+       )
+       OR EXISTS (
+           SELECT 1 FROM search_projection_jobs j
+           WHERE j.generation_id = p_generation_id
+             AND j.state NOT IN ('done', 'stale')
+       )
+       OR EXISTS (
+           SELECT 1
+           FROM search_node_versions v
+           JOIN search_node_projections p
+             ON p.generation_id = p_generation_id
+            AND p.node_id = v.node_id
+           WHERE v.deleted_at IS NOT NULL
+       )
+    THEN
       RAISE EXCEPTION 'generation is not complete and ready' USING ERRCODE = '23514';
     END IF;
     IF target.state = 'active' THEN RETURN; END IF;

--- a/apps/api/migrations/20260723000001_semantic_search_activation_readiness_hardening.down.sql
+++ b/apps/api/migrations/20260723000001_semantic_search_activation_readiness_hardening.down.sql
@@ -1,0 +1,56 @@
+-- Restore the pre-hardening activation function before removing the shared
+-- readiness helper, then remove the additive generation/state index.
+
+-- Atomically switches only a fully completed generation.  The old active
+-- generation is retained for an explicit operator rollback via the same gate.
+CREATE OR REPLACE FUNCTION weltgewebe_activate_search_generation(p_generation_id TEXT)
+RETURNS VOID LANGUAGE plpgsql AS $$
+DECLARE target search_index_generations%ROWTYPE;
+BEGIN
+    PERFORM pg_advisory_xact_lock(hashtextextended('weltgewebe.search.generation.activation', 0));
+    SELECT * INTO target FROM search_index_generations WHERE generation_id = p_generation_id FOR UPDATE;
+    IF NOT FOUND THEN RAISE EXCEPTION 'unknown search generation' USING ERRCODE = '23503'; END IF;
+    IF target.state NOT IN ('building', 'ready', 'active')
+       OR target.completed_nodes <> target.expected_nodes
+       OR EXISTS (
+           SELECT 1 FROM search_node_versions v
+           WHERE v.deleted_at IS NULL
+             AND NOT EXISTS (
+                 SELECT 1 FROM search_node_projections p
+                 WHERE p.generation_id = p_generation_id
+                   AND p.node_id = v.node_id
+                   AND p.source_version = v.source_version
+                   AND p.source_revision = v.source_revision
+                   AND p.semantic_state = 'ready'
+                   AND cardinality(p.embedding) = target.dimension
+             )
+       )
+       OR EXISTS (
+           SELECT 1 FROM search_projection_jobs j
+           WHERE j.generation_id = p_generation_id
+             AND j.state NOT IN ('done', 'stale')
+       )
+       OR EXISTS (
+           SELECT 1
+           FROM search_node_versions v
+           JOIN search_node_projections p
+             ON p.generation_id = p_generation_id
+            AND p.node_id = v.node_id
+           WHERE v.deleted_at IS NOT NULL
+       )
+    THEN
+      RAISE EXCEPTION 'generation is not complete and ready' USING ERRCODE = '23514';
+    END IF;
+    IF target.state = 'active' THEN RETURN; END IF;
+    -- A complete building generation may activate directly.  This permits a
+    -- new rebuild while the current active+ready pair remains rollback-safe.
+    -- The advisory lock makes the retirement/swap atomic to every caller.
+    UPDATE search_index_generations SET state = 'building' WHERE generation_id = p_generation_id;
+    UPDATE search_index_generations SET state = 'retired', activated_at = NULL
+      WHERE state = 'ready';
+    UPDATE search_index_generations SET state = 'ready', activated_at = NULL WHERE state = 'active';
+    UPDATE search_index_generations SET state = 'active', activated_at = clock_timestamp() WHERE generation_id = p_generation_id;
+END; $$;
+
+DROP FUNCTION IF EXISTS weltgewebe_search_generation_activation_ready(TEXT);
+DROP INDEX IF EXISTS search_projection_jobs_generation_state;

--- a/apps/api/migrations/20260723000001_semantic_search_activation_readiness_hardening.up.sql
+++ b/apps/api/migrations/20260723000001_semantic_search_activation_readiness_hardening.up.sql
@@ -1,0 +1,68 @@
+-- P0 follow-up: keep already-applied migration 20260721000001 immutable.
+-- The readiness helper and generation-state index were originally introduced
+-- by editing that historical migration; they belong in this additive migration.
+
+CREATE INDEX IF NOT EXISTS search_projection_jobs_generation_state
+    ON search_projection_jobs (generation_id, state);
+
+-- Canonical, read-only activation gate shared by worker reconciliation,
+-- operational status, and the actual activation function. Keep all readiness
+-- semantics here so those three surfaces cannot drift independently.
+CREATE OR REPLACE FUNCTION weltgewebe_search_generation_activation_ready(p_generation_id TEXT)
+RETURNS BOOLEAN LANGUAGE sql STABLE AS $$
+SELECT COALESCE((
+    SELECT g.state IN ('building', 'ready', 'active')
+       AND g.completed_nodes = g.expected_nodes
+       AND NOT EXISTS (
+           SELECT 1 FROM search_node_versions v
+           WHERE v.deleted_at IS NULL
+             AND NOT EXISTS (
+                 SELECT 1 FROM search_node_projections p
+                 WHERE p.generation_id = g.generation_id
+                   AND p.node_id = v.node_id
+                   AND p.source_version = v.source_version
+                   AND p.source_revision = v.source_revision
+                   AND p.semantic_state = 'ready'
+                   AND cardinality(p.embedding) = g.dimension
+             )
+       )
+       AND NOT EXISTS (
+           SELECT 1 FROM search_projection_jobs j
+           WHERE j.generation_id = g.generation_id
+             AND j.state NOT IN ('done', 'stale')
+       )
+       AND NOT EXISTS (
+           SELECT 1
+           FROM search_node_versions v
+           JOIN search_node_projections p
+             ON p.generation_id = g.generation_id
+            AND p.node_id = v.node_id
+           WHERE v.deleted_at IS NOT NULL
+       )
+    FROM search_index_generations g
+    WHERE g.generation_id = p_generation_id
+), FALSE);
+$$;
+
+-- Atomically switches only a fully completed generation.  The old active
+-- generation is retained for an explicit operator rollback via the same gate.
+CREATE OR REPLACE FUNCTION weltgewebe_activate_search_generation(p_generation_id TEXT)
+RETURNS VOID LANGUAGE plpgsql AS $$
+DECLARE target search_index_generations%ROWTYPE;
+BEGIN
+    PERFORM pg_advisory_xact_lock(hashtextextended('weltgewebe.search.generation.activation', 0));
+    SELECT * INTO target FROM search_index_generations WHERE generation_id = p_generation_id FOR UPDATE;
+    IF NOT FOUND THEN RAISE EXCEPTION 'unknown search generation' USING ERRCODE = '23503'; END IF;
+    IF NOT weltgewebe_search_generation_activation_ready(p_generation_id) THEN
+      RAISE EXCEPTION 'generation is not complete and ready' USING ERRCODE = '23514';
+    END IF;
+    IF target.state = 'active' THEN RETURN; END IF;
+    -- A complete building generation may activate directly.  This permits a
+    -- new rebuild while the current active+ready pair remains rollback-safe.
+    -- The advisory lock makes the retirement/swap atomic to every caller.
+    UPDATE search_index_generations SET state = 'building' WHERE generation_id = p_generation_id;
+    UPDATE search_index_generations SET state = 'retired', activated_at = NULL
+      WHERE state = 'ready';
+    UPDATE search_index_generations SET state = 'ready', activated_at = NULL WHERE state = 'active';
+    UPDATE search_index_generations SET state = 'active', activated_at = clock_timestamp() WHERE generation_id = p_generation_id;
+END; $$;

--- a/apps/api/tests/db_migration_checksum_recovery.rs
+++ b/apps/api/tests/db_migration_checksum_recovery.rs
@@ -1,0 +1,86 @@
+//! Regression proof for applied SQLx migration immutability.
+//!
+//! The test first applies the migration set that production had already
+//! recorded before the P0 incident, then upgrades with the complete current
+//! migration directory. Any edit to an already-applied migration makes SQLx
+//! reject the second step with a checksum mismatch.
+
+mod support;
+
+use std::{fs, path::PathBuf};
+
+use sqlx::{migrate::Migrator, postgres::PgPoolOptions, Row};
+
+#[tokio::test]
+#[ignore = "requires direct disposable PostgreSQL via DATABASE_URL"]
+async fn previously_applied_migrations_upgrade_without_checksum_mismatch() {
+    let url = std::env::var("DATABASE_URL")
+        .expect("DATABASE_URL must point to a direct disposable PostgreSQL database");
+    support::postgres_proof::assert_direct_disposable_database_url(&url);
+
+    let pool = PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&url)
+        .await
+        .expect("connect migration checksum recovery PostgreSQL");
+
+    let migrations = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("migrations");
+    let historical = tempfile::tempdir().expect("create historical migration directory");
+    for entry in fs::read_dir(&migrations).expect("read migrations directory") {
+        let entry = entry.expect("read migration entry");
+        let file_name = entry.file_name();
+        let file_name_text = file_name.to_string_lossy();
+        if file_name_text.starts_with("20260723000001_") {
+            continue;
+        }
+        fs::copy(entry.path(), historical.path().join(&file_name))
+            .expect("copy historical migration fixture");
+    }
+
+    Migrator::new(historical.path())
+        .await
+        .expect("load historical migrations")
+        .run(&pool)
+        .await
+        .expect("apply historical migrations with production-compatible checksums");
+
+    let historical_checksum: Vec<u8> = sqlx::query(
+        "SELECT checksum FROM _sqlx_migrations WHERE version = 20260721000001 AND success = TRUE",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("read historical semantic-search migration record")
+    .get("checksum");
+    assert!(!historical_checksum.is_empty());
+
+    Migrator::new(migrations)
+        .await
+        .expect("load current migrations")
+        .run(&pool)
+        .await
+        .expect("upgrade historical database without SQLx checksum mismatch");
+
+    let hardening_applied: bool = sqlx::query_scalar(
+        "SELECT EXISTS (SELECT 1 FROM _sqlx_migrations WHERE version = 20260723000001 AND success = TRUE)",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("read additive hardening migration record");
+    assert!(hardening_applied);
+
+    let helper_exists: bool = sqlx::query_scalar(
+        "SELECT to_regprocedure('weltgewebe_search_generation_activation_ready(text)') IS NOT NULL",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("check readiness helper");
+    assert!(helper_exists);
+
+    let index_exists: bool = sqlx::query_scalar(
+        "SELECT to_regclass('search_projection_jobs_generation_state') IS NOT NULL",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("check generation/state index");
+    assert!(index_exists);
+}

--- a/scripts/ci/run-postgres-integration-proofs.sh
+++ b/scripts/ci/run-postgres-integration-proofs.sh
@@ -354,6 +354,7 @@ if [[ "${POSTGRES_PROOF_PREFLIGHT_ONLY:-0}" == "1" ]]; then
 fi
 
 targets=(
+  db_migration_checksum_recovery
   db_auto_provision_write_path
   db_domain_account_write_path
   db_domain_backfill

--- a/scripts/ci/tests/test_migration_immutability_contract.py
+++ b/scripts/ci/tests/test_migration_immutability_contract.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+HISTORICAL = REPO / "apps/api/migrations/20260721000001_semantic_search_projection_worker.up.sql"
+HARDENING_UP = REPO / "apps/api/migrations/20260723000001_semantic_search_activation_readiness_hardening.up.sql"
+HARDENING_DOWN = REPO / "apps/api/migrations/20260723000001_semantic_search_activation_readiness_hardening.down.sql"
+EXPECTED_HISTORICAL_SHA384 = "0e1612268276f4805cfb1ef5dd3e8d688f24fbbdcc1a861a71aa7da1ad5649dbcbcd775551383e4d19c8f9f6c2a94c16"
+
+
+def test_applied_semantic_search_migration_remains_byte_immutable() -> None:
+    assert hashlib.sha384(HISTORICAL.read_bytes()).hexdigest() == EXPECTED_HISTORICAL_SHA384
+
+
+def test_activation_hardening_lives_only_in_additive_migration() -> None:
+    historical = HISTORICAL.read_text(encoding="utf-8")
+    up = HARDENING_UP.read_text(encoding="utf-8")
+    down = HARDENING_DOWN.read_text(encoding="utf-8")
+
+    assert "weltgewebe_search_generation_activation_ready" not in historical
+    assert "search_projection_jobs_generation_state" not in historical
+
+    assert "CREATE OR REPLACE FUNCTION weltgewebe_search_generation_activation_ready" in up
+    assert "CREATE INDEX IF NOT EXISTS search_projection_jobs_generation_state" in up
+    assert "IF NOT weltgewebe_search_generation_activation_ready(p_generation_id) THEN" in up
+
+    assert "DROP FUNCTION IF EXISTS weltgewebe_search_generation_activation_ready(TEXT)" in down
+    assert "DROP INDEX IF EXISTS search_projection_jobs_generation_state" in down
+    assert "target.state NOT IN ('building', 'ready', 'active')" in down


### PR DESCRIPTION
<!-- weltgewebe-risk: R3 -->

P0 production recovery for the rollout failure introduced by merged PR #1548.

Root cause: `apps/api/migrations/20260721000001_semantic_search_projection_worker.up.sql` had already been applied in production, but PR #1548 modified its bytes. SQLx correctly refused API startup with `migration 20260721000001 was previously applied but has been modified`, leaving `/api/version` at HTTP 502 while the production reconciler retried.

This hotfix restores migration `20260721000001` byte-for-byte to the previously deployed checksum and moves the readiness helper/index/activation-function hardening into new additive migration `20260723000001`.

Regression protection:
- pin the historical migration SHA-384 in a CI contract test;
- add a real SQLx upgrade proof that first applies the pre-hotfix migration set, then upgrades with the full current set;
- run that upgrade proof as the first PostgreSQL integration target.

Exact-head local evidence before publication:
- historical migration matches deployed `ed5559049466b6c9310d12b1a148b8eda8c4b2c3` byte-for-byte;
- migration immutability contract tests PASS;
- cargo fmt --check PASS;
- shfmt/shellcheck for the changed proof runner PASS;
- cargo check --locked -p weltgewebe-api PASS;
- real SQLx old-history -> current migration upgrade proof PASS against isolated Postgres 16.

The full PostgreSQL integration proof suite is running in parallel and remains merge-blocking if it reports a regression.