### PR TITLE
ci: add pinned Trivy rendered-manifest security evidence

### DIFF
--- a/.github/workflows/kubernetes-platform.yml
+++ b/.github/workflows/kubernetes-platform.yml
@@ -17,7 +17,9 @@ permissions:
       - "infra/compose/compose.prod.yml"
       - "platform/**"
       - "scripts/platform/**"
+      - "scripts/security/**"
       - "scripts/ci/tests/test_kubernetes_platform_contract.py"
+      - "scripts/ci/tests/test_trivy_rendered_manifests.py"
       - "scripts/ci/tests/test_kubernetes_ha_contract.py"
       - "repo.meta.yaml"
   push:
@@ -30,7 +32,9 @@ permissions:
       - "infra/compose/compose.prod.yml"
       - "platform/**"
       - "scripts/platform/**"
+      - "scripts/security/**"
       - "scripts/ci/tests/test_kubernetes_platform_contract.py"
+      - "scripts/ci/tests/test_trivy_rendered_manifests.py"
       - "scripts/ci/tests/test_kubernetes_ha_contract.py"
       - "repo.meta.yaml"
 
@@ -58,13 +62,38 @@ jobs:
           scripts/platform/validate_platform.py
           scripts/platform/kind_reference.py
           scripts/platform/ha_reference.py
+          scripts/security/trivy_rendered_manifests.py
       - name: Run platform contract tests
         run: >-
           python -m unittest
           scripts.ci.tests.test_kubernetes_platform_contract
           scripts.ci.tests.test_kubernetes_ha_contract
+          scripts.ci.tests.test_trivy_rendered_manifests
       - name: Render and validate all platform targets
         run: python scripts/platform/validate_platform.py --render
+
+  trivy-rendered-security:
+    needs: contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # tag: v7.0.1
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # tag: v7.0.0
+        with:
+          python-version: "3.10"
+      - name: Install validator dependency
+        run: python -m pip install --disable-pip-version-check 'PyYAML==6.0.3'
+      - name: Scan canonical rendered manifests and generate CycloneDX SBOM
+        run: python scripts/security/trivy_rendered_manifests.py
+      - name: Upload Trivy evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
+        with:
+          name: trivy-rendered-security-${{ github.run_id }}-${{ github.run_attempt }}
+          path: build/security/trivy/*.json
+          if-no-files-found: error
+          retention-days: 14
 
   kind-gitops-proof:
     needs: contract

--- a/platform/toolchain.lock.json
+++ b/platform/toolchain.lock.json
@@ -54,6 +54,13 @@
       "sha256": "e9b88b4ee95b18c706839c28d3a0220e5bc470e9cd9262410c90793c45ff8b7c",
       "format": "tar.gz",
       "binary": "helm"
+    },
+    "trivy": {
+      "version": "0.72.0",
+      "url": "https://github.com/aquasecurity/trivy/releases/download/v0.72.0/trivy_0.72.0_Linux-64bit.tar.gz",
+      "sha256": "bbb64b9695866ce4a7a8f5c9592002c5961cab378577fa3f8a040df362b9b2ea",
+      "binary": "trivy",
+      "format": "tar.gz"
     }
   },
   "artifacts": {

--- a/scripts/ci/tests/test_kubernetes_ha_contract.py
+++ b/scripts/ci/tests/test_kubernetes_ha_contract.py
@@ -194,7 +194,7 @@ class KubernetesHaContractTests(unittest.TestCase):
             "ref: ${{ github.event_name == 'pull_request' && "
             "github.event.pull_request.head.sha || github.sha }}"
         )
-        self.assertEqual(workflow.count(expected), 3)
+        self.assertEqual(workflow.count(expected), 4)
 
     def test_zone_contract_requires_three_distinct_zones(self) -> None:
         valid = {

--- a/scripts/ci/tests/test_kubernetes_platform_contract.py
+++ b/scripts/ci/tests/test_kubernetes_platform_contract.py
@@ -47,6 +47,10 @@ class KubernetesPlatformContractTests(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "unknown tool selection"):
             self.bootstrap._selected_tool_specs(lock, ["missing"])
 
+    def test_kind_reference_requests_ha_required_kubectl_cnpg_tool(self) -> None:
+        source = (ROOT / "scripts/platform/kind_reference.py").read_text(encoding="utf-8")
+        self.assertIn('"kubectl_cnpg"', source)
+
     def test_static_platform_contract_passes(self) -> None:
         result = self.validator.validate(render=False)
         self.assertEqual(result["status"], "pass")

--- a/scripts/ci/tests/test_kubernetes_platform_contract.py
+++ b/scripts/ci/tests/test_kubernetes_platform_contract.py
@@ -40,6 +40,13 @@ class KubernetesPlatformContractTests(unittest.TestCase):
             ROOT / "scripts/platform/bootstrap_tools.py",
         )
 
+    def test_tool_bootstrap_selection_is_exact_and_deduplicated(self) -> None:
+        lock = {"tools": {"kustomize": {"version": "x"}, "trivy": {"version": "y"}}}
+        selected = self.bootstrap._selected_tool_specs(lock, ["trivy", "trivy"])
+        self.assertEqual(selected, {"trivy": {"version": "y"}})
+        with self.assertRaisesRegex(RuntimeError, "unknown tool selection"):
+            self.bootstrap._selected_tool_specs(lock, ["missing"])
+
     def test_static_platform_contract_passes(self) -> None:
         result = self.validator.validate(render=False)
         self.assertEqual(result["status"], "pass")

--- a/scripts/ci/tests/test_trivy_rendered_manifests.py
+++ b/scripts/ci/tests/test_trivy_rendered_manifests.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = ROOT / "scripts/security/trivy_rendered_manifests.py"
+SPEC = importlib.util.spec_from_file_location("trivy_rendered_manifests", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+trivy_scan = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(trivy_scan)
+
+
+class TrivyRenderedManifestTests(unittest.TestCase):
+    def test_canonical_targets_come_from_validator_readback(self) -> None:
+        completed = subprocess.CompletedProcess(
+            args=["python"],
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "status": "pass",
+                    "rendered_documents": {
+                        "platform/a": 2,
+                        "platform/b": 3,
+                    },
+                }
+            ),
+            stderr="",
+        )
+        with mock.patch.object(trivy_scan, "_run", return_value=completed) as run:
+            targets = trivy_scan.canonical_render_targets()
+        self.assertEqual(targets, ["platform/a", "platform/b"])
+        self.assertIn("--render", run.call_args.args[0])
+
+    def test_invalid_validator_readback_fails_closed(self) -> None:
+        completed = subprocess.CompletedProcess(
+            args=["python"],
+            returncode=0,
+            stdout=json.dumps({"status": "pass", "rendered_documents": {"outside/a": 1}}),
+            stderr="",
+        )
+        with mock.patch.object(trivy_scan, "_run", return_value=completed):
+            with self.assertRaisesRegex(trivy_scan.TrivyProductionError, "invalid render target"):
+                trivy_scan.canonical_render_targets()
+
+    def test_misconfiguration_summary_counts_findings_and_unique_rules(self) -> None:
+        summary = trivy_scan.summarize_misconfig_report(
+            {
+                "Results": [
+                    {
+                        "Misconfigurations": [
+                            {"ID": "KSV-0001", "Severity": "HIGH"},
+                            {"ID": "KSV-0001", "Severity": "LOW"},
+                            {"AVDID": "KSV-0002", "Severity": "MEDIUM"},
+                        ]
+                    }
+                ]
+            }
+        )
+        self.assertEqual(summary["finding_count"], 3)
+        self.assertEqual(summary["rule_id_count"], 2)
+        self.assertEqual(summary["rule_ids"], ["KSV-0001", "KSV-0002"])
+        self.assertEqual(summary["severity_counts"], {"HIGH": 1, "LOW": 1, "MEDIUM": 1})
+
+    def test_findings_are_advisory_but_command_failure_is_not(self) -> None:
+        command = trivy_scan.trivy_config_command("trivy", Path("cache"), Path("report.json"), Path("rendered"))
+        self.assertIn("--skip-check-update", command)
+        self.assertNotIn("--exit-code", command)
+        with mock.patch.object(
+            trivy_scan.subprocess,
+            "run",
+            side_effect=subprocess.CalledProcessError(1, ["trivy"]),
+        ):
+            with self.assertRaisesRegex(trivy_scan.TrivyProductionError, "command failed"):
+                trivy_scan._run(["trivy", "config"])
+
+    def test_bootstrap_requests_only_security_tools(self) -> None:
+        completed = subprocess.CompletedProcess(
+            args=["python"],
+            returncode=0,
+            stdout=json.dumps({"tools": {"kustomize": "/kustomize", "trivy": "/trivy"}}),
+            stderr="",
+        )
+        with mock.patch.object(trivy_scan, "_run", return_value=completed) as run:
+            tools = trivy_scan.bootstrap_security_tools()
+        self.assertEqual(tools, {"kustomize": "/kustomize", "trivy": "/trivy"})
+        argv = run.call_args.args[0]
+        self.assertEqual(argv.count("--tool"), 2)
+        self.assertIn("--skip-artifacts", argv)
+        self.assertNotIn("kind", argv)
+
+    def test_render_targets_rejects_empty_output(self) -> None:
+        completed = subprocess.CompletedProcess(args=["kustomize"], returncode=0, stdout="", stderr="")
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.object(trivy_scan, "_run", return_value=completed):
+                with self.assertRaisesRegex(trivy_scan.TrivyProductionError, "empty Kustomize output"):
+                    trivy_scan.render_targets("kustomize", ["platform/a"], Path(tmp))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/platform/bootstrap_tools.py
+++ b/scripts/platform/bootstrap_tools.py
@@ -112,7 +112,23 @@ def _check_host(lock: dict[str, Any]) -> None:
         raise RuntimeError("unexpected platform lock")
 
 
-def install(cache: Path) -> dict[str, Any]:
+def _selected_tool_specs(lock: dict[str, Any], requested: list[str] | None) -> dict[str, Any]:
+    tools = lock["tools"]
+    if requested is None:
+        return tools
+    names = list(dict.fromkeys(requested))
+    unknown = [name for name in names if name not in tools]
+    if unknown:
+        raise RuntimeError(f"unknown tool selection: {', '.join(unknown)}")
+    return {name: tools[name] for name in names}
+
+
+def install(
+    cache: Path,
+    *,
+    tool_names: list[str] | None = None,
+    include_artifacts: bool = True,
+) -> dict[str, Any]:
     lock = json.loads(LOCK_PATH.read_text(encoding="utf-8"))
     if lock.get("schema_version") != 1:
         raise RuntimeError("unsupported toolchain lock schema")
@@ -124,7 +140,7 @@ def install(cache: Path) -> dict[str, Any]:
     artifact_dir.mkdir(parents=True, exist_ok=True)
     tool_paths: dict[str, str] = {}
 
-    for name, spec in lock["tools"].items():
+    for name, spec in _selected_tool_specs(lock, tool_names).items():
         filename = Path(urllib.parse.urlparse(spec["url"]).path).name
         archive = downloads / filename
         _download(spec["url"], spec["sha256"], archive)
@@ -147,11 +163,12 @@ def install(cache: Path) -> dict[str, Any]:
         tool_paths[name] = str(destination)
 
     artifact_paths: dict[str, str] = {}
-    for name, spec in lock["artifacts"].items():
-        destination = artifact_dir / spec["filename"]
-        _download(spec["url"], spec["sha256"], destination)
-        _assert_artifact_contract(name, destination, spec)
-        artifact_paths[name] = str(destination)
+    if include_artifacts:
+        for name, spec in lock["artifacts"].items():
+            destination = artifact_dir / spec["filename"]
+            _download(spec["url"], spec["sha256"], destination)
+            _assert_artifact_contract(name, destination, spec)
+            artifact_paths[name] = str(destination)
 
     receipt = {
         "schema_version": 1,
@@ -171,8 +188,14 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--cache", type=Path, default=DEFAULT_CACHE)
     parser.add_argument("--json", action="store_true")
+    parser.add_argument("--tool", action="append", dest="tools")
+    parser.add_argument("--skip-artifacts", action="store_true")
     args = parser.parse_args()
-    receipt = install(args.cache.resolve())
+    receipt = install(
+        args.cache.resolve(),
+        tool_names=args.tools,
+        include_artifacts=not args.skip_artifacts,
+    )
     if args.json:
         print(json.dumps(receipt, sort_keys=True))
     else:

--- a/scripts/platform/kind_reference.py
+++ b/scripts/platform/kind_reference.py
@@ -96,6 +96,8 @@ def tool_receipt() -> dict[str, Any]:
             "flux",
             "--tool",
             "helm",
+            "--tool",
+            "kubectl_cnpg",
         ]
     )
     return json.loads(raw)

--- a/scripts/platform/kind_reference.py
+++ b/scripts/platform/kind_reference.py
@@ -81,7 +81,23 @@ def control_plane_address(cluster: str) -> str:
 
 
 def tool_receipt() -> dict[str, Any]:
-    raw = output([sys.executable, "scripts/platform/bootstrap_tools.py", "--json"])
+    raw = output(
+        [
+            sys.executable,
+            "scripts/platform/bootstrap_tools.py",
+            "--json",
+            "--tool",
+            "kind",
+            "--tool",
+            "kubectl",
+            "--tool",
+            "kustomize",
+            "--tool",
+            "flux",
+            "--tool",
+            "helm",
+        ]
+    )
     return json.loads(raw)
 
 

--- a/scripts/platform/validate_platform.py
+++ b/scripts/platform/validate_platform.py
@@ -446,7 +446,18 @@ def _run(command: list[str], *, input_text: str | None = None) -> subprocess.Com
 
 def _render_and_validate() -> dict[str, int]:
     receipt = json.loads(
-        _run([sys.executable, "scripts/platform/bootstrap_tools.py", "--json"]).stdout
+        _run(
+            [
+                sys.executable,
+                "scripts/platform/bootstrap_tools.py",
+                "--json",
+                "--tool",
+                "kustomize",
+                "--tool",
+                "kubeconform",
+                "--skip-artifacts",
+            ]
+        ).stdout
     )
     kustomize = receipt["tools"]["kustomize"]
     kubeconform = receipt["tools"]["kubeconform"]

--- a/scripts/security/trivy_rendered_manifests.py
+++ b/scripts/security/trivy_rendered_manifests.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Any, Sequence
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_OUTPUT = ROOT / "build/security/trivy"
+DEFAULT_CACHE = ROOT / ".cache/weltgewebe-trivy"
+
+
+class TrivyProductionError(RuntimeError):
+    pass
+
+
+def _run(command: Sequence[str], *, cwd: Path = ROOT) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            list(command),
+            cwd=cwd,
+            text=True,
+            check=True,
+            capture_output=True,
+            timeout=300,
+        )
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        raise TrivyProductionError(f"command failed: {command[0]}") from exc
+
+
+def canonical_render_targets() -> list[str]:
+    completed = _run([sys.executable, "scripts/platform/validate_platform.py", "--render"])
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise TrivyProductionError("platform validator returned invalid JSON") from exc
+    rendered = payload.get("rendered_documents")
+    if payload.get("status") != "pass" or not isinstance(rendered, dict) or not rendered:
+        raise TrivyProductionError("platform validator did not return canonical rendered targets")
+    targets = list(rendered)
+    if any(not isinstance(target, str) or not target.startswith("platform/") for target in targets):
+        raise TrivyProductionError("platform validator returned an invalid render target")
+    return targets
+
+
+def bootstrap_security_tools() -> dict[str, str]:
+    completed = _run(
+        [
+            sys.executable,
+            "scripts/platform/bootstrap_tools.py",
+            "--json",
+            "--tool",
+            "kustomize",
+            "--tool",
+            "trivy",
+            "--skip-artifacts",
+        ]
+    )
+    try:
+        payload = json.loads(completed.stdout)
+        tools = payload["tools"]
+        selected = {name: tools[name] for name in ("kustomize", "trivy")}
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise TrivyProductionError("tool bootstrap returned an invalid receipt") from exc
+    return selected
+
+
+def _target_slug(target: str) -> str:
+    return target.replace("/", "__")
+
+
+def render_targets(kustomize: str, targets: Sequence[str], destination: Path) -> dict[str, str]:
+    destination.mkdir(parents=True, exist_ok=True)
+    rendered_paths: dict[str, str] = {}
+    for target in targets:
+        completed = _run([kustomize, "build", target])
+        if not completed.stdout.strip():
+            raise TrivyProductionError(f"empty Kustomize output for {target}")
+        output = destination / f"{_target_slug(target)}.yaml"
+        output.write_text(completed.stdout, encoding="utf-8")
+        rendered_paths[target] = str(output)
+    return rendered_paths
+
+
+def summarize_misconfig_report(report: dict[str, Any]) -> dict[str, Any]:
+    results = report.get("Results", [])
+    if results is None:
+        results = []
+    if not isinstance(results, list):
+        raise TrivyProductionError("Trivy report Results must be a list")
+    severities: Counter[str] = Counter()
+    rule_ids: set[str] = set()
+    total = 0
+    for result in results:
+        if not isinstance(result, dict):
+            raise TrivyProductionError("Trivy report contains an invalid result")
+        findings = result.get("Misconfigurations") or []
+        if not isinstance(findings, list):
+            raise TrivyProductionError("Trivy report Misconfigurations must be a list")
+        for finding in findings:
+            if not isinstance(finding, dict):
+                raise TrivyProductionError("Trivy report contains an invalid misconfiguration")
+            total += 1
+            severity = finding.get("Severity")
+            severities[str(severity).upper() if severity else "UNKNOWN"] += 1
+            rule_id = finding.get("ID") or finding.get("AVDID")
+            if rule_id:
+                rule_ids.add(str(rule_id))
+    return {
+        "finding_count": total,
+        "rule_id_count": len(rule_ids),
+        "rule_ids": sorted(rule_ids),
+        "severity_counts": dict(sorted(severities.items())),
+    }
+
+
+def trivy_config_command(trivy: str, cache: Path, report: Path, rendered_dir: Path) -> list[str]:
+    return [
+        trivy,
+        "--cache-dir",
+        str(cache),
+        "config",
+        "--skip-check-update",
+        "--format",
+        "json",
+        "--output",
+        str(report),
+        str(rendered_dir),
+    ]
+
+
+def trivy_sbom_command(trivy: str, cache: Path, output: Path) -> list[str]:
+    return [
+        trivy,
+        "--cache-dir",
+        str(cache),
+        "fs",
+        "--format",
+        "cyclonedx",
+        "--output",
+        str(output),
+        str(ROOT),
+    ]
+
+
+def produce(output: Path = DEFAULT_OUTPUT, cache: Path = DEFAULT_CACHE) -> dict[str, Any]:
+    targets = canonical_render_targets()
+    tools = bootstrap_security_tools()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    cache.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="weltgewebe-trivy-") as tmp:
+        stage = Path(tmp)
+        rendered_dir = stage / "rendered"
+        rendered_paths = render_targets(tools["kustomize"], targets, rendered_dir)
+        misconfig_report = stage / "misconfigurations.json"
+        sbom = stage / "sbom.cdx.json"
+
+        _run(trivy_config_command(tools["trivy"], cache, misconfig_report, rendered_dir))
+        try:
+            report = json.loads(misconfig_report.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise TrivyProductionError("Trivy did not produce a valid misconfiguration report") from exc
+        finding_summary = summarize_misconfig_report(report)
+
+        _run(trivy_sbom_command(tools["trivy"], cache, sbom))
+        try:
+            sbom_payload = json.loads(sbom.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise TrivyProductionError("Trivy did not produce a valid CycloneDX SBOM") from exc
+        if sbom_payload.get("bomFormat") != "CycloneDX":
+            raise TrivyProductionError("Trivy SBOM is not CycloneDX")
+
+        summary: dict[str, Any] = {
+            "schema_version": 1,
+            "status": "pass",
+            "policy": "advisory-findings-fail-closed-on-execution-error",
+            "canonical_target_count": len(targets),
+            "canonical_targets": targets,
+            "rendered_file_count": len(rendered_paths),
+            "trivy_findings": finding_summary,
+            "sbom_format": "CycloneDX",
+        }
+        summary_path = stage / "summary.json"
+        summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+        if output.is_symlink():
+            raise TrivyProductionError("refusing symlinked output directory")
+        if output.exists() and not output.is_dir():
+            raise TrivyProductionError("output path is not a directory")
+        output.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(misconfig_report, output / misconfig_report.name)
+        shutil.copy2(sbom, output / sbom.name)
+        shutil.copy2(summary_path, output / summary_path.name)
+
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Scan canonical rendered Kubernetes manifests with pinned Trivy and emit a CycloneDX SBOM.")
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--cache", type=Path, default=DEFAULT_CACHE)
+    args = parser.parse_args()
+    try:
+        result = produce(args.output.expanduser().absolute(), args.cache.expanduser().absolute())
+    except TrivyProductionError as exc:
+        print(json.dumps({"status": "error", "error": str(exc)}, sort_keys=True))
+        return 2
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
<!-- weltgewebe-risk: R3 -->

## Zweck

Schließt den Trivy-Produktionspfad von `OPERATOR-ECOSYSTEM-REDUNDANCY-V1-T045` reproduzierbar und ohne globales Roh-YAML-Gate.

## Architektur

- Trivy `v0.72.0` wird über den bestehenden SHA-256-verifizierten Plattform-Bootstrap direkt aus der offiziellen Release-Tarball-Quelle geladen.
- Keine `aquasecurity/trivy-action`-Abhängigkeit.
- Der Plattform-Bootstrap unterstützt exakte Tool-Auswahl; Validator und Security-Job laden keine unnötigen Werkzeuge oder Kubernetes-Artefakte.
- Der Kind/HA-Pfad behält explizit `kind`, `kubectl`, `kubectl_cnpg`, `kustomize`, `flux` und `helm`; diese Abhängigkeit wurde nach einem echten CI-Fund ergänzt und vertraglich getestet.
- Die zu scannenden Kustomize-Ziele werden **nicht dupliziert**: Der Security-Pfad übernimmt die kanonischen Targets aus `validate_platform.py --render`.
- Trivy scannt ausschließlich die gerenderten Manifeste mit den im gepinnten Binary enthaltenen Checks (`--skip-check-update`).
- Findings bleiben bewusst advisory; Render-, Bootstrap-, Scan-, JSON- und CycloneDX-Fehler blockieren fail-closed.
- Zusätzlich wird eine CycloneDX-SBOM als CI-Artefakt erzeugt.
- CI veröffentlicht `misconfigurations.json`, `sbom.cdx.json` und `summary.json`.

## Evidenz

- Exakter Review-Head: `4f30f930f51f0450d5ea32737e5c8bbc82a6d915`
- Basis: `63e1752e5be84e246d31304e7c9fba1cbf124d43`
- Diff-SHA-256: `78da2f5dbb05a07f591ed0f79e4f34a48842ce48034e073415dfbf661dbaa223`
- 108/108 Plattform-/HA-/Trivy-Vertragstests: PASS
- Reales `kind_reference.tool_receipt()`: `kubectl_cnpg` vorhanden
- `py_compile`: PASS
- `git diff --check`: PASS
- Kanonischer Render: PASS, 11 Targets
- Realer Trivy-Produktionslauf: PASS
- Aktueller Renderbefund: 22 Findings / 5 Rule-IDs (`KSV-0020`, `KSV-0021`, `KSV-01010`, `KSV-0109`, `KSV-0125`)
- `KSV-0014`: nicht mehr vorhanden
- CycloneDX-SBOM: PASS
- Head-/Diff-gebundener Self-Review: PASS nach Korrektur des im ersten CI-Lauf gefundenen `kubectl_cnpg`-Dependency-Drifts.

## Policy

Die verbleibenden Befunde werden nicht pauschal zum Merge-Gate erhoben, weil die T045-Triage bereits gezeigt hat, dass Rohsignal und reale Schwachstelle nicht gleichzusetzen sind. Ein späteres Blocking einzelner Rule-IDs soll explizit pro triagierter Regel erfolgen.