### PR TITLE
fix: harden Kubernetes proof truth and ownership

### DIFF
--- a/.github/workflows/kubernetes-platform.yml
+++ b/.github/workflows/kubernetes-platform.yml
@@ -11,9 +11,14 @@ permissions:
   pull_request:
     paths:
       - ".github/workflows/kubernetes-platform.yml"
-      - "apps/api/Dockerfile"
-      - "apps/api/entrypoint.sh"
+      - ".dockerignore"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "toolchain.versions.yml"
+      - "apps/api/**"
       - "apps/web/**"
+      - "scripts/dev/**"
+      - "policies/**"
       - "infra/compose/compose.prod.yml"
       - "platform/**"
       - "scripts/platform/**"
@@ -26,9 +31,14 @@ permissions:
     branches: [main]
     paths:
       - ".github/workflows/kubernetes-platform.yml"
-      - "apps/api/Dockerfile"
-      - "apps/api/entrypoint.sh"
+      - ".dockerignore"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "toolchain.versions.yml"
+      - "apps/api/**"
       - "apps/web/**"
+      - "scripts/dev/**"
+      - "policies/**"
       - "infra/compose/compose.prod.yml"
       - "platform/**"
       - "scripts/platform/**"
@@ -48,8 +58,6 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # tag: v7.0.1
-        with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # tag: v7.0.0
         with:
           python-version: "3.10"
@@ -78,8 +86,6 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # tag: v7.0.1
-        with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # tag: v7.0.0
         with:
           python-version: "3.10"
@@ -101,10 +107,9 @@ jobs:
     timeout-minutes: 45
     env:
       CLUSTER_NAME: wg-${{ github.run_id }}-${{ github.run_attempt }}
+      PROOF_OWNER_ID: gha-kind-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # tag: v7.0.1
-        with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # tag: v7.0.0
         with:
           python-version: "3.10"
@@ -116,6 +121,7 @@ jobs:
           python scripts/platform/kind_reference.py proof
           --cluster "$CLUSTER_NAME"
           --mode direct
+          --owner-id "$PROOF_OWNER_ID"
       - name: Run commit-bound GitOps reference proof
         if: github.event_name != 'pull_request'
         run: >-
@@ -123,6 +129,7 @@ jobs:
           --cluster "$CLUSTER_NAME"
           --mode gitops
           --source-commit "$GITHUB_SHA"
+          --owner-id "$PROOF_OWNER_ID"
       - name: Stage failure diagnostics
         if: failure()
         run: |
@@ -141,6 +148,13 @@ jobs:
           path: build/kubernetes-platform/failures/
           if-no-files-found: ignore
           retention-days: 7
+      - name: Reconcile owned kind proof resources
+        if: always()
+        run: >-
+          python scripts/platform/kind_reference.py down
+          --cluster "$CLUSTER_NAME"
+          --commit "$(git rev-parse HEAD)"
+          --owner-id "$PROOF_OWNER_ID"
 
   kind-ha-recovery-proof:
     needs: contract
@@ -148,10 +162,9 @@ jobs:
     timeout-minutes: 90
     env:
       CLUSTER_NAME: wg-ha-${{ github.run_id }}-${{ github.run_attempt }}
+      PROOF_OWNER_ID: gha-ha-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # tag: v7.0.1
-        with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # tag: v7.0.0
         with:
           python-version: "3.10"
@@ -161,6 +174,7 @@ jobs:
         run: >-
           python scripts/platform/ha_reference.py proof
           --cluster "$CLUSTER_NAME"
+          --owner-id "$PROOF_OWNER_ID"
       - name: Stage HA recovery receipt
         run: |
           set -euo pipefail
@@ -198,3 +212,4 @@ jobs:
           python scripts/platform/ha_reference.py down
           --cluster "$CLUSTER_NAME"
           --commit "$(git rev-parse HEAD)"
+          --owner-id "$PROOF_OWNER_ID"

--- a/docs/_generated/backlinks.md
+++ b/docs/_generated/backlinks.md
@@ -251,7 +251,7 @@ Generated automatically. Do not edit.
 
 ## docs/adr/ADR-0010__kubernetes-kanonische-plattform.md
 
-- [relates_to] docs/adr/ADR-0011__ha-referenzzelle-und-wiederherstellung.md
+- [relates_to] docs/adr/ADR-0013__ha-referenzzelle-und-wiederherstellung.md
 - [relates_to] docs/blueprints/weltgewebe-os-masterplan.md
 - [depends_on] docs/reports/kubernetes-platform-foundation-status.md
 - [relates_to] docs/techstack.md
@@ -263,14 +263,14 @@ Generated automatically. Do not edit.
 - [relates_to] docs/specs/federation-core.md
 - [relates_to] docs/specs/federation-wire-v1.md
 
-## docs/adr/ADR-0011__ha-referenzzelle-und-wiederherstellung.md
-
-- [relates_to] docs/runbooks/kubernetes-ha-recovery-proof.md
-
 ## docs/adr/ADR-0012__ereignisrueckgrat-transactional-outbox.md
 
 - [relates_to] docs/blueprints/weltgewebe-os-masterplan.md
 - [relates_to] docs/specs/federation-core.md
+
+## docs/adr/ADR-0013__ha-referenzzelle-und-wiederherstellung.md
+
+- [relates_to] docs/runbooks/kubernetes-ha-recovery-proof.md
 
 ## docs/architekturstruktur.md
 
@@ -942,7 +942,7 @@ Generated automatically. Do not edit.
 
 ## docs/runbooks/kubernetes-ha-recovery-proof.md
 
-- [relates_to] docs/adr/ADR-0011__ha-referenzzelle-und-wiederherstellung.md
+- [relates_to] docs/adr/ADR-0013__ha-referenzzelle-und-wiederherstellung.md
 
 ## docs/runbooks/ops.runbook.weltgewebe-selfhost-deploy.md
 

--- a/docs/_generated/doc-index.md
+++ b/docs/_generated/doc-index.md
@@ -26,8 +26,8 @@ Generated automatically. Do not edit.
 | adr.ADR-0009__garnrolle-verortung-sichtbarkeit | ADR-0009 — Garnrolle, Verortung und Sichtbarkeit | reference | active | docs/adr/ADR-0009__garnrolle-verortung-sichtbarkeit.md |
 | adr.ADR-0010__kubernetes-kanonische-plattform | ADR-0010 — Kubernetes als kanonische Zielplattform | reference | active | docs/adr/ADR-0010__kubernetes-kanonische-plattform.md |
 | adr.ADR-0011__foederierte-gewebezellen | ADR-0011 — Föderierte Gewebe-Zellen | reference | active | docs/adr/ADR-0011__foederierte-gewebezellen.md |
-| adr.ADR-0011__ha-referenzzelle-und-wiederherstellung | ADR-0011 — Hochverfügbare Referenzzelle und Wiederherstellungsbeweis | reference | active | docs/adr/ADR-0011__ha-referenzzelle-und-wiederherstellung.md |
 | adr.ADR-0012__ereignisrueckgrat-transactional-outbox | ADR-0012 — Ereignisrückgrat mit Transactional Outbox | reference | active | docs/adr/ADR-0012__ereignisrueckgrat-transactional-outbox.md |
+| adr.ADR-0013__ha-referenzzelle-und-wiederherstellung | ADR-0013 — Hochverfügbare Referenzzelle und Wiederherstellungsbeweis | reference | active | docs/adr/ADR-0013__ha-referenzzelle-und-wiederherstellung.md |
 | blueprint-doc-structure-task-control | Weltgewebe Dokumentationsstruktur und Task-Steuerung | blueprint | draft | docs/blueprints/doc-structure-task-control.md |
 | blueprint-doc-structure-task-control-examples | Dokumentationsstruktur und Task-Steuerung Beispiele | reference | draft | docs/blueprints/doc-structure-task-control-examples.md |
 | blueprint-doc-structure-task-control-roadmap | Dokumentationsstruktur und Task-Steuerung Roadmap | roadmap | draft | docs/blueprints/doc-structure-task-control-roadmap.md |

--- a/docs/_generated/relates-to-audit.md
+++ b/docs/_generated/relates-to-audit.md
@@ -78,8 +78,8 @@ _Keine Lücken erkannt._
 - `docs/adr/ADR-0009__garnrolle-verortung-sichtbarkeit.md`
 - `docs/adr/ADR-0010__kubernetes-kanonische-plattform.md`
 - `docs/adr/ADR-0011__foederierte-gewebezellen.md`
-- `docs/adr/ADR-0011__ha-referenzzelle-und-wiederherstellung.md`
 - `docs/adr/ADR-0012__ereignisrueckgrat-transactional-outbox.md`
+- `docs/adr/ADR-0013__ha-referenzzelle-und-wiederherstellung.md`
 - `docs/architecture/weltgewebe-os-convergence-adapter.md`
 - `docs/architekturstruktur.md`
 - `docs/blueprints/agent-operability-blaupause.md`

--- a/docs/adr/ADR-0013__ha-referenzzelle-und-wiederherstellung.md
+++ b/docs/adr/ADR-0013__ha-referenzzelle-und-wiederherstellung.md
@@ -1,6 +1,6 @@
 ---
-id: adr.ADR-0011__ha-referenzzelle-und-wiederherstellung
-title: ADR-0011 — Hochverfügbare Referenzzelle und Wiederherstellungsbeweis
+id: adr.ADR-0013__ha-referenzzelle-und-wiederherstellung
+title: ADR-0013 — Hochverfügbare Referenzzelle und Wiederherstellungsbeweis
 doc_type: reference
 status: active
 summary: >
@@ -12,7 +12,7 @@ relations:
     target: docs/runbooks/kubernetes-ha-recovery-proof.md
 ---
 
-# ADR-0011 — Hochverfügbare Referenzzelle und Wiederherstellungsbeweis
+# ADR-0013 — Hochverfügbare Referenzzelle und Wiederherstellungsbeweis
 
 Datum: 2026-07-17
 Status: Accepted

--- a/docs/runbooks/kubernetes-ha-recovery-proof.md
+++ b/docs/runbooks/kubernetes-ha-recovery-proof.md
@@ -7,7 +7,7 @@ summary: >
   Führt den eigentumsgebundenen T004-Beweis für Zonenverteilung, API-Upgrade/Rollback, PostgreSQL- und JetStream-Failover sowie PITR in einen leeren kind-Cluster aus.
 relations:
   - type: relates_to
-    target: docs/adr/ADR-0011__ha-referenzzelle-und-wiederherstellung.md
+    target: docs/adr/ADR-0013__ha-referenzzelle-und-wiederherstellung.md
 ---
 
 # Kubernetes-HA- und Recovery-Beweis
@@ -66,12 +66,13 @@ Bei einem Fehler werden Clusterzustand, Pods, Events, Flux, Gateway, CloudNative
 
 ## Manuelles eigentumsgebundenes Cleanup
 
-Nur für einen abgebrochenen Lauf mit bekanntem Commit:
+Nur für einen abgebrochenen Lauf mit bekanntem Commit und der im Proof-Receipt gebundenen Owner-ID:
 
 ```bash
 python scripts/platform/ha_reference.py down \
   --cluster weltgewebe-ha-reference \
-  --commit <exakter-commit>
+  --commit <exakter-commit> \
+  --owner-id <exakte-owner-id>
 ```
 
-Ohne passende Eigentumsmarker verweigert der Befehl das Löschen.
+Ohne exakt passenden Eigentumsmarker für Repository, Commit und Owner-ID verweigert der Befehl das Löschen. Verwaiste Marker werden nicht automatisch entfernt.

--- a/platform/README.md
+++ b/platform/README.md
@@ -46,6 +46,7 @@ verifies_with:
 - Staging und Production benötigen einen externen, auditierten Secretpfad.
 - Eigene Container laufen ohne Root, ohne Service-Account-Token, ohne Privilege Escalation und mit Default-Deny-Netzpolitik.
 - Der Referenzrunner übernimmt oder löscht niemals einen bereits vorhandenen Cluster.
+- Proof-Cluster werden lokal unter einem pro Cluster serialisierten Ownership-Lock reserviert; Cleanup verlangt den exakten Commit und dieselbe Owner-ID. Verwaiste Marker werden fail-closed nicht automatisch entfernt.
 - Produktionsdeployments, DNS, Compose und reale Replikazahlen werden durch diesen Vertrag nicht verändert.
 
 ## Beweise

--- a/scripts/ci/tests/test_kubernetes_ha_contract.py
+++ b/scripts/ci/tests/test_kubernetes_ha_contract.py
@@ -188,13 +188,29 @@ class KubernetesHaContractTests(unittest.TestCase):
                 relative,
             )
 
-    def test_ha_workflow_checks_out_the_immutable_pr_head(self) -> None:
+    def test_kubernetes_workflow_checks_out_the_event_merge_state(self) -> None:
         workflow = (ROOT / ".github/workflows/kubernetes-platform.yml").read_text()
-        expected = (
-            "ref: ${{ github.event_name == 'pull_request' && "
-            "github.event.pull_request.head.sha || github.sha }}"
+        self.assertEqual(
+            workflow.count(
+                "uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+            ),
+            4,
         )
-        self.assertEqual(workflow.count(expected), 4)
+        self.assertNotIn("github.event.pull_request.head.sha", workflow)
+        self.assertNotIn("ref: ${{ github.event_name == 'pull_request'", workflow)
+
+    def test_kubernetes_workflow_covers_api_build_inputs(self) -> None:
+        workflow = (ROOT / ".github/workflows/kubernetes-platform.yml").read_text()
+        for path in (
+            '".dockerignore"',
+            '"Cargo.toml"',
+            '"Cargo.lock"',
+            '"toolchain.versions.yml"',
+            '"apps/api/**"',
+            '"scripts/dev/**"',
+            '"policies/**"',
+        ):
+            self.assertEqual(workflow.count(f"- {path}"), 2, path)
 
     def test_zone_contract_requires_three_distinct_zones(self) -> None:
         valid = {
@@ -362,15 +378,25 @@ class KubernetesHaContractTests(unittest.TestCase):
         cleanup.assert_called_once_with("proof", "a" * 40)
 
     def test_kind_cluster_creation_is_transactional(self) -> None:
-        with mock.patch.object(self.ha.ref, "assert_available_cluster_name"), mock.patch.object(
-            self.ha.ref, "write_marker"
-        ) as marker, mock.patch.object(
+        with mock.patch.object(self.ha.ref, "reserve_cluster_name") as reserve, mock.patch.object(
             self.ha.ref, "run", side_effect=self.ha.ref.ProofError("kind failed")
         ), mock.patch.object(self.ha.ref, "delete_owned_cluster") as cleanup:
             with self.assertRaisesRegex(self.ha.ref.ProofError, "kind failed"):
-                self.ha.create_kind_cluster("kind", "proof", "node-image", "cluster.yaml", "b" * 40)
-        marker.assert_called_once_with("proof", "b" * 40)
-        cleanup.assert_called_once_with("kind", "proof")
+                self.ha.create_kind_cluster(
+                    "kind",
+                    "proof",
+                    "node-image",
+                    "cluster.yaml",
+                    "b" * 40,
+                    "owner-proof",
+                )
+        reserve.assert_called_once_with("kind", "proof", "b" * 40, "owner-proof")
+        cleanup.assert_called_once_with(
+            "kind",
+            "proof",
+            expected_commit="b" * 40,
+            expected_owner_id="owner-proof",
+        )
 
     def test_digest_locked_manifest_replaces_each_release_image_once(self) -> None:
         tagged = {
@@ -1450,9 +1476,18 @@ spec:
         self.assertEqual(proof.command, "proof")
         self.assertFalse(proof.keep)
         down = self.ha.argument_parser().parse_args(
-            ["down", "--cluster", "weltgewebe-t004-test", "--commit", "a" * 40]
+            [
+                "down",
+                "--cluster",
+                "weltgewebe-t004-test",
+                "--commit",
+                "a" * 40,
+                "--owner-id",
+                "gha-ha-123-1",
+            ]
         )
         self.assertEqual(down.commit, "a" * 40)
+        self.assertEqual(down.owner_id, "gha-ha-123-1")
 
 
 if __name__ == "__main__":

--- a/scripts/ci/tests/test_kubernetes_platform_contract.py
+++ b/scripts/ci/tests/test_kubernetes_platform_contract.py
@@ -128,6 +128,8 @@ class KubernetesPlatformContractTests(unittest.TestCase):
                 "$CLUSTER_NAME",
                 "--mode",
                 "direct",
+                "--owner-id",
+                "$PROOF_OWNER_ID",
             ],
         )
         self.assertEqual(
@@ -142,6 +144,8 @@ class KubernetesPlatformContractTests(unittest.TestCase):
                 "gitops",
                 "--source-commit",
                 "$GITHUB_SHA",
+                "--owner-id",
+                "$PROOF_OWNER_ID",
             ],
         )
         self.assertNotIn("SOURCE_REF:", workflow_text)
@@ -346,8 +350,70 @@ spec:
             original = self.reference.MARKERS
             self.reference.MARKERS = Path(tmp)
             try:
-                with self.assertRaisesRegex(self.reference.ProofError, "marker missing"):
-                    self.reference.delete_owned_cluster("kind", "foreign")
+                with self.assertRaisesRegex(self.reference.ProofError, "regular ownership marker"):
+                    self.reference.delete_owned_cluster(
+                        "kind",
+                        "foreign",
+                        expected_commit="a" * 40,
+                        expected_owner_id="owner-proof",
+                    )
+            finally:
+                self.reference.MARKERS = original
+
+    def test_reference_never_silently_removes_stale_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            original = self.reference.MARKERS
+            self.reference.MARKERS = Path(tmp)
+            try:
+                marker = self.reference.marker_path("stale")
+                marker.write_text("{}\n", encoding="utf-8")
+                with mock.patch.object(self.reference, "clusters", return_value=set()):
+                    with self.assertRaisesRegex(self.reference.ProofError, "stale ownership marker"):
+                        self.reference.assert_available_cluster_name("kind", "stale")
+                self.assertTrue(marker.is_file())
+            finally:
+                self.reference.MARKERS = original
+
+    def test_reference_refuses_cleanup_for_wrong_commit_or_owner(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            original = self.reference.MARKERS
+            self.reference.MARKERS = Path(tmp)
+            try:
+                self.reference.write_marker("proof", "a" * 40, "owner-a")
+                with mock.patch.object(self.reference, "clusters", return_value=set()):
+                    with self.assertRaisesRegex(self.reference.ProofError, "exact owner binding"):
+                        self.reference.delete_owned_cluster(
+                            "kind",
+                            "proof",
+                            expected_commit="b" * 40,
+                            expected_owner_id="owner-a",
+                        )
+                    with self.assertRaisesRegex(self.reference.ProofError, "exact owner binding"):
+                        self.reference.delete_owned_cluster(
+                            "kind",
+                            "proof",
+                            expected_commit="a" * 40,
+                            expected_owner_id="owner-b",
+                        )
+                self.assertTrue(self.reference.marker_path("proof").is_file())
+            finally:
+                self.reference.MARKERS = original
+
+    def test_reference_reservation_records_exact_owner_binding(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            original = self.reference.MARKERS
+            self.reference.MARKERS = Path(tmp)
+            try:
+                with mock.patch.object(self.reference, "clusters", return_value=set()):
+                    self.reference.reserve_cluster_name(
+                        "kind", "proof", "a" * 40, "owner-proof"
+                    )
+                marker = json.loads(
+                    self.reference.marker_path("proof").read_text(encoding="utf-8")
+                )
+                self.assertEqual(marker["schema_version"], 2)
+                self.assertEqual(marker["commit"], "a" * 40)
+                self.assertEqual(marker["owner_id"], "owner-proof")
             finally:
                 self.reference.MARKERS = original
 

--- a/scripts/platform/ha_reference.py
+++ b/scripts/platform/ha_reference.py
@@ -65,14 +65,25 @@ def wait_until(description: str, probe, *, timeout_seconds: int = 600, interval:
     raise ref.ProofError(f"timed out waiting for {description}; last={last!r}")
 
 
-def create_kind_cluster(kind: str, name: str, image: str, config: str, commit: str) -> None:
-    ref.assert_available_cluster_name(kind, name)
-    ref.write_marker(name, commit)
+def create_kind_cluster(
+    kind: str,
+    name: str,
+    image: str,
+    config: str,
+    commit: str,
+    owner_id: str,
+) -> None:
+    ref.reserve_cluster_name(kind, name, commit, owner_id)
     try:
         ref.run([kind, "create", "cluster", "--name", name, "--image", image, "--config", config], timeout=900)
         ref.configure_cluster_access(kind, name)
     except Exception:
-        ref.delete_owned_cluster(kind, name)
+        ref.delete_owned_cluster(
+            kind,
+            name,
+            expected_commit=commit,
+            expected_owner_id=owner_id,
+        )
         raise
 
 
@@ -2087,6 +2098,7 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
         )
     )
     restore_name = f"{args.cluster}-restore"
+    owner_id = args.owner_id or ref.generate_owner_id("ha-proof")
     ref.assert_available_cluster_name(kind, args.cluster)
     ref.assert_available_cluster_name(kind, restore_name)
     created_primary = created_restore = object_store_created = False
@@ -2095,7 +2107,10 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
     app_password = secrets.token_urlsafe(24)
     s3_secret_key = secrets.token_urlsafe(32)
     try:
-        create_kind_cluster(kind, args.cluster, receipt["kubernetes"]["kind_node_image"], "platform/clusters/ha/kind.yaml", commit)
+        create_kind_cluster(
+            kind, args.cluster, receipt["kubernetes"]["kind_node_image"],
+            "platform/clusters/ha/kind.yaml", commit, owner_id
+        )
         created_primary = True
         kubectl = require_active_cluster_context(kind, kubectl, args.cluster)
         image_ids = ref.build_images(kind, args.cluster, commit, timestamp)
@@ -2240,7 +2255,10 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
             kubectl, cluster="postgres-ha"
         )
 
-        create_kind_cluster(kind, restore_name, receipt["kubernetes"]["kind_node_image"], "platform/clusters/ha/restore-kind.yaml", commit)
+        create_kind_cluster(
+            kind, restore_name, receipt["kubernetes"]["kind_node_image"],
+            "platform/clusters/ha/restore-kind.yaml", commit, owner_id
+        )
         created_restore = True
         restore_kubectl = require_active_cluster_context(
             kind, kubectl, restore_name
@@ -2361,6 +2379,7 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
             },
             "change_management": change_management,
             "gateway_before": gateway_before,
+            "proof_owner_id": owner_id,
             "production_changed": False,
             "does_not_establish": [
                 "production rollout", "managed multi-region object-store durability",
@@ -2391,9 +2410,13 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
         if stopped_node:
             subprocess.run(["docker", "start", stopped_node], capture_output=True)
         if created_restore and not args.keep:
-            ref.delete_owned_cluster(kind, restore_name)
+            ref.delete_owned_cluster(
+                kind, restore_name, expected_commit=commit, expected_owner_id=owner_id
+            )
         if created_primary and not args.keep:
-            ref.delete_owned_cluster(kind, args.cluster)
+            ref.delete_owned_cluster(
+                kind, args.cluster, expected_commit=commit, expected_owner_id=owner_id
+            )
         if object_store_created and not args.keep:
             delete_external_object_store(args.cluster, commit)
 
@@ -2404,9 +2427,11 @@ def argument_parser() -> argparse.ArgumentParser:
     proof_parser = sub.add_parser("proof")
     proof_parser.add_argument("--cluster", default=DEFAULT_CLUSTER)
     proof_parser.add_argument("--keep", action="store_true")
+    proof_parser.add_argument("--owner-id")
     down = sub.add_parser("down")
     down.add_argument("--cluster", default=DEFAULT_CLUSTER)
     down.add_argument("--commit", required=True)
+    down.add_argument("--owner-id", required=True)
     return parser
 
 
@@ -2417,8 +2442,9 @@ def main() -> int:
         if args.command == "down":
             kind = receipt["tools"]["kind"]
             for name in (f"{args.cluster}-restore", args.cluster):
-                if ref.marker_path(name).exists():
-                    ref.delete_owned_cluster(kind, name)
+                ref.delete_owned_cluster_if_present(
+                    kind, name, expected_commit=args.commit, expected_owner_id=args.owner_id
+                )
             delete_external_object_store(args.cluster, args.commit)
             print(json.dumps({"status": "deleted", "cluster": args.cluster}))
             return 0

--- a/scripts/platform/kind_reference.py
+++ b/scripts/platform/kind_reference.py
@@ -2,15 +2,18 @@
 from __future__ import annotations
 
 import argparse
+import fcntl
 import hashlib
 import ipaddress
 import json
 import os
 import re
+import secrets
 import shutil
 import subprocess
 import sys
 import time
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -114,8 +117,79 @@ def marker_path(name: str) -> Path:
     return MARKERS / f"{name}.json"
 
 
+def ownership_lock_path(name: str) -> Path:
+    return MARKERS / f".{name}.ownership.lock"
+
+
 def kubeconfig_path(name: str) -> Path:
     return KUBECONFIGS / f"{name}.yaml"
+
+
+def generate_owner_id(prefix: str) -> str:
+    return f"{prefix}-{os.getpid()}-{secrets.token_hex(8)}"
+
+
+def _validate_ownership_binding(commit: str, owner_id: str) -> None:
+    if not FULL_GIT_OBJECT_ID.fullmatch(commit):
+        raise ProofError("cluster ownership requires a full lowercase Git object id")
+    if (
+        not owner_id
+        or len(owner_id) > 128
+        or re.fullmatch(r"[A-Za-z0-9._:@-]+", owner_id) is None
+    ):
+        raise ProofError("cluster ownership requires a stable owner id")
+
+
+@contextmanager
+def cluster_ownership_lock(name: str):
+    MARKERS.mkdir(parents=True, exist_ok=True)
+    path = ownership_lock_path(name)
+    with path.open("a+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _read_marker(name: str) -> dict[str, Any]:
+    marker = marker_path(name)
+    if marker.is_symlink() or not marker.is_file():
+        raise ProofError(f"cluster {name!r} has no regular ownership marker")
+    try:
+        data = json.loads(marker.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ProofError(f"cluster {name!r} ownership marker is unreadable: {error}") from error
+    if not isinstance(data, dict):
+        raise ProofError(f"cluster {name!r} ownership marker is not an object")
+    return data
+
+
+def _require_marker_binding(
+    data: dict[str, Any],
+    name: str,
+    *,
+    expected_commit: str,
+    expected_owner_id: str,
+) -> None:
+    _validate_ownership_binding(expected_commit, expected_owner_id)
+    expected = {
+        "schema_version": 2,
+        "cluster": name,
+        "repository": str(ROOT),
+        "commit": expected_commit,
+        "owner_id": expected_owner_id,
+    }
+    mismatched = {
+        key: {"expected": value, "observed": data.get(key)}
+        for key, value in expected.items()
+        if data.get(key) != value
+    }
+    if mismatched:
+        raise ProofError(
+            f"cluster {name!r} ownership marker does not match exact owner binding: "
+            f"{json.dumps(mismatched, sort_keys=True)}"
+        )
 
 
 def configure_cluster_access(kind: str, name: str) -> Path:
@@ -126,15 +200,23 @@ def configure_cluster_access(kind: str, name: str) -> Path:
     return path
 
 
-def require_owned_cluster(kind: str, name: str) -> dict[str, Any]:
-    marker = marker_path(name)
-    if name not in clusters(kind):
-        raise ProofError(f"owned cluster {name!r} is absent")
-    if not marker.is_file():
-        raise ProofError(f"cluster {name!r} has no ownership marker")
-    data = json.loads(marker.read_text(encoding="utf-8"))
-    if data.get("cluster") != name or data.get("repository") != str(ROOT):
-        raise ProofError(f"cluster {name!r} ownership marker does not match")
+def require_owned_cluster(
+    kind: str,
+    name: str,
+    *,
+    expected_commit: str,
+    expected_owner_id: str,
+) -> dict[str, Any]:
+    with cluster_ownership_lock(name):
+        if name not in clusters(kind):
+            raise ProofError(f"owned cluster {name!r} is absent")
+        data = _read_marker(name)
+        _require_marker_binding(
+            data,
+            name,
+            expected_commit=expected_commit,
+            expected_owner_id=expected_owner_id,
+        )
     configure_cluster_access(kind, name)
     return data
 
@@ -145,47 +227,93 @@ def clusters(kind: str) -> set[str]:
 
 
 def assert_available_cluster_name(kind: str, name: str) -> None:
-    existing = clusters(kind)
-    marker = marker_path(name)
-    if name in existing:
-        raise ProofError(
-            f"cluster {name!r} already exists; it is never adopted or deleted by this proof"
-        )
-    if marker.exists():
-        marker.unlink()
+    with cluster_ownership_lock(name):
+        if name in clusters(kind):
+            raise ProofError(
+                f"cluster {name!r} already exists; it is never adopted or deleted by this proof"
+            )
+        if os.path.lexists(marker_path(name)):
+            raise ProofError(
+                f"cluster {name!r} has a stale ownership marker; "
+                "explicit exact-owner cleanup is required"
+            )
 
 
-def write_marker(name: str, commit: str) -> None:
+def write_marker(name: str, commit: str, owner_id: str) -> None:
+    _validate_ownership_binding(commit, owner_id)
     MARKERS.mkdir(parents=True, exist_ok=True)
-    marker_path(name).write_text(
-        json.dumps(
-            {
-                "schema_version": 1,
-                "cluster": name,
-                "repository": str(ROOT),
-                "commit": commit,
-                "pid": os.getpid(),
-            },
-            indent=2,
-            sort_keys=True,
+    payload = {
+        "schema_version": 2,
+        "cluster": name,
+        "repository": str(ROOT),
+        "commit": commit,
+        "owner_id": owner_id,
+        "pid": os.getpid(),
+    }
+    try:
+        with marker_path(name).open("x", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+    except FileExistsError as error:
+        raise ProofError(f"cluster {name!r} ownership marker already exists") from error
+
+
+def reserve_cluster_name(kind: str, name: str, commit: str, owner_id: str) -> None:
+    _validate_ownership_binding(commit, owner_id)
+    with cluster_ownership_lock(name):
+        if name in clusters(kind):
+            raise ProofError(
+                f"cluster {name!r} already exists; it is never adopted or deleted by this proof"
+            )
+        if os.path.lexists(marker_path(name)):
+            raise ProofError(
+                f"cluster {name!r} has a stale ownership marker; "
+                "explicit exact-owner cleanup is required"
+            )
+        write_marker(name, commit, owner_id)
+
+
+def delete_owned_cluster(
+    kind: str,
+    name: str,
+    *,
+    expected_commit: str,
+    expected_owner_id: str,
+) -> None:
+    with cluster_ownership_lock(name):
+        data = _read_marker(name)
+        _require_marker_binding(
+            data,
+            name,
+            expected_commit=expected_commit,
+            expected_owner_id=expected_owner_id,
         )
-        + "\n",
-        encoding="utf-8",
-    )
+        if name in clusters(kind):
+            run([kind, "delete", "cluster", "--name", name])
+        marker_path(name).unlink()
+        kubeconfig_path(name).unlink(missing_ok=True)
 
 
-def delete_owned_cluster(kind: str, name: str) -> None:
-    marker = marker_path(name)
-    if not marker.is_file():
-        raise ProofError(f"refusing to delete unowned cluster {name!r}: marker missing")
-    data = json.loads(marker.read_text(encoding="utf-8"))
-    if data.get("cluster") != name or data.get("repository") != str(ROOT):
-        raise ProofError(f"refusing to delete cluster {name!r}: marker mismatch")
+def delete_owned_cluster_if_present(
+    kind: str,
+    name: str,
+    *,
+    expected_commit: str,
+    expected_owner_id: str,
+) -> bool:
+    if os.path.lexists(marker_path(name)):
+        delete_owned_cluster(
+            kind,
+            name,
+            expected_commit=expected_commit,
+            expected_owner_id=expected_owner_id,
+        )
+        return True
     if name in clusters(kind):
-        run([kind, "delete", "cluster", "--name", name])
-    marker.unlink(missing_ok=True)
-    kubeconfig_path(name).unlink(missing_ok=True)
-
+        raise ProofError(
+            f"refusing to delete cluster {name!r}: cluster exists without ownership marker"
+        )
+    return False
 
 def apply_yaml(kubectl: str, document: dict[str, Any] | list[dict[str, Any]]) -> None:
     documents = document if isinstance(document, list) else [document]
@@ -900,8 +1028,10 @@ def proof(args: argparse.Namespace) -> dict[str, Any]:
     kustomize = tools["kustomize"]
     flux = tools["flux"]
     helm = tools["helm"]
-    assert_available_cluster_name(kind, args.cluster)
+    owner_id = args.owner_id or generate_owner_id("kind-proof")
+    reserve_cluster_name(kind, args.cluster, commit, owner_id)
     app_namespace = "weltgewebe"
+    reserved = True
     created = False
     try:
         run(
@@ -918,7 +1048,6 @@ def proof(args: argparse.Namespace) -> dict[str, Any]:
             ],
             timeout=600,
         )
-        write_marker(args.cluster, commit)
         configure_cluster_access(kind, args.cluster)
         api_server_host = control_plane_address(args.cluster)
         created = True
@@ -952,6 +1081,7 @@ def proof(args: argparse.Namespace) -> dict[str, Any]:
             "source_ref": args.source_ref,
             "source_commit": args.source_commit,
             "commit": commit,
+            "owner_id": owner_id,
             "tool_lock_sha256": receipt["lock_sha256"],
             "image_ids": image_ids,
             "bootstrap_api_server": {"host": api_server_host, "port": 6443},
@@ -974,8 +1104,13 @@ def proof(args: argparse.Namespace) -> dict[str, Any]:
             diagnostic_snapshot(kubectl, args.cluster)
         raise
     finally:
-        if created and not args.keep:
-            delete_owned_cluster(kind, args.cluster)
+        if reserved and not args.keep:
+            delete_owned_cluster(
+                kind,
+                args.cluster,
+                expected_commit=commit,
+                expected_owner_id=owner_id,
+            )
 
 
 def argument_parser() -> argparse.ArgumentParser:
@@ -988,8 +1123,11 @@ def argument_parser() -> argparse.ArgumentParser:
     source_group.add_argument("--source-ref")
     source_group.add_argument("--source-commit")
     proof_parser.add_argument("--keep", action="store_true")
+    proof_parser.add_argument("--owner-id")
     down_parser = subparsers.add_parser("down")
     down_parser.add_argument("--cluster", default=DEFAULT_CLUSTER)
+    down_parser.add_argument("--commit", required=True)
+    down_parser.add_argument("--owner-id", required=True)
     return parser
 
 
@@ -998,8 +1136,18 @@ def main() -> int:
     try:
         receipt = tool_receipt()
         if args.command == "down":
-            delete_owned_cluster(receipt["tools"]["kind"], args.cluster)
-            print(json.dumps({"status": "deleted", "cluster": args.cluster}))
+            deleted = delete_owned_cluster_if_present(
+                receipt["tools"]["kind"],
+                args.cluster,
+                expected_commit=args.commit,
+                expected_owner_id=args.owner_id,
+            )
+            print(json.dumps({
+                "status": "deleted" if deleted else "absent",
+                "cluster": args.cluster,
+                "commit": args.commit,
+                "owner_id": args.owner_id,
+            }, sort_keys=True))
             return 0
         result = proof(args)
     except (ProofError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as error:

--- a/scripts/platform/validate_platform.py
+++ b/scripts/platform/validate_platform.py
@@ -407,9 +407,27 @@ def _assert_ha_contract() -> None:
         "ha_reference.py down",
         '--cluster "$CLUSTER_NAME"',
         '--commit "$(git rev-parse HEAD)"',
+        '--owner-id "$PROOF_OWNER_ID"',
     ):
         if marker not in cleanup_command:
             raise ContractError(f"HA workflow cleanup lacks {marker}")
+
+    kind_steps = workflow["jobs"]["kind-gitops-proof"]["steps"]
+    kind_cleanup = next(
+        (item for item in kind_steps if item.get("name") == "Reconcile owned kind proof resources"),
+        None,
+    )
+    if kind_cleanup is None or kind_cleanup.get("if") != "always()":
+        raise ContractError("kind workflow lacks unconditional owned-resource reconciliation")
+    kind_cleanup_command = kind_cleanup.get("run", "")
+    for marker in (
+        "kind_reference.py down",
+        '--cluster "$CLUSTER_NAME"',
+        '--commit "$(git rev-parse HEAD)"',
+        '--owner-id "$PROOF_OWNER_ID"',
+    ):
+        if marker not in kind_cleanup_command:
+            raise ContractError(f"kind workflow cleanup lacks {marker}")
 
 
 def _assert_compose_parity() -> None:


### PR DESCRIPTION
<!-- weltgewebe-risk: R3 -->

## Summary

- test pull requests against GitHub's checked-out merge ref instead of forcing the PR head
- broaden Kubernetes workflow triggers to the API/Rust/build inputs that can change the proved artifact
- bind kind and HA proof clusters to exact commit + run owner identity under a per-cluster lock
- refuse stale-marker adoption and cleanup with mismatched owner/commit
- add unconditional exact-bound kind cleanup to CI
- renumber the duplicate HA ADR from ADR-0011 to the genuinely free ADR-0013 and regenerate doc metadata

## Validation

- `python3 -B -m unittest scripts.ci.tests.test_kubernetes_platform_contract scripts.ci.tests.test_kubernetes_ha_contract scripts.ci.tests.test_trivy_rendered_manifests` — PASS, 112 tests
- `python3 -B scripts/platform/validate_platform.py` — PASS
- `make generate` — PASS
- `make validate-core validate-guards` — PASS
- `git diff --check` — PASS

`make validate` reached the agent-tooling test suite and then failed because the heim-pc system `python3` is 3.10 and cannot import `tomllib`; the repository pins `.python-version` to 3.12 and `tools/py` requires Python >=3.11. This pre-existing local toolchain drift is recorded separately in Bureau event 1047 and is not hidden as a green full-local validation.

## Safety boundary

No production deployment is changed by this PR. Proof cleanup is stricter: it requires the exact repository, commit, cluster and owner binding, and stale markers are preserved fail-closed for explicit reconciliation.