### PR TITLE
perf(search): instrument hybrid search request cost

### DIFF
--- a/apps/api/src/search/service.rs
+++ b/apps/api/src/search/service.rs
@@ -1,5 +1,5 @@
 //! T006 server-side hybrid search service.
-use std::{env, sync::Arc};
+use std::{env, sync::Arc, time::Instant};
 
 use axum::{
     http::StatusCode,
@@ -174,6 +174,30 @@ pub async fn execute_search(
     params: SearchQueryParams,
     provider_override: Option<Arc<dyn EmbeddingProvider>>,
 ) -> Result<SearchResponse, SearchError> {
+    let request_started = Instant::now();
+    let result = execute_search_inner(state, auth, params, provider_override).await;
+    let outcome = match &result {
+        Ok(response) if response.mode == "hybrid" => "hybrid",
+        Ok(response) if response.mode == "lexical_fallback" => "lexical_fallback",
+        Ok(_) => "success",
+        Err(SearchError::ProviderContractError(_)) => "provider_contract_error",
+        Err(SearchError::Unavailable) => "unavailable",
+        Err(SearchError::InvalidRequest) => "invalid_request",
+        Err(SearchError::Internal) => "internal",
+    };
+    state.metrics.search_request_outcome(outcome);
+    state
+        .metrics
+        .observe_search_request_duration(request_started.elapsed());
+    result
+}
+
+async fn execute_search_inner(
+    state: &ApiState,
+    auth: &AuthContext,
+    params: SearchQueryParams,
+    provider_override: Option<Arc<dyn EmbeddingProvider>>,
+) -> Result<SearchResponse, SearchError> {
     if state.config.domain_read_source != DomainReadSource::Postgres {
         return Err(SearchError::Unavailable);
     }
@@ -187,13 +211,16 @@ pub async fn execute_search(
         languages: parse_list(&params.language, &params.languages),
     };
 
-    let candidate_set = match fetch_postgres_candidates(pool, &query.raw, &filters, auth).await {
+    let repository_started = Instant::now();
+    let candidate_result = fetch_postgres_candidates(pool, &query.raw, &filters, auth).await;
+    state
+        .metrics
+        .observe_search_repository_duration(repository_started.elapsed());
+    let candidate_set = match candidate_result {
         Ok(Some(candidate_set)) => candidate_set,
         Ok(None) => return Err(SearchError::Unavailable),
         Err(SearchRepositoryError::CandidateSetTooLarge) => {
-            state
-                .metrics
-                .search_projection_outcome("candidate_set_too_large");
+            state.metrics.search_candidate_set_overflow();
             return Err(SearchError::Unavailable);
         }
         Err(SearchRepositoryError::Database(_)) | Err(SearchRepositoryError::Json(_)) => {
@@ -209,19 +236,27 @@ pub async fn execute_search(
         .cloned()
         .collect::<Vec<_>>();
 
+    state
+        .metrics
+        .observe_search_candidate_counts(candidate_set.candidates.len(), lexical_ranked.len());
+
     let provider = match provider_override {
         Some(provider) => provider,
         None => runtime_provider(&candidate_set.generation)?,
     };
 
     let query_embedding_text = query.embedding_text();
-    let (ranked, mode, fallback_reason) = match provider
+    let provider_started = Instant::now();
+    let provider_result = provider
         .embed(
             &query_embedding_text,
             candidate_set.generation.dimension as usize,
         )
-        .await
-    {
+        .await;
+    state
+        .metrics
+        .observe_search_provider_duration(provider_started.elapsed());
+    let (ranked, mode, fallback_reason) = match provider_result {
         Ok(query_vector) => (
             rank_hybrid(
                 Some(&query_vector),
@@ -233,16 +268,11 @@ pub async fn execute_search(
             "hybrid".to_string(),
             None,
         ),
-        Err(EmbeddingProviderError::Unavailable) => {
-            state
-                .metrics
-                .search_projection_outcome("fallback_unavailable");
-            (
-                lexical_ranked,
-                "lexical_fallback".to_string(),
-                Some("provider_unavailable".to_string()),
-            )
-        }
+        Err(EmbeddingProviderError::Unavailable) => (
+            lexical_ranked,
+            "lexical_fallback".to_string(),
+            Some("provider_unavailable".to_string()),
+        ),
         Err(error) => return Err(SearchError::ProviderContractError(error)),
     };
 

--- a/apps/api/src/telemetry/mod.rs
+++ b/apps/api/src/telemetry/mod.rs
@@ -3,6 +3,7 @@ use std::{
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
+    time::Duration,
 };
 
 pub mod health;
@@ -12,7 +13,10 @@ use axum::{
     http::{header, HeaderValue, Request, StatusCode},
     response::{IntoResponse, Response},
 };
-use prometheus::{Encoder, IntCounterVec, IntGauge, IntGaugeVec, Opts, Registry, TextEncoder};
+use prometheus::{
+    Encoder, Histogram, HistogramOpts, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts,
+    Registry, TextEncoder,
+};
 use tower::{Layer, Service};
 
 use crate::state::ApiState;
@@ -77,6 +81,13 @@ struct MetricsInner {
     pub nodes_cache_count: IntGauge,
     pub edges_cache_count: IntGauge,
     pub search_projection_jobs_total: IntCounterVec,
+    pub search_requests_total: IntCounterVec,
+    pub search_candidate_set_overflow_total: IntCounter,
+    pub search_request_duration_seconds: Histogram,
+    pub search_repository_duration_seconds: Histogram,
+    pub search_provider_duration_seconds: Histogram,
+    pub search_authorized_candidates: Histogram,
+    pub search_lexical_candidates: Histogram,
 }
 
 impl Metrics {
@@ -102,12 +113,74 @@ impl Metrics {
             &["outcome"],
         )?;
 
+        let search_requests_total = IntCounterVec::new(
+            Opts::new(
+                "search_requests_total",
+                "Search service outcomes using only fixed, non-user-controlled labels",
+            ),
+            &["outcome"],
+        )?;
+
+        let search_candidate_set_overflow_total = IntCounter::new(
+            "search_candidate_set_overflow_total",
+            "Search requests rejected because the authorized candidate transfer exceeded its hard bound",
+        )?;
+
+        let duration_buckets = vec![
+            0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+        ];
+        let candidate_buckets = vec![
+            1.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 750.0, 1000.0, 1001.0,
+        ];
+        let search_request_duration_seconds = Histogram::with_opts(
+            HistogramOpts::new(
+                "search_request_duration_seconds",
+                "End-to-end search service duration without query or identity labels",
+            )
+            .buckets(duration_buckets.clone()),
+        )?;
+        let search_repository_duration_seconds = Histogram::with_opts(
+            HistogramOpts::new(
+                "search_repository_duration_seconds",
+                "PostgreSQL search candidate retrieval duration without query or identity labels",
+            )
+            .buckets(duration_buckets.clone()),
+        )?;
+        let search_provider_duration_seconds = Histogram::with_opts(
+            HistogramOpts::new(
+                "search_provider_duration_seconds",
+                "Search query embedding provider duration without query, model, or vector labels",
+            )
+            .buckets(duration_buckets),
+        )?;
+        let search_authorized_candidates = Histogram::with_opts(
+            HistogramOpts::new(
+                "search_authorized_candidates",
+                "Authorized search candidates transferred to the API per request",
+            )
+            .buckets(candidate_buckets.clone()),
+        )?;
+        let search_lexical_candidates = Histogram::with_opts(
+            HistogramOpts::new(
+                "search_lexical_candidates",
+                "Lexical candidates in the authoritative top-ten prefix per search request",
+            )
+            .buckets(candidate_buckets),
+        )?;
+
         let registry = Registry::new();
         registry.register(Box::new(http_requests_total.clone()))?;
         registry.register(Box::new(build_info_metric.clone()))?;
         registry.register(Box::new(nodes_cache_count.clone()))?;
         registry.register(Box::new(edges_cache_count.clone()))?;
         registry.register(Box::new(search_projection_jobs_total.clone()))?;
+        registry.register(Box::new(search_requests_total.clone()))?;
+        registry.register(Box::new(search_candidate_set_overflow_total.clone()))?;
+        registry.register(Box::new(search_request_duration_seconds.clone()))?;
+        registry.register(Box::new(search_repository_duration_seconds.clone()))?;
+        registry.register(Box::new(search_provider_duration_seconds.clone()))?;
+        registry.register(Box::new(search_authorized_candidates.clone()))?;
+        registry.register(Box::new(search_lexical_candidates.clone()))?;
 
         build_info_metric
             .with_label_values(&[
@@ -124,6 +197,13 @@ impl Metrics {
                 nodes_cache_count,
                 edges_cache_count,
                 search_projection_jobs_total,
+                search_requests_total,
+                search_candidate_set_overflow_total,
+                search_request_duration_seconds,
+                search_repository_duration_seconds,
+                search_provider_duration_seconds,
+                search_authorized_candidates,
+                search_lexical_candidates,
             }),
         })
     }
@@ -147,6 +227,55 @@ impl Metrics {
             .search_projection_jobs_total
             .with_label_values(&[outcome])
             .inc();
+    }
+
+    /// Keep the Prometheus label set bounded even if a future caller passes an
+    /// unexpected value. Queries, identities, node ids, and provider text must
+    /// never become labels.
+    pub fn search_request_outcome(&self, outcome: &str) {
+        let outcome = match outcome {
+            "hybrid"
+            | "lexical_fallback"
+            | "success"
+            | "provider_contract_error"
+            | "unavailable"
+            | "invalid_request"
+            | "internal" => outcome,
+            _ => "internal",
+        };
+        self.inner
+            .search_requests_total
+            .with_label_values(&[outcome])
+            .inc();
+    }
+
+    pub fn search_candidate_set_overflow(&self) {
+        self.inner.search_candidate_set_overflow_total.inc();
+    }
+
+    pub fn observe_search_request_duration(&self, duration: Duration) {
+        self.inner
+            .search_request_duration_seconds
+            .observe(duration.as_secs_f64());
+    }
+
+    pub fn observe_search_repository_duration(&self, duration: Duration) {
+        self.inner
+            .search_repository_duration_seconds
+            .observe(duration.as_secs_f64());
+    }
+
+    pub fn observe_search_provider_duration(&self, duration: Duration) {
+        self.inner
+            .search_provider_duration_seconds
+            .observe(duration.as_secs_f64());
+    }
+
+    pub fn observe_search_candidate_counts(&self, authorized: usize, lexical: usize) {
+        self.inner
+            .search_authorized_candidates
+            .observe(authorized as f64);
+        self.inner.search_lexical_candidates.observe(lexical as f64);
     }
 
     pub fn render(&self) -> Result<Vec<u8>, prometheus::Error> {
@@ -241,6 +370,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::{BuildInfo, Metrics, MetricsLayer, UNMATCHED_ROUTE_LABEL};
     use axum::{body::Body, http::Request, routing::get, Router};
     use tower::ServiceExt;
@@ -252,6 +383,31 @@ mod tests {
             build_timestamp: "test",
         })
         .expect("metrics")
+    }
+
+    #[test]
+    fn search_cost_metrics_are_label_free_and_record_bounded_observations() {
+        let metrics = test_metrics();
+        metrics.search_request_outcome("hybrid");
+        metrics.search_request_outcome("must-not-become-a-label");
+        metrics.search_candidate_set_overflow();
+        metrics.observe_search_request_duration(Duration::from_millis(25));
+        metrics.observe_search_repository_duration(Duration::from_millis(10));
+        metrics.observe_search_provider_duration(Duration::from_millis(5));
+        metrics.observe_search_candidate_counts(37, 10);
+
+        let rendered = String::from_utf8(metrics.render().expect("render metrics")).expect("utf8");
+        assert!(rendered.contains("search_requests_total{outcome=\"hybrid\"} 1"));
+        assert!(rendered.contains("search_requests_total{outcome=\"internal\"} 1"));
+        assert!(!rendered.contains("must-not-become-a-label"));
+        assert!(rendered.contains("search_candidate_set_overflow_total 1"));
+        assert!(rendered.contains("search_request_duration_seconds_count 1"));
+        assert!(rendered.contains("search_repository_duration_seconds_count 1"));
+        assert!(rendered.contains("search_provider_duration_seconds_count 1"));
+        assert!(rendered.contains("search_authorized_candidates_sum 37"));
+        assert!(rendered.contains("search_lexical_candidates_sum 10"));
+        assert!(!rendered.contains("query="));
+        assert!(!rendered.contains("node_id="));
     }
 
     #[tokio::test]

--- a/apps/api/src/telemetry/mod.rs
+++ b/apps/api/src/telemetry/mod.rs
@@ -132,6 +132,7 @@ impl Metrics {
         let candidate_buckets = vec![
             1.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 750.0, 1000.0, 1001.0,
         ];
+        let lexical_candidate_buckets = vec![0.0, 1.0, 2.0, 5.0, 10.0];
         let search_request_duration_seconds = Histogram::with_opts(
             HistogramOpts::new(
                 "search_request_duration_seconds",
@@ -165,7 +166,7 @@ impl Metrics {
                 "search_lexical_candidates",
                 "Lexical candidates in the authoritative top-ten prefix per search request",
             )
-            .buckets(candidate_buckets),
+            .buckets(lexical_candidate_buckets),
         )?;
 
         let registry = Registry::new();


### PR DESCRIPTION
<!-- weltgewebe-risk: R2 -->

## Ziel

Nach T006 wird die Kosten- und Skalierungsfrage zuerst messbar gemacht, bevor Ranking-, ANN- oder Retrieval-Architektur verändert werden.

## Änderungen

- misst End-to-End-Latenz jeder Search-Service-Anfrage
- misst PostgreSQL-Kandidatenabruf separat
- misst Embedding-Provider-Latenz separat
- misst autorisierte Kandidatenmenge und lexikalische Top-10-Menge
- trennt Search-Request-Outcomes von `search_projection_jobs_total`
- erhält Überschreitungen des harten 1000er-Kandidatenlimits als eigenen label-freien Zähler
- begrenzt Request-Outcome-Labels auf einen festen Allowlist-Vertrag; unbekannte Werte fallen auf `internal` zurück
- verwendet für die lexikalische Top-10-Metrik einen eigenen kleinen Histogramm-Bucket-Satz statt des 1001er-Kandidatenbereichs

## Sicherheits- und Vertragsgrenzen

Unverändert bleiben:

- kanonische Autorisierung vor Ranking
- T003-Lexical-Ranking und T006-Hybrid-Priorität
- maximal ein semantischer Append
- fail-closed Kandidatenlimit
- API-Antwortformat, Statuscodes und öffentliche Routen

Die neuen Prometheus-Metriken enthalten keine Query-, Node-, Identity-, Modell- oder Vektorwerte als Labels.

## Validierung

- `cargo fmt --manifest-path apps/api/Cargo.toml -- --check` ✅
- neue Telemetrie-Unit-Prüfung ✅
- Search-Service-Unit-Tests: 3/3 ✅
- `api_search_t006`: 2/2 ✅
- `cargo clippy --manifest-path apps/api/Cargo.toml --all-targets -- -D warnings` ✅
- erneute Validierung nach Review-Optimierung ✅

Base: `059882cd49ee31b0b09815626f374860149174bd`
Head: `30e0d083ee6d577f49b8375ae03d2fbd736c2a3f`
Canonical diff SHA-256: `4ea46153f458e930264ad435eb8395f0d52137c785934e68e88c0a7194fb47bd`

## Folgeentscheidung

Die bestehenden Bureau-Kandidaten `candidate-45fdcbdf44dadcd457d4ace4` und `candidate-da8668c3f5e1b27b55068a86` bleiben die kanonischen Follow-ups. Ein konkretes Search-Rate-Limit oder Zwei-Phasen-/ANN-Retrieval wird erst anhand der gemessenen Produktionsdaten festgelegt; dieser PR erfindet keine ungeprüfte Schwelle.