### PR TITLE
fix(search): harden observability outcome contracts

### DIFF
--- a/apps/api/src/search/service.rs
+++ b/apps/api/src/search/service.rs
@@ -25,6 +25,7 @@ use crate::{
         },
     },
     state::ApiState,
+    telemetry::SearchRequestOutcome,
 };
 
 const DEFAULT_LIMIT: usize = 10;
@@ -47,10 +48,19 @@ pub struct SearchQueryParams {
     pub offset: Option<usize>,
 }
 
+/// Bounded search result mode. The wire format keeps the pre-existing
+/// snake_case strings so this is not a breaking API change.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SearchMode {
+    Hybrid,
+    LexicalFallback,
+}
+
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct SearchResponse {
     pub items: Vec<Node>,
-    pub mode: String,
+    pub mode: SearchMode,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fallback_reason: Option<String>,
     pub generation_id: String,
@@ -177,13 +187,14 @@ pub async fn execute_search(
     let request_started = Instant::now();
     let result = execute_search_inner(state, auth, params, provider_override).await;
     let outcome = match &result {
-        Ok(response) if response.mode == "hybrid" => "hybrid",
-        Ok(response) if response.mode == "lexical_fallback" => "lexical_fallback",
-        Ok(_) => "success",
-        Err(SearchError::ProviderContractError(_)) => "provider_contract_error",
-        Err(SearchError::Unavailable) => "unavailable",
-        Err(SearchError::InvalidRequest) => "invalid_request",
-        Err(SearchError::Internal) => "internal",
+        Ok(response) => match response.mode {
+            SearchMode::Hybrid => SearchRequestOutcome::Hybrid,
+            SearchMode::LexicalFallback => SearchRequestOutcome::LexicalFallback,
+        },
+        Err(SearchError::ProviderContractError(_)) => SearchRequestOutcome::ProviderContractError,
+        Err(SearchError::Unavailable) => SearchRequestOutcome::Unavailable,
+        Err(SearchError::InvalidRequest) => SearchRequestOutcome::InvalidRequest,
+        Err(SearchError::Internal) => SearchRequestOutcome::Internal,
     };
     state.metrics.search_request_outcome(outcome);
     state
@@ -265,12 +276,12 @@ async fn execute_search_inner(
                 DEFAULT_SEMANTIC_MINIMUM_COSINE,
                 DEFAULT_SEMANTIC_MINIMUM_MARGIN,
             ),
-            "hybrid".to_string(),
+            SearchMode::Hybrid,
             None,
         ),
         Err(EmbeddingProviderError::Unavailable) => (
             lexical_ranked,
-            "lexical_fallback".to_string(),
+            SearchMode::LexicalFallback,
             Some("provider_unavailable".to_string()),
         ),
         Err(error) => return Err(SearchError::ProviderContractError(error)),
@@ -370,5 +381,132 @@ mod tests {
                 "Werkstatt".to_string()
             ]
         );
+    }
+
+    /// Non-Postgres `ApiState` for the early-unavailable path, which returns
+    /// before ever touching a database pool. Mirrors the state builder in
+    /// `routes/health.rs`'s tests, the existing non-DB `ApiState` harness.
+    fn state_without_postgres() -> ApiState {
+        use crate::{
+            auth::{rate_limit::AuthRateLimiter, session::SessionBackend},
+            config::{AppConfig, AutoProvisionRole, DomainReadSource, PasskeyCredentialSource},
+            state::OrderedCache,
+            telemetry::{BuildInfo, Metrics},
+        };
+        use std::sync::atomic::AtomicI64;
+        use tokio::sync::{Mutex, RwLock};
+
+        let metrics = Metrics::try_new(BuildInfo {
+            version: "test",
+            commit: "test",
+            build_timestamp: "test",
+        })
+        .expect("metrics");
+
+        let config = AppConfig {
+            fade_days: 7,
+            ron_days: 84,
+            anonymize_opt_in: true,
+            delegation_expire_days: 28,
+            max_guest_owned_nodes: 1_000,
+            domain_read_source: DomainReadSource::Jsonl,
+            domain_account_write_source: crate::config::DomainAccountWriteSource::Jsonl,
+            domain_node_write_source: crate::config::DomainNodeWriteSource::Jsonl,
+            domain_edge_write_source: crate::config::DomainEdgeWriteSource::Jsonl,
+            passkey_credential_source: PasskeyCredentialSource::InMemory,
+            auth_public_login: false,
+            auth_cookie_secure: true,
+            app_base_url: None,
+            auth_trusted_proxies: None,
+            auth_allow_emails: None,
+            auth_allow_email_domains: None,
+            auth_auto_provision: false,
+            auth_auto_provision_role: AutoProvisionRole::Gast,
+            auth_rl_ip_per_min: None,
+            auth_rl_ip_per_hour: None,
+            auth_rl_email_per_min: None,
+            auth_rl_email_per_hour: None,
+            smtp_host: None,
+            smtp_port: None,
+            smtp_user: None,
+            smtp_pass: None,
+            smtp_from: None,
+            auth_log_magic_token: false,
+            webauthn_rp_id: None,
+            webauthn_rp_origin: None,
+            webauthn_rp_name: None,
+        };
+
+        let rate_limiter = Arc::new(AuthRateLimiter::new(&config));
+
+        ApiState {
+            db_pool: None,
+            db_pool_configured: false,
+            nats_client: None,
+            nats_configured: false,
+            config,
+            metrics,
+            sessions: SessionBackend::new_in_memory(),
+            challenges: Default::default(),
+            tokens: crate::auth::tokens::TokenStore::new(),
+            step_up_tokens: crate::auth::step_up_tokens::StepUpTokenStore::new(),
+            accounts: Arc::new(RwLock::new(crate::auth::accounts::AccountStore::new())),
+            nodes: Arc::new(RwLock::new(OrderedCache::new())),
+            nodes_persist: Arc::new(Mutex::new(())),
+            accounts_persist: Arc::new(Mutex::new(())),
+            domain_projection_gate: Arc::new(RwLock::new(())),
+            domain_projection_version: Arc::new(AtomicI64::new(0)),
+            edges: Arc::new(RwLock::new(OrderedCache::new())),
+            rate_limiter,
+            mailer: None,
+            webauthn: None,
+            passkey_registrations: Default::default(),
+            passkey_registration_grants: Default::default(),
+            passkey_authentications: Default::default(),
+            passkeys: Default::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn early_unavailable_path_records_exactly_one_bounded_outcome_and_no_downstream_metrics()
+    {
+        use crate::auth::role::Role;
+
+        let state = state_without_postgres();
+        let auth = AuthContext {
+            authenticated: false,
+            account_id: None,
+            device_id: None,
+            role: Role::Gast,
+            expires_at: None,
+        };
+
+        let result = execute_search(
+            &state,
+            &auth,
+            SearchQueryParams {
+                q: Some("Fahrrad".to_string()),
+                ..Default::default()
+            },
+            None,
+        )
+        .await;
+
+        assert!(matches!(result, Err(SearchError::Unavailable)));
+
+        let rendered =
+            String::from_utf8(state.metrics.render().expect("render metrics")).expect("utf8");
+        assert!(rendered.contains("search_requests_total{outcome=\"unavailable\"} 1"));
+        assert!(rendered.contains("search_request_duration_seconds_count 1"));
+        assert!(
+            rendered.contains("search_repository_duration_seconds_count 0"),
+            "the early unavailable path must return before the repository is ever queried"
+        );
+        assert!(
+            rendered.contains("search_provider_duration_seconds_count 0"),
+            "the early unavailable path must return before an embedding provider is ever called"
+        );
+        assert!(rendered.contains("search_authorized_candidates_count 0"));
+        assert!(rendered.contains("search_candidate_set_overflow_total 0"));
     }
 }

--- a/apps/api/src/telemetry/mod.rs
+++ b/apps/api/src/telemetry/mod.rs
@@ -433,7 +433,7 @@ mod tests {
     }
 
     #[test]
-    fn search_cost_metrics_are_label_free_and_record_bounded_observations() {
+    fn search_cost_metrics_use_bounded_non_user_controlled_labels_and_record_observations() {
         let metrics = test_metrics();
         metrics.search_request_outcome(SearchRequestOutcome::Hybrid);
         metrics.search_candidate_set_overflow();

--- a/apps/api/src/telemetry/mod.rs
+++ b/apps/api/src/telemetry/mod.rs
@@ -23,6 +23,32 @@ use crate::state::ApiState;
 
 const UNMATCHED_ROUTE_LABEL: &str = "<unmatched>";
 
+/// Fixed set of search service request outcomes. The label set is bounded by
+/// the type system rather than by a runtime string match, so an exhaustive
+/// match at the call site is the only place new outcomes can be introduced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SearchRequestOutcome {
+    Hybrid,
+    LexicalFallback,
+    ProviderContractError,
+    Unavailable,
+    InvalidRequest,
+    Internal,
+}
+
+impl SearchRequestOutcome {
+    fn as_label(self) -> &'static str {
+        match self {
+            Self::Hybrid => "hybrid",
+            Self::LexicalFallback => "lexical_fallback",
+            Self::ProviderContractError => "provider_contract_error",
+            Self::Unavailable => "unavailable",
+            Self::InvalidRequest => "invalid_request",
+            Self::Internal => "internal",
+        }
+    }
+}
+
 fn metrics_path_label<B>(request: &Request<B>) -> String {
     request
         .extensions()
@@ -129,8 +155,12 @@ impl Metrics {
         let duration_buckets = vec![
             0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
         ];
+        // MAX_AUTHORIZED_CANDIDATES (search/repository.rs) hard-bounds this at
+        // 1000; the repository layer rejects any request before an over-bound
+        // count would ever reach this histogram, so 1000.0 is the true max
+        // bucket and no sentinel bucket above it is meaningful.
         let candidate_buckets = vec![
-            1.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 750.0, 1000.0, 1001.0,
+            1.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 750.0, 1000.0,
         ];
         let lexical_candidate_buckets = vec![0.0, 1.0, 2.0, 5.0, 10.0];
         let search_request_duration_seconds = Histogram::with_opts(
@@ -230,23 +260,12 @@ impl Metrics {
             .inc();
     }
 
-    /// Keep the Prometheus label set bounded even if a future caller passes an
-    /// unexpected value. Queries, identities, node ids, and provider text must
-    /// never become labels.
-    pub fn search_request_outcome(&self, outcome: &str) {
-        let outcome = match outcome {
-            "hybrid"
-            | "lexical_fallback"
-            | "success"
-            | "provider_contract_error"
-            | "unavailable"
-            | "invalid_request"
-            | "internal" => outcome,
-            _ => "internal",
-        };
+    /// Queries, identities, node ids, and provider text must never become
+    /// labels; `SearchRequestOutcome` bounds the label set at compile time.
+    pub fn search_request_outcome(&self, outcome: SearchRequestOutcome) {
         self.inner
             .search_requests_total
-            .with_label_values(&[outcome])
+            .with_label_values(&[outcome.as_label()])
             .inc();
     }
 
@@ -373,7 +392,7 @@ where
 mod tests {
     use std::time::Duration;
 
-    use super::{BuildInfo, Metrics, MetricsLayer, UNMATCHED_ROUTE_LABEL};
+    use super::{BuildInfo, Metrics, MetricsLayer, SearchRequestOutcome, UNMATCHED_ROUTE_LABEL};
     use axum::{body::Body, http::Request, routing::get, Router};
     use tower::ServiceExt;
 
@@ -387,10 +406,36 @@ mod tests {
     }
 
     #[test]
+    fn search_request_outcome_records_exactly_one_observation_per_bounded_label() {
+        let metrics = test_metrics();
+        let outcomes = [
+            (SearchRequestOutcome::Hybrid, "hybrid"),
+            (SearchRequestOutcome::LexicalFallback, "lexical_fallback"),
+            (
+                SearchRequestOutcome::ProviderContractError,
+                "provider_contract_error",
+            ),
+            (SearchRequestOutcome::Unavailable, "unavailable"),
+            (SearchRequestOutcome::InvalidRequest, "invalid_request"),
+            (SearchRequestOutcome::Internal, "internal"),
+        ];
+        for (outcome, _) in outcomes {
+            metrics.search_request_outcome(outcome);
+        }
+
+        let rendered = String::from_utf8(metrics.render().expect("render metrics")).expect("utf8");
+        for (_, label) in outcomes {
+            assert!(
+                rendered.contains(&format!("search_requests_total{{outcome=\"{label}\"}} 1")),
+                "expected exactly one recorded observation for outcome {label}"
+            );
+        }
+    }
+
+    #[test]
     fn search_cost_metrics_are_label_free_and_record_bounded_observations() {
         let metrics = test_metrics();
-        metrics.search_request_outcome("hybrid");
-        metrics.search_request_outcome("must-not-become-a-label");
+        metrics.search_request_outcome(SearchRequestOutcome::Hybrid);
         metrics.search_candidate_set_overflow();
         metrics.observe_search_request_duration(Duration::from_millis(25));
         metrics.observe_search_repository_duration(Duration::from_millis(10));
@@ -399,8 +444,6 @@ mod tests {
 
         let rendered = String::from_utf8(metrics.render().expect("render metrics")).expect("utf8");
         assert!(rendered.contains("search_requests_total{outcome=\"hybrid\"} 1"));
-        assert!(rendered.contains("search_requests_total{outcome=\"internal\"} 1"));
-        assert!(!rendered.contains("must-not-become-a-label"));
         assert!(rendered.contains("search_candidate_set_overflow_total 1"));
         assert!(rendered.contains("search_request_duration_seconds_count 1"));
         assert!(rendered.contains("search_repository_duration_seconds_count 1"));
@@ -409,6 +452,19 @@ mod tests {
         assert!(rendered.contains("search_lexical_candidates_sum 10"));
         assert!(!rendered.contains("query="));
         assert!(!rendered.contains("node_id="));
+    }
+
+    #[test]
+    fn search_authorized_candidates_histogram_has_no_bucket_above_the_hard_bound() {
+        let metrics = test_metrics();
+        metrics.observe_search_candidate_counts(1000, 10);
+
+        let rendered = String::from_utf8(metrics.render().expect("render metrics")).expect("utf8");
+        assert!(rendered.contains("search_authorized_candidates_bucket{le=\"1000\"}"));
+        assert!(
+            !rendered.contains("search_authorized_candidates_bucket{le=\"1001\"}"),
+            "MAX_AUTHORIZED_CANDIDATES rejects requests before a >1000 count ever reaches this histogram"
+        );
     }
 
     #[tokio::test]

--- a/apps/api/tests/db_semantic_search_projection_worker.rs
+++ b/apps/api/tests/db_semantic_search_projection_worker.rs
@@ -73,6 +73,26 @@ async fn reset_search_state(pool: &PgPool) {
         .expect("reset T005 projection state");
 }
 
+/// Reads the current `search_requests_total{outcome="..."}` counter value out
+/// of the rendered Prometheus text exposition. Scans every line rather than
+/// assuming a fixed position, so it stays correct regardless of metric
+/// family ordering. Missing labels (never touched yet) count as zero.
+fn search_requests_total_for_outcome(metrics: &Metrics, outcome: &str) -> u64 {
+    let rendered =
+        String::from_utf8(metrics.render().expect("render metrics")).expect("utf8 metrics");
+    let prefix = format!("search_requests_total{{outcome=\"{outcome}\"}} ");
+    rendered
+        .lines()
+        .find_map(|line| line.strip_prefix(prefix.as_str()))
+        .map(|value| {
+            value
+                .trim()
+                .parse::<u64>()
+                .unwrap_or_else(|_| panic!("non-numeric search_requests_total value: {value:?}"))
+        })
+        .unwrap_or(0)
+}
+
 struct FakeProvider {
     unavailable: AtomicBool,
 }
@@ -1944,6 +1964,8 @@ async fn t006_search_api_against_postgres_projections() {
         "T006 must preserve the verified T003 class ordering"
     );
 
+    let lexical_fallback_before =
+        search_requests_total_for_outcome(&state.metrics, "lexical_fallback");
     let public = execute_search(
         &state,
         &anonymous,
@@ -1964,6 +1986,12 @@ async fn t006_search_api_against_postgres_projections() {
     assert_eq!(
         public.fallback_reason.as_deref(),
         Some("provider_unavailable")
+    );
+    assert_eq!(
+        search_requests_total_for_outcome(&state.metrics, "lexical_fallback")
+            - lexical_fallback_before,
+        1,
+        "a single lexical-fallback search must record exactly one lexical_fallback outcome"
     );
 
     let filtered = execute_search(
@@ -2113,6 +2141,7 @@ async fn t006_search_api_against_postgres_projections() {
     // Hidden/private candidates carry deliberately misleading public projection
     // scopes and high semantic similarity. Anonymous semantic retrieval still
     // cannot see them because canonical authorization ran before ranking.
+    let hybrid_before = search_requests_total_for_outcome(&state.metrics, "hybrid");
     let semantic = execute_search(
         &state,
         &anonymous,
@@ -2125,7 +2154,15 @@ async fn t006_search_api_against_postgres_projections() {
     .await
     .expect("semantic authorization boundary");
     assert!(semantic.items.is_empty());
+    assert_eq!(semantic.mode, SearchMode::Hybrid);
+    assert_eq!(
+        search_requests_total_for_outcome(&state.metrics, "hybrid") - hybrid_before,
+        1,
+        "a single available-provider hybrid search must record exactly one hybrid outcome"
+    );
 
+    let provider_contract_error_before =
+        search_requests_total_for_outcome(&state.metrics, "provider_contract_error");
     let provider_contract_failure = execute_search(
         &state,
         &anonymous,
@@ -2142,6 +2179,12 @@ async fn t006_search_api_against_postgres_projections() {
             EmbeddingProviderError::InvalidVector
         ))
     ));
+    assert_eq!(
+        search_requests_total_for_outcome(&state.metrics, "provider_contract_error")
+            - provider_contract_error_before,
+        1,
+        "a single provider-contract-error search must record exactly one provider_contract_error outcome"
+    );
 
     // The verified T004 core rejects candidate sets above 1000. T006 mirrors
     // that bound and fetches only one sentinel row beyond it, preventing an

--- a/apps/api/tests/db_semantic_search_projection_worker.rs
+++ b/apps/api/tests/db_semantic_search_projection_worker.rs
@@ -27,7 +27,7 @@ use weltgewebe_api::{
     middleware::auth::AuthContext,
     search::{
         execute_search, fetch_postgres_candidates, EmbeddingProvider, EmbeddingProviderError,
-        GenerationSpec, ProcessOutcome, ProjectionWorker, SearchError, SearchFilters,
+        GenerationSpec, ProcessOutcome, ProjectionWorker, SearchError, SearchFilters, SearchMode,
         SearchQueryParams, SearchRepositoryError, DOCUMENT_REVISION, MAX_AUTHORIZED_CANDIDATES,
         NORMALIZATION_REVISION, RANKING_REVISION,
     },
@@ -1960,7 +1960,7 @@ async fn t006_search_api_against_postgres_projections() {
         Some("t005-public-node")
     );
     assert_eq!(public.generation_id, gen_id);
-    assert_eq!(public.mode, "lexical_fallback");
+    assert_eq!(public.mode, SearchMode::LexicalFallback);
     assert_eq!(
         public.fallback_reason.as_deref(),
         Some("provider_unavailable")


### PR DESCRIPTION
<!-- weltgewebe-risk: R2 -->

## Summary

Follow-up hardening for merged PR #1554 after external review and live verification.

- replace free-form search outcome strings with bounded `SearchRequestOutcome`
- replace stringly `SearchResponse.mode` with serialized `SearchMode`, preserving the existing snake_case wire format
- remove the silent generic `success` telemetry bucket and make successful modes exhaustive
- remove the unreachable `1001` authorized-candidate histogram bucket after verifying `MAX_AUTHORIZED_CANDIDATES = 1000`
- add real request-path telemetry coverage for early unavailable, lexical fallback, hybrid, and provider contract error; assert one counter increment per request
- verify no repository dashboards, alerts, runbooks, or code still consume the removed `candidate_set_too_large` / `fallback_unavailable` projection-job outcomes

## Review findings resolved

- The reported quote-related compile error was not present in the repository; the pasted diff had lost escaping.
- The suggested lazy `into_iter().take(10)` zero-clone fallback was rejected after inspection: `lexical_ranked` is also an input to `rank_hybrid`, so that change would alter ranking semantics rather than merely optimize allocation.

## Validation

Independent second pass on final commit `1eaf4bf3d856469cb9fdb7535e2cc107889e8ec9`:

- `cargo fmt --all --check` — pass
- `cargo clippy --locked --all-targets -- -D warnings` — pass
- `cargo test --locked --lib telemetry::` — 5/5 pass
- disposable PostgreSQL 16: `cargo test --locked -p weltgewebe-api --test db_semantic_search_projection_worker -- --include-ignored --test-threads=1` — 13/13 pass
- `git diff --check origin/main...HEAD` — pass
- worktree clean after validation
