### PR TITLE
fix: harden Kubernetes proof resource lifecycle

### DIFF
--- a/docs/runbooks/kubernetes-ha-recovery-proof.md
+++ b/docs/runbooks/kubernetes-ha-recovery-proof.md
@@ -75,4 +75,4 @@ python scripts/platform/ha_reference.py down \
   --owner-id <exakte-owner-id>
 ```
 
-Ohne exakt passenden Eigentumsmarker für Repository, Commit und Owner-ID verweigert der Befehl das Löschen. Verwaiste Marker werden nicht automatisch entfernt.
+Ohne exakt passende Eigentumsbindung für Repository, Cluster, Commit und Owner-ID verweigert der Befehl das Löschen. Das gilt sowohl für die kind-Cluster als auch für Container und Volume des externen Proof-Object-Stores. Das JSON-Ergebnis weist jede Ressource als `deleted`, `absent` oder `error` aus und meldet bei gemischtem Ergebnis `partial`. Verwaiste oder unlesbare Marker werden nicht automatisch entfernt.

--- a/scripts/ci/tests/test_kubernetes_ha_contract.py
+++ b/scripts/ci/tests/test_kubernetes_ha_contract.py
@@ -374,7 +374,7 @@ class KubernetesHaContractTests(unittest.TestCase):
             stdout="",
             stderr=(
                 "Error response from daemon: get proof-object-store-data: "
-                "no such volume"
+                "No Such Volume"
             ),
         )
         with mock.patch.object(self.ha.subprocess, "run", return_value=result):

--- a/scripts/ci/tests/test_kubernetes_ha_contract.py
+++ b/scripts/ci/tests/test_kubernetes_ha_contract.py
@@ -368,6 +368,22 @@ class KubernetesHaContractTests(unittest.TestCase):
             with self.assertRaisesRegex(self.ha.ref.ProofError, "not spread"):
                 self.ha.configure_cluster_dns_ha("kubectl")
 
+    def test_external_object_store_missing_volume_is_absent_case_insensitively(self) -> None:
+        result = mock.Mock(
+            returncode=1,
+            stdout="",
+            stderr=(
+                "Error response from daemon: get proof-object-store-data: "
+                "no such volume"
+            ),
+        )
+        with mock.patch.object(self.ha.subprocess, "run", return_value=result):
+            self.assertIsNone(
+                self.ha._object_store_labels(
+                    "volume", "proof-object-store-data"
+                )
+            )
+
     def test_external_object_store_cleanup_is_ownership_bound(self) -> None:
         foreign = self.ha.external_object_store_binding(
             "proof", "a" * 40, "owner-foreign"

--- a/scripts/ci/tests/test_kubernetes_ha_contract.py
+++ b/scripts/ci/tests/test_kubernetes_ha_contract.py
@@ -9,6 +9,8 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+import yaml
+
 ROOT = Path(__file__).resolve().parents[3]
 PLATFORM_SCRIPTS = ROOT / "scripts/platform"
 if str(PLATFORM_SCRIPTS) not in sys.path:
@@ -189,15 +191,23 @@ class KubernetesHaContractTests(unittest.TestCase):
             )
 
     def test_kubernetes_workflow_checks_out_the_event_merge_state(self) -> None:
-        workflow = (ROOT / ".github/workflows/kubernetes-platform.yml").read_text()
-        self.assertEqual(
-            workflow.count(
-                "uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
-            ),
-            4,
-        )
-        self.assertNotIn("github.event.pull_request.head.sha", workflow)
-        self.assertNotIn("ref: ${{ github.event_name == 'pull_request'", workflow)
+        workflow_path = ROOT / ".github/workflows/kubernetes-platform.yml"
+        workflow_text = workflow_path.read_text()
+        workflow = yaml.safe_load(workflow_text)
+        checkout_steps = [
+            step
+            for job in workflow["jobs"].values()
+            for step in job.get("steps", [])
+            if str(step.get("uses", "")).startswith("actions/checkout@")
+        ]
+        self.assertEqual(len(checkout_steps), 4)
+        for step in checkout_steps:
+            self.assertEqual(
+                step["uses"],
+                "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+            )
+            self.assertNotIn("ref", step.get("with", {}))
+        self.assertNotIn("github.event.pull_request.head.sha", workflow_text)
 
     def test_kubernetes_workflow_covers_api_build_inputs(self) -> None:
         workflow = (ROOT / ".github/workflows/kubernetes-platform.yml").read_text()
@@ -359,28 +369,47 @@ class KubernetesHaContractTests(unittest.TestCase):
                 self.ha.configure_cluster_dns_ha("kubectl")
 
     def test_external_object_store_cleanup_is_ownership_bound(self) -> None:
-        inspect = mock.Mock(return_value=mock.Mock(returncode=0))
-        with mock.patch.object(self.ha.subprocess, "run", inspect), mock.patch.object(
-            self.ha.ref, "output", return_value="foreign-commit"
-        ):
+        foreign = self.ha.external_object_store_binding(
+            "proof", "a" * 40, "owner-foreign"
+        )
+        with mock.patch.object(
+            self.ha, "_object_store_labels", return_value=foreign
+        ), mock.patch.object(self.ha.ref, "run") as delete:
             with self.assertRaisesRegex(self.ha.ref.ProofError, "foreign"):
-                self.ha.delete_external_object_store("proof", "expected-commit")
+                self.ha.delete_external_object_store(
+                    "proof", "a" * 40, "owner-expected"
+                )
+        delete.assert_not_called()
 
     def test_external_object_store_start_cleans_partial_owned_resources(self) -> None:
-        absent = mock.Mock(returncode=1)
         with mock.patch.object(
-            self.ha.subprocess, "run", side_effect=[absent, absent]
+            self.ha, "_object_store_labels", side_effect=[None, None]
         ), mock.patch.object(self.ha.ref, "run"), mock.patch.object(
-            self.ha, "run_with_environment", side_effect=self.ha.ref.ProofError("container start failed")
-        ), mock.patch.object(self.ha, "delete_external_object_store") as cleanup:
+            self.ha,
+            "run_with_environment",
+            side_effect=self.ha.ref.ProofError("container start failed"),
+        ), mock.patch.object(
+            self.ha,
+            "reconcile_external_object_store",
+            return_value={"resources": {}, "errors": {}},
+        ) as cleanup:
             with self.assertRaisesRegex(self.ha.ref.ProofError, "container start failed"):
-                self.ha.start_external_object_store("proof", "a" * 40, "secret")
-        cleanup.assert_called_once_with("proof", "a" * 40)
+                self.ha.start_external_object_store(
+                    "proof", "a" * 40, "owner-proof", "secret"
+                )
+        cleanup.assert_called_once_with("proof", "a" * 40, "owner-proof")
 
     def test_kind_cluster_creation_is_transactional(self) -> None:
-        with mock.patch.object(self.ha.ref, "reserve_cluster_name") as reserve, mock.patch.object(
+        reservation_context = mock.MagicMock()
+        reservation_context.__enter__.return_value = None
+        reservation_context.__exit__.return_value = False
+        with mock.patch.object(
+            self.ha.ref,
+            "cluster_creation_reservation",
+            return_value=reservation_context,
+        ) as reservation, mock.patch.object(
             self.ha.ref, "run", side_effect=self.ha.ref.ProofError("kind failed")
-        ), mock.patch.object(self.ha.ref, "delete_owned_cluster") as cleanup:
+        ):
             with self.assertRaisesRegex(self.ha.ref.ProofError, "kind failed"):
                 self.ha.create_kind_cluster(
                     "kind",
@@ -390,13 +419,70 @@ class KubernetesHaContractTests(unittest.TestCase):
                     "b" * 40,
                     "owner-proof",
                 )
-        reserve.assert_called_once_with("kind", "proof", "b" * 40, "owner-proof")
-        cleanup.assert_called_once_with(
-            "kind",
-            "proof",
-            expected_commit="b" * 40,
-            expected_owner_id="owner-proof",
+        reservation.assert_called_once_with(
+            "kind", "proof", "b" * 40, "owner-proof"
         )
+
+    def test_ha_cleanup_continues_after_one_cluster_failure(self) -> None:
+        with mock.patch.object(
+            self.ha.ref,
+            "delete_owned_cluster_if_present",
+            side_effect=[self.ha.ref.ProofError("restore marker unreadable"), True],
+        ) as delete_cluster, mock.patch.object(
+            self.ha,
+            "reconcile_external_object_store",
+            return_value={
+                "resources": {
+                    "object_store_container": "deleted",
+                    "object_store_volume": "absent",
+                },
+                "errors": {},
+            },
+        ) as object_store:
+            result = self.ha.reconcile_owned_ha_resources(
+                "kind", "proof", "a" * 40, "owner-proof"
+            )
+        self.assertEqual(delete_cluster.call_count, 2)
+        object_store.assert_called_once_with("proof", "a" * 40, "owner-proof")
+        self.assertEqual(result["status"], "partial")
+        self.assertEqual(result["resources"]["restore_cluster"], "error")
+        self.assertEqual(result["resources"]["primary_cluster"], "deleted")
+        self.assertIn("restore_cluster", result["errors"])
+
+    def test_external_object_store_binding_covers_exact_owner_dimensions(self) -> None:
+        binding = self.ha.external_object_store_binding(
+            "proof", "a" * 40, "owner-proof"
+        )
+        self.assertEqual(
+            binding,
+            {
+                "weltgewebe.net/proof-repository": str(self.ha.ROOT),
+                "weltgewebe.net/proof-cluster": "proof",
+                "weltgewebe.net/proof-commit": "a" * 40,
+                "weltgewebe.net/proof-owner-id": "owner-proof",
+            },
+        )
+
+    def test_ha_cleanup_reports_absent_when_nothing_exists(self) -> None:
+        with mock.patch.object(
+            self.ha.ref, "delete_owned_cluster_if_present", return_value=False
+        ), mock.patch.object(
+            self.ha,
+            "reconcile_external_object_store",
+            return_value={
+                "resources": {
+                    "object_store_container": "absent",
+                    "object_store_volume": "absent",
+                },
+                "errors": {},
+            },
+        ):
+            result = self.ha.reconcile_owned_ha_resources(
+                "kind", "proof", "a" * 40, "owner-proof"
+            )
+        self.assertEqual(result["status"], "absent")
+        self.assertEqual(set(result["resources"].values()), {"absent"})
+        self.assertEqual(result["errors"], {})
 
     def test_digest_locked_manifest_replaces_each_release_image_once(self) -> None:
         tagged = {

--- a/scripts/ci/tests/test_kubernetes_platform_contract.py
+++ b/scripts/ci/tests/test_kubernetes_platform_contract.py
@@ -6,6 +6,8 @@ import os
 import shlex
 import subprocess
 import tempfile
+import threading
+import time
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -415,6 +417,152 @@ spec:
                 self.assertEqual(marker["commit"], "a" * 40)
                 self.assertEqual(marker["owner_id"], "owner-proof")
             finally:
+                self.reference.MARKERS = original
+
+    def test_reference_refuses_symlink_ownership_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            original = self.reference.MARKERS
+            self.reference.MARKERS = Path(tmp)
+            try:
+                target = Path(tmp) / "target.json"
+                target.write_text("{}\n", encoding="utf-8")
+                self.reference.marker_path("proof").symlink_to(target)
+                with self.assertRaisesRegex(
+                    self.reference.ProofError, "regular ownership marker"
+                ):
+                    self.reference.delete_owned_cluster(
+                        "kind",
+                        "proof",
+                        expected_commit="a" * 40,
+                        expected_owner_id="owner-proof",
+                    )
+            finally:
+                self.reference.MARKERS = original
+
+    def test_reference_refuses_cluster_without_marker_in_if_present_cleanup(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            original = self.reference.MARKERS
+            self.reference.MARKERS = Path(tmp)
+            try:
+                with mock.patch.object(
+                    self.reference, "clusters", return_value={"proof"}
+                ):
+                    with self.assertRaisesRegex(
+                        self.reference.ProofError, "exists without ownership marker"
+                    ):
+                        self.reference.delete_owned_cluster_if_present(
+                            "kind",
+                            "proof",
+                            expected_commit="a" * 40,
+                            expected_owner_id="owner-proof",
+                        )
+            finally:
+                self.reference.MARKERS = original
+
+    def test_reference_marker_publication_is_no_clobber_and_crash_atomic(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            original = self.reference.MARKERS
+            self.reference.MARKERS = Path(tmp)
+            try:
+                with mock.patch.object(
+                    self.reference.os, "link", side_effect=OSError("link failed")
+                ):
+                    with self.assertRaisesRegex(OSError, "link failed"):
+                        self.reference.write_marker(
+                            "proof", "a" * 40, "owner-proof"
+                        )
+                self.assertFalse(
+                    self.reference.marker_path("proof").exists()
+                )
+                self.assertEqual(
+                    list(Path(tmp).glob(".proof.*.marker.tmp")), []
+                )
+            finally:
+                self.reference.MARKERS = original
+
+    def test_reference_serializes_competing_reservations(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            original = self.reference.MARKERS
+            self.reference.MARKERS = Path(tmp)
+            outcomes: list[str] = []
+            start = threading.Barrier(2)
+
+            def reserve() -> None:
+                start.wait(timeout=1)
+                try:
+                    self.reference.reserve_cluster_name(
+                        "kind", "proof", "a" * 40, "owner-proof"
+                    )
+                    outcomes.append("reserved")
+                except self.reference.ProofError:
+                    outcomes.append("rejected")
+
+            try:
+                with mock.patch.object(
+                    self.reference, "clusters", return_value=set()
+                ):
+                    threads = [threading.Thread(target=reserve) for _ in range(2)]
+                    for thread in threads:
+                        thread.start()
+                    for thread in threads:
+                        thread.join(timeout=2)
+                self.assertCountEqual(outcomes, ["reserved", "rejected"])
+            finally:
+                self.reference.MARKERS = original
+
+    def test_creation_reservation_blocks_exact_owner_cleanup_until_create_finishes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            original = self.reference.MARKERS
+            self.reference.MARKERS = Path(tmp)
+            created: set[str] = set()
+            entered = threading.Event()
+            release = threading.Event()
+            cleanup_started = threading.Event()
+            cleanup_finished = threading.Event()
+            cleanup_result: list[bool] = []
+
+            def observed_clusters(_kind: str) -> set[str]:
+                return set(created)
+
+            def creator() -> None:
+                with self.reference.cluster_creation_reservation(
+                    "kind", "proof", "a" * 40, "owner-proof"
+                ):
+                    entered.set()
+                    release.wait(timeout=2)
+                    created.add("proof")
+
+            def cleanup() -> None:
+                cleanup_started.set()
+                cleanup_result.append(
+                    self.reference.delete_owned_cluster_if_present(
+                        "kind",
+                        "proof",
+                        expected_commit="a" * 40,
+                        expected_owner_id="owner-proof",
+                    )
+                )
+                cleanup_finished.set()
+
+            try:
+                with mock.patch.object(
+                    self.reference, "clusters", side_effect=observed_clusters
+                ), mock.patch.object(self.reference, "run"):
+                    creator_thread = threading.Thread(target=creator)
+                    cleanup_thread = threading.Thread(target=cleanup)
+                    creator_thread.start()
+                    self.assertTrue(entered.wait(timeout=1))
+                    cleanup_thread.start()
+                    self.assertTrue(cleanup_started.wait(timeout=1))
+                    time.sleep(0.05)
+                    self.assertFalse(cleanup_finished.is_set())
+                    release.set()
+                    creator_thread.join(timeout=2)
+                    cleanup_thread.join(timeout=2)
+                self.assertEqual(cleanup_result, [True])
+                self.assertFalse(self.reference.marker_path("proof").exists())
+            finally:
+                release.set()
                 self.reference.MARKERS = original
 
     def test_web_container_copies_postinstall_script_before_install(self) -> None:

--- a/scripts/ci/tests/test_kubernetes_platform_contract.py
+++ b/scripts/ci/tests/test_kubernetes_platform_contract.py
@@ -565,6 +565,31 @@ spec:
                 release.set()
                 self.reference.MARKERS = original
 
+    def test_creation_reservation_preserves_original_error_when_rollback_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            original = self.reference.MARKERS
+            self.reference.MARKERS = Path(tmp)
+            try:
+                with mock.patch.object(
+                    self.reference,
+                    "clusters",
+                    side_effect=[set(), {"proof"}],
+                ), mock.patch.object(
+                    self.reference,
+                    "run",
+                    side_effect=self.reference.ProofError("rollback failed"),
+                ):
+                    with self.assertRaisesRegex(
+                        self.reference.ProofError, "create failed"
+                    ):
+                        with self.reference.cluster_creation_reservation(
+                            "kind", "proof", "a" * 40, "owner-proof"
+                        ):
+                            raise self.reference.ProofError("create failed")
+                self.assertTrue(self.reference.marker_path("proof").is_file())
+            finally:
+                self.reference.MARKERS = original
+
     def test_web_container_copies_postinstall_script_before_install(self) -> None:
         dockerfile = (ROOT / "apps/web/Dockerfile").read_text()
         script_copy = dockerfile.index(

--- a/scripts/platform/ha_reference.py
+++ b/scripts/platform/ha_reference.py
@@ -73,18 +73,22 @@ def create_kind_cluster(
     commit: str,
     owner_id: str,
 ) -> None:
-    ref.reserve_cluster_name(kind, name, commit, owner_id)
-    try:
-        ref.run([kind, "create", "cluster", "--name", name, "--image", image, "--config", config], timeout=900)
-        ref.configure_cluster_access(kind, name)
-    except Exception:
-        ref.delete_owned_cluster(
-            kind,
-            name,
-            expected_commit=commit,
-            expected_owner_id=owner_id,
+    with ref.cluster_creation_reservation(kind, name, commit, owner_id):
+        ref.run(
+            [
+                kind,
+                "create",
+                "cluster",
+                "--name",
+                name,
+                "--image",
+                image,
+                "--config",
+                config,
+            ],
+            timeout=900,
         )
-        raise
+        ref.configure_cluster_access(kind, name)
 
 
 def require_active_cluster_context(kind: str, kubectl: str, cluster: str) -> str:
@@ -146,24 +150,129 @@ def external_object_store_names(cluster: str) -> tuple[str, str]:
     return f"{normalized}-object-store", f"{normalized}-object-store-data"
 
 
-def start_external_object_store(cluster: str, commit: str, s3_secret_key: str) -> tuple[str, str, str]:
+def external_object_store_binding(
+    cluster: str, commit: str, owner_id: str
+) -> dict[str, str]:
+    ref._validate_ownership_binding(commit, owner_id)
+    return {
+        "weltgewebe.net/proof-repository": str(ROOT),
+        "weltgewebe.net/proof-cluster": cluster,
+        "weltgewebe.net/proof-commit": commit,
+        "weltgewebe.net/proof-owner-id": owner_id,
+    }
+
+
+def _docker_label_args(labels: dict[str, str]) -> list[str]:
+    return [
+        argument
+        for key, value in sorted(labels.items())
+        for argument in ("--label", f"{key}={value}")
+    ]
+
+
+def _object_store_labels(resource_kind: str, name: str) -> dict[str, str] | None:
+    if resource_kind == "container":
+        argv = [
+            "docker",
+            "container",
+            "inspect",
+            "--format",
+            "{{json .Config.Labels}}",
+            name,
+        ]
+    elif resource_kind == "volume":
+        argv = [
+            "docker",
+            "volume",
+            "inspect",
+            "--format",
+            "{{json .Labels}}",
+            name,
+        ]
+    else:
+        raise ValueError(f"unsupported object-store resource kind: {resource_kind}")
+    result = subprocess.run(
+        argv, cwd=ROOT, text=True, capture_output=True, timeout=30
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        missing_markers = (
+            "No such container",
+            "No such volume",
+            "No such object",
+        )
+        if any(marker in detail for marker in missing_markers):
+            return None
+        raise ref.ProofError(
+            f"failed to inspect external object-store {resource_kind} {name}: "
+            f"{detail or f'exit {result.returncode}'}"
+        )
+    try:
+        labels = json.loads(result.stdout.strip() or "null")
+    except json.JSONDecodeError as error:
+        raise ref.ProofError(
+            f"external object-store {resource_kind} labels are unreadable: {name}"
+        ) from error
+    if not isinstance(labels, dict):
+        raise ref.ProofError(
+            f"external object-store {resource_kind} has no label object: {name}"
+        )
+    return {str(key): str(value) for key, value in labels.items()}
+
+
+def _require_object_store_binding(
+    resource_kind: str,
+    name: str,
+    observed: dict[str, str],
+    expected: dict[str, str],
+) -> None:
+    mismatched = {
+        key: {"expected": value, "observed": observed.get(key)}
+        for key, value in expected.items()
+        if observed.get(key) != value
+    }
+    if mismatched:
+        raise ref.ProofError(
+            f"refusing to delete foreign object-store {resource_kind} {name}: "
+            f"{json.dumps(mismatched, sort_keys=True)}"
+        )
+
+
+def start_external_object_store(
+    cluster: str, commit: str, owner_id: str, s3_secret_key: str
+) -> tuple[str, str, str]:
     container, volume = external_object_store_names(cluster)
-    if subprocess.run(["docker", "container", "inspect", container], capture_output=True).returncode == 0:
+    binding = external_object_store_binding(cluster, commit, owner_id)
+    if _object_store_labels("container", container) is not None:
         raise ref.ProofError(f"external object-store container already exists: {container}")
-    if subprocess.run(["docker", "volume", "inspect", volume], capture_output=True).returncode == 0:
+    if _object_store_labels("volume", volume) is not None:
         raise ref.ProofError(f"external object-store volume already exists: {volume}")
-    ref.run(["docker", "volume", "create", "--label", f"weltgewebe.net/proof-commit={commit}", volume])
+    ref.run(
+        ["docker", "volume", "create", *_docker_label_args(binding), volume]
+    )
     try:
         run_with_environment(
             [
-                "docker", "run", "--detach", "--name", container,
-                "--label", f"weltgewebe.net/proof-commit={commit}",
-                "--network", "kind",
-                "--env", "AWS_ACCESS_KEY_ID",
-                "--env", "AWS_SECRET_ACCESS_KEY",
-                "--env", "S3_BUCKET",
-                "--volume", f"{volume}:/data",
-                SEAWEEDFS_IMAGE, "mini", "-dir=/data", "-ip=0.0.0.0",
+                "docker",
+                "run",
+                "--detach",
+                "--name",
+                container,
+                *_docker_label_args(binding),
+                "--network",
+                "kind",
+                "--env",
+                "AWS_ACCESS_KEY_ID",
+                "--env",
+                "AWS_SECRET_ACCESS_KEY",
+                "--env",
+                "S3_BUCKET",
+                "--volume",
+                f"{volume}:/data",
+                SEAWEEDFS_IMAGE,
+                "mini",
+                "-dir=/data",
+                "-ip=0.0.0.0",
             ],
             {
                 "AWS_ACCESS_KEY_ID": S3_ACCESS_KEY,
@@ -172,35 +281,158 @@ def start_external_object_store(cluster: str, commit: str, s3_secret_key: str) -
             },
             timeout=120,
         )
+
         def address_probe() -> str | bool:
-            address = ref.output(["docker", "inspect", "--format", "{{(index .NetworkSettings.Networks \"kind\").IPAddress}}", container])
+            address = ref.output(
+                [
+                    "docker",
+                    "inspect",
+                    "--format",
+                    "{{(index .NetworkSettings.Networks \"kind\").IPAddress}}",
+                    container,
+                ]
+            )
             return address if address else False
-        address = str(wait_until("external object-store address", address_probe, timeout_seconds=60))
+
+        address = str(
+            wait_until(
+                "external object-store address", address_probe, timeout_seconds=60
+            )
+        )
+
         def port_probe() -> bool:
             result = subprocess.run(
-                ["docker", "exec", container, "sh", "-c", "wget -qO- http://127.0.0.1:9333/cluster/status >/dev/null"],
+                [
+                    "docker",
+                    "exec",
+                    container,
+                    "sh",
+                    "-c",
+                    "wget -qO- http://127.0.0.1:9333/cluster/status >/dev/null",
+                ],
                 capture_output=True,
             )
             return result.returncode == 0
+
         wait_until("external object-store readiness", port_probe, timeout_seconds=180)
         return container, volume, address
-    except Exception:
-        delete_external_object_store(cluster, commit)
+    except Exception as error:
+        cleanup = reconcile_external_object_store(cluster, commit, owner_id)
+        if cleanup["errors"]:
+            raise ref.ProofError(
+                "external object-store start failed and exact-owner cleanup was incomplete: "
+                f"{json.dumps(cleanup, sort_keys=True)}"
+            ) from error
         raise
 
 
-def delete_external_object_store(cluster: str, commit: str) -> None:
+def reconcile_external_object_store(
+    cluster: str, commit: str, owner_id: str
+) -> dict[str, Any]:
+    expected = external_object_store_binding(cluster, commit, owner_id)
     container, volume = external_object_store_names(cluster)
-    if subprocess.run(["docker", "container", "inspect", container], capture_output=True).returncode == 0:
-        label = ref.output(["docker", "inspect", "--format", "{{index .Config.Labels \"weltgewebe.net/proof-commit\"}}", container])
-        if label != commit:
-            raise ref.ProofError(f"refusing to delete foreign object-store container {container}")
-        ref.run(["docker", "rm", "--force", container])
-    if subprocess.run(["docker", "volume", "inspect", volume], capture_output=True).returncode == 0:
-        label = ref.output(["docker", "volume", "inspect", "--format", "{{index .Labels \"weltgewebe.net/proof-commit\"}}", volume])
-        if label != commit:
-            raise ref.ProofError(f"refusing to delete foreign object-store volume {volume}")
-        ref.run(["docker", "volume", "rm", volume])
+    resources: dict[str, str] = {}
+    errors: dict[str, str] = {}
+    for resource_key, resource_kind, name, delete_argv in (
+        (
+            "object_store_container",
+            "container",
+            container,
+            ["docker", "rm", "--force", container],
+        ),
+        (
+            "object_store_volume",
+            "volume",
+            volume,
+            ["docker", "volume", "rm", volume],
+        ),
+    ):
+        try:
+            labels = _object_store_labels(resource_kind, name)
+            if labels is None:
+                resources[resource_key] = "absent"
+                continue
+            _require_object_store_binding(resource_kind, name, labels, expected)
+            ref.run(delete_argv)
+            resources[resource_key] = "deleted"
+        except (
+            ref.ProofError,
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+            OSError,
+        ) as error:
+            resources[resource_key] = "error"
+            errors[resource_key] = str(error)
+    return {"resources": resources, "errors": errors}
+
+
+def delete_external_object_store(
+    cluster: str, commit: str, owner_id: str
+) -> dict[str, Any]:
+    result = reconcile_external_object_store(cluster, commit, owner_id)
+    if result["errors"]:
+        raise ref.ProofError(
+            "external object-store cleanup incomplete: "
+            f"{json.dumps(result, sort_keys=True)}"
+        )
+    return result
+
+
+def reconcile_owned_ha_resources(
+    kind: str,
+    cluster: str,
+    commit: str,
+    owner_id: str,
+    *,
+    include_restore: bool = True,
+    include_primary: bool = True,
+    include_object_store: bool = True,
+) -> dict[str, Any]:
+    ref._validate_ownership_binding(commit, owner_id)
+    resources: dict[str, str] = {}
+    errors: dict[str, str] = {}
+    cluster_resources = (
+        ("restore_cluster", f"{cluster}-restore", include_restore),
+        ("primary_cluster", cluster, include_primary),
+    )
+    for resource_key, name, included in cluster_resources:
+        if not included:
+            continue
+        try:
+            deleted = ref.delete_owned_cluster_if_present(
+                kind,
+                name,
+                expected_commit=commit,
+                expected_owner_id=owner_id,
+            )
+            resources[resource_key] = "deleted" if deleted else "absent"
+        except (
+            ref.ProofError,
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+            OSError,
+        ) as error:
+            resources[resource_key] = "error"
+            errors[resource_key] = str(error)
+
+    if include_object_store:
+        object_store = reconcile_external_object_store(cluster, commit, owner_id)
+        resources.update(object_store["resources"])
+        errors.update(object_store["errors"])
+
+    deleted_any = any(value == "deleted" for value in resources.values())
+    if errors:
+        status = "partial" if deleted_any else "error"
+    else:
+        status = "deleted" if deleted_any else "absent"
+    return {
+        "status": status,
+        "cluster": cluster,
+        "commit": commit,
+        "owner_id": owner_id,
+        "resources": resources,
+        "errors": errors,
+    }
 
 
 def apply_object_store_endpoint(kubectl: str, address: str) -> None:
@@ -2099,8 +2331,6 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
     )
     restore_name = f"{args.cluster}-restore"
     owner_id = args.owner_id or ref.generate_owner_id("ha-proof")
-    ref.assert_available_cluster_name(kind, args.cluster)
-    ref.assert_available_cluster_name(kind, restore_name)
     created_primary = created_restore = object_store_created = False
     stopped_node = ""
     object_store_address = ""
@@ -2120,7 +2350,9 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
         ref.install_platform_components(kubectl, flux, helm, receipt["artifacts"], ref.control_plane_address(args.cluster))
         ref.run([kubectl, "wait", "--for=condition=Ready", "nodes", "--all", "--timeout=8m"])
         primary_dns_topology = configure_cluster_dns_ha(kubectl)
-        _, _, object_store_address = start_external_object_store(args.cluster, commit, s3_secret_key)
+        _, _, object_store_address = start_external_object_store(
+            args.cluster, commit, owner_id, s3_secret_key
+        )
         object_store_created = True
         ref.apply_file(kubectl, ROOT / "platform/infrastructure/ha-data/namespace.yaml")
         apply_secret_contracts(kubectl, app_password, s3_secret_key)
@@ -2391,7 +2623,10 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
         }
         target = CACHE / "receipts"
         target.mkdir(parents=True, exist_ok=True)
-        path = target / f"{args.cluster}-{commit}-ha-recovery.json"
+        owner_receipt_key = hashlib.sha256(owner_id.encode("utf-8")).hexdigest()[:16]
+        path = target / (
+            f"{args.cluster}-{commit}-{owner_receipt_key}-ha-recovery.json"
+        )
         path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
         result["receipt_path"] = str(path)
         result["receipt_sha256"] = hashlib.sha256(path.read_bytes()).hexdigest()
@@ -2407,18 +2642,29 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
             ref.diagnostic_snapshot(kubectl, restore_name)
         raise
     finally:
+        active_error = sys.exc_info()[1]
         if stopped_node:
             subprocess.run(["docker", "start", stopped_node], capture_output=True)
-        if created_restore and not args.keep:
-            ref.delete_owned_cluster(
-                kind, restore_name, expected_commit=commit, expected_owner_id=owner_id
+        if not args.keep and (created_restore or created_primary or object_store_created):
+            cleanup = reconcile_owned_ha_resources(
+                kind,
+                args.cluster,
+                commit,
+                owner_id,
+                include_restore=created_restore,
+                include_primary=created_primary,
+                include_object_store=object_store_created,
             )
-        if created_primary and not args.keep:
-            ref.delete_owned_cluster(
-                kind, args.cluster, expected_commit=commit, expected_owner_id=owner_id
-            )
-        if object_store_created and not args.keep:
-            delete_external_object_store(args.cluster, commit)
+            if cleanup["errors"]:
+                detail = json.dumps(cleanup, sort_keys=True)
+                if active_error is None:
+                    raise ref.ProofError(
+                        f"HA proof cleanup incomplete: {detail}"
+                    )
+                print(
+                    f"HA proof cleanup incomplete while preserving original failure: {detail}",
+                    file=sys.stderr,
+                )
 
 
 def argument_parser() -> argparse.ArgumentParser:
@@ -2441,13 +2687,11 @@ def main() -> int:
         receipt = ref.tool_receipt()
         if args.command == "down":
             kind = receipt["tools"]["kind"]
-            for name in (f"{args.cluster}-restore", args.cluster):
-                ref.delete_owned_cluster_if_present(
-                    kind, name, expected_commit=args.commit, expected_owner_id=args.owner_id
-                )
-            delete_external_object_store(args.cluster, args.commit)
-            print(json.dumps({"status": "deleted", "cluster": args.cluster}))
-            return 0
+            cleanup = reconcile_owned_ha_resources(
+                kind, args.cluster, args.commit, args.owner_id
+            )
+            print(json.dumps(cleanup, sort_keys=True))
+            return 1 if cleanup["errors"] else 0
         prove(args)
     except (ref.ProofError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as error:
         if isinstance(error, subprocess.CalledProcessError):

--- a/scripts/platform/ha_reference.py
+++ b/scripts/platform/ha_reference.py
@@ -197,11 +197,11 @@ def _object_store_labels(resource_kind: str, name: str) -> dict[str, str] | None
     if result.returncode != 0:
         detail = (result.stderr or result.stdout).strip()
         missing_markers = (
-            "No such container",
-            "No such volume",
-            "No such object",
+            "no such container",
+            "no such volume",
+            "no such object",
         )
-        if any(marker in detail for marker in missing_markers):
+        if any(marker in detail.casefold() for marker in missing_markers):
             return None
         raise ref.ProofError(
             f"failed to inspect external object-store {resource_kind} {name}: "

--- a/scripts/platform/kind_reference.py
+++ b/scripts/platform/kind_reference.py
@@ -239,9 +239,22 @@ def assert_available_cluster_name(kind: str, name: str) -> None:
             )
 
 
-def write_marker(name: str, commit: str, owner_id: str) -> None:
+def _fsync_directory(path: Path) -> None:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    descriptor = os.open(path, flags)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _write_marker_locked(name: str, commit: str, owner_id: str) -> None:
     _validate_ownership_binding(commit, owner_id)
     MARKERS.mkdir(parents=True, exist_ok=True)
+    marker = marker_path(name)
+    temporary = MARKERS / f".{name}.{os.getpid()}.{secrets.token_hex(8)}.marker.tmp"
     payload = {
         "schema_version": 2,
         "cluster": name,
@@ -251,11 +264,27 @@ def write_marker(name: str, commit: str, owner_id: str) -> None:
         "pid": os.getpid(),
     }
     try:
-        with marker_path(name).open("x", encoding="utf-8") as handle:
+        with temporary.open("x", encoding="utf-8") as handle:
             json.dump(payload, handle, indent=2, sort_keys=True)
             handle.write("\n")
-    except FileExistsError as error:
-        raise ProofError(f"cluster {name!r} ownership marker already exists") from error
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            os.link(temporary, marker)
+        except FileExistsError as error:
+            raise ProofError(
+                f"cluster {name!r} ownership marker already exists"
+            ) from error
+        _fsync_directory(MARKERS)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def write_marker(name: str, commit: str, owner_id: str) -> None:
+    with cluster_ownership_lock(name):
+        if os.path.lexists(marker_path(name)):
+            raise ProofError(f"cluster {name!r} ownership marker already exists")
+        _write_marker_locked(name, commit, owner_id)
 
 
 def reserve_cluster_name(kind: str, name: str, commit: str, owner_id: str) -> None:
@@ -270,7 +299,60 @@ def reserve_cluster_name(kind: str, name: str, commit: str, owner_id: str) -> No
                 f"cluster {name!r} has a stale ownership marker; "
                 "explicit exact-owner cleanup is required"
             )
-        write_marker(name, commit, owner_id)
+        _write_marker_locked(name, commit, owner_id)
+
+
+@contextmanager
+def cluster_creation_reservation(
+    kind: str, name: str, commit: str, owner_id: str
+):
+    """Reserve one cluster name until creation either succeeds or is rolled back.
+
+    The per-cluster lock intentionally spans marker publication and ``kind create``.
+    This prevents an exact-owner reconciliation from deleting the marker in the
+    gap between reservation and cluster creation. Persistent lock files are kept
+    because unlinking flock files can create inode races between waiters.
+    """
+    _validate_ownership_binding(commit, owner_id)
+    with cluster_ownership_lock(name):
+        if name in clusters(kind):
+            raise ProofError(
+                f"cluster {name!r} already exists; it is never adopted or deleted by this proof"
+            )
+        if os.path.lexists(marker_path(name)):
+            raise ProofError(
+                f"cluster {name!r} has a stale ownership marker; "
+                "explicit exact-owner cleanup is required"
+            )
+        _write_marker_locked(name, commit, owner_id)
+        try:
+            yield
+        except Exception:
+            if name in clusters(kind):
+                run([kind, "delete", "cluster", "--name", name])
+            marker_path(name).unlink(missing_ok=True)
+            kubeconfig_path(name).unlink(missing_ok=True)
+            raise
+
+
+def _delete_owned_cluster_locked(
+    kind: str,
+    name: str,
+    *,
+    expected_commit: str,
+    expected_owner_id: str,
+) -> None:
+    data = _read_marker(name)
+    _require_marker_binding(
+        data,
+        name,
+        expected_commit=expected_commit,
+        expected_owner_id=expected_owner_id,
+    )
+    if name in clusters(kind):
+        run([kind, "delete", "cluster", "--name", name])
+    marker_path(name).unlink()
+    kubeconfig_path(name).unlink(missing_ok=True)
 
 
 def delete_owned_cluster(
@@ -281,17 +363,12 @@ def delete_owned_cluster(
     expected_owner_id: str,
 ) -> None:
     with cluster_ownership_lock(name):
-        data = _read_marker(name)
-        _require_marker_binding(
-            data,
+        _delete_owned_cluster_locked(
+            kind,
             name,
             expected_commit=expected_commit,
             expected_owner_id=expected_owner_id,
         )
-        if name in clusters(kind):
-            run([kind, "delete", "cluster", "--name", name])
-        marker_path(name).unlink()
-        kubeconfig_path(name).unlink(missing_ok=True)
 
 
 def delete_owned_cluster_if_present(
@@ -301,19 +378,21 @@ def delete_owned_cluster_if_present(
     expected_commit: str,
     expected_owner_id: str,
 ) -> bool:
-    if os.path.lexists(marker_path(name)):
-        delete_owned_cluster(
-            kind,
-            name,
-            expected_commit=expected_commit,
-            expected_owner_id=expected_owner_id,
-        )
-        return True
-    if name in clusters(kind):
-        raise ProofError(
-            f"refusing to delete cluster {name!r}: cluster exists without ownership marker"
-        )
-    return False
+    with cluster_ownership_lock(name):
+        if os.path.lexists(marker_path(name)):
+            _delete_owned_cluster_locked(
+                kind,
+                name,
+                expected_commit=expected_commit,
+                expected_owner_id=expected_owner_id,
+            )
+            return True
+        if name in clusters(kind):
+            raise ProofError(
+                f"refusing to delete cluster {name!r}: cluster exists without ownership marker"
+            )
+        return False
+
 
 def apply_yaml(kubectl: str, document: dict[str, Any] | list[dict[str, Any]]) -> None:
     documents = document if isinstance(document, list) else [document]
@@ -1029,28 +1108,29 @@ def proof(args: argparse.Namespace) -> dict[str, Any]:
     flux = tools["flux"]
     helm = tools["helm"]
     owner_id = args.owner_id or generate_owner_id("kind-proof")
-    reserve_cluster_name(kind, args.cluster, commit, owner_id)
     app_namespace = "weltgewebe"
-    reserved = True
+    reserved = False
     created = False
     try:
-        run(
-            [
-                kind,
-                "create",
-                "cluster",
-                "--name",
-                args.cluster,
-                "--image",
-                receipt["kubernetes"]["kind_node_image"],
-                "--config",
-                "platform/clusters/local/kind.yaml",
-            ],
-            timeout=600,
-        )
-        configure_cluster_access(kind, args.cluster)
-        api_server_host = control_plane_address(args.cluster)
+        with cluster_creation_reservation(kind, args.cluster, commit, owner_id):
+            run(
+                [
+                    kind,
+                    "create",
+                    "cluster",
+                    "--name",
+                    args.cluster,
+                    "--image",
+                    receipt["kubernetes"]["kind_node_image"],
+                    "--config",
+                    "platform/clusters/local/kind.yaml",
+                ],
+                timeout=600,
+            )
+            configure_cluster_access(kind, args.cluster)
+        reserved = True
         created = True
+        api_server_host = control_plane_address(args.cluster)
         image_ids = build_images(kind, args.cluster, commit, timestamp)
         install_platform_components(
             kubectl, flux, helm, receipt["artifacts"], api_server_host
@@ -1094,7 +1174,8 @@ def proof(args: argparse.Namespace) -> dict[str, Any]:
         }
         target = CACHE / "receipts"
         target.mkdir(parents=True, exist_ok=True)
-        path = target / f"{args.cluster}-{commit}.json"
+        owner_receipt_key = hashlib.sha256(owner_id.encode("utf-8")).hexdigest()[:16]
+        path = target / f"{args.cluster}-{commit}-{owner_receipt_key}.json"
         path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
         result["receipt_path"] = str(path)
         result["receipt_sha256"] = hashlib.sha256(path.read_bytes()).hexdigest()

--- a/scripts/platform/kind_reference.py
+++ b/scripts/platform/kind_reference.py
@@ -328,10 +328,21 @@ def cluster_creation_reservation(
         try:
             yield
         except Exception:
-            if name in clusters(kind):
-                run([kind, "delete", "cluster", "--name", name])
-            marker_path(name).unlink(missing_ok=True)
-            kubeconfig_path(name).unlink(missing_ok=True)
+            rollback_error: Exception | None = None
+            try:
+                if name in clusters(kind):
+                    run([kind, "delete", "cluster", "--name", name])
+            except Exception as error:
+                rollback_error = error
+            if rollback_error is None:
+                marker_path(name).unlink(missing_ok=True)
+                kubeconfig_path(name).unlink(missing_ok=True)
+            else:
+                print(
+                    f"cluster {name!r} creation rollback incomplete; "
+                    f"preserving ownership marker: {rollback_error}",
+                    file=sys.stderr,
+                )
             raise
 
 


### PR DESCRIPTION
<!-- weltgewebe-risk: R3 -->

## Summary

- bind HA object-store container and volume to exact repository, cluster, commit, and owner ID
- make kind marker publication crash-atomic/no-clobber and serialize reservation through cluster creation
- reconcile HA resources independently with truthful deleted/absent/partial/error status
- harden checkout contract assertions structurally and add concurrency/failure regression coverage
- bind local proof receipt filenames to owner identity and document exact-owner HA cleanup

## Validation

- `python -m unittest scripts.ci.tests.test_kubernetes_platform_contract scripts.ci.tests.test_kubernetes_ha_contract` — 114 tests, PASS
- `python scripts/platform/validate_platform.py --render` — PASS
- `make validate` — PASS with a temporary external `tomllib` compatibility shim because the host default is Python 3.10 while the repository toolchain declares Python 3.12
- `git diff --check` — PASS

## Review focus

Please verify fail-closed ownership semantics, per-cluster lock continuity across marker publication and `kind create`, and independent HA cleanup behavior.