### PR TITLE
feat(web): use authorized server search and similar nodes

### DIFF
--- a/apps/web/src/lib/api/search.test.ts
+++ b/apps/web/src/lib/api/search.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildSimilarNodeQuery, nodeToMapEntity, searchNodes } from "./search";
+import type { Node } from "$lib/map/types";
+
+const NODE: Node = {
+  id: "node-1",
+  kind: "Werkstatt",
+  title: "Radwerkstatt",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-02T00:00:00Z",
+  summary: "Gemeinsam Fahrräder reparieren",
+  info: "Offene Werkstatt",
+  tags: ["Fahrrad", "Hilfe"],
+  location: { lat: 54.9, lon: 8.3 },
+};
+
+describe("searchNodes", () => {
+  it("calls the authorized server search with credentials and stable kind filters", async () => {
+    const fetcher = vi.fn<typeof fetch>(
+      async () =>
+        new Response(
+          JSON.stringify({
+            items: [NODE],
+            mode: "hybrid",
+            generation_id: "generation-1",
+            offset: 0,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+
+    const response = await searchNodes("  Fahrrad Hilfe  ", {
+      kinds: ["Werkstatt", "Treffpunkt", "Werkstatt"],
+      apiBase: "https://api.example.test",
+      fetcher: fetcher as typeof fetch,
+    });
+
+    expect(response.items).toEqual([NODE]);
+    expect(fetcher).toHaveBeenCalledOnce();
+    const [url, init] = fetcher.mock.calls[0];
+    expect(String(url)).toBe(
+      "https://api.example.test/api/search?q=Fahrrad+Hilfe&limit=10&kinds=Treffpunkt%2CWerkstatt",
+    );
+    expect(init).toMatchObject({ credentials: "include" });
+  });
+
+  it("maps server nodes to canonical map entities", () => {
+    expect(nodeToMapEntity(NODE)).toMatchObject({
+      type: "node",
+      id: "node-1",
+      lat: 54.9,
+      lon: 8.3,
+      kind: "Werkstatt",
+    });
+  });
+});
+
+describe("buildSimilarNodeQuery", () => {
+  it("uses node content as bounded machine-similarity context", () => {
+    expect(buildSimilarNodeQuery(NODE)).toBe(
+      "Radwerkstatt · Werkstatt · Gemeinsam Fahrräder reparieren · Offene Werkstatt · Fahrrad · Hilfe",
+    );
+  });
+
+  it("never exceeds the T006 query contract", () => {
+    expect(buildSimilarNodeQuery({ title: "x".repeat(600) })).toHaveLength(512);
+  });
+});

--- a/apps/web/src/lib/api/search.test.ts
+++ b/apps/web/src/lib/api/search.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
-import { buildSimilarNodeQuery, nodeToMapEntity, searchNodes } from "./search";
+import {
+  buildSimilarNodeQuery,
+  MAX_SEARCH_QUERY_CHARS,
+  nodeToMapEntity,
+  searchNodes,
+} from "./search";
 import type { Node } from "$lib/map/types";
 
 const NODE: Node = {
@@ -14,20 +19,21 @@ const NODE: Node = {
   location: { lat: 54.9, lon: 8.3 },
 };
 
+function searchResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      items: [NODE],
+      mode: "hybrid",
+      generation_id: "generation-1",
+      offset: 0,
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
 describe("searchNodes", () => {
   it("calls the authorized server search with credentials and stable kind filters", async () => {
-    const fetcher = vi.fn<typeof fetch>(
-      async () =>
-        new Response(
-          JSON.stringify({
-            items: [NODE],
-            mode: "hybrid",
-            generation_id: "generation-1",
-            offset: 0,
-          }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        ),
-    );
+    const fetcher = vi.fn<typeof fetch>(async () => searchResponse());
 
     const response = await searchNodes("  Fahrrad Hilfe  ", {
       kinds: ["Werkstatt", "Treffpunkt", "Werkstatt"],
@@ -42,6 +48,20 @@ describe("searchNodes", () => {
       "https://api.example.test/api/search?q=Fahrrad+Hilfe&limit=10&kinds=Treffpunkt%2CWerkstatt",
     );
     expect(init).toMatchObject({ credentials: "include" });
+  });
+
+  it("bounds overlong queries before they reach the server contract", async () => {
+    const fetcher = vi.fn<typeof fetch>(async () => searchResponse());
+
+    await searchNodes(`  ${"😀".repeat(MAX_SEARCH_QUERY_CHARS + 20)}  `, {
+      apiBase: "https://api.example.test",
+      fetcher: fetcher as typeof fetch,
+    });
+
+    const [url] = fetcher.mock.calls[0];
+    const query = new URL(String(url)).searchParams.get("q");
+    expect(Array.from(query ?? "")).toHaveLength(MAX_SEARCH_QUERY_CHARS);
+    expect(query).toBe("😀".repeat(MAX_SEARCH_QUERY_CHARS));
   });
 
   it("maps server nodes to canonical map entities", () => {
@@ -63,6 +83,8 @@ describe("buildSimilarNodeQuery", () => {
   });
 
   it("never exceeds the T006 query contract", () => {
-    expect(buildSimilarNodeQuery({ title: "x".repeat(600) })).toHaveLength(512);
+    expect(buildSimilarNodeQuery({ title: "x".repeat(600) })).toHaveLength(
+      MAX_SEARCH_QUERY_CHARS,
+    );
   });
 });

--- a/apps/web/src/lib/api/search.ts
+++ b/apps/web/src/lib/api/search.ts
@@ -1,5 +1,7 @@
 import type { MapEntityNode, Node } from "$lib/map/types";
 
+export const MAX_SEARCH_QUERY_CHARS = 512;
+
 export type NodeSearchStatus = "idle" | "loading" | "ready" | "error";
 
 export interface NodeSearchResponse {
@@ -42,11 +44,15 @@ export function nodeToMapEntity(node: Node): MapEntityNode {
   };
 }
 
+export function normalizeSearchQuery(query: string): string {
+  return Array.from(query.trim()).slice(0, MAX_SEARCH_QUERY_CHARS).join("");
+}
+
 export async function searchNodes(
   query: string,
   options: SearchNodesOptions = {},
 ): Promise<NodeSearchResponse> {
-  const normalizedQuery = query.trim();
+  const normalizedQuery = normalizeSearchQuery(query);
   if (!normalizedQuery) {
     throw new Error("Search query must not be empty");
   }
@@ -90,5 +96,7 @@ export function buildSimilarNodeQuery(source: SimilarNodeSource): string {
   ]
     .map((part) => part?.trim())
     .filter((part): part is string => Boolean(part));
-  return Array.from(parts.join(" · ")).slice(0, 512).join("");
+  return Array.from(parts.join(" · "))
+    .slice(0, MAX_SEARCH_QUERY_CHARS)
+    .join("");
 }

--- a/apps/web/src/lib/api/search.ts
+++ b/apps/web/src/lib/api/search.ts
@@ -1,0 +1,94 @@
+import type { MapEntityNode, Node } from "$lib/map/types";
+
+export type NodeSearchStatus = "idle" | "loading" | "ready" | "error";
+
+export interface NodeSearchResponse {
+  items: Node[];
+  mode: string;
+  fallback_reason?: string;
+  generation_id: string;
+  offset: number;
+}
+
+export interface SearchNodesOptions {
+  kinds?: string[];
+  limit?: number;
+  signal?: AbortSignal;
+  fetcher?: typeof fetch;
+  apiBase?: string;
+}
+
+export class SearchApiError extends Error {
+  constructor(public readonly status: number) {
+    super(`Search request failed with HTTP ${status}`);
+    this.name = "SearchApiError";
+  }
+}
+
+export function nodeToMapEntity(node: Node): MapEntityNode {
+  return {
+    type: "node",
+    id: node.id,
+    title: node.title,
+    lat: node.location.lat,
+    lon: node.location.lon,
+    summary: node.summary,
+    info: node.info,
+    kind: node.kind,
+    tags: node.tags,
+    modules: node.modules,
+    created_at: node.created_at,
+    updated_at: node.updated_at,
+  };
+}
+
+export async function searchNodes(
+  query: string,
+  options: SearchNodesOptions = {},
+): Promise<NodeSearchResponse> {
+  const normalizedQuery = query.trim();
+  if (!normalizedQuery) {
+    throw new Error("Search query must not be empty");
+  }
+
+  const params = new URLSearchParams({
+    q: normalizedQuery,
+    limit: String(options.limit ?? 10),
+  });
+  const kinds = Array.from(
+    new Set((options.kinds ?? []).map((kind) => kind.trim()).filter(Boolean)),
+  ).sort();
+  if (kinds.length > 0) params.set("kinds", kinds.join(","));
+
+  const apiBase =
+    options.apiBase ?? import.meta.env.PUBLIC_GEWEBE_API_BASE ?? "";
+  const fetcher = options.fetcher ?? fetch;
+  const response = await fetcher(`${apiBase}/api/search?${params.toString()}`, {
+    credentials: "include",
+    headers: { Accept: "application/json" },
+    signal: options.signal,
+  });
+  if (!response.ok) throw new SearchApiError(response.status);
+  return (await response.json()) as NodeSearchResponse;
+}
+
+export interface SimilarNodeSource {
+  title?: string | null;
+  kind?: string | null;
+  summary?: string | null;
+  info?: string | null;
+  tags?: string[] | null;
+}
+
+export function buildSimilarNodeQuery(source: SimilarNodeSource): string {
+  const parts = [
+    source.title,
+    source.kind,
+    source.summary,
+    source.info,
+    ...(source.tags ?? []),
+  ]
+    .map((part) => part?.trim())
+    .filter((part): part is string => Boolean(part));
+  return Array.from(parts.join(" · ")).slice(0, 512).join("");
+}

--- a/apps/web/src/lib/components/ContextPanel.svelte
+++ b/apps/web/src/lib/components/ContextPanel.svelte
@@ -14,13 +14,18 @@
     Selection,
     SystemState,
   } from "$lib/stores/uiView";
+  import type { MapEntityViewModel } from "$lib/map/types";
 
   import NodePanel from "./panels/NodePanel.svelte";
   import AccountPanel from "./panels/AccountPanel.svelte";
   import EdgePanel from "./panels/EdgePanel.svelte";
   import KompositionPanel from "./panels/KompositionPanel.svelte";
 
-  type RelatedSelection = { type: "node" | "garnrolle"; id: string };
+  type RelatedSelection = {
+    type: "node" | "garnrolle";
+    id: string;
+    data?: MapEntityViewModel;
+  };
   type DomainChanged = {
     kind: "node";
     id: string;

--- a/apps/web/src/lib/components/SearchOverlay.svelte
+++ b/apps/web/src/lib/components/SearchOverlay.svelte
@@ -8,9 +8,13 @@
   import { contextPanelOpen } from "$lib/stores/uiView";
   import { activeFilters } from "$lib/stores/filterStore";
   import type { MapEntityViewModel } from "$lib/map/types";
+  import type { NodeSearchStatus } from "$lib/api/search";
   import { restoreTarget } from "$lib/utils/focusManager";
 
   export let filteredResults: MapEntityViewModel[] = [];
+  export let searchStatus: NodeSearchStatus = "idle";
+  export let searchMode: string | null = null;
+  export let searchFallbackReason: string | null = null;
   const dispatch = createEventDispatcher<{ select: MapEntityViewModel }>();
   let inputEl: HTMLInputElement;
   let listEl: HTMLUListElement;
@@ -109,6 +113,7 @@
     role="dialog"
     aria-label="Finden"
     aria-modal="false"
+    aria-busy={searchStatus === "loading"}
   >
     <div class="search-box">
       <span class="search-icon" aria-hidden="true">⌕</span>
@@ -137,6 +142,23 @@
     </div>
 
     {#if $searchQuery.trim().length > 0}
+      {#if searchStatus === "loading"}
+        <div class="search-status" role="status" aria-live="polite">
+          Knoten werden sicher auf dem Server gesucht…
+        </div>
+      {/if}
+      {#if searchStatus === "error"}
+        <div class="search-error" role="status" aria-live="polite">
+          Die sichere Knotensuche ist gerade nicht verfügbar. Es wird nicht auf
+          eine lokale Knotensuche zurückgefallen.
+        </div>
+      {/if}
+      {#if searchMode === "lexical_fallback" || searchFallbackReason === "provider_unavailable"}
+        <div class="search-note" role="status">
+          Die semantische Ergänzung ist vorübergehend nicht verfügbar. Die
+          serverseitige lexikalische Suche bleibt aktiv.
+        </div>
+      {/if}
       {#if visibleResults.length > 0}
         <div class="result-meta" aria-live="polite">
           {#if $activeFilters.size > 0}
@@ -197,7 +219,7 @@
               : `Alle ${filteredResults.length} Vorschläge zeigen`}</button
           >
         {/if}
-      {:else}
+      {:else if searchStatus !== "loading" && searchStatus !== "error"}
         <div class="no-results" role="status">
           Keine Treffer für „{$searchQuery}“
         </div>
@@ -266,6 +288,24 @@
     padding: 0.35rem 0.45rem 0.15rem;
     color: var(--muted);
     font-size: 0.78rem;
+  }
+  .search-status,
+  .search-error,
+  .search-note {
+    margin: 0.4rem 0.35rem 0;
+    padding: 0.55rem 0.65rem;
+    border-radius: 9px;
+    font-size: 0.8rem;
+    line-height: 1.35;
+  }
+  .search-status,
+  .search-note {
+    background: var(--accent-soft);
+    color: var(--muted);
+  }
+  .search-error {
+    border: 1px solid color-mix(in srgb, #a33 55%, transparent);
+    color: var(--text);
   }
   .results {
     list-style: none;

--- a/apps/web/src/lib/components/SearchOverlay.svelte
+++ b/apps/web/src/lib/components/SearchOverlay.svelte
@@ -163,12 +163,12 @@
         <div class="result-meta" aria-live="polite">
           {#if $activeFilters.size > 0}
             {filteredResults.length === 1
-              ? "1 Treffer in der aktuellen Kartenansicht"
-              : `${filteredResults.length} Treffer in der aktuellen Kartenansicht`}
+              ? "1 gefilterter Treffer"
+              : `${filteredResults.length} gefilterte Treffer`}
           {:else}
             {filteredResults.length === 1
-              ? "1 Treffer auf der Karte"
-              : `${filteredResults.length} Treffer auf der Karte`}
+              ? "1 Treffer"
+              : `${filteredResults.length} Treffer`}
           {/if}
         </div>
         <ul

--- a/apps/web/src/lib/components/SearchOverlay.svelte
+++ b/apps/web/src/lib/components/SearchOverlay.svelte
@@ -8,6 +8,7 @@
   import { contextPanelOpen } from "$lib/stores/uiView";
   import { activeFilters } from "$lib/stores/filterStore";
   import type { MapEntityViewModel } from "$lib/map/types";
+  import { MAX_SEARCH_QUERY_CHARS } from "$lib/api/search";
   import type { NodeSearchStatus } from "$lib/api/search";
   import { restoreTarget } from "$lib/utils/focusManager";
 
@@ -121,6 +122,7 @@
         bind:this={inputEl}
         bind:value={$searchQuery}
         type="search"
+        maxlength={MAX_SEARCH_QUERY_CHARS}
         placeholder="Gewebe durchsuchen…"
         aria-label="Suchbegriff"
         aria-autocomplete="list"

--- a/apps/web/src/lib/components/panels/NodePanel.svelte
+++ b/apps/web/src/lib/components/panels/NodePanel.svelte
@@ -13,6 +13,7 @@
   } from "$lib/panels/panelDetails";
   import { formatDate } from "$lib/utils/formatDate";
   import { nodeKindLabel } from "$lib/ui/productLanguage";
+  import type { MapEntityViewModel } from "$lib/map/types";
   import NodeConversation from "./NodeConversation.svelte";
 
   type DomainChanged = {
@@ -22,7 +23,11 @@
   };
 
   const dispatch = createEventDispatcher<{
-    selectRelated: { type: "garnrolle"; id: string };
+    selectRelated: {
+      type: "node" | "garnrolle";
+      id: string;
+      data?: MapEntityViewModel;
+    };
     domainChanged: DomainChanged;
   }>();
 
@@ -45,6 +50,10 @@
   let formLon = "";
   let formTags = "";
   let conflictNode: NodeDetails | null = null;
+  let SimilarNodesComponent:
+    | typeof import("./SimilarNodes.svelte").default
+    | null = null;
+  let similarNodesLoadStarted = false;
 
   interface NodeDetails {
     id: string;
@@ -95,6 +104,16 @@
     ($authStore.role === "weber" ||
       $authStore.role === "admin" ||
       (!!nodeCreator && nodeCreator === $authStore.account_id));
+
+  async function ensureSimilarNodesComponent() {
+    if (similarNodesLoadStarted) return;
+    similarNodesLoadStarted = true;
+    SimilarNodesComponent = (await import("./SimilarNodes.svelte")).default;
+  }
+
+  $: if ($selection?.type === "node" && !similarNodesLoadStarted) {
+    void ensureSimilarNodesComponent();
+  }
 
   $: tabs = canMutate
     ? ["uebersicht", "gespraech", "verlauf", "bearbeiten"]
@@ -474,6 +493,18 @@
                     </li>{/each}
                 </ul>
               </div>
+            {/if}
+            {#if SimilarNodesComponent}
+              <svelte:component
+                this={SimilarNodesComponent}
+                sourceId={nodeDetails?.id || $selection?.id || ""}
+                title={nodeDetails?.title || $selection?.data?.title}
+                kind={nodeDetails?.kind || $selection?.data?.kind}
+                summary={nodeDetails?.summary || $selection?.data?.summary}
+                info={nodeDetails?.info || $selection?.data?.info}
+                tags={nodeDetails?.tags || $selection?.data?.tags}
+                on:select={(event) => dispatch("selectRelated", event.detail)}
+              />
             {/if}
           {/if}
         </div>

--- a/apps/web/src/lib/components/panels/SimilarNodes.svelte
+++ b/apps/web/src/lib/components/panels/SimilarNodes.svelte
@@ -160,7 +160,9 @@
     margin-top: 0;
   }
   .similar-error {
-    color: #a33;
+    color: var(--text);
+    border-left: 3px solid color-mix(in srgb, #a33 70%, var(--text));
+    padding-left: 0.6rem;
   }
   ul {
     list-style: none;

--- a/apps/web/src/lib/components/panels/SimilarNodes.svelte
+++ b/apps/web/src/lib/components/panels/SimilarNodes.svelte
@@ -1,0 +1,195 @@
+<script lang="ts">
+  import { createEventDispatcher, onDestroy } from "svelte";
+  import { nodeKindLabel } from "$lib/ui/productLanguage";
+  import {
+    buildSimilarNodeQuery,
+    nodeToMapEntity,
+    searchNodes,
+  } from "$lib/api/search";
+  import type { MapEntityNode, MapEntityViewModel } from "$lib/map/types";
+
+  export let sourceId: string;
+  export let title: string | null | undefined = null;
+  export let kind: string | null | undefined = null;
+  export let summary: string | null | undefined = null;
+  export let info: string | null | undefined = null;
+  export let tags: string[] | null | undefined = null;
+
+  const dispatch = createEventDispatcher<{
+    select: { type: "node"; id: string; data: MapEntityViewModel };
+  }>();
+
+  let similarNodes: MapEntityNode[] = [];
+  let loading = false;
+  let error = "";
+  let mode: string | null = null;
+  let previousKey = "";
+  let abortController: AbortController | null = null;
+  let requestSequence = 0;
+
+  $: query = buildSimilarNodeQuery({ title, kind, summary, info, tags });
+
+  async function load(query: string) {
+    abortController?.abort();
+    const controller = new AbortController();
+    abortController = controller;
+    const sequence = ++requestSequence;
+    loading = true;
+    error = "";
+    mode = null;
+    similarNodes = [];
+    try {
+      const response = await searchNodes(query, {
+        limit: 6,
+        signal: controller.signal,
+      });
+      if (controller.signal.aborted || sequence !== requestSequence) return;
+      mode = response.mode;
+      similarNodes = response.items
+        .filter((item) => item.id !== sourceId)
+        .map(nodeToMapEntity)
+        .slice(0, 4);
+    } catch {
+      if (controller.signal.aborted || sequence !== requestSequence) return;
+      error =
+        "Maschinell berechnete ähnliche Knoten sind gerade nicht verfügbar.";
+    } finally {
+      if (sequence === requestSequence) loading = false;
+      if (abortController === controller) abortController = null;
+    }
+  }
+
+  $: {
+    const key = sourceId && query ? `${sourceId}\u0000${query}` : "";
+    if (key !== previousKey) {
+      previousKey = key;
+      requestSequence += 1;
+      abortController?.abort();
+      abortController = null;
+      similarNodes = [];
+      loading = false;
+      error = "";
+      mode = null;
+      if (sourceId && query) void load(query);
+    }
+  }
+
+  onDestroy(() => {
+    requestSequence += 1;
+    abortController?.abort();
+  });
+</script>
+
+<section
+  class="similar-nodes"
+  aria-labelledby="similar-nodes-heading"
+  aria-describedby="similar-nodes-explainer"
+  aria-busy={loading}
+>
+  <h4 id="similar-nodes-heading">Ähnliche Knoten</h4>
+  <p id="similar-nodes-explainer" class="similar-explainer">
+    Maschinell aus Inhalt und Schlagwörtern dieses Knotens berechnet. Das sind
+    Vorschläge – keine Fäden, keine kuratierten Beziehungen und keine Aussage
+    über gemeinsame Autorenschaft.
+  </p>
+  {#if loading}
+    <p class="ghost" role="status" aria-live="polite">
+      Ähnliche Knoten werden berechnet…
+    </p>
+  {:else if error}
+    <p class="similar-error" role="status" aria-live="polite">{error}</p>
+  {:else}
+    {#if mode === "lexical_fallback"}
+      <p class="similar-note" role="status" aria-live="polite">
+        Die semantische Ergänzung ist gerade nicht verfügbar; die Vorschläge
+        stammen aus dem lexikalischen Serverpfad.
+      </p>
+    {/if}
+    {#if similarNodes.length > 0}
+      <p class="similar-result-status" role="status" aria-live="polite">
+        {similarNodes.length} maschinell berechnete {similarNodes.length === 1
+          ? "Ähnlichkeit"
+          : "Ähnlichkeiten"} gefunden.
+      </p>
+      <ul aria-label="Maschinell berechnete ähnliche Knoten">
+        {#each similarNodes as similar}
+          <li>
+            <button
+              type="button"
+              on:click={() =>
+                dispatch("select", {
+                  type: "node",
+                  id: similar.id,
+                  data: similar,
+                })}
+            >
+              <span>{similar.title}</span>
+              <small>{nodeKindLabel(similar.kind)}</small>
+            </button>
+          </li>
+        {/each}
+      </ul>
+    {:else}
+      <p class="ghost" role="status" aria-live="polite">
+        Keine ähnlichen Knoten gefunden.
+      </p>
+    {/if}
+  {/if}
+</section>
+
+<style>
+  .similar-nodes {
+    margin-top: 1rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--panel-border);
+  }
+  h4 {
+    margin: 0;
+    font-size: 1rem;
+  }
+  .similar-explainer,
+  .similar-note,
+  .similar-error,
+  .similar-result-status {
+    margin: 0.45rem 0 0.65rem;
+    font-size: 0.82rem;
+    line-height: 1.4;
+    color: var(--muted);
+  }
+  .similar-result-status {
+    margin-top: 0;
+  }
+  .similar-error {
+    color: #a33;
+  }
+  ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.5rem;
+  }
+  button {
+    width: 100%;
+    min-height: 44px;
+    padding: 0.65rem 0.75rem;
+    border: 1px solid var(--panel-border-strong);
+    border-radius: 8px;
+    background: var(--panel-solid);
+    color: var(--text);
+    text-align: left;
+    cursor: pointer;
+    display: grid;
+    gap: 0.15rem;
+  }
+  button:hover,
+  button:focus-visible {
+    border-color: var(--accent);
+  }
+  button span {
+    font-weight: 650;
+  }
+  button small {
+    color: var(--muted);
+  }
+</style>

--- a/apps/web/src/routes/map/+page.svelte
+++ b/apps/web/src/routes/map/+page.svelte
@@ -132,10 +132,11 @@
     query: string,
     kinds: string[],
     enabled: boolean,
+    open: boolean,
   ) {
     resetNodeSearch();
     const normalizedQuery = query.trim();
-    if (!$isSearchOpen || !enabled || !normalizedQuery) return;
+    if (!open || !enabled || !normalizedQuery) return;
     const sequence = nodeSearchSequence;
     nodeSearchStatus = "loading";
     nodeSearchTimer = setTimeout(async () => {
@@ -172,7 +173,12 @@
   );
   $: nodeSearchEnabled =
     $activeFilters.size === 0 || activeSearchKinds.length > 0;
-  $: scheduleNodeSearch($searchQuery, activeSearchKinds, nodeSearchEnabled);
+  $: scheduleNodeSearch(
+    $searchQuery,
+    activeSearchKinds,
+    nodeSearchEnabled,
+    $isSearchOpen,
+  );
   $: searchBaseMarkers =
     $activeFilters.size === 0 ? markersData : filteredMarkersData;
   $: localGarnrolleResults = deriveSearchResults(

--- a/apps/web/src/routes/map/+page.svelte
+++ b/apps/web/src/routes/map/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, tick } from "svelte";
+  import { onDestroy, onMount, tick } from "svelte";
   import type { PageData } from "./$types";
   import "$lib/styles/tokens.css";
   import "maplibre-gl/dist/maplibre-gl.css";
@@ -8,7 +8,6 @@
   import TopBar from "$lib/components/TopBar.svelte";
   import ContextPanel from "$lib/components/ContextPanel.svelte";
   import ToolFan from "$lib/components/ToolFan.svelte";
-  import SearchOverlay from "$lib/components/SearchOverlay.svelte";
   import SearchDirectionIndicators from "$lib/components/SearchDirectionIndicators.svelte";
   import FilterOverlay from "$lib/components/FilterOverlay.svelte";
   import type { MapEntityViewModel } from "$lib/map/types";
@@ -104,17 +103,96 @@
   $: availableTypes = deriveAvailableFilterTypes(markersData);
   $: filteredMarkersData = deriveFilteredMarkers(markersData, $activeFilters);
   $: showNodes = $view.showNodes;
-  // Search is scoped to the currently visible markers (filtered set when a
-  // filter is active, otherwise the full set) so it never reaches hidden ones.
+  // T007: node search comes from the authorized T006 server contract. The only
+  // client-side search left here is for Garnrollen that are already public map
+  // markers; node visibility is never reconstructed from the downloaded scene.
+  // The search client itself is lazy-loaded so opening the map does not pay the
+  // search runtime cost before a person actually starts searching.
+  let nodeSearchItems: MapEntityViewModel[] = [];
+  let nodeSearchStatus: "idle" | "loading" | "ready" | "error" = "idle";
+  let nodeSearchMode: string | null = null;
+  let nodeSearchFallbackReason: string | null = null;
+  let nodeSearchTimer: ReturnType<typeof setTimeout> | undefined;
+  let nodeSearchAbortController: AbortController | null = null;
+  let nodeSearchSequence = 0;
+
+  function resetNodeSearch() {
+    if (nodeSearchTimer !== undefined) clearTimeout(nodeSearchTimer);
+    nodeSearchTimer = undefined;
+    nodeSearchAbortController?.abort();
+    nodeSearchAbortController = null;
+    nodeSearchSequence += 1;
+    nodeSearchItems = [];
+    nodeSearchStatus = "idle";
+    nodeSearchMode = null;
+    nodeSearchFallbackReason = null;
+  }
+
+  function scheduleNodeSearch(
+    query: string,
+    kinds: string[],
+    enabled: boolean,
+  ) {
+    resetNodeSearch();
+    const normalizedQuery = query.trim();
+    if (!$isSearchOpen || !enabled || !normalizedQuery) return;
+    const sequence = nodeSearchSequence;
+    nodeSearchStatus = "loading";
+    nodeSearchTimer = setTimeout(async () => {
+      nodeSearchTimer = undefined;
+      const controller = new AbortController();
+      nodeSearchAbortController = controller;
+      try {
+        const { nodeToMapEntity, searchNodes } =
+          await import("$lib/api/search");
+        const response = await searchNodes(normalizedQuery, {
+          kinds,
+          signal: controller.signal,
+        });
+        if (controller.signal.aborted || sequence !== nodeSearchSequence)
+          return;
+        nodeSearchItems = response.items.map(nodeToMapEntity);
+        nodeSearchStatus = "ready";
+        nodeSearchMode = response.mode;
+        nodeSearchFallbackReason = response.fallback_reason ?? null;
+      } catch {
+        if (controller.signal.aborted || sequence !== nodeSearchSequence)
+          return;
+        nodeSearchStatus = "error";
+      } finally {
+        if (nodeSearchAbortController === controller)
+          nodeSearchAbortController = null;
+      }
+    }, 180);
+  }
+
+  onDestroy(resetNodeSearch);
+  $: activeSearchKinds = Array.from($activeFilters).filter(
+    (filter) => filter !== "Garnrolle",
+  );
+  $: nodeSearchEnabled =
+    $activeFilters.size === 0 || activeSearchKinds.length > 0;
+  $: scheduleNodeSearch($searchQuery, activeSearchKinds, nodeSearchEnabled);
   $: searchBaseMarkers =
     $activeFilters.size === 0 ? markersData : filteredMarkersData;
-  $: filteredResults = deriveSearchResults(
-    searchBaseMarkers,
+  $: localGarnrolleResults = deriveSearchResults(
+    searchBaseMarkers.filter((item) => item.type === "garnrolle"),
     $searchQuery,
     $isSearchOpen,
   );
+  $: filteredResults = [...nodeSearchItems, ...localGarnrolleResults];
   $: searchMatchIds = deriveSearchMatchIds(filteredResults);
   $: edgesData = deriveVisibleEdges(scene.edges, filteredMarkersData);
+
+  let SearchOverlayComponent:
+    | typeof import("$lib/components/SearchOverlay.svelte").default
+    | null = null;
+
+  async function preloadSearchOverlay() {
+    SearchOverlayComponent = (
+      await import("$lib/components/SearchOverlay.svelte")
+    ).default;
+  }
 
   let mapContainer: HTMLDivElement | null = null;
   let map: MapLibreMap | null = null;
@@ -391,11 +469,18 @@
   }
 
   function handleRelatedSelect(
-    event: CustomEvent<{ type: "node" | "garnrolle"; id: string }>,
+    event: CustomEvent<{
+      type: "node" | "garnrolle";
+      id: string;
+      data?: MapEntityViewModel;
+    }>,
   ) {
-    const related = markersData.find(
-      (item) => item.id === event.detail.id && item.type === event.detail.type,
-    );
+    const related =
+      event.detail.data ??
+      markersData.find(
+        (item) =>
+          item.id === event.detail.id && item.type === event.detail.type,
+      );
     if (related) focusAndFlyToPoint(related);
   }
 
@@ -566,6 +651,7 @@
     import.meta.env.VITE_PUBLIC_ENABLE_TEST_MAP === "true";
 
   onMount(() => {
+    void preloadSearchOverlay();
     let maplibreModule: any = null;
     // onMount returns its cleanup synchronously while the initialiser below is
     // still suspended on `await import('maplibre-gl')`. If the component is
@@ -798,7 +884,16 @@
     on:selectRelated={handleRelatedSelect}
     on:domainChanged={handleDomainChanged}
   />
-  <SearchOverlay {filteredResults} on:select={handleSearchSelect} />
+  {#if SearchOverlayComponent}
+    <svelte:component
+      this={SearchOverlayComponent}
+      {filteredResults}
+      searchStatus={nodeSearchStatus}
+      searchMode={nodeSearchMode}
+      searchFallbackReason={nodeSearchFallbackReason}
+      on:select={handleSearchSelect}
+    />
+  {/if}
   <SearchDirectionIndicators
     indicators={searchDirectionIndicators}
     on:select={handleSearchDirectionSelect}

--- a/apps/web/tests/fixtures/mockApi.ts
+++ b/apps/web/tests/fixtures/mockApi.ts
@@ -97,6 +97,19 @@ export async function mockApiResponses(
     const url = route.request().url();
     const method = route.request().method();
 
+    if (new URL(url).pathname === "/api/search" && method === "GET") {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: [],
+          mode: "hybrid",
+          generation_id: "mock-search-generation",
+          offset: 0,
+        }),
+      });
+    }
+
     if (url.endsWith("/api/nodes") && method === "POST") {
       if (!isAuthenticated || !currentAccountId) {
         return route.fulfill({ status: 401 });

--- a/apps/web/tests/ui-filter.spec.ts
+++ b/apps/web/tests/ui-filter.spec.ts
@@ -47,6 +47,9 @@ test.describe("Sicht mode", () => {
           kind: "Event",
           location: { lat: 53.5, lon: 10.0 },
           summary: "A test event node.",
+          tags: [],
+          created_at: "2026-07-23T00:00:00Z",
+          updated_at: "2026-07-23T00:00:00Z",
         },
         {
           id: "node-2",
@@ -54,6 +57,9 @@ test.describe("Sicht mode", () => {
           kind: "Place",
           location: { lat: 53.6, lon: 10.1 },
           summary: "A test place node.",
+          tags: [],
+          created_at: "2026-07-23T00:00:00Z",
+          updated_at: "2026-07-23T00:00:00Z",
         },
       ].filter(
         (node) =>

--- a/apps/web/tests/ui-filter.spec.ts
+++ b/apps/web/tests/ui-filter.spec.ts
@@ -31,6 +31,47 @@ test.describe("Sicht mode", () => {
       });
     });
 
+    await page.route("**/api/search**", async (route) => {
+      const params = new URL(route.request().url()).searchParams;
+      const query = params.get("q")?.toLocaleLowerCase("de-DE") ?? "";
+      const kinds = new Set(
+        (params.get("kinds") ?? "")
+          .split(",")
+          .map((kind) => kind.trim())
+          .filter(Boolean),
+      );
+      const nodes = [
+        {
+          id: "node-1",
+          title: "Test Node 1",
+          kind: "Event",
+          location: { lat: 53.5, lon: 10.0 },
+          summary: "A test event node.",
+        },
+        {
+          id: "node-2",
+          title: "Test Node 2",
+          kind: "Place",
+          location: { lat: 53.6, lon: 10.1 },
+          summary: "A test place node.",
+        },
+      ].filter(
+        (node) =>
+          node.title.toLocaleLowerCase("de-DE").includes(query) &&
+          (kinds.size === 0 || kinds.has(node.kind)),
+      );
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: nodes,
+          mode: "hybrid",
+          generation_id: "mock-search-generation",
+          offset: 0,
+        }),
+      });
+    });
+
     await page.route("**/api/accounts", async (route) => {
       route.fulfill({
         status: 200,

--- a/apps/web/tests/ui-search-t007.spec.ts
+++ b/apps/web/tests/ui-search-t007.spec.ts
@@ -1,0 +1,239 @@
+import { test, expect, type Page } from "@playwright/test";
+import { mockApiResponses } from "./fixtures/mockApi";
+import { activateToolFanAction } from "./fixtures/toolFan";
+
+const SOURCE_NODE = {
+  id: "source-node",
+  title: "Offene Fahrradwerkstatt",
+  summary: "Gemeinsam Fahrräder reparieren",
+  info: "Werkzeuge teilen und voneinander lernen",
+  tags: ["Fahrrad", "Reparatur"],
+  kind: "Werkstatt",
+  location: { lat: 54.9, lon: 8.3 },
+  modules: [],
+  created_at: "2026-07-23T00:00:00Z",
+};
+
+const SIMILAR_NODE = {
+  id: "similar-node",
+  title: "Gemeinschaftliche Radstation",
+  summary: "Hilfe bei Fahrradreparaturen",
+  kind: "Werkstatt",
+  location: { lat: 54.91, lon: 8.31 },
+  modules: [],
+  created_at: "2026-07-23T00:00:00Z",
+};
+
+async function openSearch(page: Page) {
+  await page.goto("/map");
+  await page.waitForSelector(".map-marker");
+  await activateToolFanAction(page, "find");
+  return page.getByRole("searchbox", { name: "Suchbegriff" });
+}
+
+test.describe("T007 authorized server search contract", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockApiResponses(page);
+    await page.route("**/api/nodes", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([SOURCE_NODE]),
+      });
+    });
+    await page.route("**/api/node/source-node", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(SOURCE_NODE),
+      });
+    });
+  });
+
+  test("does not fall back to the locally loaded node scene when server search fails", async ({
+    page,
+  }) => {
+    await page.route("**/api/search**", async (route) => {
+      await route.fulfill({ status: 503, body: "search_unavailable" });
+    });
+
+    const input = await openSearch(page);
+    await input.fill("Offene Fahrradwerkstatt");
+
+    await expect(
+      page.getByText(
+        "Die sichere Knotensuche ist gerade nicht verfügbar. Es wird nicht auf eine lokale Knotensuche zurückgefallen.",
+      ),
+    ).toBeVisible();
+    await expect(page.getByRole("option")).toHaveCount(0);
+  });
+
+  test("renders lexical fallback explicitly while keeping server results usable", async ({
+    page,
+  }) => {
+    await page.route("**/api/search**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: [SOURCE_NODE],
+          mode: "lexical_fallback",
+          fallback_reason: "provider_unavailable",
+          generation_id: "fallback-generation",
+          offset: 0,
+        }),
+      });
+    });
+
+    const input = await openSearch(page);
+    await input.fill("Fahrradwerkstatt");
+
+    await expect(
+      page.getByText(
+        "Die semantische Ergänzung ist vorübergehend nicht verfügbar. Die serverseitige lexikalische Suche bleibt aktiv.",
+      ),
+    ).toBeVisible();
+    await expect(page.getByRole("option").first()).toContainText(
+      "Offene Fahrradwerkstatt",
+    );
+  });
+
+  test("ignores a stale slower response after the query changes", async ({
+    page,
+  }) => {
+    await page.route("**/api/search**", async (route) => {
+      const query = new URL(route.request().url()).searchParams.get("q") ?? "";
+      if (query === "alt") {
+        await new Promise((resolve) => setTimeout(resolve, 550));
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            items: [
+              { ...SOURCE_NODE, id: "old-node", title: "Altes Ergebnis" },
+            ],
+            mode: "hybrid",
+            generation_id: "old-generation",
+            offset: 0,
+          }),
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: [{ ...SOURCE_NODE, id: "new-node", title: "Neues Ergebnis" }],
+          mode: "hybrid",
+          generation_id: "new-generation",
+          offset: 0,
+        }),
+      });
+    });
+
+    const input = await openSearch(page);
+    await input.fill("alt");
+    await page.waitForRequest((request) => {
+      const url = new URL(request.url());
+      return (
+        url.pathname === "/api/search" && url.searchParams.get("q") === "alt"
+      );
+    });
+    await input.fill("neu");
+
+    await expect(page.getByRole("option").first()).toContainText(
+      "Neues Ergebnis",
+    );
+    await expect(page.getByText("Altes Ergebnis")).toHaveCount(0);
+    await page.waitForTimeout(600);
+    await expect(page.getByRole("option").first()).toContainText(
+      "Neues Ergebnis",
+    );
+    await expect(page.getByText("Altes Ergebnis")).toHaveCount(0);
+  });
+
+  test("shows similar nodes as machine-computed suggestions, not relations, and navigates without mutation", async ({
+    page,
+  }) => {
+    let mutationRequests = 0;
+    await page.route("**/api/search**", async (route) => {
+      const query = new URL(route.request().url()).searchParams.get("q") ?? "";
+      const items = query.includes("Werkzeuge teilen")
+        ? [SOURCE_NODE, SIMILAR_NODE]
+        : [SOURCE_NODE];
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items,
+          mode: "hybrid",
+          generation_id: "similar-generation",
+          offset: 0,
+        }),
+      });
+    });
+    await page.route("**/api/**", async (route) => {
+      if (!["GET", "HEAD"].includes(route.request().method()))
+        mutationRequests += 1;
+      await route.fallback();
+    });
+
+    const input = await openSearch(page);
+    await input.fill("Fahrradwerkstatt");
+    await page.getByRole("option").first().click();
+
+    const section = page.locator("section.similar-nodes");
+    await expect(
+      section.getByRole("heading", { name: "Ähnliche Knoten" }),
+    ).toBeVisible();
+    await expect(section).toContainText(
+      "Maschinell aus Inhalt und Schlagwörtern dieses Knotens berechnet.",
+    );
+    await expect(section).toContainText("keine Fäden");
+    await expect(section).toContainText("keine kuratierten Beziehungen");
+    await expect(
+      section.getByRole("button", { name: /Gemeinschaftliche Radstation/ }),
+    ).toBeVisible();
+    expect(mutationRequests).toBe(0);
+
+    await section
+      .getByRole("button", { name: /Gemeinschaftliche Radstation/ })
+      .click();
+    await expect(page.getByTestId("context-panel")).toBeVisible();
+    expect(mutationRequests).toBe(0);
+  });
+
+  test("keeps lexical fallback visible in the similar-nodes empty state", async ({
+    page,
+  }) => {
+    await page.route("**/api/search**", async (route) => {
+      const query = new URL(route.request().url()).searchParams.get("q") ?? "";
+      const items = [SOURCE_NODE];
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items,
+          mode: query.includes("Werkzeuge teilen")
+            ? "lexical_fallback"
+            : "hybrid",
+          fallback_reason: query.includes("Werkzeuge teilen")
+            ? "provider_unavailable"
+            : undefined,
+          generation_id: "similar-fallback-generation",
+          offset: 0,
+        }),
+      });
+    });
+
+    const input = await openSearch(page);
+    await input.fill("Fahrradwerkstatt");
+    await page.getByRole("option").first().click();
+
+    const section = page.locator("section.similar-nodes");
+    await expect(section).toContainText(
+      "Die semantische Ergänzung ist gerade nicht verfügbar; die Vorschläge stammen aus dem lexikalischen Serverpfad.",
+    );
+    await expect(section).toContainText("Keine ähnlichen Knoten gefunden.");
+  });
+});

--- a/apps/web/tests/ui-search-t007.spec.ts
+++ b/apps/web/tests/ui-search-t007.spec.ts
@@ -12,6 +12,7 @@ const SOURCE_NODE = {
   location: { lat: 54.9, lon: 8.3 },
   modules: [],
   created_at: "2026-07-23T00:00:00Z",
+  updated_at: "2026-07-23T00:00:00Z",
 };
 
 const SIMILAR_NODE = {
@@ -20,8 +21,10 @@ const SIMILAR_NODE = {
   summary: "Hilfe bei Fahrradreparaturen",
   kind: "Werkstatt",
   location: { lat: 54.91, lon: 8.31 },
+  tags: ["Fahrrad", "Reparatur"],
   modules: [],
   created_at: "2026-07-23T00:00:00Z",
+  updated_at: "2026-07-23T00:00:00Z",
 };
 
 async function openSearch(page: Page) {

--- a/apps/web/tests/ui-search.spec.ts
+++ b/apps/web/tests/ui-search.spec.ts
@@ -24,6 +24,37 @@ test.describe("Search mode", () => {
       });
     });
 
+    await page.route("**/api/search**", async (route) => {
+      const query =
+        new URL(route.request().url()).searchParams
+          .get("q")
+          ?.toLocaleLowerCase("de-DE") ?? "";
+      const matches =
+        query.includes("strick") || query === "a"
+          ? [
+              {
+                id: "mock-node-1",
+                title: "Abendliches Stricken",
+                summary: "Wir stricken gemeinsam",
+                kind: "Treffen",
+                location: { lat: 51, lon: 10 },
+                modules: [],
+                created_at: new Date().toISOString(),
+              },
+            ]
+          : [];
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: matches,
+          mode: "hybrid",
+          generation_id: "mock-search-generation",
+          offset: 0,
+        }),
+      });
+    });
+
     await page.route("**/api/node/mock-node-1", async (route) => {
       await route.fulfill({
         status: 200,
@@ -254,6 +285,18 @@ test.describe("Search mode", () => {
         status: 200,
         contentType: "application/json",
         body: JSON.stringify(manyNodes),
+      });
+    });
+    await page.route("**/api/search**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: manyNodes,
+          mode: "hybrid",
+          generation_id: "mock-search-generation",
+          offset: 0,
+        }),
       });
     });
 

--- a/apps/web/tests/ui-search.spec.ts
+++ b/apps/web/tests/ui-search.spec.ts
@@ -38,8 +38,10 @@ test.describe("Search mode", () => {
                 summary: "Wir stricken gemeinsam",
                 kind: "Treffen",
                 location: { lat: 51, lon: 10 },
+                tags: ["Stricken"],
                 modules: [],
                 created_at: new Date().toISOString(),
+                updated_at: new Date().toISOString(),
               },
             ]
           : [];
@@ -313,7 +315,7 @@ test.describe("Search mode", () => {
 
     const results = page.locator("li[role='option']");
     await expect(results).toHaveCount(6);
-    await expect(page.getByText("9 Treffer auf der Karte")).toBeVisible();
+    await expect(page.getByText("9 Treffer", { exact: true })).toBeVisible();
 
     const showMore = page.getByRole("button", {
       name: "Alle 9 Vorschläge zeigen",


### PR DESCRIPTION
<!-- weltgewebe-risk: R2 -->

## Ziel

Implementiert WELTGEWEBE-SEMANTIC-SEARCH-V1-T007: Die Knotensuche der Weboberfläche nutzt die autorisierte T006-Server-API als maßgeblichen Pfad. Zusätzlich wird ein klar getrennter Bereich „Ähnliche Knoten“ eingeführt, ausdrücklich als maschinell berechnete Ähnlichkeit und nicht als Faden, Beziehung oder gemeinsame Autorenschaft.

## Änderungen

- Knotensuche über `/api/search` mit `credentials: include`
- bestehende Knotenart-Filter auf `kinds` abgebildet
- Debounce, AbortController und Schutz vor veralteten Antworten
- Loading-, Empty-, Error- und lexikalische Fallback-Zustände
- kein lokaler Knotensuch-Fallback bei API-Ausfall
- eigenständige, nicht mutierende Oberfläche „Ähnliche Knoten“ über denselben autorisierten T006-Pfad
- Accessibility-Statusmeldungen und Tastatur-/Navigationsregressionen abgesichert

## Lokale Belege

- `pnpm check:ci`: PASS, 0 Fehler / 0 Warnungen
- `pnpm lint`: PASS
- `pnpm test:unit`: 178/178 PASS
- relevante Playwright-Suite: 18/18 PASS

## Scope

Kein Produktionsrollout, kein öffentlicher Live-Beweis, keine SemantAH-Stilllegung, kein ANN/HNSW. T011 bleibt separat.