### PR TITLE
fix(auth): restore magic-link confirmation sign-in

### DIFF
--- a/docs/deploy/CHANGELOG.md
+++ b/docs/deploy/CHANGELOG.md
@@ -10,6 +10,39 @@ relations:
 ---
 # Deployment-Änderungsprotokoll
 
+## 2026-07-23 - Magic-Link-Bestätigungsformular am Edge wieder zulassen
+
+**Geänderte Bereiche:**
+
+- `infra/caddy/Caddyfile`, `Caddyfile.heim` und `Caddyfile.vps`;
+- CSP-Vertragsprüfung und Security-Header-Guard.
+
+**Beschreibung:**
+
+Die globale Nicht-Dokument-CSP für `/api/*` setzte `form-action 'none'` auch auf
+die absichtlich als HTML-Formular ausgelieferte Magic-Link-Bestätigungsseite.
+Browser wenden mehrere CSP-Header gleichzeitig an; dadurch blockierte die
+Edge-Richtlinie sowohl die Formularübermittlung als auch das Inline-Styling der
+Bestätigungsseite, obwohl der API-Handler selbst den engeren Formularvertrag
+korrekt deklarierte.
+
+Der Edge behandelt deshalb ausschließlich `GET /api/auth/magic-link/consume`
+als schmale Dokument-Ausnahme. Sie behält `default-src 'none'`,
+`base-uri 'none'` und `frame-ancestors 'none'`, erlaubt kein Script und gibt nur
+das bereits benötigte Inline-Styling sowie `form-action 'self'` frei. `POST` auf
+demselben Pfad und alle übrigen API- und Health-Antworten bleiben auf der
+strikten `form-action 'none'`-Richtlinie.
+
+**Produktionswirkung:**
+
+Beim Rollout muss die geprüfte VPS-Caddy-Konfiguration gemeinsam mit dem
+Merge-Commit veröffentlicht und Caddy erfolgreich neu geladen werden. Danach
+muss ein GET auf den Magic-Link-Consume-Pfad die schmale CSP mit
+`form-action 'self'` liefern, während ein gewöhnlicher API-Pfad weiterhin
+`form-action 'none'` ausliefert. Ein frischer Magic-Link kann anschließend das
+Bestätigungsformular wieder same-origin absenden; Token-, Nonce- und
+Sessionlogik werden durch diese Änderung nicht verändert.
+
 ## 2026-07-14 - Schleswig-Holstein sichtbar kartografieren
 
 **Geänderte Bereiche:**

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -33,7 +33,21 @@
     reverse_proxy api:8080
   }
   reverse_proxy /* web:5173
-  @apiResponse path /api/*
+  # The magic-link confirmation endpoint intentionally serves one tiny HTML form.
+  # Give only this exact API path the form/style capabilities that its upstream
+  # response already declares; all other API responses stay non-document locked.
+  @magicLinkConfirm {
+    method GET
+    path /api/auth/magic-link/consume
+  }
+  header @magicLinkConfirm Content-Security-Policy "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none';"
+  @apiResponse {
+    path /api/*
+    not {
+      method GET
+      path /api/auth/magic-link/consume
+    }
+  }
   header @apiResponse Content-Security-Policy "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
   @frontendResponse {
     not path /api/*

--- a/infra/caddy/Caddyfile.heim
+++ b/infra/caddy/Caddyfile.heim
@@ -65,7 +65,21 @@ weltgewebe.home.arpa {
     file_server
   }
 
-  @apiResponse path /api/*
+  # The magic-link confirmation endpoint intentionally serves one tiny HTML form.
+  # Give only this exact API path the form/style capabilities that its upstream
+  # response already declares; all other API responses stay non-document locked.
+  @magicLinkConfirm {
+    method GET
+    path /api/auth/magic-link/consume
+  }
+  header @magicLinkConfirm Content-Security-Policy "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none';"
+  @apiResponse {
+    path /api/*
+    not {
+      method GET
+      path /api/auth/magic-link/consume
+    }
+  }
   header @apiResponse Content-Security-Policy "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
   @frontendResponse {
     not path /api/*

--- a/infra/caddy/Caddyfile.vps
+++ b/infra/caddy/Caddyfile.vps
@@ -97,7 +97,21 @@
 		file_server
 	}
 
-	@nonDocumentResponse path /api/* /health/*
+	# The magic-link confirmation endpoint intentionally serves one tiny HTML form.
+	# Give only this exact API path the form/style capabilities that its upstream
+	# response already declares; all other API/health responses stay non-document locked.
+	@magicLinkConfirm {
+		method GET
+		path /api/auth/magic-link/consume
+	}
+	header @magicLinkConfirm Content-Security-Policy "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none';"
+	@nonDocumentResponse {
+		path /api/* /health/*
+		not {
+			method GET
+			path /api/auth/magic-link/consume
+		}
+	}
 	header @nonDocumentResponse Content-Security-Policy "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
 	@frontendResponse {
 		not path /api/* /health/*

--- a/scripts/ci/tests/test_static_app_caddy_csp_adapted_contract.py
+++ b/scripts/ci/tests/test_static_app_caddy_csp_adapted_contract.py
@@ -7,6 +7,7 @@ import subprocess
 import unittest
 
 REPO = Path(__file__).resolve().parents[3]
+MAGIC_LINK_CONFIRM_PATH = "/api/auth/magic-link/consume"
 CASES = (
     ("infra/caddy/Caddyfile", None),
     ("infra/caddy/Caddyfile.heim", "weltgewebe.home.arpa"),
@@ -17,7 +18,10 @@ CASES = (
 def adapt(relative: str) -> dict:
     result = subprocess.run(
         ["caddy", "adapt", "--config", relative, "--adapter", "caddyfile"],
-        cwd=REPO, text=True, capture_output=True, check=False,
+        cwd=REPO,
+        text=True,
+        capture_output=True,
+        check=False,
     )
     if result.returncode != 0:
         raise AssertionError(result.stdout + result.stderr)
@@ -45,7 +49,9 @@ def collect_csp(routes: list[dict]) -> list[tuple[object, str]]:
     for route in routes:
         for handler in route.get("handle", []):
             if handler.get("handler") == "headers":
-                values = handler.get("response", {}).get("set", {}).get("Content-Security-Policy", [])
+                values = handler.get("response", {}).get("set", {}).get(
+                    "Content-Security-Policy", []
+                )
                 found.extend((route.get("match"), value) for value in values)
             if handler.get("handler") == "subroute":
                 found.extend(collect_csp(handler.get("routes", [])))
@@ -54,18 +60,45 @@ def collect_csp(routes: list[dict]) -> list[tuple[object, str]]:
 
 @unittest.skipUnless(shutil.which("caddy"), "caddy binary required")
 class StaticAppCaddyAdaptedCspTest(unittest.TestCase):
-    def test_adapted_app_route_has_only_split_csp_pair(self) -> None:
+    def test_adapted_app_route_splits_document_api_and_magic_link_csp(self) -> None:
         for relative, host in CASES:
             with self.subTest(caddyfile=relative):
                 policies = collect_csp(app_routes(adapt(relative), host))
-                self.assertEqual(len(policies), 2, policies)
-                strict = [item for item in policies if "default-src 'none'" in item[1]]
-                frontend = [item for item in policies if "default-src 'none'" not in item[1]]
+                self.assertEqual(len(policies), 3, policies)
+
+                strict = [item for item in policies if "form-action 'none'" in item[1]]
+                magic = [
+                    item
+                    for item in policies
+                    if "default-src 'none'" in item[1]
+                    and "form-action 'self'" in item[1]
+                ]
+                frontend = [
+                    item for item in policies if "default-src 'none'" not in item[1]
+                ]
                 self.assertEqual(len(strict), 1, policies)
+                self.assertEqual(len(magic), 1, policies)
                 self.assertEqual(len(frontend), 1, policies)
+
+                strict_match = json.dumps(strict[0][0])
                 self.assertIn("frame-ancestors 'none'", strict[0][1])
                 self.assertNotIn("unsafe-inline", strict[0][1])
-                directives = {part.strip().split()[0] for part in frontend[0][1].split(";") if part.strip()}
+                self.assertIn("not", strict_match)
+                self.assertIn(MAGIC_LINK_CONFIRM_PATH, strict_match)
+                self.assertIn("GET", strict_match)
+
+                magic_match = json.dumps(magic[0][0])
+                self.assertIn(MAGIC_LINK_CONFIRM_PATH, magic_match)
+                self.assertIn("GET", magic_match)
+                self.assertIn("style-src 'unsafe-inline'", magic[0][1])
+                self.assertNotIn("script-src", magic[0][1])
+                self.assertIn("frame-ancestors 'none'", magic[0][1])
+
+                directives = {
+                    part.strip().split()[0]
+                    for part in frontend[0][1].split(";")
+                    if part.strip()
+                }
                 self.assertNotIn("default-src", directives)
                 self.assertNotIn("script-src", directives)
                 self.assertIn("frame-ancestors", directives)

--- a/scripts/guard/security-headers-guard.sh
+++ b/scripts/guard/security-headers-guard.sh
@@ -79,6 +79,15 @@ for caddy in \
   if ! grep -Fq "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';" "$caddy"; then
     fail "$(realpath --relative-to "$REPO_ROOT" "$caddy") missing strict non-document/error CSP baseline"
   fi
+  if ! grep -Fq "@magicLinkConfirm {" "$caddy" || ! grep -Fq "path /api/auth/magic-link/consume" "$caddy"; then
+    fail "$(realpath --relative-to "$REPO_ROOT" "$caddy") missing exact magic-link confirmation CSP matcher"
+  fi
+  if ! grep -Fq "method GET" "$caddy"; then
+    fail "$(realpath --relative-to "$REPO_ROOT" "$caddy") magic-link confirmation CSP must be GET-only"
+  fi
+  if ! grep -Fq "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none';" "$caddy"; then
+    fail "$(realpath --relative-to "$REPO_ROOT" "$caddy") missing narrow magic-link confirmation CSP"
+  fi
   for directive in \
     "style-src 'self' 'unsafe-inline'" \
     "connect-src 'self'" \

--- a/scripts/tests/test_security_headers_guard.sh
+++ b/scripts/tests/test_security_headers_guard.sh
@@ -36,9 +36,21 @@ write_static_caddy() {
   local connect="$2"
   cat > "$file" << CADDY
 example.test {
+  @magicLinkConfirm {
+    method GET
+    path /api/auth/magic-link/consume
+  }
+  header @magicLinkConfirm Content-Security-Policy "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none';"
+  @apiResponse {
+    path /api/*
+    not {
+      method GET
+      path /api/auth/magic-link/consume
+    }
+  }
+  header @apiResponse Content-Security-Policy "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
   header {
     Content-Security-Policy "style-src 'self' 'unsafe-inline'; connect-src $connect; img-src 'self' data: blob:; worker-src 'self' blob:; font-src 'self'; media-src 'self'; manifest-src 'self'; child-src 'self'; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';"
-    Content-Security-Policy "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
     Strict-Transport-Security "max-age=31536000; includeSubDomains"
     X-Frame-Options "DENY"
     Referrer-Policy "no-referrer"
@@ -74,6 +86,13 @@ REPO_ROOT="$TEMP_DIR" bash "$GUARD" > /dev/null
 sed -i '/Strict-Transport-Security/d' "$TEMP_DIR/infra/caddy/Caddyfile.vps"
 if REPO_ROOT="$TEMP_DIR" bash "$GUARD" > /dev/null 2>&1; then
   echo "security headers guard should fail without HSTS" >&2
+  exit 1
+fi
+write_static_caddy "$TEMP_DIR/infra/caddy/Caddyfile.vps" "'self'"
+
+sed -i '/method GET/d' "$TEMP_DIR/infra/caddy/Caddyfile.vps"
+if REPO_ROOT="$TEMP_DIR" bash "$GUARD" > /dev/null 2>&1; then
+  echo "security headers guard should fail without GET-only magic-link matcher" >&2
   exit 1
 fi
 write_static_caddy "$TEMP_DIR/infra/caddy/Caddyfile.vps" "'self'"


### PR DESCRIPTION
## Problem

The edge CSP introduced by the T023–T026 remediation classified every `/api/*` response as a non-document and added `form-action 'none'`. The magic-link consume GET endpoint is intentionally an HTML confirmation form. Browsers intersected the API response CSP (`form-action 'self'`) with the edge CSP (`form-action 'none'`), so the visible **Sign In** button could not submit. The same intersection blocked the page's inline style.

## Fix

- add a GET-only CSP exception for exactly `/api/auth/magic-link/consume` on the application edge;
- keep `default-src 'none'`, no `script-src`, `frame-ancestors 'none'`, and allow only the inline style plus same-origin form submission needed by the confirmation page;
- keep POST and every other API/health response on the strict `form-action 'none'` baseline;
- apply the same contract to generic, Heim, and VPS application Caddyfiles;
- extend the adapted-Caddy regression test and static security-header guard.

## Verification

- `python3 -m unittest scripts.ci.tests.test_static_app_caddy_csp_adapted_contract` — PASS
- `scripts/guard/security-headers-guard.sh` — PASS
- `git diff --check` — PASS
- production before fix: `/api/version` carries edge CSP `default-src 'none'; ... form-action 'none'`; the magic-link GET handler itself declares `form-action 'self'`, proving the conflicting intersection.

<!-- weltgewebe-risk: R3 -->