### PR TITLE
fix(search): preserve observability contract compatibility

### DIFF
--- a/apps/api/src/search/service.rs
+++ b/apps/api/src/search/service.rs
@@ -48,13 +48,22 @@ pub struct SearchQueryParams {
     pub offset: Option<usize>,
 }
 
-/// Bounded search result mode. The wire format keeps the pre-existing
-/// snake_case strings so this is not a breaking API change.
+/// Bounded search result mode. The serialized HTTP/JSON wire format keeps the
+/// pre-existing snake_case strings, so this does not change the wire contract.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SearchMode {
     Hybrid,
     LexicalFallback,
+}
+
+impl From<SearchMode> for SearchRequestOutcome {
+    fn from(mode: SearchMode) -> Self {
+        match mode {
+            SearchMode::Hybrid => Self::Hybrid,
+            SearchMode::LexicalFallback => Self::LexicalFallback,
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
@@ -187,10 +196,7 @@ pub async fn execute_search(
     let request_started = Instant::now();
     let result = execute_search_inner(state, auth, params, provider_override).await;
     let outcome = match &result {
-        Ok(response) => match response.mode {
-            SearchMode::Hybrid => SearchRequestOutcome::Hybrid,
-            SearchMode::LexicalFallback => SearchRequestOutcome::LexicalFallback,
-        },
+        Ok(response) => response.mode.into(),
         Err(SearchError::ProviderContractError(_)) => SearchRequestOutcome::ProviderContractError,
         Err(SearchError::Unavailable) => SearchRequestOutcome::Unavailable,
         Err(SearchError::InvalidRequest) => SearchRequestOutcome::InvalidRequest,

--- a/apps/api/src/telemetry/mod.rs
+++ b/apps/api/src/telemetry/mod.rs
@@ -155,12 +155,13 @@ impl Metrics {
         let duration_buckets = vec![
             0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
         ];
-        // MAX_AUTHORIZED_CANDIDATES (search/repository.rs) hard-bounds this at
-        // 1000; the repository layer rejects any request before an over-bound
-        // count would ever reach this histogram, so 1000.0 is the true max
-        // bucket and no sentinel bucket above it is meaningful.
+        // MAX_AUTHORIZED_CANDIDATES (search/repository.rs) hard-bounds observed
+        // values at 1000. Keep the historical 1001 bucket as a compatibility
+        // series for existing Prometheus queries and dashboards even though no
+        // successful repository result can currently populate it independently
+        // from the 1000 bucket.
         let candidate_buckets = vec![
-            1.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 750.0, 1000.0,
+            1.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 750.0, 1000.0, 1001.0,
         ];
         let lexical_candidate_buckets = vec![0.0, 1.0, 2.0, 5.0, 10.0];
         let search_request_duration_seconds = Histogram::with_opts(
@@ -455,15 +456,15 @@ mod tests {
     }
 
     #[test]
-    fn search_authorized_candidates_histogram_has_no_bucket_above_the_hard_bound() {
+    fn search_authorized_candidates_histogram_keeps_legacy_1001_bucket_for_compatibility() {
         let metrics = test_metrics();
         metrics.observe_search_candidate_counts(1000, 10);
 
         let rendered = String::from_utf8(metrics.render().expect("render metrics")).expect("utf8");
         assert!(rendered.contains("search_authorized_candidates_bucket{le=\"1000\"}"));
         assert!(
-            !rendered.contains("search_authorized_candidates_bucket{le=\"1001\"}"),
-            "MAX_AUTHORIZED_CANDIDATES rejects requests before a >1000 count ever reaches this histogram"
+            rendered.contains("search_authorized_candidates_bucket{le=\"1001\"}"),
+            "the legacy 1001 bucket remains part of the exported Prometheus contract"
         );
     }
 


### PR DESCRIPTION
Follow-up to #1555 after its merge.

<!-- weltgewebe-risk: R2 -->

- keep the historical `search_authorized_candidates_bucket{le="1001"}` Prometheus series for dashboard/alert compatibility while documenting that successful repository observations remain hard-bounded at 1000
- clarify that `SearchMode` preserves the HTTP/JSON wire contract, without overstating Rust source compatibility
- centralize the exhaustive `SearchMode -> SearchRequestOutcome` mapping via `From<SearchMode>`
- update the histogram contract test accordingly

Verified locally:
- `cargo fmt --manifest-path apps/api/Cargo.toml -- --check`
- targeted outcome-label metric test
- targeted legacy-1001 histogram compatibility test
- targeted early-unavailable metric boundary test