### PR TITLE
fix(auth): make edge canonical magic-link CSP owner

### DIFF
--- a/apps/api/tests/api_auth.rs
+++ b/apps/api/tests/api_auth.rs
@@ -1472,8 +1472,52 @@ async fn consume_login_fails_bad_nonce() -> Result<()> {
         res.headers().get("location").unwrap(),
         "/login?error=invalid_token"
     );
+    assert!(
+        res.headers()
+            .get("content-type")
+            .and_then(|value| value.to_str().ok())
+            .is_none_or(|value| !value.starts_with("text/html")),
+        "invalid-nonce POST must not render an HTML document"
+    );
     // Token should NOT be consumed
     assert!(state.tokens.peek(&token).is_some());
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn consume_login_post_expired_token_is_non_document_redirect() -> Result<()> {
+    let mut state = test_state_with_accounts()?;
+    state.config.auth_public_login = true;
+    state.config.app_base_url = Some("http://localhost".to_string());
+
+    let token = state
+        .tokens
+        .create_with_expiry("u1@example.com".to_string(), chrono::Duration::seconds(-1));
+    let nonce = "expired-token-post-nonce";
+    let cookie_val = format!("{}.{}", hash_token(&token), nonce);
+    let body_str = format!("token={}&nonce={}", token, nonce);
+    let app = app(state);
+
+    let req = Request::post("/auth/magic-link/consume")
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .header("Cookie", format!("{}={}", NONCE_COOKIE_NAME, cookie_val))
+        .body(body::Body::from(body_str))?;
+
+    let res = app.oneshot(req).await?;
+    assert_eq!(res.status(), StatusCode::SEE_OTHER);
+    assert_eq!(
+        res.headers().get("location").unwrap(),
+        "/login?error=invalid_token"
+    );
+    assert!(
+        res.headers()
+            .get("content-type")
+            .and_then(|value| value.to_str().ok())
+            .is_none_or(|value| !value.starts_with("text/html")),
+        "expired-token POST must not render an HTML document"
+    );
 
     Ok(())
 }

--- a/docs/deploy/CHANGELOG.md
+++ b/docs/deploy/CHANGELOG.md
@@ -27,21 +27,29 @@ Bestätigungsseite, obwohl der API-Handler selbst den engeren Formularvertrag
 korrekt deklarierte.
 
 Der Edge behandelt deshalb ausschließlich `GET /api/auth/magic-link/consume`
-als schmale Dokument-Ausnahme. Sie behält `default-src 'none'`,
-`base-uri 'none'` und `frame-ancestors 'none'`, erlaubt kein Script und gibt nur
-das bereits benötigte Inline-Styling sowie `form-action 'self'` frei. `POST` auf
-demselben Pfad und alle übrigen API- und Health-Antworten bleiben auf der
-strikten `form-action 'none'`-Richtlinie.
+als schmale Dokument-Ausnahme. Caddy ist für öffentliche Antworten der
+kanonische CSP-Eigentümer und setzt die Richtlinie verzögert, sodass eine vom
+API-Upstream gelieferte CSP beim Schreiben der Response ersetzt statt mit ihr
+kombiniert wird. Die Ausnahme behält `default-src 'none'`, `base-uri 'none'` und
+`frame-ancestors 'none'`, erlaubt kein Script und gibt nur das bereits benötigte
+Inline-Styling sowie `form-action 'self'` frei. `POST` auf demselben Pfad und alle
+übrigen API- und Health-Antworten werden am Edge ebenfalls verzögert auf die
+strikte `form-action 'none'`-Richtlinie gesetzt. Die API-eigene GET-CSP bleibt als
+Defense-in-Depth für direkte interne Nutzung bestehen, bestimmt aber nicht die
+öffentliche Edge-Response.
 
 **Produktionswirkung:**
 
 Beim Rollout muss die geprüfte VPS-Caddy-Konfiguration gemeinsam mit dem
 Merge-Commit veröffentlicht und Caddy erfolgreich neu geladen werden. Danach
-muss ein GET auf den Magic-Link-Consume-Pfad die schmale CSP mit
-`form-action 'self'` liefern, während ein gewöhnlicher API-Pfad weiterhin
-`form-action 'none'` ausliefert. Ein frischer Magic-Link kann anschließend das
-Bestätigungsformular wieder same-origin absenden; Token-, Nonce- und
-Sessionlogik werden durch diese Änderung nicht verändert.
+muss ein GET auf den Magic-Link-Consume-Pfad genau eine schmale CSP mit
+`form-action 'self'` liefern, während ein gewöhnlicher API-Pfad und ein POST auf
+den Consume-Pfad genau eine strikte CSP mit `form-action 'none'` ausliefern. Der
+Runtime-Vertrag wird gegen einen Mock-Upstream geprüft, der absichtlich eine
+widersprechende CSP setzt; diese Upstream-CSP darf am Edge nicht mehr sichtbar
+sein. Ein frischer Magic-Link kann anschließend das Bestätigungsformular wieder
+same-origin absenden; Token-, Nonce- und Sessionlogik werden durch diese Änderung
+nicht verändert.
 
 ## 2026-07-14 - Schleswig-Holstein sichtbar kartografieren
 

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -34,13 +34,13 @@
   }
   reverse_proxy /* web:5173
   # The magic-link confirmation endpoint intentionally serves one tiny HTML form.
-  # Give only this exact API path the form/style capabilities that its upstream
-  # response already declares; all other API responses stay non-document locked.
+  # Caddy is the canonical public CSP owner: defer the write so any upstream CSP
+  # is replaced after proxying. All other API responses stay non-document locked.
   @magicLinkConfirm {
     method GET
     path /api/auth/magic-link/consume
   }
-  header @magicLinkConfirm Content-Security-Policy "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none';"
+  header @magicLinkConfirm >Content-Security-Policy "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none';"
   @apiResponse {
     path /api/*
     not {
@@ -48,7 +48,7 @@
       path /api/auth/magic-link/consume
     }
   }
-  header @apiResponse Content-Security-Policy "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
+  header @apiResponse >Content-Security-Policy "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
   @frontendResponse {
     not path /api/*
   }

--- a/infra/caddy/Caddyfile.heim
+++ b/infra/caddy/Caddyfile.heim
@@ -66,13 +66,13 @@ weltgewebe.home.arpa {
   }
 
   # The magic-link confirmation endpoint intentionally serves one tiny HTML form.
-  # Give only this exact API path the form/style capabilities that its upstream
-  # response already declares; all other API responses stay non-document locked.
+  # Caddy is the canonical public CSP owner: defer the write so any upstream CSP
+  # is replaced after proxying. All other API responses stay non-document locked.
   @magicLinkConfirm {
     method GET
     path /api/auth/magic-link/consume
   }
-  header @magicLinkConfirm Content-Security-Policy "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none';"
+  header @magicLinkConfirm >Content-Security-Policy "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none';"
   @apiResponse {
     path /api/*
     not {
@@ -80,7 +80,7 @@ weltgewebe.home.arpa {
       path /api/auth/magic-link/consume
     }
   }
-  header @apiResponse Content-Security-Policy "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
+  header @apiResponse >Content-Security-Policy "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
   @frontendResponse {
     not path /api/*
   }

--- a/infra/caddy/Caddyfile.vps
+++ b/infra/caddy/Caddyfile.vps
@@ -98,13 +98,13 @@
 	}
 
 	# The magic-link confirmation endpoint intentionally serves one tiny HTML form.
-	# Give only this exact API path the form/style capabilities that its upstream
-	# response already declares; all other API/health responses stay non-document locked.
+	# Caddy is the canonical public CSP owner: defer the write so any upstream CSP
+	# is replaced after proxying. All other API/health responses stay non-document locked.
 	@magicLinkConfirm {
 		method GET
 		path /api/auth/magic-link/consume
 	}
-	header @magicLinkConfirm Content-Security-Policy "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none';"
+	header @magicLinkConfirm >Content-Security-Policy "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none';"
 	@nonDocumentResponse {
 		path /api/* /health/*
 		not {
@@ -112,7 +112,7 @@
 			path /api/auth/magic-link/consume
 		}
 	}
-	header @nonDocumentResponse Content-Security-Policy "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
+	header @nonDocumentResponse >Content-Security-Policy "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
 	@frontendResponse {
 		not path /api/* /health/*
 	}

--- a/scripts/ci/tests/test_magic_link_csp_runtime_contract.py
+++ b/scripts/ci/tests/test_magic_link_csp_runtime_contract.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import http.client
+from pathlib import Path
+import shutil
+import socket
+import subprocess
+import tempfile
+import threading
+import time
+import unittest
+
+REPO = Path(__file__).resolve().parents[3]
+CADDY_BINARY = shutil.which("caddy")
+DOCKER_BINARY = shutil.which("docker")
+CADDY_DOCKER_IMAGE = "caddy:2.8.4"
+MAGIC_PATH = "/api/auth/magic-link/consume"
+MAGIC_POLICY = "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none';"
+STRICT_POLICY = "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
+UPSTREAM_POLICY = "default-src https://upstream.invalid; form-action https://upstream.invalid;"
+
+
+class CspUpstreamHandler(BaseHTTPRequestHandler):
+    def _respond(self) -> None:
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Security-Policy", UPSTREAM_POLICY)
+        self.end_headers()
+        self.wfile.write(b"upstream")
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib handler contract
+        self._respond()
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib handler contract
+        length = int(self.headers.get("Content-Length", "0"))
+        if length:
+            self.rfile.read(length)
+        self._respond()
+
+    def log_message(self, format: str, *args: object) -> None:
+        pass
+
+
+def free_port() -> int:
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return int(probe.getsockname()[1])
+
+
+def csp_values(headers: list[tuple[str, str]]) -> list[str]:
+    return [value for name, value in headers if name.lower() == "content-security-policy"]
+
+
+@unittest.skipUnless(
+    CADDY_BINARY or DOCKER_BINARY,
+    "caddy binary or docker required for runtime header proof",
+)
+class MagicLinkCspRuntimeContractTest(unittest.TestCase):
+    def test_edge_overwrites_upstream_csp_with_one_canonical_policy(self) -> None:
+        upstream = ThreadingHTTPServer(("127.0.0.1", 0), CspUpstreamHandler)
+        upstream_port = int(upstream.server_address[1])
+        upstream_thread = threading.Thread(target=upstream.serve_forever, daemon=True)
+        upstream_thread.start()
+
+        edge_port = free_port()
+        source = (REPO / "infra" / "caddy" / "Caddyfile").read_text(encoding="utf-8")
+        source = source.replace(
+            "{\n  auto_https off\n}",
+            "{\n  auto_https off\n  admin off\n}",
+            1,
+        )
+        source = source.replace(":8081 {", f"http://127.0.0.1:{edge_port} {{", 1)
+        source = source.replace(
+            "reverse_proxy api:8080",
+            f"reverse_proxy 127.0.0.1:{upstream_port}",
+            1,
+        )
+        source = source.replace(
+            "reverse_proxy /* web:5173",
+            f"reverse_proxy /* 127.0.0.1:{upstream_port}",
+            1,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            config = Path(tmp) / "Caddyfile"
+            config.write_text(source, encoding="utf-8")
+            cidfile = Path(tmp) / "caddy.cid"
+            if CADDY_BINARY:
+                command = [
+                    CADDY_BINARY,
+                    "run",
+                    "--config",
+                    str(config),
+                    "--adapter",
+                    "caddyfile",
+                ]
+            else:
+                assert DOCKER_BINARY is not None
+                command = [
+                    DOCKER_BINARY,
+                    "run",
+                    "--rm",
+                    "--network",
+                    "host",
+                    "--cidfile",
+                    str(cidfile),
+                    "-v",
+                    f"{config}:/etc/caddy/Caddyfile:ro",
+                    CADDY_DOCKER_IMAGE,
+                    "caddy",
+                    "run",
+                    "--config",
+                    "/etc/caddy/Caddyfile",
+                    "--adapter",
+                    "caddyfile",
+                ]
+
+            process = subprocess.Popen(
+                command,
+                cwd=REPO,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            try:
+                deadline = time.monotonic() + 5
+                while time.monotonic() < deadline:
+                    try:
+                        connection = http.client.HTTPConnection("127.0.0.1", edge_port, timeout=1)
+                        connection.request("GET", "/api/health")
+                        response = connection.getresponse()
+                        response.read()
+                        connection.close()
+                        break
+                    except OSError:
+                        time.sleep(0.05)
+                else:
+                    stderr = process.stderr.read() if process.stderr else ""
+                    self.fail(f"caddy runtime did not become ready: {stderr}")
+
+                cases = (
+                    ("GET", MAGIC_PATH, MAGIC_POLICY),
+                    ("GET", "/api/health", STRICT_POLICY),
+                    ("POST", MAGIC_PATH, STRICT_POLICY),
+                )
+                for method, path, expected_policy in cases:
+                    with self.subTest(method=method, path=path):
+                        connection = http.client.HTTPConnection("127.0.0.1", edge_port, timeout=2)
+                        body = "token=x&nonce=y" if method == "POST" else None
+                        headers = (
+                            {"Content-Type": "application/x-www-form-urlencoded"}
+                            if method == "POST"
+                            else {}
+                        )
+                        connection.request(method, path, body=body, headers=headers)
+                        response = connection.getresponse()
+                        response_headers = response.getheaders()
+                        response.read()
+                        connection.close()
+
+                        self.assertEqual(response.status, 200)
+                        self.assertEqual(csp_values(response_headers), [expected_policy])
+                        self.assertNotIn(UPSTREAM_POLICY, csp_values(response_headers))
+            finally:
+                process.terminate()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=5)
+                if process.stderr is not None:
+                    process.stderr.close()
+                if not CADDY_BINARY and DOCKER_BINARY and cidfile.exists():
+                    container_id = cidfile.read_text(encoding="utf-8").strip()
+                    if container_id:
+                        subprocess.run(
+                            [DOCKER_BINARY, "rm", "-f", container_id],
+                            stdout=subprocess.DEVNULL,
+                            stderr=subprocess.DEVNULL,
+                            check=False,
+                        )
+                upstream.shutdown()
+                upstream.server_close()
+                upstream_thread.join(timeout=5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/tests/test_magic_link_csp_runtime_contract.py
+++ b/scripts/ci/tests/test_magic_link_csp_runtime_contract.py
@@ -116,15 +116,18 @@ class MagicLinkCspRuntimeContractTest(unittest.TestCase):
                     "caddyfile",
                 ]
 
-            process = subprocess.Popen(
-                command,
-                cwd=REPO,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.PIPE,
-                text=True,
-            )
+            stderr_path = Path(tmp) / "caddy.stderr"
+            with stderr_path.open("w", encoding="utf-8") as stderr_file:
+                process = subprocess.Popen(
+                    command,
+                    cwd=REPO,
+                    stdout=subprocess.DEVNULL,
+                    stderr=stderr_file,
+                    text=True,
+                )
             try:
-                deadline = time.monotonic() + 5
+                startup_timeout = 10 if CADDY_BINARY else 60
+                deadline = time.monotonic() + startup_timeout
                 while time.monotonic() < deadline:
                     try:
                         connection = http.client.HTTPConnection("127.0.0.1", edge_port, timeout=1)
@@ -136,8 +139,13 @@ class MagicLinkCspRuntimeContractTest(unittest.TestCase):
                     except OSError:
                         time.sleep(0.05)
                 else:
-                    stderr = process.stderr.read() if process.stderr else ""
-                    self.fail(f"caddy runtime did not become ready: {stderr}")
+                    stderr = stderr_path.read_text(encoding="utf-8") if stderr_path.exists() else ""
+                    state = (
+                        f"process exited with {process.returncode}"
+                        if process.poll() is not None
+                        else f"process still running after {startup_timeout}s"
+                    )
+                    self.fail(f"caddy runtime did not become ready ({state}): {stderr}")
 
                 cases = (
                     ("GET", MAGIC_PATH, MAGIC_POLICY),

--- a/scripts/ci/tests/test_static_app_caddy_csp_adapted_contract.py
+++ b/scripts/ci/tests/test_static_app_caddy_csp_adapted_contract.py
@@ -8,10 +8,12 @@ import unittest
 
 REPO = Path(__file__).resolve().parents[3]
 MAGIC_LINK_CONFIRM_PATH = "/api/auth/magic-link/consume"
+MAGIC_POLICY = "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none';"
+STRICT_POLICY = "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
 CASES = (
-    ("infra/caddy/Caddyfile", None),
-    ("infra/caddy/Caddyfile.heim", "weltgewebe.home.arpa"),
-    ("infra/caddy/Caddyfile.vps", "weltgewebe.net"),
+    ("infra/caddy/Caddyfile", None, ["/api/*"]),
+    ("infra/caddy/Caddyfile.heim", "weltgewebe.home.arpa", ["/api/*"]),
+    ("infra/caddy/Caddyfile.vps", "weltgewebe.net", ["/api/*", "/health/*"]),
 )
 
 
@@ -44,65 +46,103 @@ def app_routes(config: dict, host: str | None) -> list[dict]:
     raise AssertionError(f"no HTTPS app route for {host}")
 
 
-def collect_csp(routes: list[dict]) -> list[tuple[object, str]]:
-    found: list[tuple[object, str]] = []
+def collect_csp(routes: list[dict]) -> list[dict]:
+    found: list[dict] = []
     for route in routes:
         for handler in route.get("handle", []):
             if handler.get("handler") == "headers":
-                values = handler.get("response", {}).get("set", {}).get(
-                    "Content-Security-Policy", []
-                )
-                found.extend((route.get("match"), value) for value in values)
+                response = handler.get("response", {})
+                for value in response.get("set", {}).get("Content-Security-Policy", []):
+                    found.append(
+                        {
+                            "match": route.get("match"),
+                            "policy": value,
+                            "deferred": response.get("deferred", False),
+                        }
+                    )
             if handler.get("handler") == "subroute":
                 found.extend(collect_csp(handler.get("routes", [])))
     return found
 
 
+def directive_map(policy: str) -> dict[str, tuple[str, ...]]:
+    directives: dict[str, tuple[str, ...]] = {}
+    for raw in policy.split(";"):
+        raw = raw.strip()
+        if not raw:
+            continue
+        parts = raw.split()
+        directives[parts[0]] = tuple(parts[1:])
+    return directives
+
+
 @unittest.skipUnless(shutil.which("caddy"), "caddy binary required")
 class StaticAppCaddyAdaptedCspTest(unittest.TestCase):
-    def test_adapted_app_route_splits_document_api_and_magic_link_csp(self) -> None:
-        for relative, host in CASES:
+    def test_adapted_app_route_has_exact_matchers_and_canonical_edge_csp(self) -> None:
+        for relative, host, protected_paths in CASES:
             with self.subTest(caddyfile=relative):
                 policies = collect_csp(app_routes(adapt(relative), host))
                 self.assertEqual(len(policies), 3, policies)
 
-                strict = [item for item in policies if "form-action 'none'" in item[1]]
-                magic = [
+                magic = [item for item in policies if item["policy"] == MAGIC_POLICY]
+                strict = [item for item in policies if item["policy"] == STRICT_POLICY]
+                frontend = [
                     item
                     for item in policies
-                    if "default-src 'none'" in item[1]
-                    and "form-action 'self'" in item[1]
+                    if item["policy"] not in {MAGIC_POLICY, STRICT_POLICY}
                 ]
-                frontend = [
-                    item for item in policies if "default-src 'none'" not in item[1]
-                ]
-                self.assertEqual(len(strict), 1, policies)
                 self.assertEqual(len(magic), 1, policies)
+                self.assertEqual(len(strict), 1, policies)
                 self.assertEqual(len(frontend), 1, policies)
 
-                strict_match = json.dumps(strict[0][0])
-                self.assertIn("frame-ancestors 'none'", strict[0][1])
-                self.assertNotIn("unsafe-inline", strict[0][1])
-                self.assertIn("not", strict_match)
-                self.assertIn(MAGIC_LINK_CONFIRM_PATH, strict_match)
-                self.assertIn("GET", strict_match)
+                magic_match = [
+                    {
+                        "method": ["GET"],
+                        "path": [MAGIC_LINK_CONFIRM_PATH],
+                    }
+                ]
+                strict_match = [
+                    {
+                        "not": [
+                            {
+                                "method": ["GET"],
+                                "path": [MAGIC_LINK_CONFIRM_PATH],
+                            }
+                        ],
+                        "path": protected_paths,
+                    }
+                ]
+                frontend_match = [{"not": [{"path": protected_paths}]}]
 
-                magic_match = json.dumps(magic[0][0])
-                self.assertIn(MAGIC_LINK_CONFIRM_PATH, magic_match)
-                self.assertIn("GET", magic_match)
-                self.assertIn("style-src 'unsafe-inline'", magic[0][1])
-                self.assertNotIn("script-src", magic[0][1])
-                self.assertIn("frame-ancestors 'none'", magic[0][1])
+                self.assertEqual(magic[0]["match"], magic_match)
+                self.assertEqual(strict[0]["match"], strict_match)
+                self.assertEqual(frontend[0]["match"], frontend_match)
 
-                directives = {
-                    part.strip().split()[0]
-                    for part in frontend[0][1].split(";")
-                    if part.strip()
-                }
-                self.assertNotIn("default-src", directives)
-                self.assertNotIn("script-src", directives)
-                self.assertIn("frame-ancestors", directives)
-                self.assertIn("not", json.dumps(frontend[0][0]))
+                self.assertTrue(
+                    magic[0]["deferred"],
+                    "magic-link CSP must overwrite any upstream CSP after proxying",
+                )
+                self.assertTrue(
+                    strict[0]["deferred"],
+                    "strict API CSP must overwrite any upstream CSP after proxying",
+                )
+
+                self.assertEqual(
+                    directive_map(magic[0]["policy"]),
+                    {
+                        "default-src": ("'none'",),
+                        "style-src": ("'unsafe-inline'",),
+                        "form-action": ("'self'",),
+                        "base-uri": ("'none'",),
+                        "frame-ancestors": ("'none'",),
+                    },
+                )
+                self.assertNotIn("script-src", directive_map(magic[0]["policy"]))
+
+                frontend_directives = directive_map(frontend[0]["policy"])
+                self.assertNotIn("default-src", frontend_directives)
+                self.assertNotIn("script-src", frontend_directives)
+                self.assertEqual(frontend_directives["frame-ancestors"], ("'none'",))
 
 
 if __name__ == "__main__":

--- a/scripts/guard/security-headers-guard.sh
+++ b/scripts/guard/security-headers-guard.sh
@@ -22,6 +22,34 @@ policy_value() {
   ' "$POLICY_FILE"
 }
 
+named_matcher_block() {
+  local file="$1"
+  local matcher="$2"
+  python3 - "$file" "$matcher" << 'PY'
+from pathlib import Path
+import re
+import sys
+
+path = Path(sys.argv[1])
+matcher = sys.argv[2]
+lines = path.read_text(encoding="utf-8").splitlines()
+start_re = re.compile(rf"^\s*@{re.escape(matcher)}\s*\{{\s*$")
+for index, line in enumerate(lines):
+    if not start_re.match(line):
+        continue
+    depth = 0
+    block = []
+    for candidate in lines[index:]:
+        block.append(candidate)
+        depth += candidate.count("{") - candidate.count("}")
+        if depth == 0:
+            print("\n".join(block))
+            raise SystemExit(0)
+    break
+raise SystemExit(1)
+PY
+}
+
 if [[ ! -f "$POLICY_FILE" ]]; then
   fail "security policy missing: $POLICY_FILE"
   exit 1
@@ -79,14 +107,30 @@ for caddy in \
   if ! grep -Fq "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';" "$caddy"; then
     fail "$(realpath --relative-to "$REPO_ROOT" "$caddy") missing strict non-document/error CSP baseline"
   fi
-  if ! grep -Fq "@magicLinkConfirm {" "$caddy" || ! grep -Fq "path /api/auth/magic-link/consume" "$caddy"; then
-    fail "$(realpath --relative-to "$REPO_ROOT" "$caddy") missing exact magic-link confirmation CSP matcher"
+  relative_caddy="$(realpath --relative-to "$REPO_ROOT" "$caddy")"
+  if ! magic_block="$(named_matcher_block "$caddy" magicLinkConfirm)"; then
+    fail "$relative_caddy missing exact magic-link confirmation CSP matcher"
+  else
+    if [[ "$(printf '%s\n' "$magic_block" | grep -Ec '^[[:space:]]*method[[:space:]]+GET[[:space:]]*$')" -ne 1 ]]; then
+      fail "$relative_caddy magic-link confirmation matcher must contain exactly one GET method constraint"
+    fi
+    if [[ "$(printf '%s\n' "$magic_block" | grep -Ec '^[[:space:]]*path[[:space:]]+/api/auth/magic-link/consume[[:space:]]*$')" -ne 1 ]]; then
+      fail "$relative_caddy magic-link confirmation matcher must contain the exact consume path"
+    fi
   fi
-  if ! grep -Fq "method GET" "$caddy"; then
-    fail "$(realpath --relative-to "$REPO_ROOT" "$caddy") magic-link confirmation CSP must be GET-only"
+
+  magic_policy="default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none';"
+  if ! grep -Fq "header @magicLinkConfirm >Content-Security-Policy \"${magic_policy}\"" "$caddy"; then
+    fail "$relative_caddy must defer and overwrite the canonical magic-link confirmation CSP"
   fi
-  if ! grep -Fq "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none';" "$caddy"; then
-    fail "$(realpath --relative-to "$REPO_ROOT" "$caddy") missing narrow magic-link confirmation CSP"
+
+  strict_policy="default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
+  strict_matcher="@apiResponse"
+  if [[ "$(basename "$caddy")" == "Caddyfile.vps" ]]; then
+    strict_matcher="@nonDocumentResponse"
+  fi
+  if ! grep -Fq "header ${strict_matcher} >Content-Security-Policy \"${strict_policy}\"" "$caddy"; then
+    fail "$relative_caddy must defer and overwrite the canonical strict API CSP"
   fi
   for directive in \
     "style-src 'self' 'unsafe-inline'" \

--- a/scripts/tests/test_security_headers_guard.sh
+++ b/scripts/tests/test_security_headers_guard.sh
@@ -34,21 +34,27 @@ JS
 write_static_caddy() {
   local file="$1"
   local connect="$2"
+  local strict_matcher="apiResponse"
+  local strict_paths="/api/*"
+  if [[ "$(basename "$file")" == "Caddyfile.vps" ]]; then
+    strict_matcher="nonDocumentResponse"
+    strict_paths="/api/* /health/*"
+  fi
   cat > "$file" << CADDY
 example.test {
   @magicLinkConfirm {
     method GET
     path /api/auth/magic-link/consume
   }
-  header @magicLinkConfirm Content-Security-Policy "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none';"
-  @apiResponse {
-    path /api/*
+  header @magicLinkConfirm >Content-Security-Policy "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none';"
+  @${strict_matcher} {
+    path ${strict_paths}
     not {
       method GET
       path /api/auth/magic-link/consume
     }
   }
-  header @apiResponse Content-Security-Policy "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
+  header @${strict_matcher} >Content-Security-Policy "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
   header {
     Content-Security-Policy "style-src 'self' 'unsafe-inline'; connect-src $connect; img-src 'self' data: blob:; worker-src 'self' blob:; font-src 'self'; media-src 'self'; manifest-src 'self'; child-src 'self'; frame-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';"
     Strict-Transport-Security "max-age=31536000; includeSubDomains"
@@ -90,9 +96,28 @@ if REPO_ROOT="$TEMP_DIR" bash "$GUARD" > /dev/null 2>&1; then
 fi
 write_static_caddy "$TEMP_DIR/infra/caddy/Caddyfile.vps" "'self'"
 
-sed -i '/method GET/d' "$TEMP_DIR/infra/caddy/Caddyfile.vps"
+python3 - "$TEMP_DIR/infra/caddy/Caddyfile.vps" << 'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+text = text.replace(
+    "  @magicLinkConfirm {\n    method GET\n    path /api/auth/magic-link/consume\n  }",
+    "  @magicLinkConfirm {\n    path /api/auth/magic-link/consume\n  }\n  @other {\n    method GET\n    path /other\n  }",
+    1,
+)
+path.write_text(text, encoding="utf-8")
+PY
 if REPO_ROOT="$TEMP_DIR" bash "$GUARD" > /dev/null 2>&1; then
-  echo "security headers guard should fail without GET-only magic-link matcher" >&2
+  echo "security headers guard should fail when GET exists outside the magic-link matcher" >&2
+  exit 1
+fi
+write_static_caddy "$TEMP_DIR/infra/caddy/Caddyfile.vps" "'self'"
+
+sed -i 's/header @magicLinkConfirm >Content-Security-Policy/header @magicLinkConfirm Content-Security-Policy/' "$TEMP_DIR/infra/caddy/Caddyfile.vps"
+if REPO_ROOT="$TEMP_DIR" bash "$GUARD" > /dev/null 2>&1; then
+  echo "security headers guard should fail when magic-link CSP is not deferred" >&2
   exit 1
 fi
 write_static_caddy "$TEMP_DIR/infra/caddy/Caddyfile.vps" "'self'"


### PR DESCRIPTION
## Summary

Follow-up hardening for merged PR #1558. The functional Magic-Link sign-in repair is already in `main`; this PR makes the public CSP ownership explicit and proves the final reverse-proxy response contract.

- make Caddy the canonical public CSP owner for Magic-Link GET and strict API/non-document responses by using deferred response-header writes;
- structurally verify exact GET + consume-path matchers and deferred adapted Caddy handlers;
- harden the shell guard so `method GET` must be inside the Magic-Link matcher and the CSP write must be deferred;
- add a real Caddy runtime proof against an upstream that deliberately emits a conflicting CSP, requiring exactly one final edge CSP for Magic-Link GET, ordinary API GET and Magic-Link POST;
- prove invalid-nonce and expired-token POST paths remain non-document redirects;
- document the edge ownership contract and deployment readback.

The runtime proof uses a local Caddy binary when available and falls back to `caddy:2.8.4` through Docker so CI does not silently skip the proof merely because the host lacks a Caddy binary.

## Verification

- `python3 -m unittest scripts.ci.tests.test_static_app_caddy_csp_adapted_contract scripts.ci.tests.test_magic_link_csp_runtime_contract -v`
- Docker fallback path of `test_magic_link_csp_runtime_contract`
- `bash scripts/tests/test_security_headers_guard.sh`
- `bash scripts/guard/security-headers-guard.sh`
- targeted `api_auth` tests for bad nonce and expired-token POST
- `cargo fmt --all -- --check`
- `git diff --cached --check` before commit

## Scope

No token, nonce, session or account authorization semantics are changed. The remaining defense-in-depth improvement—removing the tiny confirmation page's inline CSS so `style-src 'unsafe-inline'` can disappear—remains recorded in Bureau as candidate `candidate-083aa770eee2e429025c5a12`. Its current Bureau assessment is `promote`; Registry mutation remains fail-closed until the required explicit `reviewed_plan` publication approval is present.

<!-- weltgewebe-risk: R3 -->
