### PR TITLE
fix(web): Garnrolle per Klick oder Tap auf der Karte verorten

### DIFF
--- a/apps/web/src/lib/components/panels/KompositionPanel.svelte
+++ b/apps/web/src/lib/components/panels/KompositionPanel.svelte
@@ -161,7 +161,8 @@
         <div class="state-set">
           <p><strong>Ort gewählt</strong></p>
           <p class="ghost">
-            Prüfe, ob dieser Punkt zu deiner Adresse passt. Erst in den
+            Prüfe, ob dieser Punkt zu deiner Adresse passt. Zum Verschieben
+            tippe oder klicke einfach auf eine andere Stelle. Erst in den
             Einstellungen wird die Garnrolle gespeichert.
           </p>
         </div>
@@ -169,8 +170,9 @@
         <div class="state-pending">
           <p><strong>Ort ausstehend</strong></p>
           <p>
-            Halte den gewünschten Ort auf der Karte etwa eine Sekunde gedrückt.
-            Du kannst den Punkt danach bestätigen oder erneut setzen.
+            Tippe oder klicke auf den gewünschten Ort auf der Karte, um den
+            Punkt zu setzen. Du kannst ihn danach bestätigen oder erneut setzen.
+            (Ein längeres Gedrückthalten funktioniert ebenfalls.)
           </p>
         </div>
       {/if}

--- a/apps/web/src/lib/map/overlay/komposition.test.ts
+++ b/apps/web/src/lib/map/overlay/komposition.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { get } from "svelte/store";
+
+type AuthValue = { authenticated: boolean; role: string };
+
+// The overlay reads authentication through the auth store. A minimal writable
+// stand-in (hoisted so the mock factory can reference it) lets each test decide
+// whether a press is allowed to compose at all. It is implemented without
+// `svelte/store` because `vi.hoisted` runs before module imports resolve.
+const { authStore } = vi.hoisted(() => {
+  let value: AuthValue = { authenticated: true, role: "gast" };
+  const subscribers = new Set<(value: AuthValue) => void>();
+  return {
+    authStore: {
+      subscribe(run: (value: AuthValue) => void) {
+        run(value);
+        subscribers.add(run);
+        return () => subscribers.delete(run);
+      },
+      set(next: AuthValue) {
+        value = next;
+        for (const run of subscribers) run(value);
+      },
+    },
+  };
+});
+vi.mock("$lib/auth/store", () => ({ authStore }));
+
+import { setupKompositionInteraction } from "./komposition";
+import {
+  kompositionDraft,
+  leaveToNavigation,
+  enterKomposition,
+} from "$lib/stores/uiView";
+
+// The overlay classifies event targets with `instanceof HTMLElement` +
+// `closest(".map-marker")`. The suite runs under the "node" environment (no
+// DOM), so a minimal element stand-in provides both.
+class FakeElement {
+  className: string;
+  constructor(className = "") {
+    this.className = className;
+  }
+  closest(selector: string): FakeElement | null {
+    return selector === ".map-marker" &&
+      /(^|\s)map-marker(\s|$)/.test(this.className)
+      ? this
+      : null;
+  }
+}
+(globalThis as { HTMLElement?: unknown }).HTMLElement = FakeElement;
+
+type Handler = (event: unknown) => void;
+
+class FakeMap {
+  private handlers = new Map<string, Set<Handler>>();
+
+  on(type: string, handler: Handler) {
+    if (!this.handlers.has(type)) this.handlers.set(type, new Set());
+    this.handlers.get(type)!.add(handler);
+  }
+
+  off(type: string, handler: Handler) {
+    this.handlers.get(type)?.delete(handler);
+  }
+
+  emit(type: string, event: unknown) {
+    for (const handler of this.handlers.get(type) ?? []) handler(event);
+  }
+}
+
+function pointerEvent(
+  x: number,
+  y: number,
+  lng: number,
+  lat: number,
+  target: unknown = new FakeElement("maplibregl-canvas"),
+) {
+  return {
+    point: { x, y },
+    lngLat: { lng, lat },
+    originalEvent: { target },
+  };
+}
+
+function clickAt(
+  map: FakeMap,
+  down: "mousedown" | "touchstart",
+  up: "mouseup" | "touchend",
+  event: ReturnType<typeof pointerEvent>,
+) {
+  map.emit(down, event);
+  map.emit(up, event);
+}
+
+describe("setupKompositionInteraction", () => {
+  let map: FakeMap;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    authStore.set({ authenticated: true, role: "gast" });
+    leaveToNavigation();
+    map = new FakeMap();
+    cleanup = setupKompositionInteraction(map as never);
+  });
+
+  afterEach(() => {
+    cleanup();
+    leaveToNavigation();
+    vi.useRealTimers();
+  });
+
+  it("sets the point on a plain click in place-garnrolle mode", () => {
+    enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
+    clickAt(map, "mousedown", "mouseup", pointerEvent(50, 50, 10, 53.5));
+    const draft = get(kompositionDraft);
+    expect(draft?.mode).toBe("place-garnrolle");
+    expect(draft?.lngLat).toEqual([10, 53.5]);
+    expect(draft?.source).toBe("map-tap");
+  });
+
+  it("sets the point on a plain tap in place-garnrolle mode", () => {
+    enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
+    clickAt(map, "touchstart", "touchend", pointerEvent(50, 50, 9.9, 53.4));
+    expect(get(kompositionDraft)?.lngLat).toEqual([9.9, 53.4]);
+    expect(get(kompositionDraft)?.source).toBe("map-tap");
+  });
+
+  it("ignores a plain click outside place-garnrolle mode (navigation)", () => {
+    clickAt(map, "mousedown", "mouseup", pointerEvent(50, 50, 10, 53.5));
+    expect(get(kompositionDraft)).toBeNull();
+  });
+
+  it("does not open node composition on a plain click in new-knoten mode", () => {
+    enterKomposition({ mode: "new-knoten", source: "tool-fan" });
+    clickAt(map, "mousedown", "mouseup", pointerEvent(50, 50, 10, 53.5));
+    // Still node composition, but no point placed by the click.
+    expect(get(kompositionDraft)?.mode).toBe("new-knoten");
+    expect(get(kompositionDraft)?.lngLat).toBeUndefined();
+  });
+
+  it("still supports the longpress path for node composition", () => {
+    enterKomposition({ mode: "new-knoten", source: "tool-fan" });
+    map.emit("mousedown", pointerEvent(50, 50, 10, 53.5));
+    vi.advanceTimersByTime(800);
+    map.emit("mouseup", pointerEvent(50, 50, 10, 53.5));
+    const draft = get(kompositionDraft);
+    expect(draft?.mode).toBe("new-knoten");
+    expect(draft?.lngLat).toEqual([10, 53.5]);
+    expect(draft?.source).toBe("map-longpress");
+  });
+
+  it("places only once for a longpress in place-garnrolle mode (no double trigger)", () => {
+    enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
+    const setSpy = vi.fn();
+    const unsub = kompositionDraft.subscribe((value) => {
+      if (value?.lngLat) setSpy(value.lngLat);
+    });
+    map.emit("mousedown", pointerEvent(50, 50, 10, 53.5));
+    vi.advanceTimersByTime(800);
+    map.emit("mouseup", pointerEvent(50, 50, 10, 53.5));
+    unsub();
+    // The longpress fires once; the trailing mouseup must not place again.
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    expect(get(kompositionDraft)?.source).toBe("map-longpress");
+  });
+
+  it("does not move the point when the press starts on a marker", () => {
+    enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
+    const marker = new FakeElement("map-marker");
+    clickAt(
+      map,
+      "mousedown",
+      "mouseup",
+      pointerEvent(50, 50, 10, 53.5, marker),
+    );
+    expect(get(kompositionDraft)?.lngLat).toBeUndefined();
+  });
+
+  it("does not place a point for a pan (movement beyond tolerance)", () => {
+    enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
+    map.emit("mousedown", pointerEvent(50, 50, 10, 53.5));
+    map.emit("mousemove", pointerEvent(90, 90, 10.1, 53.6));
+    map.emit("mouseup", pointerEvent(90, 90, 10.1, 53.6));
+    expect(get(kompositionDraft)?.lngLat).toBeUndefined();
+  });
+
+  it("ignores a click by an anonymous user", () => {
+    authStore.set({ authenticated: false, role: "gast" });
+    enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
+    clickAt(map, "mousedown", "mouseup", pointerEvent(50, 50, 10, 53.5));
+    expect(get(kompositionDraft)?.lngLat).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/map/overlay/komposition.ts
+++ b/apps/web/src/lib/map/overlay/komposition.ts
@@ -16,10 +16,38 @@ function canComposeOnMap(): boolean {
   return get(authStore).authenticated;
 }
 
+/**
+ * The explicit Garnrolle placement mode (reached via `/map?compose=garnrolle`)
+ * is a deliberate "pick a point" step, so a plain click/tap already sets the
+ * point. Normal node composition stays a conscious longpress gesture and must
+ * never be opened by a simple click.
+ */
+function isPlacingGarnrolle(): boolean {
+  return get(kompositionDraft)?.mode === "place-garnrolle";
+}
+
+function targetIsMarker(target: EventTarget | null): boolean {
+  return (
+    target instanceof HTMLElement && target.closest(".map-marker") !== null
+  );
+}
+
+const LONG_PRESS_MS = 800;
+// 10px squared. Below this a press counts as a stationary click/tap; above it
+// the gesture is a pan/drag and never places a point.
+const TAP_MOVE_TOLERANCE_SQ = 100;
+
 export function setupKompositionInteraction(map: MapLibreMap) {
   let longPressTimer: ReturnType<typeof setTimeout> | undefined;
-  let longPressStartX = 0;
-  let longPressStartY = 0;
+  let startX = 0;
+  let startY = 0;
+  // A press only counts for composition if it started on the empty map (not on
+  // a marker) while authenticated. Marker presses and anonymous presses never
+  // arm a gesture, so their release can never set or move a point.
+  let gestureArmed = false;
+  // Set once the longpress timer has fired for the current press, so the
+  // trailing mouseup/touchend does not place the same point a second time.
+  let longPressFired = false;
 
   const clearLongPressTimer = () => {
     if (longPressTimer !== undefined) {
@@ -28,96 +56,115 @@ export function setupKompositionInteraction(map: MapLibreMap) {
     }
   };
 
-  const handleMousedown = (e: MapMouseEvent) => {
+  const cancelGesture = () => {
     clearLongPressTimer();
-    const markerClicked =
-      e.originalEvent.target instanceof HTMLElement &&
-      e.originalEvent.target.closest(".map-marker");
-    if (markerClicked) return;
-    if (!canComposeOnMap()) return;
-
-    longPressStartX = e.point.x;
-    longPressStartY = e.point.y;
-    longPressTimer = setTimeout(() => {
-      enterKomposition({
-        mode:
-          get(kompositionDraft)?.mode === "place-garnrolle"
-            ? "place-garnrolle"
-            : "new-knoten",
-        lngLat: [e.lngLat.lng, e.lngLat.lat],
-        source: "map-longpress",
-      });
-    }, 800);
+    gestureArmed = false;
+    longPressFired = false;
   };
 
-  const handleMousemove = (e: MapMouseEvent) => {
-    if (longPressTimer !== undefined) {
-      const dx = e.point.x - longPressStartX;
-      const dy = e.point.y - longPressStartY;
-      if (dx * dx + dy * dy > 100) {
-        // equivalent to 10px distance
-        clearLongPressTimer();
-      }
+  const setPoint = (
+    lngLat: { lng: number; lat: number },
+    source: "map-longpress" | "map-tap",
+  ) => {
+    enterKomposition({
+      mode: isPlacingGarnrolle() ? "place-garnrolle" : "new-knoten",
+      lngLat: [lngLat.lng, lngLat.lat],
+      source,
+    });
+  };
+
+  const beginGesture = (
+    point: { x: number; y: number },
+    lngLat: { lng: number; lat: number },
+    target: EventTarget | null,
+  ) => {
+    cancelGesture();
+    // Markers own their own click/tap (focus). A press on a marker must never
+    // arm placement, so it can never move an already-chosen Garnrolle point.
+    if (targetIsMarker(target)) return;
+    if (!canComposeOnMap()) return;
+
+    gestureArmed = true;
+    startX = point.x;
+    startY = point.y;
+    longPressTimer = setTimeout(() => {
+      longPressFired = true;
+      setPoint(lngLat, "map-longpress");
+    }, LONG_PRESS_MS);
+  };
+
+  const trackMove = (point: { x: number; y: number }) => {
+    if (!gestureArmed) return;
+    const dx = point.x - startX;
+    const dy = point.y - startY;
+    if (dx * dx + dy * dy > TAP_MOVE_TOLERANCE_SQ) {
+      // Movement beyond the tolerance is a pan, not a placement gesture.
+      cancelGesture();
     }
+  };
+
+  const endGesture = (
+    point: { x: number; y: number },
+    lngLat: { lng: number; lat: number },
+  ) => {
+    const armed = gestureArmed;
+    const alreadyPlaced = longPressFired;
+    cancelGesture();
+    if (!armed || alreadyPlaced) return;
+    const dx = point.x - startX;
+    const dy = point.y - startY;
+    if (dx * dx + dy * dy > TAP_MOVE_TOLERANCE_SQ) return;
+    // A stationary release is a click/tap. Only the explicit Garnrolle
+    // placement mode treats it as "set this point"; normal node composition
+    // deliberately stays longpress-only.
+    if (!isPlacingGarnrolle()) return;
+    setPoint(lngLat, "map-tap");
+  };
+
+  const handleMousedown = (e: MapMouseEvent) => {
+    beginGesture(e.point, e.lngLat, e.originalEvent.target);
+  };
+  const handleMousemove = (e: MapMouseEvent) => {
+    trackMove(e.point);
+  };
+  const handleMouseup = (e: MapMouseEvent) => {
+    endGesture(e.point, e.lngLat);
   };
 
   const handleTouchstart = (e: MapTouchEvent) => {
-    clearLongPressTimer();
-    const markerClicked =
-      e.originalEvent.target instanceof HTMLElement &&
-      e.originalEvent.target.closest(".map-marker");
-    if (markerClicked) return;
-    if (!canComposeOnMap()) return;
-
-    longPressStartX = e.point.x;
-    longPressStartY = e.point.y;
-    longPressTimer = setTimeout(() => {
-      enterKomposition({
-        mode:
-          get(kompositionDraft)?.mode === "place-garnrolle"
-            ? "place-garnrolle"
-            : "new-knoten",
-        lngLat: [e.lngLat.lng, e.lngLat.lat],
-        source: "map-longpress",
-      });
-    }, 800);
+    beginGesture(e.point, e.lngLat, e.originalEvent.target);
   };
-
   const handleTouchmove = (e: MapTouchEvent) => {
-    if (longPressTimer !== undefined) {
-      const dx = e.point.x - longPressStartX;
-      const dy = e.point.y - longPressStartY;
-      if (dx * dx + dy * dy > 100) {
-        // equivalent to 10px distance
-        clearLongPressTimer();
-      }
-    }
+    trackMove(e.point);
+  };
+  const handleTouchend = (e: MapTouchEvent) => {
+    endGesture(e.point, e.lngLat);
   };
 
   map.on("mousedown", handleMousedown);
-  map.on("mouseup", clearLongPressTimer);
+  map.on("mouseup", handleMouseup);
   map.on("mousemove", handleMousemove);
-  map.on("mouseout", clearLongPressTimer);
-  map.on("dragstart", clearLongPressTimer);
-  map.on("movestart", clearLongPressTimer);
+  map.on("mouseout", cancelGesture);
+  map.on("dragstart", cancelGesture);
+  map.on("movestart", cancelGesture);
 
   map.on("touchstart", handleTouchstart);
-  map.on("touchend", clearLongPressTimer);
+  map.on("touchend", handleTouchend);
   map.on("touchmove", handleTouchmove);
-  map.on("touchcancel", clearLongPressTimer);
+  map.on("touchcancel", cancelGesture);
 
   return () => {
-    clearLongPressTimer();
+    cancelGesture();
     map.off("mousedown", handleMousedown);
-    map.off("mouseup", clearLongPressTimer);
+    map.off("mouseup", handleMouseup);
     map.off("mousemove", handleMousemove);
-    map.off("mouseout", clearLongPressTimer);
-    map.off("dragstart", clearLongPressTimer);
-    map.off("movestart", clearLongPressTimer);
+    map.off("mouseout", cancelGesture);
+    map.off("dragstart", cancelGesture);
+    map.off("movestart", cancelGesture);
 
     map.off("touchstart", handleTouchstart);
-    map.off("touchend", clearLongPressTimer);
+    map.off("touchend", handleTouchend);
     map.off("touchmove", handleTouchmove);
-    map.off("touchcancel", clearLongPressTimer);
+    map.off("touchcancel", cancelGesture);
   };
 }

--- a/apps/web/src/lib/stores/uiView.ts
+++ b/apps/web/src/lib/stores/uiView.ts
@@ -22,7 +22,7 @@ import { setupUiInvariantWatcher } from "./uiInvariants";
  * NodesOverlay         | DOM markers, activeMarkers map  | MapEntityViewModel[]
  * edges.ts             | GeoJSON edge source/layers      | Edge[], MapEntityViewModel[]
  * focus.ts             | click-to-dismiss handler         | systemState
- * komposition.ts       | longpress handler                | —
+ * komposition.ts       | longpress + garnrolle-tap handler| kompositionDraft
  *
  * Invariants (enforced by uiInvariants.ts):
  *  - selection and kompositionDraft are mutually exclusive
@@ -66,7 +66,7 @@ export const contextPanelOpen = derived(
 export type KompositionDraft = {
   mode: "new-knoten" | "place-garnrolle";
   lngLat?: [number, number];
-  source: "map-longpress" | "tool-fan";
+  source: "map-longpress" | "map-tap" | "tool-fan";
 } | null;
 
 export const kompositionDraft = writable<KompositionDraft>(null);

--- a/apps/web/tests/garnrolle-self-service.spec.ts
+++ b/apps/web/tests/garnrolle-self-service.spec.ts
@@ -35,6 +35,14 @@ async function longPressMapCenter(page: Page) {
   await page.mouse.up();
 }
 
+async function clickMapCenter(page: Page) {
+  const map = page.locator("#map");
+  await expect(map).toBeVisible();
+  // A plain click (down + up at the same spot, no hold) must set the point in
+  // the explicit place-garnrolle mode.
+  await map.click({ position: { x: 50, y: 50 } });
+}
+
 test.describe("Eigene Garnrolle speichern", () => {
   test("clears sensitive Garnrolle drafts on logout", async ({ page }) => {
     await mockApiResponses(page, {
@@ -137,6 +145,73 @@ test.describe("Eigene Garnrolle speichern", () => {
     });
     await expect(
       section.locator('[data-testid="garnrolle-success"]'),
+    ).toContainText("gespeichert");
+  });
+
+  test("guest places the own Garnrolle via a plain map click and saves it exact", async ({
+    page,
+  }) => {
+    await mockApiResponses(page, {
+      auth: {
+        authenticated: true,
+        account_id: ACCOUNT_ID,
+        role: "gast",
+      },
+    });
+    await page.goto("/settings#meine-garnrolle");
+    const section = page.locator('[data-testid="my-garnrolle-section"]');
+    await expect(section).toBeVisible();
+    await expect(
+      section.locator('[data-testid="garnrolle-role-warning"]'),
+    ).toHaveCount(0);
+
+    await section.getByLabel("Anzeigename").fill("Gastgarnrolle am Ort");
+    await section.getByLabel("Adresse").fill("Poelsweg 2, Hamburg");
+    await section.getByLabel("Exakt sichtbar").check();
+
+    const save = section.locator('[data-testid="save-garnrolle"]');
+    // Without a self-selected point the exact profile cannot be saved.
+    await expect(save).toBeDisabled();
+    await section.locator('[data-testid="choose-garnrolle-location"]').click();
+
+    await expect(page).toHaveURL(/\/map\?compose=garnrolle/);
+    const placement = page.locator('[data-testid="garnrolle-placement"]');
+    await expect(placement).toContainText("Ort ausstehend");
+    // The regression: a normal click (not an 800ms longpress) must set the point.
+    await clickMapCenter(page);
+    await expect(placement).toContainText("Ort gewählt");
+    await placement
+      .locator('[data-testid="confirm-garnrolle-location"]')
+      .click();
+
+    await expect(page).toHaveURL(/\/settings#meine-garnrolle$/);
+    const returned = page.locator('[data-testid="my-garnrolle-section"]');
+    await expect(returned.getByLabel("Anzeigename")).toHaveValue(
+      "Gastgarnrolle am Ort",
+    );
+    await expect(
+      returned.locator('[data-testid="garnrolle-location-state"]'),
+    ).toContainText("Ort gewählt");
+    await expect(
+      returned.locator('[data-testid="save-garnrolle"]'),
+    ).toBeEnabled();
+
+    const requestPromise = page.waitForRequest(
+      (request) =>
+        request.url().endsWith("/api/accounts/me/profile") &&
+        request.method() === "PATCH",
+    );
+    await returned.locator('[data-testid="save-garnrolle"]').click();
+    const payload = (await requestPromise).postDataJSON();
+    expect(payload).toMatchObject({
+      title: "Gastgarnrolle am Ort",
+      address: "Poelsweg 2, Hamburg",
+      map_state: "exact",
+    });
+    expect(typeof payload.location?.lat).toBe("number");
+    expect(typeof payload.location?.lon).toBe("number");
+    await expect(
+      returned.locator('[data-testid="garnrolle-success"]'),
     ).toContainText("gespeichert");
   });
 
@@ -276,6 +351,35 @@ test.describe("Garnrollen-Kartenpunkt per Touch", () => {
       touchPoints: [touchPoint],
     });
     await page.waitForTimeout(950);
+    await client.send("Input.dispatchTouchEvent", {
+      type: "touchEnd",
+      touchPoints: [],
+    });
+    await expect(placement).toContainText("Ort gewählt");
+  });
+
+  test("accepts a plain touch tap (no longpress hold)", async ({ page }) => {
+    await mockApiResponses(page, {
+      auth: {
+        authenticated: true,
+        account_id: ACCOUNT_ID,
+        role: "gast",
+      },
+    });
+    await page.goto("/map?compose=garnrolle");
+    const placement = page.locator('[data-testid="garnrolle-placement"]');
+    await expect(placement).toContainText("Ort ausstehend");
+
+    const map = page.locator("#map canvas").first();
+    const box = await map.boundingBox();
+    if (!box) throw new Error("map has no bounding box");
+    const touchPoint = { x: box.x + 50, y: box.y + 50 };
+    const client = await page.context().newCDPSession(page);
+    await client.send("Input.dispatchTouchEvent", {
+      type: "touchStart",
+      touchPoints: [touchPoint],
+    });
+    // A quick tap, well below the longpress threshold.
     await client.send("Input.dispatchTouchEvent", {
       type: "touchEnd",
       touchPoints: [],


### PR DESCRIPTION
<!-- weltgewebe-risk: R2 -->

## Problem
Ein frisch angemeldeter Gast konnte die eigene Garnrolle im expliziten Karten-Ortswahlmodus faktisch nur per ca. 800 ms Longpress verorten. Ein normaler Klick oder Tap wirkte ohne Reaktion. Backend und API erlauben das Verorten der eigenen Gast-Garnrolle bereits; die Lücke lag im Web-Kartenpfad.

## Änderung
- Im expliziten `place-garnrolle`-Modus setzt ein stationärer normaler Klick oder Tap den Punkt.
- Normale Knoten-Komposition bleibt unverändert Longpress-only.
- Marker-Klicks und Kartenbewegungen/Pans setzen keinen Garnrollenpunkt.
- Longpress bleibt als kompatibler Weg erhalten und löst nicht doppelt aus.
- Bedienhinweis beschreibt Klick/Tap ausdrücklich.
- Neuer Gast-End-to-End-Test prüft Einstellungen → exakte Sichtbarkeit → Adresse → Kartenpunkt → `PATCH /api/accounts/me/profile` mit `map_state=exact` und numerischen Koordinaten.
- Zusätzliche Unit-Tests decken Klick, Tap, Longpress, Marker, Pan, anonyme Sitzung und Knotenmodus ab.

## Verifikation
- fokussierte `komposition.test.ts`: grün
- `garnrolle-self-service.spec.ts`: grün auf isoliertem Port 4191
- `pnpm check`: grün
- `pnpm lint`: grün
- `git diff --check`: grün

Der Gast-Rechtevertrag und die API-Berechtigungen wurden nicht geändert.