### PR TITLE
fix(web): harden Garnrolle map placement gestures

### DIFF
--- a/apps/web/src/lib/map/overlay/komposition.test.ts
+++ b/apps/web/src/lib/map/overlay/komposition.test.ts
@@ -33,22 +33,24 @@ import {
   enterKomposition,
 } from "$lib/stores/uiView";
 
-// The overlay classifies event targets with `instanceof HTMLElement` +
-// `closest(".map-marker")`. The suite runs under the "node" environment (no
-// DOM), so a minimal element stand-in provides both.
+// The production guard only requires the DOM-standard `closest` capability,
+// so these tests do not replace global HTMLElement/Element constructors. The
+// parent chain also models nested HTML/SVG content inside a map marker.
 class FakeElement {
   className: string;
-  constructor(className = "") {
+  parent: FakeElement | null;
+
+  constructor(className = "", parent: FakeElement | null = null) {
     this.className = className;
+    this.parent = parent;
   }
+
   closest(selector: string): FakeElement | null {
-    return selector === ".map-marker" &&
-      /(^|\s)map-marker(\s|$)/.test(this.className)
-      ? this
-      : null;
+    if (selector !== ".map-marker") return null;
+    if (/(^|\s)map-marker(\s|$)/.test(this.className)) return this;
+    return this.parent?.closest(selector) ?? null;
   }
 }
-(globalThis as { HTMLElement?: unknown }).HTMLElement = FakeElement;
 
 type Handler = (event: unknown) => void;
 
@@ -75,9 +77,14 @@ function pointerEvent(
   lng: number,
   lat: number,
   target: unknown = new FakeElement("maplibregl-canvas"),
+  touchCount = 1,
 ) {
   return {
     point: { x, y },
+    points: Array.from({ length: touchCount }, (_, index) => ({
+      x: x + index,
+      y: y + index,
+    })),
     lngLat: { lng, lat },
     originalEvent: { target },
   };
@@ -125,6 +132,21 @@ describe("setupKompositionInteraction", () => {
     clickAt(map, "touchstart", "touchend", pointerEvent(50, 50, 9.9, 53.4));
     expect(get(kompositionDraft)?.lngLat).toEqual([9.9, 53.4]);
     expect(get(kompositionDraft)?.source).toBe("map-tap");
+  });
+
+  it("suppresses compatibility mouse events after a touch tap", () => {
+    enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
+    const setSpy = vi.fn();
+    const unsub = kompositionDraft.subscribe((value) => {
+      if (value?.lngLat) setSpy(value.lngLat);
+    });
+
+    clickAt(map, "touchstart", "touchend", pointerEvent(50, 50, 9.9, 53.4));
+    clickAt(map, "mousedown", "mouseup", pointerEvent(50, 50, 10.1, 53.6));
+
+    unsub();
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    expect(get(kompositionDraft)?.lngLat).toEqual([9.9, 53.4]);
   });
 
   it("ignores a plain click outside place-garnrolle mode (navigation)", () => {
@@ -178,6 +200,23 @@ describe("setupKompositionInteraction", () => {
     expect(get(kompositionDraft)?.lngLat).toBeUndefined();
   });
 
+  it("does not move the point from nested SVG-like marker content", () => {
+    enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
+    const marker = new FakeElement("map-marker");
+    const svg = new FakeElement("marker-icon-svg", marker);
+    const path = new FakeElement("marker-icon-path", svg);
+    clickAt(map, "mousedown", "mouseup", pointerEvent(50, 50, 10, 53.5, path));
+    expect(get(kompositionDraft)?.lngLat).toBeUndefined();
+  });
+
+  it("does not resurrect Garnrolle placement when composition is cancelled mid-press", () => {
+    enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
+    map.emit("mousedown", pointerEvent(50, 50, 10, 53.5));
+    leaveToNavigation();
+    map.emit("mouseup", pointerEvent(50, 50, 10, 53.5));
+    expect(get(kompositionDraft)).toBeNull();
+  });
+
   it("does not place a point for a pan (movement beyond tolerance)", () => {
     enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
     map.emit("mousedown", pointerEvent(50, 50, 10, 53.5));
@@ -186,10 +225,28 @@ describe("setupKompositionInteraction", () => {
     expect(get(kompositionDraft)?.lngLat).toBeUndefined();
   });
 
+  it("does not arm placement for a multi-touch gesture", () => {
+    enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
+    map.emit(
+      "touchstart",
+      pointerEvent(50, 50, 10, 53.5, new FakeElement("maplibregl-canvas"), 2),
+    );
+    map.emit("touchend", pointerEvent(50, 50, 10, 53.5));
+    expect(get(kompositionDraft)?.lngLat).toBeUndefined();
+  });
+
   it("ignores a click by an anonymous user", () => {
     authStore.set({ authenticated: false, role: "gast" });
     enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
     clickAt(map, "mousedown", "mouseup", pointerEvent(50, 50, 10, 53.5));
+    expect(get(kompositionDraft)?.lngLat).toBeUndefined();
+  });
+
+  it("cancels an armed gesture when authentication disappears before release", () => {
+    enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
+    map.emit("mousedown", pointerEvent(50, 50, 10, 53.5));
+    authStore.set({ authenticated: false, role: "gast" });
+    map.emit("mouseup", pointerEvent(50, 50, 10, 53.5));
     expect(get(kompositionDraft)?.lngLat).toBeUndefined();
   });
 });

--- a/apps/web/src/lib/map/overlay/komposition.ts
+++ b/apps/web/src/lib/map/overlay/komposition.ts
@@ -26,28 +26,44 @@ function isPlacingGarnrolle(): boolean {
   return get(kompositionDraft)?.mode === "place-garnrolle";
 }
 
+type ClosestTarget = EventTarget & {
+  closest(selectors: string): Element | null;
+};
+
+/**
+ * Marker contents can be HTML or SVG. Checking for a structural `closest`
+ * capability covers both without mutating DOM globals in node-based tests.
+ */
 function targetIsMarker(target: EventTarget | null): boolean {
-  return (
-    target instanceof HTMLElement && target.closest(".map-marker") !== null
-  );
+  if (
+    target === null ||
+    typeof (target as { closest?: unknown }).closest !== "function"
+  ) {
+    return false;
+  }
+  return (target as ClosestTarget).closest(".map-marker") !== null;
 }
 
 const LONG_PRESS_MS = 800;
 // 10px squared. Below this a press counts as a stationary click/tap; above it
 // the gesture is a pan/drag and never places a point.
 const TAP_MOVE_TOLERANCE_SQ = 100;
+// Some touch stacks emit compatibility mouse events after touchend. Ignore that
+// synthetic follow-up briefly so one physical tap cannot place the point twice.
+const COMPAT_MOUSE_SUPPRESSION_MS = 500;
+
+type GestureMode = "new-knoten" | "place-garnrolle";
+type ActiveGesture = {
+  startX: number;
+  startY: number;
+  mode: GestureMode;
+  longPressFired: boolean;
+};
 
 export function setupKompositionInteraction(map: MapLibreMap) {
   let longPressTimer: ReturnType<typeof setTimeout> | undefined;
-  let startX = 0;
-  let startY = 0;
-  // A press only counts for composition if it started on the empty map (not on
-  // a marker) while authenticated. Marker presses and anonymous presses never
-  // arm a gesture, so their release can never set or move a point.
-  let gestureArmed = false;
-  // Set once the longpress timer has fired for the current press, so the
-  // trailing mouseup/touchend does not place the same point a second time.
-  let longPressFired = false;
+  let activeGesture: ActiveGesture | null = null;
+  let suppressMouseUntil = 0;
 
   const clearLongPressTimer = () => {
     if (longPressTimer !== undefined) {
@@ -58,16 +74,16 @@ export function setupKompositionInteraction(map: MapLibreMap) {
 
   const cancelGesture = () => {
     clearLongPressTimer();
-    gestureArmed = false;
-    longPressFired = false;
+    activeGesture = null;
   };
 
   const setPoint = (
     lngLat: { lng: number; lat: number },
     source: "map-longpress" | "map-tap",
+    mode: GestureMode,
   ) => {
     enterKomposition({
-      mode: isPlacingGarnrolle() ? "place-garnrolle" : "new-knoten",
+      mode,
       lngLat: [lngLat.lng, lngLat.lat],
       source,
     });
@@ -84,19 +100,32 @@ export function setupKompositionInteraction(map: MapLibreMap) {
     if (targetIsMarker(target)) return;
     if (!canComposeOnMap()) return;
 
-    gestureArmed = true;
-    startX = point.x;
-    startY = point.y;
+    activeGesture = {
+      startX: point.x,
+      startY: point.y,
+      mode: isPlacingGarnrolle() ? "place-garnrolle" : "new-knoten",
+      longPressFired: false,
+    };
     longPressTimer = setTimeout(() => {
-      longPressFired = true;
-      setPoint(lngLat, "map-longpress");
+      longPressTimer = undefined;
+      const gesture = activeGesture;
+      if (gesture === null) return;
+      // Authentication may change while the finger/button is still held.
+      // Re-check before producing a UI action; the API remains the final guard.
+      if (!canComposeOnMap()) {
+        cancelGesture();
+        return;
+      }
+      gesture.longPressFired = true;
+      setPoint(lngLat, "map-longpress", gesture.mode);
     }, LONG_PRESS_MS);
   };
 
   const trackMove = (point: { x: number; y: number }) => {
-    if (!gestureArmed) return;
-    const dx = point.x - startX;
-    const dy = point.y - startY;
+    const gesture = activeGesture;
+    if (gesture === null) return;
+    const dx = point.x - gesture.startX;
+    const dy = point.y - gesture.startY;
     if (dx * dx + dy * dy > TAP_MOVE_TOLERANCE_SQ) {
       // Movement beyond the tolerance is a pan, not a placement gesture.
       cancelGesture();
@@ -107,38 +136,61 @@ export function setupKompositionInteraction(map: MapLibreMap) {
     point: { x: number; y: number },
     lngLat: { lng: number; lat: number },
   ) => {
-    const armed = gestureArmed;
-    const alreadyPlaced = longPressFired;
+    const gesture = activeGesture;
+    if (gesture === null) return;
+    const dx = point.x - gesture.startX;
+    const dy = point.y - gesture.startY;
     cancelGesture();
-    if (!armed || alreadyPlaced) return;
-    const dx = point.x - startX;
-    const dy = point.y - startY;
+    if (gesture.longPressFired || !canComposeOnMap()) return;
     if (dx * dx + dy * dy > TAP_MOVE_TOLERANCE_SQ) return;
-    // A stationary release is a click/tap. Only the explicit Garnrolle
-    // placement mode treats it as "set this point"; normal node composition
-    // deliberately stays longpress-only.
-    if (!isPlacingGarnrolle()) return;
-    setPoint(lngLat, "map-tap");
+    // The mode is frozen at press start. A stationary release only places on
+    // the explicit Garnrolle picker; normal node composition stays longpress-only.
+    if (gesture.mode !== "place-garnrolle" || !isPlacingGarnrolle()) return;
+    setPoint(lngLat, "map-tap", gesture.mode);
+  };
+
+  const mouseIsSuppressed = () => Date.now() < suppressMouseUntil;
+  const suppressCompatibilityMouse = () => {
+    suppressMouseUntil = Date.now() + COMPAT_MOUSE_SUPPRESSION_MS;
   };
 
   const handleMousedown = (e: MapMouseEvent) => {
+    if (mouseIsSuppressed()) return;
     beginGesture(e.point, e.lngLat, e.originalEvent.target);
   };
   const handleMousemove = (e: MapMouseEvent) => {
+    if (mouseIsSuppressed()) return;
     trackMove(e.point);
   };
   const handleMouseup = (e: MapMouseEvent) => {
+    if (mouseIsSuppressed()) return;
     endGesture(e.point, e.lngLat);
   };
 
   const handleTouchstart = (e: MapTouchEvent) => {
+    suppressCompatibilityMouse();
+    // Pinch/zoom and other multi-touch gestures belong to the map itself and
+    // must never arm composition.
+    if (e.points.length !== 1) {
+      cancelGesture();
+      return;
+    }
     beginGesture(e.point, e.lngLat, e.originalEvent.target);
   };
   const handleTouchmove = (e: MapTouchEvent) => {
+    if (e.points.length !== 1) {
+      cancelGesture();
+      return;
+    }
     trackMove(e.point);
   };
   const handleTouchend = (e: MapTouchEvent) => {
     endGesture(e.point, e.lngLat);
+    suppressCompatibilityMouse();
+  };
+  const handleTouchcancel = () => {
+    cancelGesture();
+    suppressCompatibilityMouse();
   };
 
   map.on("mousedown", handleMousedown);
@@ -151,7 +203,7 @@ export function setupKompositionInteraction(map: MapLibreMap) {
   map.on("touchstart", handleTouchstart);
   map.on("touchend", handleTouchend);
   map.on("touchmove", handleTouchmove);
-  map.on("touchcancel", cancelGesture);
+  map.on("touchcancel", handleTouchcancel);
 
   return () => {
     cancelGesture();
@@ -165,6 +217,6 @@ export function setupKompositionInteraction(map: MapLibreMap) {
     map.off("touchstart", handleTouchstart);
     map.off("touchend", handleTouchend);
     map.off("touchmove", handleTouchmove);
-    map.off("touchcancel", cancelGesture);
+    map.off("touchcancel", handleTouchcancel);
   };
 }

--- a/apps/web/tests/garnrolle-self-service.spec.ts
+++ b/apps/web/tests/garnrolle-self-service.spec.ts
@@ -43,6 +43,22 @@ async function clickMapCenter(page: Page) {
   await map.click({ position: { x: 50, y: 50 } });
 }
 
+function expectValidLocation(location: unknown) {
+  expect(location).toEqual(
+    expect.objectContaining({
+      lat: expect.any(Number),
+      lon: expect.any(Number),
+    }),
+  );
+  const { lat, lon } = location as { lat: number; lon: number };
+  expect(Number.isFinite(lat)).toBe(true);
+  expect(Number.isFinite(lon)).toBe(true);
+  expect(lat).toBeGreaterThanOrEqual(-90);
+  expect(lat).toBeLessThanOrEqual(90);
+  expect(lon).toBeGreaterThanOrEqual(-180);
+  expect(lon).toBeLessThanOrEqual(180);
+}
+
 test.describe("Eigene Garnrolle speichern", () => {
   test("clears sensitive Garnrolle drafts on logout", async ({ page }) => {
     await mockApiResponses(page, {
@@ -208,8 +224,7 @@ test.describe("Eigene Garnrolle speichern", () => {
       address: "Poelsweg 2, Hamburg",
       map_state: "exact",
     });
-    expect(typeof payload.location?.lat).toBe("number");
-    expect(typeof payload.location?.lon).toBe("number");
+    expectValidLocation(payload.location);
     await expect(
       returned.locator('[data-testid="garnrolle-success"]'),
     ).toContainText("gespeichert");
@@ -313,8 +328,7 @@ test.describe("Eigene Garnrolle speichern", () => {
       map_state: "exact",
       tags: ["skill:Nachbarschaftshilfe"],
     });
-    expect(typeof payload.location?.lat).toBe("number");
-    expect(typeof payload.location?.lon).toBe("number");
+    expectValidLocation(payload.location);
     await expect(
       returned.locator('[data-testid="garnrolle-success"]'),
     ).toContainText("gespeichert");


### PR DESCRIPTION
<!-- weltgewebe-risk: R2 -->

## Zweck

Follow-up-Härtung zu #1562. Der Gast-Klick/Tap-Flow bleibt unverändert, aber die Gestenerkennung wird gegen reale Marker-Inhalte, Multi-Touch, Touch→Mouse-Kompatibilitätsereignisse und Abbruch während einer laufenden Geste abgesichert.

## Änderungen

- Marker-Erkennung akzeptiert HTML- und SVG-Nachfahren via `closest(.map-marker)` statt `instanceof HTMLElement`.
- Test-Suite mutiert keine globalen DOM-Konstruktoren mehr.
- Gestenmodus wird beim Press-Start eingefroren; zugleich darf ein inzwischen abgebrochener Garnrollen-Entwurf beim Release nicht wieder auferstehen.
- Authentifizierung wird vor dem Auslösen erneut geprüft.
- Multi-Touch bricht Komposition ab.
- Touch-Kompatibilitäts-Mausereignisse werden kurz unterdrückt, damit ein physischer Tap nur einmal setzt.
- E2E-Koordinatenprüfung verlangt endliche Werte in gültigen Lat/Lon-Bereichen.

## Beweise auf Head 357644a6adb3a71dd6c1d53aa508e2a4638b9c0e

- `vitest run src/lib/map/overlay/komposition.test.ts`: 14/14 grün
- `svelte-check --tsconfig ./tsconfig.json`: 0 Fehler, 0 Warnungen
- ESLint auf den 3 geänderten Dateien: grün
- Prettier-Check auf den 3 geänderten Dateien: grün
- Playwright auf exaktem Head: 2/2 relevante Fälle grün
  - Gast setzt eigene Garnrolle per normalem Kartenklick und speichert `map_state=exact`
  - schneller Touch-Tap ohne Longpress setzt den Punkt
- `git diff --check origin/main...HEAD`: grün

GitHub-Governance-Diff-SHA256: `a45385dbb142c3f16b32815ef0ebaf13e6b24d4cfb0aecde6d7c0a6e85f758f5`

Lokaler Unified-Diff-SHA256 der bereitgestellten `.txt`-Datei: `3eaab5a444da588b24540e84867facf9dcee66c5a25382c21d39cfd96c72469a`