### PR TITLE
fix(web): harden composition gesture validity

### DIFF
--- a/apps/web/src/lib/map/overlay/komposition.test.ts
+++ b/apps/web/src/lib/map/overlay/komposition.test.ts
@@ -71,15 +71,26 @@ class FakeMap {
   }
 }
 
+type PointerEventOptions = {
+  target?: unknown;
+  touchCount?: number;
+  button?: number;
+  buttons?: number;
+};
+
 function pointerEvent(
   x: number,
   y: number,
   lng: number,
   lat: number,
-  target: unknown = new FakeElement("maplibregl-canvas"),
-  touchCount = 1,
-  button = 0,
+  options: PointerEventOptions = {},
 ) {
+  const {
+    target = new FakeElement("maplibregl-canvas"),
+    touchCount = 1,
+    button = 0,
+    buttons = 0,
+  } = options;
   return {
     point: { x, y },
     points: Array.from({ length: touchCount }, (_, index) => ({
@@ -87,7 +98,7 @@ function pointerEvent(
       y: y + index,
     })),
     lngLat: { lng, lat },
-    originalEvent: { target, button },
+    originalEvent: { target, button, buttons },
   };
 }
 
@@ -204,7 +215,7 @@ describe("setupKompositionInteraction", () => {
       map,
       "mousedown",
       "mouseup",
-      pointerEvent(50, 50, 10, 53.5, marker),
+      pointerEvent(50, 50, 10, 53.5, { target: marker }),
     );
     expect(get(kompositionDraft)?.lngLat).toBeUndefined();
   });
@@ -214,7 +225,12 @@ describe("setupKompositionInteraction", () => {
     const marker = new FakeElement("map-marker");
     const svg = new FakeElement("marker-icon-svg", marker);
     const path = new FakeElement("marker-icon-path", svg);
-    clickAt(map, "mousedown", "mouseup", pointerEvent(50, 50, 10, 53.5, path));
+    clickAt(
+      map,
+      "mousedown",
+      "mouseup",
+      pointerEvent(50, 50, 10, 53.5, { target: path }),
+    );
     expect(get(kompositionDraft)?.lngLat).toBeUndefined();
   });
 
@@ -256,6 +272,27 @@ describe("setupKompositionInteraction", () => {
     expect(draft?.source).toBe("tool-fan");
   });
 
+  it("does not complete a tap after same-mode ABA re-entry", () => {
+    enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
+    map.emit("mousedown", pointerEvent(50, 50, 10, 53.5));
+    leaveToNavigation();
+    enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
+    map.emit("mouseup", pointerEvent(50, 50, 10, 53.5));
+    const draft = get(kompositionDraft);
+    expect(draft?.mode).toBe("place-garnrolle");
+    expect(draft?.lngLat).toBeUndefined();
+    expect(draft?.source).toBe("tool-fan");
+  });
+
+  it("does not complete a tap after authentication changes away and back", () => {
+    enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
+    map.emit("mousedown", pointerEvent(50, 50, 10, 53.5));
+    authStore.set({ authenticated: false, role: "gast" });
+    authStore.set({ authenticated: true, role: "gast" });
+    map.emit("mouseup", pointerEvent(50, 50, 10, 53.5));
+    expect(get(kompositionDraft)?.lngLat).toBeUndefined();
+  });
+
   it("does not revive a navigation longpress after an ABA state transition", () => {
     map.emit("mousedown", pointerEvent(50, 50, 10, 53.5));
     enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
@@ -279,31 +316,46 @@ describe("setupKompositionInteraction", () => {
       map,
       "mousedown",
       "mouseup",
-      pointerEvent(50, 50, 10, 53.5, undefined, 1, 2),
+      pointerEvent(50, 50, 10, 53.5, { button: 2 }),
     );
     clickAt(
       map,
       "mousedown",
       "mouseup",
-      pointerEvent(50, 50, 10, 53.5, undefined, 1, 1),
+      pointerEvent(50, 50, 10, 53.5, { button: 1 }),
     );
     expect(get(kompositionDraft)?.lngLat).toBeUndefined();
   });
 
   it("does not arm a longpress from a non-primary mouse button", () => {
     enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
-    map.emit("mousedown", pointerEvent(50, 50, 10, 53.5, undefined, 1, 2));
+    map.emit("mousedown", pointerEvent(50, 50, 10, 53.5, { button: 2 }));
     vi.advanceTimersByTime(800);
     expect(get(kompositionDraft)?.lngLat).toBeUndefined();
   });
 
-  it("does not let a non-primary mouseup finish an armed primary-button gesture", () => {
+  it("keeps a primary gesture armed when a non-primary mouseup reports primary held", () => {
     enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
     map.emit("mousedown", pointerEvent(50, 50, 10, 53.5));
-    map.emit("mouseup", pointerEvent(50, 50, 10, 53.5, undefined, 1, 2));
+    map.emit(
+      "mouseup",
+      pointerEvent(50, 50, 10, 53.5, { button: 2, buttons: 1 }),
+    );
     expect(get(kompositionDraft)?.lngLat).toBeUndefined();
     map.emit("mouseup", pointerEvent(50, 50, 10, 53.5));
     expect(get(kompositionDraft)?.lngLat).toEqual([10, 53.5]);
+  });
+
+  it("cancels a primary gesture when a non-primary mouseup reports primary released", () => {
+    enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
+    map.emit("mousedown", pointerEvent(50, 50, 10, 53.5));
+    map.emit(
+      "mouseup",
+      pointerEvent(50, 50, 10, 53.5, { button: 2, buttons: 0 }),
+    );
+    vi.advanceTimersByTime(800);
+    map.emit("mouseup", pointerEvent(50, 50, 10, 53.5));
+    expect(get(kompositionDraft)?.lngLat).toBeUndefined();
   });
 
   it("does not place a point for a pan (movement beyond tolerance)", () => {
@@ -316,10 +368,7 @@ describe("setupKompositionInteraction", () => {
 
   it("does not arm placement for a multi-touch gesture", () => {
     enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
-    map.emit(
-      "touchstart",
-      pointerEvent(50, 50, 10, 53.5, new FakeElement("maplibregl-canvas"), 2),
-    );
+    map.emit("touchstart", pointerEvent(50, 50, 10, 53.5, { touchCount: 2 }));
     map.emit("touchend", pointerEvent(50, 50, 10, 53.5));
     expect(get(kompositionDraft)?.lngLat).toBeUndefined();
   });

--- a/apps/web/src/lib/map/overlay/komposition.test.ts
+++ b/apps/web/src/lib/map/overlay/komposition.test.ts
@@ -78,6 +78,7 @@ function pointerEvent(
   lat: number,
   target: unknown = new FakeElement("maplibregl-canvas"),
   touchCount = 1,
+  button = 0,
 ) {
   return {
     point: { x, y },
@@ -86,7 +87,7 @@ function pointerEvent(
       y: y + index,
     })),
     lngLat: { lng, lat },
-    originalEvent: { target },
+    originalEvent: { target, button },
   };
 }
 
@@ -132,6 +133,14 @@ describe("setupKompositionInteraction", () => {
     clickAt(map, "touchstart", "touchend", pointerEvent(50, 50, 9.9, 53.4));
     expect(get(kompositionDraft)?.lngLat).toEqual([9.9, 53.4]);
     expect(get(kompositionDraft)?.source).toBe("map-tap");
+  });
+
+  it("accepts mouse placement again after compatibility suppression expires", () => {
+    enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
+    clickAt(map, "touchstart", "touchend", pointerEvent(50, 50, 9.9, 53.4));
+    vi.advanceTimersByTime(501);
+    clickAt(map, "mousedown", "mouseup", pointerEvent(50, 50, 10.1, 53.6));
+    expect(get(kompositionDraft)?.lngLat).toEqual([10.1, 53.6]);
   });
 
   it("suppresses compatibility mouse events after a touch tap", () => {
@@ -215,6 +224,40 @@ describe("setupKompositionInteraction", () => {
     leaveToNavigation();
     map.emit("mouseup", pointerEvent(50, 50, 10, 53.5));
     expect(get(kompositionDraft)).toBeNull();
+  });
+
+  it("does not resurrect Garnrolle placement when the longpress timer fires after cancellation", () => {
+    enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
+    map.emit("mousedown", pointerEvent(50, 50, 10, 53.5));
+    leaveToNavigation();
+    vi.advanceTimersByTime(800);
+    expect(get(kompositionDraft)).toBeNull();
+  });
+
+  it("does not let a stale longpress overwrite a changed composition mode", () => {
+    enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
+    map.emit("mousedown", pointerEvent(50, 50, 10, 53.5));
+    enterKomposition({ mode: "new-knoten", source: "tool-fan" });
+    vi.advanceTimersByTime(800);
+    const draft = get(kompositionDraft);
+    expect(draft?.mode).toBe("new-knoten");
+    expect(draft?.lngLat).toBeUndefined();
+  });
+
+  it("ignores right and middle mouse buttons for placement", () => {
+    enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
+    clickAt(map, "mousedown", "mouseup", pointerEvent(50, 50, 10, 53.5, undefined, 1, 2));
+    clickAt(map, "mousedown", "mouseup", pointerEvent(50, 50, 10, 53.5, undefined, 1, 1));
+    expect(get(kompositionDraft)?.lngLat).toBeUndefined();
+  });
+
+  it("does not let a non-primary mouseup finish an armed primary-button gesture", () => {
+    enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
+    map.emit("mousedown", pointerEvent(50, 50, 10, 53.5));
+    map.emit("mouseup", pointerEvent(50, 50, 10, 53.5, undefined, 1, 2));
+    expect(get(kompositionDraft)?.lngLat).toBeUndefined();
+    map.emit("mouseup", pointerEvent(50, 50, 10, 53.5));
+    expect(get(kompositionDraft)?.lngLat).toEqual([10, 53.5]);
   });
 
   it("does not place a point for a pan (movement beyond tolerance)", () => {

--- a/apps/web/src/lib/map/overlay/komposition.test.ts
+++ b/apps/web/src/lib/map/overlay/komposition.test.ts
@@ -244,10 +244,56 @@ describe("setupKompositionInteraction", () => {
     expect(draft?.lngLat).toBeUndefined();
   });
 
+  it("does not let a stale longpress affect a re-entered Garnrolle composition", () => {
+    enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
+    map.emit("mousedown", pointerEvent(50, 50, 10, 53.5));
+    leaveToNavigation();
+    enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
+    vi.advanceTimersByTime(800);
+    const draft = get(kompositionDraft);
+    expect(draft?.mode).toBe("place-garnrolle");
+    expect(draft?.lngLat).toBeUndefined();
+    expect(draft?.source).toBe("tool-fan");
+  });
+
+  it("does not revive a navigation longpress after an ABA state transition", () => {
+    map.emit("mousedown", pointerEvent(50, 50, 10, 53.5));
+    enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
+    leaveToNavigation();
+    vi.advanceTimersByTime(800);
+    expect(get(kompositionDraft)).toBeNull();
+  });
+
+  it("does not revive a gesture after authentication changes away and back", () => {
+    enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
+    map.emit("mousedown", pointerEvent(50, 50, 10, 53.5));
+    authStore.set({ authenticated: false, role: "gast" });
+    authStore.set({ authenticated: true, role: "gast" });
+    vi.advanceTimersByTime(800);
+    expect(get(kompositionDraft)?.lngLat).toBeUndefined();
+  });
+
   it("ignores right and middle mouse buttons for placement", () => {
     enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
-    clickAt(map, "mousedown", "mouseup", pointerEvent(50, 50, 10, 53.5, undefined, 1, 2));
-    clickAt(map, "mousedown", "mouseup", pointerEvent(50, 50, 10, 53.5, undefined, 1, 1));
+    clickAt(
+      map,
+      "mousedown",
+      "mouseup",
+      pointerEvent(50, 50, 10, 53.5, undefined, 1, 2),
+    );
+    clickAt(
+      map,
+      "mousedown",
+      "mouseup",
+      pointerEvent(50, 50, 10, 53.5, undefined, 1, 1),
+    );
+    expect(get(kompositionDraft)?.lngLat).toBeUndefined();
+  });
+
+  it("does not arm a longpress from a non-primary mouse button", () => {
+    enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
+    map.emit("mousedown", pointerEvent(50, 50, 10, 53.5, undefined, 1, 2));
+    vi.advanceTimersByTime(800);
     expect(get(kompositionDraft)?.lngLat).toBeUndefined();
   });
 

--- a/apps/web/src/lib/map/overlay/komposition.test.ts
+++ b/apps/web/src/lib/map/overlay/komposition.test.ts
@@ -53,6 +53,9 @@ class FakeElement {
 }
 
 type Handler = (event: unknown) => void;
+type FakeDocumentTarget = EventTarget & {
+  visibilityState: "visible" | "hidden";
+};
 
 class FakeMap {
   private handlers = new Map<string, Set<Handler>>();
@@ -115,9 +118,17 @@ function clickAt(
 describe("setupKompositionInteraction", () => {
   let map: FakeMap;
   let cleanup: () => void;
+  let browserWindow: EventTarget;
+  let browserDocument: FakeDocumentTarget;
 
   beforeEach(() => {
     vi.useFakeTimers();
+    browserWindow = new EventTarget();
+    browserDocument = Object.assign(new EventTarget(), {
+      visibilityState: "visible" as const,
+    });
+    vi.stubGlobal("window", browserWindow);
+    vi.stubGlobal("document", browserDocument);
     authStore.set({ authenticated: true, role: "gast" });
     leaveToNavigation();
     map = new FakeMap();
@@ -127,6 +138,7 @@ describe("setupKompositionInteraction", () => {
   afterEach(() => {
     cleanup();
     leaveToNavigation();
+    vi.unstubAllGlobals();
     vi.useRealTimers();
   });
 
@@ -356,6 +368,33 @@ describe("setupKompositionInteraction", () => {
     vi.advanceTimersByTime(800);
     map.emit("mouseup", pointerEvent(50, 50, 10, 53.5));
     expect(get(kompositionDraft)?.lngLat).toBeUndefined();
+  });
+
+  it("cancels an armed gesture when the window loses focus", () => {
+    enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
+    map.emit("mousedown", pointerEvent(50, 50, 10, 53.5));
+    browserWindow.dispatchEvent(new Event("blur"));
+    vi.advanceTimersByTime(800);
+    map.emit("mouseup", pointerEvent(50, 50, 10, 53.5));
+    expect(get(kompositionDraft)?.lngLat).toBeUndefined();
+  });
+
+  it("cancels an armed gesture when the document becomes hidden", () => {
+    enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
+    map.emit("mousedown", pointerEvent(50, 50, 10, 53.5));
+    browserDocument.visibilityState = "hidden";
+    browserDocument.dispatchEvent(new Event("visibilitychange"));
+    vi.advanceTimersByTime(800);
+    map.emit("mouseup", pointerEvent(50, 50, 10, 53.5));
+    expect(get(kompositionDraft)?.lngLat).toBeUndefined();
+  });
+
+  it("keeps an armed gesture when the document remains visible", () => {
+    enterKomposition({ mode: "place-garnrolle", source: "tool-fan" });
+    map.emit("mousedown", pointerEvent(50, 50, 10, 53.5));
+    browserDocument.dispatchEvent(new Event("visibilitychange"));
+    map.emit("mouseup", pointerEvent(50, 50, 10, 53.5));
+    expect(get(kompositionDraft)?.lngLat).toEqual([10, 53.5]);
   });
 
   it("does not place a point for a pan (movement beyond tolerance)", () => {

--- a/apps/web/src/lib/map/overlay/komposition.ts
+++ b/apps/web/src/lib/map/overlay/komposition.ts
@@ -57,6 +57,7 @@ type ActiveGesture = {
   startX: number;
   startY: number;
   mode: GestureMode;
+  initialDraftMode: string | null;
   longPressFired: boolean;
 };
 
@@ -75,6 +76,11 @@ export function setupKompositionInteraction(map: MapLibreMap) {
   const cancelGesture = () => {
     clearLongPressTimer();
     activeGesture = null;
+  };
+
+  const gestureIsStillValid = (gesture: ActiveGesture) => {
+    if (!canComposeOnMap()) return false;
+    return (get(kompositionDraft)?.mode ?? null) === gesture.initialDraftMode;
   };
 
   const setPoint = (
@@ -104,6 +110,7 @@ export function setupKompositionInteraction(map: MapLibreMap) {
       startX: point.x,
       startY: point.y,
       mode: isPlacingGarnrolle() ? "place-garnrolle" : "new-knoten",
+      initialDraftMode: get(kompositionDraft)?.mode ?? null,
       longPressFired: false,
     };
     longPressTimer = setTimeout(() => {
@@ -112,7 +119,7 @@ export function setupKompositionInteraction(map: MapLibreMap) {
       if (gesture === null) return;
       // Authentication may change while the finger/button is still held.
       // Re-check before producing a UI action; the API remains the final guard.
-      if (!canComposeOnMap()) {
+      if (!gestureIsStillValid(gesture)) {
         cancelGesture();
         return;
       }
@@ -141,7 +148,7 @@ export function setupKompositionInteraction(map: MapLibreMap) {
     const dx = point.x - gesture.startX;
     const dy = point.y - gesture.startY;
     cancelGesture();
-    if (gesture.longPressFired || !canComposeOnMap()) return;
+    if (gesture.longPressFired || !gestureIsStillValid(gesture)) return;
     if (dx * dx + dy * dy > TAP_MOVE_TOLERANCE_SQ) return;
     // The mode is frozen at press start. A stationary release only places on
     // the explicit Garnrolle picker; normal node composition stays longpress-only.
@@ -155,7 +162,7 @@ export function setupKompositionInteraction(map: MapLibreMap) {
   };
 
   const handleMousedown = (e: MapMouseEvent) => {
-    if (mouseIsSuppressed()) return;
+    if (mouseIsSuppressed() || e.originalEvent.button !== 0) return;
     beginGesture(e.point, e.lngLat, e.originalEvent.target);
   };
   const handleMousemove = (e: MapMouseEvent) => {
@@ -163,7 +170,7 @@ export function setupKompositionInteraction(map: MapLibreMap) {
     trackMove(e.point);
   };
   const handleMouseup = (e: MapMouseEvent) => {
-    if (mouseIsSuppressed()) return;
+    if (mouseIsSuppressed() || e.originalEvent.button !== 0) return;
     endGesture(e.point, e.lngLat);
   };
 

--- a/apps/web/src/lib/map/overlay/komposition.ts
+++ b/apps/web/src/lib/map/overlay/komposition.ts
@@ -66,9 +66,13 @@ export function setupKompositionInteraction(map: MapLibreMap) {
   let activeGesture: ActiveGesture | null = null;
   let suppressMouseUntil = 0;
   let interactionRevision = 0;
+  const browserWindow = typeof window === "undefined" ? null : window;
+  const browserDocument = typeof document === "undefined" ? null : document;
 
   // Bind a gesture to one exact composition/auth generation rather than only
-  // to a mode value. This also rejects ABA transitions such as
+  // to a mode value. Every store emission invalidates the gesture deliberately:
+  // a false-positive cancellation is safer than completing a stale placement.
+  // This also rejects ABA transitions such as
   // place-garnrolle -> navigation -> place-garnrolle during one held press.
   const unsubscribeDraftRevision = kompositionDraft.subscribe(() => {
     interactionRevision += 1;
@@ -128,8 +132,9 @@ export function setupKompositionInteraction(map: MapLibreMap) {
       longPressTimer = undefined;
       const gesture = activeGesture;
       if (gesture === null) return;
-      // Authentication may change while the finger/button is still held.
-      // Re-check before producing a UI action; the API remains the final guard.
+      // Authentication or composition state may change while the pointer is
+      // held. Re-check the exact revision before producing a UI action; the API
+      // remains the final guard.
       if (!gestureIsStillValid(gesture)) {
         cancelGesture();
         return;
@@ -158,8 +163,9 @@ export function setupKompositionInteraction(map: MapLibreMap) {
     if (gesture === null) return;
     const dx = point.x - gesture.startX;
     const dy = point.y - gesture.startY;
+    const gestureWasValid = gestureIsStillValid(gesture);
     cancelGesture();
-    if (gesture.longPressFired || !gestureIsStillValid(gesture)) return;
+    if (gesture.longPressFired || !gestureWasValid) return;
     if (dx * dx + dy * dy > TAP_MOVE_TOLERANCE_SQ) return;
     // The mode is frozen at press start. A stationary release only places on
     // the explicit Garnrolle picker; normal node composition stays longpress-only.
@@ -220,6 +226,9 @@ export function setupKompositionInteraction(map: MapLibreMap) {
     cancelGesture();
     suppressCompatibilityMouse();
   };
+  const handleVisibilityChange = () => {
+    if (browserDocument?.visibilityState !== "visible") cancelGesture();
+  };
 
   map.on("mousedown", handleMousedown);
   map.on("mouseup", handleMouseup);
@@ -232,6 +241,9 @@ export function setupKompositionInteraction(map: MapLibreMap) {
   map.on("touchend", handleTouchend);
   map.on("touchmove", handleTouchmove);
   map.on("touchcancel", handleTouchcancel);
+
+  browserWindow?.addEventListener("blur", cancelGesture);
+  browserDocument?.addEventListener("visibilitychange", handleVisibilityChange);
 
   return () => {
     cancelGesture();
@@ -248,5 +260,11 @@ export function setupKompositionInteraction(map: MapLibreMap) {
     map.off("touchend", handleTouchend);
     map.off("touchmove", handleTouchmove);
     map.off("touchcancel", handleTouchcancel);
+
+    browserWindow?.removeEventListener("blur", cancelGesture);
+    browserDocument?.removeEventListener(
+      "visibilitychange",
+      handleVisibilityChange,
+    );
   };
 }

--- a/apps/web/src/lib/map/overlay/komposition.ts
+++ b/apps/web/src/lib/map/overlay/komposition.ts
@@ -57,7 +57,7 @@ type ActiveGesture = {
   startX: number;
   startY: number;
   mode: GestureMode;
-  initialDraftMode: string | null;
+  interactionRevision: number;
   longPressFired: boolean;
 };
 
@@ -65,6 +65,17 @@ export function setupKompositionInteraction(map: MapLibreMap) {
   let longPressTimer: ReturnType<typeof setTimeout> | undefined;
   let activeGesture: ActiveGesture | null = null;
   let suppressMouseUntil = 0;
+  let interactionRevision = 0;
+
+  // Bind a gesture to one exact composition/auth generation rather than only
+  // to a mode value. This also rejects ABA transitions such as
+  // place-garnrolle -> navigation -> place-garnrolle during one held press.
+  const unsubscribeDraftRevision = kompositionDraft.subscribe(() => {
+    interactionRevision += 1;
+  });
+  const unsubscribeAuthRevision = authStore.subscribe(() => {
+    interactionRevision += 1;
+  });
 
   const clearLongPressTimer = () => {
     if (longPressTimer !== undefined) {
@@ -80,7 +91,7 @@ export function setupKompositionInteraction(map: MapLibreMap) {
 
   const gestureIsStillValid = (gesture: ActiveGesture) => {
     if (!canComposeOnMap()) return false;
-    return (get(kompositionDraft)?.mode ?? null) === gesture.initialDraftMode;
+    return gesture.interactionRevision === interactionRevision;
   };
 
   const setPoint = (
@@ -110,7 +121,7 @@ export function setupKompositionInteraction(map: MapLibreMap) {
       startX: point.x,
       startY: point.y,
       mode: isPlacingGarnrolle() ? "place-garnrolle" : "new-knoten",
-      initialDraftMode: get(kompositionDraft)?.mode ?? null,
+      interactionRevision,
       longPressFired: false,
     };
     longPressTimer = setTimeout(() => {
@@ -214,6 +225,8 @@ export function setupKompositionInteraction(map: MapLibreMap) {
 
   return () => {
     cancelGesture();
+    unsubscribeDraftRevision();
+    unsubscribeAuthRevision();
     map.off("mousedown", handleMousedown);
     map.off("mouseup", handleMouseup);
     map.off("mousemove", handleMousemove);

--- a/apps/web/src/lib/map/overlay/komposition.ts
+++ b/apps/web/src/lib/map/overlay/komposition.ts
@@ -171,9 +171,13 @@ export function setupKompositionInteraction(map: MapLibreMap) {
   const suppressCompatibilityMouse = () => {
     suppressMouseUntil = Date.now() + COMPAT_MOUSE_SUPPRESSION_MS;
   };
+  const isPrimaryMouseButton = (e: MapMouseEvent) =>
+    e.originalEvent.button === 0;
+  const primaryMouseButtonIsHeld = (e: MapMouseEvent) =>
+    (e.originalEvent.buttons & 1) !== 0;
 
   const handleMousedown = (e: MapMouseEvent) => {
-    if (mouseIsSuppressed() || e.originalEvent.button !== 0) return;
+    if (mouseIsSuppressed() || !isPrimaryMouseButton(e)) return;
     beginGesture(e.point, e.lngLat, e.originalEvent.target);
   };
   const handleMousemove = (e: MapMouseEvent) => {
@@ -181,7 +185,13 @@ export function setupKompositionInteraction(map: MapLibreMap) {
     trackMove(e.point);
   };
   const handleMouseup = (e: MapMouseEvent) => {
-    if (mouseIsSuppressed() || e.originalEvent.button !== 0) return;
+    if (mouseIsSuppressed()) return;
+    if (!isPrimaryMouseButton(e)) {
+      // A foreign-button release may happen while the primary button remains
+      // held. Keep the gesture only when the browser explicitly reports that.
+      if (!primaryMouseButtonIsHeld(e)) cancelGesture();
+      return;
+    }
     endGesture(e.point, e.lngLat);
   };
 


### PR DESCRIPTION
Follow-up to #1563.

<!-- weltgewebe-risk: R2 -->

- bind armed gestures to an exact composition/auth interaction revision, so cancelled, superseded, or ABA-reentered states cannot resurrect stale long-presses or taps
- accept desktop composition gestures only from the primary mouse button; a non-primary release preserves the gesture only while the browser still reports the primary button held, otherwise it cancels the orphaned gesture
- cancel an armed gesture when the browser window loses focus or the document becomes hidden, while preserving it for visibility events that remain visible
- use named event-fixture options and add regression coverage for long-press and release-path ABA transitions, auth ABA changes, right/middle clicks, mixed-button state, focus/visibility loss, non-primary long-press, and mouse input after touch compatibility suppression expires

Verification:
- `pnpm test:unit src/lib/map/overlay/komposition.test.ts`
- `pnpm lint`
- `pnpm check:ci`