### PR TITLE
fix(web): show node creator and fit panel tabs

### DIFF
--- a/apps/api/src/auth/accounts.rs
+++ b/apps/api/src/auth/accounts.rs
@@ -38,6 +38,15 @@ impl AccountStore {
         self.get(account_id).is_some_and(|acc| !acc.public.disabled)
     }
 
+    /// Returns the trimmed public display title for an active account.
+    /// Missing, disabled and blank-titled accounts remain non-public.
+    pub fn public_display_title(&self, account_id: &str) -> Option<&str> {
+        self.get(account_id)
+            .filter(|account| !account.public.disabled)
+            .map(|account| account.public.title.trim())
+            .filter(|title| !title.is_empty())
+    }
+
     fn recompute_email_index_for_key(&mut self, key: &str) {
         let mut candidates = Vec::new();
         for (id, acc) in self.map.iter() {
@@ -215,6 +224,32 @@ mod tests {
             !store.is_account_active("missing"),
             "missing account is not active"
         );
+    }
+
+    #[test]
+    fn public_display_title_hides_missing_disabled_and_blank_accounts() {
+        let mut store = AccountStore::new();
+
+        let mut active = dummy_account("active", None);
+        active.public.title = "  Öffentliche Garnrolle  ".to_string();
+        store.insert(active);
+
+        let mut disabled = dummy_account("disabled", None);
+        disabled.public.title = "Verborgene Garnrolle".to_string();
+        disabled.public.disabled = true;
+        store.insert(disabled);
+
+        let mut blank = dummy_account("blank", None);
+        blank.public.title = "   ".to_string();
+        store.insert(blank);
+
+        assert_eq!(
+            store.public_display_title("active"),
+            Some("Öffentliche Garnrolle")
+        );
+        assert_eq!(store.public_display_title("disabled"), None);
+        assert_eq!(store.public_display_title("blank"), None);
+        assert_eq!(store.public_display_title("missing"), None);
     }
 
     #[test]

--- a/apps/api/src/routes/nodes.rs
+++ b/apps/api/src/routes/nodes.rs
@@ -115,6 +115,20 @@ pub struct Node {
     pub location: Location,
 }
 
+#[derive(Serialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum NodeHistoryKind {
+    Created,
+    Updated,
+}
+
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct NodeHistoryEvent {
+    pub date: String,
+    pub event: &'static str,
+    pub kind: NodeHistoryKind,
+}
+
 #[derive(Serialize)]
 pub struct NodeDetails {
     #[serde(flatten)]
@@ -122,6 +136,25 @@ pub struct NodeDetails {
     /// Current public Garnrollen title for the immutable creator binding.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub created_by_account_current_title: Option<String>,
+    /// Newest-first, typed timeline derived from the authoritative node dates.
+    pub history: Vec<NodeHistoryEvent>,
+}
+
+fn node_history(node: &Node) -> Vec<NodeHistoryEvent> {
+    let mut history = Vec::with_capacity(2);
+    if node.updated_at != node.created_at {
+        history.push(NodeHistoryEvent {
+            date: node.updated_at.clone(),
+            event: "Knoten aktualisiert.",
+            kind: NodeHistoryKind::Updated,
+        });
+    }
+    history.push(NodeHistoryEvent {
+        date: node.created_at.clone(),
+        event: "Knoten wurde im Gewebe verankert.",
+        kind: NodeHistoryKind::Created,
+    });
+    history
 }
 
 fn deserialize_some<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
@@ -498,9 +531,12 @@ pub async fn get_node(
         None => None,
     };
 
+    let history = node_history(&node);
+
     Ok(Json(NodeDetails {
         node,
         created_by_account_current_title,
+        history,
     }))
 }
 

--- a/apps/api/src/routes/nodes.rs
+++ b/apps/api/src/routes/nodes.rs
@@ -115,6 +115,15 @@ pub struct Node {
     pub location: Location,
 }
 
+#[derive(Serialize)]
+pub struct NodeDetails {
+    #[serde(flatten)]
+    pub node: Node,
+    /// Public Garnrollen title for the immutable creator binding.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_by_account_title: Option<String>,
+}
+
 fn deserialize_some<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
 where
     T: Deserialize<'de>,
@@ -469,13 +478,31 @@ pub async fn load_nodes() -> OrderedCache<Node> {
 pub async fn get_node(
     State(state): State<ApiState>,
     Path(id): Path<String>,
-) -> Result<Json<Node>, StatusCode> {
-    let nodes = state.nodes.read().await;
-    nodes
+) -> Result<Json<NodeDetails>, StatusCode> {
+    // Clone before reading accounts so this endpoint never holds several state
+    // locks at once.
+    let node = state
+        .nodes
+        .read()
+        .await
         .get(&id)
         .cloned()
-        .map(Json)
-        .ok_or(StatusCode::NOT_FOUND)
+        .ok_or(StatusCode::NOT_FOUND)?;
+    let created_by_account_title = match node.created_by_account_id.as_deref() {
+        Some(account_id) => state
+            .accounts
+            .read()
+            .await
+            .get(account_id)
+            .filter(|account| !account.public.disabled)
+            .map(|account| account.public.title.clone()),
+        None => None,
+    };
+
+    Ok(Json(NodeDetails {
+        node,
+        created_by_account_title,
+    }))
 }
 
 /// Append a single node record as a JSONL line. Durability via fsync.

--- a/apps/api/src/routes/nodes.rs
+++ b/apps/api/src/routes/nodes.rs
@@ -119,9 +119,9 @@ pub struct Node {
 pub struct NodeDetails {
     #[serde(flatten)]
     pub node: Node,
-    /// Public Garnrollen title for the immutable creator binding.
+    /// Current public Garnrollen title for the immutable creator binding.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub created_by_account_title: Option<String>,
+    pub created_by_account_current_title: Option<String>,
 }
 
 fn deserialize_some<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
@@ -488,20 +488,19 @@ pub async fn get_node(
         .get(&id)
         .cloned()
         .ok_or(StatusCode::NOT_FOUND)?;
-    let created_by_account_title = match node.created_by_account_id.as_deref() {
+    let created_by_account_current_title = match node.created_by_account_id.as_deref() {
         Some(account_id) => state
             .accounts
             .read()
             .await
-            .get(account_id)
-            .filter(|account| !account.public.disabled)
-            .map(|account| account.public.title.clone()),
+            .public_display_title(account_id)
+            .map(str::to_owned),
         None => None,
     };
 
     Ok(Json(NodeDetails {
         node,
-        created_by_account_title,
+        created_by_account_current_title,
     }))
 }
 

--- a/apps/api/tests/api_nodes.rs
+++ b/apps/api/tests/api_nodes.rs
@@ -236,7 +236,7 @@ async fn node_details_include_only_current_public_creator_titles() -> anyhow::Re
     write_lines(
         &in_dir.join("demo.nodes.jsonl"),
         &[
-            r#"{"id":"active-node","location":{"lon":10.0,"lat":53.5},"title":"A","created_by_account_id":"active-account"}"#,
+            r#"{"id":"active-node","location":{"lon":10.0,"lat":53.5},"title":"A","created_at":"2025-01-01T12:00:00Z","updated_at":"2025-01-02T12:00:00Z","created_by_account_id":"active-account"}"#,
             r#"{"id":"disabled-node","location":{"lon":10.1,"lat":53.6},"title":"B","created_by_account_id":"disabled-account"}"#,
             r#"{"id":"missing-node","location":{"lon":10.2,"lat":53.7},"title":"C","created_by_account_id":"missing-account"}"#,
             r#"{"id":"blank-node","location":{"lon":10.3,"lat":53.8},"title":"D","created_by_account_id":"blank-account"}"#,
@@ -294,6 +294,28 @@ async fn node_details_include_only_current_public_creator_titles() -> anyhow::Re
                 .and_then(serde_json::Value::as_str),
             expected_current_title,
         );
+        if expected_current_title.is_none() {
+            assert!(
+                node.get("created_by_account_current_title").is_none(),
+                "non-public creator titles are omitted instead of serialized as null",
+            );
+        }
+
+        let history = node["history"]
+            .as_array()
+            .context("history must be an array")?;
+        assert_eq!(
+            history.last().and_then(|event| event["kind"].as_str()),
+            Some("created")
+        );
+        if node_id == "active-node" {
+            assert_eq!(history.len(), 2);
+            assert_eq!(history[0]["kind"], "updated");
+            assert_eq!(history[0]["date"], "2025-01-02T12:00:00Z");
+            assert_eq!(history[1]["date"], "2025-01-01T12:00:00Z");
+        } else {
+            assert_eq!(history.len(), 1);
+        }
     }
 
     Ok(())

--- a/apps/api/tests/api_nodes.rs
+++ b/apps/api/tests/api_nodes.rs
@@ -230,7 +230,7 @@ async fn nodes_bbox_and_limit() -> anyhow::Result<()> {
 
 #[tokio::test]
 #[serial]
-async fn node_details_include_only_active_creator_titles() -> anyhow::Result<()> {
+async fn node_details_include_only_current_public_creator_titles() -> anyhow::Result<()> {
     let tmp = make_tmp_dir();
     let in_dir = tmp.path().join("in");
     write_lines(
@@ -238,41 +238,63 @@ async fn node_details_include_only_active_creator_titles() -> anyhow::Result<()>
         &[
             r#"{"id":"active-node","location":{"lon":10.0,"lat":53.5},"title":"A","created_by_account_id":"active-account"}"#,
             r#"{"id":"disabled-node","location":{"lon":10.1,"lat":53.6},"title":"B","created_by_account_id":"disabled-account"}"#,
+            r#"{"id":"missing-node","location":{"lon":10.2,"lat":53.7},"title":"C","created_by_account_id":"missing-account"}"#,
+            r#"{"id":"blank-node","location":{"lon":10.3,"lat":53.8},"title":"D","created_by_account_id":"blank-account"}"#,
+            r#"{"id":"anonymous-node","location":{"lon":10.4,"lat":53.9},"title":"E"}"#,
         ],
     );
     let _env = set_gewebe_in_dir(&in_dir);
 
     let mut active = weber_account("active-account");
-    active.public.title = "Öffentliche Garnrolle".to_string();
+    active.public.title = "  Öffentliche Garnrolle  ".to_string();
     let mut disabled = weber_account("disabled-account");
     disabled.public.title = "Verborgene Garnrolle".to_string();
     disabled.public.disabled = true;
+    let mut blank = weber_account("blank-account");
+    blank.public.title = "   ".to_string();
     let mut accounts = AccountStore::new();
     accounts.insert(active);
     accounts.insert(disabled);
+    accounts.insert(blank);
 
     let mut state = test_state().await?;
     state.accounts = Arc::new(RwLock::new(accounts));
     let app = Router::new().merge(api_router()).with_state(state);
 
-    let response = app
-        .clone()
-        .oneshot(Request::get("/nodes/active-node").body(body::Body::empty())?)
-        .await?;
-    assert_eq!(response.status(), StatusCode::OK);
-    let body = body::to_bytes(response.into_body(), usize::MAX).await?;
-    let node: serde_json::Value = serde_json::from_slice(&body)?;
-    assert_eq!(node["created_by_account_id"], "active-account");
-    assert_eq!(node["created_by_account_title"], "Öffentliche Garnrolle");
+    let cases = [
+        (
+            "active-node",
+            Some("active-account"),
+            Some("Öffentliche Garnrolle"),
+        ),
+        ("disabled-node", Some("disabled-account"), None),
+        ("missing-node", Some("missing-account"), None),
+        ("blank-node", Some("blank-account"), None),
+        ("anonymous-node", None, None),
+    ];
 
-    let response = app
-        .oneshot(Request::get("/nodes/disabled-node").body(body::Body::empty())?)
-        .await?;
-    assert_eq!(response.status(), StatusCode::OK);
-    let body = body::to_bytes(response.into_body(), usize::MAX).await?;
-    let node: serde_json::Value = serde_json::from_slice(&body)?;
-    assert_eq!(node["created_by_account_id"], "disabled-account");
-    assert!(node.get("created_by_account_title").is_none());
+    for (node_id, expected_creator_id, expected_current_title) in cases {
+        let response = app
+            .clone()
+            .oneshot(Request::get(format!("/nodes/{node_id}")).body(body::Body::empty())?)
+            .await?;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body::to_bytes(response.into_body(), usize::MAX).await?;
+        let node: serde_json::Value = serde_json::from_slice(&body)?;
+
+        assert_eq!(node["id"], node_id, "flattened node id remains top-level");
+        assert!(node.get("node").is_none(), "response remains flat");
+        assert_eq!(
+            node.get("created_by_account_id")
+                .and_then(serde_json::Value::as_str),
+            expected_creator_id,
+        );
+        assert_eq!(
+            node.get("created_by_account_current_title")
+                .and_then(serde_json::Value::as_str),
+            expected_current_title,
+        );
+    }
 
     Ok(())
 }

--- a/apps/api/tests/api_nodes.rs
+++ b/apps/api/tests/api_nodes.rs
@@ -230,6 +230,55 @@ async fn nodes_bbox_and_limit() -> anyhow::Result<()> {
 
 #[tokio::test]
 #[serial]
+async fn node_details_include_only_active_creator_titles() -> anyhow::Result<()> {
+    let tmp = make_tmp_dir();
+    let in_dir = tmp.path().join("in");
+    write_lines(
+        &in_dir.join("demo.nodes.jsonl"),
+        &[
+            r#"{"id":"active-node","location":{"lon":10.0,"lat":53.5},"title":"A","created_by_account_id":"active-account"}"#,
+            r#"{"id":"disabled-node","location":{"lon":10.1,"lat":53.6},"title":"B","created_by_account_id":"disabled-account"}"#,
+        ],
+    );
+    let _env = set_gewebe_in_dir(&in_dir);
+
+    let mut active = weber_account("active-account");
+    active.public.title = "Öffentliche Garnrolle".to_string();
+    let mut disabled = weber_account("disabled-account");
+    disabled.public.title = "Verborgene Garnrolle".to_string();
+    disabled.public.disabled = true;
+    let mut accounts = AccountStore::new();
+    accounts.insert(active);
+    accounts.insert(disabled);
+
+    let mut state = test_state().await?;
+    state.accounts = Arc::new(RwLock::new(accounts));
+    let app = Router::new().merge(api_router()).with_state(state);
+
+    let response = app
+        .clone()
+        .oneshot(Request::get("/nodes/active-node").body(body::Body::empty())?)
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body::to_bytes(response.into_body(), usize::MAX).await?;
+    let node: serde_json::Value = serde_json::from_slice(&body)?;
+    assert_eq!(node["created_by_account_id"], "active-account");
+    assert_eq!(node["created_by_account_title"], "Öffentliche Garnrolle");
+
+    let response = app
+        .oneshot(Request::get("/nodes/disabled-node").body(body::Body::empty())?)
+        .await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body::to_bytes(response.into_body(), usize::MAX).await?;
+    let node: serde_json::Value = serde_json::from_slice(&body)?;
+    assert_eq!(node["created_by_account_id"], "disabled-account");
+    assert!(node.get("created_by_account_title").is_none());
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
 async fn nodes_patch_info_lifecycle() -> anyhow::Result<()> {
     let tmp = make_tmp_dir();
     let in_dir = tmp.path().join("in");

--- a/apps/web/src/lib/components/ContextPanel.svelte
+++ b/apps/web/src/lib/components/ContextPanel.svelte
@@ -24,6 +24,7 @@
   type RelatedSelection = {
     type: "node" | "garnrolle";
     id: string;
+    title?: string;
     data?: MapEntityViewModel;
   };
   type DomainChanged = {

--- a/apps/web/src/lib/components/ContextPanel.svelte
+++ b/apps/web/src/lib/components/ContextPanel.svelte
@@ -24,7 +24,6 @@
   type RelatedSelection = {
     type: "node" | "garnrolle";
     id: string;
-    title?: string;
     data?: MapEntityViewModel;
   };
   type DomainChanged = {

--- a/apps/web/src/lib/components/panels/AccountPanel.svelte
+++ b/apps/web/src/lib/components/panels/AccountPanel.svelte
@@ -90,7 +90,9 @@
 </script>
 
 <div class="account-mode">
-  <h3>{accountDetails?.title || $selection?.data?.title || $selection?.id}</h3>
+  <h3 tabindex="-1" data-testid="account-heading">
+    {accountDetails?.title || $selection?.data?.title || "Garnrolle"}
+  </h3>
   {#if summary}<p class="summary">{summary}</p>{/if}
 
   <div class="tabs" role="tablist" aria-label="Garnrollen-Tabs">

--- a/apps/web/src/lib/components/panels/NodePanel.svelte
+++ b/apps/web/src/lib/components/panels/NodePanel.svelte
@@ -26,7 +26,6 @@
     selectRelated: {
       type: "node" | "garnrolle";
       id: string;
-      title?: string;
       data?: MapEntityViewModel;
     };
     domainChanged: DomainChanged;
@@ -83,35 +82,6 @@
     history?: NodeHistoryEvent[];
   }
 
-  function buildTimelineEvents(
-    history: NodeHistoryEvent[],
-    createdAt: string | undefined,
-  ): NodeHistoryEvent[] {
-    const events = history.map((event) => ({
-      ...event,
-      // Legacy history entries had no kind. Matching created_at is the stable
-      // backwards-compatible signal until every producer emits kind="created".
-      kind:
-        event.kind === "created" ||
-        (!event.kind && !!createdAt && event.date === createdAt)
-          ? ("created" as const)
-          : event.kind,
-    }));
-
-    if (createdAt && !events.some((event) => event.kind === "created")) {
-      events.push({
-        date: createdAt,
-        event: "Knoten wurde geknüpft.",
-        kind: "created",
-      });
-    }
-
-    return events.sort(
-      (left, right) =>
-        new Date(right.date).getTime() - new Date(left.date).getTime(),
-    );
-  }
-
   function resetMutationState() {
     activeTab = "uebersicht";
     editing = false;
@@ -136,14 +106,8 @@
   $: nodeCreator =
     nodeDetails?.created_by_account_id ||
     ($selection?.data?.created_by_account_id as string | undefined);
-  $: currentCreatorTitle =
-    nodeDetails?.created_by_account_current_title?.trim() || "";
-  $: createdAt =
-    nodeDetails?.created_at || $selection?.data?.created_at || undefined;
-  $: timelineEvents = buildTimelineEvents(
-    nodeDetails?.history || [],
-    createdAt,
-  );
+  $: currentCreatorTitle = nodeDetails?.created_by_account_current_title || "";
+  $: timelineEvents = nodeDetails?.history || [];
   $: canMutate =
     $authStore.authenticated &&
     ($authStore.role === "weber" ||
@@ -589,7 +553,6 @@
                           dispatch("selectRelated", {
                             type: "garnrolle",
                             id: nodeCreator,
-                            title: currentCreatorTitle,
                           })}>{currentCreatorTitle}</button
                       >
                     </span>{/if}

--- a/apps/web/src/lib/components/panels/NodePanel.svelte
+++ b/apps/web/src/lib/components/panels/NodePanel.svelte
@@ -26,6 +26,7 @@
     selectRelated: {
       type: "node" | "garnrolle";
       id: string;
+      title?: string;
       data?: MapEntityViewModel;
     };
     domainChanged: DomainChanged;
@@ -55,6 +56,12 @@
     | null = null;
   let similarNodesLoadStarted = false;
 
+  type NodeHistoryEvent = {
+    date: string;
+    event: string;
+    kind?: "created" | "updated";
+  };
+
   interface NodeDetails {
     id: string;
     title: string;
@@ -66,14 +73,43 @@
     created_at?: string;
     updated_at?: string;
     created_by_account_id?: string | null;
-    created_by_account_title?: string | null;
+    created_by_account_current_title?: string | null;
     kind?: string;
     participants?: {
       account_title?: string;
       account_id: string;
       edge_kind?: string;
     }[];
-    history?: { date: string; event: string }[];
+    history?: NodeHistoryEvent[];
+  }
+
+  function buildTimelineEvents(
+    history: NodeHistoryEvent[],
+    createdAt: string | undefined,
+  ): NodeHistoryEvent[] {
+    const events = history.map((event) => ({
+      ...event,
+      // Legacy history entries had no kind. Matching created_at is the stable
+      // backwards-compatible signal until every producer emits kind="created".
+      kind:
+        event.kind === "created" ||
+        (!event.kind && !!createdAt && event.date === createdAt)
+          ? ("created" as const)
+          : event.kind,
+    }));
+
+    if (createdAt && !events.some((event) => event.kind === "created")) {
+      events.push({
+        date: createdAt,
+        event: "Knoten wurde geknüpft.",
+        kind: "created",
+      });
+    }
+
+    return events.sort(
+      (left, right) =>
+        new Date(right.date).getTime() - new Date(left.date).getTime(),
+    );
   }
 
   function resetMutationState() {
@@ -100,6 +136,14 @@
   $: nodeCreator =
     nodeDetails?.created_by_account_id ||
     ($selection?.data?.created_by_account_id as string | undefined);
+  $: currentCreatorTitle =
+    nodeDetails?.created_by_account_current_title?.trim() || "";
+  $: createdAt =
+    nodeDetails?.created_at || $selection?.data?.created_at || undefined;
+  $: timelineEvents = buildTimelineEvents(
+    nodeDetails?.history || [],
+    createdAt,
+  );
   $: canMutate =
     $authStore.authenticated &&
     ($authStore.role === "weber" ||
@@ -529,27 +573,27 @@
           tabindex="0"
         >
           {#if isLoadingDetails}<p class="ghost">Lade Verlauf…</p>
-          {:else if nodeDetails?.history?.length}<ul class="timeline">
-              {#each nodeDetails.history as event}<li>
+          {:else if timelineEvents.length}<ul class="timeline">
+              {#each timelineEvents as event}<li>
                   <span class="date">{formatDate(event.date)}</span><span
                     class="event">{event.event}</span
                   >
+                  {#if event.kind === "created" && currentCreatorTitle && nodeCreator}<span
+                      class="creator"
+                    >
+                      <span>Urheber:</span>
+                      <button
+                        type="button"
+                        aria-label={`Garnrolle ${currentCreatorTitle} öffnen`}
+                        on:click={() =>
+                          dispatch("selectRelated", {
+                            type: "garnrolle",
+                            id: nodeCreator,
+                            title: currentCreatorTitle,
+                          })}>{currentCreatorTitle}</button
+                      >
+                    </span>{/if}
                 </li>{/each}
-            </ul>
-          {:else if nodeDetails?.created_at || $selection?.data?.created_at}<ul
-              class="timeline"
-            >
-              <li>
-                <span class="date"
-                  >{formatDate(
-                    nodeDetails?.created_at || $selection?.data?.created_at,
-                  )}</span
-                ><span class="event">Knoten wurde geknüpft.</span>
-                {#if nodeCreator}<span class="creator"
-                    >Urheber: {nodeDetails?.created_by_account_title ||
-                      nodeCreator}</span
-                  >{/if}
-              </li>
             </ul>
           {:else}<p class="ghost">Noch kein Verlauf.</p>{/if}
         </div>
@@ -649,11 +693,37 @@
     border-color: var(--accent);
   }
   .creator {
-    display: block;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.25rem;
     margin-top: 0.25rem;
     color: var(--muted);
     font-size: 0.85rem;
+  }
+  .creator button {
+    min-height: 44px;
+    max-width: 100%;
+    padding: 0.35rem 0.25rem;
+    border: 0;
+    border-radius: 0.25rem;
+    background: transparent;
+    color: var(--text);
+    font: inherit;
+    font-weight: 650;
     overflow-wrap: anywhere;
+    white-space: normal;
+    text-align: left;
+    text-decoration: underline;
+    text-underline-offset: 0.15em;
+    cursor: pointer;
+  }
+  .creator button:hover {
+    color: var(--accent);
+  }
+  .creator button:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
   }
   .edit-form,
   .mutation-actions {
@@ -743,6 +813,11 @@
     white-space: pre-wrap;
   }
   @media (max-width: 420px) {
+    .node-tabs > button {
+      padding-inline: 0.15rem;
+      line-height: 1.15;
+      white-space: normal;
+    }
     .coordinate-grid,
     .form-actions {
       grid-template-columns: 1fr;

--- a/apps/web/src/lib/components/panels/NodePanel.svelte
+++ b/apps/web/src/lib/components/panels/NodePanel.svelte
@@ -66,6 +66,7 @@
     created_at?: string;
     updated_at?: string;
     created_by_account_id?: string | null;
+    created_by_account_title?: string | null;
     kind?: string;
     participants?: {
       account_title?: string;
@@ -398,7 +399,7 @@
       </div>
     </form>
   {:else}
-    <div class="tabs" role="tablist" aria-label="Knoten-Tabs">
+    <div class="tabs node-tabs" role="tablist" aria-label="Knoten-Tabs">
       <button
         class:active={activeTab === "uebersicht"}
         on:click={() => setTab("uebersicht")}
@@ -544,6 +545,10 @@
                     nodeDetails?.created_at || $selection?.data?.created_at,
                   )}</span
                 ><span class="event">Knoten wurde geknüpft.</span>
+                {#if nodeCreator}<span class="creator"
+                    >Urheber: {nodeDetails?.created_by_account_title ||
+                      nodeCreator}</span
+                  >{/if}
               </li>
             </ul>
           {:else}<p class="ghost">Noch kein Verlauf.</p>{/if}
@@ -583,6 +588,14 @@
     margin: 0;
     font-size: 1.5rem;
     line-height: 1.2;
+  }
+  .node-tabs {
+    gap: 0;
+  }
+  .node-tabs > button {
+    flex: 1 1 0;
+    min-width: 0;
+    padding-inline: 0.25rem;
   }
   .summary {
     color: var(--muted);
@@ -634,6 +647,13 @@
   .participants button:hover,
   .participants button:focus-visible {
     border-color: var(--accent);
+  }
+  .creator {
+    display: block;
+    margin-top: 0.25rem;
+    color: var(--muted);
+    font-size: 0.85rem;
+    overflow-wrap: anywhere;
   }
   .edit-form,
   .mutation-actions {

--- a/apps/web/src/lib/components/panels/NodePanel.svelte
+++ b/apps/web/src/lib/components/panels/NodePanel.svelte
@@ -26,6 +26,7 @@
     selectRelated: {
       type: "node" | "garnrolle";
       id: string;
+      title?: string;
       data?: MapEntityViewModel;
     };
     domainChanged: DomainChanged;
@@ -553,6 +554,7 @@
                           dispatch("selectRelated", {
                             type: "garnrolle",
                             id: nodeCreator,
+                            title: currentCreatorTitle,
                           })}>{currentCreatorTitle}</button
                       >
                     </span>{/if}
@@ -665,6 +667,7 @@
     font-size: 0.85rem;
   }
   .creator button {
+    min-width: 44px;
     min-height: 44px;
     max-width: 100%;
     padding: 0.35rem 0.25rem;
@@ -779,6 +782,7 @@
     .node-tabs > button {
       padding-inline: 0.15rem;
       line-height: 1.15;
+      overflow-wrap: anywhere;
       white-space: normal;
     }
     .coordinate-grid,

--- a/apps/web/src/routes/api/node/[id]/+server.ts
+++ b/apps/web/src/routes/api/node/[id]/+server.ts
@@ -32,6 +32,7 @@ export function GET({ params }: RequestEvent) {
       {
         date: node.created_at,
         event: "Knoten wurde im Gewebe verankert.",
+        kind: "created" as const,
       },
       // If updated_at exists and is different, add it
       ...(node.updated_at && node.updated_at !== node.created_at
@@ -39,6 +40,7 @@ export function GET({ params }: RequestEvent) {
             {
               date: node.updated_at,
               event: "Knoten aktualisiert.",
+              kind: "updated" as const,
             },
           ]
         : []),

--- a/apps/web/src/routes/api/node/[id]/+server.ts
+++ b/apps/web/src/routes/api/node/[id]/+server.ts
@@ -32,7 +32,6 @@ export function GET({ params }: RequestEvent) {
       {
         date: node.created_at,
         event: "Knoten wurde im Gewebe verankert.",
-        kind: "created" as const,
       },
       // If updated_at exists and is different, add it
       ...(node.updated_at && node.updated_at !== node.created_at
@@ -40,7 +39,6 @@ export function GET({ params }: RequestEvent) {
             {
               date: node.updated_at,
               event: "Knoten aktualisiert.",
-              kind: "updated" as const,
             },
           ]
         : []),

--- a/apps/web/src/routes/map/+page.svelte
+++ b/apps/web/src/routes/map/+page.svelte
@@ -26,6 +26,7 @@
     selection,
     systemState,
     contextPanelOpen,
+    enterFokus,
     enterKomposition,
     leaveToNavigation,
     lastCreatedNodeId,
@@ -478,6 +479,7 @@
     event: CustomEvent<{
       type: "node" | "garnrolle";
       id: string;
+      title?: string;
       data?: MapEntityViewModel;
     }>,
   ) {
@@ -487,7 +489,18 @@
         (item) =>
           item.id === event.detail.id && item.type === event.detail.type,
       );
-    if (related) focusAndFlyToPoint(related);
+    if (related) {
+      focusAndFlyToPoint(related);
+      return;
+    }
+
+    // Public relations may point to Garnrollen that intentionally have no map
+    // position. Open their panel without inventing coordinates or a fly-to.
+    enterFokus({
+      type: event.detail.type,
+      id: event.detail.id,
+      data: event.detail.title ? { title: event.detail.title } : undefined,
+    });
   }
 
   async function handleDomainChanged(

--- a/apps/web/src/routes/map/+page.svelte
+++ b/apps/web/src/routes/map/+page.svelte
@@ -479,7 +479,6 @@
     event: CustomEvent<{
       type: "node" | "garnrolle";
       id: string;
-      title?: string;
       data?: MapEntityViewModel;
     }>,
   ) {
@@ -499,7 +498,6 @@
     enterFokus({
       type: event.detail.type,
       id: event.detail.id,
-      data: event.detail.title ? { title: event.detail.title } : undefined,
     });
   }
 

--- a/apps/web/src/routes/map/+page.svelte
+++ b/apps/web/src/routes/map/+page.svelte
@@ -475,10 +475,11 @@
     focusAndFlyToPoint(event.detail);
   }
 
-  function handleRelatedSelect(
+  async function handleRelatedSelect(
     event: CustomEvent<{
       type: "node" | "garnrolle";
       id: string;
+      title?: string;
       data?: MapEntityViewModel;
     }>,
   ) {
@@ -498,7 +499,12 @@
     enterFokus({
       type: event.detail.type,
       id: event.detail.id,
+      data: event.detail.title ? { title: event.detail.title } : undefined,
     });
+    await tick();
+    document
+      .querySelector<HTMLElement>('[data-testid="account-heading"]')
+      ?.focus();
   }
 
   async function handleDomainChanged(

--- a/apps/web/tests/map-interaction.spec.ts
+++ b/apps/web/tests/map-interaction.spec.ts
@@ -407,6 +407,19 @@ test.describe("Map Interaction & Context Panel", () => {
   }) => {
     const nodeId = "b52be17c-4ab7-4434-98ce-520f86290cf0";
     const creatorId = "unlocated-public-account";
+    await page.route(`**/api/accounts/${creatorId}`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: creatorId,
+          title: "Unverortete Garnrolle",
+          summary: "Öffentliche Garnrolle ohne Kartenposition",
+          created_at: "2025-01-01T11:00:00Z",
+          updated_at: "2025-01-01T11:00:00Z",
+        }),
+      });
+    });
     await page.route(`**/api/nodes/${nodeId}`, async (route) => {
       await route.fulfill({
         status: 200,

--- a/apps/web/tests/map-interaction.spec.ts
+++ b/apps/web/tests/map-interaction.spec.ts
@@ -249,6 +249,7 @@ test.describe("Map Interaction & Context Panel", () => {
   test("NodePanel keyboard navigation allows arrow keys, Home, and End", async ({
     page,
   }) => {
+    await page.setViewportSize({ width: 1024, height: 768 });
     await page.waitForSelector(".map-marker", { timeout: 10000 });
 
     // Ensure we open a node. In our mock data, nodes usually have the title "Demo Node" or "Hamburg Workshop".
@@ -332,6 +333,29 @@ test.describe("Map Interaction & Context Panel", () => {
     await expect(verlaufTab).toHaveAttribute("tabindex", "-1");
     await expect(panel.locator("#panel-bearbeiten")).toBeVisible();
 
+    const tabList = panel.getByRole("tablist", { name: "Knoten-Tabs" });
+    const tabListBox = await tabList.boundingBox();
+    const bearbeitenBox = await bearbeitenTab.boundingBox();
+    expect(tabListBox).not.toBeNull();
+    expect(bearbeitenBox).not.toBeNull();
+    expect(bearbeitenBox!.x + bearbeitenBox!.width).toBeLessThanOrEqual(
+      tabListBox!.x + tabListBox!.width + 1,
+    );
+    await expect
+      .poll(() =>
+        tabList.evaluate(
+          (element) => element.scrollWidth <= element.clientWidth + 1,
+        ),
+      )
+      .toBe(true);
+    await expect
+      .poll(() =>
+        bearbeitenTab.evaluate(
+          (element) => element.scrollWidth <= element.clientWidth + 1,
+        ),
+      )
+      .toBe(true);
+
     // ArrowRight from the last tab wraps to the first tab.
     await page.keyboard.press("ArrowRight");
     await expect(uebersichtTab).toBeFocused();
@@ -354,6 +378,47 @@ test.describe("Map Interaction & Context Panel", () => {
     await page.keyboard.press("End");
     await expect(bearbeitenTab).toBeFocused();
     await expect(bearbeitenTab).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("NodePanel shows the public creator in the creation history", async ({
+    page,
+  }) => {
+    const nodeId = "b52be17c-4ab7-4434-98ce-520f86290cf0";
+    const creatorId = "7d97a42e-3704-4a33-a61f-0e0a6b4d65d8";
+    await page.route(`**/api/nodes/${nodeId}`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: nodeId,
+          kind: "Knoten",
+          title: "fairschenkbox",
+          summary: "Öffentliche Fair-Schenk-Box",
+          location: { lat: 53.558894813662505, lon: 10.060228407382967 },
+          created_at: "2025-01-01T12:00:00Z",
+          updated_at: "2025-01-01T12:00:00Z",
+          created_by_account_id: creatorId,
+          created_by_account_title: "weltgewebeknoten1",
+        }),
+      });
+    });
+
+    await page.waitForSelector(`.map-marker[data-id="${nodeId}"]`, {
+      timeout: 10000,
+    });
+    await page
+      .locator(`.map-marker[data-id="${nodeId}"]`)
+      .evaluate((marker) => {
+        marker.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+
+    const panel = page.locator(`[data-testid="context-panel"]`);
+    await expect(panel).toBeVisible();
+    await panel.getByRole("tab", { name: "Verlauf" }).click();
+
+    await expect(
+      panel.getByText("Urheber: weltgewebeknoten1", { exact: true }),
+    ).toBeVisible();
   });
 
   test("AccountPanel keyboard navigation allows arrow keys, Home, and End", async ({

--- a/apps/web/tests/map-interaction.spec.ts
+++ b/apps/web/tests/map-interaction.spec.ts
@@ -356,6 +356,28 @@ test.describe("Map Interaction & Context Panel", () => {
       )
       .toBe(true);
 
+    // The same labels remain fully readable when the panel switches to a
+    // narrow mobile layout; they wrap instead of being silently ellipsized.
+    await page.setViewportSize({ width: 375, height: 667 });
+    await expect
+      .poll(() =>
+        tabList.evaluate(
+          (element) => element.scrollWidth <= element.clientWidth + 1,
+        ),
+      )
+      .toBe(true);
+    await expect
+      .poll(() =>
+        tabList
+          .getByRole("tab")
+          .evaluateAll((elements) =>
+            elements.every(
+              (element) => element.scrollWidth <= element.clientWidth + 1,
+            ),
+          ),
+      )
+      .toBe(true);
+
     // ArrowRight from the last tab wraps to the first tab.
     await page.keyboard.press("ArrowRight");
     await expect(uebersichtTab).toBeFocused();
@@ -380,11 +402,11 @@ test.describe("Map Interaction & Context Panel", () => {
     await expect(bearbeitenTab).toHaveAttribute("aria-selected", "true");
   });
 
-  test("NodePanel shows the public creator in the creation history", async ({
+  test("NodePanel keeps the public creator on a typed creation event", async ({
     page,
   }) => {
     const nodeId = "b52be17c-4ab7-4434-98ce-520f86290cf0";
-    const creatorId = "7d97a42e-3704-4a33-a61f-0e0a6b4d65d8";
+    const creatorId = "unlocated-public-account";
     await page.route(`**/api/nodes/${nodeId}`, async (route) => {
       await route.fulfill({
         status: 200,
@@ -396,9 +418,21 @@ test.describe("Map Interaction & Context Panel", () => {
           summary: "Öffentliche Fair-Schenk-Box",
           location: { lat: 53.558894813662505, lon: 10.060228407382967 },
           created_at: "2025-01-01T12:00:00Z",
-          updated_at: "2025-01-01T12:00:00Z",
+          updated_at: "2025-01-02T12:00:00Z",
           created_by_account_id: creatorId,
-          created_by_account_title: "weltgewebeknoten1",
+          created_by_account_current_title: "Unverortete Garnrolle",
+          history: [
+            {
+              date: "2025-01-02T12:00:00Z",
+              event: "Knoten aktualisiert.",
+              kind: "updated",
+            },
+            {
+              date: "2025-01-01T12:00:00Z",
+              event: "Knoten wurde im Gewebe verankert.",
+              kind: "created",
+            },
+          ],
         }),
       });
     });
@@ -417,8 +451,69 @@ test.describe("Map Interaction & Context Panel", () => {
     await panel.getByRole("tab", { name: "Verlauf" }).click();
 
     await expect(
-      panel.getByText("Urheber: weltgewebeknoten1", { exact: true }),
+      panel.getByText("Knoten aktualisiert.", { exact: true }),
     ).toBeVisible();
+    await expect(
+      panel.getByText("Knoten wurde im Gewebe verankert.", { exact: true }),
+    ).toHaveCount(1);
+    const creatorButton = panel.getByRole("button", {
+      name: "Garnrolle Unverortete Garnrolle öffnen",
+    });
+    await expect(creatorButton).toHaveText("Unverortete Garnrolle");
+
+    await creatorButton.click();
+    await expect(panel.getByRole("tab", { name: "Profil" })).toBeVisible();
+    await expect(
+      panel.getByRole("heading", { name: "Unverortete Garnrolle" }),
+    ).toBeVisible();
+  });
+
+  test("NodePanel never exposes a creator id when no public title exists", async ({
+    page,
+  }) => {
+    const nodeId = "b52be17c-4ab7-4434-98ce-520f86290cf0";
+    const creatorId = "7d97a42e-3704-4a33-a61f-0e0a6b4d65d8";
+    await page.route(`**/api/nodes/${nodeId}`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: nodeId,
+          kind: "Knoten",
+          title: "fairschenkbox",
+          location: { lat: 53.558894813662505, lon: 10.060228407382967 },
+          created_at: "2025-01-01T12:00:00Z",
+          updated_at: "2025-01-01T12:00:00Z",
+          created_by_account_id: creatorId,
+          history: [
+            {
+              date: "2025-01-01T12:00:00Z",
+              event: "Knoten wurde im Gewebe verankert.",
+              kind: "created",
+            },
+          ],
+        }),
+      });
+    });
+
+    await page.waitForSelector(`.map-marker[data-id="${nodeId}"]`, {
+      timeout: 10000,
+    });
+    await page
+      .locator(`.map-marker[data-id="${nodeId}"]`)
+      .evaluate((marker) => {
+        marker.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+
+    const panel = page.locator(`[data-testid="context-panel"]`);
+    await expect(panel).toBeVisible();
+    await panel.getByRole("tab", { name: "Verlauf" }).click();
+
+    await expect(
+      panel.getByText("Knoten wurde im Gewebe verankert.", { exact: true }),
+    ).toBeVisible();
+    await expect(panel.getByText("Urheber:", { exact: true })).toHaveCount(0);
+    await expect(panel.getByText(creatorId, { exact: false })).toHaveCount(0);
   });
 
   test("AccountPanel keyboard navigation allows arrow keys, Home, and End", async ({

--- a/apps/web/tests/map-interaction.spec.ts
+++ b/apps/web/tests/map-interaction.spec.ts
@@ -358,7 +358,7 @@ test.describe("Map Interaction & Context Panel", () => {
 
     // The same labels remain fully readable when the panel switches to a
     // narrow mobile layout; they wrap instead of being silently ellipsized.
-    await page.setViewportSize({ width: 375, height: 667 });
+    await page.setViewportSize({ width: 320, height: 667 });
     await expect
       .poll(() =>
         tabList.evaluate(
@@ -407,7 +407,12 @@ test.describe("Map Interaction & Context Panel", () => {
   }) => {
     const nodeId = "b52be17c-4ab7-4434-98ce-520f86290cf0";
     const creatorId = "unlocated-public-account";
+    let releaseAccountResponse!: () => void;
+    const accountResponseBarrier = new Promise<void>((resolve) => {
+      releaseAccountResponse = resolve;
+    });
     await page.route(`**/api/accounts/${creatorId}`, async (route) => {
+      await accountResponseBarrier;
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -475,10 +480,19 @@ test.describe("Map Interaction & Context Panel", () => {
     await expect(creatorButton).toHaveText("Unverortete Garnrolle");
 
     await creatorButton.click();
+    const accountHeading = panel.getByTestId("account-heading");
+    await expect(accountHeading).toHaveText("Unverortete Garnrolle");
+    await expect(accountHeading).toBeFocused();
+    await expect(panel.getByText(creatorId, { exact: false })).toHaveCount(0);
     await expect(panel.getByRole("tab", { name: "Profil" })).toBeVisible();
+
+    releaseAccountResponse();
     await expect(
-      panel.getByRole("heading", { name: "Unverortete Garnrolle" }),
+      panel.getByText("Öffentliche Garnrolle ohne Kartenposition", {
+        exact: true,
+      }),
     ).toBeVisible();
+    await expect(accountHeading).toHaveText("Unverortete Garnrolle");
   });
 
   test("NodePanel never exposes a creator id when no public title exists", async ({

--- a/docs/specs/garnrolle-knoten-faden.md
+++ b/docs/specs/garnrolle-knoten-faden.md
@@ -102,6 +102,21 @@ created_by_account_id = Account-ID der authentifizierten Sitzung
 Der Client darf diese Bindung weder vorgeben noch ändern. Beim Ersetzen oder
 Bearbeiten eines Knotens bleibt sie erhalten.
 
+Der Detailendpunkt `GET /api/nodes/{id}` ergänzt diese unveränderliche Bindung
+um zwei abgeleitete, nicht persistierte Projektionen:
+
+- `created_by_account_current_title` ist ausschließlich der **heutige öffentliche**
+  Garnrollenname. Das Feld fehlt bei deaktivierten, fehlenden oder leeren
+  Accounts und ist kein historischer Namenssnapshot.
+- `history` enthält die typisierten Ereignisse `created` und – sofern
+  `updated_at` von `created_at` abweicht – `updated`, jeweils aus den
+  autoritativen Knotendaten abgeleitet und neuestes Ereignis zuerst.
+
+Die Benutzeroberfläche darf eine interne Account-ID niemals als sichtbaren
+Namensersatz ausgeben. Ein öffentlicher aktueller Name darf zur heutigen
+Garnrolle führen; eine unveränderliche historische Namensanzeige benötigt ein
+eigenes persistiertes Ereignis- und Snapshotmodell.
+
 Für bestehende Knoten, deren Urheber historisch nicht belegt ist, wird keine
 Urheberschaft erfunden. Sie besitzen keine `created_by_account_id`. Daraus folgt:
 


### PR DESCRIPTION
<!-- weltgewebe-risk: R3 -->

## Problem

Im Knotenverlauf fehlte die Urheberschaft. Auf Tabletbreite wurde der rechte Reiter „Bearbeiten“ abgeschnitten. Die erste Fassung konnte bei deaktivierten oder fehlenden Accounts die interne Creator-ID anzeigen und verlor die Urheberschaft, sobald echte Historieneinträge vorhanden waren.

## Lösung

- liefert im Knoten-Detailendpunkt ausschließlich den getrimmten **aktuellen öffentlichen** Garnrollennamen;
- blendet Namen für deaktivierte, fehlende und leere Accounts vollständig aus;
- zeigt niemals die interne Creator-ID als UI-Fallback;
- kennzeichnet Verlaufsereignisse maschinenlesbar als `created` oder `updated`;
- zeigt die Urheberschaft auch bei weiteren Historieneinträgen und verhindert Dopplungen durch den typisierten API-Produzenten;
- macht öffentliche Urheber anklickbar, auch wenn ihre Garnrolle absichtlich keine Kartenposition hat;
- setzt den Fokus nach dem Wechsel auf die Garnrollenüberschrift, ohne zwischenzeitlich eine UUID anzuzeigen;
- verteilt die Knoten-Reiter auf Tabletbreite gleichmäßig und lässt sie auf schmalen Geräten lesbar umbrechen statt sie mit Ellipse abzuschneiden;
- hält die Kartenroute innerhalb des festen Ladebudgets.

## Datenschutz- und Bedeutungsvertrag

`created_by_account_id` bleibt die unveränderliche technische Bindung. `created_by_account_current_title` ist ausdrücklich der heutige öffentliche Anzeigename, kein historischer Namenssnapshot. Fehlt dieser freigegebene Name, erscheint im Verlauf keine Urheberidentität.

## Abnahme auf Commit 372a56d219ee1ddf8449573e389e6c9c7803ab18

- `cargo test -p weltgewebe-api`: grün;
- `cargo clippy -p weltgewebe-api --all-targets -- -D warnings`: grün;
- `pnpm exec svelte-check --tsconfig ./tsconfig.json`: 0 Fehler, 0 Warnungen;
- ESLint der geänderten Webdateien: grün;
- `pnpm exec vitest run`: 25 Dateien, 208 Tests, 0 Fehler;
- `pnpm run build`: grün; `/map` 79.584 / 80.000 Byte gzip;
- Playwright NodePanel auf dem commitgebundenen Preview-Build: 3 Tests, 0 Fehler;
- GitHub Build & Lint, Rust/API, CodeQL, Web-E2E und Cloudflare-Prüfungen: grün;
- R3-Reviewachsen `privacy` und `accessibility`: PASS, jeweils head- und diffgebunden;
- kanonischer Gate-Diff SHA-256: `9c5011678b3eb21048862990fed4fa9498d680fd692fd7bb0870f866ae225e09`;
- herunterladbarer GitHub-PR-Diff SHA-256: `b1a527c92f6f7d83e719c5fe112ee3dcad5a19eb7d30f4491c4d4152e2b739c0`.

## Bewusste Grenze

Ein historischer Name zum Zeitpunkt des Knüpfens wird noch nicht gespeichert. Das erfordert ein persistiertes Ereignis- beziehungsweise Snapshotmodell und wird separat im Bureau geführt.

<!-- final-review-evidence-recheck: 2026-07-24T11:00:13Z -->
