### PR TITLE
fix(accounts): remove legacy RoN identity bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,9 @@ Weitere wichtige Prüfpfade:
 | Gespräch | Conversation/Message | geplant und vertraglich beschrieben, aber noch kein vollständiger produktiver Persistenzpfad |
 
 Neue und öffentlich ausgegebene Accounts sind ausschließlich Garnrollen. Die
-Kartenwirkung wird über `map_state=not_on_map|exact|radius` beschrieben. Alte
-`ron`-/`mode`-Datensätze werden lesend privacy-sicher normalisiert; die nullable
-Datenbankspalte `mode` bleibt vorerst nur als Rollbackbrücke. Ihre Entfernung
-braucht einen eigenen Post-Cutover-Beobachtungs-, Daten- und Rückfallbeleg.
+Kartenwirkung wird über `map_state=not_on_map|exact|radius` beschrieben. Die
+frühere RoN-Identität und die Datenbankspalte `mode` sind nach belegtem
+Produktionscutover entfernt.
 
 ## Daten- und Datenschutzgrenze
 

--- a/apps/api/migrations/20260724000001_remove_ron_legacy.down.sql
+++ b/apps/api/migrations/20260724000001_remove_ron_legacy.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE domain_accounts ADD COLUMN mode TEXT;

--- a/apps/api/migrations/20260724000001_remove_ron_legacy.up.sql
+++ b/apps/api/migrations/20260724000001_remove_ron_legacy.up.sql
@@ -1,0 +1,17 @@
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM domain_accounts
+        WHERE kind IS DISTINCT FROM 'garnrolle'
+           OR mode IS NOT NULL
+           OR private_payload ? 'ron_flag'
+           OR private_payload ? 'visibility'
+           OR private_payload ? 'suppress_public_pos'
+    ) THEN
+        RAISE EXCEPTION 'cannot remove legacy account identity fields while legacy rows remain';
+    END IF;
+END
+$$;
+
+ALTER TABLE domain_accounts DROP COLUMN mode;

--- a/apps/api/migrations/20260724000001_remove_ron_legacy.up.sql
+++ b/apps/api/migrations/20260724000001_remove_ron_legacy.up.sql
@@ -4,7 +4,6 @@ BEGIN
         SELECT 1
         FROM domain_accounts
         WHERE kind IS DISTINCT FROM 'garnrolle'
-           OR mode IS NOT NULL
            OR private_payload ? 'ron_flag'
            OR private_payload ? 'visibility'
            OR private_payload ? 'suppress_public_pos'

--- a/apps/api/src/domain_db.rs
+++ b/apps/api/src/domain_db.rs
@@ -75,7 +75,6 @@ type AccountRow = (
     String,
     String,
     String,
-    Option<String>,
     String,
     i64,
     bool,
@@ -347,16 +346,14 @@ pub async fn audit_auth_user_id_backfill_readiness(
     })
 }
 
-/// Project one raw `domain_accounts` row into an `AccountInternal`, applying
-/// the same legacy-field normalization (`ron`/`mode`/`visibility`) as the bulk
-/// loader. Returns `None` (with a warning logged) when the row fails
+/// Project one canonical `domain_accounts` row into an `AccountInternal`.
+/// Returns `None` (with a warning logged) when the row fails
 /// projection — the caller decides what "no account" means in its context.
 fn account_row_to_internal(row: AccountRow) -> Option<AccountInternal> {
     let (
         id,
         kind,
         title,
-        legacy_mode,
         db_map_state,
         radius_m,
         disabled,
@@ -369,37 +366,35 @@ fn account_row_to_internal(row: AccountRow) -> Option<AccountInternal> {
         private_text,
     ) = row;
 
+    if kind != "garnrolle" {
+        tracing::warn!(account_id = %id, account_type = %kind, "rejecting non-canonical database account");
+        return None;
+    }
+    if !matches!(db_map_state.as_str(), "not_on_map" | "exact" | "radius") {
+        tracing::warn!(account_id = %id, map_state = %db_map_state, "rejecting database account with invalid map_state");
+        return None;
+    }
+
     let public_payload = parse_payload(&public_text);
     let private_payload = parse_payload(&private_text);
-    let ron_flag = private_payload
-        .get("ron_flag")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-    let visibility = private_payload.get("visibility").and_then(|v| v.as_str());
-    let suppress_public_pos = private_payload
-        .get("suppress_public_pos")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-    let legacy_not_on_map = kind == "ron"
-        || ron_flag
-        || legacy_mode.as_deref() == Some("ron")
-        || visibility == Some("private")
-        || suppress_public_pos;
-    let effective_map_state = if legacy_not_on_map
-        || db_map_state == "not_on_map"
-        || location_lat.is_none()
-        || location_lon.is_none()
+    for forbidden in ["visibility", "suppress_public_pos", "ron_flag"] {
+        if private_payload.get(forbidden).is_some() {
+            tracing::warn!(account_id = %id, field = forbidden, "rejecting removed private account field");
+            return None;
+        }
+    }
+    let effective_map_state = if db_map_state != "not_on_map"
+        && (location_lat.is_none() || location_lon.is_none())
     {
+        tracing::warn!(account_id = %id, "suppressing mapped database account without an internal location");
         "not_on_map"
-    } else if db_map_state == "radius" || visibility == Some("approximate") || radius_m > 0 {
-        "radius"
     } else {
-        "exact"
+        db_map_state.as_str()
     };
-    let effective_radius_m = match effective_map_state {
-        "radius" if radius_m == 0 => 250,
-        "radius" => radius_m,
-        _ => 0,
+    let effective_radius_m = if effective_map_state == "radius" {
+        radius_m
+    } else {
+        0
     };
 
     let mut record = Map::new();
@@ -450,7 +445,7 @@ fn account_row_to_internal(row: AccountRow) -> Option<AccountInternal> {
 
 pub async fn load_accounts_from_postgres(pool: &PgPool) -> Result<AccountStore> {
     let rows: Vec<AccountRow> = sqlx::query_as(
-        "SELECT id, kind, title, mode, map_state, radius_m, disabled, \
+        "SELECT id, kind, title, map_state, radius_m, disabled, \
          location_lat, location_lon, role, email, \
          webauthn_user_id::text, public_payload::text, private_payload::text \
          FROM domain_accounts ORDER BY id ASC",
@@ -531,7 +526,7 @@ pub async fn find_account_by_normalized_email(
     email_norm: &str,
 ) -> Result<Option<AccountInternal>> {
     let row: Option<AccountRow> = sqlx::query_as(
-        "SELECT id, kind, title, mode, map_state, radius_m, disabled, \
+        "SELECT id, kind, title, map_state, radius_m, disabled, \
          location_lat, location_lon, role, email, \
          webauthn_user_id::text, public_payload::text, private_payload::text \
          FROM domain_accounts WHERE lower(btrim(email)) = $1",
@@ -1171,7 +1166,6 @@ pub struct NewDomainAccountRow {
     pub id: String,
     pub kind: String,
     pub title: String,
-    pub legacy_mode: Option<String>,
     pub map_state: String,
     pub radius_m: i64,
     pub disabled: bool,
@@ -1192,16 +1186,14 @@ impl NewDomainAccountRow {
     ///
     /// This mirrors the Phase C backfill mapping exactly so the Phase D loader
     /// reconstructs the same public projection. In particular:
-    /// - `kind` ← `type` (default `garnrolle`)
-    /// - `kind` is canonicalised to `garnrolle`
-    /// - `map_state` is `not_on_map`, `exact`, or `radius`; legacy `ron` fields
-    ///   only force the privacy-safe `not_on_map` state
-    /// - the deprecated database `mode` column receives NULL for new writes
+    /// - `type` must be the canonical `garnrolle`
+    /// - `map_state` must be `not_on_map`, `exact`, or `radius`
+    /// - removed identity and visibility fields are rejected rather than repaired
     /// - `radius_m` is accepted only from 50 through 5,000 metres for a
-    ///   radius projection; historical approximate records without a valid
-    ///   private binding fail closed as `not_on_map`
-    /// - `private_payload` preserves legacy visibility fields where needed and
-    ///   the typed private `radius_projection` binding. The binding is never
+    ///   radius projection; records without a valid private binding fail closed
+    ///   as `not_on_map`
+    /// - `private_payload` carries the typed private `radius_projection` binding.
+    ///   The binding is never
     ///   copied into `AccountPublic` or an outbox payload.
     /// - `created_at` / `updated_at` are taken from the record if present, else
     ///   NULL. The current create path never sets them, so account-create rows
@@ -1216,20 +1208,22 @@ impl NewDomainAccountRow {
             .map(|s| s.to_string())
             .context("account record is missing a non-empty id")?;
 
-        let legacy_kind = v
-            .get("type")
-            .and_then(|v| v.as_str())
-            .unwrap_or("garnrolle");
-        let kind = "garnrolle".to_string();
+        let kind = match v.get("type").and_then(|value| value.as_str()) {
+            Some("garnrolle") => "garnrolle".to_string(),
+            Some(other) => anyhow::bail!("invalid account type: {other}"),
+            None => anyhow::bail!("account record is missing type=garnrolle"),
+        };
+        for forbidden in ["mode", "ron_flag", "visibility", "suppress_public_pos"] {
+            if v.get(forbidden).is_some() {
+                anyhow::bail!("removed account field is not accepted: {forbidden}");
+            }
+        }
         let title = v
             .get("title")
             .and_then(|v| v.as_str())
             .unwrap_or("Untitled")
             .to_string();
 
-        let ron_flag = v.get("ron_flag").and_then(|v| v.as_bool()).unwrap_or(false);
-        let visibility = v.get("visibility").and_then(|v| v.as_str());
-        let explicit_mode = v.get("mode").and_then(|v| v.as_str());
         let disabled = v.get("disabled").and_then(|v| v.as_bool()).unwrap_or(false);
 
         let location_lat = v
@@ -1269,29 +1263,18 @@ impl NewDomainAccountRow {
         let created_at = v.get("created_at").and_then(parse_ts);
         let updated_at = v.get("updated_at").and_then(parse_ts);
 
-        let legacy_not_on_map = legacy_kind == "ron"
-            || ron_flag
-            || explicit_mode == Some("ron")
-            || visibility == Some("private")
-            || v.get("suppress_public_pos")
-                .and_then(|value| value.as_bool())
-                .unwrap_or(false);
         let radius_raw = v.get("radius_m").and_then(|v| v.as_u64()).unwrap_or(0);
         let mut radius_m = i64::try_from(radius_raw).unwrap_or(0);
         let invalid_radius = radius_raw > 0
             && u32::try_from(radius_raw)
                 .ok()
                 .is_none_or(|radius_m| !(MIN_RADIUS_M..=MAX_RADIUS_M).contains(&radius_m));
-        let explicit_map_state = v.get("map_state").and_then(|v| v.as_str());
-        if let Some(state) = explicit_map_state {
-            if !matches!(state, "not_on_map" | "exact" | "radius") {
-                anyhow::bail!("invalid account map_state: {state}");
-            }
-        }
-        let radius_requested = invalid_radius
-            || explicit_map_state == Some("radius")
-            || visibility == Some("approximate")
-            || radius_m > 0;
+        let explicit_map_state = match v.get("map_state").and_then(|value| value.as_str()) {
+            Some(state @ ("not_on_map" | "exact" | "radius")) => state,
+            Some(state) => anyhow::bail!("invalid account map_state: {state}"),
+            None => anyhow::bail!("account record is missing map_state"),
+        };
+        let radius_requested = invalid_radius || explicit_map_state == "radius" || radius_m > 0;
         if radius_requested && radius_m == 0 && !invalid_radius {
             radius_m = 250;
         }
@@ -1315,10 +1298,7 @@ impl NewDomainAccountRow {
         } else {
             None
         };
-        let map_state = if legacy_not_on_map
-            || explicit_map_state == Some("not_on_map")
-            || private_location.is_none()
-        {
+        let map_state = if explicit_map_state == "not_on_map" || private_location.is_none() {
             radius_m = 0;
             "not_on_map".to_string()
         } else if radius_requested {
@@ -1344,12 +1324,6 @@ impl NewDomainAccountRow {
         {
             priv_map.insert("address".to_string(), Value::String(address.to_string()));
         }
-        if let Some(vis) = visibility {
-            priv_map.insert("visibility".to_string(), Value::String(vis.to_string()));
-            if vis == "private" {
-                priv_map.insert("suppress_public_pos".to_string(), Value::Bool(true));
-            }
-        }
         if let Some(projection) = v.get(RADIUS_PROJECTION_KEY) {
             priv_map.insert(RADIUS_PROJECTION_KEY.to_string(), projection.clone());
         }
@@ -1364,7 +1338,6 @@ impl NewDomainAccountRow {
             id,
             kind,
             title,
-            legacy_mode: None,
             map_state,
             radius_m,
             disabled,
@@ -1429,22 +1402,21 @@ pub async fn insert_account_from_jsonl_record(
 
     let result = sqlx::query(
         "INSERT INTO domain_accounts \
-            (id, kind, title, mode, map_state, radius_m, disabled, \
+            (id, kind, title, map_state, radius_m, disabled, \
              location_lat, location_lon, \
              role, email, webauthn_user_id, \
              created_at, updated_at, \
              public_payload, private_payload) \
          VALUES \
-            ($1, $2, $3, $4, $5, $6, $7, \
-             $8, $9, \
-             $10, $11, $12::uuid, \
-             $13, $14, \
-             $15::jsonb, $16::jsonb)",
+            ($1, $2, $3, $4, $5, $6, \
+             $7, $8, \
+             $9, $10, $11::uuid, \
+             $12, $13, \
+             $14::jsonb, $15::jsonb)",
     )
     .bind(&row.id)
     .bind(&row.kind)
     .bind(&row.title)
-    .bind(row.legacy_mode.as_deref())
     .bind(&row.map_state)
     .bind(row.radius_m)
     .bind(row.disabled)
@@ -1625,10 +1597,10 @@ pub async fn update_account_profile_in_postgres(
            location_lat = COALESCE($5, location_lat), \
            location_lon = COALESCE($6, location_lon), \
            public_payload = (public_payload - 'summary' - 'tags') || $7::jsonb, \
-           private_payload = (private_payload - 'address' - 'visibility' - 'suppress_public_pos' - 'ron_flag' - 'radius_projection') || $8::jsonb, \
+           private_payload = (private_payload - 'address' - 'radius_projection') || $8::jsonb, \
            updated_at = now() \
          WHERE id = $1 \
-         RETURNING id, kind, title, mode, map_state, radius_m, disabled, \
+         RETURNING id, kind, title, map_state, radius_m, disabled, \
            location_lat, location_lon, role, email, webauthn_user_id::text, \
            public_payload::text, private_payload::text",
     )
@@ -2022,9 +1994,8 @@ mod write_path_tests {
     use super::*;
     use serde_json::json;
 
-    // The tests below exercise the row-mapper/backfill-parity surface for
-    // JSONL-shaped records. Not every legacy/privacy field covered here is
-    // currently route-reachable through `POST /accounts`.
+    // The tests below exercise the canonical JSONL-to-PostgreSQL mapper.
+    // Removed identity fields are rejected rather than normalized.
 
     /// The create route builds exactly this record shape before persistence.
     fn create_record() -> Value {
@@ -2054,7 +2025,6 @@ mod write_path_tests {
         assert_eq!(row.id, "writepath-unit-1");
         assert_eq!(row.kind, "garnrolle");
         assert_eq!(row.title, "Unit");
-        assert_eq!(row.legacy_mode, None);
         assert_eq!(row.map_state, "radius");
         assert_eq!(row.radius_m, 250);
         assert!(!row.disabled);
@@ -2082,24 +2052,17 @@ mod write_path_tests {
     }
 
     #[test]
-    fn private_visibility_sets_suppress_public_pos() {
+    fn removed_visibility_field_is_rejected() {
         let record = json!({
             "id": "writepath-unit-private",
             "type": "garnrolle",
             "title": "Private",
-            "location": { "lat": 53.5, "lon": 10.0 },
+            "map_state": "not_on_map",
             "visibility": "private"
         });
-        let row = NewDomainAccountRow::from_jsonl_record(&record).expect("map");
-        let private: Value = serde_json::from_str(&row.private_payload).expect("private json");
-        assert_eq!(
-            private.get("visibility").and_then(|v| v.as_str()),
-            Some("private")
-        );
-        assert_eq!(
-            private.get("suppress_public_pos").and_then(|v| v.as_bool()),
-            Some(true)
-        );
+        let error = NewDomainAccountRow::from_jsonl_record(&record)
+            .expect_err("removed visibility field must be rejected");
+        assert!(error.to_string().contains("removed account field"));
     }
 
     #[test]
@@ -2131,24 +2094,18 @@ mod write_path_tests {
         assert_eq!(row.radius_m, 0);
         assert_eq!(row.location_lat, Some(53.5));
         assert_eq!(row.location_lon, Some(10.0));
-        assert_eq!(row.legacy_mode, None);
     }
 
     #[test]
-    fn legacy_approximate_without_binding_fails_closed() {
+    fn missing_map_state_is_rejected() {
         let record = json!({
-            "id": "writepath-unit-approx",
+            "id": "writepath-unit-missing-state",
             "type": "garnrolle",
-            "title": "Approx",
-            "location": { "lat": 53.5, "lon": 10.0 },
-            "visibility": "approximate",
-            "radius_m": 0
+            "title": "Missing state"
         });
-        let row = NewDomainAccountRow::from_jsonl_record(&record).expect("map");
-        assert_eq!(row.map_state, "not_on_map");
-        assert_eq!(row.radius_m, 0);
-        assert_eq!(row.location_lat, Some(53.5));
-        assert_eq!(row.location_lon, Some(10.0));
+        let error = NewDomainAccountRow::from_jsonl_record(&record)
+            .expect_err("canonical records require map_state");
+        assert!(error.to_string().contains("missing map_state"));
     }
 
     #[test]
@@ -2157,6 +2114,7 @@ mod write_path_tests {
             "id": "writepath-unit-oversized-radius",
             "type": "garnrolle",
             "title": "Oversized radius",
+            "map_state": "radius",
             "location": { "lat": 53.5, "lon": 10.0 },
             "radius_m": u64::MAX
         });
@@ -2201,24 +2159,36 @@ mod write_path_tests {
     }
 
     #[test]
-    fn ron_flag_normalizes_to_not_on_map() {
+    fn removed_ron_flag_is_rejected() {
         let record = json!({
-            "id": "writepath-unit-ron",
+            "id": "writepath-unit-removed-field",
             "type": "garnrolle",
-            "title": "Ron",
+            "title": "Removed field",
+            "map_state": "not_on_map",
             "ron_flag": true
         });
-        let row = NewDomainAccountRow::from_jsonl_record(&record).expect("map");
-        assert_eq!(row.legacy_mode, None);
-        assert_eq!(row.map_state, "not_on_map");
-        let private: Value = serde_json::from_str(&row.private_payload).expect("private json");
-        assert!(private.get("ron_flag").is_none());
+        let error = NewDomainAccountRow::from_jsonl_record(&record)
+            .expect_err("removed ron_flag must be rejected");
+        assert!(error.to_string().contains("removed account field"));
     }
 
     #[test]
     fn email_is_trimmed_and_after_trim_empty_becomes_none() {
-        let with_email = |email: Value| json!({ "id": "wp-email", "type": "garnrolle", "title": "E", "email": email });
-        let no_email = json!({ "id": "wp-email", "type": "garnrolle", "title": "E" });
+        let with_email = |email: Value| {
+            json!({
+                "id": "wp-email",
+                "type": "garnrolle",
+                "title": "E",
+                "map_state": "not_on_map",
+                "email": email
+            })
+        };
+        let no_email = json!({
+            "id": "wp-email",
+            "type": "garnrolle",
+            "title": "E",
+            "map_state": "not_on_map"
+        });
 
         let map = |v: &Value| {
             NewDomainAccountRow::from_jsonl_record(v)

--- a/apps/api/src/lib.rs
+++ b/apps/api/src/lib.rs
@@ -227,7 +227,9 @@ pub async fn run() -> anyhow::Result<()> {
                     "failed to recover JSONL node-delete journal before loading domain data",
                 )?;
             (
-                routes::accounts::load_all_accounts().await,
+                routes::accounts::load_all_accounts()
+                    .await
+                    .context("failed to load canonical JSONL accounts")?,
                 routes::nodes::load_nodes().await,
                 routes::edges::load_edges().await,
                 0,

--- a/apps/api/src/routes/accounts.rs
+++ b/apps/api/src/routes/accounts.rs
@@ -483,63 +483,60 @@ pub(crate) fn map_json_to_public_account(v: &Value) -> Option<AccountPublic> {
     })
 }
 
-pub async fn load_all_accounts() -> AccountStore {
+pub async fn load_all_accounts() -> std::io::Result<AccountStore> {
     let mut store = AccountStore::new();
     let path = accounts_path();
 
     let file = match File::open(&path).await {
-        Ok(f) => f,
-        Err(e) => {
-            tracing::warn!(
-                ?path,
-                ?e,
-                "Failed to open accounts file, returning empty map"
-            );
-            return store;
-        }
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(store),
+        Err(error) => return Err(error),
     };
 
     let mut lines = BufReader::new(file).lines();
-    while let Ok(Some(line)) = lines.next_line().await {
-        let v: Value = match serde_json::from_str(&line) {
-            Ok(v) => v,
-            Err(_) => continue,
-        };
+    let mut line_number = 0usize;
+    while let Some(line) = lines.next_line().await? {
+        line_number += 1;
+        let value: Value = serde_json::from_str(&line).map_err(|error| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("invalid JSONL account record at {path:?} line {line_number}: {error}"),
+            )
+        })?;
 
-        let role = v
+        let public = map_json_to_public_account(&value).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "account record at {path:?} line {line_number} violates the canonical Garnrolle contract"
+                ),
+            )
+        })?;
+
+        let role = value
             .get("role")
-            .and_then(|v| v.as_str())
+            .and_then(|value| value.as_str())
             .map(Role::from_str_lossy)
             .unwrap_or(Role::Gast);
-
-        let email = v
+        let email = value
             .get("email")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
-
-        // Read persisted webauthn_user_id if present; otherwise generate a new one.
-        // NOTE: This generated ID is stable only for the lifetime of this process.
-        // Once passkey registration is implemented (register-verify), the generated
-        // webauthn_user_id MUST be persisted back to the account data source so that
-        // registered passkeys remain bound to the correct identity across restarts.
-        let webauthn_user_id = v
+            .and_then(|value| value.as_str())
+            .map(ToOwned::to_owned);
+        let webauthn_user_id = value
             .get("webauthn_user_id")
-            .and_then(|v| v.as_str())
-            .and_then(|s| Uuid::parse_str(s).ok())
+            .and_then(|value| value.as_str())
+            .and_then(|value| Uuid::parse_str(value).ok())
             .unwrap_or_else(Uuid::new_v4);
 
-        if let Some(public) = map_json_to_public_account(&v) {
-            let account = AccountInternal {
-                public,
-                role,
-                email,
-                webauthn_user_id,
-            };
-            store.insert_unindexed(account);
-        }
+        store.insert_unindexed(AccountInternal {
+            public,
+            role,
+            email,
+            webauthn_user_id,
+        });
     }
     store.rebuild_email_index();
-    store
+    Ok(store)
 }
 
 pub async fn list_accounts(
@@ -1401,6 +1398,16 @@ mod tests {
             "title": "Invalid state",
             "map_state": "public-ish",
             "location": { "lat": 53.5, "lon": 10.0 }
+        });
+        assert!(map_json_to_public_account(&input).is_none());
+    }
+
+    #[test]
+    fn missing_map_state_is_rejected() {
+        let input = serde_json::json!({
+            "id": "test-missing-map-state",
+            "type": "garnrolle",
+            "title": "Missing state"
         });
         assert!(map_json_to_public_account(&input).is_none());
     }

--- a/apps/api/src/routes/accounts.rs
+++ b/apps/api/src/routes/accounts.rs
@@ -66,7 +66,7 @@ pub struct Location {
 /// Public view of an Account.
 /// STRICTLY does not contain the internal exact `location` (residence).
 /// `map_state` and `public_pos` express visibility without creating a second
-/// identity type. Legacy `ron`/`mode` fields are accepted only by the mapper.
+/// identity type. Removed identity and visibility fields are rejected.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum GarnrolleMapState {
@@ -350,11 +350,24 @@ pub(crate) fn map_json_to_public_account(v: &Value) -> Option<AccountPublic> {
         }
     };
 
-    let kind = v
-        .get("type")
-        .and_then(|v| v.as_str())
-        .unwrap_or("garnrolle")
-        .to_string();
+    let kind = match v.get("type").and_then(|value| value.as_str()) {
+        Some("garnrolle") => "garnrolle",
+        Some(other) => {
+            tracing::warn!(%id, account_type = %other, "rejecting non-canonical account type");
+            return None;
+        }
+        None => {
+            tracing::warn!(%id, "rejecting account without canonical type");
+            return None;
+        }
+    };
+
+    for forbidden in ["mode", "ron_flag", "visibility", "suppress_public_pos"] {
+        if v.get(forbidden).is_some() {
+            tracing::warn!(%id, field = forbidden, "rejecting removed account field");
+            return None;
+        }
+    }
 
     let title = v
         .get("title")
@@ -391,39 +404,23 @@ pub(crate) fn map_json_to_public_account(v: &Value) -> Option<AccountPublic> {
     };
     let invalid_radius = radius_raw > 0 && !(MIN_RADIUS_M..=MAX_RADIUS_M).contains(&radius_m);
 
-    // Legacy compatibility is read-only. Old `type=ron`, `mode=ron` or
-    // `ron_flag=true` records become an ordinary Garnrolle that is not on the
-    // public map. No location is invented and no private position is exposed.
-    let has_ron_flag = v.get("ron_flag").and_then(|v| v.as_bool()).unwrap_or(false);
-    let legacy_mode = v.get("mode").and_then(|v| v.as_str());
-    let explicit_map_state = v.get("map_state").and_then(|v| v.as_str());
-    if let Some(state) = explicit_map_state {
-        if !matches!(state, "not_on_map" | "exact" | "radius") {
+    let explicit_map_state = match v.get("map_state").and_then(|value| value.as_str()) {
+        Some(state @ ("not_on_map" | "exact" | "radius")) => state,
+        Some(state) => {
             tracing::warn!(%id, %state, "rejecting account with invalid map_state");
             return None;
         }
-    }
-    let legacy_visibility = v.get("visibility").and_then(|v| v.as_str());
-    if legacy_visibility == Some("approximate") && radius_m == 0 {
-        radius_m = 250;
-    }
-
-    let legacy_not_on_map = kind == "ron"
-        || has_ron_flag
-        || legacy_mode == Some("ron")
-        || legacy_visibility == Some("private")
-        || v.get("suppress_public_pos")
-            .and_then(|value| value.as_bool())
-            .unwrap_or(false);
+        None => {
+            tracing::warn!(%id, "rejecting account without map_state");
+            return None;
+        }
+    };
 
     let internal_location = match (lat, lon) {
         (Some(lat), Some(lon)) => Some(Location { lat, lon }),
         _ => None,
     };
-    let radius_requested = invalid_radius
-        || explicit_map_state == Some("radius")
-        || radius_m > 0
-        || legacy_visibility == Some("approximate");
+    let radius_requested = invalid_radius || explicit_map_state == "radius" || radius_m > 0;
     let radius_public_pos = if radius_requested && !invalid_radius {
         internal_location.as_ref().and_then(|location| {
             radius_projection_public_pos(v.get(RADIUS_PROJECTION_KEY), location, radius_m)
@@ -432,10 +429,10 @@ pub(crate) fn map_json_to_public_account(v: &Value) -> Option<AccountPublic> {
         None
     };
 
-    let map_state = if legacy_not_on_map
-        || explicit_map_state == Some("not_on_map")
-        || internal_location.is_none()
-    {
+    let map_state = if explicit_map_state == "not_on_map" {
+        GarnrolleMapState::NotOnMap
+    } else if internal_location.is_none() {
+        tracing::warn!(account_id = %id, "suppressing mapped account without an internal location");
         GarnrolleMapState::NotOnMap
     } else if radius_requested {
         if radius_public_pos.is_some() {
@@ -475,7 +472,7 @@ pub(crate) fn map_json_to_public_account(v: &Value) -> Option<AccountPublic> {
 
     Some(AccountPublic {
         id,
-        kind: "garnrolle".to_string(),
+        kind: kind.to_string(),
         title,
         summary,
         public_pos,
@@ -917,10 +914,6 @@ fn update_jsonl_profile_record(
     object.insert("title".to_string(), json!(update.title));
     object.insert("map_state".to_string(), json!(update.map_state));
     object.insert("radius_m".to_string(), json!(update.radius_m));
-    object.remove("mode");
-    object.remove("ron_flag");
-    object.remove("visibility");
-    object.remove("suppress_public_pos");
     match &update.summary {
         Some(summary) => {
             object.insert("summary".to_string(), json!(summary));
@@ -1383,8 +1376,8 @@ mod tests {
             "id": "test-leak-guard",
             "type": "garnrolle",
             "title": "Leak Test",
-            "location": { "lat": 53.5, "lon": 10.0 },
-            "visibility": "public"
+            "map_state": "exact",
+            "location": { "lat": 53.5, "lon": 10.0 }
         });
 
         let account = map_json_to_public_account(&input).expect("Mapping failed");
@@ -1434,61 +1427,52 @@ mod tests {
     }
 
     #[test]
-    fn test_guard_private_hides_public_pos() {
-        let input = serde_json::json!({
-            "id": "test-private",
-            "type": "garnrolle",
-            "title": "Private Test",
-            "location": { "lat": 53.5, "lon": 10.0 },
-            "visibility": "private" // Legacy field
-        });
-
-        let account = map_json_to_public_account(&input).expect("Mapping failed");
-
-        // GUARD: Private legacy visibility becomes an ordinary Garnrolle off the public map.
-        assert_eq!(account.map_state, GarnrolleMapState::NotOnMap);
-        assert!(account.public_pos.is_none());
+    fn removed_identity_and_visibility_fields_are_rejected() {
+        for (field, value) in [
+            ("mode", json!("verortet")),
+            ("ron_flag", json!(true)),
+            ("visibility", json!("private")),
+            ("suppress_public_pos", json!(true)),
+        ] {
+            let mut input = json!({
+                "id": format!("removed-{field}"),
+                "type": "garnrolle",
+                "title": "Removed field",
+                "map_state": "not_on_map",
+                "radius_m": 0
+            });
+            input[field] = value;
+            assert!(
+                map_json_to_public_account(&input).is_none(),
+                "removed field {field} must not be interpreted"
+            );
+        }
     }
 
     #[test]
-    fn test_guard_legacy_radius_maps_to_radius_state() {
-        let input = serde_json::json!({
-            "id": "test-verortet-zero",
-            "type": "garnrolle",
-            "title": "Verortet Zero",
-            "location": { "lat": 53.5, "lon": 10.0 },
-            "mode": "verortet",
-            "radius_m": 0
+    fn non_canonical_or_missing_account_type_is_rejected() {
+        let non_canonical = json!({
+            "id": "removed-account-type",
+            "type": "ron",
+            "title": "Removed type",
+            "map_state": "not_on_map"
         });
+        assert!(map_json_to_public_account(&non_canonical).is_none());
 
-        let account = map_json_to_public_account(&input).expect("Mapping failed");
-
-        assert_eq!(account.radius_m, 0);
-        assert!(account.public_pos.is_some());
+        let missing = json!({
+            "id": "missing-account-type",
+            "title": "Missing type",
+            "map_state": "not_on_map"
+        });
+        assert!(map_json_to_public_account(&missing).is_none());
     }
 
     #[test]
-    fn test_guard_unknown_visibility_defaults_to_public() {
+    fn radius_without_private_binding_fails_closed() {
         let input = json!({
-            "id": "test-unknown-vis",
+            "id": "radius-without-binding",
             "type": "garnrolle",
-            "title": "Unknown Vis",
-            "location": { "lat": 53.5, "lon": 10.0 },
-            "visibility": "garbage_value"
-        });
-
-        let account = map_json_to_public_account(&input).expect("Mapping failed");
-
-        assert_eq!(account.map_state, GarnrolleMapState::Exact);
-        assert!(account.public_pos.is_some());
-    }
-
-    #[test]
-    fn legacy_radius_without_private_binding_fails_closed() {
-        let input = json!({
-            "id": "legacy-radius",
-            "type": "garnrolle",
-            "title": "Legacy radius",
+            "title": "Radius without binding",
             "location": { "lat": 53.5, "lon": 10.0 },
             "map_state": "radius",
             "radius_m": 500,
@@ -1501,11 +1485,12 @@ mod tests {
     }
 
     #[test]
-    fn oversized_radius_without_explicit_state_fails_closed() {
+    fn oversized_radius_fails_closed() {
         let input = json!({
             "id": "oversized-radius",
             "type": "garnrolle",
             "title": "Oversized radius",
+            "map_state": "radius",
             "location": { "lat": 53.5, "lon": 10.0 },
             "radius_m": u64::MAX,
         });
@@ -1690,72 +1675,6 @@ mod tests {
         });
         input[RADIUS_PROJECTION_KEY] = projection;
         let account = map_json_to_public_account(&input).expect("valid account");
-        assert_eq!(account.map_state, GarnrolleMapState::NotOnMap);
-        assert!(account.public_pos.is_none());
-    }
-}
-
-#[cfg(test)]
-mod additional_tests {
-    use super::*;
-    use serde_json::json;
-
-    #[test]
-    fn test_legacy_verortet_without_location_normalizes_to_not_on_map() {
-        let input = json!({
-            "id": "test-verortet-no-loc",
-            "type": "garnrolle",
-            "title": "No Loc",
-            "mode": "verortet",
-        });
-
-        let account = map_json_to_public_account(&input)
-            .expect("A Garnrolle without location remains a valid account");
-        assert_eq!(account.kind, "garnrolle");
-        assert_eq!(account.map_state, GarnrolleMapState::NotOnMap);
-        assert!(account.public_pos.is_none());
-    }
-
-    #[test]
-    fn test_ron_without_location_succeeds() {
-        let input = serde_json::json!({
-            "id": "test-ron-no-loc",
-            "type": "ron",
-            "title": "No Loc Ron",
-            "mode": "ron",
-        });
-
-        let account = map_json_to_public_account(&input)
-            .expect("legacy RoN without location should normalize");
-        assert_eq!(account.map_state, GarnrolleMapState::NotOnMap);
-        assert!(account.public_pos.is_none());
-    }
-
-    #[test]
-    fn test_legacy_type_ron_maps_correctly() {
-        let input = json!({
-            "id": "test-legacy-type-ron",
-            "type": "ron",
-            "title": "Legacy Type Ron",
-            // Notice: no "mode" field here
-        });
-
-        let account = map_json_to_public_account(&input).expect("Mapping failed");
-        assert_eq!(account.map_state, GarnrolleMapState::NotOnMap);
-        assert!(account.public_pos.is_none());
-    }
-
-    #[test]
-    fn test_legacy_ron_flag_maps_correctly() {
-        let input = json!({
-            "id": "test-legacy-ron-flag",
-            "type": "garnrolle",
-            "title": "Legacy Ron Flag",
-            "ron_flag": true
-            // Notice: no "mode" field here
-        });
-
-        let account = map_json_to_public_account(&input).expect("Mapping failed");
         assert_eq!(account.map_state, GarnrolleMapState::NotOnMap);
         assert!(account.public_pos.is_none());
     }

--- a/apps/api/src/routes/auth.rs
+++ b/apps/api/src/routes/auth.rs
@@ -3199,9 +3199,9 @@ pub async fn passkey_testing_bootstrap_session(
 
         if let Err(error) = sqlx::query(
             "INSERT INTO domain_accounts \
-                (id, kind, title, mode, map_state, radius_m, disabled, role, email, webauthn_user_id, public_payload, private_payload) \
+                (id, kind, title, map_state, radius_m, disabled, role, email, webauthn_user_id, public_payload, private_payload) \
              VALUES \
-                ($1, 'garnrolle', 'Passkey Proof User', NULL, 'not_on_map', 0, false, 'gast', $2, $3::uuid, '{}'::jsonb, '{}'::jsonb) \
+                ($1, 'garnrolle', 'Passkey Proof User', 'not_on_map', 0, false, 'gast', $2, $3::uuid, '{}'::jsonb, '{}'::jsonb) \
              ON CONFLICT (id) DO UPDATE SET \
                 title = EXCLUDED.title, \
                 disabled = false, \

--- a/apps/api/tests/auth_auto_provision_persistence.rs
+++ b/apps/api/tests/auth_auto_provision_persistence.rs
@@ -179,12 +179,42 @@ async fn auto_provision_persists_before_cache_and_survives_reload() -> Result<()
 
     // Simulated restart: a fresh load from the JSONL file alone must
     // reconstruct the exact same account — no reliance on the in-memory cache.
-    let reloaded = load_all_accounts().await;
+    let reloaded = load_all_accounts().await?;
     let reloaded_account = reloaded
         .get(&account_id)
         .expect("account must be loadable from PostgreSQL/JSONL after a restart");
     assert_eq!(reloaded_account.email.as_deref(), Some(email));
     assert_eq!(reloaded_account.role, Role::Gast);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn jsonl_loader_rejects_legacy_account_instead_of_hiding_it() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let in_dir = tmp.path().join("in");
+    std::fs::create_dir_all(&in_dir)?;
+    let _env = set_gewebe_in_dir(&in_dir);
+
+    std::fs::write(
+        in_dir.join("demo.accounts.jsonl"),
+        concat!(
+            r#"{"id":"legacy-disabled","type":"garnrolle","title":"Legacy disabled","map_state":"not_on_map","email":"blocked@example.com","disabled":true,"visibility":"private"}"#,
+            "\n"
+        ),
+    )?;
+
+    let error = match load_all_accounts().await {
+        Ok(_) => panic!("legacy JSONL account must stop startup instead of disappearing"),
+        Err(error) => error,
+    };
+    let message = error.to_string();
+    assert!(message.contains("line 1"), "unexpected error: {message}");
+    assert!(
+        message.contains("canonical Garnrolle contract"),
+        "unexpected error: {message}"
+    );
 
     Ok(())
 }

--- a/apps/api/tests/db_auto_provision_write_path.rs
+++ b/apps/api/tests/db_auto_provision_write_path.rs
@@ -248,8 +248,8 @@ async fn auto_provision_resolves_cross_process_duplicate_email_race() -> Result<
     // NOT present in the in-memory cache.
     sqlx::query(
         "INSERT INTO domain_accounts \
-            (id, kind, title, mode, map_state, radius_m, role, email, public_payload, private_payload) \
-         VALUES ($1, 'garnrolle', 'Garnrolle', NULL, 'not_on_map', 0, 'gast', $2, '{}'::jsonb, '{}'::jsonb)",
+            (id, kind, title, map_state, radius_m, role, email, public_payload, private_payload) \
+         VALUES ($1, 'garnrolle', 'Garnrolle', 'not_on_map', 0, 'gast', $2, '{}'::jsonb, '{}'::jsonb)",
     )
     .bind(existing_id)
     .bind(email)
@@ -309,8 +309,8 @@ async fn auto_provision_refuses_disabled_cross_process_winner() -> Result<()> {
     let email = "auto-provision-proof-disabled@example.invalid";
     sqlx::query(
         "INSERT INTO domain_accounts \
-            (id, kind, title, mode, map_state, radius_m, disabled, role, email, public_payload, private_payload) \
-         VALUES ('aaaaaaaa-aaaa-4aaa-8aaa-000000000100', 'garnrolle', 'Garnrolle', NULL, \
+            (id, kind, title, map_state, radius_m, disabled, role, email, public_payload, private_payload) \
+         VALUES ('aaaaaaaa-aaaa-4aaa-8aaa-000000000100', 'garnrolle', 'Garnrolle', \
                  'not_on_map', 0, true, 'gast', $1, '{}'::jsonb, '{}'::jsonb)",
     )
     .bind(email)

--- a/apps/api/tests/db_domain_account_write_path.rs
+++ b/apps/api/tests/db_domain_account_write_path.rs
@@ -298,16 +298,15 @@ async fn account_create_persists_stable_webauthn_user_id_across_reload() -> Resu
     assert!(created.get("location").is_none());
 
     // domain_accounts row: explicit columns.
-    let (kind, mode, map_state, role, title, lat, lon): (
+    let (kind, map_state, role, title, lat, lon): (
         String,
-        Option<String>,
         String,
         String,
         String,
         Option<f64>,
         Option<f64>,
     ) = sqlx::query_as(
-        "SELECT kind, mode, map_state, role, title, location_lat, location_lon \
+        "SELECT kind, map_state, role, title, location_lat, location_lon \
          FROM domain_accounts WHERE id = $1",
     )
     .bind(id)
@@ -315,7 +314,6 @@ async fn account_create_persists_stable_webauthn_user_id_across_reload() -> Resu
     .await
     .expect("account row must exist after create");
     assert_eq!(kind, "garnrolle");
-    assert_eq!(mode, None);
     assert_eq!(map_state, "exact");
     assert_eq!(role, "weber");
     assert_eq!(title, "Write Path");
@@ -331,7 +329,7 @@ async fn account_create_persists_stable_webauthn_user_id_across_reload() -> Resu
         db_webauthn_user_id.expect("new account must persist webauthn_user_id");
     let db_uuid = uuid::Uuid::parse_str(&db_webauthn_user_id)?;
 
-    // JSONB payloads: public carries summary+tags; private mirrors backfill mode.
+    // JSONB payloads: public carries summary+tags; private carries private account data.
     let (public_text, private_text): (String, String) = sqlx::query_as(
         "SELECT public_payload::text, private_payload::text FROM domain_accounts WHERE id = $1",
     )
@@ -515,8 +513,8 @@ async fn postgres_account_create_duplicate_id_conflicts_without_side_effects() -
     let id = DUP_ID;
     sqlx::query(
         "INSERT INTO domain_accounts \
-            (id, kind, title, mode, map_state, radius_m, role, public_payload, private_payload) \
-         VALUES ($1, 'garnrolle', 'Existing', NULL, 'not_on_map', 0, 'weber', '{}'::jsonb, '{}'::jsonb)",
+            (id, kind, title, map_state, radius_m, role, public_payload, private_payload) \
+         VALUES ($1, 'garnrolle', 'Existing', 'not_on_map', 0, 'weber', '{}'::jsonb, '{}'::jsonb)",
     )
     .bind(id)
     .execute(&pool)
@@ -573,6 +571,7 @@ fn account_record(id: &str, email: Option<&str>) -> serde_json::Value {
     m.insert("id".into(), serde_json::json!(id));
     m.insert("type".into(), serde_json::json!("garnrolle"));
     m.insert("title".into(), serde_json::json!("Email Unique Fixture"));
+    m.insert("map_state".into(), serde_json::json!("not_on_map"));
     if let Some(e) = email {
         m.insert("email".into(), serde_json::json!(e));
     }
@@ -662,8 +661,8 @@ async fn route_maps_db_email_conflict_to_409_without_side_effects() -> Result<()
     // Seed a row directly in PostgreSQL (deliberately absent from the cache).
     sqlx::query(
         "INSERT INTO domain_accounts \
-            (id, kind, title, mode, map_state, radius_m, role, email, public_payload, private_payload) \
-         VALUES ($1, 'garnrolle', 'Existing', NULL, 'not_on_map', 0, 'weber', $2, '{}'::jsonb, '{}'::jsonb)",
+            (id, kind, title, map_state, radius_m, role, email, public_payload, private_payload) \
+         VALUES ($1, 'garnrolle', 'Existing', 'not_on_map', 0, 'weber', $2, '{}'::jsonb, '{}'::jsonb)",
     )
     .bind(&existing_id)
     .bind(EMAIL_ALPHA)
@@ -730,10 +729,10 @@ async fn update_account_email_helper_persists_and_classifies_duplicate() -> Resu
 
     sqlx::query(
         "INSERT INTO domain_accounts \
-            (id, kind, title, mode, map_state, radius_m, role, email, public_payload, private_payload) \
+            (id, kind, title, map_state, radius_m, role, email, public_payload, private_payload) \
          VALUES \
-            ($1, 'garnrolle', 'Step Up Account', NULL, 'not_on_map', 0, 'weber', $2, '{}'::jsonb, '{}'::jsonb), \
-            ($3, 'garnrolle', 'Other Account', NULL, 'not_on_map', 0, 'weber', $4, '{}'::jsonb, '{}'::jsonb)",
+            ($1, 'garnrolle', 'Step Up Account', 'not_on_map', 0, 'weber', $2, '{}'::jsonb, '{}'::jsonb), \
+            ($3, 'garnrolle', 'Other Account', 'not_on_map', 0, 'weber', $4, '{}'::jsonb, '{}'::jsonb)",
     )
     .bind(STEP_UP_EMAIL_ID)
     .bind("old-step-up@example.invalid")
@@ -814,8 +813,8 @@ async fn step_up_update_email_persists_to_postgres_and_reloads() -> Result<()> {
 
     sqlx::query(
         "INSERT INTO domain_accounts \
-            (id, kind, title, mode, map_state, radius_m, role, email, public_payload, private_payload) \
-         VALUES ($1, 'garnrolle', 'Step Up Account', NULL, 'not_on_map', 0, 'admin', $2, '{}'::jsonb, '{}'::jsonb)",
+            (id, kind, title, map_state, radius_m, role, email, public_payload, private_payload) \
+         VALUES ($1, 'garnrolle', 'Step Up Account', 'not_on_map', 0, 'admin', $2, '{}'::jsonb, '{}'::jsonb)",
     )
     .bind(STEP_UP_EMAIL_ID)
     .bind("old-route-step-up@example.invalid")

--- a/apps/api/tests/db_domain_backfill.rs
+++ b/apps/api/tests/db_domain_backfill.rs
@@ -415,21 +415,20 @@ async fn import_accounts(pool: &sqlx::PgPool, content: &str) -> BackfillReport {
 
         let upsert_result = sqlx::query(
             "INSERT INTO domain_accounts
-                 (id, kind, title, mode, map_state, radius_m, disabled,
+                 (id, kind, title, map_state, radius_m, disabled,
                   location_lat, location_lon,
                   role, email, webauthn_user_id,
                   created_at, updated_at,
                   public_payload, private_payload)
              VALUES
-                 ($1, $2, $3, $4, $5, $6, $7,
-                  $8, $9,
-                  $10, $11, $12::uuid,
-                  $13, $14,
-                  $15::jsonb, $16::jsonb)
+                 ($1, $2, $3, $4, $5, $6,
+                  $7, $8,
+                  $9, $10, $11::uuid,
+                  $12, $13,
+                  $14::jsonb, $15::jsonb)
              ON CONFLICT (id) DO UPDATE SET
                  kind             = EXCLUDED.kind,
                  title            = EXCLUDED.title,
-                 mode             = EXCLUDED.mode,
                  map_state        = EXCLUDED.map_state,
                  radius_m         = EXCLUDED.radius_m,
                  disabled         = EXCLUDED.disabled,
@@ -446,7 +445,6 @@ async fn import_accounts(pool: &sqlx::PgPool, content: &str) -> BackfillReport {
         .bind(&id)
         .bind(&row.kind)
         .bind(&row.title)
-        .bind(row.legacy_mode.as_deref())
         .bind(&row.map_state)
         .bind(row.radius_m)
         .bind(row.disabled)
@@ -505,8 +503,8 @@ const EDGE_FIXTURE: &str = r#"
 "#;
 
 const ACCOUNT_FIXTURE: &str = r#"
-{"id":"backfill-proof-account-alpha","type":"garnrolle","title":"Alpha Account","mode":"verortet","radius_m":100,"location":{"lat":53.5,"lon":10.0},"role":"weber","email":"alpha@proof.example","summary":"Alpha summary"}
-{"id":"backfill-proof-account-beta","type":"ron","title":"Beta Account","mode":"ron","radius_m":0,"role":"gast"}
+{"id":"backfill-proof-account-alpha","type":"garnrolle","title":"Alpha Account","map_state":"exact","radius_m":0,"location":{"lat":53.5,"lon":10.0},"role":"weber","email":"alpha@proof.example","summary":"Alpha summary"}
+{"id":"backfill-proof-account-beta","type":"garnrolle","title":"Beta Account","map_state":"not_on_map","radius_m":0,"role":"gast"}
 "#;
 
 const MALFORMED_NODE_FIXTURE: &str = r#"
@@ -522,11 +520,11 @@ const DUPLICATE_ID_NODE_FIXTURE: &str = r#"
 "#;
 
 const DUPLICATE_EMAIL_ACCOUNT_FIXTURE: &str = r#"
-{"id":"backfill-proof-account-dup-email-a","type":"garnrolle","title":"Dup Email A","mode":"verortet","radius_m":0,"location":{"lat":53.0,"lon":10.0},"role":"gast","email":"dup@proof.example"}
-{"id":"backfill-proof-account-dup-email-b","type":"garnrolle","title":"Dup Email B","mode":"verortet","radius_m":0,"location":{"lat":53.0,"lon":10.0},"role":"gast","email":"  DUP@proof.example  "}
+{"id":"backfill-proof-account-dup-email-a","type":"garnrolle","title":"Dup Email A","map_state":"exact","radius_m":0,"location":{"lat":53.0,"lon":10.0},"role":"gast","email":"dup@proof.example"}
+{"id":"backfill-proof-account-dup-email-b","type":"garnrolle","title":"Dup Email B","map_state":"exact","radius_m":0,"location":{"lat":53.0,"lon":10.0},"role":"gast","email":"  DUP@proof.example  "}
 "#;
 
-const LEGACY_ACCOUNT_FIXTURE: &str = r#"
+const REMOVED_ACCOUNT_FIXTURE: &str = r#"
 {"id":"legacy-private","location":{"lat":50.0,"lon":10.0},"visibility":"private"}
 {"id":"legacy-missing-type","location":{"lat":51.0,"lon":11.0}}
 {"id":"legacy-missing-mode-ron-flag","ron_flag":true}
@@ -743,9 +741,7 @@ async fn domain_backfill_edges_deterministic_and_idempotent() {
     pool.close().await;
 }
 
-/// Proves that two legacy account fixtures normalize to canonical Garnrollen,
-/// with an unbound historical radius account failing closed, and re-import
-/// idempotently.
+/// Proves that two canonical Garnrollen import and re-import idempotently.
 #[tokio::test]
 #[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
 async fn domain_backfill_accounts_deterministic_and_idempotent() {
@@ -769,31 +765,25 @@ async fn domain_backfill_accounts_deterministic_and_idempotent() {
         "no duplicate emails in clean fixture"
     );
 
-    // Field mapping for a legacy approximate account. Historical records have
-    // no private random projection, so the import must preserve the residence
-    // privately but suppress the public radius state.
     type AccountProjectionRow = (
         String,
-        Option<String>,
         String,
         String,
         Option<String>,
         Option<f64>,
         Option<f64>,
     );
-    let (kind, mode, map_state, role, email, loc_lat, loc_lon): AccountProjectionRow =
-        sqlx::query_as(
-            "SELECT kind, mode, map_state, role, email, location_lat, location_lon
+    let (kind, map_state, role, email, loc_lat, loc_lon): AccountProjectionRow = sqlx::query_as(
+        "SELECT kind, map_state, role, email, location_lat, location_lon
              FROM domain_accounts WHERE id = $1",
-        )
-        .bind("backfill-proof-account-alpha")
-        .fetch_one(&pool)
-        .await
-        .expect("account alpha must exist after import");
+    )
+    .bind("backfill-proof-account-alpha")
+    .fetch_one(&pool)
+    .await
+    .expect("account alpha must exist after import");
 
     assert_eq!(kind, "garnrolle");
-    assert_eq!(mode, None);
-    assert_eq!(map_state, "not_on_map");
+    assert_eq!(map_state, "exact");
     assert_eq!(role, "weber");
     assert_eq!(email.as_deref(), Some("alpha@proof.example"));
     assert!(
@@ -805,7 +795,7 @@ async fn domain_backfill_accounts_deterministic_and_idempotent() {
         "location_lon must map correctly"
     );
 
-    // Legacy hidden account: no location
+    // A canonical not-on-map Garnrolle needs no location.
     let (beta_lat, beta_lon): (Option<f64>, Option<f64>) =
         sqlx::query_as("SELECT location_lat, location_lon FROM domain_accounts WHERE id = $1")
             .bind("backfill-proof-account-beta")
@@ -820,14 +810,6 @@ async fn domain_backfill_accounts_deterministic_and_idempotent() {
         beta_lon.is_none(),
         "hidden account must have NULL location_lon"
     );
-
-    // Unsafe historical radius is cleared while private coordinates remain.
-    let (radius_m,): (i64,) = sqlx::query_as("SELECT radius_m FROM domain_accounts WHERE id = $1")
-        .bind("backfill-proof-account-alpha")
-        .fetch_one(&pool)
-        .await
-        .expect("radius_m must be readable");
-    assert_eq!(radius_m, 0);
 
     // Second import (idempotency)
     let r2 = import_accounts(&pool, ACCOUNT_FIXTURE).await;
@@ -1031,10 +1013,10 @@ async fn domain_backfill_duplicate_account_emails_audited() {
     pool.close().await;
 }
 
-/// Proves that legacy accounts import correctly preserving semantics.
+/// Proves that removed account identities and visibility fields are rejected.
 #[tokio::test]
 #[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
-async fn domain_backfill_legacy_account_semantics() {
+async fn domain_backfill_rejects_removed_account_fields() {
     let pool = connect_pool().await;
     run_migrations(&pool).await;
 
@@ -1043,82 +1025,18 @@ async fn domain_backfill_legacy_account_semantics() {
         .await
         .expect("pre-test cleanup failed");
 
-    let r = import_accounts(&pool, LEGACY_ACCOUNT_FIXTURE).await;
-    assert_eq!(r.records_read, 4);
-    assert_eq!(r.records_inserted, 4);
+    let report = import_accounts(&pool, REMOVED_ACCOUNT_FIXTURE).await;
+    assert_eq!(report.records_read, 4);
+    assert_eq!(report.records_inserted, 0);
+    assert_eq!(report.records_updated, 0);
+    assert_eq!(report.skipped_records, 4);
 
-    // legacy-private: visibility: "private" + location.
-    // Compile-safety: use SQL scalar extraction (private_payload->>'key')
-    // to read JSONB as TEXT, avoiding the sqlx/json feature dependency.
-    let (kind, mode, map_state, visibility, suppress_public_pos): (
-        String,
-        Option<String>,
-        String,
-        Option<String>,
-        Option<String>,
-    ) = sqlx::query_as(
-        "SELECT
-             kind,
-             mode,
-             map_state,
-             private_payload->>'visibility',
-             private_payload->>'suppress_public_pos'
-         FROM domain_accounts
-         WHERE id = $1",
-    )
-    .bind("legacy-private")
-    .fetch_one(&pool)
-    .await
-    .expect("legacy-private must exist");
-    assert_eq!(kind, "garnrolle", "missing type defaults to garnrolle");
-    assert_eq!(mode, None);
-    assert_eq!(map_state, "not_on_map");
-    assert_eq!(
-        visibility.as_deref(),
-        Some("private"),
-        "private_payload.visibility must be preserved"
-    );
-    assert_eq!(
-        suppress_public_pos.as_deref(),
-        Some("true"),
-        "private visibility must set suppress_public_pos=true"
-    );
-
-    // legacy-missing-type: missing type + location
-    let (kind, mode, map_state): (String, Option<String>, String) = sqlx::query_as(
-        "SELECT kind, mode, map_state FROM domain_accounts WHERE id = 'legacy-missing-type'",
-    )
-    .fetch_one(&pool)
-    .await
-    .expect("legacy-missing-type must exist");
-    assert_eq!(kind, "garnrolle");
-    assert_eq!(mode, None);
-    assert_eq!(map_state, "exact");
-
-    // legacy-missing-mode-ron-flag: missing mode + ron_flag: true
-    let (mode, map_state): (Option<String>, String) = sqlx::query_as(
-        "SELECT mode, map_state FROM domain_accounts WHERE id = 'legacy-missing-mode-ron-flag'",
-    )
-    .fetch_one(&pool)
-    .await
-    .expect("legacy-missing-mode-ron-flag must exist");
-    assert_eq!(mode, None);
-    assert_eq!(map_state, "not_on_map");
-
-    // legacy-approximate: no private projection binding, therefore fail closed
-    let (radius_m, map_state): (i64, String) = sqlx::query_as(
-        "SELECT radius_m, map_state FROM domain_accounts WHERE id = 'legacy-approximate'",
-    )
-    .fetch_one(&pool)
-    .await
-    .expect("legacy-approximate must exist");
-    assert_eq!(radius_m, 0);
-    assert_eq!(map_state, "not_on_map");
-
-    sqlx::query("DELETE FROM domain_accounts WHERE id LIKE 'legacy-%'")
-        .execute(&pool)
-        .await
-        .expect("post-test cleanup failed");
+    let (count,): (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM domain_accounts WHERE id LIKE 'legacy-%'")
+            .fetch_one(&pool)
+            .await
+            .expect("count rejected account rows");
+    assert_eq!(count, 0, "removed account shapes must not reach PostgreSQL");
 
     pool.close().await;
 }

--- a/apps/api/tests/db_domain_node_write_path.rs
+++ b/apps/api/tests/db_domain_node_write_path.rs
@@ -223,10 +223,10 @@ async fn postgres_write_app_with_guest_limit(
 ) -> Result<(Router, String, ApiState)> {
     let operator = admin_operator(operator_id);
     sqlx::query(
-        "INSERT INTO domain_accounts (id, kind, title, mode, role, disabled, webauthn_user_id) \
+        "INSERT INTO domain_accounts (id, kind, title, map_state, role, disabled, webauthn_user_id) \
          VALUES ($1, 'garnrolle', $2, 'not_on_map', 'admin', FALSE, $3::uuid) \
          ON CONFLICT (id) DO UPDATE SET \
-             kind = EXCLUDED.kind, title = EXCLUDED.title, mode = EXCLUDED.mode, \
+             kind = EXCLUDED.kind, title = EXCLUDED.title, map_state = EXCLUDED.map_state, \
              role = EXCLUDED.role, disabled = FALSE, webauthn_user_id = EXCLUDED.webauthn_user_id",
     )
     .bind(operator_id)
@@ -1211,8 +1211,8 @@ async fn postgres_node_create_rejects_creator_deleted_by_inflight_exit() -> Resu
     let node_id = "writepath-node-race-create";
     sqlx::query(
         "INSERT INTO domain_accounts \
-         (id, kind, title, mode, map_state, radius_m, disabled, role, public_payload, private_payload) \
-         VALUES ($1, 'garnrolle', 'Race Guest', 'ron', 'not_on_map', 0, FALSE, 'gast', '{}', '{}')",
+         (id, kind, title, map_state, radius_m, disabled, role, public_payload, private_payload) \
+         VALUES ($1, 'garnrolle', 'Race Guest', 'not_on_map', 0, FALSE, 'gast', '{}', '{}')",
     )
     .bind(creator_id)
     .execute(&pool)
@@ -2220,8 +2220,8 @@ async fn delete_node_rejects_untyped_postgres_account_collision_without_partial_
     seed_node(&pool, NODE_A, Some("kept"), None).await;
     sqlx::query(
         "INSERT INTO domain_accounts \
-         (id, kind, title, mode, map_state, role, disabled, webauthn_user_id) \
-         VALUES ($1, 'garnrolle', 'Colliding Account', NULL, 'not_on_map', 'weber', FALSE, $2::uuid)",
+         (id, kind, title, map_state, role, disabled, webauthn_user_id) \
+         VALUES ($1, 'garnrolle', 'Colliding Account', 'not_on_map', 'weber', FALSE, $2::uuid)",
     )
     .bind(NODE_A)
     .bind(uuid::Uuid::new_v4().to_string())

--- a/apps/api/tests/db_domain_read_path.rs
+++ b/apps/api/tests/db_domain_read_path.rs
@@ -337,7 +337,9 @@ async fn jsonl_postgres_legacy_list_order_gap_diagnostic() {
     let jsonl_edges = weltgewebe_api::routes::edges::load_edges().await;
     let pg_edges = load_edges_from_postgres(&pool).await.unwrap();
 
-    let jsonl_accounts = weltgewebe_api::routes::accounts::load_all_accounts().await;
+    let jsonl_accounts = weltgewebe_api::routes::accounts::load_all_accounts()
+        .await
+        .expect("load canonical JSONL accounts");
     let pg_accounts = load_accounts_from_postgres(&pool).await.unwrap();
 
     // 4. Assert Diagnostic Outcomes

--- a/apps/api/tests/db_domain_read_path.rs
+++ b/apps/api/tests/db_domain_read_path.rs
@@ -97,14 +97,14 @@ async fn edges_loader_respects_max_edges_cache_limit() {
 #[tokio::test]
 #[ignore]
 #[serial]
-async fn accounts_loader_rebuilds_email_index_and_privacy_projection() {
+async fn accounts_loader_rebuilds_email_index_and_rejects_removed_fields() {
     let pool = prepare_pool().await;
     sqlx::query(
         "INSERT INTO domain_accounts \
-         (id, kind, title, mode, map_state, radius_m, disabled, location_lat, location_lon, role, email, public_payload, private_payload) \
+         (id, kind, title, map_state, radius_m, disabled, location_lat, location_lon, role, email, public_payload, private_payload) \
          VALUES \
-         ('rp-account-a', 'garnrolle', 'Visible', 'verortet', 'exact', 0, false, 53.55, 9.99, 'gast', 'ReadPath@Example.test', '{\"summary\":\"Public\"}'::jsonb, '{}'::jsonb), \
-         ('rp-account-b', 'garnrolle', 'Suppressed', 'verortet', 'exact', 0, false, 53.56, 9.98, 'gast', NULL, '{}'::jsonb, '{\"suppress_public_pos\":true}'::jsonb)",
+         ('rp-account-a', 'garnrolle', 'Visible', 'exact', 0, false, 53.55, 9.99, 'gast', 'ReadPath@Example.test', '{\"summary\":\"Public\"}'::jsonb, '{}'::jsonb), \
+         ('rp-account-b', 'garnrolle', 'Suppressed', 'exact', 0, false, 53.56, 9.98, 'gast', NULL, '{}'::jsonb, '{\"suppress_public_pos\":true}'::jsonb)",
     )
     .execute(&pool)
     .await
@@ -116,38 +116,12 @@ async fn accounts_loader_rebuilds_email_index_and_privacy_projection() {
     let visible = store
         .get_by_email("readpath@example.test")
         .expect("case-insensitive email lookup");
-    let suppressed = store.get("rp-account-b").expect("suppressed account");
-
     assert_eq!(visible.public.summary.as_deref(), Some("Public"));
     assert!(visible.public.public_pos.is_some());
-    assert!(suppressed.public.public_pos.is_none());
-    clean(&pool).await;
-}
-
-#[tokio::test]
-#[ignore]
-#[serial]
-async fn accounts_loader_respects_mode_column_ron_even_with_location() {
-    let pool = prepare_pool().await;
-    sqlx::query(
-        "INSERT INTO domain_accounts \
-         (id, kind, title, mode, map_state, radius_m, disabled, location_lat, location_lon, role, public_payload, private_payload) \
-         VALUES \
-         ('rp-account-ron-location', 'garnrolle', 'RoN With Location', 'ron', 'exact', 0, false, 53.55, 9.99, 'gast', '{}'::jsonb, '{}'::jsonb)",
-    )
-    .execute(&pool)
-    .await
-    .expect("insert ron account");
-
-    let store = load_accounts_from_postgres(&pool)
-        .await
-        .expect("load accounts");
-    let account = store
-        .get("rp-account-ron-location")
-        .expect("ron account present");
-
-    assert_eq!(account.public.map_state, GarnrolleMapState::NotOnMap);
-    assert!(account.public.public_pos.is_none());
+    assert!(
+        store.get("rp-account-b").is_none(),
+        "removed suppress_public_pos field must reject the row"
+    );
     clean(&pool).await;
 }
 
@@ -158,10 +132,10 @@ async fn accounts_loader_requires_valid_private_radius_binding() {
     let pool = prepare_pool().await;
     sqlx::query(
         "INSERT INTO domain_accounts \
-         (id, kind, title, mode, map_state, radius_m, disabled, location_lat, location_lon, role, public_payload, private_payload) \
+         (id, kind, title, map_state, radius_m, disabled, location_lat, location_lon, role, public_payload, private_payload) \
          VALUES \
-         ('rp-account-approximate', 'garnrolle', 'Legacy approximate', 'verortet', 'radius', 250, false, 53.55, 9.99, 'gast', '{}'::jsonb, '{\"visibility\":\"approximate\"}'::jsonb), \
-         ('rp-account-safe-radius', 'garnrolle', 'Safe radius', NULL, 'radius', 250, false, 53.55, 9.99, 'gast', '{}'::jsonb, \
+         ('rp-account-approximate', 'garnrolle', 'Legacy approximate', 'radius', 250, false, 53.55, 9.99, 'gast', '{}'::jsonb, '{\"visibility\":\"approximate\"}'::jsonb), \
+         ('rp-account-safe-radius', 'garnrolle', 'Safe radius', 'radius', 250, false, 53.55, 9.99, 'gast', '{}'::jsonb, \
           '{\"radius_projection\":{\"version\":1,\"anchor\":{\"lat\":53.55,\"lon\":9.99},\"radius_m\":250,\"public_pos\":{\"lat\":53.5505,\"lon\":9.99}}}'::jsonb)",
     )
     .execute(&pool)
@@ -171,16 +145,14 @@ async fn accounts_loader_requires_valid_private_radius_binding() {
     let store = load_accounts_from_postgres(&pool)
         .await
         .expect("load accounts");
-    let legacy = store
-        .get("rp-account-approximate")
-        .expect("legacy approximate account present");
     let safe = store
         .get("rp-account-safe-radius")
         .expect("safe radius account present");
 
-    assert_eq!(legacy.public.map_state, GarnrolleMapState::NotOnMap);
-    assert_eq!(legacy.public.radius_m, 0);
-    assert!(legacy.public.public_pos.is_none());
+    assert!(
+        store.get("rp-account-approximate").is_none(),
+        "removed visibility field must reject the radius row"
+    );
 
     assert_eq!(safe.public.map_state, GarnrolleMapState::Radius);
     assert_eq!(safe.public.radius_m, 250);
@@ -196,13 +168,13 @@ async fn accounts_loader_requires_valid_private_radius_binding() {
 #[tokio::test]
 #[ignore]
 #[serial]
-async fn accounts_loader_private_visibility_suppresses_public_pos() {
+async fn accounts_loader_rejects_removed_private_visibility() {
     let pool = prepare_pool().await;
     sqlx::query(
         "INSERT INTO domain_accounts \
-         (id, kind, title, mode, map_state, radius_m, disabled, location_lat, location_lon, role, public_payload, private_payload) \
+         (id, kind, title, map_state, radius_m, disabled, location_lat, location_lon, role, public_payload, private_payload) \
          VALUES \
-         ('rp-account-private', 'garnrolle', 'Private', 'verortet', 'exact', 0, false, 53.55, 9.99, 'gast', '{}'::jsonb, '{\"visibility\":\"private\"}'::jsonb)",
+         ('rp-account-private', 'garnrolle', 'Private', 'exact', 0, false, 53.55, 9.99, 'gast', '{}'::jsonb, '{\"visibility\":\"private\"}'::jsonb)",
     )
     .execute(&pool)
     .await
@@ -211,12 +183,10 @@ async fn accounts_loader_private_visibility_suppresses_public_pos() {
     let store = load_accounts_from_postgres(&pool)
         .await
         .expect("load accounts");
-    let account = store
-        .get("rp-account-private")
-        .expect("private account present");
-
-    assert_eq!(account.public.map_state, GarnrolleMapState::NotOnMap);
-    assert!(account.public.public_pos.is_none());
+    assert!(
+        store.get("rp-account-private").is_none(),
+        "removed private visibility field must reject the row"
+    );
     clean(&pool).await;
 }
 
@@ -227,9 +197,9 @@ async fn accounts_loader_explicit_not_on_map_hides_internal_location() {
     let pool = prepare_pool().await;
     sqlx::query(
         "INSERT INTO domain_accounts \
-         (id, kind, title, mode, map_state, radius_m, disabled, location_lat, location_lon, role, public_payload, private_payload) \
+         (id, kind, title, map_state, radius_m, disabled, location_lat, location_lon, role, public_payload, private_payload) \
          VALUES \
-         ('rp-account-explicit-hidden', 'garnrolle', 'Explicitly Hidden', NULL, 'not_on_map', 0, false, 53.55, 9.99, 'gast', '{}'::jsonb, '{}'::jsonb)",
+         ('rp-account-explicit-hidden', 'garnrolle', 'Explicitly Hidden', 'not_on_map', 0, false, 53.55, 9.99, 'gast', '{}'::jsonb, '{}'::jsonb)",
     )
     .execute(&pool)
     .await
@@ -254,13 +224,13 @@ async fn accounts_loader_explicit_not_on_map_hides_internal_location() {
 #[tokio::test]
 #[ignore]
 #[serial]
-async fn accounts_loader_ron_flag_normalizes_to_not_on_map_even_with_location() {
+async fn accounts_loader_rejects_removed_ron_flag() {
     let pool = prepare_pool().await;
     sqlx::query(
         "INSERT INTO domain_accounts \
-         (id, kind, title, mode, map_state, radius_m, disabled, location_lat, location_lon, role, public_payload, private_payload) \
+         (id, kind, title, map_state, radius_m, disabled, location_lat, location_lon, role, public_payload, private_payload) \
          VALUES \
-         ('rp-account-ron-flag', 'garnrolle', 'RoN Flag', 'verortet', 'exact', 0, false, 53.55, 9.99, 'gast', '{}'::jsonb, '{\"ron_flag\":true}'::jsonb)",
+         ('rp-account-ron-flag', 'garnrolle', 'RoN Flag', 'exact', 0, false, 53.55, 9.99, 'gast', '{}'::jsonb, '{\"ron_flag\":true}'::jsonb)",
     )
     .execute(&pool)
     .await
@@ -269,12 +239,10 @@ async fn accounts_loader_ron_flag_normalizes_to_not_on_map_even_with_location() 
     let store = load_accounts_from_postgres(&pool)
         .await
         .expect("load accounts");
-    let account = store
-        .get("rp-account-ron-flag")
-        .expect("ron-flag account present");
-
-    assert_eq!(account.public.map_state, GarnrolleMapState::NotOnMap);
-    assert!(account.public.public_pos.is_none());
+    assert!(
+        store.get("rp-account-ron-flag").is_none(),
+        "removed ron_flag must reject the row"
+    );
     clean(&pool).await;
 }
 
@@ -352,11 +320,11 @@ async fn jsonl_postgres_legacy_list_order_gap_diagnostic() {
 
     sqlx::query(
         "INSERT INTO domain_accounts \
-         (id, kind, title, mode, map_state, role, email, public_payload, private_payload) \
+         (id, kind, title, map_state, role, email, public_payload, private_payload) \
          VALUES \
-         ('rp-list-account-c', 'garnrolle', 'C', NULL, 'not_on_map', 'gast', 'rp-list-account-c@example.invalid', '{}'::jsonb, '{}'::jsonb), \
-         ('rp-list-account-a', 'garnrolle', 'A', NULL, 'not_on_map', 'gast', 'rp-list-account-a@example.invalid', '{}'::jsonb, '{}'::jsonb), \
-         ('rp-list-account-b', 'garnrolle', 'B', NULL, 'not_on_map', 'gast', 'rp-list-account-b@example.invalid', '{}'::jsonb, '{}'::jsonb)"
+         ('rp-list-account-c', 'garnrolle', 'C', 'not_on_map', 'gast', 'rp-list-account-c@example.invalid', '{}'::jsonb, '{}'::jsonb), \
+         ('rp-list-account-a', 'garnrolle', 'A', 'not_on_map', 'gast', 'rp-list-account-a@example.invalid', '{}'::jsonb, '{}'::jsonb), \
+         ('rp-list-account-b', 'garnrolle', 'B', 'not_on_map', 'gast', 'rp-list-account-b@example.invalid', '{}'::jsonb, '{}'::jsonb)"
     )
     .execute(&pool)
     .await

--- a/apps/api/tests/db_domain_schema_migrations.rs
+++ b/apps/api/tests/db_domain_schema_migrations.rs
@@ -223,6 +223,106 @@ async fn domain_schema_tables_exist_after_migration() {
     pool.close().await;
 }
 
+/// Final identity cutover proof: obsolete `mode` contents are discarded, but
+/// semantically meaningful legacy identity markers still block the column drop.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
+async fn final_identity_migration_discards_mode_but_blocks_legacy_markers() {
+    let pool = connect_pool().await;
+    run_migrations(&pool).await;
+
+    const ACCOUNT_ID: &str = "final-identity-migration-probe";
+    sqlx::query("DELETE FROM domain_accounts WHERE id = $1")
+        .bind(ACCOUNT_ID)
+        .execute(&pool)
+        .await
+        .expect("pre-test cleanup failed");
+
+    sqlx::raw_sql(include_str!(
+        "../migrations/20260724000001_remove_ron_legacy.down.sql"
+    ))
+    .execute(&pool)
+    .await
+    .expect("restore nullable compatibility column");
+
+    sqlx::query(
+        "INSERT INTO domain_accounts (
+             id, kind, mode, title, map_state, radius_m, role,
+             public_payload, private_payload
+         ) VALUES ($1, 'garnrolle', 'ron', 'Canonical Garnrolle',
+                   'not_on_map', 0, 'gast', '{}'::jsonb, '{}'::jsonb)",
+    )
+    .bind(ACCOUNT_ID)
+    .execute(&pool)
+    .await
+    .expect("insert canonical row with obsolete mode value");
+
+    sqlx::raw_sql(include_str!(
+        "../migrations/20260724000001_remove_ron_legacy.up.sql"
+    ))
+    .execute(&pool)
+    .await
+    .expect("obsolete mode value must not block the final column drop");
+    assert!(
+        !column_exists(&pool, "domain_accounts", "mode").await,
+        "mode column must be absent after successful cutover"
+    );
+
+    sqlx::raw_sql(include_str!(
+        "../migrations/20260724000001_remove_ron_legacy.down.sql"
+    ))
+    .execute(&pool)
+    .await
+    .expect("restore compatibility column for fail-closed case");
+    sqlx::query(
+        r#"UPDATE domain_accounts
+         SET private_payload = '{"visibility":"private"}'::jsonb
+         WHERE id = $1"#,
+    )
+    .bind(ACCOUNT_ID)
+    .execute(&pool)
+    .await
+    .expect("add semantic legacy marker");
+
+    let error = sqlx::raw_sql(include_str!(
+        "../migrations/20260724000001_remove_ron_legacy.up.sql"
+    ))
+    .execute(&pool)
+    .await
+    .expect_err("semantic legacy marker must block the cutover");
+    assert!(
+        error.to_string().contains("legacy rows remain"),
+        "unexpected migration error: {error}"
+    );
+    assert!(
+        column_exists(&pool, "domain_accounts", "mode").await,
+        "failed migration must leave the schema unchanged"
+    );
+
+    sqlx::query(
+        "UPDATE domain_accounts
+         SET private_payload = private_payload - 'visibility'
+         WHERE id = $1",
+    )
+    .bind(ACCOUNT_ID)
+    .execute(&pool)
+    .await
+    .expect("remove semantic legacy marker");
+    sqlx::raw_sql(include_str!(
+        "../migrations/20260724000001_remove_ron_legacy.up.sql"
+    ))
+    .execute(&pool)
+    .await
+    .expect("cutover must succeed after remediation");
+
+    sqlx::query("DELETE FROM domain_accounts WHERE id = $1")
+        .bind(ACCOUNT_ID)
+        .execute(&pool)
+        .await
+        .expect("post-test cleanup failed");
+    pool.close().await;
+}
+
 /// Security cutover proof: an historical radius row is never re-exposed by
 /// the new migration or its intentionally irreversible down migration.
 #[tokio::test]

--- a/apps/api/tests/db_domain_schema_migrations.rs
+++ b/apps/api/tests/db_domain_schema_migrations.rs
@@ -215,6 +215,10 @@ async fn domain_schema_tables_exist_after_migration() {
         index_exists(&pool, "domain_accounts_email_lookup").await,
         "domain_accounts_email_lookup index must exist"
     );
+    assert!(
+        !column_exists(&pool, "domain_accounts", "mode").await,
+        "removed domain_accounts.mode column must not exist"
+    );
 
     pool.close().await;
 }
@@ -233,13 +237,13 @@ async fn radius_privacy_migration_hides_legacy_rows_irreversibly() {
         .expect("pre-test cleanup failed");
     sqlx::query(
         "INSERT INTO domain_accounts (
-             id, kind, title, mode, map_state, radius_m, role,
+             id, kind, title, map_state, radius_m, role,
              location_lat, location_lon, public_payload, private_payload
          ) VALUES
-         ('radius-migration-legacy', 'garnrolle', 'Legacy radius', NULL, 'radius', 500, 'weber',
+         ('radius-migration-legacy', 'garnrolle', 'Legacy radius', 'radius', 500, 'weber',
           53.5, 10.0, '{}'::jsonb,
           '{\"visibility\":\"approximate\",\"radius_projection\":{\"legacy\":true},\"keep\":\"yes\"}'::jsonb),
-         ('radius-migration-exact', 'garnrolle', 'Exact', NULL, 'exact', 0, 'weber',
+         ('radius-migration-exact', 'garnrolle', 'Exact', 'exact', 0, 'weber',
           53.6, 10.1, '{}'::jsonb, '{\"keep\":\"exact\"}'::jsonb)",
     )
     .execute(&pool)
@@ -419,22 +423,21 @@ async fn domain_schema_basic_insert_and_read() {
         .expect("pre-test cleanup of domain_accounts failed");
 
     sqlx::query(
-        "INSERT INTO domain_accounts (id, kind, title, mode, map_state, radius_m, role, public_payload, private_payload)
-            VALUES ('test-account-schema-probe', 'garnrolle', 'Test Account', NULL, 'not_on_map', 0, 'gast', '{}'::jsonb, '{}'::jsonb)",
+        "INSERT INTO domain_accounts (id, kind, title, map_state, radius_m, role, public_payload, private_payload)
+            VALUES ('test-account-schema-probe', 'garnrolle', 'Test Account', 'not_on_map', 0, 'gast', '{}'::jsonb, '{}'::jsonb)",
     )
     .execute(&pool)
     .await
     .expect("failed to insert test row into domain_accounts");
 
-    let (kind, mode, map_state): (String, Option<String>, String) =
-        sqlx::query_as("SELECT kind, mode, map_state FROM domain_accounts WHERE id = $1")
+    let (kind, map_state): (String, String) =
+        sqlx::query_as("SELECT kind, map_state FROM domain_accounts WHERE id = $1")
             .bind("test-account-schema-probe")
             .fetch_one(&pool)
             .await
             .expect("failed to read back test row from domain_accounts");
 
     assert_eq!(kind, "garnrolle");
-    assert_eq!(mode, None);
     assert_eq!(map_state, "not_on_map");
 
     sqlx::query("DELETE FROM domain_accounts WHERE id = 'test-account-schema-probe'")
@@ -668,8 +671,8 @@ async fn domain_accounts_normalized_email_uniqueness_is_enforced() {
 
     // Insert first account with email
     sqlx::query(
-        "INSERT INTO domain_accounts (id, kind, title, mode, map_state, radius_m, role, email, public_payload, private_payload)
-         VALUES ('test-email-dup-a', 'garnrolle', 'dup-a', NULL, 'not_on_map', 0, 'gast', 'alpha@example.invalid', '{}', '{}')",
+        "INSERT INTO domain_accounts (id, kind, title, map_state, radius_m, role, email, public_payload, private_payload)
+         VALUES ('test-email-dup-a', 'garnrolle', 'dup-a', 'not_on_map', 0, 'gast', 'alpha@example.invalid', '{}', '{}')",
     )
     .execute(&pool)
     .await
@@ -679,8 +682,8 @@ async fn domain_accounts_normalized_email_uniqueness_is_enforced() {
     // rejected specifically by the normalized unique index (TODO 2A), identified
     // by constraint name so any unrelated database error fails the test.
     let dup_result = sqlx::query(
-        "INSERT INTO domain_accounts (id, kind, title, mode, map_state, radius_m, role, email, public_payload, private_payload)
-         VALUES ('test-email-dup-b', 'garnrolle', 'dup-b', NULL, 'not_on_map', 0, 'gast', 'ALPHA@example.invalid', '{}', '{}')",
+        "INSERT INTO domain_accounts (id, kind, title, map_state, radius_m, role, email, public_payload, private_payload)
+         VALUES ('test-email-dup-b', 'garnrolle', 'dup-b', 'not_on_map', 0, 'gast', 'ALPHA@example.invalid', '{}', '{}')",
     )
     .execute(&pool)
     .await;
@@ -696,16 +699,16 @@ async fn domain_accounts_normalized_email_uniqueness_is_enforced() {
 
     // Two accounts without email (NULL) must both succeed
     sqlx::query(
-        "INSERT INTO domain_accounts (id, kind, title, mode, map_state, radius_m, role, public_payload, private_payload)
-         VALUES ('test-email-null-a', 'garnrolle', 'null-a', NULL, 'not_on_map', 0, 'gast', '{}', '{}')",
+        "INSERT INTO domain_accounts (id, kind, title, map_state, radius_m, role, public_payload, private_payload)
+         VALUES ('test-email-null-a', 'garnrolle', 'null-a', 'not_on_map', 0, 'gast', '{}', '{}')",
     )
     .execute(&pool)
     .await
     .expect("first NULL-email insert must succeed");
 
     sqlx::query(
-        "INSERT INTO domain_accounts (id, kind, title, mode, map_state, radius_m, role, public_payload, private_payload)
-         VALUES ('test-email-null-b', 'garnrolle', 'null-b', NULL, 'not_on_map', 0, 'gast', '{}', '{}')",
+        "INSERT INTO domain_accounts (id, kind, title, map_state, radius_m, role, public_payload, private_payload)
+         VALUES ('test-email-null-b', 'garnrolle', 'null-b', 'not_on_map', 0, 'gast', '{}', '{}')",
     )
     .execute(&pool)
     .await
@@ -716,8 +719,8 @@ async fn domain_accounts_normalized_email_uniqueness_is_enforced() {
     // "" and whitespace-only must fail with that specific constraint.
     for (probe_id, probe_email) in [("test-email-empty", ""), ("test-email-ws", "   ")] {
         let res = sqlx::query(
-            "INSERT INTO domain_accounts (id, kind, title, mode, map_state, radius_m, role, email, public_payload, private_payload)
-             VALUES ($1, 'garnrolle', 'empty-email', NULL, 'not_on_map', 0, 'gast', $2, '{}', '{}')",
+            "INSERT INTO domain_accounts (id, kind, title, map_state, radius_m, role, email, public_payload, private_payload)
+             VALUES ($1, 'garnrolle', 'empty-email', 'not_on_map', 0, 'gast', $2, '{}', '{}')",
         )
         .bind(probe_id)
         .bind(probe_email)
@@ -741,16 +744,16 @@ async fn domain_accounts_normalized_email_uniqueness_is_enforced() {
         .expect("pre-test cleanup of test-radius-u32-max failed");
 
     sqlx::query(
-        "INSERT INTO domain_accounts (id, kind, title, mode, map_state, radius_m, location_lat, location_lon, role, public_payload, private_payload)
-         VALUES ('test-radius-u32-max', 'garnrolle', 'radius-max', NULL, 'radius', 4294967295, 53.5, 10.0, 'gast', '{}', '{}')",
+        "INSERT INTO domain_accounts (id, kind, title, map_state, radius_m, location_lat, location_lon, role, public_payload, private_payload)
+         VALUES ('test-radius-u32-max', 'garnrolle', 'radius-max', 'radius', 4294967295, 53.5, 10.0, 'gast', '{}', '{}')",
     )
     .execute(&pool)
     .await
     .expect("u32::MAX radius_m must be accepted");
 
     let overflow_result = sqlx::query(
-        "INSERT INTO domain_accounts (id, kind, title, mode, map_state, radius_m, location_lat, location_lon, role, public_payload, private_payload)
-         VALUES ('test-radius-overflow', 'garnrolle', 'radius-overflow', NULL, 'radius', 4294967296, 53.5, 10.0, 'gast', '{}', '{}')",
+        "INSERT INTO domain_accounts (id, kind, title, map_state, radius_m, location_lat, location_lon, role, public_payload, private_payload)
+         VALUES ('test-radius-overflow', 'garnrolle', 'radius-overflow', 'radius', 4294967296, 53.5, 10.0, 'gast', '{}', '{}')",
     )
     .execute(&pool)
     .await;

--- a/apps/api/tests/db_governance.rs
+++ b/apps/api/tests/db_governance.rs
@@ -104,8 +104,8 @@ async fn seed_guest_node(pool: &sqlx::PgPool, account_id: &str, node_id: &str) {
 async fn seed_account(pool: &sqlx::PgPool, id: &str, role: &str) {
     sqlx::query(
         "INSERT INTO domain_accounts \
-         (id, kind, title, mode, map_state, radius_m, disabled, role, public_payload, private_payload) \
-         VALUES ($1, 'garnrolle', $2, 'ron', 'not_on_map', 0, FALSE, $3, '{}', '{}')",
+         (id, kind, title, map_state, radius_m, disabled, role, public_payload, private_payload) \
+         VALUES ($1, 'garnrolle', $2, 'not_on_map', 0, FALSE, $3, '{}', '{}')",
     )
     .bind(id)
     .bind(format!("Account {id}"))

--- a/apps/api/tests/db_passkey_fk_readiness.rs
+++ b/apps/api/tests/db_passkey_fk_readiness.rs
@@ -103,9 +103,9 @@ async fn passkey_account_fk_readiness_audit_detects_orphans() {
 
     sqlx::query(
         "INSERT INTO domain_accounts \
-            (id, kind, title, mode, map_state, radius_m, disabled, role, email, webauthn_user_id, public_payload, private_payload) \
+            (id, kind, title, map_state, radius_m, disabled, role, email, webauthn_user_id, public_payload, private_payload) \
          VALUES \
-            ($1, 'garnrolle', 'FK Readiness Account', NULL, 'not_on_map', 0, false, 'weber', $2, $3::uuid, '{}'::jsonb, '{}'::jsonb)",
+            ($1, 'garnrolle', 'FK Readiness Account', 'not_on_map', 0, false, 'weber', $2, $3::uuid, '{}'::jsonb, '{}'::jsonb)",
     )
     .bind(&valid_account_id)
     .bind(format!("{valid_account_id}@example.invalid"))

--- a/apps/api/tests/db_passkey_store_persistence.rs
+++ b/apps/api/tests/db_passkey_store_persistence.rs
@@ -990,9 +990,9 @@ async fn passkey_register_reload_auth_route_proof() {
     let webauthn_user_id = Uuid::new_v4();
     sqlx::query(
         "INSERT INTO domain_accounts \
-            (id, kind, title, mode, map_state, radius_m, disabled, role, email, webauthn_user_id, public_payload, private_payload) \
+            (id, kind, title, map_state, radius_m, disabled, role, email, webauthn_user_id, public_payload, private_payload) \
          VALUES \
-            ($1, 'garnrolle', 'Route Reload Proof User', NULL, 'not_on_map', 0, false, 'weber', $2, $3::uuid, '{}'::jsonb, '{}'::jsonb)",
+            ($1, 'garnrolle', 'Route Reload Proof User', 'not_on_map', 0, false, 'weber', $2, $3::uuid, '{}'::jsonb, '{}'::jsonb)",
     )
     .bind(&account_id)
     .bind(&email)

--- a/apps/api/tests/db_webauthn_user_id_backfill_audit.rs
+++ b/apps/api/tests/db_webauthn_user_id_backfill_audit.rs
@@ -98,8 +98,8 @@ async fn cleanup(pool: &sqlx::PgPool) {
 async fn insert_account(pool: &sqlx::PgPool, id: &str, user_id: Option<Uuid>) {
     sqlx::query(
         "INSERT INTO domain_accounts \
-            (id, kind, title, mode, map_state, radius_m, role, webauthn_user_id, public_payload, private_payload) \
-         VALUES ($1, 'garnrolle', $2, NULL, 'not_on_map', 0, 'gast', $3::uuid, '{}'::jsonb, '{}'::jsonb)",
+            (id, kind, title, map_state, radius_m, role, webauthn_user_id, public_payload, private_payload) \
+         VALUES ($1, 'garnrolle', $2, 'not_on_map', 0, 'gast', $3::uuid, '{}'::jsonb, '{}'::jsonb)",
     )
     .bind(id)
     .bind(id)

--- a/architecture/overview.md
+++ b/architecture/overview.md
@@ -110,9 +110,8 @@ darstellen.
 ## Bewusste Ausbaugrenzen
 
 - JSONL ist noch nicht vollständig durch PostgreSQL abgelöst.
-- Neue Accounts und öffentliche Projektionen verwenden nur noch Garnrolle plus
-  `map_state`. Legacy-RoN wird lesend auf `not_on_map` normalisiert; die nullable
-  DB-Spalte `mode` bleibt bis zum belegten Produktionscutover als Rollbackbrücke.
+- Accounts und öffentliche Projektionen verwenden ausschließlich Garnrolle plus
+  `map_state`. Die frühere RoN-Identität und die Spalte `mode` sind entfernt.
 - Der produktive Gesprächspfad ist auf genau einen öffentlichen Raum je
   PostgreSQL-Knoten begrenzt; private Räume, Anhänge und Föderation fehlen.
 - NATS im Stack bedeutet noch keinen belegten Transactional-Outbox-Betrieb.

--- a/architecture/security.md
+++ b/architecture/security.md
@@ -102,9 +102,8 @@ auditierte Vorgänge.
 
 ## Offene Risiken
 
-- Legacy-RoN-Daten werden privacy-sicher zu `not_on_map` normalisiert. Vor der
-  späteren Entfernung der nullable Rollbackspalte `mode` ist ein Produktions-
-  und Rückrollbeleg nötig.
+- `map_state=not_on_map` unterdrückt jede öffentliche Position, ohne dafür eine
+  zweite Identität oder einen Legacy-Modus zu verwenden.
 - Der vollständige PostgreSQL-Cutover ist nicht abgeschlossen.
 - Branch-/Ruleset-Schutz muss nach Stabilisierung der Pflichtcheckliste aktiv
   und minimal gehalten werden.

--- a/docs/_generated/backlinks.md
+++ b/docs/_generated/backlinks.md
@@ -69,6 +69,10 @@ Generated automatically. Do not edit.
 
 - [relates_to] docs/reports/domain-postgres-instance-coherence-decision.md
 
+## apps/api/migrations/20260724000001_remove_ron_legacy.up.sql
+
+- [relates_to] docs/reports/garnrolle-identity-cutover-proof.md
+
 ## apps/api/src/auth/accounts.rs
 
 - [relates_to] docs/reports/domain-account-email-uniqueness-audit.md
@@ -423,6 +427,7 @@ Generated automatically. Do not edit.
 - [relates_to] docs/architekturstruktur.md
 - [relates_to] docs/blueprints/domain-scale-foundation.md
 - [relates_to] docs/domain/vocabulary.md
+- [relates_to] docs/reports/garnrolle-identity-cutover-proof.md
 - [relates_to] docs/reports/optimierungsbericht.md
 - [relates_to] docs/reports/weltgewebe-os-v1-t018-conversation-convergence-plan.md
 - [relates_to] docs/runbooks/db-recovery.md
@@ -559,6 +564,7 @@ Generated automatically. Do not edit.
 - [relates_to] docs/datenmodell.md
 - [relates_to] docs/domain/modules.md
 - [relates_to] docs/reference/glossar.md
+- [relates_to] docs/reports/garnrolle-identity-cutover-proof.md
 - [relates_to] docs/specs/contract.md
 - [relates_to] docs/specs/garnrolle-knoten-faden.md
 - [relates_to] docs/specs/governance-antraege.md
@@ -815,6 +821,10 @@ Generated automatically. Do not edit.
 - [relates_to] docs/reports/domain-edge-write-path-proof.md
 - [relates_to] docs/reports/domain-node-write-path-proof.md
 - [relates_to] docs/reports/optimierungsstatus.md
+
+## docs/reports/garnrolle-identity-cutover-proof.md
+
+- [relates_to] docs/domain/vocabulary.md
 
 ## docs/reports/inwx-zone-reconciliation-plan.md
 
@@ -1218,6 +1228,10 @@ Generated automatically. Do not edit.
 ## scripts/ci/tests/test_check_github_action_pinning.py
 
 - [relates_to] docs/reports/github-action-ref-pinning-audit.md
+
+## scripts/ci/tests/test_garnrolle_ontology_contract.py
+
+- [relates_to] docs/reports/garnrolle-identity-cutover-proof.md
 
 ## scripts/ci/tests/test_reconcile_public_login_smtp_env.py
 

--- a/docs/_generated/doc-index.md
+++ b/docs/_generated/doc-index.md
@@ -150,6 +150,7 @@ Generated automatically. Do not edit.
 | reports.domain-postgres-instance-coherence-decision | Domain PostgreSQL Instance Coherence Decision — DOMAIN-PG-002 | report | active | docs/reports/domain-postgres-instance-coherence-decision.md |
 | reports.domain-provider-role-finding | Finding: Aktuelle Domain- und Provider-Rollen | report | active | docs/reports/domain-provider-role-finding.md |
 | reports.domain-read-path-proof | Domain Read Path Proof | report | active | docs/reports/domain-read-path-proof.md |
+| reports.garnrolle-identity-cutover-proof | Garnrolle Identity Cutover Proof | report | active | docs/reports/garnrolle-identity-cutover-proof.md |
 | reports.github-action-ref-pinning-audit | GitHub Action Reference Pinning Audit — OPT-INF-002 | report | active | docs/reports/github-action-ref-pinning-audit.md |
 | reports.github-actions-node24-readiness | GitHub Actions Node-24 Runtime Readiness — OPT-CI-005 | report | active | docs/reports/github-actions-node24-readiness.md |
 | reports.inwx-zone-reconciliation-plan | INWX Zone Reconciliation Plan | report | deprecated | docs/reports/inwx-zone-reconciliation-plan.md |

--- a/docs/_generated/relates-to-audit.md
+++ b/docs/_generated/relates-to-audit.md
@@ -14,12 +14,12 @@ Generated automatically. Do not edit.
 
 | Metrik | Wert |
 | --- | --- |
-| Relationen gesamt | 645 |
+| Relationen gesamt | 650 |
 | — depends_on | 25 |
-| — relates_to | 603 |
+| — relates_to | 608 |
 | — supersedes | 12 |
 | — verifies | 5 |
-| relates_to Anteil | 93% |
+| relates_to Anteil | 94% |
 
 ### Mögliche supersedes-Lücken
 
@@ -31,7 +31,7 @@ _Keine Lücken erkannt._
 
 > Zusammenhängende Gruppen im relates_to-Graphen.
 
-**Cluster 1** (258 Dokumente):
+**Cluster 1** (261 Dokumente):
 
 - `.github/workflows/api.yml`
 - `.github/workflows/basemap-runtime-proof.yml`
@@ -41,6 +41,7 @@ _Keine Lücken erkannt._
 - `agent-policy.yaml`
 - `apps/api/migrations/20260531000002_create_domain_edges.up.sql`
 - `apps/api/migrations/20260716000001_multi_instance_foundation.up.sql`
+- `apps/api/migrations/20260724000001_remove_ron_legacy.up.sql`
 - `apps/api/src/auth/accounts.rs`
 - `apps/api/src/auth/ephemeral_db.rs`
 - `apps/api/src/domain_db.rs`
@@ -192,6 +193,7 @@ _Keine Lücken erkannt._
 - `docs/reports/domain-provider-role-finding.md`
 - `docs/reports/domain-read-path-proof.md`
 - `docs/reports/domain-runtime-data-source-reconciliation.md`
+- `docs/reports/garnrolle-identity-cutover-proof.md`
 - `docs/reports/github-action-ref-pinning-audit.md`
 - `docs/reports/github-actions-node24-readiness.md`
 - `docs/reports/inwx-zone-reconciliation-plan.md`
@@ -265,6 +267,7 @@ _Keine Lücken erkannt._
 - `scripts/ci/fixtures/repoground_vertical_pilot.v1.json`
 - `scripts/ci/tests/test_check_actions_node24_readiness.py`
 - `scripts/ci/tests/test_check_github_action_pinning.py`
+- `scripts/ci/tests/test_garnrolle_ontology_contract.py`
 - `scripts/ci/tests/test_reconcile_public_login_smtp_env.py`
 - `scripts/ci/tests/test_repoground_vertical_pilot.py`
 - `scripts/ci/validate_repoground_vertical_pilot.py`

--- a/docs/_generated/relations-analysis.md
+++ b/docs/_generated/relations-analysis.md
@@ -14,12 +14,12 @@ Generated automatically. Do not edit.
 
 | Metrik | Wert |
 | --- | --- |
-| Dokumente gesamt | 184 |
-| Dokumente mit ausgehenden Relationen | 183 |
-| Dokumente als Ziel referenziert | 138 |
-| Relationen gesamt | 645 |
+| Dokumente gesamt | 185 |
+| Dokumente mit ausgehenden Relationen | 184 |
+| Dokumente als Ziel referenziert | 139 |
+| Relationen gesamt | 650 |
 | — depends_on | 25 |
-| — relates_to | 603 |
+| — relates_to | 608 |
 | — supersedes | 12 |
 | — verifies | 5 |
 | Isolierte Dokumente | 0 |
@@ -46,6 +46,7 @@ Generated automatically. Do not edit.
 - ⚠️ High inbound count (12): `docs/deployment.md` — central dependency, review carefully
 - ⚠️ High inbound count (11): `docs/blueprints/auth-roadmap.md` — central dependency, review carefully
 - ⚠️ High inbound count (11): `docs/roadmap.md` — central dependency, review carefully
+- ⚠️ High inbound count (10): `docs/datenmodell.md` — central dependency, review carefully
 
 ### Zyklen (depends_on)
 
@@ -75,6 +76,7 @@ _Keine Zyklen gefunden._
 - `docs/deployment.md` — 12 eingehende Relationen
 - `docs/blueprints/auth-roadmap.md` — 11 eingehende Relationen
 - `docs/roadmap.md` — 11 eingehende Relationen
+- `docs/datenmodell.md` — 10 eingehende Relationen
 
 ### Isolierte Dokumente
 

--- a/docs/_generated/report-lifecycle-inventory.md
+++ b/docs/_generated/report-lifecycle-inventory.md
@@ -16,23 +16,23 @@ Primary references are exact path matches in canonical documentation surfaces. D
 
 | Metric | Count |
 | --- | ---: |
-| files_total | 50 |
-| files_with_frontmatter | 50 |
+| files_total | 51 |
+| files_with_frontmatter | 51 |
 | files_without_frontmatter | 0 |
-| files_with_status | 50 |
+| files_with_status | 51 |
 | files_missing_status | 0 |
-| files_with_lifecycle_state | 45 |
+| files_with_lifecycle_state | 46 |
 | files_missing_lifecycle_state | 5 |
-| files_with_lifecycle | 44 |
+| files_with_lifecycle | 45 |
 | files_missing_lifecycle | 6 |
-| files_with_owner_task | 46 |
+| files_with_owner_task | 47 |
 | files_missing_owner_task | 4 |
-| files_with_review_after | 37 |
+| files_with_review_after | 38 |
 | files_missing_review_after | 13 |
-| files_primary_referenced | 43 |
+| files_primary_referenced | 44 |
 | files_primary_unreferenced | 7 |
-| files_with_derived_references | 50 |
-| files_with_relations | 50 |
+| files_with_derived_references | 51 |
+| files_with_relations | 51 |
 | files_with_missing_supersession_target | 0 |
 
 ## Doc Type Distribution
@@ -41,7 +41,7 @@ Primary references are exact path matches in canonical documentation surfaces. D
 | --- | ---: |
 | documentation | 1 |
 | reference | 1 |
-| report | 44 |
+| report | 45 |
 | status | 2 |
 | status-matrix | 2 |
 
@@ -82,6 +82,7 @@ Primary references are exact path matches in canonical documentation surfaces. D
 | docs/reports/domain-provider-role-finding.md | report | active | active | audit | DEPLOY-DNS-001 | 2026-07-23 |  | 4 | 4 | 3 |  |  |
 | docs/reports/domain-read-path-proof.md | report | active | active | proof | OPT-ARC-001 | 2026-07-16 |  | 4 | 4 | 5 |  |  |
 | docs/reports/domain-runtime-data-source-reconciliation.md | report | active | active | audit | DB-PROOF-001 | 2026-07-18 |  | 1 | 4 | 5 |  |  |
+| docs/reports/garnrolle-identity-cutover-proof.md | report | active | active | proof | OPT-ARC-001 | 2026-10-24 |  | 1 | 4 | 4 |  |  |
 | docs/reports/github-action-ref-pinning-audit.md | report | active | active | audit | OPT-INF-002 | 2026-09-30 |  | 0 | 4 | 4 |  |  |
 | docs/reports/github-actions-node24-readiness.md | report | active | active | audit | OPT-CI-005 | 2026-09-29 |  | 2 | 4 | 5 |  |  |
 | docs/reports/inwx-zone-reconciliation-plan.md | report | deprecated | archived | planning | DEPLOY-DNS-001 |  |  | 1 | 5 | 4 | review_after |  |
@@ -157,6 +158,7 @@ Primary references are exact path matches in canonical documentation surfaces. D
 | docs/reports/domain-provider-role-finding.md | 3 | relates_to | docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md, docs/runbooks/domain-mail-cutover.md, docs/tasks/board.md |
 | docs/reports/domain-read-path-proof.md | 5 | relates_to | docs/blueprints/domain-data-postgres-cutover.md, docs/reports/domain-account-write-path-proof.md, docs/reports/domain-backfill-proof.md, docs/reports/optimierungsstatus.md, docs/tasks/board.md |
 | docs/reports/domain-runtime-data-source-reconciliation.md | 5 | relates_to | docs/blueprints/domain-data-postgres-cutover.md, docs/reports/domain-edge-reference-audit.md, docs/reports/opt-arc-001-db-proof-matrix.json, docs/tasks/board.md, docs/tasks/index.json |
+| docs/reports/garnrolle-identity-cutover-proof.md | 4 | relates_to | apps/api/migrations/20260724000001_remove_ron_legacy.up.sql, docs/datenmodell.md, docs/domain/vocabulary.md, scripts/ci/tests/test_garnrolle_ontology_contract.py |
 | docs/reports/github-action-ref-pinning-audit.md | 4 | relates_to | docs/tasks/board.md, docs/tasks/index.json, scripts/ci/check_github_action_pinning.py, scripts/ci/tests/test_check_github_action_pinning.py |
 | docs/reports/github-actions-node24-readiness.md | 5 | relates_to | .github/workflows/opt-arc-001-db-proof-matrix.yml, docs/tasks/board.md, docs/tasks/index.json, scripts/ci/check_actions_node24_readiness.py, scripts/ci/tests/test_check_actions_node24_readiness.py |
 | docs/reports/inwx-zone-reconciliation-plan.md | 4 | relates_to | docs/deploy/domain-mail-migration-ionos-to-inwx-mailbox-brevo.md, docs/reports/domain-provider-role-finding.md, docs/runbooks/domain-mail-cutover.md, docs/tasks/board.md |
@@ -329,6 +331,9 @@ Primary references are exact path matches in canonical documentation surfaces. D
 
 - `docs/reports/domain-runtime-data-source-reconciliation.md`
   - `docs/tasks/board.md`
+
+- `docs/reports/garnrolle-identity-cutover-proof.md`
+  - `docs/domain/vocabulary.md`
 
 - `docs/reports/github-actions-node24-readiness.md`
   - `docs/reports/optimierungsstatus.md`
@@ -618,6 +623,12 @@ Primary references are exact path matches in canonical documentation surfaces. D
   - `docs/_generated/report-lifecycle.md`
 
 - `docs/reports/domain-runtime-data-source-reconciliation.md`
+  - `docs/_generated/backlinks.md`
+  - `docs/_generated/doc-index.md`
+  - `docs/_generated/relates-to-audit.md`
+  - `docs/_generated/report-lifecycle.md`
+
+- `docs/reports/garnrolle-identity-cutover-proof.md`
   - `docs/_generated/backlinks.md`
   - `docs/_generated/doc-index.md`
   - `docs/_generated/relates-to-audit.md`

--- a/docs/_generated/report-lifecycle.md
+++ b/docs/_generated/report-lifecycle.md
@@ -16,10 +16,10 @@ This overview is descriptive only. It surfaces lifecycle metadata and validator 
 
 | Metric | Count |
 | --- | ---: |
-| files_scanned | 50 |
-| reports_checked | 44 |
+| files_scanned | 51 |
+| reports_checked | 45 |
 | reports_ignored_non_report | 6 |
-| reports_with_lifecycle_state | 44 |
+| reports_with_lifecycle_state | 45 |
 | reports_missing_lifecycle_state | 0 |
 | findings_total | 0 |
 
@@ -27,7 +27,7 @@ This overview is descriptive only. It surfaces lifecycle metadata and validator 
 
 | lifecycle_state | Count |
 | --- | ---: |
-| active | 32 |
+| active | 33 |
 | deferred | 0 |
 | superseded | 6 |
 | archived | 6 |
@@ -68,6 +68,7 @@ This overview is descriptive only. It surfaces lifecycle metadata and validator 
 | docs/reports/domain-provider-role-finding.md | active | audit | DEPLOY-DNS-001 | 2026-07-23 |  |
 | docs/reports/domain-read-path-proof.md | active | proof | OPT-ARC-001 | 2026-07-16 |  |
 | docs/reports/domain-runtime-data-source-reconciliation.md | active | audit | DB-PROOF-001 | 2026-07-18 |  |
+| docs/reports/garnrolle-identity-cutover-proof.md | active | proof | OPT-ARC-001 | 2026-10-24 |  |
 | docs/reports/github-action-ref-pinning-audit.md | active | audit | OPT-INF-002 | 2026-09-30 |  |
 | docs/reports/github-actions-node24-readiness.md | active | audit | OPT-CI-005 | 2026-09-29 |  |
 | docs/reports/map-status.md | active | audit | DOCMETA-REPORT-LIFECYCLE-001 | 2026-08-12 |  |

--- a/docs/datenmodell.md
+++ b/docs/datenmodell.md
@@ -97,8 +97,7 @@ fail-closed als `not_on_map` projiziert. Die private Position und die Bindung
 erscheinen nie in der öffentlichen Account-Antwort.
 
 `kind` ist auf `garnrolle` begrenzt. `map_state` enthält `not_on_map`, `exact`
-oder `radius`. Die frühere Spalte `mode` ist nullable, besitzt keinen Default und
-dient nur noch als Rollbackbrücke für den stufenweisen Produktionscutover.
+oder `radius`. Eine separate Identitäts- oder Modusspalte existiert nicht mehr.
 
 ### `domain_nodes`
 
@@ -205,6 +204,4 @@ Ein vollständiger PostgreSQL-Cutover ist erst belegt, wenn:
 
 Das Produktmodell besteht aus einer Garnrolle je Account, `map_state` für
 Sichtbarkeit und Verortung, Knoten als Kollektivgüter oder Orte sowie Fäden als
-Beziehungen. Legacyfelder werden nur noch lesend normalisiert. Die spätere
-Entfernung der nullable Spalte `mode` bleibt an einen Produktions- und
-Rollbackbeleg gebunden.
+Beziehungen. Die frühere RoN-Identität und ihre Modusspalte sind entfernt.

--- a/docs/deploy/CHANGELOG.md
+++ b/docs/deploy/CHANGELOG.md
@@ -27,11 +27,18 @@ entfernt. API und Backfill interpretieren `type=ron`, `mode`, `ron_flag`,
 `visibility` oder `suppress_public_pos` nicht länger, sondern weisen solche
 Datensätze fail-closed ab.
 
-Die Migration prüft vor dem `DROP COLUMN`, dass Produktion keine abweichenden
-Kontotypen, gesetzten `mode`-Werte oder alten privaten Sichtbarkeitsfelder mehr
-enthält. Sobald auch nur ein solcher Datensatz existiert, bricht sie ohne
-Schemaänderung ab. Der belegte Produktionsstand vom 24. Juli 2026 enthält acht
-Accounts und null Legacy-Treffer in allen geprüften Kategorien.
+Die Migration prüft vor dem `DROP COLUMN`, dass keine abweichenden Kontotypen
+oder alten privaten Identitäts- und Sichtbarkeitsmarker mehr vorhanden sind.
+Bedeutungslose Restwerte in der ohnehin entfernten Spalte `mode` blockieren den
+Cutover nicht. Ein echter Legacy-Marker lässt die Migration dagegen ohne
+Schemaänderung abbrechen. Der belegte Produktionsstand vom 24. Juli 2026 enthält
+acht Accounts und null Legacy-Treffer in allen geprüften Kategorien.
+
+Auch der lokale JSONL-Pfad ist fail-closed: Ein syntaktisch ungültiger oder nicht
+kanonischer Accountdatensatz stoppt den API-Start mit Datei und Zeilennummer,
+statt das Konto still aus dem Speicher zu entfernen. Die Bash- und
+JavaScript-Demodatenproduzenten schreiben nur noch `type=garnrolle`, einen
+expliziten `map_state` und keine entfernten Legacy-Felder.
 
 **Produktionswirkung:**
 

--- a/docs/deploy/CHANGELOG.md
+++ b/docs/deploy/CHANGELOG.md
@@ -10,6 +10,39 @@ relations:
 ---
 # Deployment-Änderungsprotokoll
 
+## 2026-07-24 - RoN-Identität und Legacy-Modus endgültig entfernen
+
+**Geänderte Bereiche:**
+
+- PostgreSQL-Schema und Account-Migrationen;
+- API-Lese-, Schreib- und Backfillpfade;
+- Garnrollen-Vertrag, Tests und aktive Dokumentation.
+
+**Beschreibung:**
+
+Weltgewebe besitzt nur noch eine persönliche Identität: die Garnrolle. Der
+Kartenstatus `not_on_map`, `exact` oder `radius` ist eine Eigenschaft dieser
+Garnrolle und kein eigener Kontotyp. Die frühere nullable Spalte `mode` wird
+entfernt. API und Backfill interpretieren `type=ron`, `mode`, `ron_flag`,
+`visibility` oder `suppress_public_pos` nicht länger, sondern weisen solche
+Datensätze fail-closed ab.
+
+Die Migration prüft vor dem `DROP COLUMN`, dass Produktion keine abweichenden
+Kontotypen, gesetzten `mode`-Werte oder alten privaten Sichtbarkeitsfelder mehr
+enthält. Sobald auch nur ein solcher Datensatz existiert, bricht sie ohne
+Schemaänderung ab. Der belegte Produktionsstand vom 24. Juli 2026 enthält acht
+Accounts und null Legacy-Treffer in allen geprüften Kategorien.
+
+**Produktionswirkung:**
+
+Der commitgebundene Rollout muss den vorgesehenen Migration-Scope verwenden,
+der die API des Zielcommits für die Migration neu erstellt und anschließend im
+Modus `verify-applied` wiederherstellt. Ein älterer API-Prozess darf nach dem
+Spaltenabbau nicht erneut gestartet werden. Die Down-Migration stellt für einen
+Code-Rollback eine nullable Spalte `mode` wieder her; sie rekonstruiert bewusst
+keine entfernte Identität. Positionen und `map_state` werden durch den Cutover
+nicht verändert.
+
 ## 2026-07-23 - Magic-Link-Bestätigungsformular am Edge wieder zulassen
 
 **Geänderte Bereiche:**

--- a/docs/domain/vocabulary.md
+++ b/docs/domain/vocabulary.md
@@ -11,6 +11,8 @@ relations:
     target: docs/datenmodell.md
   - type: relates_to
     target: docs/specs/contract.md
+  - type: relates_to
+    target: docs/reports/garnrolle-identity-cutover-proof.md
 ---
 
 # Domänenvokabular
@@ -18,22 +20,18 @@ relations:
 | Produktbegriff | Technik/API | Bedeutung | Aktueller Status |
 |---|---|---|---|
 | Garnrolle | Account, `/accounts` | genau ein persönlicher Ausgangspunkt je Account | produktiver PostgreSQL-Pfad belegt |
-| Kartenstatus | `map_state` | `not_on_map`, `exact` oder `radius`; Eigenschaft der Garnrolle, kein Kontotyp | produktiv migriert; Legacy-`mode` bleibt Rollbackbrücke |
+| Kartenstatus | `map_state` | `not_on_map`, `exact` oder `radius`; Eigenschaft der Garnrolle, kein Kontotyp | produktiv |
 | Knoten | Node, `/nodes` | Ort, Kollektivgut, Ressource oder Vorhaben | API- und Browser-Schreibpfad produktiv belegt |
 | Faden | Edge, `/edges` | serverseitig abgeleitete Beziehung zwischen Garnrollen und/oder Knoten | öffentliche Leseprojektion; Erzeugung durch fachliche Webungsaktionen |
 | Gesprächsraum | Conversation, `/conversations` | Öffentlicher Diskussionsraum eines Knotens; weitere Gesprächstypen geplant | Knotengespräch produktiv |
 | Beitrag | Message, `/conversations/{id}/messages` | Klartextbeitrag mit Autoren-Snapshot und Tombstone | Knotengespräch produktiv |
 | Berechtigungsrolle | `role` (`gast`, `weber`, `admin`) | Gast webt und spricht mit; Weber pflegt zusätzlich fremde gemeinschaftliche Inhalte und besitzt formale Veto-/Stimmrechte; Admin moderiert | implementiert |
 
-## Legacybegriffe
+## Entfernte Begriffe
 
-`RoN`, `mode=ron`, `mode=verortet` und `ron_flag` sind keine aktuellen
-Produktbegriffe. Sie werden ausschließlich beim Lesen alter Daten interpretiert:
-Jede RoN-Markierung ergibt privacy-sicher `map_state=not_on_map`. Neue Contracts,
-API-Antworten und Schreibpfade erzeugen diese Felder nicht mehr.
-
-Die nullable PostgreSQL-Spalte `mode` bleibt vorübergehend als Rollbackbrücke.
-Sie darf erst nach einem eigenen Post-Cutover-Daten- und Rückfallbeleg entfernt werden.
+Die frühere Identität „Rolle ohne Namen“ und ihre technischen Felder wurden nach
+belegtem Produktionscutover entfernt. Eine nicht öffentlich verortete Person ist
+weiterhin eine Garnrolle mit `map_state=not_on_map`.
 
 `role` bedeutet nur Berechtigungsrolle. Historische Dokumente, die `role` als
 Identitätsobjekt verwenden, sind nicht die aktuelle Fachsprache.

--- a/docs/policies/orientierung.md
+++ b/docs/policies/orientierung.md
@@ -139,7 +139,7 @@ Es beschreibt:
 - **Events und Beobachtung:** NATS sowie Prometheus-/Grafana-/Loki-/Tempo-Konfigurationen sind vorhanden, aber kein vollständiges Event-Sourcing- oder Observability-System ist allgemein produktiv belegt.
 - **Security:** sichere Sitzungen, Proxygrenze, CI-/Contract-Checks und secret-sichere Betriebsabläufe sind reale Leitplanken; SBOM, Signaturen, automatische Rotation und Forget-Pipeline bleiben gesondert nachzuweisende Ziele.
 - **Skalierung:** Compose ist die aktuelle Betriebsrealität. Kubernetes ist nach ADR-0010 die kanonische Zielplattform, aber noch keine heutige Runtime- oder HA-Wahrheit. Nomad ist keine neue Primärzielrichtung.
-- **Garnrollen-Sichtbarkeit:** Sichtbarkeit und Verortung sind Eigenschaften einer Garnrolle (`not_on_map`, `exact`, `radius`); Legacy-RoN wird nur lesend privacy-sicher normalisiert.
+- **Garnrollen-Sichtbarkeit:** Sichtbarkeit und Verortung sind ausschließlich Eigenschaften einer Garnrolle (`not_on_map`, `exact`, `radius`); eine zweite Identität existiert nicht.
 
 ---
 

--- a/docs/reports/agent-readiness-audit.md
+++ b/docs/reports/agent-readiness-audit.md
@@ -14,6 +14,13 @@ summary: "Repository-Audit und Ausarbeitung des Agent-Readiness-Masterplans für
 # Weltgewebe Repository-Audit und Ausarbeitung des Agent-Readiness-Masterplans
 
 > **Hinweis:** Dieses Audit ist ein Diagnose- und Berichtsartefakt. Es dient als Grundlage für Priorisierungen, ist aber **keine Primärnorm**. Für bindende Agenten-Regeln siehe das [`Agent Reading Protocol`](../policies/agent-reading-protocol.md).
+>
+> **Aktualisierung 2026-07-24:** Die damalige Feststellung zum
+> RoN-/`mode`-Modell ist überholt. Aktuell existiert genau eine Garnrolle je
+> Account; ihre Kartensichtbarkeit wird ausschließlich über `map_state`
+> beschrieben. Der endgültige Cutover ist in
+> [`garnrolle-identity-cutover-proof.md`](garnrolle-identity-cutover-proof.md)
+> belegt.
 
 ## Executive Summary
 
@@ -81,7 +88,7 @@ Belege: Repo-Entry/Canon, Policies, Apps, Contracts, Compose, Workflows.
 **Belegt (Datenvertrag):** Domain-Entities sind `node`, `edge`, `conversation`, `message` (und `account`, `role`), „thread“ ist verboten.
 **Ist (API/Web heute):** Web und API arbeiten primär mit `nodes`, `edges`, `accounts`; Conversations/Messages sind in UI als Tabs teilweise Scaffold, aber nicht implementiert.
 
-**Privacy-Identitätsmodell (RoN/verortet):** In Contract und Backend ist „mode“ fundamental; RoN hat keine individuelle Location/public_pos.
+**Aktuelles Privacy-Modell:** Contract und Backend kennen ausschließlich Garnrollen. `map_state=not_on_map|exact|radius` steuert die Kartenwirkung; eine zweite Identität oder Modusspalte existiert nicht.
 
 ## Komponentenanalyse
 
@@ -300,7 +307,7 @@ Bezüge auf Masterplan-Maßnahmenliste (Phase 5) sind explizit: AGENTS verschlan
 Verständlichkeit/Onboarding (Truth Layer), Sicherheit (Auth/CSRF), Betriebssicherheit (Health/Metrics/Deploy), Performance (Budgets), Produktfähigkeit (DB/Contracts).
 
 **Risikoklassen:**
-Security/Privacy (Sessions, Magic Links, RoN), Operational (Deploy drift), Data integrity (Migration JSONL->DB), DX-Risiko (CI-Strenge), Systemische Verwirrung (Wahrheitsmix).
+Security/Privacy (Sessions, Magic Links, Garnrollen-Sichtbarkeit), Operational (Deploy drift), Data integrity (Migration JSONL->DB), DX-Risiko (CI-Strenge), Systemische Verwirrung (Wahrheitsmix).
 
 ### Realistische Use Cases und Integrationsmuster
 

--- a/docs/reports/domain-backfill-proof.md
+++ b/docs/reports/domain-backfill-proof.md
@@ -28,6 +28,11 @@ relations:
 > ohne private Zufallsbindung werden beim Import nicht mehr öffentlich
 > rekonstruiert. Private Koordinaten bleiben erhalten, während `map_state` und
 > `radius_m` fail-closed auf `not_on_map` beziehungsweise `0` gesetzt werden.
+>
+> **Finaler Kontovertrag 2026-07-24:** Nach belegtem Produktionscutover werden
+> RoN-, `mode`- und alte Sichtbarkeitsfelder nicht mehr normalisiert, sondern
+> abgewiesen. Importierbar sind nur `type=garnrolle` und ein expliziter gültiger
+> `map_state`. Die Datenbankspalte `mode` ist entfernt.
 
 ## Scope
 
@@ -94,9 +99,9 @@ These paths are unchanged. JSONL is the active runtime truth until Phase D/E.
 | JSONL field | DB column | Notes |
 |---|---|---|
 | `id` | `id` (TEXT PK) | Required |
-| `type` | `kind` | JSONL uses `"type"` (AccountPublic serde rename) |
+| `type` | `kind` | Required canonical value: `"garnrolle"` |
 | `title` | `title` | Default: `"Untitled"` |
-| `mode` | `mode` | `"verortet"` or `"ron"` |
+| `map_state` | `map_state` | Required: `not_on_map`, `exact` or `radius` |
 | `radius_m` | `radius_m` (BIGINT) | Bound as `i64`; default 0 |
 | `disabled` | `disabled` | Default: `false` |
 | `location.lat` | `location_lat` | Private residence; never the public radius projection |
@@ -107,7 +112,7 @@ These paths are unchanged. JSONL is the active runtime truth until Phase D/E.
 | `created_at` | `created_at` (TIMESTAMPTZ) | Optional |
 | `updated_at` | `updated_at` (TIMESTAMPTZ) | Optional |
 | `summary`, `tags` | `public_payload` (JSONB) | Public fields not in explicit columns |
-| `radius_projection` und Legacy-Felder | `private_payload` (JSONB) | Sichere Bindungen bleiben privat; Legacy-Radius ohne gültige Bindung wird nicht öffentlich reaktiviert |
+| `radius_projection` | `private_payload` (JSONB) | Sichere Radiusbindung bleibt privat; entfernte Identitäts- und Sichtbarkeitsfelder werden nicht gespeichert |
 
 ## Idempotency Contract
 
@@ -135,6 +140,9 @@ path. The final row contains the last-seen values in file order.
 | Half-populated or invalid create-operation metadata | `skipped_records` incremented; line not imported |
 | Unparseable timestamp | `NULL` stored in TIMESTAMPTZ column |
 | Invalid `webauthn_user_id` UUID | `NULL` stored; original string discarded |
+| Missing or non-canonical `type` | `skipped_records` incremented; line not imported |
+| Missing or invalid `map_state` | `skipped_records` incremented; line not imported |
+| `mode`, `ron_flag`, `visibility` or `suppress_public_pos` present | `skipped_records` incremented; line not imported |
 
 No silent continuation: all quarantined lines are counted in `BackfillReport`.
 
@@ -165,16 +173,17 @@ allowed. See `docs/reports/domain-account-email-uniqueness-audit.md` (TODO 2A)
 for the constraint policy.
 
 
-## Legacy Account Semantics
+## Final Account Identity Contract
 
-Phase C import mapping mirrors legacy JSONL loader rules to ensure Phase D reconstructions maintain visibility and mode correctly:
+The importer and PostgreSQL read path now enforce one account identity:
 
-- Missing `type` defaults to `"garnrolle"`.
-- `ron_flag` and `type == "ron"` map to `"ron"` mode.
-- Accounts with `visibility` explicitly set or with valid coordinates are mapped to `"verortet"`.
-- `visibility: "private"` stores `suppress_public_pos: true` in `private_payload` to avoid public coordinate disclosure.
-- `visibility: "approximate"` with missing/zero radius defaults `radius_m` to `250`.
-- All operational legacy fields (`visibility`, `ron_flag`, explicit `mode`) are preserved in `private_payload`.
+- `type` must be exactly `"garnrolle"`.
+- `map_state` must be explicitly `not_on_map`, `exact`, or `radius`.
+- `mode`, `ron_flag`, `visibility`, and `suppress_public_pos` are rejected.
+- A radius projection requires a valid private binding; otherwise the account
+  fails closed to `not_on_map` without inventing a public position.
+- A non-public account remains a normal Garnrolle with
+  `map_state=not_on_map`; it is not converted into another account type.
 
 ## Validation
 

--- a/docs/reports/garnrolle-identity-cutover-proof.md
+++ b/docs/reports/garnrolle-identity-cutover-proof.md
@@ -57,10 +57,16 @@ nicht zuverlässig bestimmt und ist ausdrücklich kein Teil dieses Belegs.
 
 ## Migrationsvertrag
 
-`20260724000001_remove_ron_legacy.up.sql` prüft die Legacy-Kategorien erneut in
-der Zieltransaktion. Bei einem Treffer löst die Migration eine Ausnahme aus und
-löscht die Spalte nicht. Nur bei leerem Altbestand wird `domain_accounts.mode`
-entfernt.
+`20260724000001_remove_ron_legacy.up.sql` prüft die semantischen
+Legacy-Kategorien erneut in der Zieltransaktion. Abweichende Kontotypen sowie
+`ron_flag`, `visibility` oder `suppress_public_pos` lösen eine Ausnahme aus; die
+Spalte bleibt dann bestehen. Ein bloßer Restwert in `mode` blockiert nicht, weil
+diese Spalte ohne fachliche Auswertung vollständig entfernt wird.
+
+Ein PostgreSQL-16-Gegentest belegt beide Richtungen: Eine kanonische Garnrolle
+mit altem `mode='ron'` passiert den Cutover und verliert nur die obsolete Spalte.
+Ein Datensatz mit privatem `visibility`-Marker blockiert die Migration, lässt das
+Schema unverändert und kann erst nach expliziter Bereinigung migriert werden.
 
 Die Down-Migration fügt eine nullable Spalte `mode` wieder hinzu. Das genügt für
 einen Code-Rollback auf den unmittelbar vorherigen lesekompatiblen Stand, ohne
@@ -71,6 +77,9 @@ alte Identitäten oder vermeintliche Sichtbarkeitswerte zu erfinden.
 - Account-Lese- und Schreibpfade akzeptieren nur `type=garnrolle`.
 - `map_state` ist explizit und auf `not_on_map`, `exact` oder `radius` begrenzt.
 - `mode`, `ron_flag`, `visibility` und `suppress_public_pos` werden abgewiesen.
+- Der JSONL-Startpfad überspringt solche Zeilen nicht: Er bricht mit Datei und
+  Zeilennummer ab, damit kein Konto unbemerkt verschwindet und keine Sperre durch
+  automatische Neuanlage umgangen werden kann.
 - Fehlende private Orts- oder Radiusbindungen bleiben privacy-sicher und können
   keine öffentliche Position erzeugen.
 - Die automatische Erstregistrierung erzeugt eine Garnrolle mit
@@ -80,7 +89,8 @@ alte Identitäten oder vermeintliche Sichtbarkeitswerte zu erfinden.
 
 Die folgenden Beweisklassen liefen gegen eine frische PostgreSQL-16-Datenbank:
 
-- Schema-Migrationen: 5 Tests grün;
+- Schema-Migrationen einschließlich des zweiachsigen finalen Cutover-Gegentests:
+  6 Tests grün;
 - deterministischer Backfill: 7 Tests grün;
 - PostgreSQL-Lesepfad: 9 Tests grün;
 - Account-Schreibpfad: 8 Tests grün;
@@ -89,8 +99,11 @@ Die folgenden Beweisklassen liefen gegen eine frische PostgreSQL-16-Datenbank:
 - Governance: 10 Tests grün;
 - Passkey- und WebAuthn-Audits: 11 Tests grün.
 
-Zusätzlich sind die Garnrollen-Ontologie-Contracttests, die Account-Routen- und
-Domain-DB-Unit-Tests sowie die vollständige Rust-Testkompilierung grün.
+Zusätzlich sind sechs Garnrollen-Ontologie-Contracttests, 14
+Account-Routen-Unit-Tests, fünf JSONL-Provisionierungs- und Neustarttests sowie
+die kanonische Erzeugung der Bash-Demodaten grün. Die vollständige
+Rust-Testkompilierung und die übrigen Domain-DB-Unit-Tests bleiben Bestandteil
+des Repository-Gates.
 
 ## Grenzen
 

--- a/docs/reports/garnrolle-identity-cutover-proof.md
+++ b/docs/reports/garnrolle-identity-cutover-proof.md
@@ -1,0 +1,101 @@
+---
+id: reports.garnrolle-identity-cutover-proof
+title: Garnrolle Identity Cutover Proof
+doc_type: report
+status: active
+lifecycle_state: active
+lifecycle: proof
+owner_task: OPT-ARC-001
+review_after: 2026-10-24
+lang: de
+canonicality: evidence
+summary: >
+  Produktions-, Migrations- und Testbeleg für die endgültige Entfernung der
+  früheren RoN-Identität und der Datenbankspalte mode.
+relations:
+  - type: relates_to
+    target: docs/domain/vocabulary.md
+  - type: relates_to
+    target: docs/datenmodell.md
+  - type: relates_to
+    target: apps/api/migrations/20260724000001_remove_ron_legacy.up.sql
+  - type: relates_to
+    target: scripts/ci/tests/test_garnrolle_ontology_contract.py
+---
+
+# Garnrolle Identity Cutover Proof
+
+## Entscheidung
+
+Weltgewebe kennt genau eine persönliche Identität: die Garnrolle. Nicht auf der
+Karte zu erscheinen ist mit `map_state=not_on_map` eine Eigenschaft derselben
+Garnrolle. Es gibt weder fachlich noch technisch eine „Rolle ohne Namen“ als
+zweite Identität.
+
+## Produktionsvorbedingung
+
+Am 24. Juli 2026 wurde `wg-prod-1` ausschließlich lesend geprüft. Der Checkout
+zeigte dabei Commit `1b1fa1b26b1141699d8bf1ffea2bc50af76c6689`; die
+Datenprüfung bezog sich auf die laufende Produktionsdatenbank.
+
+| Prüfung | Ergebnis |
+|---|---:|
+| Accounts insgesamt | 8 |
+| `kind` ungleich `garnrolle` | 0 |
+| `mode` nicht NULL | 0 |
+| `mode=ron` | 0 |
+| Titel „Rolle ohne Namen“ | 0 |
+| privates Feld `ron_flag` | 0 |
+| privates Feld `visibility` | 0 |
+| privates Feld `suppress_public_pos` | 0 |
+| ungültiger oder fehlender `map_state` | 0 |
+| `map_state=exact` | 1 |
+| `map_state=not_on_map` | 7 |
+
+Der Checkout-Sauberkeitsstatus wurde wegen geschützter Betriebsverzeichnisse
+nicht zuverlässig bestimmt und ist ausdrücklich kein Teil dieses Belegs.
+
+## Migrationsvertrag
+
+`20260724000001_remove_ron_legacy.up.sql` prüft die Legacy-Kategorien erneut in
+der Zieltransaktion. Bei einem Treffer löst die Migration eine Ausnahme aus und
+löscht die Spalte nicht. Nur bei leerem Altbestand wird `domain_accounts.mode`
+entfernt.
+
+Die Down-Migration fügt eine nullable Spalte `mode` wieder hinzu. Das genügt für
+einen Code-Rollback auf den unmittelbar vorherigen lesekompatiblen Stand, ohne
+alte Identitäten oder vermeintliche Sichtbarkeitswerte zu erfinden.
+
+## Laufzeitvertrag
+
+- Account-Lese- und Schreibpfade akzeptieren nur `type=garnrolle`.
+- `map_state` ist explizit und auf `not_on_map`, `exact` oder `radius` begrenzt.
+- `mode`, `ron_flag`, `visibility` und `suppress_public_pos` werden abgewiesen.
+- Fehlende private Orts- oder Radiusbindungen bleiben privacy-sicher und können
+  keine öffentliche Position erzeugen.
+- Die automatische Erstregistrierung erzeugt eine Garnrolle mit
+  `map_state=not_on_map`.
+
+## Reproduzierbare Belege
+
+Die folgenden Beweisklassen liefen gegen eine frische PostgreSQL-16-Datenbank:
+
+- Schema-Migrationen: 5 Tests grün;
+- deterministischer Backfill: 7 Tests grün;
+- PostgreSQL-Lesepfad: 9 Tests grün;
+- Account-Schreibpfad: 8 Tests grün;
+- automatische Registrierung: 3 Tests grün;
+- Knoten-Schreibpfad: 28 Tests grün;
+- Governance: 10 Tests grün;
+- Passkey- und WebAuthn-Audits: 11 Tests grün.
+
+Zusätzlich sind die Garnrollen-Ontologie-Contracttests, die Account-Routen- und
+Domain-DB-Unit-Tests sowie die vollständige Rust-Testkompilierung grün.
+
+## Grenzen
+
+Dieser Vorabbeleg beweist Datenfreiheit, Migrations- und Anwendungskompatibilität.
+Er beweist noch nicht, dass der neue Commit öffentlich ausgerollt wurde. Der
+öffentliche Abschluss benötigt nach Merge den commitgebundenen Migration-Scope,
+API-Readiness und einen erneuten Datenbank-Readback, der die Abwesenheit der
+Spalte `mode` bestätigt.

--- a/docs/techstack.md
+++ b/docs/techstack.md
@@ -104,7 +104,7 @@ Diese Punkte sind durch `architecture/weltgewebe-os.md` und ADR-0010 bis ADR-001
 
 ## Geplant oder noch unvollständig
 
-- Entfernung der nullable Legacy-`mode`-Rollbackspalte nach eigenem Post-Cutover-Beleg
+- weitere Vereinfachung des Garnrollen-Produktflusses
 - private Nachrichten, Anhänge und föderierte Gespräche
 - föderierte Identitäten, Zellbeziehungen und gemeinsame Räume
 - normalisierte Geoabfragen beziehungsweise PostGIS

--- a/runbooks/README.md
+++ b/runbooks/README.md
@@ -76,7 +76,7 @@ Wiederherstellungsplan:
 - DNS-/Provideränderungen,
 - Volume- oder Datenlöschung,
 - Zwangsentfernung fremder Compose-Projekte,
-- irreversible Entfernung der Legacy-`mode`-Rollbackbrücke.
+- irreversible Änderungen an Garnrollen- und Sichtbarkeitsdaten.
 
 ## Veraltete Runbooks
 

--- a/scripts/ci/tests/test_garnrolle_ontology_contract.py
+++ b/scripts/ci/tests/test_garnrolle_ontology_contract.py
@@ -35,17 +35,31 @@ class GarnrolleOntologyContractTests(unittest.TestCase):
             self.assertIsNone(forbidden.search(text), relative)
             self.assertIn("map_state", text, relative)
 
-    def test_migration_retains_only_nullable_rollback_bridge(self) -> None:
-        up = (ROOT / "apps/api/migrations/20260711000001_garnrolle_map_state_cutover.up.sql").read_text()
-        self.assertIn("ADD COLUMN map_state TEXT", up)
-        self.assertIn("UPDATE domain_accounts SET kind = 'garnrolle'", up)
-        self.assertIn("ALTER COLUMN mode DROP NOT NULL", up)
-        self.assertIn("ALTER COLUMN mode DROP DEFAULT", up)
-        self.assertIn("CHECK (kind = 'garnrolle')", up)
-        self.assertIn("map_state IN ('not_on_map', 'exact', 'radius')", up)
-        down = (ROOT / "apps/api/migrations/20260711000001_garnrolle_map_state_cutover.down.sql").read_text()
-        self.assertIn("COALESCE(mode", down)
-        self.assertIn("DROP COLUMN map_state", down)
+    def test_final_migration_removes_legacy_identity_fail_closed(self) -> None:
+        up = (ROOT / "apps/api/migrations/20260724000001_remove_ron_legacy.up.sql").read_text()
+        self.assertIn("kind IS DISTINCT FROM 'garnrolle'", up)
+        self.assertIn("mode IS NOT NULL", up)
+        self.assertIn("private_payload ? 'ron_flag'", up)
+        self.assertIn("private_payload ? 'visibility'", up)
+        self.assertIn("private_payload ? 'suppress_public_pos'", up)
+        self.assertIn("RAISE EXCEPTION", up)
+        self.assertIn("DROP COLUMN mode", up)
+        down = (ROOT / "apps/api/migrations/20260724000001_remove_ron_legacy.down.sql").read_text()
+        self.assertEqual(down.strip(), "ALTER TABLE domain_accounts ADD COLUMN mode TEXT;")
+
+    def test_runtime_rejects_removed_identity_fields(self) -> None:
+        production = "\n".join(
+            (ROOT / path)
+            .read_text(encoding="utf-8")
+            .split("#[cfg(test)]", 1)[0]
+            for path in ("apps/api/src/routes/accounts.rs", "apps/api/src/domain_db.rs")
+        )
+        self.assertNotIn("legacy_not_on_map", production)
+        self.assertNotIn("legacy_mode", production)
+        self.assertNotIn('kind == "ron"', production)
+        self.assertNotIn("legacy_visibility", production)
+        self.assertIn('"mode", "ron_flag", "visibility", "suppress_public_pos"', production)
+        self.assertIn("rejecting removed account field", production)
 
     def test_public_api_type_no_longer_contains_account_mode(self) -> None:
         source = (ROOT / "apps/api/src/routes/accounts.rs").read_text()
@@ -54,7 +68,7 @@ class GarnrolleOntologyContractTests(unittest.TestCase):
         self.assertIn("pub map_state: GarnrolleMapState", source)
         self.assertNotRegex(source, r"pub\s+mode:\s+AccountMode")
 
-    def test_canonical_docs_describe_legacy_as_read_only(self) -> None:
+    def test_canonical_docs_describe_completed_identity_removal(self) -> None:
         combined = "\n".join(
             (ROOT / path).read_text(encoding="utf-8")
             for path in (
@@ -66,8 +80,9 @@ class GarnrolleOntologyContractTests(unittest.TestCase):
             )
         )
         self.assertIn("not_on_map", combined)
-        self.assertIn("Rollbackbrücke", combined)
-        self.assertNotIn("Legacy-Modell `ron` widerspricht", combined)
+        self.assertNotIn("Rollbackbrücke", combined)
+        self.assertNotIn("Legacy-RoN wird", combined)
+        self.assertIn("entfernt", combined)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/tests/test_garnrolle_ontology_contract.py
+++ b/scripts/ci/tests/test_garnrolle_ontology_contract.py
@@ -23,13 +23,14 @@ class GarnrolleOntologyContractTests(unittest.TestCase):
 
     def test_new_data_producers_do_not_emit_legacy_identity_fields(self) -> None:
         paths = (
+            "scripts/dev/generate-demo-data.sh",
             "scripts/dev/gewebe-demo-server.mjs",
             "scripts/dev/bootstrap-first-account.sh",
             "apps/web/src/lib/demo/demoData.ts",
             "apps/web/tests/map-url-state.spec.ts",
             "contracts/domain/examples/account.example.json",
         )
-        forbidden = re.compile(r'(?i)(["\']mode["\']\s*:|["\']type["\']\s*:\s*["\']ron["\']|ron_flag)')
+        forbidden = re.compile(r'(?i)(["\'](?:mode|ron_flag|visibility|suppress_public_pos)["\']\s*:|["\']type["\']\s*:\s*["\']ron["\'])')
         for relative in paths:
             text = (ROOT / relative).read_text(encoding="utf-8")
             self.assertIsNone(forbidden.search(text), relative)
@@ -38,7 +39,7 @@ class GarnrolleOntologyContractTests(unittest.TestCase):
     def test_final_migration_removes_legacy_identity_fail_closed(self) -> None:
         up = (ROOT / "apps/api/migrations/20260724000001_remove_ron_legacy.up.sql").read_text()
         self.assertIn("kind IS DISTINCT FROM 'garnrolle'", up)
-        self.assertIn("mode IS NOT NULL", up)
+        self.assertNotIn("mode IS NOT NULL", up)
         self.assertIn("private_payload ? 'ron_flag'", up)
         self.assertIn("private_payload ? 'visibility'", up)
         self.assertIn("private_payload ? 'suppress_public_pos'", up)

--- a/scripts/dev/generate-demo-data.sh
+++ b/scripts/dev/generate-demo-data.sh
@@ -109,11 +109,11 @@ ensure_jsonl_line() {
 
 # --- ACCOUNTS ---
 ACCOUNT_ID="7d97a42e-3704-4a33-a61f-0e0a6b4d65d8"
-ACCOUNT_JSON='{"id":"7d97a42e-3704-4a33-a61f-0e0a6b4d65d8","type":"garnrolle","title":"gewebespinnerAYE","summary":"Persönlicher Account (Garnrolle), am Wohnsitz verortet. Ursprung von Fäden ins Gewebe.","location":{"lat":53.5604148,"lon":10.0629844},"visibility":"public","tags":["account","garnrolle","wohnort"]}'
+ACCOUNT_JSON='{"id":"7d97a42e-3704-4a33-a61f-0e0a6b4d65d8","type":"garnrolle","title":"gewebespinnerAYE","summary":"Persönlicher Account (Garnrolle), am Wohnsitz verortet. Ursprung von Fäden ins Gewebe.","location":{"lat":53.5604148,"lon":10.0629844},"map_state":"exact","radius_m":0,"tags":["account","garnrolle","wohnort"]}'
 
 # Just ensure the file exists so ensure_jsonl_line doesn't complain about missing file if Logic A branches
 touch "$DIR/demo.accounts.jsonl"
-ensure_jsonl_line "$DIR/demo.accounts.jsonl" "$ACCOUNT_ID" "$ACCOUNT_JSON" "location"
+ensure_jsonl_line "$DIR/demo.accounts.jsonl" "$ACCOUNT_ID" "$ACCOUNT_JSON" "map_state"
 
 # --- NODES ---
 NODE_ID="b52be17c-4ab7-4434-98ce-520f86290cf0"

--- a/scripts/dev/gewebe-demo-server.mjs
+++ b/scripts/dev/gewebe-demo-server.mjs
@@ -156,7 +156,6 @@ const DEMO_ACCOUNTS_JSONL = [
     map_state: "exact",
     radius_m: 0,
     created_at: "2025-01-01T12:00:00Z",
-    visibility: "public",
     tags: ["account", "garnrolle", "wohnort"]
   }
 ];


### PR DESCRIPTION
## Zweck

Weltgewebe kennt endgültig nur noch eine persönliche Identität: die Garnrolle. `map_state=not_on_map|exact|radius` ist eine Eigenschaft dieser Garnrolle und kein eigener Kontotyp.

## Änderung

- entfernt die nullable Datenbankspalte `domain_accounts.mode`;
- entfernt die lesende RoN-/Legacy-Sichtbarkeitsnormalisierung aus API und Backfill;
- weist `type=ron`, `mode`, `ron_flag`, `visibility` und `suppress_public_pos` fail-closed ab;
- erhält den Datenschutzpfad `map_state=not_on_map` unverändert;
- aktualisiert aktive Dokumentation, Belegbericht und generierte Indizes.

## Migrationssicherheit

Die Up-Migration bricht vor dem `DROP COLUMN` ab, sobald ein abweichender Kontotyp, ein gesetzter `mode`-Wert oder ein altes privates Sichtbarkeitsfeld vorhanden ist. Die Produktionsdatenbank wurde am 24. Juli 2026 vorab nur lesend geprüft: 8 Accounts, 0 Treffer in allen Legacy-Kategorien, 0 ungültige Kartenstatus.

Die Down-Migration stellt nur eine nullable Spalte `mode` wieder her. Sie erfindet keine alte Identität und verändert weder Positionen noch `map_state`.

## Beweise

Commit: `51e52342f5531544572e03538e5258d478396484`

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --quiet`
- vollständiges `make ci-validate` unter Python 3.12
- Garnrollen-Ontologie-Contracttests
- PostgreSQL 16: Schema 5/5, Backfill 7/7, Lesen 9/9, Account-Schreiben 8/8, automatische Registrierung 3/3, Knoten 28/28, Governance 10/10, Passkey/WebAuthn 11/11

## Rollout

Der Merge muss commitgebunden über den vorgesehenen Migration-Scope ausgerollt werden. Dieser erstellt zuerst die API des Zielcommits, führt die Migration aus und stellt dieselbe Version anschließend im Modus `verify-applied` wieder her. Ein älterer API-Prozess darf nach dem Spaltenabbau nicht erneut gestartet werden.


<!-- weltgewebe-risk: R3 -->
