### PR TITLE
fix(search): bind production activation runtime identity

### DIFF
--- a/scripts/ci/tests/test_semantic_search_production_activation.py
+++ b/scripts/ci/tests/test_semantic_search_production_activation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 
@@ -67,6 +68,46 @@ def test_activation_is_commit_locked_identity_bound_and_gate_first() -> None:
     assert "WELTGEWEBE_SEARCH_MIN_CPU_COUNT" in script
     assert "getconf _NPROCESSORS_ONLN" in script
     assert "SemantAH" in script
+
+
+def test_activation_derives_compose_identity_from_the_verified_release_commit() -> None:
+    script = ACTIVATE.read_text(encoding="utf-8")
+    assert 'build_identity_short="${COMMIT:0:8}"' in script
+    assert 'build_timestamp="$(git -C "$release_dir" show -s --format=%cI "$COMMIT")"' in script
+    assert 'export API_VERSION="$build_identity_short"' in script
+    assert 'export WELTGEWEBE_BUILD="$build_identity_short"' in script
+    assert 'export GIT_COMMIT_SHA="$COMMIT"' in script
+    assert 'export BUILD_TIMESTAMP="$build_timestamp"' in script
+    public_readback = script.index('public frontend commit mismatch')
+    identity_export = script.index('export API_VERSION="$build_identity_short"')
+    compose_config = script.index('compose=(docker compose')
+    assert public_readback < identity_export < compose_config
+
+
+def test_activation_compares_canonical_and_unprefixed_model_digests() -> None:
+    script = ACTIVATE.read_text(encoding="utf-8")
+    assert 'local digest="${1#sha256:}"' in script
+    assert '[[ "$digest" =~ ^[0-9a-f]{64}$ ]] || return 1' in script
+    assert 'observed_digest_normalized="$(normalize_sha256_digest "$observed_digest")"' in script
+    assert 'expected_digest_normalized="$(normalize_sha256_digest "$MODEL_REVISION")"' in script
+    assert '[[ "$observed_digest_normalized" == "$expected_digest_normalized" ]]' in script
+    assert '[[ "$observed_digest" == "$MODEL_REVISION" ]]' not in script
+
+
+def test_digest_normalizer_accepts_both_ollama_and_canonical_forms() -> None:
+    script = ACTIVATE.read_text(encoding="utf-8")
+    function = script.split("normalize_sha256_digest() {", 1)[1].split("\n}\n", 1)[0]
+    helper = "normalize_sha256_digest() {" + function + "\n}\n"
+    digest = "df5bd2e3c74cd8d069d21dc038f1b359fcdc9458fce1c99bd43c9eb1518ff907"
+    command = helper + f'normalize_sha256_digest "{digest}"; normalize_sha256_digest "sha256:{digest}"'
+    result = subprocess.run(["bash", "-c", command], check=True, capture_output=True, text=True)
+    assert result.stdout.splitlines() == [digest, digest]
+    malformed = subprocess.run(
+        ["bash", "-c", helper + 'normalize_sha256_digest "sha256:not-a-digest"'],
+        capture_output=True,
+        text=True,
+    )
+    assert malformed.returncode != 0
 
 
 def test_persistent_worker_waits_for_exact_model_and_runs_bounded_batches() -> None:

--- a/scripts/ops/activate-production-search-vps.sh
+++ b/scripts/ops/activate-production-search-vps.sh
@@ -45,6 +45,12 @@ require_command() {
   command -v "$1" > /dev/null 2>&1 || fail "required command not found: $1"
 }
 
+normalize_sha256_digest() {
+  local digest="${1#sha256:}"
+  [[ "$digest" =~ ^[0-9a-f]{64}$ ]] || return 1
+  printf '%s\n' "$digest"
+}
+
 PREVIOUS_GENERATION_ID=""
 semantic_probe_status="unobserved"
 rollback_status="not_attempted"
@@ -135,6 +141,14 @@ remote_main="$(git -C "$SOURCE_CHECKOUT" ls-remote origin refs/heads/main | awk 
 [[ "$(curl -fsS "$API_VERSION_URL" | jq -er '.commit')" == "$COMMIT" ]] || fail "public API commit mismatch"
 [[ "$(curl -fsS "$FRONTEND_VERSION_URL" | jq -er '.commit')" == "$COMMIT" ]] || fail "public frontend commit mismatch"
 
+build_identity_short="${COMMIT:0:8}"
+build_timestamp="$(git -C "$release_dir" show -s --format=%cI "$COMMIT")"
+[[ "$build_timestamp" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|[+-][0-9]{2}:[0-9]{2})$ ]] || fail "release commit timestamp is not valid RFC3339"
+export API_VERSION="$build_identity_short"
+export WELTGEWEBE_BUILD="$build_identity_short"
+export GIT_COMMIT_SHA="$COMMIT"
+export BUILD_TIMESTAMP="$build_timestamp"
+
 available_disk="$(df -B1 --output=avail / | awk 'NR==2 {print $1}')"
 available_memory="$(awk '/^MemAvailable:/ {print $2 * 1024}' /proc/meminfo)"
 available_cpus="$(getconf _NPROCESSORS_ONLN)"
@@ -167,7 +181,9 @@ version_body="$("${compose[@]}" exec -T api wget -qO- "$OLLAMA_URL/api/version")
 [[ "$(jq -er '.version' <<< "$version_body")" == "0.12.6" ]] || fail "Ollama runtime version mismatch"
 tags_body="$("${compose[@]}" exec -T api wget -qO- "$OLLAMA_URL/api/tags")"
 observed_digest="$(jq -er --arg model "$MODEL_ID" '.models[] | select(.name == $model) | .digest' <<< "$tags_body")"
-[[ "$observed_digest" == "$MODEL_REVISION" ]] || fail "Ollama model digest mismatch"
+observed_digest_normalized="$(normalize_sha256_digest "$observed_digest")" || fail "Ollama model digest is malformed"
+expected_digest_normalized="$(normalize_sha256_digest "$MODEL_REVISION")" || fail "pinned Ollama model revision is malformed"
+[[ "$observed_digest_normalized" == "$expected_digest_normalized" ]] || fail "Ollama model digest mismatch"
 
 [[ "$(docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$api_cid" | awk -F= '$1=="WELTGEWEBE_SEARCH_OLLAMA_URL" {print $2}')" == "$OLLAMA_URL/" ]] || fail "API search provider URL is not literal loopback"
 


### PR DESCRIPTION
<!-- weltgewebe-risk: R3 -->

## Ziel

Die produktive T012-Aktivierung soll die bereits verifizierte Release-Identität selbst an `docker compose config` binden und den von Ollama unpräfixiert gelieferten, inhaltlich identischen SHA-256-Digest korrekt vergleichen.

## Nicht-Ziele

Keine Änderung an Modell-ID, Modellrevision, Runtime, Dimension, Generation-ID, Privacy-Vertrag, Rollbackvertrag oder commitgebundener Deploykette.

## Zu bewahrende Invarianten

- Identitätswerte werden erst nach Release-, `origin/main`-, API- und Frontend-Commit-Prüfung exportiert.
- Digest-Vergleich akzeptiert ausschließlich 64 Kleinhex-Zeichen; nur ein optionales `sha256:`-Präfix wird entfernt.
- Ein fremder oder malformed Digest bleibt blockierend.
- Aktivierung und Rollback bleiben fail-closed.

## Fehlerszenarien und Rückfallweg

Ungültiger Release-Zeitstempel, fehlende Compose-Identität, malformed Digest oder Digest-Abweichung brechen vor Generation-Aktivierung ab. Der bestehende Rollbackvertrag bleibt unverändert.

## Prüfungen

- `bash -n scripts/ops/activate-production-search-vps.sh`
- `shfmt -d -i 2 -ci -sr scripts/ops/activate-production-search-vps.sh`
- `shellcheck scripts/ops/activate-production-search-vps.sh`
- `python3 -m pytest -q scripts/ci/tests/test_semantic_search_production_activation.py` → `10 passed`

## Reviewevidenz

R3: zwei unterschiedliche hashgebundene Reviewberichte, mindestens eine Hochrisikoachse. Base `5a5dfa862811b0f11c58baf939780d0761f51152`, Head `480ceafa613278354109e817fac76b2291a0c0ea`.

## Veröffentlichung und Liveprüfung

Nach Merge ausschließlich automatischer Reconciler-Deploy. Anschließend Readback von Release/API/Frontend/Receipt auf den Merge-Commit, Aktivierung der gepinnten Suchgeneration und produktive Privacy-/Suchproben.