### PR TITLE
fix(search): stream activation SQL to psql

### DIFF
--- a/scripts/ci/tests/test_semantic_search_production_activation.py
+++ b/scripts/ci/tests/test_semantic_search_production_activation.py
@@ -59,7 +59,7 @@ def test_activation_is_commit_locked_identity_bound_and_gate_first() -> None:
     assert "active generation has no public semantic probe candidate" in script
     assert "any(.items[]?; .id == $probe_id)" in script
     assert 'semantic_probe_status="candidate_bound"' in script
-    assert 'gate_ready="$(psql_exec -At -v gen=' in script
+    assert 'gate_ready="$(psql_exec_sql ' in script
     assert "rollback_activation()" in script
     assert 'rollback_status="verified"' in script
     assert "rollback could not be verified" in script
@@ -69,6 +69,27 @@ def test_activation_is_commit_locked_identity_bound_and_gate_first() -> None:
     assert "getconf _NPROCESSORS_ONLN" in script
     assert "SemantAH" in script
 
+
+
+def test_activation_routes_psql_variables_through_stdin() -> None:
+    script = ACTIVATE.read_text(encoding="utf-8")
+    helper_body = script.split("psql_exec_sql() {", 1)[1].split("\n}\n", 1)[0]
+    helper = "psql_exec_sql() {" + helper_body + "\n}\n"
+    command = (
+        r"""psql_exec() { printf 'argv=%s\n' "$*" >&2; cat; }
+"""
+        + helper
+        + """psql_exec_sql "SELECT :'gen';" -At -v gen=probe-value
+"""
+    )
+    result = subprocess.run(["bash", "-c", command], check=True, capture_output=True, text=True)
+    assert result.stdout == "SELECT :'gen';\n"
+    assert result.stderr == "argv=-At -v gen=probe-value\n"
+
+    variable_sql_lines = [line for line in script.splitlines() if ":'" in line]
+    assert variable_sql_lines
+    assert all("psql_exec_sql" in line for line in variable_sql_lines)
+    assert all(" -c " not in line and "-Atc" not in line for line in variable_sql_lines)
 
 def test_activation_derives_compose_identity_from_the_verified_release_commit() -> None:
     script = ACTIVATE.read_text(encoding="utf-8")

--- a/scripts/ops/activate-production-search-vps.sh
+++ b/scripts/ops/activate-production-search-vps.sh
@@ -195,6 +195,12 @@ psql_exec() {
   "${compose[@]}" exec -T db psql -v ON_ERROR_STOP=1 -U "$postgres_user" -d "$postgres_db" "$@"
 }
 
+psql_exec_sql() {
+  local sql="$1"
+  shift
+  printf '%s\n' "$sql" | psql_exec "$@"
+}
+
 if ! PREVIOUS_GENERATION_ID="$(psql_exec -Atc "SELECT generation_id FROM search_index_generations WHERE state = 'active' ORDER BY activated_at DESC LIMIT 1;")"; then
   fail "failed to capture previous active search generation"
 fi
@@ -225,7 +231,7 @@ done
 
 [[ "$expected" =~ ^[0-9]+$ && "$completed" == "$expected" ]] || fail "search generation is incomplete"
 
-probe_json="$(psql_exec -At -v gen="$GENERATION_ID" -c "SELECT json_build_object('id', p.node_id, 'title', p.title)::text FROM search_node_projections p JOIN domain_nodes n ON n.id=p.node_id WHERE p.generation_id=:'gen' AND n.search_visibility='public' AND p.status='active' AND p.semantic_state='ready' AND cardinality(p.embedding)=$DIMENSION ORDER BY p.node_id LIMIT 1;")"
+probe_json="$(psql_exec_sql "SELECT json_build_object('id', p.node_id, 'title', p.title)::text FROM search_node_projections p JOIN domain_nodes n ON n.id=p.node_id WHERE p.generation_id=:'gen' AND n.search_visibility='public' AND p.status='active' AND p.semantic_state='ready' AND cardinality(p.embedding)=$DIMENSION ORDER BY p.node_id LIMIT 1;" -At -v gen="$GENERATION_ID")"
 
 probe_node_id=""
 probe_title=""
@@ -238,12 +244,12 @@ else
   echo "Notice: active generation has no public semantic probe candidate"
 fi
 
-gate_ready="$(psql_exec -At -v gen="$GENERATION_ID" -c "SELECT weltgewebe_search_generation_activation_ready(:'gen');")"
+gate_ready="$(psql_exec_sql "SELECT weltgewebe_search_generation_activation_ready(:'gen');" -At -v gen="$GENERATION_ID")"
 [[ "$gate_ready" == "t" ]] || fail "database activation gate rejected generation"
-psql_exec -v gen="$GENERATION_ID" -c "SELECT weltgewebe_activate_search_generation(:'gen');" > /dev/null
+psql_exec_sql "SELECT weltgewebe_activate_search_generation(:'gen');" -v gen="$GENERATION_ID" > /dev/null
 
 verify_activation() {
-  identity_ok="$(psql_exec -v gen="$GENERATION_ID" -v prov="$PROVIDER" -v model="$MODEL_ID" -v rev="$MODEL_REVISION" -v rid="$RUNTIME_IDENTITY" -v dim="$DIMENSION" -Atc "SELECT count(*)=1 FROM search_index_generations WHERE generation_id=:'gen' AND state='active' AND provider=:'prov' AND model_id=:'model' AND model_revision=:'rev' AND runtime_identity=:'rid' AND dimension=:'dim'::integer AND completed_nodes=expected_nodes;")"
+  identity_ok="$(psql_exec_sql "SELECT count(*)=1 FROM search_index_generations WHERE generation_id=:'gen' AND state='active' AND provider=:'prov' AND model_id=:'model' AND model_revision=:'rev' AND runtime_identity=:'rid' AND dimension=:'dim'::integer AND completed_nodes=expected_nodes;" -At -v gen="$GENERATION_ID" -v prov="$PROVIDER" -v model="$MODEL_ID" -v rev="$MODEL_REVISION" -v rid="$RUNTIME_IDENTITY" -v dim="$DIMENSION")"
   [[ "$identity_ok" == "t" ]] || return 1
 
   if [[ "$semantic_probe_status" == "candidate_bound" ]]; then
@@ -280,12 +286,12 @@ rollback_activation() {
   local rollback_ok
   if [[ -n "$PREVIOUS_GENERATION_ID" ]]; then
     if [[ "$PREVIOUS_GENERATION_ID" != "$GENERATION_ID" ]]; then
-      psql_exec -v prev_gen="$PREVIOUS_GENERATION_ID" -c "SELECT weltgewebe_activate_search_generation(:'prev_gen');" > /dev/null || return 1
+      psql_exec_sql "SELECT weltgewebe_activate_search_generation(:'prev_gen');" -v prev_gen="$PREVIOUS_GENERATION_ID" > /dev/null || return 1
     fi
-    rollback_ok="$(psql_exec -At -v prev_gen="$PREVIOUS_GENERATION_ID" -v gen="$GENERATION_ID" -c "SELECT count(*)=1 FROM search_index_generations WHERE generation_id=:'prev_gen' AND state='active' AND (:'prev_gen'=:'gen' OR NOT EXISTS (SELECT 1 FROM search_index_generations WHERE generation_id=:'gen' AND state='active'));")" || return 1
+    rollback_ok="$(psql_exec_sql "SELECT count(*)=1 FROM search_index_generations WHERE generation_id=:'prev_gen' AND state='active' AND (:'prev_gen'=:'gen' OR NOT EXISTS (SELECT 1 FROM search_index_generations WHERE generation_id=:'gen' AND state='active'));" -At -v prev_gen="$PREVIOUS_GENERATION_ID" -v gen="$GENERATION_ID")" || return 1
   else
-    psql_exec -v gen="$GENERATION_ID" -c "BEGIN; SELECT pg_advisory_xact_lock(hashtextextended('weltgewebe.search.generation.activation', 0)); UPDATE search_index_generations SET state='ready', activated_at=NULL WHERE generation_id=:'gen' AND state='active'; COMMIT;" > /dev/null || return 1
-    rollback_ok="$(psql_exec -At -v gen="$GENERATION_ID" -c "SELECT count(*)=1 FROM search_index_generations WHERE generation_id=:'gen' AND state='ready' AND NOT EXISTS (SELECT 1 FROM search_index_generations WHERE state='active');")" || return 1
+    psql_exec_sql "BEGIN; SELECT pg_advisory_xact_lock(hashtextextended('weltgewebe.search.generation.activation', 0)); UPDATE search_index_generations SET state='ready', activated_at=NULL WHERE generation_id=:'gen' AND state='active'; COMMIT;" -v gen="$GENERATION_ID" > /dev/null || return 1
+    rollback_ok="$(psql_exec_sql "SELECT count(*)=1 FROM search_index_generations WHERE generation_id=:'gen' AND state='ready' AND NOT EXISTS (SELECT 1 FROM search_index_generations WHERE state='active');" -At -v gen="$GENERATION_ID")" || return 1
   fi
   [[ "$rollback_ok" == "t" ]]
 }


### PR DESCRIPTION
<!-- weltgewebe-risk: R3 -->

Bureau-Task: WELTGEWEBE-SEMANTIC-SEARCH-V1-T012

## Ziel

Den letzten produktiv belegten T012-Aktivierungsblocker beseitigen, ohne SQL-Inhalt, Suchgeneration, Modellidentität, Privacy-Vertrag oder Rollbacklogik zu verändern.

## Produktionsbefund

Der commitgebundene Aktivierungslauf nach PR #1572 baute die Generation vollständig: 3 erwartete und 3 fertige Knoten, 0 fehlgeschlagene Jobs, Generation `ready`, Aktivierungsgate `true`. Der Lauf stoppte vor dem Cutover.

Ein read-only Produktionsbeweis zeigt die Ursache:

- `psql -v gen=probe-value -c "SELECT :'gen';"` → Exit 1, PostgreSQL-Syntaxfehler am Doppelpunkt
- dieselbe Abfrage über stdin → Exit 0, Ausgabe `probe-value`

`psql` führt seine Variablenersetzung bei diesem Kommandomodus nicht aus; die SQL-Variable erreicht PostgreSQL unverändert.

## Änderung

- ergänzt `psql_exec_sql`, das SQL über stdin an den bestehenden commit- und containergebundenen `psql_exec`-Pfad sendet
- führt ausschließlich die Abfragen mit `:'...'`-Variablen über diesen Pfad aus
- behält `ON_ERROR_STOP`, Provider-/Modell-/Runtime-Prüfungen, Aktivierungsgate, Identitäts-Readback und Rollback unverändert
- ergänzt einen ausführbaren Regressionstest und einen Guard gegen erneute `-c`-/`-Atc`-Nutzung bei psql-Variablen

## Nicht-Ziele

Keine Änderung an Generation-ID, Modell-ID, Modellrevision, Runtime-Identität, Dimension, Dokumentrevision, Ranking, Sichtbarkeit, Suchdaten oder Aktivierungsfunktion.

## Prüfungen

- `bash -n scripts/ops/activate-production-search-vps.sh`
- `shfmt -d -i 2 -ci -sr scripts/ops/activate-production-search-vps.sh`
- `shellcheck scripts/ops/activate-production-search-vps.sh`
- `python3 -m pytest -q scripts/ci/tests/test_semantic_search_production_activation.py` → 11 passed
- `git diff --check`

## Reviewevidenz

R3: zwei unabhängige, revisions- und diffgebundene Reviews auf getrennten Achsen; mindestens eine Hochrisikoachse Security/Privacy.

## Rollout

Nach Merge ausschließlich automatischer Reconciler-Deploy. Danach erneuter commitgebundener Aktivierungslauf, Generation-/Job-/Receipt-Readback, öffentliche Hybrid-Suchprobe, Privacy-Proben, Bureau-Closeout und Bereinigung der eigenen Diagnoseartefakte.