### PR TITLE
ci(kubernetes): bootstrap digest-bound OCI mirror publisher

### DIFF
--- a/.github/workflows/kubernetes-proof-oci-mirror.yml
+++ b/.github/workflows/kubernetes-proof-oci-mirror.yml
@@ -1,6 +1,7 @@
+---
 name: Kubernetes proof OCI mirror publisher
 
-on:
+"on":
   pull_request:
     paths:
       - ".github/workflows/kubernetes-proof-oci-mirror.yml"
@@ -10,7 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       expected_head:
-        description: Full repository commit containing the reviewed mirror seed
+        description: Full reviewed main commit containing the mirror seed
         required: true
         type: string
       expected_seed_sha256:
@@ -22,18 +23,41 @@ permissions:
   contents: read
 
 concurrency:
-  group: kubernetes-proof-oci-mirror-${{ github.event.pull_request.head.sha || inputs.expected_head || github.sha }}
+  group: >-
+    kubernetes-proof-oci-mirror-${{
+      github.event.pull_request.head.sha || inputs.expected_head || github.sha
+    }}
   cancel-in-progress: false
 
 jobs:
   contract:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
+    env:
+      EXPECTED_HEAD: ${{ inputs.expected_head }}
+      EXPECTED_SEED_SHA256: ${{ inputs.expected_seed_sha256 }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # tag: v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # tag: v7.0.0
         with:
           python-version: "3.10"
+      - name: Verify trusted dispatch identity
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = "refs/heads/main"
+          test "$GITHUB_SHA" = "$EXPECTED_HEAD"
+          test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD"
+          main_head="$(gh api repos/heimgewebe/weltgewebe/git/ref/heads/main --jq .object.sha)"
+          test "$main_head" = "$EXPECTED_HEAD"
+          observed_seed="$(sha256sum platform/oci-proof-mirror.seed.json | cut -d' ' -f1)"
+          test "$observed_seed" = "$EXPECTED_SEED_SHA256"
       - name: Install contract dependency
         run: python -m pip install --disable-pip-version-check 'PyYAML==6.0.3'
       - name: Compile and validate publisher
@@ -46,7 +70,7 @@ jobs:
   publish:
     if: github.event_name == 'workflow_dispatch'
     needs: contract
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120
     permissions:
       contents: read
@@ -54,41 +78,135 @@ jobs:
     env:
       EXPECTED_HEAD: ${{ inputs.expected_head }}
       EXPECTED_SEED_SHA256: ${{ inputs.expected_seed_sha256 }}
-      GH_TOKEN: ${{ github.token }}
+      DOCKER_CONFIG: ${{ runner.temp }}/weltgewebe-docker-config
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # tag: v7.0.1
         with:
-          ref: ${{ inputs.expected_head }}
+          ref: ${{ github.sha }}
           fetch-depth: 1
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # tag: v7.0.0
         with:
           python-version: "3.10"
-      - name: Verify immutable publisher inputs
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # tag: v4
+        with:
+          version: v0.35.0
+      - name: Verify immutable trusted-main publisher inputs
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          test "$GITHUB_REF" = "refs/heads/main"
+          test "$GITHUB_SHA" = "$EXPECTED_HEAD"
           test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD"
-          test "$(sha256sum platform/oci-proof-mirror.seed.json | cut -d' ' -f1)" = "$EXPECTED_SEED_SHA256"
+          main_head="$(gh api repos/heimgewebe/weltgewebe/git/ref/heads/main --jq .object.sha)"
+          test "$main_head" = "$EXPECTED_HEAD"
+          observed_seed="$(sha256sum platform/oci-proof-mirror.seed.json | cut -d' ' -f1)"
+          test "$observed_seed" = "$EXPECTED_SEED_SHA256"
           python scripts/platform/publish_oci_mirror.py validate
-      - name: Authenticate repository-owned GHCR publisher
-        run: echo "$GH_TOKEN" | docker login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
+          docker buildx imagetools create --help | grep -F -- '--prefer-index'
+      - name: Preflight existing package ownership and access
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p build/kubernetes-platform
+          package_api="/orgs/heimgewebe/packages/container/weltgewebe-proof-oci"
+          error_file="$RUNNER_TEMP/package-preflight-error.txt"
+          if package_before_json="$(gh api "$package_api" 2>"$error_file")"; then
+            repositories_before_json="$(gh api "$package_api/repositories")"
+            repository_count="$(jq 'length' <<<"$repositories_before_json")"
+            test "$repository_count" -le 1
+            if test "$repository_count" -eq 1; then
+              test "$(jq -r '.[0].full_name' <<<"$repositories_before_json")" = "heimgewebe/weltgewebe"
+            fi
+            gh api --method PATCH "$package_api" -f visibility=private >/dev/null
+            repository_id="$(gh api repos/heimgewebe/weltgewebe --jq .id)"
+            gh api --method PUT "$package_api/repositories/$repository_id" >/dev/null
+            package_json="$(gh api "$package_api")"
+            repositories_json="$(gh api "$package_api/repositories")"
+            test "$(jq 'length' <<<"$repositories_json")" -eq 1
+            test "$(jq -r '.[0].full_name' <<<"$repositories_json")" = "heimgewebe/weltgewebe"
+            test "$(jq -r .visibility <<<"$package_json")" = "private"
+            state="prepared-existing"
+          elif grep -Fq '(HTTP 404)' "$error_file"; then
+            package_before_json='null'
+            repositories_before_json='[]'
+            package_json='null'
+            repositories_json='[]'
+            state="absent"
+          else
+            cat "$error_file" >&2
+            exit 1
+          fi
+          jq -n \
+            --arg status pass \
+            --arg state "$state" \
+            --arg expected_repository heimgewebe/weltgewebe \
+            --argjson package_before "$package_before_json" \
+            --argjson repositories_before "$repositories_before_json" \
+            --argjson package_after "$package_json" \
+            --argjson repositories_after "$repositories_json" \
+            '{schema_version: 1, status: $status, state: $state,
+              expected_repository: $expected_repository,
+              before: {package: $package_before, repositories: $repositories_before},
+              after: {package: $package_after, repositories: $repositories_after}}' \
+            > build/kubernetes-platform/oci-mirror-package-preflight.json
+      - name: Authenticate source and target registries
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$DOCKER_CONFIG"
+          echo "$GH_TOKEN" | docker login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
+          if test -n "$DOCKERHUB_USERNAME" && test -n "$DOCKERHUB_TOKEN"; then
+            echo "$DOCKERHUB_TOKEN" | docker login docker.io \
+              --username "$DOCKERHUB_USERNAME" --password-stdin
+          else
+            echo "Docker Hub credentials are not configured; bounded anonymous access will be used."
+          fi
       - name: Publish exact digest-preserving OCI mirror
         run: >-
           python scripts/platform/publish_oci_mirror.py publish
           --expected-head "$EXPECTED_HEAD"
           --expected-seed-sha256 "$EXPECTED_SEED_SHA256"
           --output build/kubernetes-platform/oci-mirror-provenance.json
-      - name: Bind private package access to this repository
+      - name: Enforce and attest private package access
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           package_api="/orgs/heimgewebe/packages/container/weltgewebe-proof-oci"
           repository_id="$(gh api repos/heimgewebe/weltgewebe --jq .id)"
-          gh api --method PUT "$package_api/repositories/$repository_id"
-          test "$(gh api "$package_api" --jq .visibility)" = "private"
-          gh api "$package_api/repositories" --jq '.[].full_name' | grep -Fx 'heimgewebe/weltgewebe'
+          gh api --method PATCH "$package_api" -f visibility=private >/dev/null
+          gh api --method PUT "$package_api/repositories/$repository_id" >/dev/null
+          package_json="$(gh api "$package_api")"
+          repositories_json="$(gh api "$package_api/repositories")"
+          test "$(jq -r .visibility <<<"$package_json")" = "private"
+          test "$(jq 'length' <<<"$repositories_json")" -eq 1
+          test "$(jq -r '.[0].full_name' <<<"$repositories_json")" = "heimgewebe/weltgewebe"
+          jq -n \
+            --arg status pass \
+            --arg expected_repository heimgewebe/weltgewebe \
+            --argjson package "$package_json" \
+            --argjson repositories "$repositories_json" \
+            '{schema_version: 1, status: $status,
+              expected_repository: $expected_repository,
+              package: $package, repositories: $repositories}' \
+            > build/kubernetes-platform/oci-mirror-package-access.json
+      - name: Logout registry credentials
+        if: always()
+        run: |
+          docker logout ghcr.io || true
+          docker logout docker.io || true
+          rm -rf "$DOCKER_CONFIG"
       - name: Upload mirror provenance
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
         with:
           name: kubernetes-proof-oci-mirror-${{ inputs.expected_head }}
-          path: build/kubernetes-platform/oci-mirror-provenance.json
+          path: build/kubernetes-platform/*.json
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/kubernetes-proof-oci-mirror.yml
+++ b/.github/workflows/kubernetes-proof-oci-mirror.yml
@@ -45,6 +45,19 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # tag: v7.0.0
         with:
           python-version: "3.10"
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # tag: v4
+        with:
+          version: v0.35.0
+      - name: Verify pinned Buildx multi-architecture digest inspection
+        run: |
+          set -euo pipefail
+          expected="sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5"
+          reference="docker.io/kindest/node:v1.36.1@$expected"
+          observed="$(
+            docker buildx imagetools inspect "$reference"               --format '{{json .Manifest.Digest}}' | jq -r .
+          )"
+          test "$observed" = "$expected"
+          docker buildx imagetools create --help | grep -F -- '--prefer-index'
       - name: Verify trusted dispatch identity
         if: github.event_name == 'workflow_dispatch'
         env:
@@ -105,7 +118,7 @@ jobs:
           test "$observed_seed" = "$EXPECTED_SEED_SHA256"
           python scripts/platform/publish_oci_mirror.py validate
           docker buildx imagetools create --help | grep -F -- '--prefer-index'
-      - name: Preflight existing package ownership and access
+      - name: Preflight existing package metadata
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -113,28 +126,15 @@ jobs:
           mkdir -p build/kubernetes-platform
           package_api="/orgs/heimgewebe/packages/container/weltgewebe-proof-oci"
           error_file="$RUNNER_TEMP/package-preflight-error.txt"
-          if package_before_json="$(gh api "$package_api" 2>"$error_file")"; then
-            repositories_before_json="$(gh api "$package_api/repositories")"
-            repository_count="$(jq 'length' <<<"$repositories_before_json")"
-            test "$repository_count" -le 1
-            if test "$repository_count" -eq 1; then
-              test "$(jq -r '.[0].full_name' <<<"$repositories_before_json")" = "heimgewebe/weltgewebe"
-            fi
-            gh api --method PATCH "$package_api" -f visibility=private >/dev/null
-            repository_id="$(gh api repos/heimgewebe/weltgewebe --jq .id)"
-            gh api --method PUT "$package_api/repositories/$repository_id" >/dev/null
-            package_json="$(gh api "$package_api")"
-            repositories_json="$(gh api "$package_api/repositories")"
-            test "$(jq 'length' <<<"$repositories_json")" -eq 1
-            test "$(jq -r '.[0].full_name' <<<"$repositories_json")" = "heimgewebe/weltgewebe"
+          if package_json="$(gh api "$package_api" 2>"$error_file")"; then
+            test "$(jq -r .owner.login <<<"$package_json")" = "heimgewebe"
+            test "$(jq -r .name <<<"$package_json")" = "weltgewebe-proof-oci"
+            test "$(jq -r .package_type <<<"$package_json")" = "container"
             test "$(jq -r .visibility <<<"$package_json")" = "private"
-            state="prepared-existing"
+            state="existing-private-visible-to-workflow"
           elif grep -Fq '(HTTP 404)' "$error_file"; then
-            package_before_json='null'
-            repositories_before_json='[]'
             package_json='null'
-            repositories_json='[]'
-            state="absent"
+            state="not-visible-or-absent"
           else
             cat "$error_file" >&2
             exit 1
@@ -142,15 +142,12 @@ jobs:
           jq -n \
             --arg status pass \
             --arg state "$state" \
-            --arg expected_repository heimgewebe/weltgewebe \
-            --argjson package_before "$package_before_json" \
-            --argjson repositories_before "$repositories_before_json" \
-            --argjson package_after "$package_json" \
-            --argjson repositories_after "$repositories_json" \
+            --arg workflow_repository "$GITHUB_REPOSITORY" \
+            --arg association_contract "first workflow GITHUB_TOKEN publication links the package automatically" \
+            --argjson package "$package_json" \
             '{schema_version: 1, status: $status, state: $state,
-              expected_repository: $expected_repository,
-              before: {package: $package_before, repositories: $repositories_before},
-              after: {package: $package_after, repositories: $repositories_after}}' \
+              workflow_repository: $workflow_repository,
+              association_contract: $association_contract, package: $package}' \
             > build/kubernetes-platform/oci-mirror-package-preflight.json
       - name: Authenticate source and target registries
         env:
@@ -173,29 +170,27 @@ jobs:
           --expected-head "$EXPECTED_HEAD"
           --expected-seed-sha256 "$EXPECTED_SEED_SHA256"
           --output build/kubernetes-platform/oci-mirror-provenance.json
-      - name: Enforce and attest private package access
+      - name: Attest private package metadata
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           package_api="/orgs/heimgewebe/packages/container/weltgewebe-proof-oci"
-          repository_id="$(gh api repos/heimgewebe/weltgewebe --jq .id)"
-          gh api --method PATCH "$package_api" -f visibility=private >/dev/null
-          gh api --method PUT "$package_api/repositories/$repository_id" >/dev/null
           package_json="$(gh api "$package_api")"
-          repositories_json="$(gh api "$package_api/repositories")"
+          test "$(jq -r .owner.login <<<"$package_json")" = "heimgewebe"
+          test "$(jq -r .name <<<"$package_json")" = "weltgewebe-proof-oci"
+          test "$(jq -r .package_type <<<"$package_json")" = "container"
           test "$(jq -r .visibility <<<"$package_json")" = "private"
-          test "$(jq 'length' <<<"$repositories_json")" -eq 1
-          test "$(jq -r '.[0].full_name' <<<"$repositories_json")" = "heimgewebe/weltgewebe"
+          test "$(jq -r .version_count <<<"$package_json")" -ge 1
           jq -n \
             --arg status pass \
-            --arg expected_repository heimgewebe/weltgewebe \
+            --arg workflow_repository "$GITHUB_REPOSITORY" \
+            --arg association_contract "published with this repository GITHUB_TOKEN" \
             --argjson package "$package_json" \
-            --argjson repositories "$repositories_json" \
             '{schema_version: 1, status: $status,
-              expected_repository: $expected_repository,
-              package: $package, repositories: $repositories}' \
-            > build/kubernetes-platform/oci-mirror-package-access.json
+              workflow_repository: $workflow_repository,
+              association_contract: $association_contract, package: $package}' \
+            > build/kubernetes-platform/oci-mirror-package-metadata.json
       - name: Logout registry credentials
         if: always()
         run: |
@@ -208,5 +203,90 @@ jobs:
         with:
           name: kubernetes-proof-oci-mirror-${{ inputs.expected_head }}
           path: build/kubernetes-platform/*.json
+          if-no-files-found: error
+          retention-days: 14
+  verify-read-access:
+    if: github.event_name == 'workflow_dispatch'
+    needs: publish
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: read
+    env:
+      EXPECTED_HEAD: ${{ inputs.expected_head }}
+      DOCKER_CONFIG: ${{ runner.temp }}/weltgewebe-docker-read-config
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # tag: v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # tag: v4
+        with:
+          version: v0.35.0
+      - name: Download publisher evidence
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # tag: v8
+        with:
+          name: kubernetes-proof-oci-mirror-${{ inputs.expected_head }}
+          path: build/kubernetes-platform
+      - name: Authenticate repository read access
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$DOCKER_CONFIG"
+          echo "$GH_TOKEN" | docker login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
+      - name: Verify repository read access and every mirror digest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = "refs/heads/main"
+          test "$GITHUB_SHA" = "$EXPECTED_HEAD"
+          provenance="build/kubernetes-platform/oci-mirror-provenance.json"
+          test "$(jq -r .status "$provenance")" = "pass"
+          test "$(jq -r .source_head "$provenance")" = "$EXPECTED_HEAD"
+          checked=0
+          while IFS=$'\t' read -r name mirror expected; do
+            observed="$(
+              docker buildx imagetools inspect "$mirror" \
+                --format '{{json .Manifest.Digest}}' | jq -r .
+            )"
+            test "$observed" = "$expected"
+            checked=$((checked + 1))
+            printf 'verified %s %s\n' "$name" "$observed"
+          done < <(
+            jq -r '.images | to_entries[] |
+              [.key, .value.mirror, .value.mirror_digest] | @tsv' "$provenance"
+          )
+          test "$checked" -eq "$(jq -r .image_count "$provenance")"
+          package_api="/orgs/heimgewebe/packages/container/weltgewebe-proof-oci"
+          package_json="$(gh api "$package_api")"
+          test "$(jq -r .owner.login <<<"$package_json")" = "heimgewebe"
+          test "$(jq -r .name <<<"$package_json")" = "weltgewebe-proof-oci"
+          test "$(jq -r .package_type <<<"$package_json")" = "container"
+          test "$(jq -r .visibility <<<"$package_json")" = "private"
+          jq -n \
+            --arg status pass \
+            --arg source_head "$EXPECTED_HEAD" \
+            --arg workflow_repository "$GITHUB_REPOSITORY" \
+            --argjson checked_images "$checked" \
+            --argjson package "$package_json" \
+            '{schema_version: 1, status: $status, source_head: $source_head,
+              workflow_repository: $workflow_repository,
+              checked_images: $checked_images, package: $package}' \
+            > build/kubernetes-platform/oci-mirror-read-access.json
+      - name: Logout registry credentials
+        if: always()
+        run: |
+          docker logout ghcr.io || true
+          rm -rf "$DOCKER_CONFIG"
+      - name: Upload read-access evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
+        with:
+          name: kubernetes-proof-oci-mirror-read-access-${{ inputs.expected_head }}
+          path: build/kubernetes-platform/oci-mirror-read-access.json
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/kubernetes-proof-oci-mirror.yml
+++ b/.github/workflows/kubernetes-proof-oci-mirror.yml
@@ -1,0 +1,94 @@
+name: Kubernetes proof OCI mirror publisher
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/kubernetes-proof-oci-mirror.yml"
+      - "platform/oci-proof-mirror.seed.json"
+      - "scripts/platform/publish_oci_mirror.py"
+      - "scripts/ci/tests/test_kubernetes_oci_mirror_publisher.py"
+  workflow_dispatch:
+    inputs:
+      expected_head:
+        description: Full repository commit containing the reviewed mirror seed
+        required: true
+        type: string
+      expected_seed_sha256:
+        description: SHA-256 of platform/oci-proof-mirror.seed.json
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: kubernetes-proof-oci-mirror-${{ github.event.pull_request.head.sha || inputs.expected_head || github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # tag: v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # tag: v7.0.0
+        with:
+          python-version: "3.10"
+      - name: Install contract dependency
+        run: python -m pip install --disable-pip-version-check 'PyYAML==6.0.3'
+      - name: Compile and validate publisher
+        run: |
+          set -euo pipefail
+          python -m py_compile scripts/platform/publish_oci_mirror.py
+          python scripts/platform/publish_oci_mirror.py validate
+          python -m unittest scripts.ci.tests.test_kubernetes_oci_mirror_publisher
+
+  publish:
+    if: github.event_name == 'workflow_dispatch'
+    needs: contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      contents: read
+      packages: write
+    env:
+      EXPECTED_HEAD: ${{ inputs.expected_head }}
+      EXPECTED_SEED_SHA256: ${{ inputs.expected_seed_sha256 }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # tag: v7.0.1
+        with:
+          ref: ${{ inputs.expected_head }}
+          fetch-depth: 1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # tag: v7.0.0
+        with:
+          python-version: "3.10"
+      - name: Verify immutable publisher inputs
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD"
+          test "$(sha256sum platform/oci-proof-mirror.seed.json | cut -d' ' -f1)" = "$EXPECTED_SEED_SHA256"
+          python scripts/platform/publish_oci_mirror.py validate
+      - name: Authenticate repository-owned GHCR publisher
+        run: echo "$GH_TOKEN" | docker login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
+      - name: Publish exact digest-preserving OCI mirror
+        run: >-
+          python scripts/platform/publish_oci_mirror.py publish
+          --expected-head "$EXPECTED_HEAD"
+          --expected-seed-sha256 "$EXPECTED_SEED_SHA256"
+          --output build/kubernetes-platform/oci-mirror-provenance.json
+      - name: Bind private package access to this repository
+        run: |
+          set -euo pipefail
+          package_api="/orgs/heimgewebe/packages/container/weltgewebe-proof-oci"
+          repository_id="$(gh api repos/heimgewebe/weltgewebe --jq .id)"
+          gh api --method PUT "$package_api/repositories/$repository_id"
+          test "$(gh api "$package_api" --jq .visibility)" = "private"
+          gh api "$package_api/repositories" --jq '.[].full_name' | grep -Fx 'heimgewebe/weltgewebe'
+      - name: Upload mirror provenance
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag: v7.0.1
+        with:
+          name: kubernetes-proof-oci-mirror-${{ inputs.expected_head }}
+          path: build/kubernetes-platform/oci-mirror-provenance.json
+          if-no-files-found: error
+          retention-days: 14

--- a/platform/oci-proof-mirror.seed.json
+++ b/platform/oci-proof-mirror.seed.json
@@ -5,116 +5,212 @@
     "registry": "ghcr.io",
     "repository": "ghcr.io/heimgewebe/weltgewebe-proof-oci",
     "visibility": "private",
-    "retention": "retain every digest referenced by platform/oci-proof-mirror.lock.json; delete only unreferenced versions after 14 days",
-    "max_versions": 30
+    "retention": {
+      "state": "bootstrap_pending_lock",
+      "future_lock_path": "platform/oci-proof-mirror.lock.json",
+      "orphan_grace_days": 14
+    }
   },
   "publisher": {
-    "canonical_attempts": 3,
+    "canonical_inspect_attempts": 3,
+    "mirror_publish_attempts": 3,
+    "mirror_verify_attempts": 3,
+    "retry_backoff_seconds": [
+      5,
+      10
+    ],
+    "operation_timeout_seconds": 900,
+    "overall_deadline_seconds": 6300,
+    "max_parallelism": 3,
     "require_identical_manifest_digest": true,
     "require_expected_head": true,
-    "require_expected_seed_sha256": true
+    "require_expected_seed_sha256": true,
+    "require_protected_main": true
   },
   "images": {
     "kind_node": {
-      "canonical": "kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5",
-      "suites": ["kind-gitops", "ha-recovery"],
+      "canonical": "docker.io/kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5",
+      "suites": [
+        "kind-gitops",
+        "ha-recovery"
+      ],
       "load_into_kind": false
     },
     "cilium_agent": {
       "canonical": "quay.io/cilium/cilium:v1.19.5@sha256:20fbbc14ac20b55a292c0dcda5571bf31cde30a7dbc68c29db3e709390ab0732",
-      "suites": ["kind-gitops", "ha-recovery"]
+      "suites": [
+        "kind-gitops",
+        "ha-recovery"
+      ],
+      "load_into_kind": true
     },
     "cilium_operator": {
       "canonical": "quay.io/cilium/operator-generic:v1.19.5@sha256:be848a365776e07d0c5a895eda7aec928ddc52a5a1fa2f432fd7a286609e1db4",
-      "suites": ["kind-gitops", "ha-recovery"]
+      "suites": [
+        "kind-gitops",
+        "ha-recovery"
+      ],
+      "load_into_kind": true
     },
     "cilium_envoy": {
       "canonical": "quay.io/cilium/cilium-envoy:v1.36.8-1781157951-a7f42a3390781539911b5b9107881b35ecc4e752@sha256:326f872e19ce8aa45170efbf583b3f301586ba3feead14b864676d4baf3b45ed",
-      "suites": ["kind-gitops", "ha-recovery"]
+      "suites": [
+        "kind-gitops",
+        "ha-recovery"
+      ],
+      "load_into_kind": true
     },
     "hubble_relay": {
       "canonical": "quay.io/cilium/hubble-relay:v1.19.5@sha256:24409bfa1bca075c92acb26ba4b49cd573d99d68d5370f7cc825078185222a0c",
-      "suites": ["kind-gitops", "ha-recovery"]
+      "suites": [
+        "kind-gitops",
+        "ha-recovery"
+      ],
+      "load_into_kind": true
     },
     "flux_source_controller": {
       "canonical": "ghcr.io/fluxcd/source-controller:v1.9.3@sha256:ff8f3c92f1bcb433e858c948040c3a3393fe73f5dd72048a4502bfaf0a4c26cd",
-      "suites": ["kind-gitops", "ha-recovery"]
+      "suites": [
+        "kind-gitops",
+        "ha-recovery"
+      ],
+      "load_into_kind": true
     },
     "flux_kustomize_controller": {
       "canonical": "ghcr.io/fluxcd/kustomize-controller:v1.9.3@sha256:0203eb80743814f67bebb5f0b22c7db620bc461cc0b23732e0367a38fce04e4c",
-      "suites": ["kind-gitops", "ha-recovery"]
+      "suites": [
+        "kind-gitops",
+        "ha-recovery"
+      ],
+      "load_into_kind": true
     },
     "flux_helm_controller": {
       "canonical": "ghcr.io/fluxcd/helm-controller:v1.6.2@sha256:e17ab0e5885d80cebb9890663f85d59cd3866adebfc09a4d8bd2d512ef980bc4",
-      "suites": ["kind-gitops", "ha-recovery"]
+      "suites": [
+        "kind-gitops",
+        "ha-recovery"
+      ],
+      "load_into_kind": true
     },
     "flux_notification_controller": {
       "canonical": "ghcr.io/fluxcd/notification-controller:v1.9.2@sha256:9ce503e7bcb8493fafe2aaef0c2ac4396df4f6890256acf9cd444a2dcd2a69ed",
-      "suites": ["kind-gitops", "ha-recovery"]
+      "suites": [
+        "kind-gitops",
+        "ha-recovery"
+      ],
+      "load_into_kind": true
     },
     "local_postgres": {
-      "canonical": "postgres:16@sha256:be01cf82fc7dbba824acf0a82e150b4b360f3ff93c6631d7844af431e841a95c",
-      "suites": ["kind-gitops"]
+      "canonical": "docker.io/library/postgres:16@sha256:be01cf82fc7dbba824acf0a82e150b4b360f3ff93c6631d7844af431e841a95c",
+      "suites": [
+        "kind-gitops"
+      ],
+      "load_into_kind": true
     },
     "local_nats": {
-      "canonical": "nats:2.10-alpine@sha256:b83efabe3e7def1e0a4a31ec6e078999bb17c80363f881df35edc70fcb6bb927",
-      "suites": ["kind-gitops"]
+      "canonical": "docker.io/library/nats:2.10-alpine@sha256:b83efabe3e7def1e0a4a31ec6e078999bb17c80363f881df35edc70fcb6bb927",
+      "suites": [
+        "kind-gitops"
+      ],
+      "load_into_kind": true
     },
     "cloudnative_pg_operator": {
       "canonical": "ghcr.io/cloudnative-pg/cloudnative-pg@sha256:a2701eb97cdd2a34b1fdb2cb51987f544b706e40bec72ae7146cd8580efefebb",
-      "suites": ["ha-recovery"]
+      "suites": [
+        "ha-recovery"
+      ],
+      "load_into_kind": true
     },
     "cloudnative_pg_postgresql": {
       "canonical": "ghcr.io/cloudnative-pg/postgresql:16.14@sha256:05eae7037dc6a7077cc3fc91a65fe023279060572a237d11aa83e11179443ad1",
-      "suites": ["ha-recovery"]
+      "suites": [
+        "ha-recovery"
+      ],
+      "load_into_kind": true
     },
     "ha_nats": {
-      "canonical": "nats@sha256:c11af972c99ae542de8925e6a7d9c533aa1eb039660420d2074beed6089b3bf0",
-      "suites": ["ha-recovery"]
+      "canonical": "docker.io/library/nats@sha256:c11af972c99ae542de8925e6a7d9c533aa1eb039660420d2074beed6089b3bf0",
+      "suites": [
+        "ha-recovery"
+      ],
+      "load_into_kind": true
     },
     "nats_box": {
-      "canonical": "natsio/nats-box@sha256:9d5f35d286c3dcfca18bb2339b51345f9f89b580b237ab16ddfe609bdca9c72d",
-      "suites": ["ha-recovery"]
+      "canonical": "docker.io/natsio/nats-box@sha256:9d5f35d286c3dcfca18bb2339b51345f9f89b580b237ab16ddfe609bdca9c72d",
+      "suites": [
+        "ha-recovery"
+      ],
+      "load_into_kind": true
     },
     "seaweedfs": {
-      "canonical": "chrislusf/seaweedfs@sha256:f898c91e42d7da5f4bb13f1efd424ff03ba85b420312eb929708a384e8a8b03d",
-      "suites": ["ha-recovery"]
+      "canonical": "docker.io/chrislusf/seaweedfs@sha256:f898c91e42d7da5f4bb13f1efd424ff03ba85b420312eb929708a384e8a8b03d",
+      "suites": [
+        "ha-recovery"
+      ],
+      "load_into_kind": true
     },
     "cert_manager_controller": {
       "canonical": "quay.io/jetstack/cert-manager-controller@sha256:e370f7800a53078e9d74324287a7d52b553864e55f5b4e521f911c3f6c7da203",
-      "suites": ["ha-recovery"]
+      "suites": [
+        "ha-recovery"
+      ],
+      "load_into_kind": true
     },
     "cert_manager_cainjector": {
       "canonical": "quay.io/jetstack/cert-manager-cainjector@sha256:ad1dcc5b2fccc420f9b3fbee7ce8a869450c540fd4f2f41de2d95b1ca0c4d701",
-      "suites": ["ha-recovery"]
+      "suites": [
+        "ha-recovery"
+      ],
+      "load_into_kind": true
     },
     "cert_manager_webhook": {
       "canonical": "quay.io/jetstack/cert-manager-webhook@sha256:c33cca307541e2d58861a55b1af5f390b7e19c8741e48b433693b73a7cce88b3",
-      "suites": ["ha-recovery"]
+      "suites": [
+        "ha-recovery"
+      ],
+      "load_into_kind": true
     },
     "barman_cloud_plugin": {
       "canonical": "ghcr.io/cloudnative-pg/plugin-barman-cloud@sha256:71589dbac582333442812b07b31f7ea4d00324a8358aac7ca507dabf9f4b6c96",
-      "suites": ["ha-recovery"]
+      "suites": [
+        "ha-recovery"
+      ],
+      "load_into_kind": true
     },
     "barman_cloud_sidecar": {
       "canonical": "ghcr.io/cloudnative-pg/plugin-barman-cloud-sidecar@sha256:990361af3319f9e23aafa0f6d7981f99bf1f69b4e6a85cf1bc7d71d6f09bb288",
-      "suites": ["ha-recovery"]
+      "suites": [
+        "ha-recovery"
+      ],
+      "load_into_kind": true
     },
     "build_rust": {
-      "canonical": "rust:1.89.0-bookworm@sha256:948f9b08a66e7fe01b03a98ef1c7568292e07ec2e4fe90d88c07bb14563c84ff",
-      "suites": ["app-build"]
+      "canonical": "docker.io/library/rust:1.89.0-bookworm@sha256:948f9b08a66e7fe01b03a98ef1c7568292e07ec2e4fe90d88c07bb14563c84ff",
+      "suites": [
+        "app-build"
+      ],
+      "load_into_kind": false
     },
     "build_debian": {
-      "canonical": "debian:bookworm-slim@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818",
-      "suites": ["app-build"]
+      "canonical": "docker.io/library/debian:bookworm-slim@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818",
+      "suites": [
+        "app-build"
+      ],
+      "load_into_kind": false
     },
     "build_node": {
-      "canonical": "node:20.19.0-alpine@sha256:8bda036ddd59ea51a23bc1a1035d3b5c614e72c01366d989f4120e8adca196d4",
-      "suites": ["app-build"]
+      "canonical": "docker.io/library/node:20.19.0-alpine@sha256:8bda036ddd59ea51a23bc1a1035d3b5c614e72c01366d989f4120e8adca196d4",
+      "suites": [
+        "app-build"
+      ],
+      "load_into_kind": false
     },
     "build_caddy": {
-      "canonical": "caddy:2.7@sha256:236c6a30ccb84fa412a5360ca8b586d804faba0621ea182fb45902608cd8a563",
-      "suites": ["app-build"]
+      "canonical": "docker.io/library/caddy:2.7@sha256:236c6a30ccb84fa412a5360ca8b586d804faba0621ea182fb45902608cd8a563",
+      "suites": [
+        "app-build"
+      ],
+      "load_into_kind": false
     }
   }
 }

--- a/platform/oci-proof-mirror.seed.json
+++ b/platform/oci-proof-mirror.seed.json
@@ -1,0 +1,120 @@
+{
+  "schema_version": 1,
+  "owner": "heimgewebe/weltgewebe",
+  "target": {
+    "registry": "ghcr.io",
+    "repository": "ghcr.io/heimgewebe/weltgewebe-proof-oci",
+    "visibility": "private",
+    "retention": "retain every digest referenced by platform/oci-proof-mirror.lock.json; delete only unreferenced versions after 14 days",
+    "max_versions": 30
+  },
+  "publisher": {
+    "canonical_attempts": 3,
+    "require_identical_manifest_digest": true,
+    "require_expected_head": true,
+    "require_expected_seed_sha256": true
+  },
+  "images": {
+    "kind_node": {
+      "canonical": "kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5",
+      "suites": ["kind-gitops", "ha-recovery"],
+      "load_into_kind": false
+    },
+    "cilium_agent": {
+      "canonical": "quay.io/cilium/cilium:v1.19.5@sha256:20fbbc14ac20b55a292c0dcda5571bf31cde30a7dbc68c29db3e709390ab0732",
+      "suites": ["kind-gitops", "ha-recovery"]
+    },
+    "cilium_operator": {
+      "canonical": "quay.io/cilium/operator-generic:v1.19.5@sha256:be848a365776e07d0c5a895eda7aec928ddc52a5a1fa2f432fd7a286609e1db4",
+      "suites": ["kind-gitops", "ha-recovery"]
+    },
+    "cilium_envoy": {
+      "canonical": "quay.io/cilium/cilium-envoy:v1.36.8-1781157951-a7f42a3390781539911b5b9107881b35ecc4e752@sha256:326f872e19ce8aa45170efbf583b3f301586ba3feead14b864676d4baf3b45ed",
+      "suites": ["kind-gitops", "ha-recovery"]
+    },
+    "hubble_relay": {
+      "canonical": "quay.io/cilium/hubble-relay:v1.19.5@sha256:24409bfa1bca075c92acb26ba4b49cd573d99d68d5370f7cc825078185222a0c",
+      "suites": ["kind-gitops", "ha-recovery"]
+    },
+    "flux_source_controller": {
+      "canonical": "ghcr.io/fluxcd/source-controller:v1.9.3@sha256:ff8f3c92f1bcb433e858c948040c3a3393fe73f5dd72048a4502bfaf0a4c26cd",
+      "suites": ["kind-gitops", "ha-recovery"]
+    },
+    "flux_kustomize_controller": {
+      "canonical": "ghcr.io/fluxcd/kustomize-controller:v1.9.3@sha256:0203eb80743814f67bebb5f0b22c7db620bc461cc0b23732e0367a38fce04e4c",
+      "suites": ["kind-gitops", "ha-recovery"]
+    },
+    "flux_helm_controller": {
+      "canonical": "ghcr.io/fluxcd/helm-controller:v1.6.2@sha256:e17ab0e5885d80cebb9890663f85d59cd3866adebfc09a4d8bd2d512ef980bc4",
+      "suites": ["kind-gitops", "ha-recovery"]
+    },
+    "flux_notification_controller": {
+      "canonical": "ghcr.io/fluxcd/notification-controller:v1.9.2@sha256:9ce503e7bcb8493fafe2aaef0c2ac4396df4f6890256acf9cd444a2dcd2a69ed",
+      "suites": ["kind-gitops", "ha-recovery"]
+    },
+    "local_postgres": {
+      "canonical": "postgres:16@sha256:be01cf82fc7dbba824acf0a82e150b4b360f3ff93c6631d7844af431e841a95c",
+      "suites": ["kind-gitops"]
+    },
+    "local_nats": {
+      "canonical": "nats:2.10-alpine@sha256:b83efabe3e7def1e0a4a31ec6e078999bb17c80363f881df35edc70fcb6bb927",
+      "suites": ["kind-gitops"]
+    },
+    "cloudnative_pg_operator": {
+      "canonical": "ghcr.io/cloudnative-pg/cloudnative-pg@sha256:a2701eb97cdd2a34b1fdb2cb51987f544b706e40bec72ae7146cd8580efefebb",
+      "suites": ["ha-recovery"]
+    },
+    "cloudnative_pg_postgresql": {
+      "canonical": "ghcr.io/cloudnative-pg/postgresql:16.14@sha256:05eae7037dc6a7077cc3fc91a65fe023279060572a237d11aa83e11179443ad1",
+      "suites": ["ha-recovery"]
+    },
+    "ha_nats": {
+      "canonical": "nats@sha256:c11af972c99ae542de8925e6a7d9c533aa1eb039660420d2074beed6089b3bf0",
+      "suites": ["ha-recovery"]
+    },
+    "nats_box": {
+      "canonical": "natsio/nats-box@sha256:9d5f35d286c3dcfca18bb2339b51345f9f89b580b237ab16ddfe609bdca9c72d",
+      "suites": ["ha-recovery"]
+    },
+    "seaweedfs": {
+      "canonical": "chrislusf/seaweedfs@sha256:f898c91e42d7da5f4bb13f1efd424ff03ba85b420312eb929708a384e8a8b03d",
+      "suites": ["ha-recovery"]
+    },
+    "cert_manager_controller": {
+      "canonical": "quay.io/jetstack/cert-manager-controller@sha256:e370f7800a53078e9d74324287a7d52b553864e55f5b4e521f911c3f6c7da203",
+      "suites": ["ha-recovery"]
+    },
+    "cert_manager_cainjector": {
+      "canonical": "quay.io/jetstack/cert-manager-cainjector@sha256:ad1dcc5b2fccc420f9b3fbee7ce8a869450c540fd4f2f41de2d95b1ca0c4d701",
+      "suites": ["ha-recovery"]
+    },
+    "cert_manager_webhook": {
+      "canonical": "quay.io/jetstack/cert-manager-webhook@sha256:c33cca307541e2d58861a55b1af5f390b7e19c8741e48b433693b73a7cce88b3",
+      "suites": ["ha-recovery"]
+    },
+    "barman_cloud_plugin": {
+      "canonical": "ghcr.io/cloudnative-pg/plugin-barman-cloud@sha256:71589dbac582333442812b07b31f7ea4d00324a8358aac7ca507dabf9f4b6c96",
+      "suites": ["ha-recovery"]
+    },
+    "barman_cloud_sidecar": {
+      "canonical": "ghcr.io/cloudnative-pg/plugin-barman-cloud-sidecar@sha256:990361af3319f9e23aafa0f6d7981f99bf1f69b4e6a85cf1bc7d71d6f09bb288",
+      "suites": ["ha-recovery"]
+    },
+    "build_rust": {
+      "canonical": "rust:1.89.0-bookworm@sha256:948f9b08a66e7fe01b03a98ef1c7568292e07ec2e4fe90d88c07bb14563c84ff",
+      "suites": ["app-build"]
+    },
+    "build_debian": {
+      "canonical": "debian:bookworm-slim@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818",
+      "suites": ["app-build"]
+    },
+    "build_node": {
+      "canonical": "node:20.19.0-alpine@sha256:8bda036ddd59ea51a23bc1a1035d3b5c614e72c01366d989f4120e8adca196d4",
+      "suites": ["app-build"]
+    },
+    "build_caddy": {
+      "canonical": "caddy:2.7@sha256:236c6a30ccb84fa412a5360ca8b586d804faba0621ea182fb45902608cd8a563",
+      "suites": ["app-build"]
+    }
+  }
+}

--- a/scripts/ci/tests/test_kubernetes_oci_mirror_publisher.py
+++ b/scripts/ci/tests/test_kubernetes_oci_mirror_publisher.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class KubernetesOciMirrorPublisherContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.publisher = load_module(
+            "weltgewebe_publish_oci_mirror",
+            ROOT / "scripts/platform/publish_oci_mirror.py",
+        )
+
+    def test_seed_is_private_repository_owned_and_digest_only(self) -> None:
+        result = self.publisher.validate()
+        self.assertEqual(result["status"], "pass")
+        self.assertEqual(result["owner"], "heimgewebe/weltgewebe")
+        self.assertEqual(
+            result["target_repository"],
+            "ghcr.io/heimgewebe/weltgewebe-proof-oci",
+        )
+        self.assertEqual(result["visibility"], "private")
+        self.assertEqual(result["image_count"], 25)
+        self.assertEqual(len(result["seed_sha256"]), 64)
+
+    def test_manifest_digest_mismatch_fails_without_retry(self) -> None:
+        canonical = "registry.invalid/image:v1@sha256:" + "a" * 64
+        with mock.patch.object(
+            self.publisher,
+            "_manifest_digest",
+            side_effect=["sha256:" + "a" * 64, "sha256:" + "b" * 64],
+        ), mock.patch.object(self.publisher, "_run") as run, mock.patch.object(
+            self.publisher.time, "sleep"
+        ) as sleep:
+            with self.assertRaises(self.publisher.PublisherError):
+                self.publisher._publish_one(
+                    "ghcr.io/heimgewebe/weltgewebe-proof-oci",
+                    "test",
+                    canonical,
+                    3,
+                )
+        run.assert_called_once()
+        sleep.assert_not_called()
+
+    def test_transient_publication_failure_is_bounded(self) -> None:
+        canonical = "registry.invalid/image:v1@sha256:" + "a" * 64
+        error = subprocess.CalledProcessError(1, ["docker", "buildx"])
+        with mock.patch.object(
+            self.publisher,
+            "_manifest_digest",
+            return_value="sha256:" + "a" * 64,
+        ), mock.patch.object(
+            self.publisher, "_run", side_effect=error
+        ) as run, mock.patch.object(self.publisher.time, "sleep") as sleep:
+            with self.assertRaises(self.publisher.PublisherError):
+                self.publisher._publish_one(
+                    "ghcr.io/heimgewebe/weltgewebe-proof-oci",
+                    "test",
+                    canonical,
+                    3,
+                )
+        self.assertEqual(run.call_count, 3)
+        self.assertEqual([call.args[0] for call in sleep.call_args_list], [1.0, 2.0])
+
+    def test_publish_requires_exact_head_and_seed_before_any_registry_write(self) -> None:
+        with mock.patch.object(self.publisher, "_git_head", return_value="a" * 40), mock.patch.object(
+            self.publisher, "_sha256", return_value="b" * 64
+        ), mock.patch.object(self.publisher, "_publish_one") as publish_one:
+            with tempfile.TemporaryDirectory() as tmp:
+                with self.assertRaises(self.publisher.PublisherError):
+                    self.publisher.publish(
+                        "c" * 40,
+                        "b" * 64,
+                        Path(tmp) / "provenance.json",
+                    )
+        publish_one.assert_not_called()
+
+    def test_successful_publication_writes_head_and_seed_bound_provenance(self) -> None:
+        seed = {
+            "schema_version": 1,
+            "owner": "heimgewebe/weltgewebe",
+            "target": {
+                "repository": "ghcr.io/heimgewebe/weltgewebe-proof-oci",
+                "visibility": "private",
+            },
+            "publisher": {"canonical_attempts": 3},
+            "images": {
+                "test": {
+                    "canonical": "registry.invalid/image:v1@sha256:" + "a" * 64,
+                    "suites": ["kind-gitops"],
+                }
+            },
+        }
+        published = {
+            "canonical": seed["images"]["test"]["canonical"],
+            "canonical_digest": "sha256:" + "a" * 64,
+            "mirror_tag": "ghcr.io/heimgewebe/weltgewebe-proof-oci:test-aaaaaaaaaaaaaaaa",
+            "mirror": "ghcr.io/heimgewebe/weltgewebe-proof-oci@sha256:" + "a" * 64,
+            "mirror_digest": "sha256:" + "a" * 64,
+        }
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.object(
+            self.publisher, "_git_head", return_value="c" * 40
+        ), mock.patch.object(
+            self.publisher, "_sha256", return_value="d" * 64
+        ), mock.patch.object(
+            self.publisher, "_load_seed", return_value=seed
+        ), mock.patch.object(
+            self.publisher, "_publish_one", return_value=published
+        ):
+            output = Path(tmp) / "provenance.json"
+            result = self.publisher.publish("c" * 40, "d" * 64, output)
+            observed = json.loads(output.read_text(encoding="utf-8"))
+        self.assertEqual(result, observed)
+        self.assertEqual(observed["source_head"], "c" * 40)
+        self.assertEqual(observed["seed_sha256"], "d" * 64)
+        self.assertEqual(observed["images"]["test"]["mirror_digest"], "sha256:" + "a" * 64)
+
+    def test_workflow_separates_pr_contract_from_manual_package_write(self) -> None:
+        path = ROOT / ".github/workflows/kubernetes-proof-oci-mirror.yml"
+        source = path.read_text(encoding="utf-8")
+        workflow = yaml.safe_load(source)
+        jobs = workflow["jobs"]
+        self.assertEqual(workflow["permissions"], {"contents": "read"})
+        self.assertEqual(jobs["publish"]["permissions"], {"contents": "read", "packages": "write"})
+        self.assertEqual(jobs["publish"]["if"], "github.event_name == 'workflow_dispatch'")
+        steps = {
+            step["name"]: step
+            for step in jobs["publish"]["steps"]
+            if "name" in step
+        }
+        verify = steps["Verify immutable publisher inputs"]["run"]
+        self.assertIn("git rev-parse HEAD", verify)
+        self.assertIn("sha256sum platform/oci-proof-mirror.seed.json", verify)
+        publish = steps["Publish exact digest-preserving OCI mirror"]["run"]
+        self.assertIn('--expected-head "$EXPECTED_HEAD"', publish)
+        self.assertIn('--expected-seed-sha256 "$EXPECTED_SEED_SHA256"', publish)
+        bind = steps["Bind private package access to this repository"]["run"]
+        self.assertIn("visibility", bind)
+        self.assertIn("heimgewebe/weltgewebe", bind)
+        self.assertNotIn("weltgewebe-api", source)
+        self.assertNotIn("weltgewebe-web", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/tests/test_kubernetes_oci_mirror_publisher.py
+++ b/scripts/ci/tests/test_kubernetes_oci_mirror_publisher.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import importlib.util
 import json
-import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -30,7 +29,10 @@ class KubernetesOciMirrorPublisherContractTests(unittest.TestCase):
             ROOT / "scripts/platform/publish_oci_mirror.py",
         )
 
-    def test_seed_is_private_repository_owned_and_digest_only(self) -> None:
+    def policy(self) -> dict[str, object]:
+        return dict(self.publisher.EXPECTED_PUBLISHER_POLICY)
+
+    def test_seed_is_private_repository_owned_and_exactly_inventoried(self) -> None:
         result = self.publisher.validate()
         self.assertEqual(result["status"], "pass")
         self.assertEqual(result["owner"], "heimgewebe/weltgewebe")
@@ -39,125 +41,248 @@ class KubernetesOciMirrorPublisherContractTests(unittest.TestCase):
             "ghcr.io/heimgewebe/weltgewebe-proof-oci",
         )
         self.assertEqual(result["visibility"], "private")
-        self.assertEqual(result["image_count"], 25)
+        self.assertEqual(result["retention_state"], "bootstrap_pending_lock")
+        self.assertEqual(set(result["inventory"]), set(self.publisher.EXPECTED_IMAGES))
+        self.assertEqual(result["publisher_policy"]["max_parallelism"], 3)
         self.assertEqual(len(result["seed_sha256"]), 64)
 
-    def test_manifest_digest_mismatch_fails_without_retry(self) -> None:
-        canonical = "registry.invalid/image:v1@sha256:" + "a" * 64
+    def test_inventory_replacement_is_rejected_even_when_count_is_unchanged(self) -> None:
+        seed = json.loads(self.publisher.SEED_PATH.read_text(encoding="utf-8"))
+        seed["images"]["replacement"] = seed["images"].pop("kind_node")
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "seed.json"
+            path.write_text(json.dumps(seed), encoding="utf-8")
+            with mock.patch.object(self.publisher, "SEED_PATH", path):
+                with self.assertRaisesRegex(self.publisher.PublisherError, "inventory mismatch"):
+                    self.publisher._load_seed()
+
+    def test_invalid_suite_and_non_boolean_kind_binding_are_rejected(self) -> None:
+        seed = json.loads(self.publisher.SEED_PATH.read_text(encoding="utf-8"))
+        seed["images"]["kind_node"]["suites"] = ["wrong"]
+        seed["images"]["kind_node"]["load_into_kind"] = "false"
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "seed.json"
+            path.write_text(json.dumps(seed), encoding="utf-8")
+            with mock.patch.object(self.publisher, "SEED_PATH", path):
+                with self.assertRaisesRegex(self.publisher.PublisherError, "suite binding"):
+                    self.publisher._load_seed()
+
+    def test_every_source_is_registry_qualified_and_target_is_not_a_source(self) -> None:
+        seed = self.publisher._load_seed()
+        target = seed["target"]["repository"]
+        for spec in seed["images"].values():
+            repository = self.publisher._reference_repository(spec["canonical"])
+            self.assertIn(".", repository.split("/", 1)[0])
+            self.assertNotEqual(repository, target)
+            self.assertFalse(repository.startswith("ghcr.io/heimgewebe/"))
+
+    def test_canonical_manifest_availability_is_retried_with_bounded_backoff(self) -> None:
+        digest = "sha256:" + "a" * 64
+        deadline = self.publisher.Deadline.after(60)
         with mock.patch.object(
             self.publisher,
-            "_manifest_digest",
-            side_effect=["sha256:" + "a" * 64, "sha256:" + "b" * 64],
-        ), mock.patch.object(self.publisher, "_run") as run, mock.patch.object(
-            self.publisher.time, "sleep"
-        ) as sleep:
-            with self.assertRaises(self.publisher.PublisherError):
-                self.publisher._publish_one(
-                    "ghcr.io/heimgewebe/weltgewebe-proof-oci",
-                    "test",
-                    canonical,
-                    3,
-                )
-        run.assert_called_once()
-        sleep.assert_not_called()
+            "_manifest_digest_once",
+            side_effect=[self.publisher.AvailabilityError("429"), digest],
+        ) as inspect, mock.patch.object(self.publisher, "_sleep_backoff") as backoff:
+            observed = self.publisher._manifest_digest(
+                "docker.io/library/test:v1@" + digest,
+                attempts=3,
+                backoff_seconds=[5, 10],
+                operation_timeout=30,
+                deadline=deadline,
+            )
+        self.assertEqual(observed, digest)
+        self.assertEqual(inspect.call_count, 2)
+        backoff.assert_called_once_with(5, deadline)
 
-    def test_transient_publication_failure_is_bounded(self) -> None:
-        canonical = "registry.invalid/image:v1@sha256:" + "a" * 64
-        error = subprocess.CalledProcessError(1, ["docker", "buildx"])
+    def test_integrity_failure_is_not_retried(self) -> None:
+        deadline = self.publisher.Deadline.after(60)
         with mock.patch.object(
             self.publisher,
-            "_manifest_digest",
-            return_value="sha256:" + "a" * 64,
-        ), mock.patch.object(
-            self.publisher, "_run", side_effect=error
-        ) as run, mock.patch.object(self.publisher.time, "sleep") as sleep:
-            with self.assertRaises(self.publisher.PublisherError):
-                self.publisher._publish_one(
-                    "ghcr.io/heimgewebe/weltgewebe-proof-oci",
-                    "test",
-                    canonical,
-                    3,
+            "_manifest_digest_once",
+            side_effect=self.publisher.IntegrityError("wrong digest"),
+        ) as inspect, mock.patch.object(self.publisher, "_sleep_backoff") as backoff:
+            with self.assertRaises(self.publisher.IntegrityError):
+                self.publisher._manifest_digest(
+                    "docker.io/library/test:v1@sha256:" + "a" * 64,
+                    attempts=3,
+                    backoff_seconds=[5, 10],
+                    operation_timeout=30,
+                    deadline=deadline,
                 )
-        self.assertEqual(run.call_count, 3)
-        self.assertEqual([call.args[0] for call in sleep.call_args_list], [1.0, 2.0])
+        inspect.assert_called_once()
+        backoff.assert_not_called()
 
-    def test_publish_requires_exact_head_and_seed_before_any_registry_write(self) -> None:
+    def test_existing_correct_mirror_tag_is_reused_without_mutation(self) -> None:
+        digest = "sha256:" + "a" * 64
+        canonical = "docker.io/library/test:v1@" + digest
+        with mock.patch.object(
+            self.publisher, "_manifest_digest", side_effect=[digest, digest]
+        ), mock.patch.object(self.publisher, "_create_mirror") as create:
+            result = self.publisher._publish_one(
+                "ghcr.io/heimgewebe/weltgewebe-proof-oci",
+                "test",
+                canonical,
+                self.policy(),
+                self.publisher.Deadline.after(60),
+            )
+        self.assertEqual(result["action"], "reused")
+        self.assertTrue(result["mirror_tag"].endswith("test-" + "a" * 64))
+        create.assert_not_called()
+
+    def test_copy_preserves_single_manifest_shape_and_uses_full_digest_tag(self) -> None:
+        result = mock.Mock(returncode=0)
+        with mock.patch.object(self.publisher.subprocess, "run", return_value=result) as run:
+            self.publisher._create_mirror_once(
+                "ghcr.io/heimgewebe/weltgewebe-proof-oci:test-" + "a" * 64,
+                "docker.io/library/test:v1@sha256:" + "a" * 64,
+                timeout=30,
+            )
+        argv = run.call_args.args[0]
+        self.assertIn("--prefer-index=false", argv)
+        self.assertTrue(any("test-" + "a" * 64 in item for item in argv))
+
+    def test_publish_rejects_unreviewed_head_before_registry_work(self) -> None:
         with mock.patch.object(self.publisher, "_git_head", return_value="a" * 40), mock.patch.object(
             self.publisher, "_sha256", return_value="b" * 64
-        ), mock.patch.object(self.publisher, "_publish_one") as publish_one:
-            with tempfile.TemporaryDirectory() as tmp:
-                with self.assertRaises(self.publisher.PublisherError):
-                    self.publisher.publish(
-                        "c" * 40,
-                        "b" * 64,
-                        Path(tmp) / "provenance.json",
-                    )
-        publish_one.assert_not_called()
+        ), mock.patch.object(self.publisher, "_load_seed") as load_seed:
+            with self.assertRaisesRegex(self.publisher.PublisherError, "head mismatch"):
+                self.publisher.publish(
+                    "c" * 40,
+                    "b" * 64,
+                    ROOT / "build/kubernetes-platform/provenance.json",
+                )
+        load_seed.assert_not_called()
 
-    def test_successful_publication_writes_head_and_seed_bound_provenance(self) -> None:
+    def test_partial_batch_failure_is_written_to_durable_provenance(self) -> None:
+        digest = "sha256:" + "a" * 64
         seed = {
-            "schema_version": 1,
             "owner": "heimgewebe/weltgewebe",
             "target": {
                 "repository": "ghcr.io/heimgewebe/weltgewebe-proof-oci",
                 "visibility": "private",
+                "retention": {"state": "bootstrap_pending_lock"},
             },
-            "publisher": {"canonical_attempts": 3},
+            "publisher": {
+                **self.policy(),
+                "max_parallelism": 2,
+            },
             "images": {
-                "test": {
-                    "canonical": "registry.invalid/image:v1@sha256:" + "a" * 64,
+                "one": {
+                    "canonical": "docker.io/library/one:v1@" + digest,
                     "suites": ["kind-gitops"],
-                }
+                    "load_into_kind": True,
+                },
+                "two": {
+                    "canonical": "docker.io/library/two:v1@" + digest,
+                    "suites": ["kind-gitops"],
+                    "load_into_kind": True,
+                },
             },
         }
-        published = {
-            "canonical": seed["images"]["test"]["canonical"],
-            "canonical_digest": "sha256:" + "a" * 64,
-            "mirror_tag": "ghcr.io/heimgewebe/weltgewebe-proof-oci:test-aaaaaaaaaaaaaaaa",
-            "mirror": "ghcr.io/heimgewebe/weltgewebe-proof-oci@sha256:" + "a" * 64,
-            "mirror_digest": "sha256:" + "a" * 64,
-        }
-        with tempfile.TemporaryDirectory() as tmp, mock.patch.object(
+
+        def publish_one(_target, name, canonical, _policy, _deadline):
+            if name == "two":
+                raise self.publisher.AvailabilityError("offline")
+            return {
+                "action": "published",
+                "canonical": canonical,
+                "canonical_digest": digest,
+                "mirror_tag": "mirror:one",
+                "mirror": "mirror@" + digest,
+                "mirror_digest": digest,
+            }
+
+        output_dir = ROOT / "build/kubernetes-platform"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(dir=output_dir) as tmp, mock.patch.object(
             self.publisher, "_git_head", return_value="c" * 40
         ), mock.patch.object(
             self.publisher, "_sha256", return_value="d" * 64
         ), mock.patch.object(
             self.publisher, "_load_seed", return_value=seed
         ), mock.patch.object(
-            self.publisher, "_publish_one", return_value=published
+            self.publisher, "_tool_versions", return_value={"docker": "x", "buildx": "y"}
+        ), mock.patch.object(
+            self.publisher, "_publish_one", side_effect=publish_one
         ):
             output = Path(tmp) / "provenance.json"
-            result = self.publisher.publish("c" * 40, "d" * 64, output)
+            with self.assertRaisesRegex(self.publisher.PublisherError, "failed batch"):
+                self.publisher.publish("c" * 40, "d" * 64, output)
             observed = json.loads(output.read_text(encoding="utf-8"))
-        self.assertEqual(result, observed)
-        self.assertEqual(observed["source_head"], "c" * 40)
-        self.assertEqual(observed["seed_sha256"], "d" * 64)
-        self.assertEqual(observed["images"]["test"]["mirror_digest"], "sha256:" + "a" * 64)
+        self.assertEqual(observed["status"], "partial")
+        self.assertEqual(observed["completed_count"], 1)
+        self.assertEqual(observed["failures"]["two"]["error_class"], "registry_unavailable")
 
-    def test_workflow_separates_pr_contract_from_manual_package_write(self) -> None:
+    def test_provenance_output_cannot_escape_build_evidence_root(self) -> None:
+        with self.assertRaisesRegex(self.publisher.PublisherError, "must remain below"):
+            self.publisher._validated_output_path(Path("/tmp/provenance.json"))
+
+    def test_workflow_executes_privileged_code_only_from_current_main(self) -> None:
         path = ROOT / ".github/workflows/kubernetes-proof-oci-mirror.yml"
         source = path.read_text(encoding="utf-8")
         workflow = yaml.safe_load(source)
         jobs = workflow["jobs"]
         self.assertEqual(workflow["permissions"], {"contents": "read"})
         self.assertEqual(jobs["publish"]["permissions"], {"contents": "read", "packages": "write"})
-        self.assertEqual(jobs["publish"]["if"], "github.event_name == 'workflow_dispatch'")
-        steps = {
-            step["name"]: step
-            for step in jobs["publish"]["steps"]
-            if "name" in step
+        for job_name in ("contract", "publish"):
+            checkout = next(
+                step for step in jobs[job_name]["steps"]
+                if str(step.get("uses", "")).startswith("actions/checkout@")
+            )
+            self.assertEqual(checkout["with"]["ref"], "${{ github.sha }}")
+            self.assertFalse(checkout["with"]["persist-credentials"])
+        contract_steps = {
+            step["name"]: step for step in jobs["contract"]["steps"] if "name" in step
         }
-        verify = steps["Verify immutable publisher inputs"]["run"]
-        self.assertIn("git rev-parse HEAD", verify)
-        self.assertIn("sha256sum platform/oci-proof-mirror.seed.json", verify)
-        publish = steps["Publish exact digest-preserving OCI mirror"]["run"]
+        trusted = contract_steps["Verify trusted dispatch identity"]["run"]
+        self.assertIn('test "$GITHUB_REF" = "refs/heads/main"', trusted)
+        self.assertIn('test "$GITHUB_SHA" = "$EXPECTED_HEAD"', trusted)
+        self.assertIn("git/ref/heads/main", trusted)
+        self.assertIn("EXPECTED_SEED_SHA256", trusted)
+        self.assertNotIn("GH_TOKEN", jobs["publish"]["env"])
+
+    def test_workflow_preflights_package_and_always_uploads_partial_evidence(self) -> None:
+        workflow = yaml.safe_load(
+            (ROOT / ".github/workflows/kubernetes-proof-oci-mirror.yml").read_text(encoding="utf-8")
+        )
+        steps = workflow["jobs"]["publish"]["steps"]
+        named = {step["name"]: step for step in steps if "name" in step}
+        order = [step.get("name") for step in steps]
+        self.assertLess(
+            order.index("Preflight existing package ownership and access"),
+            order.index("Publish exact digest-preserving OCI mirror"),
+        )
+        preflight = named["Preflight existing package ownership and access"]["run"]
+        self.assertIn("visibility=private", preflight)
+        self.assertIn("package_before", preflight)
+        self.assertIn("package_after", preflight)
+        self.assertIn("jq 'length'", preflight)
+        self.assertIn("heimgewebe/weltgewebe", preflight)
+        publish = named["Publish exact digest-preserving OCI mirror"]["run"]
         self.assertIn('--expected-head "$EXPECTED_HEAD"', publish)
         self.assertIn('--expected-seed-sha256 "$EXPECTED_SEED_SHA256"', publish)
-        bind = steps["Bind private package access to this repository"]["run"]
-        self.assertIn("visibility", bind)
-        self.assertIn("heimgewebe/weltgewebe", bind)
-        self.assertNotIn("weltgewebe-api", source)
-        self.assertNotIn("weltgewebe-web", source)
+        self.assertEqual(named["Logout registry credentials"]["if"], "always()")
+        self.assertEqual(named["Upload mirror provenance"]["if"], "always()")
+        self.assertEqual(named["Upload mirror provenance"]["with"]["retention-days"], 14)
+        self.assertIn("DOCKERHUB_TOKEN", named["Authenticate source and target registries"]["env"])
+
+    def test_workflow_pins_runner_buildx_and_preserve_index_capability(self) -> None:
+        workflow = yaml.safe_load(
+            (ROOT / ".github/workflows/kubernetes-proof-oci-mirror.yml").read_text(encoding="utf-8")
+        )
+        publish = workflow["jobs"]["publish"]
+        self.assertEqual(publish["runs-on"], "ubuntu-24.04")
+        buildx = next(
+            step for step in publish["steps"]
+            if str(step.get("uses", "")).startswith("docker/setup-buildx-action@")
+        )
+        self.assertEqual(buildx["with"]["version"], "v0.35.0")
+        verify = next(
+            step for step in publish["steps"]
+            if step.get("name") == "Verify immutable trusted-main publisher inputs"
+        )
+        self.assertIn("--prefer-index", verify["run"])
 
 
 if __name__ == "__main__":

--- a/scripts/ci/tests/test_kubernetes_oci_mirror_publisher.py
+++ b/scripts/ci/tests/test_kubernetes_oci_mirror_publisher.py
@@ -225,7 +225,7 @@ class KubernetesOciMirrorPublisherContractTests(unittest.TestCase):
         jobs = workflow["jobs"]
         self.assertEqual(workflow["permissions"], {"contents": "read"})
         self.assertEqual(jobs["publish"]["permissions"], {"contents": "read", "packages": "write"})
-        for job_name in ("contract", "publish"):
+        for job_name in ("contract", "publish", "verify-read-access"):
             checkout = next(
                 step for step in jobs[job_name]["steps"]
                 if str(step.get("uses", "")).startswith("actions/checkout@")
@@ -242,7 +242,7 @@ class KubernetesOciMirrorPublisherContractTests(unittest.TestCase):
         self.assertIn("EXPECTED_SEED_SHA256", trusted)
         self.assertNotIn("GH_TOKEN", jobs["publish"]["env"])
 
-    def test_workflow_preflights_package_and_always_uploads_partial_evidence(self) -> None:
+    def test_workflow_preflights_metadata_and_always_uploads_partial_evidence(self) -> None:
         workflow = yaml.safe_load(
             (ROOT / ".github/workflows/kubernetes-proof-oci-mirror.yml").read_text(encoding="utf-8")
         )
@@ -250,15 +250,20 @@ class KubernetesOciMirrorPublisherContractTests(unittest.TestCase):
         named = {step["name"]: step for step in steps if "name" in step}
         order = [step.get("name") for step in steps]
         self.assertLess(
-            order.index("Preflight existing package ownership and access"),
+            order.index("Preflight existing package metadata"),
             order.index("Publish exact digest-preserving OCI mirror"),
         )
-        preflight = named["Preflight existing package ownership and access"]["run"]
-        self.assertIn("visibility=private", preflight)
-        self.assertIn("package_before", preflight)
-        self.assertIn("package_after", preflight)
-        self.assertIn("jq 'length'", preflight)
-        self.assertIn("heimgewebe/weltgewebe", preflight)
+        preflight = named["Preflight existing package metadata"]["run"]
+        self.assertIn(".owner.login", preflight)
+        self.assertIn(".package_type", preflight)
+        self.assertIn(".visibility", preflight)
+        self.assertIn("not-visible-or-absent", preflight)
+        self.assertNotIn("/repositories", preflight)
+        self.assertNotIn("--method PATCH", preflight)
+        postflight = named["Attest private package metadata"]["run"]
+        self.assertIn(".version_count", postflight)
+        self.assertNotIn("/repositories", postflight)
+        self.assertNotIn("--method PATCH", postflight)
         publish = named["Publish exact digest-preserving OCI mirror"]["run"]
         self.assertIn('--expected-head "$EXPECTED_HEAD"', publish)
         self.assertIn('--expected-seed-sha256 "$EXPECTED_SEED_SHA256"', publish)
@@ -267,22 +272,51 @@ class KubernetesOciMirrorPublisherContractTests(unittest.TestCase):
         self.assertEqual(named["Upload mirror provenance"]["with"]["retention-days"], 14)
         self.assertIn("DOCKERHUB_TOKEN", named["Authenticate source and target registries"]["env"])
 
-    def test_workflow_pins_runner_buildx_and_preserve_index_capability(self) -> None:
+    def test_workflow_has_separate_repository_read_access_proof(self) -> None:
         workflow = yaml.safe_load(
             (ROOT / ".github/workflows/kubernetes-proof-oci-mirror.yml").read_text(encoding="utf-8")
         )
-        publish = workflow["jobs"]["publish"]
-        self.assertEqual(publish["runs-on"], "ubuntu-24.04")
-        buildx = next(
-            step for step in publish["steps"]
-            if str(step.get("uses", "")).startswith("docker/setup-buildx-action@")
+        verify = workflow["jobs"]["verify-read-access"]
+        self.assertEqual(verify["needs"], "publish")
+        self.assertEqual(verify["permissions"], {"contents": "read", "packages": "read"})
+        named = {step["name"]: step for step in verify["steps"] if "name" in step}
+        download = named["Download publisher evidence"]
+        self.assertTrue(str(download["uses"]).startswith("actions/download-artifact@"))
+        check = named["Verify repository read access and every mirror digest"]["run"]
+        self.assertIn(".images | to_entries[]", check)
+        self.assertIn("docker buildx imagetools inspect", check)
+        self.assertIn("checked_images", check)
+        self.assertIn(".visibility", check)
+        self.assertNotIn("/repositories", check)
+        self.assertEqual(named["Logout registry credentials"]["if"], "always()")
+        self.assertEqual(named["Upload read-access evidence"]["if"], "always()")
+
+    def test_workflow_pins_runner_buildx_and_multiarch_inspection(self) -> None:
+        workflow = yaml.safe_load(
+            (ROOT / ".github/workflows/kubernetes-proof-oci-mirror.yml").read_text(encoding="utf-8")
         )
-        self.assertEqual(buildx["with"]["version"], "v0.35.0")
-        verify = next(
-            step for step in publish["steps"]
+        for job_name in ("contract", "publish", "verify-read-access"):
+            job = workflow["jobs"][job_name]
+            self.assertEqual(job["runs-on"], "ubuntu-24.04")
+            buildx = next(
+                step for step in job["steps"]
+                if str(step.get("uses", "")).startswith("docker/setup-buildx-action@")
+            )
+            self.assertEqual(buildx["with"]["version"], "v0.35.0")
+        contract = {
+            step["name"]: step
+            for step in workflow["jobs"]["contract"]["steps"]
+            if "name" in step
+        }
+        smoke = contract["Verify pinned Buildx multi-architecture digest inspection"]["run"]
+        self.assertIn("kindest/node", smoke)
+        self.assertIn(".Manifest.Digest", smoke)
+        self.assertIn("--prefer-index", smoke)
+        publish_verify = next(
+            step for step in workflow["jobs"]["publish"]["steps"]
             if step.get("name") == "Verify immutable trusted-main publisher inputs"
         )
-        self.assertIn("--prefer-index", verify["run"])
+        self.assertIn("--prefer-index", publish_verify["run"])
 
 
 if __name__ == "__main__":

--- a/scripts/platform/publish_oci_mirror.py
+++ b/scripts/platform/publish_oci_mirror.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+SEED_PATH = ROOT / "platform/oci-proof-mirror.seed.json"
+FULL_COMMIT = re.compile(r"[0-9a-f]{40}")
+FULL_DIGEST = re.compile(r"sha256:[0-9a-f]{64}")
+SAFE_NAME = re.compile(r"[a-z0-9_]+")
+
+
+class PublisherError(RuntimeError):
+    pass
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _canonical_json(payload: dict[str, Any]) -> bytes:
+    return (json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode()
+
+
+def _output(argv: list[str], *, timeout: int = 300) -> str:
+    print("+", " ".join(argv), file=sys.stderr, flush=True)
+    return subprocess.run(
+        argv,
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    ).stdout.strip()
+
+
+def _run(argv: list[str], *, timeout: int = 1800) -> None:
+    print("+", " ".join(argv), file=sys.stderr, flush=True)
+    subprocess.run(argv, cwd=ROOT, check=True, timeout=timeout)
+
+
+def _load_seed() -> dict[str, Any]:
+    try:
+        seed = json.loads(SEED_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise PublisherError(f"mirror seed is unreadable: {error}") from error
+    if seed.get("schema_version") != 1:
+        raise PublisherError("unsupported mirror seed schema")
+    if seed.get("owner") != "heimgewebe/weltgewebe":
+        raise PublisherError("mirror seed owner mismatch")
+    target = seed.get("target")
+    publisher = seed.get("publisher")
+    images = seed.get("images")
+    if not isinstance(target, dict) or not isinstance(publisher, dict):
+        raise PublisherError("mirror seed lacks target or publisher policy")
+    if target.get("registry") != "ghcr.io":
+        raise PublisherError("mirror target must remain ghcr.io")
+    if target.get("repository") != "ghcr.io/heimgewebe/weltgewebe-proof-oci":
+        raise PublisherError("mirror target repository mismatch")
+    if target.get("visibility") != "private":
+        raise PublisherError("mirror package must remain private")
+    if target.get("max_versions") != 30:
+        raise PublisherError("mirror version budget must remain 30")
+    if publisher != {
+        "canonical_attempts": 3,
+        "require_identical_manifest_digest": True,
+        "require_expected_head": True,
+        "require_expected_seed_sha256": True,
+    }:
+        raise PublisherError("unexpected mirror publisher policy")
+    if not isinstance(images, dict) or len(images) != 25:
+        raise PublisherError("mirror seed must contain exactly 25 external images")
+    for name, spec in images.items():
+        if not SAFE_NAME.fullmatch(name) or not isinstance(spec, dict):
+            raise PublisherError(f"unsafe mirror image entry: {name}")
+        canonical = spec.get("canonical")
+        suites = spec.get("suites")
+        if not isinstance(canonical, str) or "@sha256:" not in canonical:
+            raise PublisherError(f"mirror source {name} is not digest-bound")
+        if not FULL_DIGEST.fullmatch(canonical.rsplit("@", 1)[1]):
+            raise PublisherError(f"mirror source {name} has malformed digest")
+        if not isinstance(suites, list) or not suites:
+            raise PublisherError(f"mirror source {name} has no suite binding")
+        if canonical.startswith("weltgewebe-") or "weltgewebe-api" in canonical or "weltgewebe-web" in canonical:
+            raise PublisherError("publisher may not publish application images")
+    return seed
+
+
+def _git_head() -> str:
+    head = _output(["git", "rev-parse", "HEAD"])
+    if not FULL_COMMIT.fullmatch(head):
+        raise PublisherError("checked-out head is not a full commit")
+    return head
+
+
+def _manifest_digest(reference: str) -> str:
+    raw = _output(
+        [
+            "docker",
+            "buildx",
+            "imagetools",
+            "inspect",
+            reference,
+            "--format",
+            "{{json .Manifest.Digest}}",
+        ],
+        timeout=600,
+    )
+    try:
+        digest = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise PublisherError(f"Docker returned malformed manifest digest for {reference}") from error
+    if not isinstance(digest, str) or not FULL_DIGEST.fullmatch(digest):
+        raise PublisherError(f"Docker returned no full manifest digest for {reference}")
+    return digest
+
+
+def _publish_one(
+    target_repository: str,
+    name: str,
+    canonical: str,
+    attempts: int,
+) -> dict[str, str]:
+    canonical_digest = canonical.rsplit("@", 1)[1]
+    observed_canonical = _manifest_digest(canonical)
+    if observed_canonical != canonical_digest:
+        raise PublisherError(
+            f"canonical manifest digest mismatch for {name}: "
+            f"{observed_canonical} != {canonical_digest}"
+        )
+    target_tag = f"{target_repository}:{name}-{canonical_digest.removeprefix('sha256:')[:16]}"
+    failures: list[str] = []
+    for attempt in range(attempts):
+        try:
+            _run(
+                [
+                    "docker",
+                    "buildx",
+                    "imagetools",
+                    "create",
+                    "--tag",
+                    target_tag,
+                    canonical,
+                ],
+                timeout=3600,
+            )
+            mirror_digest = _manifest_digest(target_tag)
+            if mirror_digest != canonical_digest:
+                raise PublisherError(
+                    f"mirror digest mismatch for {name}: "
+                    f"{mirror_digest} != {canonical_digest}"
+                )
+            return {
+                "canonical": canonical,
+                "canonical_digest": canonical_digest,
+                "mirror_tag": target_tag,
+                "mirror": f"{target_repository}@{mirror_digest}",
+                "mirror_digest": mirror_digest,
+            }
+        except PublisherError:
+            raise
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as error:
+            failures.append(f"attempt {attempt + 1}/{attempts}: {error}")
+            if attempt + 1 < attempts:
+                time.sleep(float(2**attempt))
+    raise PublisherError(
+        f"mirror publication failed for {name} after bounded retries: "
+        + " | ".join(failures)
+    )
+
+
+def publish(expected_head: str, expected_seed_sha256: str, output: Path) -> dict[str, Any]:
+    if not FULL_COMMIT.fullmatch(expected_head):
+        raise PublisherError("expected head must be a full lowercase commit")
+    if not re.fullmatch(r"[0-9a-f]{64}", expected_seed_sha256):
+        raise PublisherError("expected seed SHA-256 must contain 64 lowercase hex characters")
+    observed_head = _git_head()
+    observed_seed = _sha256(SEED_PATH)
+    if observed_head != expected_head:
+        raise PublisherError(f"head mismatch: {observed_head} != {expected_head}")
+    if observed_seed != expected_seed_sha256:
+        raise PublisherError(f"seed mismatch: {observed_seed} != {expected_seed_sha256}")
+    seed = _load_seed()
+    entries: dict[str, Any] = {}
+    for name, spec in seed["images"].items():
+        result = _publish_one(
+            seed["target"]["repository"],
+            name,
+            spec["canonical"],
+            seed["publisher"]["canonical_attempts"],
+        )
+        result["suites"] = spec["suites"]
+        result["load_into_kind"] = spec.get("load_into_kind", True)
+        entries[name] = result
+    payload = {
+        "schema_version": 1,
+        "status": "pass",
+        "owner": seed["owner"],
+        "source_head": observed_head,
+        "seed_sha256": observed_seed,
+        "target": seed["target"],
+        "image_count": len(entries),
+        "images": entries,
+    }
+    output = output.resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=output.parent, prefix=f".{output.name}.", suffix=".tmp"
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(_canonical_json(payload))
+            handle.flush()
+            os.fsync(handle.fileno())
+        temporary.replace(output)
+    finally:
+        temporary.unlink(missing_ok=True)
+    return payload
+
+
+def validate() -> dict[str, Any]:
+    seed = _load_seed()
+    return {
+        "schema_version": 1,
+        "status": "pass",
+        "owner": seed["owner"],
+        "target_repository": seed["target"]["repository"],
+        "visibility": seed["target"]["visibility"],
+        "image_count": len(seed["images"]),
+        "seed_sha256": _sha256(SEED_PATH),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("validate")
+    publish_parser = sub.add_parser("publish")
+    publish_parser.add_argument("--expected-head", required=True)
+    publish_parser.add_argument("--expected-seed-sha256", required=True)
+    publish_parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        if args.command == "validate":
+            result = validate()
+        else:
+            result = publish(
+                args.expected_head,
+                args.expected_seed_sha256,
+                args.output,
+            )
+        print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+        return 0
+    except (PublisherError, OSError, subprocess.CalledProcessError) as error:
+        print(f"OCI mirror publisher failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/platform/publish_oci_mirror.py
+++ b/scripts/platform/publish_oci_mirror.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import concurrent.futures
 import hashlib
 import json
 import os
@@ -10,18 +11,107 @@ import subprocess
 import sys
 import tempfile
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 ROOT = Path(__file__).resolve().parents[2]
 SEED_PATH = ROOT / "platform/oci-proof-mirror.seed.json"
+OUTPUT_ROOT = (ROOT / "build/kubernetes-platform").resolve()
 FULL_COMMIT = re.compile(r"[0-9a-f]{40}")
 FULL_DIGEST = re.compile(r"sha256:[0-9a-f]{64}")
 SAFE_NAME = re.compile(r"[a-z0-9_]+")
+ALLOWED_SUITES = frozenset({"kind-gitops", "ha-recovery", "app-build"})
+NOT_FOUND_MARKERS = (
+    "manifest unknown",
+    "not found",
+    "name unknown",
+    "404",
+)
+
+EXPECTED_IMAGES: dict[str, tuple[tuple[str, ...], bool, str]] = {
+    "kind_node": (("kind-gitops", "ha-recovery"), False, "docker.io/kindest/node"),
+    "cilium_agent": (("kind-gitops", "ha-recovery"), True, "quay.io/cilium/cilium"),
+    "cilium_operator": (("kind-gitops", "ha-recovery"), True, "quay.io/cilium/operator-generic"),
+    "cilium_envoy": (("kind-gitops", "ha-recovery"), True, "quay.io/cilium/cilium-envoy"),
+    "hubble_relay": (("kind-gitops", "ha-recovery"), True, "quay.io/cilium/hubble-relay"),
+    "flux_source_controller": (("kind-gitops", "ha-recovery"), True, "ghcr.io/fluxcd/source-controller"),
+    "flux_kustomize_controller": (("kind-gitops", "ha-recovery"), True, "ghcr.io/fluxcd/kustomize-controller"),
+    "flux_helm_controller": (("kind-gitops", "ha-recovery"), True, "ghcr.io/fluxcd/helm-controller"),
+    "flux_notification_controller": (("kind-gitops", "ha-recovery"), True, "ghcr.io/fluxcd/notification-controller"),
+    "local_postgres": (("kind-gitops",), True, "docker.io/library/postgres"),
+    "local_nats": (("kind-gitops",), True, "docker.io/library/nats"),
+    "cloudnative_pg_operator": (("ha-recovery",), True, "ghcr.io/cloudnative-pg/cloudnative-pg"),
+    "cloudnative_pg_postgresql": (("ha-recovery",), True, "ghcr.io/cloudnative-pg/postgresql"),
+    "ha_nats": (("ha-recovery",), True, "docker.io/library/nats"),
+    "nats_box": (("ha-recovery",), True, "docker.io/natsio/nats-box"),
+    "seaweedfs": (("ha-recovery",), True, "docker.io/chrislusf/seaweedfs"),
+    "cert_manager_controller": (("ha-recovery",), True, "quay.io/jetstack/cert-manager-controller"),
+    "cert_manager_cainjector": (("ha-recovery",), True, "quay.io/jetstack/cert-manager-cainjector"),
+    "cert_manager_webhook": (("ha-recovery",), True, "quay.io/jetstack/cert-manager-webhook"),
+    "barman_cloud_plugin": (("ha-recovery",), True, "ghcr.io/cloudnative-pg/plugin-barman-cloud"),
+    "barman_cloud_sidecar": (("ha-recovery",), True, "ghcr.io/cloudnative-pg/plugin-barman-cloud-sidecar"),
+    "build_rust": (("app-build",), False, "docker.io/library/rust"),
+    "build_debian": (("app-build",), False, "docker.io/library/debian"),
+    "build_node": (("app-build",), False, "docker.io/library/node"),
+    "build_caddy": (("app-build",), False, "docker.io/library/caddy"),
+}
+
+EXPECTED_PUBLISHER_POLICY = {
+    "canonical_inspect_attempts": 3,
+    "mirror_publish_attempts": 3,
+    "mirror_verify_attempts": 3,
+    "retry_backoff_seconds": [5, 10],
+    "operation_timeout_seconds": 900,
+    "overall_deadline_seconds": 6300,
+    "max_parallelism": 3,
+    "require_identical_manifest_digest": True,
+    "require_expected_head": True,
+    "require_expected_seed_sha256": True,
+    "require_protected_main": True,
+}
 
 
 class PublisherError(RuntimeError):
-    pass
+    error_class = "publisher_error"
+
+
+class AvailabilityError(PublisherError):
+    error_class = "registry_unavailable"
+
+
+class IntegrityError(PublisherError):
+    error_class = "integrity_mismatch"
+
+
+class ManifestNotFoundError(PublisherError):
+    error_class = "manifest_not_found"
+
+
+class DeadlineExceededError(PublisherError):
+    error_class = "deadline_exceeded"
+
+
+class Deadline:
+    def __init__(self, expires_at: float) -> None:
+        self.expires_at = expires_at
+
+    @classmethod
+    def after(cls, seconds: int) -> "Deadline":
+        return cls(time.monotonic() + float(seconds))
+
+    def remaining(self) -> float:
+        return self.expires_at - time.monotonic()
+
+    def timeout(self, maximum: int) -> int:
+        remaining = self.remaining()
+        if remaining <= 1:
+            raise DeadlineExceededError("publisher deadline exhausted")
+        return max(1, min(maximum, int(remaining)))
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def _sha256(path: Path) -> str:
@@ -32,21 +122,34 @@ def _canonical_json(payload: dict[str, Any]) -> bytes:
     return (json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode()
 
 
-def _output(argv: list[str], *, timeout: int = 300) -> str:
-    print("+", " ".join(argv), file=sys.stderr, flush=True)
-    return subprocess.run(
-        argv,
-        cwd=ROOT,
-        check=True,
-        capture_output=True,
-        text=True,
-        timeout=timeout,
-    ).stdout.strip()
+def _atomic_write(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(_canonical_json(payload))
+            handle.flush()
+            os.fsync(handle.fileno())
+        temporary.replace(path)
+        directory_fd = os.open(path.parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    finally:
+        temporary.unlink(missing_ok=True)
 
 
-def _run(argv: list[str], *, timeout: int = 1800) -> None:
-    print("+", " ".join(argv), file=sys.stderr, flush=True)
-    subprocess.run(argv, cwd=ROOT, check=True, timeout=timeout)
+def _reference_repository(reference: str) -> str:
+    without_digest = reference.rsplit("@", 1)[0]
+    head, separator, tail = without_digest.rpartition("/")
+    if not separator:
+        raise PublisherError(f"source reference is not registry-qualified: {reference}")
+    image = tail.split(":", 1)[0]
+    return f"{head}/{image}"
 
 
 def _load_seed() -> dict[str, Any]:
@@ -63,48 +166,95 @@ def _load_seed() -> dict[str, Any]:
     images = seed.get("images")
     if not isinstance(target, dict) or not isinstance(publisher, dict):
         raise PublisherError("mirror seed lacks target or publisher policy")
-    if target.get("registry") != "ghcr.io":
-        raise PublisherError("mirror target must remain ghcr.io")
-    if target.get("repository") != "ghcr.io/heimgewebe/weltgewebe-proof-oci":
-        raise PublisherError("mirror target repository mismatch")
-    if target.get("visibility") != "private":
-        raise PublisherError("mirror package must remain private")
-    if target.get("max_versions") != 30:
-        raise PublisherError("mirror version budget must remain 30")
-    if publisher != {
-        "canonical_attempts": 3,
-        "require_identical_manifest_digest": True,
-        "require_expected_head": True,
-        "require_expected_seed_sha256": True,
-    }:
+    expected_target = {
+        "registry": "ghcr.io",
+        "repository": "ghcr.io/heimgewebe/weltgewebe-proof-oci",
+        "visibility": "private",
+        "retention": {
+            "state": "bootstrap_pending_lock",
+            "future_lock_path": "platform/oci-proof-mirror.lock.json",
+            "orphan_grace_days": 14,
+        },
+    }
+    if target != expected_target:
+        raise PublisherError("unexpected mirror target or bootstrap retention contract")
+    if publisher != EXPECTED_PUBLISHER_POLICY:
         raise PublisherError("unexpected mirror publisher policy")
-    if not isinstance(images, dict) or len(images) != 25:
-        raise PublisherError("mirror seed must contain exactly 25 external images")
-    for name, spec in images.items():
+    if not isinstance(images, dict) or set(images) != set(EXPECTED_IMAGES):
+        missing = sorted(set(EXPECTED_IMAGES) - set(images or {}))
+        extra = sorted(set(images or {}) - set(EXPECTED_IMAGES))
+        raise PublisherError(f"mirror inventory mismatch; missing={missing}, extra={extra}")
+    for name, expected in EXPECTED_IMAGES.items():
+        spec = images[name]
         if not SAFE_NAME.fullmatch(name) or not isinstance(spec, dict):
             raise PublisherError(f"unsafe mirror image entry: {name}")
-        canonical = spec.get("canonical")
-        suites = spec.get("suites")
+        if set(spec) != {"canonical", "suites", "load_into_kind"}:
+            raise PublisherError(f"mirror source {name} contains unexpected fields")
+        canonical = spec["canonical"]
+        suites = spec["suites"]
+        load_into_kind = spec["load_into_kind"]
         if not isinstance(canonical, str) or "@sha256:" not in canonical:
             raise PublisherError(f"mirror source {name} is not digest-bound")
         if not FULL_DIGEST.fullmatch(canonical.rsplit("@", 1)[1]):
             raise PublisherError(f"mirror source {name} has malformed digest")
-        if not isinstance(suites, list) or not suites:
-            raise PublisherError(f"mirror source {name} has no suite binding")
-        if canonical.startswith("weltgewebe-") or "weltgewebe-api" in canonical or "weltgewebe-web" in canonical:
-            raise PublisherError("publisher may not publish application images")
+        expected_suites, expected_load, expected_repository = expected
+        if (
+            not isinstance(suites, list)
+            or len(suites) != len(set(suites))
+            or not set(suites).issubset(ALLOWED_SUITES)
+            or tuple(suites) != expected_suites
+        ):
+            raise PublisherError(f"mirror source {name} has an invalid suite binding")
+        if not isinstance(load_into_kind, bool) or load_into_kind is not expected_load:
+            raise PublisherError(f"mirror source {name} has an invalid kind-load binding")
+        repository = _reference_repository(canonical)
+        if repository != expected_repository:
+            raise PublisherError(
+                f"mirror source {name} repository mismatch: {repository} != {expected_repository}"
+            )
+        if repository.startswith("ghcr.io/heimgewebe/"):
+            raise PublisherError("publisher may not mirror Heimgewebe-owned application images")
+        if repository == target["repository"]:
+            raise PublisherError("mirror target may not be used as a canonical source")
     return seed
 
 
 def _git_head() -> str:
-    head = _output(["git", "rev-parse", "HEAD"])
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    head = result.stdout.strip()
     if not FULL_COMMIT.fullmatch(head):
         raise PublisherError("checked-out head is not a full commit")
     return head
 
 
-def _manifest_digest(reference: str) -> str:
-    raw = _output(
+def _command_output(argv: list[str], *, timeout: int) -> str:
+    print("+", " ".join(argv), file=sys.stderr, flush=True)
+    result = subprocess.run(
+        argv,
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        details = (result.stderr or result.stdout or "command failed").strip()
+        lowered = details.lower()
+        if any(marker in lowered for marker in NOT_FOUND_MARKERS):
+            raise ManifestNotFoundError(details)
+        raise AvailabilityError(details)
+    return result.stdout.strip()
+
+
+def _manifest_digest_once(reference: str, *, timeout: int) -> str:
+    raw = _command_output(
         [
             "docker",
             "buildx",
@@ -114,69 +264,201 @@ def _manifest_digest(reference: str) -> str:
             "--format",
             "{{json .Manifest.Digest}}",
         ],
-        timeout=600,
+        timeout=timeout,
     )
     try:
         digest = json.loads(raw)
     except json.JSONDecodeError as error:
-        raise PublisherError(f"Docker returned malformed manifest digest for {reference}") from error
+        raise IntegrityError(f"Docker returned malformed manifest digest for {reference}") from error
     if not isinstance(digest, str) or not FULL_DIGEST.fullmatch(digest):
-        raise PublisherError(f"Docker returned no full manifest digest for {reference}")
+        raise IntegrityError(f"Docker returned no full manifest digest for {reference}")
     return digest
+
+
+def _sleep_backoff(seconds: int, deadline: Deadline) -> None:
+    if deadline.remaining() <= seconds + 1:
+        raise DeadlineExceededError("publisher deadline cannot accommodate retry backoff")
+    time.sleep(float(seconds))
+
+
+def _manifest_digest(
+    reference: str,
+    *,
+    attempts: int,
+    backoff_seconds: list[int],
+    operation_timeout: int,
+    deadline: Deadline,
+    allow_missing: bool = False,
+) -> str | None:
+    failures: list[str] = []
+    for attempt in range(attempts):
+        try:
+            return _manifest_digest_once(
+                reference,
+                timeout=deadline.timeout(operation_timeout),
+            )
+        except ManifestNotFoundError:
+            if allow_missing:
+                return None
+            raise
+        except IntegrityError:
+            raise
+        except (AvailabilityError, subprocess.TimeoutExpired) as error:
+            failures.append(f"attempt {attempt + 1}/{attempts}: {error}")
+            if attempt + 1 < attempts:
+                _sleep_backoff(backoff_seconds[attempt], deadline)
+    raise AvailabilityError(
+        f"manifest inspection failed for {reference} after bounded retries: "
+        + " | ".join(failures)
+    )
+
+
+def _create_mirror_once(
+    target_tag: str,
+    canonical: str,
+    *,
+    timeout: int,
+) -> None:
+    argv = [
+        "docker",
+        "buildx",
+        "imagetools",
+        "create",
+        "--prefer-index=false",
+        "--tag",
+        target_tag,
+        canonical,
+    ]
+    print("+", " ".join(argv), file=sys.stderr, flush=True)
+    result = subprocess.run(argv, cwd=ROOT, check=False, timeout=timeout)
+    if result.returncode != 0:
+        raise AvailabilityError(f"mirror copy exited with status {result.returncode}")
+
+
+def _create_mirror(
+    target_tag: str,
+    canonical: str,
+    *,
+    attempts: int,
+    backoff_seconds: list[int],
+    operation_timeout: int,
+    deadline: Deadline,
+) -> None:
+    failures: list[str] = []
+    for attempt in range(attempts):
+        try:
+            _create_mirror_once(
+                target_tag,
+                canonical,
+                timeout=deadline.timeout(operation_timeout),
+            )
+            return
+        except (AvailabilityError, subprocess.TimeoutExpired) as error:
+            failures.append(f"attempt {attempt + 1}/{attempts}: {error}")
+            if attempt + 1 < attempts:
+                _sleep_backoff(backoff_seconds[attempt], deadline)
+    raise AvailabilityError(
+        f"mirror publication failed for {target_tag} after bounded retries: "
+        + " | ".join(failures)
+    )
 
 
 def _publish_one(
     target_repository: str,
     name: str,
     canonical: str,
-    attempts: int,
-) -> dict[str, str]:
+    policy: dict[str, Any],
+    deadline: Deadline,
+) -> dict[str, Any]:
     canonical_digest = canonical.rsplit("@", 1)[1]
-    observed_canonical = _manifest_digest(canonical)
+    observed_canonical = _manifest_digest(
+        canonical,
+        attempts=policy["canonical_inspect_attempts"],
+        backoff_seconds=policy["retry_backoff_seconds"],
+        operation_timeout=policy["operation_timeout_seconds"],
+        deadline=deadline,
+    )
     if observed_canonical != canonical_digest:
-        raise PublisherError(
+        raise IntegrityError(
             f"canonical manifest digest mismatch for {name}: "
             f"{observed_canonical} != {canonical_digest}"
         )
-    target_tag = f"{target_repository}:{name}-{canonical_digest.removeprefix('sha256:')[:16]}"
-    failures: list[str] = []
-    for attempt in range(attempts):
-        try:
-            _run(
-                [
-                    "docker",
-                    "buildx",
-                    "imagetools",
-                    "create",
-                    "--tag",
-                    target_tag,
-                    canonical,
-                ],
-                timeout=3600,
-            )
-            mirror_digest = _manifest_digest(target_tag)
-            if mirror_digest != canonical_digest:
-                raise PublisherError(
-                    f"mirror digest mismatch for {name}: "
-                    f"{mirror_digest} != {canonical_digest}"
-                )
-            return {
-                "canonical": canonical,
-                "canonical_digest": canonical_digest,
-                "mirror_tag": target_tag,
-                "mirror": f"{target_repository}@{mirror_digest}",
-                "mirror_digest": mirror_digest,
-            }
-        except PublisherError:
-            raise
-        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as error:
-            failures.append(f"attempt {attempt + 1}/{attempts}: {error}")
-            if attempt + 1 < attempts:
-                time.sleep(float(2**attempt))
-    raise PublisherError(
-        f"mirror publication failed for {name} after bounded retries: "
-        + " | ".join(failures)
+    target_tag = f"{target_repository}:{name}-{canonical_digest.removeprefix('sha256:')}"
+    existing = _manifest_digest(
+        target_tag,
+        attempts=policy["mirror_verify_attempts"],
+        backoff_seconds=policy["retry_backoff_seconds"],
+        operation_timeout=policy["operation_timeout_seconds"],
+        deadline=deadline,
+        allow_missing=True,
     )
+    if existing is not None:
+        if existing != canonical_digest:
+            raise IntegrityError(
+                f"existing mirror tag digest mismatch for {name}: "
+                f"{existing} != {canonical_digest}"
+            )
+        return {
+            "action": "reused",
+            "canonical": canonical,
+            "canonical_digest": canonical_digest,
+            "mirror_tag": target_tag,
+            "mirror": f"{target_repository}@{existing}",
+            "mirror_digest": existing,
+        }
+    _create_mirror(
+        target_tag,
+        canonical,
+        attempts=policy["mirror_publish_attempts"],
+        backoff_seconds=policy["retry_backoff_seconds"],
+        operation_timeout=policy["operation_timeout_seconds"],
+        deadline=deadline,
+    )
+    mirror_digest = _manifest_digest(
+        target_tag,
+        attempts=policy["mirror_verify_attempts"],
+        backoff_seconds=policy["retry_backoff_seconds"],
+        operation_timeout=policy["operation_timeout_seconds"],
+        deadline=deadline,
+    )
+    if mirror_digest != canonical_digest:
+        raise IntegrityError(
+            f"mirror digest mismatch for {name}: {mirror_digest} != {canonical_digest}"
+        )
+    return {
+        "action": "published",
+        "canonical": canonical,
+        "canonical_digest": canonical_digest,
+        "mirror_tag": target_tag,
+        "mirror": f"{target_repository}@{mirror_digest}",
+        "mirror_digest": mirror_digest,
+    }
+
+
+def _tool_versions() -> dict[str, str]:
+    versions: dict[str, str] = {}
+    commands = {
+        "docker": ["docker", "version", "--format", "{{.Client.Version}}"],
+        "buildx": ["docker", "buildx", "version"],
+    }
+    for name, argv in commands.items():
+        result = subprocess.run(
+            argv,
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        versions[name] = result.stdout.strip()
+    return versions
+
+
+def _validated_output_path(output: Path) -> Path:
+    resolved = output.resolve()
+    if not resolved.is_relative_to(OUTPUT_ROOT):
+        raise PublisherError(f"provenance output must remain below {OUTPUT_ROOT}")
+    return resolved
 
 
 def publish(expected_head: str, expected_seed_sha256: str, output: Path) -> dict[str, Any]:
@@ -184,6 +466,7 @@ def publish(expected_head: str, expected_seed_sha256: str, output: Path) -> dict
         raise PublisherError("expected head must be a full lowercase commit")
     if not re.fullmatch(r"[0-9a-f]{64}", expected_seed_sha256):
         raise PublisherError("expected seed SHA-256 must contain 64 lowercase hex characters")
+    output = _validated_output_path(output)
     observed_head = _git_head()
     observed_seed = _sha256(SEED_PATH)
     if observed_head != expected_head:
@@ -191,54 +474,99 @@ def publish(expected_head: str, expected_seed_sha256: str, output: Path) -> dict
     if observed_seed != expected_seed_sha256:
         raise PublisherError(f"seed mismatch: {observed_seed} != {expected_seed_sha256}")
     seed = _load_seed()
-    entries: dict[str, Any] = {}
-    for name, spec in seed["images"].items():
-        result = _publish_one(
-            seed["target"]["repository"],
-            name,
-            spec["canonical"],
-            seed["publisher"]["canonical_attempts"],
-        )
-        result["suites"] = spec["suites"]
-        result["load_into_kind"] = spec.get("load_into_kind", True)
-        entries[name] = result
-    payload = {
-        "schema_version": 1,
-        "status": "pass",
+    policy = seed["publisher"]
+    deadline = Deadline.after(policy["overall_deadline_seconds"])
+    payload: dict[str, Any] = {
+        "schema_version": 2,
+        "status": "running",
         "owner": seed["owner"],
         "source_head": observed_head,
         "seed_sha256": observed_seed,
         "target": seed["target"],
-        "image_count": len(entries),
-        "images": entries,
+        "started_at": _utc_now(),
+        "workflow": {
+            "repository": os.environ.get("GITHUB_REPOSITORY"),
+            "run_id": os.environ.get("GITHUB_RUN_ID"),
+            "run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT"),
+            "actor": os.environ.get("GITHUB_ACTOR"),
+            "event_name": os.environ.get("GITHUB_EVENT_NAME"),
+        },
+        "tool_versions": {},
+        "image_count": len(seed["images"]),
+        "completed_count": 0,
+        "images": {},
+        "failures": {},
     }
-    output = output.resolve()
-    output.parent.mkdir(parents=True, exist_ok=True)
-    descriptor, temporary_name = tempfile.mkstemp(
-        dir=output.parent, prefix=f".{output.name}.", suffix=".tmp"
-    )
-    temporary = Path(temporary_name)
+    _atomic_write(output, payload)
     try:
-        with os.fdopen(descriptor, "wb") as handle:
-            handle.write(_canonical_json(payload))
-            handle.flush()
-            os.fsync(handle.fileno())
-        temporary.replace(output)
-    finally:
-        temporary.unlink(missing_ok=True)
+        payload["tool_versions"] = _tool_versions()
+        _atomic_write(output, payload)
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as error:
+        payload["status"] = "failed"
+        payload["completed_at"] = _utc_now()
+        payload["failures"]["publisher_toolchain"] = {
+            "error_class": "toolchain_unavailable",
+            "message": str(error),
+        }
+        _atomic_write(output, payload)
+        raise PublisherError("publisher toolchain inspection failed") from error
+    ordered = list(seed["images"].items())
+    max_parallelism = policy["max_parallelism"]
+    for batch_start in range(0, len(ordered), max_parallelism):
+        batch = ordered[batch_start : batch_start + max_parallelism]
+        with concurrent.futures.ThreadPoolExecutor(max_workers=len(batch)) as executor:
+            futures = {}
+            for offset, (name, spec) in enumerate(batch, start=batch_start + 1):
+                print(f"Publishing {offset}/{len(ordered)}: {name}", file=sys.stderr, flush=True)
+                future = executor.submit(
+                    _publish_one,
+                    seed["target"]["repository"],
+                    name,
+                    spec["canonical"],
+                    policy,
+                    deadline,
+                )
+                futures[future] = (name, spec)
+            for future in concurrent.futures.as_completed(futures):
+                name, spec = futures[future]
+                try:
+                    result = future.result()
+                    result["suites"] = spec["suites"]
+                    result["load_into_kind"] = spec["load_into_kind"]
+                    payload["images"][name] = result
+                    payload["completed_count"] = len(payload["images"])
+                except Exception as error:  # captured into durable partial provenance
+                    error_class = getattr(error, "error_class", type(error).__name__)
+                    payload["failures"][name] = {
+                        "error_class": error_class,
+                        "message": str(error),
+                    }
+        _atomic_write(output, payload)
+        if payload["failures"]:
+            payload["status"] = "partial" if payload["images"] else "failed"
+            payload["completed_at"] = _utc_now()
+            _atomic_write(output, payload)
+            failed = ", ".join(sorted(payload["failures"]))
+            raise PublisherError(f"mirror publication stopped after failed batch: {failed}")
+    payload["status"] = "pass"
+    payload["completed_at"] = _utc_now()
+    _atomic_write(output, payload)
     return payload
 
 
 def validate() -> dict[str, Any]:
     seed = _load_seed()
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "status": "pass",
         "owner": seed["owner"],
         "target_repository": seed["target"]["repository"],
         "visibility": seed["target"]["visibility"],
+        "retention_state": seed["target"]["retention"]["state"],
+        "inventory": sorted(seed["images"]),
         "image_count": len(seed["images"]),
         "seed_sha256": _sha256(SEED_PATH),
+        "publisher_policy": seed["publisher"],
     }
 
 
@@ -262,7 +590,12 @@ def main() -> int:
             )
         print(json.dumps(result, ensure_ascii=False, sort_keys=True))
         return 0
-    except (PublisherError, OSError, subprocess.CalledProcessError) as error:
+    except (
+        PublisherError,
+        OSError,
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+    ) as error:
         print(f"OCI mirror publisher failed: {error}", file=sys.stderr)
         return 1
 


### PR DESCRIPTION
<!-- weltgewebe-risk: R3 -->

## Zweck

Bootstrap für `WELTGEWEBE-OS-V1-T043`: repositorygebundene Veröffentlichung eines privaten, digestidentischen GHCR-Spiegels für die 25 externen OCI-Eingaben der Kubernetes-Proofs.

## Sicherheitsvertrag

- Privilegierter Publishercode läuft ausschließlich aus dem aktuellen `main`-Commit.
- `GITHUB_REF`, `GITHUB_SHA`, aktueller Remote-`main`, Checkout-HEAD und eingegebener Head müssen identisch sein.
- Der Seed ist zusätzlich an seinen vollständigen SHA-256 gebunden.
- Checkout-Credentials werden nicht persistiert; `GH_TOKEN` existiert nur in den benötigten Schritten.
- Alle Quellen sind vollständig registry- und digestqualifiziert.
- Die exakte Inventar-, Suite-, Repository- und kind-Load-Bindung wird fail-closed geprüft.
- `--prefer-index=false` verhindert bei Einzelmanifesten die automatische Indexerzeugung; der gepinnte Buildx-Contract prüft zusätzlich einen realen Multi-Arch-Digest.
- Ein vorhandener korrekter Mirror-Digest wird wiederverwendet; ein abweichender Digest blockiert ohne Mutation.
- Verfügbarkeitsfehler werden begrenzt wiederholt; Integritätsfehler niemals.
- Höchstens drei Images werden parallel innerhalb eines globalen 105-Minuten-Budgets bearbeitet.
- Ein bereits sichtbares Paket muss vor dem ersten OCI-Schreibzugriff exakt dem erwarteten privaten Containerpaket entsprechen.
- Nicht dokumentierte Paket-REST-Mutationen werden nicht verwendet.
- Nach der Veröffentlichung belegt ein eigener Job mit ausschließlich `packages: read`, dass dieses Repository alle 25 Digestreferenzen und die privaten Paketmetadaten lesen kann.
- Teilmutationen und Toolchainfehler erzeugen atomare Provenance; Evidenz wird auch bei Fehlschlag hochgeladen.
- Docker-/Buildx-Version, Workflowlauf, Actor, Zeitpunkte und pro Image `published`/`reused` werden protokolliert.
- Die Retention wird im Bootstrap ausdrücklich als `bootstrap_pending_lock` ausgewiesen und nicht fälschlich als bereits umgesetzt behauptet.

## Umgesetzte Reviewbefunde

- falsche Trust Boundary zwischen Contract- und Publish-Job beseitigt;
- frei wählbarer ausführbarer Commit ausgeschlossen;
- `persist-credentials: false` und schrittweise Tokenreichweite;
- digesttreue Manifestkopie mit gepinntem Buildx;
- kanonischer Inspect in eigener Retrylogik;
- getrennte Retrybudgets für Source-Inspect, Publish und Mirror-Verify;
- Idempotenz vor Mutation;
- vollständige Digesttags statt 16-stelligem Präfix;
- begrenzte Parallelität und globales Deadlinebudget;
- ehrlicher Retentionstatus statt Verweis auf einen noch nicht vorhandenen Lock;
- exakte Inventarschlüssel statt bloßem `image_count == 25`;
- strikte Suite-, Feld-, Quellrepository- und `load_into_kind`-Validierung;
- vollständig qualifizierte Docker-Hub-Referenzen;
- optionale authentifizierte Docker-Hub-Quelle;
- dauerhafte Teilprovenance und `if: always()`-Upload;
- fester Runner und gepinnte Buildx-Version;
- YAML-Hygiene mit Dokumentstart und gequotetem `on`;
- nicht unterstützte `/repositories`- und `PATCH`-Paketaufrufe entfernt;
- separater revisionsgebundener `packages: read`-Nachweis ergänzt.

## Prüfung auf Head `fe2b47cd193ee68f5260f3054548d5b6ceec1e1c`

- Publisher-Vertragstests — 15 Tests PASS
- gesamte relevante Kubernetes-Vertragssuite — 159 Tests PASS
- realer Multi-Arch-Inspect für `kindest/node` — exakter Digest PASS
- Ruff für Publisher und Tests — PASS
- `python scripts/platform/publish_oci_mirror.py validate` — PASS
- `yamllint --strict -c .yamllint.yml .github/workflows/kubernetes-proof-oci-mirror.yml` — PASS
- `git diff --check` — PASS
- GitHub-Diff-SHA-256: `d581d0a7584e32d69179317971df852265c681c2df1add8fa6f9651f53ce149c`

`actionlint` wurde lokal nicht ausgeführt, weil im isolierten Arbeitskontext keine kontrollierte Installation vorhanden war. GitHub Actions und die Repository-Gates prüfen den veröffentlichten Workflow erneut.

## Abgrenzung

Dieser PR veröffentlicht noch kein Paket und schaltet die kind-/HA-Proofs noch nicht auf den Spiegel um. Nach Merge wird der Publisher ausschließlich auf dem gemergten `main`-Commit ausgeführt. Die autoritativ gelesenen Mirror-Digests bilden anschließend den revisionskontrollierten Lock für den Strict-Proof-Cutover.
