### PR TITLE
fix(kubernetes): initialize OCI Docker config at runtime

### DIFF
--- a/.github/workflows/kubernetes-proof-oci-mirror.yml
+++ b/.github/workflows/kubernetes-proof-oci-mirror.yml
@@ -91,7 +91,6 @@ jobs:
     env:
       EXPECTED_HEAD: ${{ inputs.expected_head }}
       EXPECTED_SEED_SHA256: ${{ inputs.expected_seed_sha256 }}
-      DOCKER_CONFIG: ${{ runner.temp }}/weltgewebe-docker-config
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # tag: v7.0.1
         with:
@@ -104,6 +103,12 @@ jobs:
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # tag: v4
         with:
           version: v0.35.0
+      - name: Initialize isolated Docker config
+        run: |
+          set -euo pipefail
+          docker_config="$RUNNER_TEMP/weltgewebe-docker-config"
+          mkdir -p "$docker_config"
+          echo "DOCKER_CONFIG=$docker_config" >> "$GITHUB_ENV"
       - name: Verify immutable trusted-main publisher inputs
         env:
           GH_TOKEN: ${{ github.token }}
@@ -215,7 +220,6 @@ jobs:
       packages: read
     env:
       EXPECTED_HEAD: ${{ inputs.expected_head }}
-      DOCKER_CONFIG: ${{ runner.temp }}/weltgewebe-docker-read-config
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # tag: v7.0.1
         with:
@@ -225,6 +229,12 @@ jobs:
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # tag: v4
         with:
           version: v0.35.0
+      - name: Initialize isolated Docker config
+        run: |
+          set -euo pipefail
+          docker_config="$RUNNER_TEMP/weltgewebe-docker-read-config"
+          mkdir -p "$docker_config"
+          echo "DOCKER_CONFIG=$docker_config" >> "$GITHUB_ENV"
       - name: Download publisher evidence
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # tag: v8
         with:

--- a/scripts/ci/tests/test_kubernetes_oci_mirror_publisher.py
+++ b/scripts/ci/tests/test_kubernetes_oci_mirror_publisher.py
@@ -318,6 +318,29 @@ class KubernetesOciMirrorPublisherContractTests(unittest.TestCase):
         )
         self.assertIn("--prefer-index", publish_verify["run"])
 
+    def test_workflow_uses_runtime_temp_only_inside_steps(self) -> None:
+        path = ROOT / ".github/workflows/kubernetes-proof-oci-mirror.yml"
+        source = path.read_text(encoding="utf-8")
+        workflow = yaml.safe_load(source)
+        for job_name in ("contract", "publish", "verify-read-access"):
+            env = workflow["jobs"][job_name].get("env", {})
+            self.assertFalse(
+                any("runner." in str(value) for value in env.values()),
+                f"{job_name} job env must not use runner context",
+            )
+        for job_name, suffix in (
+            ("publish", "weltgewebe-docker-config"),
+            ("verify-read-access", "weltgewebe-docker-read-config"),
+        ):
+            step = next(
+                item
+                for item in workflow["jobs"][job_name]["steps"]
+                if item.get("name") == "Initialize isolated Docker config"
+            )
+            self.assertIn("$RUNNER_TEMP/" + suffix, step["run"])
+            self.assertIn('>> "$GITHUB_ENV"', step["run"])
+        self.assertNotIn("${{ runner.temp }}", source)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- weltgewebe-risk: R3 -->

## Fehler

Der erste revisionsgebundene `workflow_dispatch` von `kubernetes-proof-oci-mirror.yml` wurde vor Ausführung mit HTTP 422 abgewiesen. GitHub kann `runner.temp` nicht in Job-Level-`env` auswerten.

## Korrektur

- beide Job-Level-Ausdrücke `${{ runner.temp }}` entfernt;
- isolierte Docker-Konfiguration in einem normalen Laufzeitschritt aus `$RUNNER_TEMP` erzeugt;
- `DOCKER_CONFIG` über `$GITHUB_ENV` ausschließlich für nachfolgende Schritte gesetzt;
- getrennte Pfade für Publish- und Readback-Job beibehalten;
- Regressionstest verbietet `runner.*` in Job-`env` und prüft beide Initialisierungsschritte.

## Wirkung

Der abgewiesene Lauf führte keinen Job aus und schrieb keine OCI-Images. Der Fix verändert weder Seed noch Publisherlogik noch Paketberechtigungen.

## Prüfung

- Publisher-Vertragstests: 16 PASS
- `yamllint --strict`: PASS
- Ruff: PASS
- `git diff --check`: PASS
