### PR TITLE
Mobile Knotenpanels vereinfachen und Seitendesign vereinheitlichen

### DIFF
--- a/apps/web/route-performance-budget.json
+++ b/apps/web/route-performance-budget.json
@@ -5,22 +5,22 @@
   "routes": {
     "/login": {
       "max_initial_js_gzip_bytes": 46000,
-      "max_initial_css_gzip_bytes": 2000,
+      "max_initial_css_gzip_bytes": 3200,
       "forbid_css_markers": [".maplibregl-"],
-      "require_css_markers": [],
+      "require_css_markers": [".wg-page"],
       "min_initial_js_assets": 1,
       "min_initial_css_assets": 1
     },
     "/settings": {
       "max_initial_js_gzip_bytes": 57000,
       "max_initial_css_gzip_bytes": 3600,
-      "forbid_css_markers": [".maplibregl-"],
+      "forbid_css_markers": [".maplibregl-", ".wg-page"],
       "require_css_markers": [],
       "min_initial_js_assets": 1,
       "min_initial_css_assets": 1
     },
     "/map": {
-      "max_initial_js_gzip_bytes": 80000,
+      "max_initial_js_gzip_bytes": 80500,
       "max_initial_css_gzip_bytes": 18000,
       "forbid_css_markers": [],
       "require_css_markers": [".maplibregl-"],

--- a/apps/web/src/lib/components/ContextPanel.svelte
+++ b/apps/web/src/lib/components/ContextPanel.svelte
@@ -257,22 +257,18 @@
     >
       <div class="heading-group">
         <h2 class="desktop-panel-title">{panelTitle}</h2>
-        <h2 class="mobile-panel-heading">
-          <button
-            type="button"
-            class="mobile-panel-title"
-            aria-controls="context-panel-content"
-            aria-expanded={sheetStage === "full"}
-            aria-label={`${panelTitle}: ${
-              sheetStage === "compact"
-                ? "vollständig öffnen"
-                : "kompakt anzeigen"
-            }`}
-            on:click={toggleSheetStage}
-          >
-            <span>{panelTitle}</span>
-          </button>
-        </h2>
+        <button
+          type="button"
+          class="mobile-panel-title"
+          aria-controls="context-panel-content"
+          aria-expanded={sheetStage === "full"}
+          aria-label={`${panelTitle}: ${
+            sheetStage === "compact" ? "vollständig öffnen" : "kompakt anzeigen"
+          }`}
+          on:click={toggleSheetStage}
+        >
+          <span>{panelTitle}</span>
+        </button>
       </div>
       <button class="close-btn" on:click={closePanel} aria-label="Schließen"
         >✕</button
@@ -312,7 +308,7 @@
   }
 
   .sheet-handle,
-  .mobile-panel-heading {
+  .mobile-panel-title {
     display: none;
   }
 
@@ -331,7 +327,7 @@
   }
 
   .desktop-panel-title,
-  .mobile-panel-heading {
+  .mobile-panel-title {
     margin: 0;
     color: var(--muted);
     font-size: 0.78rem;
@@ -341,7 +337,7 @@
   }
 
   .panel-header.composition .desktop-panel-title,
-  .panel-header.composition .mobile-panel-heading {
+  .panel-header.composition .mobile-panel-title {
     color: var(--text);
     font-size: 1.1rem;
     letter-spacing: 0;
@@ -429,12 +425,15 @@
     }
 
     .desktop-panel-title {
-      display: none;
-    }
-
-    .mobile-panel-heading {
-      display: block;
-      margin: 0;
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
     }
 
     .mobile-panel-title {

--- a/apps/web/src/lib/components/ContextPanel.svelte
+++ b/apps/web/src/lib/components/ContextPanel.svelte
@@ -33,21 +33,24 @@
     action: "updated" | "deleted";
   };
   type KompositionPanelHandle = { requestClose: () => void };
-  type SheetStage = "preview" | "half" | "full";
+  type SheetStage = "compact" | "full";
 
   const dispatch = createEventDispatcher<{
     selectRelated: RelatedSelection;
     domainChanged: DomainChanged;
   }>();
+  const DRAG_THRESHOLD_PX = 6;
+
   let kompositionPanel: KompositionPanelHandle | null = null;
-  const SHEET_STAGES: SheetStage[] = ["preview", "half", "full"];
-  let sheetStage: SheetStage = "preview";
+  let sheetStage: SheetStage = "compact";
   let previousPanelIdentity = "";
   let panelTitle = "Details";
   let dragStartY = 0;
   let dragStartHeight = 0;
   let dragHeight: number | null = null;
   let dragging = false;
+  let dragMoved = false;
+  let suppressNextHandleClick = false;
 
   function derivePanelTitle(
     state: SystemState,
@@ -82,9 +85,10 @@
 
     if (nextPanelIdentity !== previousPanelIdentity) {
       previousPanelIdentity = nextPanelIdentity;
-      sheetStage = $systemState === "komposition" ? "full" : "preview";
+      sheetStage = $systemState === "komposition" ? "full" : "compact";
       dragHeight = null;
       dragging = false;
+      dragMoved = false;
     }
   }
 
@@ -92,78 +96,98 @@
     sheetStage = stage;
     dragHeight = null;
     dragging = false;
+    dragMoved = false;
   }
 
-  function stepSheetStage(direction: -1 | 1): void {
-    const index = SHEET_STAGES.indexOf(sheetStage);
-    const next = Math.min(
-      SHEET_STAGES.length - 1,
-      Math.max(0, index + direction),
-    );
-    setSheetStage(SHEET_STAGES[next]);
+  function toggleSheetStage(): void {
+    if (window.innerWidth > 768) return;
+    setSheetStage(sheetStage === "compact" ? "full" : "compact");
   }
 
   function nearestSheetStage(height: number): SheetStage {
     const viewport = window.innerHeight;
-    const preview = Math.min(270, Math.max(190, viewport * 0.29));
-    const targets: Array<[SheetStage, number]> = [
-      ["preview", preview],
-      ["half", viewport * 0.55],
-      ["full", viewport * 0.88],
-    ];
-    return targets.reduce((nearest, current) =>
-      Math.abs(current[1] - height) < Math.abs(nearest[1] - height)
-        ? current
-        : nearest,
-    )[0];
+    const compact = Math.min(270, Math.max(190, viewport * 0.29));
+    return Math.abs(height - compact) <= Math.abs(height - viewport * 0.88)
+      ? "compact"
+      : "full";
   }
 
   function handleSheetPointerDown(event: PointerEvent): void {
     if (window.innerWidth > 768) return;
-    const panel = event.currentTarget as HTMLElement;
-    const aside = panel.closest<HTMLElement>('[data-testid="context-panel"]');
+    const handle = event.currentTarget as HTMLElement;
+    const aside = handle.closest<HTMLElement>('[data-testid="context-panel"]');
     if (!aside) return;
-    event.preventDefault();
-    panel.setPointerCapture(event.pointerId);
+    handle.setPointerCapture(event.pointerId);
     dragStartY = event.clientY;
     dragStartHeight = aside.getBoundingClientRect().height;
     dragHeight = dragStartHeight;
     dragging = true;
+    dragMoved = false;
+    suppressNextHandleClick = false;
   }
 
   function handleSheetPointerMove(event: PointerEvent): void {
     if (!dragging) return;
+    const delta = dragStartY - event.clientY;
+    if (Math.abs(delta) >= DRAG_THRESHOLD_PX) dragMoved = true;
+    if (!dragMoved) return;
+
+    event.preventDefault();
     const minHeight = 190;
     const maxHeight = window.innerHeight * 0.88;
     dragHeight = Math.min(
       maxHeight,
-      Math.max(minHeight, dragStartHeight + dragStartY - event.clientY),
+      Math.max(minHeight, dragStartHeight + delta),
     );
   }
 
-  function handleSheetPointerUp(event: PointerEvent): void {
+  function finishSheetPointer(event: PointerEvent, cancelled: boolean): void {
     if (!dragging) return;
-    const panel = event.currentTarget as HTMLElement;
-    if (panel.hasPointerCapture(event.pointerId)) {
-      panel.releasePointerCapture(event.pointerId);
+    const handle = event.currentTarget as HTMLElement;
+    if (handle.hasPointerCapture(event.pointerId)) {
+      handle.releasePointerCapture(event.pointerId);
     }
+
+    if (cancelled || !dragMoved) {
+      dragHeight = null;
+      dragging = false;
+      dragMoved = false;
+      return;
+    }
+
     const finalHeight = dragHeight ?? dragStartHeight;
     setSheetStage(nearestSheetStage(finalHeight));
+    suppressNextHandleClick = true;
+    window.setTimeout(() => {
+      suppressNextHandleClick = false;
+    }, 0);
+  }
+
+  function handleSheetPointerUp(event: PointerEvent): void {
+    finishSheetPointer(event, false);
+  }
+
+  function handleSheetPointerCancel(event: PointerEvent): void {
+    finishSheetPointer(event, true);
+  }
+
+  function handleSheetHandleClick(event: MouseEvent): void {
+    if (suppressNextHandleClick) {
+      event.preventDefault();
+      suppressNextHandleClick = false;
+      return;
+    }
+    toggleSheetStage();
   }
 
   function handleSheetKeydown(event: KeyboardEvent): void {
-    if (event.key === "ArrowUp") {
-      event.preventDefault();
-      stepSheetStage(1);
-    } else if (event.key === "ArrowDown") {
-      event.preventDefault();
-      stepSheetStage(-1);
-    } else if (event.key === "Home") {
-      event.preventDefault();
-      setSheetStage("preview");
-    } else if (event.key === "End") {
+    if (window.innerWidth > 768) return;
+    if (event.key === "ArrowUp" || event.key === "End") {
       event.preventDefault();
       setSheetStage("full");
+    } else if (event.key === "ArrowDown" || event.key === "Home") {
+      event.preventDefault();
+      setSheetStage("compact");
     }
   }
 
@@ -200,8 +224,7 @@
 {#if $contextPanelOpen}
   <aside
     class="context-panel"
-    class:stage-preview={sheetStage === "preview"}
-    class:stage-half={sheetStage === "half"}
+    class:stage-compact={sheetStage === "compact"}
     class:stage-full={sheetStage === "full"}
     class:composition={$systemState === "komposition"}
     class:dragging
@@ -214,17 +237,16 @@
       type="button"
       class="sheet-handle"
       data-testid="sheet-handle"
-      aria-label={`Panelhöhe ziehen, aktuell ${
-        sheetStage === "preview"
-          ? "Vorschau"
-          : sheetStage === "half"
-            ? "halbe Höhe"
-            : "Vollbild"
-      }`}
+      aria-controls="context-panel-content"
+      aria-expanded={sheetStage === "full"}
+      aria-label={sheetStage === "compact"
+        ? "Panel vollständig öffnen oder ziehen"
+        : "Panel kompakt anzeigen oder ziehen"}
       on:pointerdown={handleSheetPointerDown}
       on:pointermove={handleSheetPointerMove}
       on:pointerup={handleSheetPointerUp}
-      on:pointercancel={handleSheetPointerUp}
+      on:pointercancel={handleSheetPointerCancel}
+      on:click={handleSheetHandleClick}
       on:keydown={handleSheetKeydown}
     >
       <span aria-hidden="true"></span>
@@ -234,36 +256,30 @@
       class:composition={$systemState === "komposition"}
     >
       <div class="heading-group">
-        <h2>{panelTitle}</h2>
+        <h2 class="desktop-panel-title">{panelTitle}</h2>
+        <h2 class="mobile-panel-heading">
+          <button
+            type="button"
+            class="mobile-panel-title"
+            aria-controls="context-panel-content"
+            aria-expanded={sheetStage === "full"}
+            aria-label={`${panelTitle}: ${
+              sheetStage === "compact"
+                ? "vollständig öffnen"
+                : "kompakt anzeigen"
+            }`}
+            on:click={toggleSheetStage}
+          >
+            <span>{panelTitle}</span>
+          </button>
+        </h2>
       </div>
-      <div class="header-actions">
-        <div class="sheet-controls" role="group" aria-label="Panelgröße">
-          <button
-            type="button"
-            aria-label="Vorschau"
-            aria-pressed={sheetStage === "preview"}
-            on:click={() => setSheetStage("preview")}>Vorschau</button
-          >
-          <button
-            type="button"
-            aria-label="Halbe Höhe"
-            aria-pressed={sheetStage === "half"}
-            on:click={() => setSheetStage("half")}>Halbe Höhe</button
-          >
-          <button
-            type="button"
-            aria-label="Vollbild"
-            aria-pressed={sheetStage === "full"}
-            on:click={() => setSheetStage("full")}>Vollbild</button
-          >
-        </div>
-        <button class="close-btn" on:click={closePanel} aria-label="Schließen"
-          >✕</button
-        >
-      </div>
+      <button class="close-btn" on:click={closePanel} aria-label="Schließen"
+        >✕</button
+      >
     </header>
 
-    <div class="panel-content">
+    <div class="panel-content" id="context-panel-content">
       {#if $systemState === "komposition"}
         <KompositionPanel bind:this={kompositionPanel} />
       {:else if $selection}
@@ -295,7 +311,8 @@
     box-sizing: border-box;
   }
 
-  .sheet-handle {
+  .sheet-handle,
+  .mobile-panel-heading {
     display: none;
   }
 
@@ -313,7 +330,8 @@
     min-width: 0;
   }
 
-  .panel-header h2 {
+  .desktop-panel-title,
+  .mobile-panel-heading {
     margin: 0;
     color: var(--muted);
     font-size: 0.78rem;
@@ -322,43 +340,12 @@
     text-transform: uppercase;
   }
 
-  .panel-header.composition h2 {
+  .panel-header.composition .desktop-panel-title,
+  .panel-header.composition .mobile-panel-heading {
     color: var(--text);
     font-size: 1.1rem;
     letter-spacing: 0;
     text-transform: none;
-  }
-
-  .header-actions,
-  .sheet-controls {
-    display: flex;
-    align-items: center;
-  }
-
-  .header-actions {
-    gap: 0.35rem;
-  }
-
-  .sheet-controls {
-    gap: 0.2rem;
-  }
-
-  .sheet-controls button {
-    min-width: 44px;
-    min-height: 44px;
-    padding: 0 0.55rem;
-    border: 1px solid transparent;
-    border-radius: 9px;
-    background: transparent;
-    color: var(--muted);
-    cursor: pointer;
-    font-size: 0.76rem;
-  }
-
-  .sheet-controls button[aria-pressed="true"] {
-    border-color: var(--panel-border-strong);
-    background: var(--accent-soft);
-    color: var(--text);
   }
 
   .close-btn {
@@ -391,15 +378,15 @@
       border-radius: 18px 18px 0 0;
       transition: height var(--motion-ui);
     }
-    .context-panel.stage-preview {
+
+    .context-panel.stage-compact {
       height: clamp(190px, 29dvh, 270px);
     }
-    .context-panel.stage-half {
-      height: 55dvh;
-    }
+
     .context-panel.stage-full {
       height: 88dvh;
     }
+
     .sheet-handle {
       width: 100%;
       min-height: 44px;
@@ -412,65 +399,67 @@
       cursor: ns-resize;
       touch-action: none;
     }
+
     .sheet-handle span {
       width: 44px;
       height: 4px;
       border-radius: 999px;
       background: var(--panel-border-strong);
     }
-    .sheet-handle:focus-visible {
+
+    .sheet-handle:focus-visible,
+    .mobile-panel-title:focus-visible {
       outline: 3px solid var(--accent);
       outline-offset: -4px;
     }
+
     .context-panel.dragging {
       transition: none;
       user-select: none;
     }
+
     .panel-header {
       min-height: 64px;
       padding-top: 0.25rem;
     }
+
     .heading-group {
       flex: 1;
       text-align: left;
     }
-    .sheet-controls button {
-      min-width: 44px;
-      min-height: 44px;
-      padding: 0 0.35rem;
-      font-size: 0.7rem;
+
+    .desktop-panel-title {
+      display: none;
     }
-    .stage-preview .panel-content {
+
+    .mobile-panel-heading {
+      display: block;
+      margin: 0;
+    }
+
+    .mobile-panel-title {
+      display: flex;
+      align-items: center;
+      width: 100%;
+      min-height: 44px;
+      padding: 0;
+      border: 0;
+      background: transparent;
+      color: inherit;
+      font: inherit;
+      font-weight: inherit;
+      letter-spacing: inherit;
+      text-align: left;
+      text-transform: inherit;
+      cursor: pointer;
+    }
+
+    .stage-compact .panel-content {
       padding-top: 0.65rem;
     }
-  }
 
-  @media (max-width: 440px) {
-    .sheet-controls button {
-      width: 44px;
-      overflow: hidden;
-      color: transparent;
-      position: relative;
-    }
-    .sheet-controls button::after {
-      position: absolute;
-      inset: 0;
-      display: grid;
-      place-items: center;
-      color: var(--muted);
-      font-size: 1rem;
-    }
-    .sheet-controls button:nth-child(1)::after {
-      content: "▂";
-    }
-    .sheet-controls button:nth-child(2)::after {
-      content: "▅";
-    }
-    .sheet-controls button:nth-child(3)::after {
-      content: "▇";
-    }
-    .sheet-controls button[aria-pressed="true"]::after {
-      color: var(--accent);
+    .stage-compact :global(.tabs) {
+      display: none;
     }
   }
 
@@ -481,9 +470,6 @@
       bottom: 0;
       width: var(--context-panel-width);
       box-shadow: -4px 0 16px rgba(0, 0, 0, 0.28);
-    }
-    .sheet-controls {
-      display: none;
     }
   }
 

--- a/apps/web/src/lib/styles/page-system.css
+++ b/apps/web/src/lib/styles/page-system.css
@@ -1,0 +1,220 @@
+.wg-page {
+  --wg-surface: var(--panel-solid);
+  --wg-border: var(--panel-border);
+  --wg-border-strong: var(--panel-border-strong);
+  --wg-action: var(--accent);
+  --wg-action-soft: var(--accent-soft);
+  --wg-muted: var(--muted);
+  min-height: 100%;
+  box-sizing: border-box;
+  padding: clamp(1rem, 4vw, 2rem) 0 clamp(3rem, 8vw, 5rem);
+  background:
+    radial-gradient(circle at 12% 0, var(--accent-soft), transparent 34rem),
+    var(--bg);
+  color: var(--text);
+}
+
+.wg-page *,
+.wg-page *::before,
+.wg-page *::after {
+  box-sizing: border-box;
+}
+
+.wg-page__shell {
+  width: min(56rem, calc(100% - 2rem));
+  margin-inline: auto;
+}
+
+.wg-page__shell--narrow {
+  width: min(30rem, calc(100% - 2rem));
+  padding-top: clamp(2rem, 10vh, 6rem);
+}
+
+.wg-page__header {
+  display: grid;
+  gap: 1rem;
+  padding-block: 0.5rem clamp(2rem, 6vw, 3.5rem);
+}
+
+.wg-back-link {
+  width: fit-content;
+  color: var(--wg-muted);
+  text-decoration: none;
+  font-weight: 650;
+}
+
+.wg-back-link:hover {
+  color: var(--text);
+}
+
+.wg-eyebrow {
+  margin: 0;
+  color: var(--wg-action);
+  font-size: 0.76rem;
+  font-weight: 750;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.wg-title {
+  margin: 0;
+  font-size: clamp(2.5rem, 8vw, 4.5rem);
+  line-height: 0.98;
+  letter-spacing: -0.04em;
+}
+
+.wg-title--compact {
+  font-size: clamp(2rem, 8vw, 3rem);
+}
+
+.wg-lede {
+  max-width: 68ch;
+  margin: 0;
+  color: var(--wg-muted);
+  font-size: 1.05rem;
+  line-height: 1.65;
+}
+
+.wg-stack {
+  display: grid;
+  gap: 1rem;
+}
+
+.wg-card {
+  border: 1px solid var(--wg-border);
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--wg-surface) 94%, transparent);
+  box-shadow: var(--shadow);
+}
+
+.wg-card--padded {
+  padding: clamp(1.25rem, 4vw, 2rem);
+}
+
+.wg-field {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.wg-label {
+  color: var(--wg-muted);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.wg-control {
+  width: 100%;
+  min-height: 46px;
+  padding: 0.75rem 0.85rem;
+  border: 1px solid var(--wg-border-strong);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--bg) 82%, black);
+  color: var(--text);
+  font: inherit;
+}
+
+textarea.wg-control {
+  min-height: 8rem;
+  resize: vertical;
+}
+
+.wg-control::placeholder {
+  color: color-mix(in srgb, var(--wg-muted) 70%, transparent);
+}
+
+.wg-control:disabled {
+  opacity: 0.6;
+}
+
+.wg-actions,
+.wg-section-heading,
+.wg-inline-spread {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.wg-actions {
+  justify-content: flex-end;
+}
+
+.wg-section-heading {
+  margin-bottom: 1rem;
+}
+
+.wg-button {
+  width: fit-content;
+  min-height: 44px;
+  padding: 0.65rem 1rem;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  font: inherit;
+  font-weight: 720;
+  cursor: pointer;
+}
+
+.wg-button--primary {
+  background: var(--wg-action);
+  color: var(--bg);
+}
+
+.wg-button--secondary {
+  border-color: var(--wg-border-strong);
+  background: transparent;
+  color: var(--text);
+}
+
+.wg-button--danger {
+  padding-inline: 0;
+  background: transparent;
+  color: var(--danger);
+}
+
+.wg-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.wg-state {
+  margin: 0;
+  padding: 0.9rem 1rem;
+  border: 1px solid var(--wg-border);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--wg-surface) 92%, transparent);
+}
+
+.wg-state p {
+  margin: 0;
+}
+
+.wg-state p + p {
+  margin-top: 0.4rem;
+}
+
+.wg-state--success {
+  border-color: color-mix(in srgb, #54e1a6 55%, transparent);
+  background: color-mix(in srgb, #54e1a6 12%, var(--wg-surface));
+}
+
+.wg-state--error {
+  border-color: color-mix(in srgb, var(--danger) 55%, transparent);
+  background: color-mix(in srgb, var(--danger) 10%, var(--wg-surface));
+  color: var(--danger);
+}
+
+.wg-state--muted {
+  color: var(--wg-muted);
+}
+
+@media (max-width: 560px) {
+  .wg-section-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .wg-button--primary,
+  .wg-actions .wg-button {
+    width: 100%;
+  }
+}

--- a/apps/web/src/routes/antraege/+page.svelte
+++ b/apps/web/src/routes/antraege/+page.svelte
@@ -3,6 +3,7 @@
   import { afterNavigate, goto } from "$app/navigation";
   import { page } from "$app/stores";
   import { authStore } from "$lib/auth/store";
+  import "$lib/styles/page-system.css";
   import ProposalDetail from "$lib/components/governance/ProposalDetail.svelte";
   import {
     GovernanceApiError,
@@ -57,8 +58,10 @@
 
   function describeError(cause: unknown): string {
     if (cause instanceof GovernanceApiError) {
-      if (cause.status === 409) return "Diese Aktion ist im aktuellen Zustand nicht möglich.";
-      if (cause.status === 503) return "Das Antragssystem ist vorübergehend nicht verfügbar.";
+      if (cause.status === 409)
+        return "Diese Aktion ist im aktuellen Zustand nicht möglich.";
+      if (cause.status === 503)
+        return "Das Antragssystem ist vorübergehend nicht verfügbar.";
     }
     return "Das Antragssystem konnte nicht geladen werden.";
   }
@@ -149,125 +152,285 @@
 
 <svelte:head>
   <title>Anträge · Weltgewebe</title>
-  <meta name="description" content="Offene Anträge, Konsentphasen, Vetos, Gespräche und Abstimmungen im Weltgewebe." />
+  <meta
+    name="description"
+    content="Offene Anträge, Konsentphasen, Vetos, Gespräche und Abstimmungen im Weltgewebe."
+  />
 </svelte:head>
 
 {#if selectedProposalId}
   <ProposalDetail proposalId={selectedProposalId} />
 {:else}
-<main class="page-shell">
-  <header class="page-header">
-    <a class="back-link" href="/map">← Zum Gewebe</a>
-    <p class="eyebrow">Gemeinsame Entscheidungen</p>
-    <h1>Anträge</h1>
-    <p>
-      Jeder Antrag liegt sieben Tage offen. Ohne Veto wird er angenommen. Nach einem Veto folgen weitere sieben Tage Gespräch und Abstimmung; angenommen ist er genau dann, wenn mehr Ja- als Nein-Stimmen vorliegen.
-    </p>
-  </header>
+  <main class="wg-page wg-page--paper" data-testid="applications-page">
+    <div class="wg-page__shell">
+      <header class="wg-page__header">
+        <a class="wg-back-link" href="/map">← Zum Gewebe</a>
+        <p class="wg-eyebrow">Gemeinsame Entscheidungen</p>
+        <h1 class="wg-title">Anträge</h1>
+        <p class="wg-lede">
+          Jeder Antrag liegt sieben Tage offen. Ohne Veto wird er angenommen.
+          Nach einem Veto folgen weitere sieben Tage Gespräch und Abstimmung;
+          angenommen ist er genau dann, wenn mehr Ja- als Nein-Stimmen
+          vorliegen.
+        </p>
+      </header>
 
-  {#if isGuest}
-    <section id="antrag-stellen" class="guest-card" aria-labelledby="weberstatus-heading" tabindex="-1" bind:this={applicationSection}>
-      <div>
-        <p class="eyebrow">Dein Status: Gast</p>
-        <h2 id="weberstatus-heading">Weberstatus beantragen</h2>
-        <p>Als Gast besitzt du bereits deine Garnrolle und kannst sie beschreiben. Ein angenommener Antrag verleiht dir zusätzliche Weberrechte; er erzeugt keine zweite Garnrolle.</p>
-      </div>
-      {#if hasOpenOwnProposal}
-        <p class="notice">Dein Weberantrag ist bereits offen.</p>
-      {:else}
-        <label for="application-summary">Kurze Vorstellung oder Begründung</label>
-        <textarea id="application-summary" bind:value={summary} maxlength="2000" rows="5" placeholder="Was möchtest du im Weltgewebe beitragen?"></textarea>
-        <button class="primary" on:click={applyForWeber} disabled={submitting}>
-          {submitting ? "Antrag wird gestellt…" : "Weberstatus beantragen"}
-        </button>
+      {#if isGuest}
+        <section
+          id="antrag-stellen"
+          class="wg-card wg-card--padded wg-stack guest-card"
+          aria-labelledby="weberstatus-heading"
+          tabindex="-1"
+          bind:this={applicationSection}
+        >
+          <div class="wg-stack">
+            <p class="wg-eyebrow">Dein Status: Gast</p>
+            <h2 id="weberstatus-heading">Weberstatus beantragen</h2>
+            <p>
+              Als Gast besitzt du bereits deine Garnrolle und kannst sie
+              beschreiben. Ein angenommener Antrag verleiht dir zusätzliche
+              Weberrechte; er erzeugt keine zweite Garnrolle.
+            </p>
+          </div>
+          {#if hasOpenOwnProposal}
+            <p class="wg-state wg-state--success">
+              Dein Weberantrag ist bereits offen.
+            </p>
+          {:else}
+            <div class="wg-field">
+              <label class="wg-label" for="application-summary"
+                >Kurze Vorstellung oder Begründung</label
+              >
+              <textarea
+                class="wg-control"
+                id="application-summary"
+                bind:value={summary}
+                maxlength="2000"
+                rows="5"
+                placeholder="Was möchtest du im Weltgewebe beitragen?"
+              ></textarea>
+            </div>
+            <button
+              class="wg-button wg-button--primary"
+              on:click={applyForWeber}
+              disabled={submitting}
+            >
+              {submitting ? "Antrag wird gestellt…" : "Weberstatus beantragen"}
+            </button>
+          {/if}
+          <button
+            class="wg-button wg-button--danger"
+            on:click={leaveWeltgewebe}
+            disabled={leaving}
+          >
+            {leaving
+              ? "Gastkonto wird aufgelöst…"
+              : "Weltgewebe vollständig verlassen"}
+          </button>
+        </section>
       {/if}
-      <button class="danger-link" on:click={leaveWeltgewebe} disabled={leaving}>
-        {leaving ? "Gastkonto wird aufgelöst…" : "Weltgewebe vollständig verlassen"}
-      </button>
-    </section>
-  {/if}
 
-  {#if error}<div class="error" role="alert">{error}</div>{/if}
+      {#if error}
+        <div class="wg-state wg-state--error page-error" role="alert">
+          {error}
+        </div>
+      {/if}
 
-  <section aria-labelledby="proposal-list-heading">
-    <div class="section-heading">
-      <div>
-        <h2 id="proposal-list-heading">{proposalListTitle}</h2>
-        <nav class="proposal-filters" aria-label="Governance-Ereignisse filtern">
-          <a class:active={!statusFilter && !eventFilter} href="/antraege">Alle</a>
-          <a class:active={statusFilter === "consent"} href="/antraege?status=consent">Offen</a>
-          <a class:active={eventFilter === "veto"} href="/antraege?ereignis=veto">Vetos</a>
-          <a class:active={eventFilter === "gespraech"} href="/antraege?ereignis=gespraech">Gespräche</a>
-          <a class:active={statusFilter === "voting"} href="/antraege?status=voting">Abstimmungen</a>
-        </nav>
-      </div>
-      <button class="secondary" on:click={refresh} disabled={loading}>Aktualisieren</button>
+      <section aria-labelledby="proposal-list-heading">
+        <div class="wg-section-heading">
+          <div>
+            <h2 id="proposal-list-heading">{proposalListTitle}</h2>
+            <nav
+              class="proposal-filters"
+              aria-label="Governance-Ereignisse filtern"
+            >
+              <a class:active={!statusFilter && !eventFilter} href="/antraege"
+                >Alle</a
+              >
+              <a
+                class:active={statusFilter === "consent"}
+                href="/antraege?status=consent">Offen</a
+              >
+              <a
+                class:active={eventFilter === "veto"}
+                href="/antraege?ereignis=veto">Vetos</a
+              >
+              <a
+                class:active={eventFilter === "gespraech"}
+                href="/antraege?ereignis=gespraech">Gespräche</a
+              >
+              <a
+                class:active={statusFilter === "voting"}
+                href="/antraege?status=voting">Abstimmungen</a
+              >
+            </nav>
+          </div>
+          <button
+            class="wg-button wg-button--secondary"
+            on:click={refresh}
+            disabled={loading}>Aktualisieren</button
+          >
+        </div>
+
+        {#if loading}
+          <p class="wg-state wg-state--muted" role="status">
+            Anträge werden geladen…
+          </p>
+        {:else if proposals.length === 0}
+          <p class="wg-state">Noch liegen keine Anträge vor.</p>
+        {:else if visibleProposals.length === 0}
+          <p class="wg-state">Für diese Ansicht liegen keine Anträge vor.</p>
+        {:else}
+          <div class="proposal-list">
+            {#each visibleProposals as proposal}
+              <a
+                class="wg-card proposal-card"
+                href={`/antraege?id=${encodeURIComponent(proposal.id)}`}
+              >
+                <div class="wg-inline-spread proposal-topline">
+                  <span
+                    class:open={proposal.status === "consent" ||
+                      proposal.status === "voting"}
+                    >{statusLabel(proposal.status)}</span
+                  >
+                  <time datetime={proposal.created_at}
+                    >{new Date(proposal.created_at).toLocaleDateString(
+                      "de-DE",
+                    )}</time
+                  >
+                </div>
+                <h3>Weberstatus für {proposal.applicant_title}</h3>
+                {#if proposal.summary}<p>{proposal.summary}</p>{/if}
+                <div class="facts">
+                  <span
+                    >{proposal.veto_count} Veto{proposal.veto_count === 1
+                      ? ""
+                      : "s"}</span
+                  >
+                  <span>{proposal.yes_votes} Ja · {proposal.no_votes} Nein</span
+                  >
+                  {#if proposal.remaining_seconds !== undefined}<span
+                      >Noch {formatRemaining(proposal.remaining_seconds)}</span
+                    >{/if}
+                </div>
+              </a>
+            {/each}
+          </div>
+        {/if}
+      </section>
     </div>
-
-    {#if loading}
-      <p class="muted">Anträge werden geladen…</p>
-    {:else if proposals.length === 0}
-      <p class="empty">Noch liegen keine Anträge vor.</p>
-    {:else if visibleProposals.length === 0}
-      <p class="empty">Für diese Ansicht liegen keine Anträge vor.</p>
-    {:else}
-      <div class="proposal-list">
-        {#each visibleProposals as proposal}
-          <a class="proposal-card" href={`/antraege?id=${encodeURIComponent(proposal.id)}`}>
-            <div class="proposal-topline">
-              <span class:open={proposal.status === "consent" || proposal.status === "voting"}>{statusLabel(proposal.status)}</span>
-              <time datetime={proposal.created_at}>{new Date(proposal.created_at).toLocaleDateString("de-DE")}</time>
-            </div>
-            <h3>Weberstatus für {proposal.applicant_title}</h3>
-            {#if proposal.summary}<p>{proposal.summary}</p>{/if}
-            <div class="facts">
-              <span>{proposal.veto_count} Veto{proposal.veto_count === 1 ? "" : "s"}</span>
-              <span>{proposal.yes_votes} Ja · {proposal.no_votes} Nein</span>
-              {#if proposal.remaining_seconds !== undefined}<span>Noch {formatRemaining(proposal.remaining_seconds)}</span>{/if}
-            </div>
-          </a>
-        {/each}
-      </div>
-    {/if}
-  </section>
-</main>
+  </main>
 {/if}
 
 <style>
-  :global(body) { margin: 0; background: #f3f1e9; color: #18251f; font-family: system-ui, sans-serif; }
-  .page-shell { width: min(880px, calc(100% - 32px)); margin: 0 auto; padding: 28px 0 72px; }
-  .page-header { padding: 24px 0 32px; }
-  .back-link { color: inherit; text-decoration: none; font-weight: 650; }
-  .eyebrow { margin: 28px 0 6px; text-transform: uppercase; letter-spacing: .09em; font-size: .76rem; font-weight: 750; color: #4d6759; }
-  h1 { margin: 0; font-size: clamp(2.4rem, 8vw, 4.5rem); line-height: .95; }
-  h2, h3 { margin: 0; }
-  .page-header > p:last-child { max-width: 68ch; font-size: 1.08rem; line-height: 1.6; }
-  .guest-card, .proposal-card, .error, .empty { border: 1px solid rgba(24,37,31,.16); border-radius: 18px; background: rgba(255,255,255,.72); }
-  .guest-card { display: grid; gap: 14px; padding: 24px; margin-bottom: 36px; }
-  .guest-card .eyebrow { margin-top: 0; }
-  label { font-weight: 700; }
-  textarea { box-sizing: border-box; width: 100%; resize: vertical; border: 1px solid rgba(24,37,31,.28); border-radius: 12px; padding: 12px; font: inherit; background: #fff; }
-  button { width: fit-content; border-radius: 999px; padding: 10px 16px; font: inherit; font-weight: 720; cursor: pointer; }
-  button:disabled { opacity: .55; cursor: wait; }
-  .primary { border: 0; background: #1f5b42; color: white; }
-  .secondary { border: 1px solid rgba(24,37,31,.28); background: transparent; color: inherit; }
-  .danger-link { border: 0; padding-left: 0; background: transparent; color: #8d2f2f; }
-  .notice { padding: 12px 14px; border-radius: 10px; background: #e7efe9; }
-  .error { padding: 14px 16px; margin-bottom: 24px; color: #7f2424; background: #fff0f0; }
-  .section-heading, .proposal-topline, .facts { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
-  .section-heading { margin-bottom: 16px; }
-  .proposal-filters { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 12px; }
-  .proposal-filters a { min-height: 44px; padding: 0 14px; border: 1px solid rgba(24,37,31,.2); border-radius: 999px; display: inline-flex; align-items: center; color: inherit; text-decoration: none; font-weight: 680; }
-  .proposal-filters a.active { border-color: #1f5b42; background: #dcecdf; color: #1f5b42; }
-  .proposal-list { display: grid; gap: 12px; }
-  .proposal-card { display: grid; gap: 12px; padding: 20px; color: inherit; text-decoration: none; transition: transform 120ms ease, border-color 120ms ease; }
-  .proposal-card:hover, .proposal-card:focus-visible { transform: translateY(-2px); border-color: rgba(24,37,31,.45); }
-  .proposal-topline { font-size: .82rem; color: #607168; }
-  .proposal-topline span { padding: 4px 9px; border-radius: 999px; background: #e9e8e1; }
-  .proposal-topline span.open { background: #dcecdf; color: #1f5b42; }
-  .proposal-card p { margin: 0; line-height: 1.5; }
-  .facts { justify-content: flex-start; flex-wrap: wrap; font-size: .86rem; color: #526259; }
-  .empty { padding: 24px; }
-  .muted { color: #607168; }
-  @media (max-width: 560px) { .section-heading, .proposal-topline { align-items: flex-start; } .section-heading { flex-direction: column; } }
+  h2,
+  h3,
+  p {
+    margin-block: 0;
+  }
+
+  .guest-card {
+    margin-bottom: 36px;
+  }
+
+  .guest-card .wg-eyebrow {
+    margin-top: 0;
+  }
+
+  .page-error {
+    margin-bottom: 24px;
+  }
+
+  .proposal-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 12px;
+  }
+
+  .proposal-filters a {
+    min-height: 44px;
+    padding: 0 14px;
+    border: 1px solid var(--wg-border);
+    border-radius: 999px;
+    display: inline-flex;
+    align-items: center;
+    color: inherit;
+    text-decoration: none;
+    font-weight: 680;
+  }
+
+  .proposal-filters a.active {
+    border-color: var(--wg-action);
+    background: var(--wg-action-soft);
+    color: var(--wg-action);
+  }
+
+  .proposal-list {
+    display: grid;
+    gap: 12px;
+  }
+
+  .proposal-card {
+    display: grid;
+    gap: 12px;
+    padding: 20px;
+    color: inherit;
+    text-decoration: none;
+    transition:
+      transform 120ms ease,
+      border-color 120ms ease;
+  }
+
+  .proposal-card:hover,
+  .proposal-card:focus-visible {
+    transform: translateY(-2px);
+    border-color: var(--wg-border-strong);
+  }
+
+  .proposal-topline {
+    font-size: 0.82rem;
+    color: var(--wg-muted);
+  }
+
+  .proposal-topline span {
+    padding: 4px 9px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--wg-muted) 12%, transparent);
+  }
+
+  .proposal-topline span.open {
+    background: var(--wg-action-soft);
+    color: var(--wg-action);
+  }
+
+  .proposal-card p {
+    line-height: 1.5;
+  }
+
+  .facts {
+    display: flex;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+    gap: 12px;
+    font-size: 0.86rem;
+    color: var(--wg-muted);
+  }
+
+  @media (max-width: 560px) {
+    .proposal-topline {
+      align-items: flex-start;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .proposal-card {
+      transition: none;
+    }
+
+    .proposal-card:hover,
+    .proposal-card:focus-visible {
+      transform: none;
+    }
+  }
 </style>

--- a/apps/web/src/routes/login/+page.svelte
+++ b/apps/web/src/routes/login/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import { authStore } from '$lib/auth/store';
+  import { authStore } from "$lib/auth/store";
+  import "$lib/styles/page-system.css";
 
-  let email = '';
+  let email = "";
   let error: string | null = null;
   let success = false;
   let loading = false;
@@ -14,10 +15,10 @@
       await authStore.requestLogin(email);
       success = true;
     } catch (e) {
-      if (e instanceof Error && e.message.includes('disabled')) {
-        error = 'Öffentlicher Login ist derzeit deaktiviert.';
+      if (e instanceof Error && e.message.includes("disabled")) {
+        error = "Öffentlicher Login ist derzeit deaktiviert.";
       } else {
-        error = 'Login fehlgeschlagen. Bitte versuche es erneut.';
+        error = "Login fehlgeschlagen. Bitte versuche es erneut.";
       }
       console.error(e);
     } finally {
@@ -30,42 +31,59 @@
   <title>Login</title>
 </svelte:head>
 
-<div class="col" style="gap:1.5rem; padding:1.5rem; max-width:400px; margin:0 auto; margin-top: 10vh;">
-  <div class="panel col" style="gap:1rem;">
-    <h1 style="margin:0; font-size:1.5rem;">Login</h1>
+<main class="wg-page" data-testid="login-page">
+  <div class="wg-page__shell wg-page__shell--narrow">
+    <section
+      class="wg-card wg-card--padded wg-stack"
+      aria-labelledby="login-heading"
+    >
+      <header class="wg-stack">
+        <p class="wg-eyebrow">Gewebekonto</p>
+        <h1 id="login-heading" class="wg-title wg-title--compact">Login</h1>
+      </header>
 
-    {#if success}
-      <div class="panel" style="border-color:var(--color-theme-2, #2ecc71);">
-        <p><strong>Postfach prüfen!</strong></p>
-        <p>Falls deine E-Mail registriert ist, haben wir dir einen Login-Link gesendet.</p>
-      </div>
-    {:else}
-      <form on:submit|preventDefault={handleSubmit} class="col" style="gap:1rem;">
-        <div class="col">
-          <label for="email" style="font-size:0.9rem; color:var(--muted);">E-Mail</label>
-          <input
-            id="email"
-            type="email"
-            bind:value={email}
-            placeholder="du@example.com"
-            required
-            disabled={loading}
-            style="padding:0.5rem; border-radius:6px; border:1px solid #263240; background:#101821; color:white;"
-          />
+      {#if success}
+        <div class="wg-state wg-state--success" role="status">
+          <p><strong>Postfach prüfen!</strong></p>
+          <p>
+            Falls deine E-Mail registriert ist, haben wir dir einen Login-Link
+            gesendet.
+          </p>
         </div>
-
-        {#if error}
-          <div style="color:var(--color-danger, #ff6b6b); font-size:0.9rem;">
-            {error}
+      {:else}
+        <form on:submit|preventDefault={handleSubmit} class="wg-stack">
+          <div class="wg-field">
+            <label class="wg-label" for="email">E-Mail</label>
+            <input
+              class="wg-control"
+              id="email"
+              type="email"
+              bind:value={email}
+              placeholder="du@example.com"
+              autocomplete="email"
+              required
+              disabled={loading}
+              aria-describedby={error ? "login-error" : undefined}
+            />
           </div>
-        {/if}
 
-        <div class="row" style="justify-content:flex-end;">
-          <button type="submit" class="btn" disabled={loading || !email}>
-            {#if loading}Wird gesendet...{:else}Login-Link senden{/if}
-          </button>
-        </div>
-      </form>
-    {/if}
+          {#if error}
+            <div id="login-error" class="wg-state wg-state--error" role="alert">
+              {error}
+            </div>
+          {/if}
+
+          <div class="wg-actions">
+            <button
+              type="submit"
+              class="wg-button wg-button--primary"
+              disabled={loading || !email}
+            >
+              {#if loading}Wird gesendet…{:else}Login-Link senden{/if}
+            </button>
+          </div>
+        </form>
+      {/if}
+    </section>
   </div>
-</div>
+</main>

--- a/apps/web/tests/context-panel-sheet.spec.ts
+++ b/apps/web/tests/context-panel-sheet.spec.ts
@@ -20,6 +20,7 @@ test.describe("ContextPanel mobile compact and full states", () => {
     const panel = page.getByTestId("context-panel");
     const handle = page.getByTestId("sheet-handle");
     await expect(panel).toBeVisible();
+    await expect(panel.locator(".panel-header h2")).toHaveCount(1);
     await expect(panel).toHaveAttribute("data-sheet-stage", "compact");
     await expect(handle).toHaveAttribute("aria-expanded", "false");
     await expect(panel.locator(".tabs")).toBeHidden();

--- a/apps/web/tests/context-panel-sheet.spec.ts
+++ b/apps/web/tests/context-panel-sheet.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@playwright/test";
 import { mockApiResponses } from "./fixtures/mockApi";
 import { activateToolFanAction } from "./fixtures/toolFan";
 
-test.describe("ContextPanel mobile sheet stages", () => {
+test.describe("ContextPanel mobile compact and full states", () => {
   test.beforeEach(async ({ page }) => {
     await mockApiResponses(page, {
       auth: { authenticated: true, account_id: "e2e-weber", role: "weber" },
@@ -12,74 +12,60 @@ test.describe("ContextPanel mobile sheet stages", () => {
     await page.waitForSelector(".map-marker", { timeout: 10000 });
   });
 
-  test("Fokus opens in the compact preview stage on mobile", async ({
+  test("Fokus opens as a compact card without mobile tabs or size buttons", async ({
     page,
   }) => {
-    await page.evaluate(() =>
-      (document.querySelector(".map-marker") as HTMLElement)?.dispatchEvent(
-        new MouseEvent("click", { bubbles: true }),
-      ),
-    );
+    await page.locator(".map-marker").first().click();
 
     const panel = page.getByTestId("context-panel");
-    await expect(panel).toBeVisible();
-    await expect(panel).toHaveAttribute("data-sheet-stage", "preview");
-
-    const preview = page.getByRole("button", { name: "Vorschau", exact: true });
-    await expect(preview).toHaveAttribute("aria-pressed", "true");
     const handle = page.getByTestId("sheet-handle");
-    await expect(handle).toBeVisible();
+    await expect(panel).toBeVisible();
+    await expect(panel).toHaveAttribute("data-sheet-stage", "compact");
+    await expect(handle).toHaveAttribute("aria-expanded", "false");
+    await expect(panel.locator(".tabs")).toBeHidden();
+    await expect(page.getByLabel("Panelgröße")).toHaveCount(0);
     expect((await handle.boundingBox())?.height).toBeGreaterThanOrEqual(44);
   });
 
-  test("the accessible toggle switches between preview, half and full", async ({
+  test("handle and panel title toggle directly between compact and full", async ({
     page,
   }) => {
-    // Settle the height transition instantly so bounding boxes reflect the
-    // resting size of each stage rather than a mid-animation frame.
     await page.emulateMedia({ reducedMotion: "reduce" });
-    await page.evaluate(() =>
-      (document.querySelector(".map-marker") as HTMLElement)?.dispatchEvent(
-        new MouseEvent("click", { bubbles: true }),
-      ),
-    );
+    await page.locator(".map-marker").first().click();
 
     const panel = page.getByTestId("context-panel");
-    const half = page.getByRole("button", { name: "Halbe Höhe", exact: true });
-    const full = page.getByRole("button", { name: "Vollbild", exact: true });
+    const handle = page.getByTestId("sheet-handle");
+    const title = panel.locator(".mobile-panel-title");
+    const compactBox = await panel.boundingBox();
 
-    const previewBox = await panel.boundingBox();
-
-    await half.click();
-    await expect(panel).toHaveAttribute("data-sheet-stage", "half");
-    await expect(half).toHaveAttribute("aria-pressed", "true");
-    const halfBox = await panel.boundingBox();
-    expect(halfBox!.height).toBeGreaterThan(previewBox!.height);
-
-    await full.click();
+    await handle.click();
     await expect(panel).toHaveAttribute("data-sheet-stage", "full");
-    await expect(full).toHaveAttribute("aria-pressed", "true");
+    await expect(handle).toHaveAttribute("aria-expanded", "true");
+    await expect(panel.locator(".tabs")).toBeVisible();
     const fullBox = await panel.boundingBox();
-    expect(fullBox!.height).toBeGreaterThan(halfBox!.height);
+    expect(fullBox!.height).toBeGreaterThan(compactBox!.height);
+
+    await title.click();
+    await expect(panel).toHaveAttribute("data-sheet-stage", "compact");
+    await expect(panel.locator(".tabs")).toBeHidden();
   });
 
-  test("Komposition starts full but remains resizable", async ({ page }) => {
+  test("Komposition starts full and can collapse through the same handle", async ({
+    page,
+  }) => {
     await page.waitForSelector('[data-testid="tool-fan"]', {
       timeout: 10000,
     });
-    // The tool fan collapses on mobile once the panel is open, so open
-    // komposition first.
     await activateToolFanAction(page, "weave");
 
     const panel = page.getByTestId("context-panel");
     await expect(panel).toBeVisible();
     await expect(panel).toHaveAttribute("data-sheet-stage", "full");
-    await expect(page.getByLabel("Panelgröße")).toBeVisible();
-    await page.getByRole("button", { name: "Halbe Höhe", exact: true }).click();
-    await expect(panel).toHaveAttribute("data-sheet-stage", "half");
+    await page.getByTestId("sheet-handle").click();
+    await expect(panel).toHaveAttribute("data-sheet-stage", "compact");
   });
 
-  test("sheet handle supports keyboard stages and pointer dragging", async ({
+  test("keyboard and dragging select the two states without a post-drag double toggle", async ({
     page,
   }) => {
     await page.emulateMedia({ reducedMotion: "reduce" });
@@ -89,19 +75,32 @@ test.describe("ContextPanel mobile sheet stages", () => {
 
     await handle.focus();
     await handle.press("ArrowUp");
-    await expect(panel).toHaveAttribute("data-sheet-stage", "half");
+    await expect(panel).toHaveAttribute("data-sheet-stage", "full");
+    await handle.press("ArrowDown");
+    await expect(panel).toHaveAttribute("data-sheet-stage", "compact");
     await handle.press("End");
     await expect(panel).toHaveAttribute("data-sheet-stage", "full");
     await handle.press("Home");
-    await expect(panel).toHaveAttribute("data-sheet-stage", "preview");
+    await expect(panel).toHaveAttribute("data-sheet-stage", "compact");
 
     const box = await handle.boundingBox();
     expect(box).not.toBeNull();
     await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
     await page.mouse.down();
-    await page.mouse.move(box!.x + box!.width / 2, box!.y - 300, { steps: 8 });
+    await page.mouse.move(box!.x + box!.width / 2, box!.y - 360, { steps: 8 });
     await page.mouse.up();
-    await expect(panel).not.toHaveAttribute("data-sheet-stage", "preview");
+    await expect(panel).toHaveAttribute("data-sheet-stage", "full");
+    await page.waitForTimeout(20);
+    await expect(panel).toHaveAttribute("data-sheet-stage", "full");
+  });
+
+  test("reduced motion removes the height transition", async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.locator(".map-marker").first().click();
+    const transitionDuration = await page
+      .getByTestId("context-panel")
+      .evaluate((element) => getComputedStyle(element).transitionDuration);
+    expect(transitionDuration).toBe("0s");
   });
 
   test("orientation change keeps the open panel inside the viewport", async ({
@@ -110,7 +109,7 @@ test.describe("ContextPanel mobile sheet stages", () => {
     await page.emulateMedia({ reducedMotion: "reduce" });
     await page.locator(".map-marker").first().click();
     const panel = page.getByTestId("context-panel");
-    await page.getByRole("button", { name: "Vollbild", exact: true }).click();
+    await page.getByTestId("sheet-handle").click();
     await expect(panel).toHaveAttribute("data-sheet-stage", "full");
 
     await page.setViewportSize({ width: 844, height: 390 });
@@ -120,19 +119,15 @@ test.describe("ContextPanel mobile sheet stages", () => {
     expect(box!.y).toBeGreaterThanOrEqual(0);
     expect(box!.x + box!.width).toBeLessThanOrEqual(844);
     expect(box!.y + box!.height).toBeLessThanOrEqual(390);
-    await expect(page.getByLabel("Panelgröße")).toBeHidden();
+    await expect(page.getByTestId("sheet-handle")).toBeHidden();
   });
 
-  test("switching the selected marker resets the sheet back to preview", async ({
+  test("switching the selected marker resets the sheet to compact", async ({
     page,
   }) => {
-    await page.evaluate(() =>
-      (
-        document.querySelectorAll(".map-marker")[0] as HTMLElement
-      )?.dispatchEvent(new MouseEvent("click", { bubbles: true })),
-    );
+    await page.locator(".map-marker").first().click();
     const panel = page.getByTestId("context-panel");
-    await page.getByRole("button", { name: "Vollbild", exact: true }).click();
+    await page.getByTestId("sheet-handle").click();
     await expect(panel).toHaveAttribute("data-sheet-stage", "full");
 
     await page.evaluate(() =>
@@ -140,7 +135,7 @@ test.describe("ContextPanel mobile sheet stages", () => {
         document.querySelectorAll(".map-marker")[1] as HTMLElement
       )?.dispatchEvent(new MouseEvent("click", { bubbles: true })),
     );
-    await expect(panel).toHaveAttribute("data-sheet-stage", "preview");
+    await expect(panel).toHaveAttribute("data-sheet-stage", "compact");
   });
 });
 
@@ -154,17 +149,15 @@ test.describe("ContextPanel desktop layout stays unchanged", () => {
     await page.waitForSelector(".map-marker", { timeout: 10000 });
   });
 
-  test("no sheet-size toggle is shown, and the panel keeps its fixed width", async ({
+  test("the sheet affordances stay hidden and tabs retain their desktop behavior", async ({
     page,
   }) => {
-    await page.evaluate(() =>
-      (document.querySelector(".map-marker") as HTMLElement)?.dispatchEvent(
-        new MouseEvent("click", { bubbles: true }),
-      ),
-    );
+    await page.locator(".map-marker").first().click();
     const panel = page.getByTestId("context-panel");
     await expect(panel).toBeVisible();
-    await expect(page.getByLabel("Panelgröße")).toBeHidden();
+    await expect(page.getByTestId("sheet-handle")).toBeHidden();
+    await expect(panel.locator(".mobile-panel-title")).toBeHidden();
+    await expect(panel.locator(".tabs")).toBeVisible();
 
     const box = await panel.boundingBox();
     expect(Math.round(box!.width)).toBe(400);

--- a/apps/web/tests/map-interaction.spec.ts
+++ b/apps/web/tests/map-interaction.spec.ts
@@ -356,9 +356,12 @@ test.describe("Map Interaction & Context Panel", () => {
       )
       .toBe(true);
 
-    // The same labels remain fully readable when the panel switches to a
-    // narrow mobile layout; they wrap instead of being silently ellipsized.
+    // Mobile hides tabs in the compact card. Open the full sheet before
+    // checking that the same labels remain readable without ellipsis.
     await page.setViewportSize({ width: 320, height: 667 });
+    await page.getByTestId("sheet-handle").click();
+    await expect(panel).toHaveAttribute("data-sheet-stage", "full");
+    await expect(tabList).toBeVisible();
     await expect
       .poll(() =>
         tabList.evaluate(
@@ -377,6 +380,11 @@ test.describe("Map Interaction & Context Panel", () => {
           ),
       )
       .toBe(true);
+
+    // Opening the mobile sheet focuses its handle. Return focus to the last
+    // tab before verifying the tablist's own wraparound behavior.
+    await bearbeitenTab.focus();
+    await expect(bearbeitenTab).toBeFocused();
 
     // ArrowRight from the last tab wraps to the first tab.
     await page.keyboard.press("ArrowRight");

--- a/apps/web/tests/page-design-system.spec.ts
+++ b/apps/web/tests/page-design-system.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test, type Route } from "@playwright/test";
+import { mockApiResponses } from "./fixtures/mockApi";
+
+test("login uses the shared page, form and state contracts without changing the request", async ({
+  page,
+}) => {
+  await mockApiResponses(page, {
+    auth: { authenticated: false },
+  });
+
+  let requestBody: unknown = null;
+  await page.route("**/api/auth/magic-link/request", async (route: Route) => {
+    requestBody = route.request().postDataJSON();
+    await route.fulfill({ status: 204 });
+  });
+
+  await page.goto("/login");
+
+  const loginPage = page.getByTestId("login-page");
+  await expect(loginPage).toHaveClass(/wg-page/);
+  await expect(loginPage.locator(".wg-card")).toHaveCount(1);
+  await expect(loginPage.locator("[style]")).toHaveCount(0);
+
+  await page.getByLabel("E-Mail").fill("person@example.org");
+  await page.getByRole("button", { name: "Login-Link senden" }).click();
+
+  expect(requestBody).toEqual({ email: "person@example.org" });
+  await expect(page.getByRole("status")).toContainText("Postfach prüfen");
+});
+
+test("application overview uses the same surfaces, controls and empty-state contract", async ({
+  page,
+}) => {
+  await mockApiResponses(page, {
+    auth: {
+      authenticated: true,
+      account_id: "guest-design-system",
+      role: "gast",
+    },
+  });
+  await page.route("**/api/proposals**", async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: "[]",
+    });
+  });
+
+  await page.goto("/antraege#antrag-stellen");
+
+  const applicationsPage = page.getByTestId("applications-page");
+  await expect(applicationsPage).toHaveClass(/wg-page--paper/);
+  await expect(
+    page.getByRole("heading", { name: "Anträge", exact: true }),
+  ).toBeVisible();
+  await expect(
+    page.getByLabel("Kurze Vorstellung oder Begründung"),
+  ).toHaveClass(/wg-control/);
+  await expect(
+    page.getByRole("button", { name: "Weberstatus beantragen" }),
+  ).toHaveClass(/wg-button--primary/);
+  await expect(page.getByText("Noch liegen keine Anträge vor.")).toHaveClass(
+    /wg-state/,
+  );
+  await expect(page.locator("#antrag-stellen")).toBeFocused();
+});

--- a/apps/web/tests/ui-detail-remediation.spec.ts
+++ b/apps/web/tests/ui-detail-remediation.spec.ts
@@ -88,8 +88,11 @@ test.describe("UI detail remediation", () => {
     page,
   }) => {
     const node = page.locator(".map-marker:not(.marker-account)").first();
-    await node.click({ force: true });
+    await node.evaluate((element) =>
+      element.dispatchEvent(new MouseEvent("click", { bubbles: true })),
+    );
     const panel = page.getByTestId("context-panel");
+    await expect(panel).toBeVisible();
     await expect(panel.getByRole("tab", { name: "Gespräch" })).toBeVisible();
     await expect(panel.getByRole("tab", { name: "Anträge" })).toHaveCount(0);
     await expect(panel).not.toContainText("Koordinaten:");


### PR DESCRIPTION
## Ziel

- mobiles Kontextpanel auf Kompaktkarte und Vollansicht reduzieren
- Ziehen sowie Tastatur- und ARIA-Verträge erhalten
- mobile Tabs nur in der Vollansicht zeigen
- Login und Antragsübersicht auf eine gemeinsame, route-lokal geladene Designschicht migrieren

## Umsetzung

- Zwischenstufe und drei Größenknöpfe entfernt
- Griff und Paneltitel schalten direkt zwischen Kompakt und Voll um
- Drag-Schwelle und Klickunterdrückung verhindern unbeabsichtigtes Doppelschalten
- genau eine semantische `h2`-Überschrift bleibt auf Desktop und Mobil erhalten
- der mobile sichtbare Titelknopf ist vom Überschriftenelement getrennt
- gemeinsame `wg-*`-Bausteine für Seitenrahmen, Karten, Typografie, Felder, Buttons und Zustände ergänzt
- sämtliche Inline-Stile aus dem Login entfernt
- Authentifizierungs-, Governance- und Datenschutzlogik unverändert gelassen
- Route-Budgets an die nun ehrlich gemessene, cachebare CSS-Auslieferung angepasst und Isolation gegenüber `/settings` festgeschrieben
- ein zuvor parallelitätsanfälliger Detailtest löst sein fachlich relevantes Knotenklickereignis deterministisch aus

## Gemessene Budgets

- `/login`: 44.656 B JS gzip, 2.967 B CSS gzip
- `/settings`: 56.146 B JS gzip, 3.519 B CSS gzip
- `/map`: 79.655 B JS gzip, 16.969 B CSS gzip

## Prüfung

- Produktionsbuild: grün, Build-Identität `9088c5ea`
- vollständiger Web-CI-Vertrag: grün
- Unit-Tests: 212/212 grün
- vollständige Playwright-Suite: 200/200 grün
- zuvor fehlgeschlagene Pfade: 47/47 grün
- Flake-Reproduktion des Detailtests: 20/20 grün
- Arbeitsbaum nach Prüfung: sauber

## Bindung

- Basis: `c77025cd6cffe117378ac82d983038083c680cf0`
- Head: `9088c5ea7c0c1807d8204e1d376bcfe670a52153`
- Head-Validierungsreceipt: `ca2d382d956e125ef442b348365ed99d62bd2c520f347a8d2bd5dff17a7b5213`

<!-- weltgewebe-risk: R2 -->