### PR TITLE
feat(web): UI-Grundlage vereinheitlichen und mobiles Panel vereinfachen

### DIFF
--- a/apps/web/route-performance-budget.json
+++ b/apps/web/route-performance-budget.json
@@ -5,7 +5,7 @@
   "routes": {
     "/login": {
       "max_initial_js_gzip_bytes": 46000,
-      "max_initial_css_gzip_bytes": 2000,
+      "max_initial_css_gzip_bytes": 3400,
       "forbid_css_markers": [".maplibregl-"],
       "require_css_markers": [],
       "min_initial_js_assets": 1,

--- a/apps/web/src/lib/components/ContextPanel.svelte
+++ b/apps/web/src/lib/components/ContextPanel.svelte
@@ -33,14 +33,13 @@
     action: "updated" | "deleted";
   };
   type KompositionPanelHandle = { requestClose: () => void };
-  type SheetStage = "preview" | "half" | "full";
+  type SheetStage = "preview" | "full";
 
   const dispatch = createEventDispatcher<{
     selectRelated: RelatedSelection;
     domainChanged: DomainChanged;
   }>();
   let kompositionPanel: KompositionPanelHandle | null = null;
-  const SHEET_STAGES: SheetStage[] = ["preview", "half", "full"];
   let sheetStage: SheetStage = "preview";
   let previousPanelIdentity = "";
   let panelTitle = "Details";
@@ -48,6 +47,7 @@
   let dragStartHeight = 0;
   let dragHeight: number | null = null;
   let dragging = false;
+  let dragMoved = false;
 
   function derivePanelTitle(
     state: SystemState,
@@ -85,6 +85,7 @@
       sheetStage = $systemState === "komposition" ? "full" : "preview";
       dragHeight = null;
       dragging = false;
+      dragMoved = false;
     }
   }
 
@@ -92,79 +93,82 @@
     sheetStage = stage;
     dragHeight = null;
     dragging = false;
+    dragMoved = false;
   }
 
-  function stepSheetStage(direction: -1 | 1): void {
-    const index = SHEET_STAGES.indexOf(sheetStage);
-    const next = Math.min(
-      SHEET_STAGES.length - 1,
-      Math.max(0, index + direction),
-    );
-    setSheetStage(SHEET_STAGES[next]);
+  function toggleSheetStage(): void {
+    setSheetStage(sheetStage === "preview" ? "full" : "preview");
   }
 
   function nearestSheetStage(height: number): SheetStage {
     const viewport = window.innerHeight;
     const preview = Math.min(270, Math.max(190, viewport * 0.29));
-    const targets: Array<[SheetStage, number]> = [
-      ["preview", preview],
-      ["half", viewport * 0.55],
-      ["full", viewport * 0.88],
-    ];
-    return targets.reduce((nearest, current) =>
-      Math.abs(current[1] - height) < Math.abs(nearest[1] - height)
-        ? current
-        : nearest,
-    )[0];
+    return height < (preview + viewport * 0.88) / 2 ? "preview" : "full";
   }
 
   function handleSheetPointerDown(event: PointerEvent): void {
-    if (window.innerWidth > 768) return;
-    const panel = event.currentTarget as HTMLElement;
-    const aside = panel.closest<HTMLElement>('[data-testid="context-panel"]');
+    const handle = event.currentTarget as HTMLElement;
+    const aside = handle.closest<HTMLElement>('[data-testid="context-panel"]');
     if (!aside) return;
     event.preventDefault();
-    panel.setPointerCapture(event.pointerId);
+    handle.setPointerCapture(event.pointerId);
     dragStartY = event.clientY;
     dragStartHeight = aside.getBoundingClientRect().height;
     dragHeight = dragStartHeight;
     dragging = true;
+    dragMoved = false;
   }
 
   function handleSheetPointerMove(event: PointerEvent): void {
     if (!dragging) return;
     const minHeight = 190;
     const maxHeight = window.innerHeight * 0.88;
+    dragMoved = dragMoved || Math.abs(event.clientY - dragStartY) > 6;
     dragHeight = Math.min(
       maxHeight,
       Math.max(minHeight, dragStartHeight + dragStartY - event.clientY),
     );
   }
 
+  function releasePointer(event: PointerEvent): void {
+    const handle = event.currentTarget as HTMLElement;
+    if (handle.hasPointerCapture(event.pointerId)) {
+      handle.releasePointerCapture(event.pointerId);
+    }
+  }
+
   function handleSheetPointerUp(event: PointerEvent): void {
     if (!dragging) return;
-    const panel = event.currentTarget as HTMLElement;
-    if (panel.hasPointerCapture(event.pointerId)) {
-      panel.releasePointerCapture(event.pointerId);
-    }
-    const finalHeight = dragHeight ?? dragStartHeight;
-    setSheetStage(nearestSheetStage(finalHeight));
+    releasePointer(event);
+    setSheetStage(
+      dragMoved
+        ? nearestSheetStage(dragHeight ?? dragStartHeight)
+        : sheetStage === "preview"
+          ? "full"
+          : "preview",
+    );
+  }
+
+  function handleSheetPointerCancel(event: PointerEvent): void {
+    if (!dragging) return;
+    releasePointer(event);
+    setSheetStage(sheetStage);
+  }
+
+  function handleSheetClick(event: MouseEvent): void {
+    if (event.detail === 0) toggleSheetStage();
   }
 
   function handleSheetKeydown(event: KeyboardEvent): void {
-    if (event.key === "ArrowUp") {
-      event.preventDefault();
-      stepSheetStage(1);
-    } else if (event.key === "ArrowDown") {
-      event.preventDefault();
-      stepSheetStage(-1);
-    } else if (event.key === "Home") {
-      event.preventDefault();
-      setSheetStage("preview");
-    } else if (event.key === "End") {
-      event.preventDefault();
-      setSheetStage("full");
-    }
+    const stage =
+      event.key === "ArrowUp" || event.key === "End"
+        ? "full"
+        : event.key === "ArrowDown" || event.key === "Home"
+          ? "preview"
+          : null;
+    if (!stage) return;
+    event.preventDefault();
+    setSheetStage(stage);
   }
 
   function closePanel() {
@@ -190,8 +194,9 @@
       $contextPanelOpen &&
       !$isSearchOpen &&
       !$isFilterOpen
-    )
+    ) {
       closePanel();
+    }
   }
 </script>
 
@@ -201,7 +206,6 @@
   <aside
     class="context-panel"
     class:stage-preview={sheetStage === "preview"}
-    class:stage-half={sheetStage === "half"}
     class:stage-full={sheetStage === "full"}
     class:composition={$systemState === "komposition"}
     class:dragging
@@ -214,17 +218,13 @@
       type="button"
       class="sheet-handle"
       data-testid="sheet-handle"
-      aria-label={`Panelhöhe ziehen, aktuell ${
-        sheetStage === "preview"
-          ? "Vorschau"
-          : sheetStage === "half"
-            ? "halbe Höhe"
-            : "Vollbild"
-      }`}
+      aria-label={`Panel, ${sheetStage === "preview" ? "Kompaktkarte" : "Vollansicht"}; ziehen oder wechseln`}
+      aria-pressed={sheetStage === "full"}
       on:pointerdown={handleSheetPointerDown}
       on:pointermove={handleSheetPointerMove}
       on:pointerup={handleSheetPointerUp}
-      on:pointercancel={handleSheetPointerUp}
+      on:pointercancel={handleSheetPointerCancel}
+      on:click={handleSheetClick}
       on:keydown={handleSheetKeydown}
     >
       <span aria-hidden="true"></span>
@@ -234,33 +234,22 @@
       class:composition={$systemState === "komposition"}
     >
       <div class="heading-group">
-        <h2>{panelTitle}</h2>
-      </div>
-      <div class="header-actions">
-        <div class="sheet-controls" role="group" aria-label="Panelgröße">
+        <h2 class="desktop-heading">{panelTitle}</h2>
+        <h2 class="mobile-heading">
           <button
             type="button"
-            aria-label="Vorschau"
-            aria-pressed={sheetStage === "preview"}
-            on:click={() => setSheetStage("preview")}>Vorschau</button
-          >
-          <button
-            type="button"
-            aria-label="Halbe Höhe"
-            aria-pressed={sheetStage === "half"}
-            on:click={() => setSheetStage("half")}>Halbe Höhe</button
-          >
-          <button
-            type="button"
-            aria-label="Vollbild"
+            class="heading-toggle"
+            aria-label={`${panelTitle}, ${sheetStage === "preview" ? "Kompaktkarte" : "Vollansicht"}; Ansicht wechseln`}
             aria-pressed={sheetStage === "full"}
-            on:click={() => setSheetStage("full")}>Vollbild</button
+            on:click={toggleSheetStage}
           >
-        </div>
-        <button class="close-btn" on:click={closePanel} aria-label="Schließen"
-          >✕</button
-        >
+            {panelTitle}
+          </button>
+        </h2>
       </div>
+      <button class="close-btn" on:click={closePanel} aria-label="Schließen"
+        >✕</button
+      >
     </header>
 
     <div class="panel-content">
@@ -311,6 +300,7 @@
 
   .heading-group {
     min-width: 0;
+    flex: 1;
   }
 
   .panel-header h2 {
@@ -322,43 +312,29 @@
     text-transform: uppercase;
   }
 
+  .heading-toggle {
+    max-width: 100%;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    font-weight: inherit;
+    letter-spacing: inherit;
+    text-align: left;
+    text-transform: inherit;
+  }
+
+  .mobile-heading {
+    display: none;
+  }
+
   .panel-header.composition h2 {
     color: var(--text);
     font-size: 1.1rem;
     letter-spacing: 0;
     text-transform: none;
-  }
-
-  .header-actions,
-  .sheet-controls {
-    display: flex;
-    align-items: center;
-  }
-
-  .header-actions {
-    gap: 0.35rem;
-  }
-
-  .sheet-controls {
-    gap: 0.2rem;
-  }
-
-  .sheet-controls button {
-    min-width: 44px;
-    min-height: 44px;
-    padding: 0 0.55rem;
-    border: 1px solid transparent;
-    border-radius: 9px;
-    background: transparent;
-    color: var(--muted);
-    cursor: pointer;
-    font-size: 0.76rem;
-  }
-
-  .sheet-controls button[aria-pressed="true"] {
-    border-color: var(--panel-border-strong);
-    background: var(--accent-soft);
-    color: var(--text);
   }
 
   .close-btn {
@@ -382,6 +358,14 @@
   }
 
   @media (max-width: 768px) {
+    .desktop-heading {
+      display: none;
+    }
+
+    .mobile-heading {
+      display: block;
+    }
+
     .context-panel {
       bottom: 0;
       left: 0;
@@ -391,15 +375,15 @@
       border-radius: 18px 18px 0 0;
       transition: height var(--motion-ui);
     }
+
     .context-panel.stage-preview {
       height: clamp(190px, 29dvh, 270px);
     }
-    .context-panel.stage-half {
-      height: 55dvh;
-    }
+
     .context-panel.stage-full {
       height: 88dvh;
     }
+
     .sheet-handle {
       width: 100%;
       min-height: 44px;
@@ -412,65 +396,41 @@
       cursor: ns-resize;
       touch-action: none;
     }
+
     .sheet-handle span {
       width: 44px;
       height: 4px;
       border-radius: 999px;
       background: var(--panel-border-strong);
     }
-    .sheet-handle:focus-visible {
+
+    .sheet-handle:focus-visible,
+    .heading-toggle:focus-visible {
       outline: 3px solid var(--accent);
       outline-offset: -4px;
     }
+
     .context-panel.dragging {
       transition: none;
       user-select: none;
     }
+
     .panel-header {
       min-height: 64px;
       padding-top: 0.25rem;
     }
-    .heading-group {
-      flex: 1;
-      text-align: left;
-    }
-    .sheet-controls button {
-      min-width: 44px;
+
+    .heading-toggle {
       min-height: 44px;
-      padding: 0 0.35rem;
-      font-size: 0.7rem;
+      cursor: pointer;
     }
+
     .stage-preview .panel-content {
       padding-top: 0.65rem;
     }
-  }
 
-  @media (max-width: 440px) {
-    .sheet-controls button {
-      width: 44px;
-      overflow: hidden;
-      color: transparent;
-      position: relative;
-    }
-    .sheet-controls button::after {
-      position: absolute;
-      inset: 0;
-      display: grid;
-      place-items: center;
-      color: var(--muted);
-      font-size: 1rem;
-    }
-    .sheet-controls button:nth-child(1)::after {
-      content: "▂";
-    }
-    .sheet-controls button:nth-child(2)::after {
-      content: "▅";
-    }
-    .sheet-controls button:nth-child(3)::after {
-      content: "▇";
-    }
-    .sheet-controls button[aria-pressed="true"]::after {
-      color: var(--accent);
+    .stage-preview .panel-content :global(.tabs) {
+      display: none;
     }
   }
 
@@ -481,9 +441,6 @@
       bottom: 0;
       width: var(--context-panel-width);
       box-shadow: -4px 0 16px rgba(0, 0, 0, 0.28);
-    }
-    .sheet-controls {
-      display: none;
     }
   }
 

--- a/apps/web/src/lib/components/governance/GovernanceFaden.svelte
+++ b/apps/web/src/lib/components/governance/GovernanceFaden.svelte
@@ -130,12 +130,13 @@
 
 <style>
   .faden-card {
-    border: 1px solid rgba(24, 37, 31, 0.16);
-    border-radius: 18px;
-    background: rgba(255, 255, 255, 0.72);
+    border: 1px solid var(--panel-border);
+    border-radius: var(--radius-lg);
+    background: var(--surface);
     padding: 22px;
     margin-top: 16px;
     overflow: hidden;
+    box-shadow: 0 16px 54px rgba(0, 0, 0, 0.2);
   }
   .heading-row {
     display: flex;
@@ -146,8 +147,8 @@
   .heading-row strong {
     white-space: nowrap;
     border-radius: 999px;
-    background: #dcecdf;
-    color: #1f5b42;
+    background: var(--success-soft);
+    color: var(--success);
     padding: 7px 11px;
   }
   .eyebrow {
@@ -156,14 +157,14 @@
     letter-spacing: 0.09em;
     font-size: 0.72rem;
     font-weight: 750;
-    color: #4d6759;
+    color: var(--success);
   }
   h2 {
     margin: 0;
   }
   .explanation,
   figcaption {
-    color: #607168;
+    color: var(--muted);
     line-height: 1.5;
   }
   figure {
@@ -178,24 +179,24 @@
     fill: none;
     stroke-width: 2.5;
     stroke-linecap: round;
-    opacity: 0.72;
+    opacity: 0.82;
   }
   .applicant-threads path {
-    stroke: #315d48;
+    stroke: var(--success);
   }
   .veto-threads path {
-    stroke: #9b4d43;
+    stroke: var(--danger);
   }
   .message-threads path {
-    stroke: #476a8a;
+    stroke: var(--accent);
   }
   .vote-threads path {
-    stroke: #806b37;
+    stroke: var(--notice);
   }
   .endpoint circle,
   .proposal-node circle {
-    fill: #f8f7f1;
-    stroke: rgba(24, 37, 31, 0.34);
+    fill: var(--surface-raised);
+    stroke: var(--panel-border-strong);
     stroke-width: 2;
   }
   .endpoint.inactive {
@@ -206,21 +207,21 @@
     font-family: system-ui, sans-serif;
     font-size: 12px;
     font-weight: 700;
-    fill: #25382e;
+    fill: var(--text);
   }
   text.count {
     font-size: 14px;
   }
   .proposal-node circle {
-    fill: #1f5b42;
-    stroke: #163f30;
+    fill: var(--accent);
+    stroke: #91bdff;
   }
   .proposal-node text {
-    fill: #fff;
+    fill: #09111d;
   }
   .proposal-title {
     font-size: 10px;
-    font-weight: 600;
+    font-weight: 650;
   }
   figcaption {
     margin-top: 8px;
@@ -233,12 +234,13 @@
     margin: 18px 0 0;
   }
   .faden-counts div {
-    border-radius: 12px;
-    background: #eeece5;
+    border: 1px solid var(--panel-border);
+    border-radius: var(--radius);
+    background: rgba(255, 255, 255, 0.035);
     padding: 10px;
   }
   dt {
-    color: #607168;
+    color: var(--muted);
     font-size: 0.76rem;
   }
   dd {

--- a/apps/web/src/lib/components/governance/ProposalDetail.svelte
+++ b/apps/web/src/lib/components/governance/ProposalDetail.svelte
@@ -36,9 +36,15 @@
 
   function describeError(cause: unknown): string {
     if (cause instanceof GovernanceApiError) {
-      if (cause.status === 403) return "Über den eigenen Weberantrag kannst du nicht selbst entscheiden.";
-      if (cause.status === 409) return "Die Aktion passt nicht mehr zur aktuellen Antragsphase.";
-      if (cause.status === 503) return "Das Antragssystem ist vorübergehend nicht verfügbar.";
+      if (cause.status === 403) {
+        return "Über den eigenen Weberantrag kannst du nicht selbst entscheiden.";
+      }
+      if (cause.status === 409) {
+        return "Die Aktion passt nicht mehr zur aktuellen Antragsphase.";
+      }
+      if (cause.status === 503) {
+        return "Das Antragssystem ist vorübergehend nicht verfügbar.";
+      }
     }
     return "Der Antrag konnte nicht geladen oder geändert werden.";
   }
@@ -110,128 +116,316 @@
 
 <svelte:head><title>Antrag · Weltgewebe</title></svelte:head>
 
-<main class="page-shell">
-  <a class="back-link" href="/antraege">← Alle Anträge</a>
+<main class="wg-page" aria-labelledby="proposal-heading">
+  <div class="wg-page__inner proposal-page">
+    <a class="wg-back-link" href="/antraege">← Alle Anträge</a>
 
-  {#if loading}
-    <p>Antrag wird geladen…</p>
-  {:else if error && !proposal}
-    <div class="error" role="alert">{error}</div>
-  {:else if proposal}
-    <header class="proposal-header">
-      <div class="topline">
-        <span class:open={isOpen}>{statusLabel(proposal.status)}</span>
-        {#if proposal.remaining_seconds !== undefined}<strong>Noch {formatRemaining(proposal.remaining_seconds)}</strong>{/if}
-      </div>
-      <p class="eyebrow">Weberantrag</p>
-      <h1>{proposal.applicant_title}</h1>
-      {#if proposal.summary}<p class="summary">{proposal.summary}</p>{/if}
-      <dl>
-        <div><dt>Gestellt</dt><dd>{new Date(proposal.created_at).toLocaleString("de-DE")}</dd></div>
-        <div><dt>Vetos</dt><dd>{proposal.veto_count}</dd></div>
-        <div><dt>Abstimmung</dt><dd>{proposal.yes_votes} Ja · {proposal.no_votes} Nein · {proposal.abstain_votes} Enthaltung</dd></div>
-      </dl>
-    </header>
+    {#if loading}
+      <p class="wg-muted loading-state">Antrag wird geladen…</p>
+    {:else if error && !proposal}
+      <div class="wg-status wg-status--error" role="alert">{error}</div>
+    {:else if proposal}
+      <header class="wg-page__header proposal-header">
+        <div class="topline">
+          <span class:open={isOpen}>{statusLabel(proposal.status)}</span>
+          {#if proposal.remaining_seconds !== undefined}
+            <strong>Noch {formatRemaining(proposal.remaining_seconds)}</strong>
+          {/if}
+        </div>
+        <p class="wg-eyebrow">Weberantrag</p>
+        <h1 id="proposal-heading" class="wg-title">
+          {proposal.applicant_title}
+        </h1>
+        {#if proposal.summary}
+          <p class="wg-lede summary">{proposal.summary}</p>
+        {/if}
+        <dl>
+          <div>
+            <dt>Gestellt</dt>
+            <dd>{new Date(proposal.created_at).toLocaleString("de-DE")}</dd>
+          </div>
+          <div>
+            <dt>Vetos</dt>
+            <dd>{proposal.veto_count}</dd>
+          </div>
+          <div>
+            <dt>Abstimmung</dt>
+            <dd>
+              {proposal.yes_votes} Ja · {proposal.no_votes} Nein ·
+              {proposal.abstain_votes} Enthaltung
+            </dd>
+          </div>
+        </dl>
+      </header>
 
-    {#if error}<div class="error" role="alert">{error}</div>{/if}
+      {#if error}
+        <div class="wg-status wg-status--error detail-error" role="alert">
+          {error}
+        </div>
+      {/if}
 
-    <GovernanceFaden {proposal} {messages} />
+      <GovernanceFaden {proposal} {messages} />
 
-    {#if proposal.vetoes.length > 0}
-      <section class="card" aria-labelledby="vetos-heading">
-        <h2 id="vetos-heading">Vetos</h2>
+      {#if proposal.vetoes.length > 0}
+        <section
+          class="wg-surface wg-surface--padded detail-card"
+          aria-labelledby="vetos-heading"
+        >
+          <h2 id="vetos-heading">Vetos</h2>
+          <div class="entries">
+            {#each proposal.vetoes as item}
+              <article>
+                <div class="entry-meta">
+                  <strong>{item.weber_title}</strong>
+                  <time datetime={item.created_at}>
+                    {new Date(item.created_at).toLocaleString("de-DE")}
+                  </time>
+                </div>
+                <p>{item.reason}</p>
+              </article>
+            {/each}
+          </div>
+        </section>
+      {/if}
+
+      {#if canDecide && proposal.status === "consent"}
+        <section
+          class="wg-surface wg-surface--padded wg-surface--accent action-card"
+          aria-labelledby="veto-heading"
+        >
+          <h2 id="veto-heading">Begründetes Veto einlegen</h2>
+          <p class="wg-muted">
+            Ein Veto verhindert keine Entscheidung. Es eröffnet nach Ablauf der
+            ersten sieben Tage eine weitere siebentägige Gesprächs- und
+            Abstimmungsphase.
+          </p>
+          <label for="veto-reason">Einwand und mögliche Lösung</label>
+          <textarea
+            class="wg-input"
+            id="veto-reason"
+            bind:value={vetoReason}
+            maxlength="2000"
+            rows="4"
+            placeholder="Konkreter Einwand und mögliche Lösung"></textarea>
+          <button
+            class="wg-button wg-button--primary"
+            on:click={veto}
+            disabled={!vetoReason.trim() || submitting}
+          >
+            Veto einlegen
+          </button>
+        </section>
+      {/if}
+
+      {#if canDecide && proposal.status === "voting"}
+        <section
+          class="wg-surface wg-surface--padded wg-surface--accent action-card"
+          aria-labelledby="vote-heading"
+        >
+          <h2 id="vote-heading">Abstimmen</h2>
+          <p class="wg-muted">
+            Es gibt keine Mindestbeteiligung. Der Antrag wird angenommen, wenn
+            am Ende mehr Ja- als Nein-Stimmen vorliegen.
+          </p>
+          <div class="vote-buttons">
+            {#each ["ja", "nein", "enthaltung"] as choice}
+              <button
+                class="wg-button wg-button--quiet"
+                class:active={proposal.own_vote === choice}
+                aria-pressed={proposal.own_vote === choice}
+                on:click={() => vote(choice as VoteChoice)}
+                disabled={submitting}
+              >
+                {choice === "ja"
+                  ? "Ja"
+                  : choice === "nein"
+                    ? "Nein"
+                    : "Enthaltung"}
+              </button>
+            {/each}
+          </div>
+        </section>
+      {/if}
+
+      <section
+        class="wg-surface wg-surface--padded detail-card"
+        aria-labelledby="conversation-heading"
+      >
+        <h2 id="conversation-heading">Gesprächsraum</h2>
+        {#if messages.length === 0}
+          <p class="wg-muted">Noch keine Gesprächsbeiträge.</p>
+        {/if}
         <div class="entries">
-          {#each proposal.vetoes as item}
+          {#each messages as message}
             <article>
-              <div class="entry-meta"><strong>{item.weber_title}</strong><time datetime={item.created_at}>{new Date(item.created_at).toLocaleString("de-DE")}</time></div>
-              <p>{item.reason}</p>
+              <div class="entry-meta">
+                <strong>{message.author_title}</strong>
+                <time datetime={message.created_at}>
+                  {new Date(message.created_at).toLocaleString("de-DE")}
+                </time>
+              </div>
+              <p>{message.body}</p>
             </article>
           {/each}
         </div>
-      </section>
-    {/if}
-
-    {#if canDecide && proposal.status === "consent"}
-      <section class="card action-card" aria-labelledby="veto-heading">
-        <h2 id="veto-heading">Begründetes Veto einlegen</h2>
-        <p>Ein Veto verhindert keine Entscheidung. Es eröffnet nach Ablauf der ersten sieben Tage eine weitere siebentägige Gesprächs- und Abstimmungsphase.</p>
-        <textarea bind:value={vetoReason} maxlength="2000" rows="4" placeholder="Konkreter Einwand und mögliche Lösung"></textarea>
-        <button class="primary" on:click={veto} disabled={!vetoReason.trim() || submitting}>Veto einlegen</button>
-      </section>
-    {/if}
-
-    {#if canDecide && proposal.status === "voting"}
-      <section class="card action-card" aria-labelledby="vote-heading">
-        <h2 id="vote-heading">Abstimmen</h2>
-        <p>Es gibt keine Mindestbeteiligung. Der Antrag wird angenommen, wenn am Ende mehr Ja- als Nein-Stimmen vorliegen.</p>
-        <div class="vote-buttons">
-          {#each ["ja", "nein", "enthaltung"] as choice}
-            <button class:active={proposal.own_vote === choice} on:click={() => vote(choice as VoteChoice)} disabled={submitting}>
-              {choice === "ja" ? "Ja" : choice === "nein" ? "Nein" : "Enthaltung"}
+        {#if canDiscuss && isOpen}
+          <div class="message-form">
+            <label for="message-body">Beitrag verfassen</label>
+            <textarea
+              class="wg-input"
+              id="message-body"
+              bind:value={messageBody}
+              maxlength="4000"
+              rows="4"></textarea>
+            <button
+              class="wg-button wg-button--primary"
+              on:click={postMessage}
+              disabled={!messageBody.trim() || submitting}
+            >
+              Beitrag senden
             </button>
-          {/each}
-        </div>
+          </div>
+        {:else if !$authStore.authenticated}
+          <p class="wg-status wg-status--notice">
+            Melde dich an, um im Gesprächsraum mitzuschreiben.
+          </p>
+        {/if}
       </section>
     {/if}
-
-    <section class="card" aria-labelledby="conversation-heading">
-      <h2 id="conversation-heading">Gesprächsraum</h2>
-      {#if messages.length === 0}<p class="muted">Noch keine Gesprächsbeiträge.</p>{/if}
-      <div class="entries">
-        {#each messages as message}
-          <article>
-            <div class="entry-meta"><strong>{message.author_title}</strong><time datetime={message.created_at}>{new Date(message.created_at).toLocaleString("de-DE")}</time></div>
-            <p>{message.body}</p>
-          </article>
-        {/each}
-      </div>
-      {#if canDiscuss && isOpen}
-        <div class="message-form">
-          <label for="message-body">Beitrag verfassen</label>
-          <textarea id="message-body" bind:value={messageBody} maxlength="4000" rows="4"></textarea>
-          <button class="primary" on:click={postMessage} disabled={!messageBody.trim() || submitting}>Beitrag senden</button>
-        </div>
-      {:else if !$authStore.authenticated}
-        <p class="guest-note">Melde dich an, um im Gesprächsraum mitzuschreiben.</p>
-      {/if}
-    </section>
-  {/if}
+  </div>
 </main>
 
 <style>
-  :global(body) { margin: 0; background: #f3f1e9; color: #18251f; font-family: system-ui, sans-serif; }
-  .page-shell { width: min(820px, calc(100% - 32px)); margin: 0 auto; padding: 32px 0 72px; }
-  .back-link { color: inherit; text-decoration: none; font-weight: 700; }
-  .proposal-header { padding: 44px 0 28px; }
-  .topline, .entry-meta, dl, .vote-buttons { display: flex; gap: 12px; align-items: center; }
-  .topline { justify-content: space-between; color: #526259; }
-  .topline span { padding: 5px 10px; border-radius: 999px; background: #e4e3dc; }
-  .topline span.open { background: #dcecdf; color: #1f5b42; }
-  .eyebrow { margin: 28px 0 5px; text-transform: uppercase; letter-spacing: .09em; font-size: .76rem; font-weight: 750; color: #4d6759; }
-  h1 { margin: 0; font-size: clamp(2.2rem, 8vw, 4.2rem); line-height: 1; }
-  h2 { margin: 0 0 12px; }
-  .summary { max-width: 65ch; font-size: 1.1rem; line-height: 1.6; }
-  dl { flex-wrap: wrap; margin: 24px 0 0; }
-  dl div { min-width: 150px; }
-  dt { color: #607168; font-size: .8rem; }
-  dd { margin: 3px 0 0; font-weight: 700; }
-  .card, .error { border: 1px solid rgba(24,37,31,.16); border-radius: 18px; background: rgba(255,255,255,.72); padding: 22px; margin-top: 16px; }
-  .action-card { background: #eef3ec; }
-  .entries { display: grid; gap: 14px; }
-  article { border-top: 1px solid rgba(24,37,31,.12); padding-top: 14px; }
-  article:first-child { border-top: 0; padding-top: 0; }
-  .entry-meta { justify-content: space-between; color: #607168; font-size: .84rem; }
-  article p { margin-bottom: 0; white-space: pre-wrap; line-height: 1.5; }
-  textarea { box-sizing: border-box; width: 100%; resize: vertical; border: 1px solid rgba(24,37,31,.28); border-radius: 12px; padding: 12px; font: inherit; background: #fff; }
-  button { border: 1px solid rgba(24,37,31,.25); border-radius: 999px; padding: 10px 16px; font: inherit; font-weight: 720; cursor: pointer; background: #fff; }
-  button.active { outline: 3px solid rgba(31,91,66,.28); background: #dcecdf; }
-  button:disabled { opacity: .55; cursor: wait; }
-  .primary { border: 0; background: #1f5b42; color: #fff; }
-  .action-card, .message-form { display: grid; gap: 12px; }
-  .message-form { margin-top: 20px; }
-  .vote-buttons { flex-wrap: wrap; }
-  .error { color: #7f2424; background: #fff0f0; }
-  .muted, .guest-note { color: #607168; }
-  .guest-note { padding: 12px; border-radius: 10px; background: #eeece5; }
-  @media (max-width: 560px) { .topline, .entry-meta { align-items: flex-start; flex-direction: column; } }
+  .proposal-page {
+    width: min(820px, calc(100% - 32px));
+  }
+
+  .loading-state {
+    margin-top: 36px;
+  }
+
+  .proposal-header {
+    padding-top: 32px;
+  }
+
+  .topline,
+  .entry-meta,
+  dl,
+  .vote-buttons {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+  }
+
+  .topline {
+    justify-content: space-between;
+    color: var(--muted);
+  }
+
+  .topline span {
+    padding: 5px 10px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.06);
+  }
+
+  .topline span.open {
+    background: var(--success-soft);
+    color: var(--success);
+  }
+
+  .summary {
+    max-width: 65ch;
+  }
+
+  dl {
+    flex-wrap: wrap;
+    margin: 24px 0 0;
+  }
+
+  dl div {
+    min-width: 150px;
+  }
+
+  dt {
+    color: var(--muted);
+    font-size: 0.8rem;
+  }
+
+  dd {
+    margin: 3px 0 0;
+    font-weight: 700;
+  }
+
+  .detail-card,
+  .action-card,
+  .detail-error {
+    margin-top: 16px;
+  }
+
+  .detail-card h2,
+  .action-card h2 {
+    margin: 0 0 12px;
+  }
+
+  .entries {
+    display: grid;
+    gap: 14px;
+  }
+
+  article {
+    border-top: 1px solid var(--panel-border);
+    padding-top: 14px;
+  }
+
+  article:first-child {
+    border-top: 0;
+    padding-top: 0;
+  }
+
+  .entry-meta {
+    justify-content: space-between;
+    color: var(--muted);
+    font-size: 0.84rem;
+  }
+
+  article p {
+    margin-bottom: 0;
+    white-space: pre-wrap;
+    line-height: 1.5;
+  }
+
+  .action-card,
+  .message-form {
+    display: grid;
+    gap: 12px;
+  }
+
+  .message-form {
+    margin-top: 20px;
+  }
+
+  .message-form label {
+    font-weight: 700;
+  }
+
+  .vote-buttons {
+    flex-wrap: wrap;
+  }
+
+  .vote-buttons .active {
+    border-color: var(--accent);
+    background: var(--accent-soft);
+  }
+
+  @media (max-width: 560px) {
+    .proposal-page {
+      width: min(100% - 24px, 820px);
+    }
+
+    .topline,
+    .entry-meta {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+  }
 </style>

--- a/apps/web/src/lib/styles/page-foundation.css
+++ b/apps/web/src/lib/styles/page-foundation.css
@@ -1,0 +1,212 @@
+.wg-page {
+  --surface: rgba(24, 27, 34, 0.88);
+  --surface-raised: rgba(30, 34, 43, 0.96);
+  --surface-hover: rgba(39, 45, 56, 0.96);
+  --success: #7fd9aa;
+  --success-soft: rgba(89, 195, 139, 0.14);
+  --danger-soft: rgba(255, 133, 133, 0.14);
+  --notice: #e6c87a;
+  --notice-soft: rgba(230, 200, 122, 0.14);
+  --radius-lg: 18px;
+  --content-max: 880px;
+  --content-narrow: 520px;
+  min-height: 100%;
+  color: var(--text);
+  background:
+    radial-gradient(
+      circle at 15% 0%,
+      rgba(106, 166, 255, 0.11),
+      transparent 32rem
+    ),
+    var(--bg);
+}
+.wg-page--center {
+  display: grid;
+  align-items: center;
+}
+.wg-page__inner {
+  width: min(var(--content-max), calc(100% - 32px));
+  margin: 0 auto;
+  padding: 28px 0 72px;
+}
+.wg-page__inner--narrow {
+  width: min(var(--content-narrow), calc(100% - 32px));
+}
+.wg-page__header {
+  padding: 24px 0 32px;
+}
+.wg-back-link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  color: var(--text);
+  text-decoration: none;
+  font-weight: 700;
+}
+.wg-back-link:hover {
+  color: var(--accent);
+}
+.wg-eyebrow {
+  margin: 24px 0 6px;
+  color: var(--success);
+  font-size: 0.76rem;
+  font-weight: 760;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.wg-title {
+  margin: 0;
+  font-size: clamp(2.35rem, 8vw, 4.5rem);
+  line-height: 0.98;
+  letter-spacing: -0.035em;
+}
+.wg-title--compact {
+  font-size: clamp(2rem, 7vw, 3.35rem);
+}
+.wg-lede {
+  max-width: 68ch;
+  margin: 18px 0 0;
+  color: var(--muted);
+  font-size: 1.06rem;
+  line-height: 1.65;
+}
+.wg-stack,
+.wg-field {
+  display: grid;
+  gap: 1rem;
+}
+.wg-field {
+  gap: 0.45rem;
+}
+.wg-field label,
+.wg-field__label {
+  font-weight: 700;
+}
+.wg-surface {
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+}
+.wg-surface--padded {
+  padding: clamp(18px, 4vw, 28px);
+}
+.wg-surface--accent {
+  border-color: rgba(106, 166, 255, 0.28);
+  background: var(--surface-raised);
+}
+.wg-input {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 48px;
+  border: 1px solid var(--panel-border-strong);
+  border-radius: var(--radius);
+  padding: 0.75rem 0.85rem;
+  background: #0b0e13;
+  color: var(--text);
+  font: inherit;
+}
+textarea.wg-input {
+  min-height: 112px;
+  resize: vertical;
+}
+.wg-input::placeholder {
+  color: var(--muted);
+}
+.wg-input:focus-visible {
+  border-color: var(--accent);
+  outline: 3px solid var(--accent-soft);
+  outline-offset: 1px;
+}
+.wg-button {
+  box-sizing: border-box;
+  width: fit-content;
+  min-height: 44px;
+  border: 1px solid var(--panel-border-strong);
+  border-radius: 999px;
+  padding: 0.65rem 1rem;
+  background: var(--surface-raised);
+  color: var(--text);
+  font: inherit;
+  font-weight: 740;
+  cursor: pointer;
+  text-decoration: none;
+}
+.wg-button--primary {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: #09111d;
+}
+.wg-button--quiet,
+.wg-button--danger {
+  background: transparent;
+}
+.wg-button--danger {
+  border-color: transparent;
+  color: var(--danger);
+}
+.wg-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+.wg-status,
+.wg-empty {
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius);
+  padding: 0.9rem 1rem;
+}
+.wg-status--success {
+  border-color: var(--success);
+  background: var(--success-soft);
+  color: var(--success);
+}
+.wg-status--error {
+  border-color: var(--danger);
+  background: var(--danger-soft);
+  color: var(--danger);
+}
+.wg-status--notice {
+  border-color: var(--notice);
+  background: var(--notice-soft);
+  color: var(--notice);
+}
+.wg-empty {
+  background: rgba(255, 255, 255, 0.025);
+  color: var(--muted);
+}
+.wg-muted {
+  color: var(--muted);
+}
+.wg-filter-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+.wg-filter-list a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  border: 1px solid var(--panel-border);
+  border-radius: 999px;
+  padding: 0 0.9rem;
+  color: var(--muted);
+  text-decoration: none;
+  font-weight: 680;
+}
+.wg-filter-list a.active,
+.wg-filter-list a[aria-current="page"] {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--text);
+}
+@media (max-width: 560px) {
+  .wg-page__inner {
+    width: min(100% - 24px, var(--content-max));
+    padding-top: 16px;
+  }
+  .wg-page__inner--narrow {
+    width: min(100% - 24px, var(--content-narrow));
+  }
+  .wg-surface--padded {
+    padding: 18px;
+  }
+}

--- a/apps/web/src/routes/antraege/+page.svelte
+++ b/apps/web/src/routes/antraege/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import "$lib/styles/page-foundation.css";
   import { onMount, tick } from "svelte";
   import { afterNavigate, goto } from "$app/navigation";
   import { page } from "$app/stores";
@@ -57,8 +58,12 @@
 
   function describeError(cause: unknown): string {
     if (cause instanceof GovernanceApiError) {
-      if (cause.status === 409) return "Diese Aktion ist im aktuellen Zustand nicht möglich.";
-      if (cause.status === 503) return "Das Antragssystem ist vorübergehend nicht verfügbar.";
+      if (cause.status === 409) {
+        return "Diese Aktion ist im aktuellen Zustand nicht möglich.";
+      }
+      if (cause.status === 503) {
+        return "Das Antragssystem ist vorübergehend nicht verfügbar.";
+      }
     }
     return "Das Antragssystem konnte nicht geladen werden.";
   }
@@ -149,125 +154,306 @@
 
 <svelte:head>
   <title>Anträge · Weltgewebe</title>
-  <meta name="description" content="Offene Anträge, Konsentphasen, Vetos, Gespräche und Abstimmungen im Weltgewebe." />
+  <meta
+    name="description"
+    content="Offene Anträge, Konsentphasen, Vetos, Gespräche und Abstimmungen im Weltgewebe."
+  />
 </svelte:head>
 
 {#if selectedProposalId}
   <ProposalDetail proposalId={selectedProposalId} />
 {:else}
-<main class="page-shell">
-  <header class="page-header">
-    <a class="back-link" href="/map">← Zum Gewebe</a>
-    <p class="eyebrow">Gemeinsame Entscheidungen</p>
-    <h1>Anträge</h1>
-    <p>
-      Jeder Antrag liegt sieben Tage offen. Ohne Veto wird er angenommen. Nach einem Veto folgen weitere sieben Tage Gespräch und Abstimmung; angenommen ist er genau dann, wenn mehr Ja- als Nein-Stimmen vorliegen.
-    </p>
-  </header>
+  <main class="wg-page" aria-labelledby="proposals-heading">
+    <div class="wg-page__inner">
+      <header class="wg-page__header">
+        <a class="wg-back-link" href="/map">← Zum Gewebe</a>
+        <p class="wg-eyebrow">Gemeinsame Entscheidungen</p>
+        <h1 id="proposals-heading" class="wg-title">Anträge</h1>
+        <p class="wg-lede">
+          Jeder Antrag liegt sieben Tage offen. Ohne Veto wird er angenommen.
+          Nach einem Veto folgen weitere sieben Tage Gespräch und Abstimmung;
+          angenommen ist er genau dann, wenn mehr Ja- als Nein-Stimmen
+          vorliegen.
+        </p>
+      </header>
 
-  {#if isGuest}
-    <section id="antrag-stellen" class="guest-card" aria-labelledby="weberstatus-heading" tabindex="-1" bind:this={applicationSection}>
-      <div>
-        <p class="eyebrow">Dein Status: Gast</p>
-        <h2 id="weberstatus-heading">Weberstatus beantragen</h2>
-        <p>Als Gast besitzt du bereits deine Garnrolle und kannst sie beschreiben. Ein angenommener Antrag verleiht dir zusätzliche Weberrechte; er erzeugt keine zweite Garnrolle.</p>
-      </div>
-      {#if hasOpenOwnProposal}
-        <p class="notice">Dein Weberantrag ist bereits offen.</p>
-      {:else}
-        <label for="application-summary">Kurze Vorstellung oder Begründung</label>
-        <textarea id="application-summary" bind:value={summary} maxlength="2000" rows="5" placeholder="Was möchtest du im Weltgewebe beitragen?"></textarea>
-        <button class="primary" on:click={applyForWeber} disabled={submitting}>
-          {submitting ? "Antrag wird gestellt…" : "Weberstatus beantragen"}
-        </button>
+      {#if isGuest}
+        <section
+          id="antrag-stellen"
+          class="wg-surface wg-surface--padded wg-surface--accent guest-card"
+          aria-labelledby="weberstatus-heading"
+          tabindex="-1"
+          bind:this={applicationSection}
+        >
+          <div>
+            <p class="wg-eyebrow guest-eyebrow">Dein Status: Gast</p>
+            <h2 id="weberstatus-heading">Weberstatus beantragen</h2>
+            <p class="wg-muted">
+              Als Gast besitzt du bereits deine Garnrolle und kannst sie
+              beschreiben. Ein angenommener Antrag verleiht dir zusätzliche
+              Weberrechte; er erzeugt keine zweite Garnrolle.
+            </p>
+          </div>
+          {#if hasOpenOwnProposal}
+            <p class="wg-status wg-status--notice">
+              Dein Weberantrag ist bereits offen.
+            </p>
+          {:else}
+            <div class="wg-field">
+              <label for="application-summary">
+                Kurze Vorstellung oder Begründung
+              </label>
+              <textarea
+                class="wg-input"
+                id="application-summary"
+                bind:value={summary}
+                maxlength="2000"
+                rows="5"
+                placeholder="Was möchtest du im Weltgewebe beitragen?"
+              ></textarea>
+            </div>
+            <button
+              class="wg-button wg-button--primary"
+              on:click={applyForWeber}
+              disabled={submitting}
+            >
+              {submitting ? "Antrag wird gestellt…" : "Weberstatus beantragen"}
+            </button>
+          {/if}
+          <button
+            class="wg-button wg-button--danger"
+            on:click={leaveWeltgewebe}
+            disabled={leaving}
+          >
+            {leaving
+              ? "Gastkonto wird aufgelöst…"
+              : "Weltgewebe vollständig verlassen"}
+          </button>
+        </section>
       {/if}
-      <button class="danger-link" on:click={leaveWeltgewebe} disabled={leaving}>
-        {leaving ? "Gastkonto wird aufgelöst…" : "Weltgewebe vollständig verlassen"}
-      </button>
-    </section>
-  {/if}
 
-  {#if error}<div class="error" role="alert">{error}</div>{/if}
+      {#if error}
+        <div class="wg-status wg-status--error page-error" role="alert">
+          {error}
+        </div>
+      {/if}
 
-  <section aria-labelledby="proposal-list-heading">
-    <div class="section-heading">
-      <div>
-        <h2 id="proposal-list-heading">{proposalListTitle}</h2>
-        <nav class="proposal-filters" aria-label="Governance-Ereignisse filtern">
-          <a class:active={!statusFilter && !eventFilter} href="/antraege">Alle</a>
-          <a class:active={statusFilter === "consent"} href="/antraege?status=consent">Offen</a>
-          <a class:active={eventFilter === "veto"} href="/antraege?ereignis=veto">Vetos</a>
-          <a class:active={eventFilter === "gespraech"} href="/antraege?ereignis=gespraech">Gespräche</a>
-          <a class:active={statusFilter === "voting"} href="/antraege?status=voting">Abstimmungen</a>
-        </nav>
-      </div>
-      <button class="secondary" on:click={refresh} disabled={loading}>Aktualisieren</button>
+      <section aria-labelledby="proposal-list-heading">
+        <div class="section-heading">
+          <div>
+            <h2 id="proposal-list-heading">{proposalListTitle}</h2>
+            <nav
+              class="wg-filter-list proposal-filters"
+              aria-label="Governance-Ereignisse filtern"
+            >
+              <a
+                class:active={!statusFilter && !eventFilter}
+                aria-current={!statusFilter && !eventFilter
+                  ? "page"
+                  : undefined}
+                href="/antraege">Alle</a
+              >
+              <a
+                class:active={statusFilter === "consent"}
+                aria-current={statusFilter === "consent" ? "page" : undefined}
+                href="/antraege?status=consent">Offen</a
+              >
+              <a
+                class:active={eventFilter === "veto"}
+                aria-current={eventFilter === "veto" ? "page" : undefined}
+                href="/antraege?ereignis=veto">Vetos</a
+              >
+              <a
+                class:active={eventFilter === "gespraech"}
+                aria-current={eventFilter === "gespraech" ? "page" : undefined}
+                href="/antraege?ereignis=gespraech">Gespräche</a
+              >
+              <a
+                class:active={statusFilter === "voting"}
+                aria-current={statusFilter === "voting" ? "page" : undefined}
+                href="/antraege?status=voting">Abstimmungen</a
+              >
+            </nav>
+          </div>
+          <button
+            class="wg-button wg-button--quiet"
+            on:click={refresh}
+            disabled={loading}
+          >
+            Aktualisieren
+          </button>
+        </div>
+
+        {#if loading}
+          <p class="wg-muted">Anträge werden geladen…</p>
+        {:else if !error || proposals.length > 0}
+          {#if proposals.length === 0}
+            <div class="wg-empty">Noch liegen keine Anträge vor.</div>
+          {:else if visibleProposals.length === 0}
+            <div class="wg-empty">
+              Für diese Ansicht liegen keine Anträge vor.
+            </div>
+          {:else}
+            <div class="proposal-list">
+              {#each visibleProposals as proposal}
+                <a
+                  class="wg-surface proposal-card"
+                  href={`/antraege?id=${encodeURIComponent(proposal.id)}`}
+                >
+                  <div class="proposal-topline">
+                    <span
+                      class:open={proposal.status === "consent" ||
+                        proposal.status === "voting"}
+                    >
+                      {statusLabel(proposal.status)}
+                    </span>
+                    <time datetime={proposal.created_at}>
+                      {new Date(proposal.created_at).toLocaleDateString(
+                        "de-DE",
+                      )}
+                    </time>
+                  </div>
+                  <h3>Weberstatus für {proposal.applicant_title}</h3>
+                  {#if proposal.summary}<p>{proposal.summary}</p>{/if}
+                  <div class="facts">
+                    <span>
+                      {proposal.veto_count} Veto{proposal.veto_count === 1
+                        ? ""
+                        : "s"}
+                    </span>
+                    <span
+                      >{proposal.yes_votes} Ja · {proposal.no_votes} Nein</span
+                    >
+                    {#if proposal.remaining_seconds !== undefined}
+                      <span
+                        >Noch {formatRemaining(
+                          proposal.remaining_seconds,
+                        )}</span
+                      >
+                    {/if}
+                  </div>
+                </a>
+              {/each}
+            </div>
+          {/if}
+        {/if}
+      </section>
     </div>
-
-    {#if loading}
-      <p class="muted">Anträge werden geladen…</p>
-    {:else if proposals.length === 0}
-      <p class="empty">Noch liegen keine Anträge vor.</p>
-    {:else if visibleProposals.length === 0}
-      <p class="empty">Für diese Ansicht liegen keine Anträge vor.</p>
-    {:else}
-      <div class="proposal-list">
-        {#each visibleProposals as proposal}
-          <a class="proposal-card" href={`/antraege?id=${encodeURIComponent(proposal.id)}`}>
-            <div class="proposal-topline">
-              <span class:open={proposal.status === "consent" || proposal.status === "voting"}>{statusLabel(proposal.status)}</span>
-              <time datetime={proposal.created_at}>{new Date(proposal.created_at).toLocaleDateString("de-DE")}</time>
-            </div>
-            <h3>Weberstatus für {proposal.applicant_title}</h3>
-            {#if proposal.summary}<p>{proposal.summary}</p>{/if}
-            <div class="facts">
-              <span>{proposal.veto_count} Veto{proposal.veto_count === 1 ? "" : "s"}</span>
-              <span>{proposal.yes_votes} Ja · {proposal.no_votes} Nein</span>
-              {#if proposal.remaining_seconds !== undefined}<span>Noch {formatRemaining(proposal.remaining_seconds)}</span>{/if}
-            </div>
-          </a>
-        {/each}
-      </div>
-    {/if}
-  </section>
-</main>
+  </main>
 {/if}
 
 <style>
-  :global(body) { margin: 0; background: #f3f1e9; color: #18251f; font-family: system-ui, sans-serif; }
-  .page-shell { width: min(880px, calc(100% - 32px)); margin: 0 auto; padding: 28px 0 72px; }
-  .page-header { padding: 24px 0 32px; }
-  .back-link { color: inherit; text-decoration: none; font-weight: 650; }
-  .eyebrow { margin: 28px 0 6px; text-transform: uppercase; letter-spacing: .09em; font-size: .76rem; font-weight: 750; color: #4d6759; }
-  h1 { margin: 0; font-size: clamp(2.4rem, 8vw, 4.5rem); line-height: .95; }
-  h2, h3 { margin: 0; }
-  .page-header > p:last-child { max-width: 68ch; font-size: 1.08rem; line-height: 1.6; }
-  .guest-card, .proposal-card, .error, .empty { border: 1px solid rgba(24,37,31,.16); border-radius: 18px; background: rgba(255,255,255,.72); }
-  .guest-card { display: grid; gap: 14px; padding: 24px; margin-bottom: 36px; }
-  .guest-card .eyebrow { margin-top: 0; }
-  label { font-weight: 700; }
-  textarea { box-sizing: border-box; width: 100%; resize: vertical; border: 1px solid rgba(24,37,31,.28); border-radius: 12px; padding: 12px; font: inherit; background: #fff; }
-  button { width: fit-content; border-radius: 999px; padding: 10px 16px; font: inherit; font-weight: 720; cursor: pointer; }
-  button:disabled { opacity: .55; cursor: wait; }
-  .primary { border: 0; background: #1f5b42; color: white; }
-  .secondary { border: 1px solid rgba(24,37,31,.28); background: transparent; color: inherit; }
-  .danger-link { border: 0; padding-left: 0; background: transparent; color: #8d2f2f; }
-  .notice { padding: 12px 14px; border-radius: 10px; background: #e7efe9; }
-  .error { padding: 14px 16px; margin-bottom: 24px; color: #7f2424; background: #fff0f0; }
-  .section-heading, .proposal-topline, .facts { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
-  .section-heading { margin-bottom: 16px; }
-  .proposal-filters { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 12px; }
-  .proposal-filters a { min-height: 44px; padding: 0 14px; border: 1px solid rgba(24,37,31,.2); border-radius: 999px; display: inline-flex; align-items: center; color: inherit; text-decoration: none; font-weight: 680; }
-  .proposal-filters a.active { border-color: #1f5b42; background: #dcecdf; color: #1f5b42; }
-  .proposal-list { display: grid; gap: 12px; }
-  .proposal-card { display: grid; gap: 12px; padding: 20px; color: inherit; text-decoration: none; transition: transform 120ms ease, border-color 120ms ease; }
-  .proposal-card:hover, .proposal-card:focus-visible { transform: translateY(-2px); border-color: rgba(24,37,31,.45); }
-  .proposal-topline { font-size: .82rem; color: #607168; }
-  .proposal-topline span { padding: 4px 9px; border-radius: 999px; background: #e9e8e1; }
-  .proposal-topline span.open { background: #dcecdf; color: #1f5b42; }
-  .proposal-card p { margin: 0; line-height: 1.5; }
-  .facts { justify-content: flex-start; flex-wrap: wrap; font-size: .86rem; color: #526259; }
-  .empty { padding: 24px; }
-  .muted { color: #607168; }
-  @media (max-width: 560px) { .section-heading, .proposal-topline { align-items: flex-start; } .section-heading { flex-direction: column; } }
+  h2,
+  h3 {
+    margin: 0;
+  }
+
+  .guest-card {
+    display: grid;
+    gap: 1rem;
+    margin-bottom: 36px;
+  }
+
+  .guest-card:focus-visible {
+    outline: 3px solid var(--accent-soft);
+    outline-offset: 4px;
+  }
+
+  .guest-eyebrow {
+    margin-top: 0;
+  }
+
+  .page-error {
+    margin-bottom: 24px;
+  }
+
+  .section-heading,
+  .proposal-topline,
+  .facts {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  .section-heading {
+    margin-bottom: 16px;
+  }
+
+  .proposal-filters {
+    margin-top: 12px;
+  }
+
+  .proposal-list {
+    display: grid;
+    gap: 12px;
+  }
+
+  .proposal-card {
+    display: grid;
+    gap: 12px;
+    padding: 20px;
+    color: var(--text);
+    text-decoration: none;
+  }
+
+  .proposal-card:hover,
+  .proposal-card:focus-visible {
+    border-color: var(--panel-border-strong);
+    background: var(--surface-hover);
+  }
+
+  .proposal-topline {
+    color: var(--muted);
+    font-size: 0.82rem;
+  }
+
+  .proposal-topline span {
+    padding: 4px 9px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.06);
+  }
+
+  .proposal-topline span.open {
+    background: var(--success-soft);
+    color: var(--success);
+  }
+
+  .proposal-card p {
+    margin: 0;
+    color: var(--muted);
+    line-height: 1.5;
+  }
+
+  .facts {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+    color: var(--muted);
+    font-size: 0.86rem;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .proposal-card {
+      transition:
+        transform 120ms ease,
+        border-color 120ms ease,
+        background-color 120ms ease;
+    }
+
+    .proposal-card:hover,
+    .proposal-card:focus-visible {
+      transform: translateY(-2px);
+    }
+  }
+
+  @media (max-width: 560px) {
+    .section-heading,
+    .proposal-topline {
+      align-items: flex-start;
+    }
+
+    .section-heading {
+      flex-direction: column;
+    }
+  }
 </style>

--- a/apps/web/src/routes/login/+page.svelte
+++ b/apps/web/src/routes/login/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import { authStore } from '$lib/auth/store';
+  import "$lib/styles/page-foundation.css";
+  import { authStore } from "$lib/auth/store";
 
-  let email = '';
+  let email = "";
   let error: string | null = null;
   let success = false;
   let loading = false;
@@ -13,13 +14,13 @@
     try {
       await authStore.requestLogin(email);
       success = true;
-    } catch (e) {
-      if (e instanceof Error && e.message.includes('disabled')) {
-        error = 'Öffentlicher Login ist derzeit deaktiviert.';
+    } catch (cause) {
+      if (cause instanceof Error && cause.message.includes("disabled")) {
+        error = "Öffentlicher Login ist derzeit deaktiviert.";
       } else {
-        error = 'Login fehlgeschlagen. Bitte versuche es erneut.';
+        error = "Anmeldung fehlgeschlagen. Bitte versuche es erneut.";
       }
-      console.error(e);
+      console.error(cause);
     } finally {
       loading = false;
     }
@@ -27,45 +28,85 @@
 </script>
 
 <svelte:head>
-  <title>Login</title>
+  <title>Anmelden · Weltgewebe</title>
+  <meta
+    name="description"
+    content="Im Weltgewebe anmelden, um Commons gemeinsam zu pflegen und zu verändern."
+  />
 </svelte:head>
 
-<div class="col" style="gap:1.5rem; padding:1.5rem; max-width:400px; margin:0 auto; margin-top: 10vh;">
-  <div class="panel col" style="gap:1rem;">
-    <h1 style="margin:0; font-size:1.5rem;">Login</h1>
+<main class="wg-page wg-page--center" aria-labelledby="login-heading">
+  <div class="wg-page__inner wg-page__inner--narrow">
+    <a class="wg-back-link" href="/map">← Zum Gewebe</a>
 
-    {#if success}
-      <div class="panel" style="border-color:var(--color-theme-2, #2ecc71);">
-        <p><strong>Postfach prüfen!</strong></p>
-        <p>Falls deine E-Mail registriert ist, haben wir dir einen Login-Link gesendet.</p>
-      </div>
-    {:else}
-      <form on:submit|preventDefault={handleSubmit} class="col" style="gap:1rem;">
-        <div class="col">
-          <label for="email" style="font-size:0.9rem; color:var(--muted);">E-Mail</label>
-          <input
-            id="email"
-            type="email"
-            bind:value={email}
-            placeholder="du@example.com"
-            required
-            disabled={loading}
-            style="padding:0.5rem; border-radius:6px; border:1px solid #263240; background:#101821; color:white;"
-          />
+    <header class="wg-page__header">
+      <p class="wg-eyebrow">Gemeingüter gemeinsam verwalten</p>
+      <h1 id="login-heading" class="wg-title wg-title--compact">Anmelden</h1>
+      <p class="wg-lede">
+        Mit deiner E-Mail erhältst du einen einmaligen Anmeldelink. Ein Passwort
+        ist nicht nötig.
+      </p>
+    </header>
+
+    <section class="wg-surface wg-surface--padded wg-surface--accent">
+      {#if success}
+        <div class="wg-status wg-status--success wg-stack" role="status">
+          <strong>Postfach prüfen</strong>
+          <p>
+            Falls deine E-Mail registriert ist, haben wir dir einen Anmeldelink
+            gesendet.
+          </p>
         </div>
-
-        {#if error}
-          <div style="color:var(--color-danger, #ff6b6b); font-size:0.9rem;">
-            {error}
+      {:else}
+        <form on:submit|preventDefault={handleSubmit} class="wg-stack">
+          <div class="wg-field">
+            <label for="email">E-Mail-Adresse</label>
+            <input
+              class="wg-input"
+              id="email"
+              type="email"
+              bind:value={email}
+              placeholder="du@example.com"
+              autocomplete="email"
+              inputmode="email"
+              aria-describedby="email-hint"
+              required
+              disabled={loading}
+            />
+            <span id="email-hint" class="wg-muted">
+              Der Link kann nur einmal verwendet werden und läuft automatisch
+              ab.
+            </span>
           </div>
-        {/if}
 
-        <div class="row" style="justify-content:flex-end;">
-          <button type="submit" class="btn" disabled={loading || !email}>
-            {#if loading}Wird gesendet...{:else}Login-Link senden{/if}
-          </button>
-        </div>
-      </form>
-    {/if}
+          {#if error}
+            <div class="wg-status wg-status--error" role="alert">{error}</div>
+          {/if}
+
+          <div class="login-actions">
+            <button
+              type="submit"
+              class="wg-button wg-button--primary"
+              disabled={loading || !email}
+            >
+              {loading ? "Wird gesendet…" : "Anmeldelink senden"}
+            </button>
+          </div>
+        </form>
+      {/if}
+    </section>
   </div>
-</div>
+</main>
+
+<style>
+  .login-actions {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  @media (max-width: 480px) {
+    .login-actions .wg-button {
+      width: 100%;
+    }
+  }
+</style>

--- a/apps/web/tests/context-panel-sheet.spec.ts
+++ b/apps/web/tests/context-panel-sheet.spec.ts
@@ -1,8 +1,16 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import { mockApiResponses } from "./fixtures/mockApi";
 import { activateToolFanAction } from "./fixtures/toolFan";
 
-test.describe("ContextPanel mobile sheet stages", () => {
+async function openFirstNode(page: Page): Promise<void> {
+  await page.evaluate(() =>
+    (document.querySelector(".map-marker") as HTMLElement)?.dispatchEvent(
+      new MouseEvent("click", { bubbles: true }),
+    ),
+  );
+}
+
+test.describe("ContextPanel mobile compact and full stages", () => {
   test.beforeEach(async ({ page }) => {
     await mockApiResponses(page, {
       auth: { authenticated: true, account_id: "e2e-weber", role: "weber" },
@@ -12,74 +20,65 @@ test.describe("ContextPanel mobile sheet stages", () => {
     await page.waitForSelector(".map-marker", { timeout: 10000 });
   });
 
-  test("Fokus opens in the compact preview stage on mobile", async ({
+  test("Fokus opens as a compact card without separate size buttons", async ({
     page,
   }) => {
-    await page.evaluate(() =>
-      (document.querySelector(".map-marker") as HTMLElement)?.dispatchEvent(
-        new MouseEvent("click", { bubbles: true }),
-      ),
-    );
+    await openFirstNode(page);
 
     const panel = page.getByTestId("context-panel");
+    const handle = page.getByTestId("sheet-handle");
     await expect(panel).toBeVisible();
     await expect(panel).toHaveAttribute("data-sheet-stage", "preview");
-
-    const preview = page.getByRole("button", { name: "Vorschau", exact: true });
-    await expect(preview).toHaveAttribute("aria-pressed", "true");
-    const handle = page.getByTestId("sheet-handle");
     await expect(handle).toBeVisible();
+    await expect(handle).toHaveAttribute("aria-pressed", "false");
     expect((await handle.boundingBox())?.height).toBeGreaterThanOrEqual(44);
+    await expect(page.getByLabel("Panelgröße")).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: "Halbe Höhe", exact: true }),
+    ).toHaveCount(0);
   });
 
-  test("the accessible toggle switches between preview, half and full", async ({
+  test("tapping the handle and title switches between compact and full", async ({
     page,
   }) => {
-    // Settle the height transition instantly so bounding boxes reflect the
-    // resting size of each stage rather than a mid-animation frame.
     await page.emulateMedia({ reducedMotion: "reduce" });
-    await page.evaluate(() =>
-      (document.querySelector(".map-marker") as HTMLElement)?.dispatchEvent(
-        new MouseEvent("click", { bubbles: true }),
-      ),
-    );
+    await openFirstNode(page);
 
     const panel = page.getByTestId("context-panel");
-    const half = page.getByRole("button", { name: "Halbe Höhe", exact: true });
-    const full = page.getByRole("button", { name: "Vollbild", exact: true });
+    const handle = page.getByTestId("sheet-handle");
+    const compactBox = await panel.boundingBox();
 
-    const previewBox = await panel.boundingBox();
-
-    await half.click();
-    await expect(panel).toHaveAttribute("data-sheet-stage", "half");
-    await expect(half).toHaveAttribute("aria-pressed", "true");
-    const halfBox = await panel.boundingBox();
-    expect(halfBox!.height).toBeGreaterThan(previewBox!.height);
-
-    await full.click();
+    await handle.click();
     await expect(panel).toHaveAttribute("data-sheet-stage", "full");
-    await expect(full).toHaveAttribute("aria-pressed", "true");
+    await expect(handle).toHaveAttribute("aria-pressed", "true");
     const fullBox = await panel.boundingBox();
-    expect(fullBox!.height).toBeGreaterThan(halfBox!.height);
+    expect(fullBox!.height).toBeGreaterThan(compactBox!.height);
+
+    const titleToggle = page.getByRole("button", {
+      name: /Knoten, Vollansicht; Ansicht wechseln/,
+    });
+    await expect(titleToggle).toBeEnabled();
+    await titleToggle.click();
+    await expect(panel).toHaveAttribute("data-sheet-stage", "preview");
   });
 
-  test("Komposition starts full but remains resizable", async ({ page }) => {
+  test("Komposition starts full but can be collapsed to a compact card", async ({
+    page,
+  }) => {
     await page.waitForSelector('[data-testid="tool-fan"]', {
       timeout: 10000,
     });
-    // The tool fan collapses on mobile once the panel is open, so open
-    // komposition first.
     await activateToolFanAction(page, "weave");
 
     const panel = page.getByTestId("context-panel");
+    const handle = page.getByTestId("sheet-handle");
     await expect(panel).toBeVisible();
     await expect(panel).toHaveAttribute("data-sheet-stage", "full");
-    await expect(page.getByLabel("Panelgröße")).toBeVisible();
-    await page.getByRole("button", { name: "Halbe Höhe", exact: true }).click();
-    await expect(panel).toHaveAttribute("data-sheet-stage", "half");
+    await handle.click();
+    await expect(panel).toHaveAttribute("data-sheet-stage", "preview");
   });
 
-  test("sheet handle supports keyboard stages and pointer dragging", async ({
+  test("the handle supports keyboard changes and pointer dragging", async ({
     page,
   }) => {
     await page.emulateMedia({ reducedMotion: "reduce" });
@@ -89,19 +88,38 @@ test.describe("ContextPanel mobile sheet stages", () => {
 
     await handle.focus();
     await handle.press("ArrowUp");
-    await expect(panel).toHaveAttribute("data-sheet-stage", "half");
+    await expect(panel).toHaveAttribute("data-sheet-stage", "full");
+    await handle.press("ArrowDown");
+    await expect(panel).toHaveAttribute("data-sheet-stage", "preview");
     await handle.press("End");
     await expect(panel).toHaveAttribute("data-sheet-stage", "full");
     await handle.press("Home");
     await expect(panel).toHaveAttribute("data-sheet-stage", "preview");
+    await handle.press("Space");
+    await expect(panel).toHaveAttribute("data-sheet-stage", "full");
+    await handle.press("Home");
 
     const box = await handle.boundingBox();
     expect(box).not.toBeNull();
     await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
     await page.mouse.down();
-    await page.mouse.move(box!.x + box!.width / 2, box!.y - 300, { steps: 8 });
+    await page.mouse.move(box!.x + box!.width / 2, box!.y - 360, {
+      steps: 8,
+    });
     await page.mouse.up();
-    await expect(panel).not.toHaveAttribute("data-sheet-stage", "preview");
+    await expect(panel).toHaveAttribute("data-sheet-stage", "full");
+  });
+
+  test("node tabs appear only in the full mobile view", async ({ page }) => {
+    await openFirstNode(page);
+    const panel = page.getByTestId("context-panel");
+    const tabs = panel.locator(".tabs");
+
+    await expect(panel).toHaveAttribute("data-sheet-stage", "preview");
+    await expect(tabs).toBeHidden();
+    await page.getByTestId("sheet-handle").click();
+    await expect(panel).toHaveAttribute("data-sheet-stage", "full");
+    await expect(tabs).toBeVisible();
   });
 
   test("orientation change keeps the open panel inside the viewport", async ({
@@ -110,7 +128,7 @@ test.describe("ContextPanel mobile sheet stages", () => {
     await page.emulateMedia({ reducedMotion: "reduce" });
     await page.locator(".map-marker").first().click();
     const panel = page.getByTestId("context-panel");
-    await page.getByRole("button", { name: "Vollbild", exact: true }).click();
+    await page.getByTestId("sheet-handle").click();
     await expect(panel).toHaveAttribute("data-sheet-stage", "full");
 
     await page.setViewportSize({ width: 844, height: 390 });
@@ -120,10 +138,10 @@ test.describe("ContextPanel mobile sheet stages", () => {
     expect(box!.y).toBeGreaterThanOrEqual(0);
     expect(box!.x + box!.width).toBeLessThanOrEqual(844);
     expect(box!.y + box!.height).toBeLessThanOrEqual(390);
-    await expect(page.getByLabel("Panelgröße")).toBeHidden();
+    await expect(page.getByTestId("sheet-handle")).toBeHidden();
   });
 
-  test("switching the selected marker resets the sheet back to preview", async ({
+  test("switching the selected marker resets the sheet to compact", async ({
     page,
   }) => {
     await page.evaluate(() =>
@@ -132,7 +150,7 @@ test.describe("ContextPanel mobile sheet stages", () => {
       )?.dispatchEvent(new MouseEvent("click", { bubbles: true })),
     );
     const panel = page.getByTestId("context-panel");
-    await page.getByRole("button", { name: "Vollbild", exact: true }).click();
+    await page.getByTestId("sheet-handle").click();
     await expect(panel).toHaveAttribute("data-sheet-stage", "full");
 
     await page.evaluate(() =>
@@ -154,17 +172,19 @@ test.describe("ContextPanel desktop layout stays unchanged", () => {
     await page.waitForSelector(".map-marker", { timeout: 10000 });
   });
 
-  test("no sheet-size toggle is shown, and the panel keeps its fixed width", async ({
+  test("the panel keeps its fixed width and hides mobile controls", async ({
     page,
   }) => {
-    await page.evaluate(() =>
-      (document.querySelector(".map-marker") as HTMLElement)?.dispatchEvent(
-        new MouseEvent("click", { bubbles: true }),
-      ),
-    );
+    await openFirstNode(page);
     const panel = page.getByTestId("context-panel");
     await expect(panel).toBeVisible();
-    await expect(page.getByLabel("Panelgröße")).toBeHidden();
+    await expect(page.getByTestId("sheet-handle")).toBeHidden();
+    await expect(
+      page.getByRole("button", {
+        name: /Knoten, Kompaktkarte; Ansicht wechseln/,
+      }),
+    ).toBeHidden();
+    await expect(panel.locator(".desktop-heading")).toHaveText("Knoten");
 
     const box = await panel.boundingBox();
     expect(Math.round(box!.width)).toBe(400);

--- a/apps/web/tests/page-foundation.spec.ts
+++ b/apps/web/tests/page-foundation.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "@playwright/test";
+import { mockApiResponses } from "./fixtures/mockApi";
+
+test("login uses the shared page, form and status foundation", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/login");
+
+  await expect(page).toHaveTitle("Anmelden · Weltgewebe");
+  await expect(
+    page.getByRole("heading", { name: "Anmelden", level: 1 }),
+  ).toBeVisible();
+  await expect(page.locator("main.wg-page")).toBeVisible();
+  await expect(page.locator("main [style]")).toHaveCount(0);
+
+  const email = page.getByLabel("E-Mail-Adresse");
+  const submit = page.getByRole("button", { name: "Anmeldelink senden" });
+  expect((await email.boundingBox())!.height).toBeGreaterThanOrEqual(44);
+  expect((await submit.boundingBox())!.height).toBeGreaterThanOrEqual(44);
+
+  const background = await page
+    .locator("body")
+    .evaluate((element) => getComputedStyle(element).backgroundColor);
+  expect(background).toBe("rgb(15, 17, 21)");
+});
+
+test("the proposal overview uses the same responsive page foundation", async ({
+  page,
+}) => {
+  await mockApiResponses(page, {
+    auth: { authenticated: false },
+  });
+  await page.route("**/api/proposals**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: "[]",
+    });
+  });
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/antraege");
+
+  await expect(page.locator("main.wg-page")).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Anträge", level: 1 }),
+  ).toBeVisible();
+  await expect(page.getByText("Noch liegen keine Anträge vor.")).toBeVisible();
+
+  const filters = page.getByRole("navigation", {
+    name: "Governance-Ereignisse filtern",
+  });
+  for (const link of await filters.getByRole("link").all()) {
+    expect((await link.boundingBox())!.height).toBeGreaterThanOrEqual(44);
+  }
+
+  const active = filters.getByRole("link", { name: "Alle", exact: true });
+  await expect(active).toHaveAttribute("aria-current", "page");
+  const background = await page
+    .locator("body")
+    .evaluate((element) => getComputedStyle(element).backgroundColor);
+  expect(background).toBe("rgb(15, 17, 21)");
+});
+
+test("a proposal API failure does not masquerade as an empty list", async ({
+  page,
+}) => {
+  await mockApiResponses(page, {
+    auth: { authenticated: false },
+  });
+  await page.route("**/api/proposals**", async (route) => {
+    await route.fulfill({ status: 503, body: "temporarily unavailable" });
+  });
+  await page.goto("/antraege");
+
+  await expect(
+    page.getByRole("alert").filter({
+      hasText: "Das Antragssystem ist vorübergehend nicht verfügbar.",
+    }),
+  ).toBeVisible();
+  await expect(page.getByText("Noch liegen keine Anträge vor.")).toHaveCount(0);
+  await expect(
+    page.getByText("Für diese Ansicht liegen keine Anträge vor."),
+  ).toHaveCount(0);
+});


### PR DESCRIPTION
## Ziel

Die Weltgewebe-Oberfläche wird in zwei klar abgegrenzten Bereichen vereinheitlicht: Das mobile Kontextpanel erhält nur noch eine Kompaktkarte und eine Vollansicht; Login und Governance verwenden einen gemeinsamen dunklen Seitenbaukasten.

## Änderungen

- mobiles Kontextpanel: zwei statt drei Höhenzustände
- Umschalten per Griff, Paneltitel und Tastatur; Ziehen bleibt erhalten
- Tabs erscheinen mobil nur in der Vollansicht
- Desktop-Seitenpanel bleibt unverändert
- gemeinsamer, routenspezifischer Seitenbaukasten für Login und Governance
- Login ohne Inline-Stile, mit klarer passwortloser Anmeldung
- Antragsliste, Detailansicht und Governance-Faden im selben visuellen System
- aktive Filter mit `aria-current`, Abstimmungen mit `aria-pressed`
- Veto-Feld sichtbar beschriftet
- API-Fehler werden nicht mehr zusätzlich als leere Liste dargestellt
- Bewegungsreduktion wird respektiert

## Prüfung

- `pnpm check:ci`: 0 Fehler, 0 Warnungen
- `pnpm run build:e2e`: grün
- `pnpm run ci`: grün
- 21 fokussierte Playwright-Verträge: grün
- finale Routengrößen:
  - `/login`: 44.950 B JS / 3.213 B CSS gzip
  - `/settings`: 56.200 B JS / 3.519 B CSS gzip
  - `/map`: 79.962 B JS / 16.921 B CSS gzip

## Reviewbindung

- Basis: `c77025cd6cffe117378ac82d983038083c680cf0`
- Head: `88ad0e3a3742bdbe2fa543c1f988f168aee261b5`
- kanonischer Diff-SHA-256: `b8b19b97a737ddc3a0c9882d28f50d18979755b0da376ab86b78ac9bbf3672de`

## Getrennte Folgebefunde

- großer Client-Chunk: Bureau-Kandidat `candidate-6627523075dd221f8a60b9cc` bereits vorhanden
- globaler Versionshinweis mit zu kleinem Bedienziel: Bureau-Kandidat `candidate-50da648af03e8228fc80f85a` neu registriert