### PR TITLE
fix(web): Kompaktpanel und mobile Queransicht härten

### DIFF
--- a/apps/web/route-performance-budget.json
+++ b/apps/web/route-performance-budget.json
@@ -11,6 +11,14 @@
       "min_initial_js_assets": 1,
       "min_initial_css_assets": 1
     },
+    "/antraege": {
+      "max_initial_js_gzip_bytes": 55000,
+      "max_initial_css_gzip_bytes": 5000,
+      "forbid_css_markers": [".maplibregl-"],
+      "require_css_markers": [".wg-page"],
+      "min_initial_js_assets": 1,
+      "min_initial_css_assets": 1
+    },
     "/settings": {
       "max_initial_js_gzip_bytes": 57000,
       "max_initial_css_gzip_bytes": 3600,

--- a/apps/web/src/lib/components/ContextPanel.svelte
+++ b/apps/web/src/lib/components/ContextPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { createEventDispatcher } from "svelte";
+  import { createEventDispatcher, onMount } from "svelte";
   import {
     selection,
     systemState,
@@ -40,6 +40,8 @@
     domainChanged: DomainChanged;
   }>();
   const DRAG_THRESHOLD_PX = 6;
+  const MOBILE_SHEET_MEDIA =
+    "(max-width: 768px), (max-height: 500px) and (pointer: coarse)";
 
   let kompositionPanel: KompositionPanelHandle | null = null;
   let sheetStage: SheetStage = "compact";
@@ -51,6 +53,17 @@
   let dragging = false;
   let dragMoved = false;
   let suppressNextHandleClick = false;
+  let mobileSheetMode = false;
+
+  onMount(() => {
+    const media = window.matchMedia(MOBILE_SHEET_MEDIA);
+    const updateMobileSheetMode = () => {
+      mobileSheetMode = media.matches;
+    };
+    updateMobileSheetMode();
+    media.addEventListener("change", updateMobileSheetMode);
+    return () => media.removeEventListener("change", updateMobileSheetMode);
+  });
 
   function derivePanelTitle(
     state: SystemState,
@@ -100,7 +113,7 @@
   }
 
   function toggleSheetStage(): void {
-    if (window.innerWidth > 768) return;
+    if (!mobileSheetMode) return;
     setSheetStage(sheetStage === "compact" ? "full" : "compact");
   }
 
@@ -113,7 +126,7 @@
   }
 
   function handleSheetPointerDown(event: PointerEvent): void {
-    if (window.innerWidth > 768) return;
+    if (!mobileSheetMode) return;
     const handle = event.currentTarget as HTMLElement;
     const aside = handle.closest<HTMLElement>('[data-testid="context-panel"]');
     if (!aside) return;
@@ -181,7 +194,7 @@
   }
 
   function handleSheetKeydown(event: KeyboardEvent): void {
-    if (window.innerWidth > 768) return;
+    if (!mobileSheetMode) return;
     if (event.key === "ArrowUp" || event.key === "End") {
       event.preventDefault();
       setSheetStage("full");
@@ -281,6 +294,7 @@
       {:else if $selection}
         {#if $selection.type === "node"}
           <NodePanel
+            compact={mobileSheetMode && sheetStage === "compact"}
             on:selectRelated={handleRelated}
             on:domainChanged={handleDomainChanged}
           />
@@ -297,10 +311,14 @@
 <style>
   .context-panel {
     position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: var(--context-panel-width);
     z-index: var(--z-map-context-panel);
     background: var(--panel);
     color: var(--text);
-    box-shadow: var(--shadow);
+    box-shadow: -4px 0 16px rgba(0, 0, 0, 0.28);
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -364,14 +382,17 @@
     overscroll-behavior: contain;
   }
 
-  @media (max-width: 768px) {
+  @media (max-width: 768px), (max-height: 500px) and (pointer: coarse) {
     .context-panel {
+      top: auto;
       bottom: 0;
       left: 0;
       right: 0;
+      width: auto;
       max-height: none;
       padding-bottom: env(safe-area-inset-bottom);
       border-radius: 18px 18px 0 0;
+      box-shadow: var(--shadow);
       transition: height var(--motion-ui);
     }
 
@@ -459,16 +480,6 @@
 
     .stage-compact :global(.tabs) {
       display: none;
-    }
-  }
-
-  @media (min-width: 769px) {
-    .context-panel {
-      top: 0;
-      right: 0;
-      bottom: 0;
-      width: var(--context-panel-width);
-      box-shadow: -4px 0 16px rgba(0, 0, 0, 0.28);
     }
   }
 

--- a/apps/web/src/lib/components/panels/NodePanel.svelte
+++ b/apps/web/src/lib/components/panels/NodePanel.svelte
@@ -32,6 +32,8 @@
     domainChanged: DomainChanged;
   }>();
 
+  export let compact = false;
+
   type NodeTab = "uebersicht" | "gespraech" | "verlauf" | "bearbeiten";
   let activeTab: NodeTab = "uebersicht";
   let tabs: NodeTab[] = ["uebersicht", "gespraech", "verlauf"];
@@ -319,9 +321,13 @@
 
 <div class="node-mode">
   <h3>{nodeDetails?.title || $selection?.data?.title || $selection?.id}</h3>
-  {#if summary && !editing}<p class="summary">{summary}</p>{/if}
+  {#if summary && (!editing || compact)}<p class="summary">{summary}</p>{/if}
 
-  {#if editing}
+  {#if compact}
+    <div class="compact-node-summary" data-testid="node-compact-summary">
+      <p><strong>Knotenart:</strong> {kind}</p>
+    </div>
+  {:else if editing}
     <form class="edit-form" on:submit|preventDefault={saveNode}>
       <label>
         Titel

--- a/apps/web/src/routes/antraege/+page.svelte
+++ b/apps/web/src/routes/antraege/+page.svelte
@@ -244,23 +244,31 @@
               class="proposal-filters"
               aria-label="Governance-Ereignisse filtern"
             >
-              <a class:active={!statusFilter && !eventFilter} href="/antraege"
-                >Alle</a
+              <a
+                class:active={!statusFilter && !eventFilter}
+                aria-current={!statusFilter && !eventFilter
+                  ? "page"
+                  : undefined}
+                href="/antraege">Alle</a
               >
               <a
                 class:active={statusFilter === "consent"}
+                aria-current={statusFilter === "consent" ? "page" : undefined}
                 href="/antraege?status=consent">Offen</a
               >
               <a
                 class:active={eventFilter === "veto"}
+                aria-current={eventFilter === "veto" ? "page" : undefined}
                 href="/antraege?ereignis=veto">Vetos</a
               >
               <a
                 class:active={eventFilter === "gespraech"}
+                aria-current={eventFilter === "gespraech" ? "page" : undefined}
                 href="/antraege?ereignis=gespraech">Gespräche</a
               >
               <a
                 class:active={statusFilter === "voting"}
+                aria-current={statusFilter === "voting" ? "page" : undefined}
                 href="/antraege?status=voting">Abstimmungen</a
               >
             </nav>
@@ -276,46 +284,51 @@
           <p class="wg-state wg-state--muted" role="status">
             Anträge werden geladen…
           </p>
-        {:else if proposals.length === 0}
-          <p class="wg-state">Noch liegen keine Anträge vor.</p>
-        {:else if visibleProposals.length === 0}
-          <p class="wg-state">Für diese Ansicht liegen keine Anträge vor.</p>
-        {:else}
-          <div class="proposal-list">
-            {#each visibleProposals as proposal}
-              <a
-                class="wg-card proposal-card"
-                href={`/antraege?id=${encodeURIComponent(proposal.id)}`}
-              >
-                <div class="wg-inline-spread proposal-topline">
-                  <span
-                    class:open={proposal.status === "consent" ||
-                      proposal.status === "voting"}
-                    >{statusLabel(proposal.status)}</span
-                  >
-                  <time datetime={proposal.created_at}
-                    >{new Date(proposal.created_at).toLocaleDateString(
-                      "de-DE",
-                    )}</time
-                  >
-                </div>
-                <h3>Weberstatus für {proposal.applicant_title}</h3>
-                {#if proposal.summary}<p>{proposal.summary}</p>{/if}
-                <div class="facts">
-                  <span
-                    >{proposal.veto_count} Veto{proposal.veto_count === 1
-                      ? ""
-                      : "s"}</span
-                  >
-                  <span>{proposal.yes_votes} Ja · {proposal.no_votes} Nein</span
-                  >
-                  {#if proposal.remaining_seconds !== undefined}<span
-                      >Noch {formatRemaining(proposal.remaining_seconds)}</span
-                    >{/if}
-                </div>
-              </a>
-            {/each}
-          </div>
+        {:else if !error || proposals.length > 0}
+          {#if proposals.length === 0}
+            <p class="wg-state">Noch liegen keine Anträge vor.</p>
+          {:else if visibleProposals.length === 0}
+            <p class="wg-state">Für diese Ansicht liegen keine Anträge vor.</p>
+          {:else}
+            <div class="proposal-list">
+              {#each visibleProposals as proposal}
+                <a
+                  class="wg-card proposal-card"
+                  href={`/antraege?id=${encodeURIComponent(proposal.id)}`}
+                >
+                  <div class="wg-inline-spread proposal-topline">
+                    <span
+                      class:open={proposal.status === "consent" ||
+                        proposal.status === "voting"}
+                      >{statusLabel(proposal.status)}</span
+                    >
+                    <time datetime={proposal.created_at}
+                      >{new Date(proposal.created_at).toLocaleDateString(
+                        "de-DE",
+                      )}</time
+                    >
+                  </div>
+                  <h3>Weberstatus für {proposal.applicant_title}</h3>
+                  {#if proposal.summary}<p>{proposal.summary}</p>{/if}
+                  <div class="facts">
+                    <span
+                      >{proposal.veto_count} Veto{proposal.veto_count === 1
+                        ? ""
+                        : "s"}</span
+                    >
+                    <span
+                      >{proposal.yes_votes} Ja · {proposal.no_votes} Nein</span
+                    >
+                    {#if proposal.remaining_seconds !== undefined}<span
+                        >Noch {formatRemaining(
+                          proposal.remaining_seconds,
+                        )}</span
+                      >{/if}
+                  </div>
+                </a>
+              {/each}
+            </div>
+          {/if}
         {/if}
       </section>
     </div>

--- a/apps/web/tests/context-panel-sheet.spec.ts
+++ b/apps/web/tests/context-panel-sheet.spec.ts
@@ -51,6 +51,30 @@ test.describe("ContextPanel mobile compact and full states", () => {
     await expect(panel.locator(".tabs")).toBeHidden();
   });
 
+  test("compact mode always shows the summary instead of the previously selected tab", async ({
+    page,
+  }) => {
+    await page.locator(".map-marker").first().click();
+    const panel = page.getByTestId("context-panel");
+    const handle = page.getByTestId("sheet-handle");
+
+    await handle.click();
+    await panel.getByRole("tab", { name: "Gespräch" }).click();
+    await expect(panel.locator("#panel-gespraech")).toBeVisible();
+
+    await panel.locator(".mobile-panel-title").click();
+    await expect(panel).toHaveAttribute("data-sheet-stage", "compact");
+    await expect(panel.getByTestId("node-compact-summary")).toBeVisible();
+    await expect(panel.locator("#panel-gespraech")).toHaveCount(0);
+
+    await handle.click();
+    await expect(panel.locator("#panel-gespraech")).toBeVisible();
+    await expect(panel.getByRole("tab", { name: "Gespräch" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
   test("Komposition starts full and can collapse through the same handle", async ({
     page,
   }) => {
@@ -104,23 +128,39 @@ test.describe("ContextPanel mobile compact and full states", () => {
     expect(transitionDuration).toBe("0s");
   });
 
-  test("orientation change keeps the open panel inside the viewport", async ({
-    page,
+  test("a coarse-pointer phone keeps the mobile sheet in landscape", async ({
+    browser,
   }) => {
-    await page.emulateMedia({ reducedMotion: "reduce" });
-    await page.locator(".map-marker").first().click();
-    const panel = page.getByTestId("context-panel");
-    await page.getByTestId("sheet-handle").click();
+    const context = await browser.newContext({
+      viewport: { width: 844, height: 390 },
+      hasTouch: true,
+      isMobile: true,
+    });
+    const landscapePage = await context.newPage();
+    await mockApiResponses(landscapePage, {
+      auth: { authenticated: true, account_id: "e2e-weber", role: "weber" },
+    });
+    await landscapePage.goto("/map");
+    await landscapePage.waitForSelector(".map-marker", { timeout: 10000 });
+    expect(
+      await landscapePage.evaluate(
+        () => window.matchMedia("(pointer: coarse)").matches,
+      ),
+    ).toBe(true);
+
+    await landscapePage.locator(".map-marker").first().click();
+    const panel = landscapePage.getByTestId("context-panel");
+    const handle = landscapePage.getByTestId("sheet-handle");
+    await expect(handle).toBeVisible();
+    await expect(panel).toHaveAttribute("data-sheet-stage", "compact");
+    await handle.click();
     await expect(panel).toHaveAttribute("data-sheet-stage", "full");
 
-    await page.setViewportSize({ width: 844, height: 390 });
     const box = await panel.boundingBox();
     expect(box).not.toBeNull();
-    expect(box!.x).toBeGreaterThanOrEqual(0);
-    expect(box!.y).toBeGreaterThanOrEqual(0);
-    expect(box!.x + box!.width).toBeLessThanOrEqual(844);
+    expect(Math.round(box!.width)).toBe(844);
     expect(box!.y + box!.height).toBeLessThanOrEqual(390);
-    await expect(page.getByTestId("sheet-handle")).toBeHidden();
+    await context.close();
   });
 
   test("switching the selected marker resets the sheet to compact", async ({

--- a/apps/web/tests/page-design-system.spec.ts
+++ b/apps/web/tests/page-design-system.spec.ts
@@ -20,6 +20,7 @@ test("login uses the shared page, form and state contracts without changing the 
   await expect(loginPage).toHaveClass(/wg-page/);
   await expect(loginPage.locator(".wg-card")).toHaveCount(1);
   await expect(loginPage.locator("[style]")).toHaveCount(0);
+  await expect(loginPage).toHaveCSS("background-image", /radial-gradient/);
 
   await page.getByLabel("E-Mail").fill("person@example.org");
   await page.getByRole("button", { name: "Login-Link senden" }).click();
@@ -63,4 +64,31 @@ test("application overview uses the same surfaces, controls and empty-state cont
     /wg-state/,
   );
   await expect(page.locator("#antrag-stellen")).toBeFocused();
+  const filters = page.getByRole("navigation", {
+    name: "Governance-Ereignisse filtern",
+  });
+  await expect(filters.getByRole("link")).toHaveCount(5);
+  await expect(filters.getByRole("link", { name: "Alle" })).toHaveAttribute(
+    "aria-current",
+    "page",
+  );
+});
+
+test("a proposal API failure is not presented as an empty list", async ({
+  page,
+}) => {
+  await mockApiResponses(page, { auth: { authenticated: false } });
+  await page.route("**/api/proposals**", async (route: Route) => {
+    await route.fulfill({ status: 503, body: "temporarily unavailable" });
+  });
+
+  await page.goto("/antraege");
+
+  await expect(page.getByRole("alert")).toContainText(
+    "Das Antragssystem ist vorübergehend nicht verfügbar.",
+  );
+  await expect(page.getByText("Noch liegen keine Anträge vor.")).toHaveCount(0);
+  await expect(
+    page.getByText("Für diese Ansicht liegen keine Anträge vor."),
+  ).toHaveCount(0);
 });


### PR DESCRIPTION
<!-- weltgewebe-risk: R2 -->

## Ziel

Dieser Folge-PR härtet den bereits über PR #1577 gemergten mobilen Panel- und Seitendesign-Umbau. Er enthält ausschließlich die beim Abschlussreview verbleibenden Korrekturen.

## Änderungen

- `NodePanel` erhält einen expliziten Kompaktmodus statt nur versteckter Tabs
- nach einem zuvor gewählten Gesprächs- oder Verlaufstab zeigt die Kompaktkarte zuverlässig Titel, Kurzbeschreibung und Knotenart
- beim erneuten Öffnen bleibt der zuvor gewählte volle Tab erhalten
- Touchgeräte bleiben auch im Querformat bei 844 × 390 Pixeln im mobilen Bottom-Sheet-Modus
- mobile Zustandslogik und CSS verwenden dieselbe `matchMedia`-Definition
- aktive Governance-Filter erhalten `aria-current="page"`
- ein fehlgeschlagener Antrag-API-Aufruf wird nicht mehr zusätzlich als leere Liste dargestellt
- `/antraege` erhält einen eigenen, gemessenen Performancevertrag

## Prüfung

- `pnpm check:ci`: 0 Fehler, 0 Warnungen
- `pnpm run ci`: grün
- `pnpm run build:e2e`: zweimal grün
- fokussierte Panel- und Designsystemtests: grün
- angrenzende Karten-, Detail- und Governance-Tests: grün

Gemessene Routengrößen:

- `/login`: 44.654 B JS / 2.967 B CSS gzip
- `/antraege`: 54.017 B JS / 4.816 B CSS gzip
- `/settings`: 56.143 B JS / 3.519 B CSS gzip
- `/map`: 80.238 B JS / 16.990 B CSS gzip

## Reviewbindung

- Basis: `2a7ccb8edeb55f527133e48c20803c40df3c3a0e`
- Head: `2a0e40d90661bd4888b484a6134357faecc246c8`
- kanonischer lokaler Diff-SHA-256: `cfd6fe95cbf4ac1fb8b51f7135ccad18a9dbd7081e5d641d9846ce469e11557d`
- GitHub-Textdiff-SHA-256: `8f539402a97542a6eb3f25efcdf9d975b3356f22802aebaf5a87594d1c1e7ade`
- GitHub-Patch-SHA-256: `e5408cf842806fcca89ff981ffaf4952a912427bae60f48e6a652618e63703c7`

## Abgrenzung

PR #1578 ist durch den gemergten PR #1577 überholt. Dieser Folge-PR übernimmt nur dessen noch relevante Reviewhärtungen und vermeidet einen doppelten Grundumbau.
