### PR TITLE
fix(web): kompaktes Kontextpanel und Seitensystem härten

### DIFF
--- a/apps/web/route-performance-budget.json
+++ b/apps/web/route-performance-budget.json
@@ -11,6 +11,14 @@
       "min_initial_js_assets": 1,
       "min_initial_css_assets": 1
     },
+    "/antraege": {
+      "max_initial_js_gzip_bytes": 55000,
+      "max_initial_css_gzip_bytes": 5050,
+      "forbid_css_markers": [".maplibregl-"],
+      "require_css_markers": [".wg-page"],
+      "min_initial_js_assets": 1,
+      "min_initial_css_assets": 1
+    },
     "/settings": {
       "max_initial_js_gzip_bytes": 57000,
       "max_initial_css_gzip_bytes": 3600,

--- a/apps/web/src/lib/components/ContextPanel.svelte
+++ b/apps/web/src/lib/components/ContextPanel.svelte
@@ -40,6 +40,7 @@
     domainChanged: DomainChanged;
   }>();
   const DRAG_THRESHOLD_PX = 6;
+  const MOBILE_BREAKPOINT_PX = 768;
 
   let kompositionPanel: KompositionPanelHandle | null = null;
   let sheetStage: SheetStage = "compact";
@@ -50,7 +51,9 @@
   let dragHeight: number | null = null;
   let dragging = false;
   let dragMoved = false;
-  let suppressNextHandleClick = false;
+  let activePointerId: number | null = null;
+  let viewportWidth = MOBILE_BREAKPOINT_PX + 1;
+  let compactContent = false;
 
   function derivePanelTitle(
     state: SystemState,
@@ -74,6 +77,9 @@
     return "Details";
   }
 
+  $: compactContent =
+    viewportWidth <= MOBILE_BREAKPOINT_PX && sheetStage === "compact";
+
   $: {
     panelTitle = derivePanelTitle($systemState, $kompositionDraft, $selection);
     const nextPanelIdentity =
@@ -89,6 +95,7 @@
       dragHeight = null;
       dragging = false;
       dragMoved = false;
+      activePointerId = null;
     }
   }
 
@@ -97,10 +104,11 @@
     dragHeight = null;
     dragging = false;
     dragMoved = false;
+    activePointerId = null;
   }
 
   function toggleSheetStage(): void {
-    if (window.innerWidth > 768) return;
+    if (viewportWidth > MOBILE_BREAKPOINT_PX) return;
     setSheetStage(sheetStage === "compact" ? "full" : "compact");
   }
 
@@ -113,21 +121,28 @@
   }
 
   function handleSheetPointerDown(event: PointerEvent): void {
-    if (window.innerWidth > 768) return;
+    if (
+      viewportWidth > MOBILE_BREAKPOINT_PX ||
+      !event.isPrimary ||
+      event.button !== 0 ||
+      dragging
+    )
+      return;
     const handle = event.currentTarget as HTMLElement;
     const aside = handle.closest<HTMLElement>('[data-testid="context-panel"]');
     if (!aside) return;
+    event.preventDefault();
     handle.setPointerCapture(event.pointerId);
+    activePointerId = event.pointerId;
     dragStartY = event.clientY;
     dragStartHeight = aside.getBoundingClientRect().height;
     dragHeight = dragStartHeight;
     dragging = true;
     dragMoved = false;
-    suppressNextHandleClick = false;
   }
 
   function handleSheetPointerMove(event: PointerEvent): void {
-    if (!dragging) return;
+    if (!dragging || event.pointerId !== activePointerId) return;
     const delta = dragStartY - event.clientY;
     if (Math.abs(delta) >= DRAG_THRESHOLD_PX) dragMoved = true;
     if (!dragMoved) return;
@@ -142,25 +157,23 @@
   }
 
   function finishSheetPointer(event: PointerEvent, cancelled: boolean): void {
-    if (!dragging) return;
+    if (!dragging || event.pointerId !== activePointerId) return;
+    const moved = dragMoved;
+    const finalHeight = dragHeight ?? dragStartHeight;
     const handle = event.currentTarget as HTMLElement;
+
+    dragHeight = null;
+    dragging = false;
+    dragMoved = false;
+    activePointerId = null;
     if (handle.hasPointerCapture(event.pointerId)) {
       handle.releasePointerCapture(event.pointerId);
     }
 
-    if (cancelled || !dragMoved) {
-      dragHeight = null;
-      dragging = false;
-      dragMoved = false;
-      return;
-    }
+    if (cancelled) return;
 
-    const finalHeight = dragHeight ?? dragStartHeight;
-    setSheetStage(nearestSheetStage(finalHeight));
-    suppressNextHandleClick = true;
-    window.setTimeout(() => {
-      suppressNextHandleClick = false;
-    }, 0);
+    if (moved) setSheetStage(nearestSheetStage(finalHeight));
+    else toggleSheetStage();
   }
 
   function handleSheetPointerUp(event: PointerEvent): void {
@@ -171,17 +184,20 @@
     finishSheetPointer(event, true);
   }
 
+  function handleSheetLostPointerCapture(event: PointerEvent): void {
+    if (!dragging || event.pointerId !== activePointerId) return;
+    dragHeight = null;
+    dragging = false;
+    dragMoved = false;
+    activePointerId = null;
+  }
+
   function handleSheetHandleClick(event: MouseEvent): void {
-    if (suppressNextHandleClick) {
-      event.preventDefault();
-      suppressNextHandleClick = false;
-      return;
-    }
-    toggleSheetStage();
+    if (event.detail === 0) toggleSheetStage();
   }
 
   function handleSheetKeydown(event: KeyboardEvent): void {
-    if (window.innerWidth > 768) return;
+    if (viewportWidth > MOBILE_BREAKPOINT_PX) return;
     if (event.key === "ArrowUp" || event.key === "End") {
       event.preventDefault();
       setSheetStage("full");
@@ -219,7 +235,7 @@
   }
 </script>
 
-<svelte:window on:keydown={handleKeydown} />
+<svelte:window bind:innerWidth={viewportWidth} on:keydown={handleKeydown} />
 
 {#if $contextPanelOpen}
   <aside
@@ -246,6 +262,7 @@
       on:pointermove={handleSheetPointerMove}
       on:pointerup={handleSheetPointerUp}
       on:pointercancel={handleSheetPointerCancel}
+      on:lostpointercapture={handleSheetLostPointerCapture}
       on:click={handleSheetHandleClick}
       on:keydown={handleSheetKeydown}
     >
@@ -281,11 +298,15 @@
       {:else if $selection}
         {#if $selection.type === "node"}
           <NodePanel
+            compact={compactContent}
             on:selectRelated={handleRelated}
             on:domainChanged={handleDomainChanged}
           />
         {:else if $selection.type === "account" || $selection.type === "garnrolle"}
-          <AccountPanel on:selectRelated={handleRelated} />
+          <AccountPanel
+            compact={compactContent}
+            on:selectRelated={handleRelated}
+          />
         {:else if $selection.type === "edge"}
           <EdgePanel />
         {/if}
@@ -455,10 +476,6 @@
 
     .stage-compact .panel-content {
       padding-top: 0.65rem;
-    }
-
-    .stage-compact :global(.tabs) {
-      display: none;
     }
   }
 

--- a/apps/web/src/lib/components/panels/AccountPanel.svelte
+++ b/apps/web/src/lib/components/panels/AccountPanel.svelte
@@ -7,6 +7,8 @@
   } from "$lib/panels/panelDetails";
   import { formatDate } from "$lib/utils/formatDate";
 
+  export let compact = false;
+
   const dispatch = createEventDispatcher<{
     selectRelated: { type: "node"; id: string };
   }>();
@@ -95,48 +97,51 @@
   </h3>
   {#if summary}<p class="summary">{summary}</p>{/if}
 
-  <div class="tabs" role="tablist" aria-label="Garnrollen-Tabs">
-    <button
-      class:active={activeTab === "profil"}
-      on:click={() => setTab("profil")}
-      on:keydown={handleKeydown}
-      role="tab"
-      aria-selected={activeTab === "profil"}
-      aria-controls="panel-profil"
-      id="tab-profil"
-      tabindex={activeTab === "profil" ? 0 : -1}>Profil</button
-    >
-    <button
-      class:active={activeTab === "aktivitaet"}
-      on:click={() => setTab("aktivitaet")}
-      on:keydown={handleKeydown}
-      role="tab"
-      aria-selected={activeTab === "aktivitaet"}
-      aria-controls="panel-aktivitaet"
-      id="tab-aktivitaet"
-      tabindex={activeTab === "aktivitaet" ? 0 : -1}>Aktivität</button
-    >
-    <button
-      class:active={activeTab === "knoten"}
-      on:click={() => setTab("knoten")}
-      on:keydown={handleKeydown}
-      role="tab"
-      aria-selected={activeTab === "knoten"}
-      aria-controls="panel-knoten"
-      id="tab-knoten"
-      tabindex={activeTab === "knoten" ? 0 : -1}>Knoten</button
-    >
-  </div>
+  {#if !compact}
+    <div class="tabs" role="tablist" aria-label="Garnrollen-Tabs">
+      <button
+        class:active={activeTab === "profil"}
+        on:click={() => setTab("profil")}
+        on:keydown={handleKeydown}
+        role="tab"
+        aria-selected={activeTab === "profil"}
+        aria-controls="panel-profil"
+        id="tab-profil"
+        tabindex={activeTab === "profil" ? 0 : -1}>Profil</button
+      >
+      <button
+        class:active={activeTab === "aktivitaet"}
+        on:click={() => setTab("aktivitaet")}
+        on:keydown={handleKeydown}
+        role="tab"
+        aria-selected={activeTab === "aktivitaet"}
+        aria-controls="panel-aktivitaet"
+        id="tab-aktivitaet"
+        tabindex={activeTab === "aktivitaet" ? 0 : -1}>Aktivität</button
+      >
+      <button
+        class:active={activeTab === "knoten"}
+        on:click={() => setTab("knoten")}
+        on:keydown={handleKeydown}
+        role="tab"
+        aria-selected={activeTab === "knoten"}
+        aria-controls="panel-knoten"
+        id="tab-knoten"
+        tabindex={activeTab === "knoten" ? 0 : -1}>Knoten</button
+      >
+    </div>
+  {/if}
 
   <div class="tab-content">
     {#if isLoadingDetails && !accountDetails}
       <p class="ghost">Lade Details…</p>
-    {:else if activeTab === "profil"}
+    {:else if compact || activeTab === "profil"}
       <div
         class="overview"
         id="panel-profil"
-        role="tabpanel"
-        aria-labelledby="tab-profil"
+        role={compact ? "region" : "tabpanel"}
+        aria-label={compact ? "Garnrollenprofil" : undefined}
+        aria-labelledby={compact ? undefined : "tab-profil"}
       >
         {#if accountDetails?.created_at || $selection?.data?.created_at}<p>
             <strong>Dabei seit:</strong>

--- a/apps/web/src/lib/components/panels/NodePanel.svelte
+++ b/apps/web/src/lib/components/panels/NodePanel.svelte
@@ -16,6 +16,8 @@
   import type { MapEntityViewModel } from "$lib/map/types";
   import NodeConversation from "./NodeConversation.svelte";
 
+  export let compact = false;
+
   type DomainChanged = {
     kind: "node";
     id: string;
@@ -319,9 +321,9 @@
 
 <div class="node-mode">
   <h3>{nodeDetails?.title || $selection?.data?.title || $selection?.id}</h3>
-  {#if summary && !editing}<p class="summary">{summary}</p>{/if}
+  {#if summary && (!editing || compact)}<p class="summary">{summary}</p>{/if}
 
-  {#if editing}
+  {#if editing && !compact}
     <form class="edit-form" on:submit|preventDefault={saveNode}>
       <label>
         Titel
@@ -408,61 +410,65 @@
       </div>
     </form>
   {:else}
-    <div class="tabs node-tabs" role="tablist" aria-label="Knoten-Tabs">
-      <button
-        class:active={activeTab === "uebersicht"}
-        on:click={() => setTab("uebersicht")}
-        on:keydown={handleKeydown}
-        role="tab"
-        aria-selected={activeTab === "uebersicht"}
-        aria-controls="panel-uebersicht"
-        id="tab-uebersicht"
-        bind:this={overviewTab}
-        tabindex={activeTab === "uebersicht" ? 0 : -1}>Übersicht</button
-      >
-      <button
-        class:active={activeTab === "gespraech"}
-        on:click={() => setTab("gespraech")}
-        on:keydown={handleKeydown}
-        role="tab"
-        aria-selected={activeTab === "gespraech"}
-        aria-controls="panel-gespraech"
-        id="tab-gespraech"
-        tabindex={activeTab === "gespraech" ? 0 : -1}>Gespräch</button
-      >
-      <button
-        class:active={activeTab === "verlauf"}
-        on:click={() => setTab("verlauf")}
-        on:keydown={handleKeydown}
-        role="tab"
-        aria-selected={activeTab === "verlauf"}
-        aria-controls="panel-verlauf"
-        id="tab-verlauf"
-        tabindex={activeTab === "verlauf" ? 0 : -1}>Verlauf</button
-      >
-      {#if canMutate}
+    {#if !compact}
+      <div class="tabs node-tabs" role="tablist" aria-label="Knoten-Tabs">
         <button
-          class:active={activeTab === "bearbeiten"}
-          on:click={() => setTab("bearbeiten")}
+          class:active={activeTab === "uebersicht"}
+          on:click={() => setTab("uebersicht")}
           on:keydown={handleKeydown}
           role="tab"
-          aria-selected={activeTab === "bearbeiten"}
-          aria-controls="panel-bearbeiten"
-          id="tab-bearbeiten"
-          bind:this={editTab}
-          tabindex={activeTab === "bearbeiten" ? 0 : -1}>Bearbeiten</button
+          aria-selected={activeTab === "uebersicht"}
+          aria-controls="panel-uebersicht"
+          id="tab-uebersicht"
+          bind:this={overviewTab}
+          tabindex={activeTab === "uebersicht" ? 0 : -1}>Übersicht</button
         >
-      {/if}
-    </div>
+        <button
+          class:active={activeTab === "gespraech"}
+          on:click={() => setTab("gespraech")}
+          on:keydown={handleKeydown}
+          role="tab"
+          aria-selected={activeTab === "gespraech"}
+          aria-controls="panel-gespraech"
+          id="tab-gespraech"
+          tabindex={activeTab === "gespraech" ? 0 : -1}>Gespräch</button
+        >
+        <button
+          class:active={activeTab === "verlauf"}
+          on:click={() => setTab("verlauf")}
+          on:keydown={handleKeydown}
+          role="tab"
+          aria-selected={activeTab === "verlauf"}
+          aria-controls="panel-verlauf"
+          id="tab-verlauf"
+          tabindex={activeTab === "verlauf" ? 0 : -1}>Verlauf</button
+        >
+        {#if canMutate}
+          <button
+            class:active={activeTab === "bearbeiten"}
+            on:click={() => setTab("bearbeiten")}
+            on:keydown={handleKeydown}
+            role="tab"
+            aria-selected={activeTab === "bearbeiten"}
+            aria-controls="panel-bearbeiten"
+            id="tab-bearbeiten"
+            bind:this={editTab}
+            tabindex={activeTab === "bearbeiten" ? 0 : -1}>Bearbeiten</button
+          >
+        {/if}
+      </div>
+    {/if}
 
     <div class="tab-content">
-      {#if activeTab === "uebersicht"}
+      {#if compact || activeTab === "uebersicht"}
+        <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
         <div
           class="overview"
           id="panel-uebersicht"
-          role="tabpanel"
-          aria-labelledby="tab-uebersicht"
-          tabindex="0"
+          role={compact ? "region" : "tabpanel"}
+          aria-label={compact ? "Knotenübersicht" : undefined}
+          aria-labelledby={compact ? undefined : "tab-uebersicht"}
+          tabindex={compact ? undefined : 0}
         >
           {#if isLoadingDetails}<p class="ghost">Lade Details…</p>
           {:else}

--- a/apps/web/src/lib/styles/page-system.css
+++ b/apps/web/src/lib/styles/page-system.css
@@ -4,14 +4,20 @@
   --wg-border-strong: var(--panel-border-strong);
   --wg-action: var(--accent);
   --wg-action-soft: var(--accent-soft);
+  --wg-on-action: var(--accent-contrast);
   --wg-muted: var(--muted);
-  min-height: 100%;
+  min-height: 100vh;
+  min-height: 100dvh;
   box-sizing: border-box;
   padding: clamp(1rem, 4vw, 2rem) 0 clamp(3rem, 8vw, 5rem);
   background:
     radial-gradient(circle at 12% 0, var(--accent-soft), transparent 34rem),
     var(--bg);
   color: var(--text);
+}
+
+.wg-page--paper {
+  --wg-surface: color-mix(in srgb, var(--panel-solid) 96%, var(--accent));
 }
 
 .wg-page *,
@@ -43,7 +49,8 @@
   font-weight: 650;
 }
 
-.wg-back-link:hover {
+.wg-back-link:hover,
+.wg-back-link:focus-visible {
   color: var(--text);
 }
 
@@ -113,6 +120,13 @@
   font: inherit;
 }
 
+.wg-back-link:focus-visible,
+.wg-button:focus-visible,
+.wg-control:focus-visible {
+  outline: 3px solid var(--wg-action);
+  outline-offset: 2px;
+}
+
 textarea.wg-control {
   min-height: 8rem;
   resize: vertical;
@@ -156,7 +170,7 @@ textarea.wg-control {
 
 .wg-button--primary {
   background: var(--wg-action);
-  color: var(--bg);
+  color: var(--wg-on-action);
 }
 
 .wg-button--secondary {

--- a/apps/web/src/lib/styles/tokens.css
+++ b/apps/web/src/lib/styles/tokens.css
@@ -8,6 +8,7 @@
   --muted: #9aa4b2;
   --accent: #6aa6ff;
   --accent-soft: rgba(106, 166, 255, 0.18);
+  --accent-contrast: #0f1115;
   --primary: var(--accent);
   --fg: var(--text);
   --ghost: var(--muted);

--- a/apps/web/tests/context-panel-sheet.spec.ts
+++ b/apps/web/tests/context-panel-sheet.spec.ts
@@ -51,6 +51,34 @@ test.describe("ContextPanel mobile compact and full states", () => {
     await expect(panel.locator(".tabs")).toBeHidden();
   });
 
+  test("the compact card shows the overview while preserving the active full-view tab", async ({
+    page,
+  }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.locator(".map-marker:not(.marker-account)").first().click();
+
+    const panel = page.getByTestId("context-panel");
+    const handle = page.getByTestId("sheet-handle");
+    await handle.click();
+
+    const conversationTab = panel.getByRole("tab", { name: "Gespräch" });
+    await conversationTab.click();
+    await expect(conversationTab).toHaveAttribute("aria-selected", "true");
+    await expect(panel.locator("#panel-gespraech")).toBeVisible();
+
+    await panel.locator(".mobile-panel-title").click();
+    await expect(panel).toHaveAttribute("data-sheet-stage", "compact");
+    await expect(panel.locator(".tabs")).toHaveCount(0);
+    await expect(
+      panel.getByRole("region", { name: "Knotenübersicht" }),
+    ).toBeVisible();
+    await expect(panel.locator("#panel-gespraech")).toHaveCount(0);
+
+    await panel.locator(".mobile-panel-title").click();
+    await expect(conversationTab).toHaveAttribute("aria-selected", "true");
+    await expect(panel.locator("#panel-gespraech")).toBeVisible();
+  });
+
   test("Komposition starts full and can collapse through the same handle", async ({
     page,
   }) => {
@@ -91,8 +119,26 @@ test.describe("ContextPanel mobile compact and full states", () => {
     await page.mouse.move(box!.x + box!.width / 2, box!.y - 360, { steps: 8 });
     await page.mouse.up();
     await expect(panel).toHaveAttribute("data-sheet-stage", "full");
-    await page.waitForTimeout(20);
+    await handle.dispatchEvent("click", { detail: 1 });
     await expect(panel).toHaveAttribute("data-sheet-stage", "full");
+  });
+
+  test("non-primary pointers cannot start a sheet drag", async ({ page }) => {
+    await page.locator(".map-marker").first().click();
+    const panel = page.getByTestId("context-panel");
+    const handle = page.getByTestId("sheet-handle");
+
+    await handle.dispatchEvent("pointerdown", {
+      pointerId: 23,
+      pointerType: "touch",
+      isPrimary: false,
+      button: 0,
+      clientY: 100,
+    });
+
+    await expect(panel).toHaveAttribute("data-sheet-stage", "compact");
+    await expect(panel).not.toHaveClass(/dragging/);
+    await expect(panel).not.toHaveAttribute("style");
   });
 
   test("reduced motion removes the height transition", async ({ page }) => {
@@ -113,14 +159,14 @@ test.describe("ContextPanel mobile compact and full states", () => {
     await page.getByTestId("sheet-handle").click();
     await expect(panel).toHaveAttribute("data-sheet-stage", "full");
 
-    await page.setViewportSize({ width: 844, height: 390 });
+    await page.setViewportSize({ width: 740, height: 390 });
     const box = await panel.boundingBox();
     expect(box).not.toBeNull();
     expect(box!.x).toBeGreaterThanOrEqual(0);
     expect(box!.y).toBeGreaterThanOrEqual(0);
-    expect(box!.x + box!.width).toBeLessThanOrEqual(844);
+    expect(box!.x + box!.width).toBeLessThanOrEqual(740);
     expect(box!.y + box!.height).toBeLessThanOrEqual(390);
-    await expect(page.getByTestId("sheet-handle")).toBeHidden();
+    await expect(page.getByTestId("sheet-handle")).toBeVisible();
   });
 
   test("switching the selected marker resets the sheet to compact", async ({
@@ -162,5 +208,33 @@ test.describe("ContextPanel desktop layout stays unchanged", () => {
 
     const box = await panel.boundingBox();
     expect(Math.round(box!.width)).toBe(400);
+  });
+});
+
+test.describe("ContextPanel touch input", () => {
+  test.use({ hasTouch: true, viewport: { width: 390, height: 844 } });
+
+  test.beforeEach(async ({ page }) => {
+    await mockApiResponses(page, {
+      auth: { authenticated: true, account_id: "e2e-weber", role: "weber" },
+    });
+    await page.goto("/map");
+    await page.waitForSelector(".map-marker", { timeout: 10000 });
+  });
+
+  test("one touch tap toggles the handle exactly once", async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.locator(".map-marker").first().click();
+    const panel = page.getByTestId("context-panel");
+    const handle = page.getByTestId("sheet-handle");
+    const box = await handle.boundingBox();
+    expect(box).not.toBeNull();
+
+    await page.touchscreen.tap(
+      box!.x + box!.width / 2,
+      box!.y + box!.height / 2,
+    );
+
+    await expect(panel).toHaveAttribute("data-sheet-stage", "full");
   });
 });

--- a/apps/web/tests/page-design-system.spec.ts
+++ b/apps/web/tests/page-design-system.spec.ts
@@ -21,6 +21,19 @@ test("login uses the shared page, form and state contracts without changing the 
   await expect(loginPage.locator(".wg-card")).toHaveCount(1);
   await expect(loginPage.locator("[style]")).toHaveCount(0);
 
+  const loginBox = await loginPage.boundingBox();
+  expect(loginBox?.height).toBeGreaterThanOrEqual(
+    await page.evaluate(() => window.innerHeight),
+  );
+
+  const emailInput = page.getByLabel("E-Mail");
+  await emailInput.focus();
+  await expect
+    .poll(() =>
+      emailInput.evaluate((element) => getComputedStyle(element).outlineWidth),
+    )
+    .toBe("3px");
+
   await page.getByLabel("E-Mail").fill("person@example.org");
   await page.getByRole("button", { name: "Login-Link senden" }).click();
 
@@ -50,6 +63,13 @@ test("application overview uses the same surfaces, controls and empty-state cont
 
   const applicationsPage = page.getByTestId("applications-page");
   await expect(applicationsPage).toHaveClass(/wg-page--paper/);
+  await expect
+    .poll(() =>
+      applicationsPage.evaluate((element) =>
+        getComputedStyle(element).getPropertyValue("--wg-surface").trim(),
+      ),
+    )
+    .toContain("color-mix");
   await expect(
     page.getByRole("heading", { name: "Anträge", exact: true }),
   ).toBeVisible();


### PR DESCRIPTION
<!-- weltgewebe-risk: R2 -->

## Ausgangslage

PR #1577 hat die vereinfachten mobilen Kontextpanels und das gemeinsame Seitensystem bereits auf `main` gebracht. Der ältere parallele PR #1578 ist dadurch konfliktbehaftet und fachlich überholt. Dieser PR härtet den tatsächlich gemergten Stand auf dem exakten Basiscommit `2a7ccb8edeb55f527133e48c20803c40df3c3a0e`.

## Änderungen

- Kompaktansicht rendert eine definierte Übersicht statt nur die Tabnavigation zu verstecken.
- Aktiver Gesprächs-, Profil- oder Bearbeitungszustand bleibt beim Zusammenklappen erhalten und erscheint beim Wiederöffnen erneut.
- Pointer-Vertrag prüft Primärpointer und Button, bindet die Pointer-ID, räumt verlorene Capture auf und vermeidet den zeitabhängigen 0-ms-Doppelklickschutz.
- Echter Touch-Tap, Nicht-Primärpointer und mobiles Querformat sind browsergetestet.
- Gemeinsames Seitensystem erhält Viewport-Höhe, Fokusindikatoren, eine wirksame `wg-page--paper`-Variante und einen expliziten Kontrasttoken für Primäraktionen.
- `/antraege` erhält ein eigenes gemessenes Performance-Budget.

## Prüfung

- `pnpm check:ci` — 0 Fehler, 0 Warnungen
- `pnpm lint` — grün
- `pnpm test:unit` — 26 Dateien, 212 Tests grün
- relevante Playwright-Suite — 35/35 grün, einschließlich Touch, Drag, Tastatur und Querformat
- `pnpm build` — grün
- Route-Budgets: `/login` 44.693 B JS / 3.058 B CSS; `/antraege` 53.999 B JS / 4.907 B CSS; `/settings` 56.188 B JS / 3.528 B CSS; `/map` 80.004 B JS / 16.972 B CSS, jeweils gzip
- `git diff --check` — grün

## Bewusst getrennte Folgearbeit

- Forced Colors und High-Contrast verbleiben im bestehenden Bureau-Task `WELTGEWEBE-OS-V1-T035`.
- Der 803,48-kB-Client-Chunk und die knappen Routenreserven sind als reviewter Bureau-Vorschlag `WELTGEWEBE-OS-V1-T046` vorbereitet; seine Veröffentlichung ist aktuell durch einen fremden Bureau-Publikationslease blockiert.

Supersedes #1578. Kein Merge durch diesen PR-Erstellungsauftrag.