### PR TITLE
fix(web): mobiles Panel SSR-stabil und pointer-sicher machen

### DIFF
--- a/apps/web/src/lib/components/ContextPanel.svelte
+++ b/apps/web/src/lib/components/ContextPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { createEventDispatcher, onMount } from "svelte";
+  import { createEventDispatcher } from "svelte";
   import {
     selection,
     systemState,
@@ -40,8 +40,6 @@
     domainChanged: DomainChanged;
   }>();
   const DRAG_THRESHOLD_PX = 6;
-  const MOBILE_SHEET_MEDIA =
-    "(max-width: 768px), (max-height: 500px) and (pointer: coarse)";
 
   let kompositionPanel: KompositionPanelHandle | null = null;
   let sheetStage: SheetStage = "compact";
@@ -53,17 +51,6 @@
   let dragging = false;
   let dragMoved = false;
   let suppressNextHandleClick = false;
-  let mobileSheetMode = false;
-
-  onMount(() => {
-    const media = window.matchMedia(MOBILE_SHEET_MEDIA);
-    const updateMobileSheetMode = () => {
-      mobileSheetMode = media.matches;
-    };
-    updateMobileSheetMode();
-    media.addEventListener("change", updateMobileSheetMode);
-    return () => media.removeEventListener("change", updateMobileSheetMode);
-  });
 
   function derivePanelTitle(
     state: SystemState,
@@ -113,7 +100,6 @@
   }
 
   function toggleSheetStage(): void {
-    if (!mobileSheetMode) return;
     setSheetStage(sheetStage === "compact" ? "full" : "compact");
   }
 
@@ -126,8 +112,8 @@
   }
 
   function handleSheetPointerDown(event: PointerEvent): void {
-    if (!mobileSheetMode) return;
     const handle = event.currentTarget as HTMLElement;
+    if (event.button !== 0 || handle.getClientRects().length === 0) return;
     const aside = handle.closest<HTMLElement>('[data-testid="context-panel"]');
     if (!aside) return;
     handle.setPointerCapture(event.pointerId);
@@ -194,7 +180,8 @@
   }
 
   function handleSheetKeydown(event: KeyboardEvent): void {
-    if (!mobileSheetMode) return;
+    const handle = event.currentTarget as HTMLElement;
+    if (handle.getClientRects().length === 0) return;
     if (event.key === "ArrowUp" || event.key === "End") {
       event.preventDefault();
       setSheetStage("full");
@@ -294,7 +281,6 @@
       {:else if $selection}
         {#if $selection.type === "node"}
           <NodePanel
-            compact={mobileSheetMode && sheetStage === "compact"}
             on:selectRelated={handleRelated}
             on:domainChanged={handleDomainChanged}
           />
@@ -478,6 +464,11 @@
       padding-top: 0.65rem;
     }
 
+    .stage-compact :global(.compact-node-summary) {
+      display: block;
+    }
+
+    .stage-compact :global(.node-full-content),
     .stage-compact :global(.tabs) {
       display: none;
     }

--- a/apps/web/src/lib/components/ContextPanel.svelte
+++ b/apps/web/src/lib/components/ContextPanel.svelte
@@ -464,7 +464,8 @@
       padding-top: 0.65rem;
     }
 
-    .stage-compact :global(.compact-node-summary) {
+    .stage-compact :global(.compact-node-summary),
+    .stage-compact :global(.node-mode.editing .node-summary) {
       display: block;
     }
 

--- a/apps/web/src/lib/components/panels/NodePanel.svelte
+++ b/apps/web/src/lib/components/panels/NodePanel.svelte
@@ -317,15 +317,12 @@
   }
 </script>
 
-<div class="node-mode">
+<div class="node-mode" class:editing>
   <h3>{nodeDetails?.title || $selection?.data?.title || $selection?.id}</h3>
+  {#if summary}<p class="summary node-summary">{summary}</p>{/if}
   <div class="compact-node-summary" data-testid="node-compact-summary">
-    {#if summary}<p class="summary">{summary}</p>{/if}
     <p><strong>Knotenart:</strong> {kind}</p>
   </div>
-  {#if summary && !editing}<p class="summary node-full-content">
-      {summary}
-    </p>{/if}
 
   {#if editing}
     <form
@@ -612,6 +609,9 @@
     line-height: 1.2;
   }
   .compact-node-summary {
+    display: none;
+  }
+  .node-mode.editing .node-summary {
     display: none;
   }
   .node-tabs {

--- a/apps/web/src/lib/components/panels/NodePanel.svelte
+++ b/apps/web/src/lib/components/panels/NodePanel.svelte
@@ -32,8 +32,6 @@
     domainChanged: DomainChanged;
   }>();
 
-  export let compact = false;
-
   type NodeTab = "uebersicht" | "gespraech" | "verlauf" | "bearbeiten";
   let activeTab: NodeTab = "uebersicht";
   let tabs: NodeTab[] = ["uebersicht", "gespraech", "verlauf"];
@@ -321,14 +319,19 @@
 
 <div class="node-mode">
   <h3>{nodeDetails?.title || $selection?.data?.title || $selection?.id}</h3>
-  {#if summary && (!editing || compact)}<p class="summary">{summary}</p>{/if}
+  <div class="compact-node-summary" data-testid="node-compact-summary">
+    {#if summary}<p class="summary">{summary}</p>{/if}
+    <p><strong>Knotenart:</strong> {kind}</p>
+  </div>
+  {#if summary && !editing}<p class="summary node-full-content">
+      {summary}
+    </p>{/if}
 
-  {#if compact}
-    <div class="compact-node-summary" data-testid="node-compact-summary">
-      <p><strong>Knotenart:</strong> {kind}</p>
-    </div>
-  {:else if editing}
-    <form class="edit-form" on:submit|preventDefault={saveNode}>
+  {#if editing}
+    <form
+      class="edit-form node-full-content"
+      on:submit|preventDefault={saveNode}
+    >
       <label>
         Titel
         <input
@@ -414,7 +417,11 @@
       </div>
     </form>
   {:else}
-    <div class="tabs node-tabs" role="tablist" aria-label="Knoten-Tabs">
+    <div
+      class="tabs node-tabs node-full-content"
+      role="tablist"
+      aria-label="Knoten-Tabs"
+    >
       <button
         class:active={activeTab === "uebersicht"}
         on:click={() => setTab("uebersicht")}
@@ -461,7 +468,7 @@
       {/if}
     </div>
 
-    <div class="tab-content">
+    <div class="tab-content node-full-content">
       {#if activeTab === "uebersicht"}
         <div
           class="overview"
@@ -603,6 +610,9 @@
     margin: 0;
     font-size: 1.5rem;
     line-height: 1.2;
+  }
+  .compact-node-summary {
+    display: none;
   }
   .node-tabs {
     gap: 0;

--- a/apps/web/src/routes/antraege/+page.svelte
+++ b/apps/web/src/routes/antraege/+page.svelte
@@ -247,28 +247,28 @@
               <a
                 class:active={!statusFilter && !eventFilter}
                 aria-current={!statusFilter && !eventFilter
-                  ? "page"
+                  ? "true"
                   : undefined}
                 href="/antraege">Alle</a
               >
               <a
                 class:active={statusFilter === "consent"}
-                aria-current={statusFilter === "consent" ? "page" : undefined}
+                aria-current={statusFilter === "consent" ? "true" : undefined}
                 href="/antraege?status=consent">Offen</a
               >
               <a
                 class:active={eventFilter === "veto"}
-                aria-current={eventFilter === "veto" ? "page" : undefined}
+                aria-current={eventFilter === "veto" ? "true" : undefined}
                 href="/antraege?ereignis=veto">Vetos</a
               >
               <a
                 class:active={eventFilter === "gespraech"}
-                aria-current={eventFilter === "gespraech" ? "page" : undefined}
+                aria-current={eventFilter === "gespraech" ? "true" : undefined}
                 href="/antraege?ereignis=gespraech">Gespräche</a
               >
               <a
                 class:active={statusFilter === "voting"}
-                aria-current={statusFilter === "voting" ? "page" : undefined}
+                aria-current={statusFilter === "voting" ? "true" : undefined}
                 href="/antraege?status=voting">Abstimmungen</a
               >
             </nav>

--- a/apps/web/tests/context-panel-sheet.spec.ts
+++ b/apps/web/tests/context-panel-sheet.spec.ts
@@ -23,6 +23,7 @@ test.describe("ContextPanel mobile compact and full states", () => {
     await expect(panel.locator(".panel-header h2")).toHaveCount(1);
     await expect(panel).toHaveAttribute("data-sheet-stage", "compact");
     await expect(handle).toHaveAttribute("aria-expanded", "false");
+    await expect(panel.getByTestId("node-compact-summary")).toBeVisible();
     await expect(panel.locator(".tabs")).toBeHidden();
     await expect(page.getByLabel("Panelgröße")).toHaveCount(0);
     expect((await handle.boundingBox())?.height).toBeGreaterThanOrEqual(44);
@@ -65,14 +66,39 @@ test.describe("ContextPanel mobile compact and full states", () => {
     await panel.locator(".mobile-panel-title").click();
     await expect(panel).toHaveAttribute("data-sheet-stage", "compact");
     await expect(panel.getByTestId("node-compact-summary")).toBeVisible();
-    await expect(panel.locator("#panel-gespraech")).toHaveCount(0);
+    await expect(panel.locator("#panel-gespraech")).toHaveCount(1);
+    await expect(panel.locator("#panel-gespraech")).toBeHidden();
 
     await handle.click();
+    await expect(panel.getByTestId("node-compact-summary")).toBeHidden();
     await expect(panel.locator("#panel-gespraech")).toBeVisible();
     await expect(panel.getByRole("tab", { name: "Gespräch" })).toHaveAttribute(
       "aria-selected",
       "true",
     );
+  });
+
+  test("collapsing preserves an unsaved edit draft", async ({ page }) => {
+    await page.locator(".map-marker").first().click();
+    const panel = page.getByTestId("context-panel");
+    const handle = page.getByTestId("sheet-handle");
+
+    await handle.click();
+    await panel.getByRole("tab", { name: "Bearbeiten" }).click();
+    await panel
+      .getByRole("button", { name: "Bearbeiten", exact: true })
+      .click();
+    const titleInput = panel.getByLabel("Titel");
+    await titleInput.fill("Ungespeicherter Entwurf");
+
+    await panel.locator(".mobile-panel-title").click();
+    await expect(panel).toHaveAttribute("data-sheet-stage", "compact");
+    await expect(titleInput).toBeHidden();
+    await expect(panel.getByTestId("node-compact-summary")).toBeVisible();
+
+    await handle.click();
+    await expect(titleInput).toBeVisible();
+    await expect(titleInput).toHaveValue("Ungespeicherter Entwurf");
   });
 
   test("Komposition starts full and can collapse through the same handle", async ({
@@ -119,6 +145,27 @@ test.describe("ContextPanel mobile compact and full states", () => {
     await expect(panel).toHaveAttribute("data-sheet-stage", "full");
   });
 
+  test("secondary mouse buttons do not start sheet dragging", async ({
+    page,
+  }) => {
+    await page.locator(".map-marker").first().click();
+    const panel = page.getByTestId("context-panel");
+    const handle = page.getByTestId("sheet-handle");
+
+    for (const event of [
+      { pointerId: 41, button: 1, buttons: 4 },
+      { pointerId: 42, button: 2, buttons: 2 },
+    ]) {
+      await handle.dispatchEvent("pointerdown", {
+        ...event,
+        pointerType: "mouse",
+        clientY: 700,
+      });
+      await expect(panel).not.toHaveClass(/dragging/);
+      await expect(panel).toHaveAttribute("data-sheet-stage", "compact");
+    }
+  });
+
   test("reduced motion removes the height transition", async ({ page }) => {
     await page.emulateMedia({ reducedMotion: "reduce" });
     await page.locator(".map-marker").first().click();
@@ -128,11 +175,11 @@ test.describe("ContextPanel mobile compact and full states", () => {
     expect(transitionDuration).toBe("0s");
   });
 
-  test("a coarse-pointer phone keeps the mobile sheet in landscape", async ({
+  test("rotating a coarse-pointer phone keeps the live panel mobile", async ({
     browser,
   }) => {
     const context = await browser.newContext({
-      viewport: { width: 844, height: 390 },
+      viewport: { width: 390, height: 844 },
       hasTouch: true,
       isMobile: true,
     });
@@ -153,6 +200,12 @@ test.describe("ContextPanel mobile compact and full states", () => {
     const handle = landscapePage.getByTestId("sheet-handle");
     await expect(handle).toBeVisible();
     await expect(panel).toHaveAttribute("data-sheet-stage", "compact");
+    await expect(panel.getByTestId("node-compact-summary")).toBeVisible();
+
+    await landscapePage.setViewportSize({ width: 844, height: 390 });
+    await expect(handle).toBeVisible();
+    await expect(panel).toHaveAttribute("data-sheet-stage", "compact");
+    await expect(panel.getByTestId("node-compact-summary")).toBeVisible();
     await handle.click();
     await expect(panel).toHaveAttribute("data-sheet-stage", "full");
 

--- a/apps/web/tests/page-design-system.spec.ts
+++ b/apps/web/tests/page-design-system.spec.ts
@@ -70,7 +70,7 @@ test("application overview uses the same surfaces, controls and empty-state cont
   await expect(filters.getByRole("link")).toHaveCount(5);
   await expect(filters.getByRole("link", { name: "Alle" })).toHaveAttribute(
     "aria-current",
-    "page",
+    "true",
   );
 });
 


### PR DESCRIPTION
## Zweck

Dieser Folge-PR härtet die bereits produktive mobile Paneländerung aus #1579 anhand eines nachträglichen Reviews. Er verändert keinen Backendvertrag.

<!-- weltgewebe-risk: R2 -->

Risk-Class: R2

## Bestätigt und behoben

- Der Kompakt-/Vollinhalt hängt nicht mehr von einem erst nach `onMount` ermittelten `matchMedia`-State ab. Beide Ansichten werden stabil gerendert; CSS wählt ab dem ersten Paint die sichtbare Ansicht.
- Mittlere und rechte Maustaste können keinen Dragzustand mehr starten.
- Ein dynamischer Wechsel vom Hoch- ins Querformat wird im bereits geöffneten Touch-Kontext geprüft.
- Aktive In-Page-Filter verwenden den generischen `aria-current="true"`-Wert.
- Die Kurzbeschreibung existiert trotz DOM-stabiler Ansichten nur einmal. Damit bleiben Textsuche, Accessibility-Baum und bestehende Mutationstests eindeutig.

## Geprüft, aber nicht übernommen

- Der Compact-Wrapper war nicht unvollständig; die frühere Implementierung entfernte Tabs und Tabpanels bereits korrekt aus dem DOM.
- Der Bearbeitungszustand wird beim Einklappen nicht verworfen. Ein Test belegt, dass ein ungespeicherter Entwurf nach dem erneuten Öffnen erhalten bleibt.
- `kind` besitzt bereits den kanonischen Fallback `Knoten`.

## Technische Umsetzung

- `ContextPanel` enthält keinen renderkritischen Media-Query-JavaScriptzustand mehr.
- `NodePanel` hält die interaktive Vollansicht DOM-stabil; `display: none` entfernt inaktive Formulare, Tabs und Tabpanels aus Layout, Fokusreihenfolge und Accessibility-Baum.
- Die Kurzbeschreibung ist ein einzelner DOM-Knoten und bleibt in der Kompaktansicht auch während eines erhaltenen Bearbeitungsentwurfs sichtbar.
- Die bestehende globale Tab-Unterdrückung im Kompaktzustand bleibt für `AccountPanel` erhalten.

## Lokale Belege auf Head `ba7d47d318bac7ca8bfd844aed558f054bfa544c`

- `pnpm check:ci`: PASS, 0 Fehler, 0 Warnungen
- `pnpm lint`: PASS
- `pnpm run ci`: PASS
- vollständiger `pnpm test:ci`: PASS, 204/204 Browsertests
- fokussierter Wiederholungsbeweis für `node-mutations`, `context-panel-sheet` und `page-design-system`: PASS
- angrenzende Tests `map-interaction` und `governance`: PASS
- lokaler kanonischer Diff: 12.394 Bytes
- lokaler Diff-SHA-256: `c213ba2f4317c30a48a731b9afd90dfbf72293b12022e3ba8901a9e1ff9e4691`
- GitHub-Textdiff: 12.404 Bytes
- GitHub-Textdiff-SHA-256: `ddf03d2fb58c059383d78f58f5baec1c9232a1ee28152b48a289dcfba074504e`
- GitHub-Patch-SHA-256: `e6d5f72e67a6745c9afcfade9580b407adb76730a6c2b7b46046233debfb0408`

## Umfang

5 Dateien, 94 Einfügungen, 39 Löschungen.
