### PR TITLE
fix(web): mobiles Kontextpanel und Seitensystem härten

### DIFF
--- a/apps/web/src/lib/components/ContextPanel.svelte
+++ b/apps/web/src/lib/components/ContextPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { createEventDispatcher, onMount } from "svelte";
+  import { createEventDispatcher } from "svelte";
   import {
     selection,
     systemState,
@@ -40,8 +40,6 @@
     domainChanged: DomainChanged;
   }>();
   const DRAG_THRESHOLD_PX = 6;
-  const MOBILE_SHEET_MEDIA =
-    "(max-width: 768px), (max-height: 500px) and (pointer: coarse)";
 
   let kompositionPanel: KompositionPanelHandle | null = null;
   let sheetStage: SheetStage = "compact";
@@ -53,17 +51,13 @@
   let dragging = false;
   let dragMoved = false;
   let activePointerId: number | null = null;
-  let mobileSheetMode = false;
 
-  onMount(() => {
-    const media = window.matchMedia(MOBILE_SHEET_MEDIA);
-    const updateMobileSheetMode = () => {
-      mobileSheetMode = media.matches;
-    };
-    updateMobileSheetMode();
-    media.addEventListener("change", updateMobileSheetMode);
-    return () => media.removeEventListener("change", updateMobileSheetMode);
-  });
+  function resetSheetPointerState(): void {
+    dragHeight = null;
+    dragging = false;
+    dragMoved = false;
+    activePointerId = null;
+  }
 
   function derivePanelTitle(
     state: SystemState,
@@ -99,23 +93,16 @@
     if (nextPanelIdentity !== previousPanelIdentity) {
       previousPanelIdentity = nextPanelIdentity;
       sheetStage = $systemState === "komposition" ? "full" : "compact";
-      dragHeight = null;
-      dragging = false;
-      dragMoved = false;
-      activePointerId = null;
+      resetSheetPointerState();
     }
   }
 
   function setSheetStage(stage: SheetStage): void {
     sheetStage = stage;
-    dragHeight = null;
-    dragging = false;
-    dragMoved = false;
-    activePointerId = null;
+    resetSheetPointerState();
   }
 
   function toggleSheetStage(): void {
-    if (!mobileSheetMode) return;
     setSheetStage(sheetStage === "compact" ? "full" : "compact");
   }
 
@@ -128,9 +115,9 @@
   }
 
   function handleSheetPointerDown(event: PointerEvent): void {
-    if (!mobileSheetMode || !event.isPrimary || event.button !== 0 || dragging)
-      return;
+    if (!event.isPrimary || event.button !== 0 || dragging) return;
     const handle = event.currentTarget as HTMLElement;
+    if (handle.getClientRects().length === 0) return;
     const aside = handle.closest<HTMLElement>('[data-testid="context-panel"]');
     if (!aside) return;
     event.preventDefault();
@@ -164,10 +151,9 @@
     const finalHeight = dragHeight ?? dragStartHeight;
     const handle = event.currentTarget as HTMLElement;
 
-    dragHeight = null;
-    dragging = false;
-    dragMoved = false;
-    activePointerId = null;
+    // Reset before releasePointerCapture(): browsers may synchronously dispatch
+    // lostpointercapture, which must then observe an already-clean state.
+    resetSheetPointerState();
     if (handle.hasPointerCapture(event.pointerId)) {
       handle.releasePointerCapture(event.pointerId);
     }
@@ -187,20 +173,19 @@
 
   function handleSheetLostPointerCapture(event: PointerEvent): void {
     if (!dragging || event.pointerId !== activePointerId) return;
-    dragHeight = null;
-    dragging = false;
-    dragMoved = false;
-    activePointerId = null;
+    resetSheetPointerState();
   }
 
   function handleSheetHandleClick(event: MouseEvent): void {
-    // detail === 0 marks keyboard or synthetic activation. Pointer taps are
-    // already completed exactly once by finishSheetPointer.
-    if (event.detail === 0) toggleSheetStage();
+    if (event.detail !== 0) return;
+    const handle = event.currentTarget as HTMLElement;
+    if (handle.getClientRects().length === 0) return;
+    toggleSheetStage();
   }
 
   function handleSheetKeydown(event: KeyboardEvent): void {
-    if (!mobileSheetMode) return;
+    const handle = event.currentTarget as HTMLElement;
+    if (handle.getClientRects().length === 0) return;
     if (event.key === "ArrowUp" || event.key === "End") {
       event.preventDefault();
       setSheetStage("full");
@@ -301,15 +286,11 @@
       {:else if $selection}
         {#if $selection.type === "node"}
           <NodePanel
-            compact={mobileSheetMode && sheetStage === "compact"}
             on:selectRelated={handleRelated}
             on:domainChanged={handleDomainChanged}
           />
         {:else if $selection.type === "account" || $selection.type === "garnrolle"}
-          <AccountPanel
-            compact={mobileSheetMode && sheetStage === "compact"}
-            on:selectRelated={handleRelated}
-          />
+          <AccountPanel on:selectRelated={handleRelated} />
         {:else if $selection.type === "edge"}
           <EdgePanel />
         {/if}
@@ -488,9 +469,15 @@
       padding-top: 0.65rem;
     }
 
-    /* CSS owns the first visible compact layout. The matching JS media query
-       then adds interaction and ARIA state without changing the breakpoint. */
-    .stage-compact :global(.tabs) {
+    .stage-compact :global(.compact-node-summary),
+    .stage-compact :global(.compact-account-summary),
+    .stage-compact :global(.node-mode.editing .node-summary) {
+      display: block;
+    }
+
+    .stage-compact :global(.node-full-content),
+    .stage-compact :global(.tabs),
+    .stage-compact :global(.account-full-content) {
       display: none;
     }
   }

--- a/apps/web/src/lib/components/ContextPanel.svelte
+++ b/apps/web/src/lib/components/ContextPanel.svelte
@@ -52,7 +52,7 @@
   let dragHeight: number | null = null;
   let dragging = false;
   let dragMoved = false;
-  let suppressNextHandleClick = false;
+  let activePointerId: number | null = null;
   let mobileSheetMode = false;
 
   onMount(() => {
@@ -102,6 +102,7 @@
       dragHeight = null;
       dragging = false;
       dragMoved = false;
+      activePointerId = null;
     }
   }
 
@@ -110,6 +111,7 @@
     dragHeight = null;
     dragging = false;
     dragMoved = false;
+    activePointerId = null;
   }
 
   function toggleSheetStage(): void {
@@ -126,21 +128,23 @@
   }
 
   function handleSheetPointerDown(event: PointerEvent): void {
-    if (!mobileSheetMode) return;
+    if (!mobileSheetMode || !event.isPrimary || event.button !== 0 || dragging)
+      return;
     const handle = event.currentTarget as HTMLElement;
     const aside = handle.closest<HTMLElement>('[data-testid="context-panel"]');
     if (!aside) return;
+    event.preventDefault();
     handle.setPointerCapture(event.pointerId);
+    activePointerId = event.pointerId;
     dragStartY = event.clientY;
     dragStartHeight = aside.getBoundingClientRect().height;
     dragHeight = dragStartHeight;
     dragging = true;
     dragMoved = false;
-    suppressNextHandleClick = false;
   }
 
   function handleSheetPointerMove(event: PointerEvent): void {
-    if (!dragging) return;
+    if (!dragging || event.pointerId !== activePointerId) return;
     const delta = dragStartY - event.clientY;
     if (Math.abs(delta) >= DRAG_THRESHOLD_PX) dragMoved = true;
     if (!dragMoved) return;
@@ -155,25 +159,22 @@
   }
 
   function finishSheetPointer(event: PointerEvent, cancelled: boolean): void {
-    if (!dragging) return;
+    if (!dragging || event.pointerId !== activePointerId) return;
+    const moved = dragMoved;
+    const finalHeight = dragHeight ?? dragStartHeight;
     const handle = event.currentTarget as HTMLElement;
+
+    dragHeight = null;
+    dragging = false;
+    dragMoved = false;
+    activePointerId = null;
     if (handle.hasPointerCapture(event.pointerId)) {
       handle.releasePointerCapture(event.pointerId);
     }
 
-    if (cancelled || !dragMoved) {
-      dragHeight = null;
-      dragging = false;
-      dragMoved = false;
-      return;
-    }
-
-    const finalHeight = dragHeight ?? dragStartHeight;
-    setSheetStage(nearestSheetStage(finalHeight));
-    suppressNextHandleClick = true;
-    window.setTimeout(() => {
-      suppressNextHandleClick = false;
-    }, 0);
+    if (cancelled) return;
+    if (moved) setSheetStage(nearestSheetStage(finalHeight));
+    else toggleSheetStage();
   }
 
   function handleSheetPointerUp(event: PointerEvent): void {
@@ -184,13 +185,18 @@
     finishSheetPointer(event, true);
   }
 
+  function handleSheetLostPointerCapture(event: PointerEvent): void {
+    if (!dragging || event.pointerId !== activePointerId) return;
+    dragHeight = null;
+    dragging = false;
+    dragMoved = false;
+    activePointerId = null;
+  }
+
   function handleSheetHandleClick(event: MouseEvent): void {
-    if (suppressNextHandleClick) {
-      event.preventDefault();
-      suppressNextHandleClick = false;
-      return;
-    }
-    toggleSheetStage();
+    // detail === 0 marks keyboard or synthetic activation. Pointer taps are
+    // already completed exactly once by finishSheetPointer.
+    if (event.detail === 0) toggleSheetStage();
   }
 
   function handleSheetKeydown(event: KeyboardEvent): void {
@@ -259,6 +265,7 @@
       on:pointermove={handleSheetPointerMove}
       on:pointerup={handleSheetPointerUp}
       on:pointercancel={handleSheetPointerCancel}
+      on:lostpointercapture={handleSheetLostPointerCapture}
       on:click={handleSheetHandleClick}
       on:keydown={handleSheetKeydown}
     >
@@ -299,7 +306,10 @@
             on:domainChanged={handleDomainChanged}
           />
         {:else if $selection.type === "account" || $selection.type === "garnrolle"}
-          <AccountPanel on:selectRelated={handleRelated} />
+          <AccountPanel
+            compact={mobileSheetMode && sheetStage === "compact"}
+            on:selectRelated={handleRelated}
+          />
         {:else if $selection.type === "edge"}
           <EdgePanel />
         {/if}
@@ -478,6 +488,8 @@
       padding-top: 0.65rem;
     }
 
+    /* CSS owns the first visible compact layout. The matching JS media query
+       then adds interaction and ARIA state without changing the breakpoint. */
     .stage-compact :global(.tabs) {
       display: none;
     }

--- a/apps/web/src/lib/components/panels/AccountPanel.svelte
+++ b/apps/web/src/lib/components/panels/AccountPanel.svelte
@@ -7,8 +7,6 @@
   } from "$lib/panels/panelDetails";
   import { formatDate } from "$lib/utils/formatDate";
 
-  export let compact = false;
-
   const dispatch = createEventDispatcher<{
     selectRelated: { type: "node"; id: string };
   }>();
@@ -97,52 +95,82 @@
   </h3>
   {#if summary}<p class="summary">{summary}</p>{/if}
 
-  {#if !compact}
-    <div class="tabs" role="tablist" aria-label="Garnrollen-Tabs">
-      <button
-        class:active={activeTab === "profil"}
-        on:click={() => setTab("profil")}
-        on:keydown={handleKeydown}
-        role="tab"
-        aria-selected={activeTab === "profil"}
-        aria-controls="panel-profil"
-        id="tab-profil"
-        tabindex={activeTab === "profil" ? 0 : -1}>Profil</button
-      >
-      <button
-        class:active={activeTab === "aktivitaet"}
-        on:click={() => setTab("aktivitaet")}
-        on:keydown={handleKeydown}
-        role="tab"
-        aria-selected={activeTab === "aktivitaet"}
-        aria-controls="panel-aktivitaet"
-        id="tab-aktivitaet"
-        tabindex={activeTab === "aktivitaet" ? 0 : -1}>Aktivität</button
-      >
-      <button
-        class:active={activeTab === "knoten"}
-        on:click={() => setTab("knoten")}
-        on:keydown={handleKeydown}
-        role="tab"
-        aria-selected={activeTab === "knoten"}
-        aria-controls="panel-knoten"
-        id="tab-knoten"
-        tabindex={activeTab === "knoten" ? 0 : -1}>Knoten</button
-      >
-    </div>
-  {/if}
+  <div
+    class="compact-account-summary"
+    data-testid="account-compact-summary"
+    role="region"
+    aria-label="Garnrollenprofil"
+  >
+    {#if isLoadingDetails && !accountDetails}
+      <p class="ghost">Lade Profil…</p>
+    {:else}
+      {#if accountDetails?.created_at || $selection?.data?.created_at}<p>
+          <strong>Dabei seit:</strong>
+          {formatDate(
+            accountDetails?.created_at || $selection?.data?.created_at,
+          )}
+        </p>{/if}
+      {#if skills.length > 0}<p>
+          <strong>Fähigkeiten:</strong>
+          {skills.join(", ")}
+        </p>{/if}
+      {#if goods.length > 0}<p>
+          <strong>Güter:</strong>
+          {goods.join(", ")}
+        </p>{/if}
+      {#if interests.length > 0}<p>
+          <strong>Interessen:</strong>
+          {interests.join(", ")}
+        </p>{/if}
+    {/if}
+  </div>
 
-  <div class="tab-content">
+  <div
+    class="tabs account-full-content"
+    role="tablist"
+    aria-label="Garnrollen-Tabs"
+  >
+    <button
+      class:active={activeTab === "profil"}
+      on:click={() => setTab("profil")}
+      on:keydown={handleKeydown}
+      role="tab"
+      aria-selected={activeTab === "profil"}
+      aria-controls="panel-profil"
+      id="tab-profil"
+      tabindex={activeTab === "profil" ? 0 : -1}>Profil</button
+    >
+    <button
+      class:active={activeTab === "aktivitaet"}
+      on:click={() => setTab("aktivitaet")}
+      on:keydown={handleKeydown}
+      role="tab"
+      aria-selected={activeTab === "aktivitaet"}
+      aria-controls="panel-aktivitaet"
+      id="tab-aktivitaet"
+      tabindex={activeTab === "aktivitaet" ? 0 : -1}>Aktivität</button
+    >
+    <button
+      class:active={activeTab === "knoten"}
+      on:click={() => setTab("knoten")}
+      on:keydown={handleKeydown}
+      role="tab"
+      aria-selected={activeTab === "knoten"}
+      aria-controls="panel-knoten"
+      id="tab-knoten"
+      tabindex={activeTab === "knoten" ? 0 : -1}>Knoten</button
+    >
+  </div>
+
+  <div class="tab-content account-full-content">
     {#if isLoadingDetails && !accountDetails}
       <p class="ghost">Lade Details…</p>
-    {:else if compact || activeTab === "profil"}
+    {:else if activeTab === "profil"}
       <div
         class="overview"
         id="panel-profil"
-        role={compact ? "region" : "tabpanel"}
-        aria-label={compact ? "Garnrollenprofil" : undefined}
-        aria-labelledby={compact ? undefined : "tab-profil"}
-        data-testid={compact ? "account-compact-summary" : undefined}
+        role="tabpanel"
+        aria-labelledby="tab-profil"
       >
         {#if accountDetails?.created_at || $selection?.data?.created_at}<p>
             <strong>Dabei seit:</strong>
@@ -214,6 +242,10 @@
     color: var(--muted);
     font-size: 0.9rem;
   }
+  .compact-account-summary {
+    display: none;
+  }
+  .compact-account-summary p,
   .overview p {
     margin: 0 0 0.65rem;
     font-size: 0.95rem;

--- a/apps/web/src/lib/components/panels/AccountPanel.svelte
+++ b/apps/web/src/lib/components/panels/AccountPanel.svelte
@@ -7,6 +7,8 @@
   } from "$lib/panels/panelDetails";
   import { formatDate } from "$lib/utils/formatDate";
 
+  export let compact = false;
+
   const dispatch = createEventDispatcher<{
     selectRelated: { type: "node"; id: string };
   }>();
@@ -95,48 +97,52 @@
   </h3>
   {#if summary}<p class="summary">{summary}</p>{/if}
 
-  <div class="tabs" role="tablist" aria-label="Garnrollen-Tabs">
-    <button
-      class:active={activeTab === "profil"}
-      on:click={() => setTab("profil")}
-      on:keydown={handleKeydown}
-      role="tab"
-      aria-selected={activeTab === "profil"}
-      aria-controls="panel-profil"
-      id="tab-profil"
-      tabindex={activeTab === "profil" ? 0 : -1}>Profil</button
-    >
-    <button
-      class:active={activeTab === "aktivitaet"}
-      on:click={() => setTab("aktivitaet")}
-      on:keydown={handleKeydown}
-      role="tab"
-      aria-selected={activeTab === "aktivitaet"}
-      aria-controls="panel-aktivitaet"
-      id="tab-aktivitaet"
-      tabindex={activeTab === "aktivitaet" ? 0 : -1}>Aktivität</button
-    >
-    <button
-      class:active={activeTab === "knoten"}
-      on:click={() => setTab("knoten")}
-      on:keydown={handleKeydown}
-      role="tab"
-      aria-selected={activeTab === "knoten"}
-      aria-controls="panel-knoten"
-      id="tab-knoten"
-      tabindex={activeTab === "knoten" ? 0 : -1}>Knoten</button
-    >
-  </div>
+  {#if !compact}
+    <div class="tabs" role="tablist" aria-label="Garnrollen-Tabs">
+      <button
+        class:active={activeTab === "profil"}
+        on:click={() => setTab("profil")}
+        on:keydown={handleKeydown}
+        role="tab"
+        aria-selected={activeTab === "profil"}
+        aria-controls="panel-profil"
+        id="tab-profil"
+        tabindex={activeTab === "profil" ? 0 : -1}>Profil</button
+      >
+      <button
+        class:active={activeTab === "aktivitaet"}
+        on:click={() => setTab("aktivitaet")}
+        on:keydown={handleKeydown}
+        role="tab"
+        aria-selected={activeTab === "aktivitaet"}
+        aria-controls="panel-aktivitaet"
+        id="tab-aktivitaet"
+        tabindex={activeTab === "aktivitaet" ? 0 : -1}>Aktivität</button
+      >
+      <button
+        class:active={activeTab === "knoten"}
+        on:click={() => setTab("knoten")}
+        on:keydown={handleKeydown}
+        role="tab"
+        aria-selected={activeTab === "knoten"}
+        aria-controls="panel-knoten"
+        id="tab-knoten"
+        tabindex={activeTab === "knoten" ? 0 : -1}>Knoten</button
+      >
+    </div>
+  {/if}
 
   <div class="tab-content">
     {#if isLoadingDetails && !accountDetails}
       <p class="ghost">Lade Details…</p>
-    {:else if activeTab === "profil"}
+    {:else if compact || activeTab === "profil"}
       <div
         class="overview"
         id="panel-profil"
-        role="tabpanel"
-        aria-labelledby="tab-profil"
+        role={compact ? "region" : "tabpanel"}
+        aria-label={compact ? "Garnrollenprofil" : undefined}
+        aria-labelledby={compact ? undefined : "tab-profil"}
+        data-testid={compact ? "account-compact-summary" : undefined}
       >
         {#if accountDetails?.created_at || $selection?.data?.created_at}<p>
             <strong>Dabei seit:</strong>

--- a/apps/web/src/lib/components/panels/NodePanel.svelte
+++ b/apps/web/src/lib/components/panels/NodePanel.svelte
@@ -32,6 +32,8 @@
     domainChanged: DomainChanged;
   }>();
 
+  // Compact mode temporarily replaces the rendered panel, but keeps the
+  // active tab and bound edit values in component state for lossless reopening.
   export let compact = false;
 
   type NodeTab = "uebersicht" | "gespraech" | "verlauf" | "bearbeiten";
@@ -324,7 +326,12 @@
   {#if summary && (!editing || compact)}<p class="summary">{summary}</p>{/if}
 
   {#if compact}
-    <div class="compact-node-summary" data-testid="node-compact-summary">
+    <div
+      class="compact-node-summary"
+      data-testid="node-compact-summary"
+      role="region"
+      aria-label="Knotenübersicht"
+    >
       <p><strong>Knotenart:</strong> {kind}</p>
     </div>
   {:else if editing}

--- a/apps/web/src/lib/styles/page-system.css
+++ b/apps/web/src/lib/styles/page-system.css
@@ -4,14 +4,20 @@
   --wg-border-strong: var(--panel-border-strong);
   --wg-action: var(--accent);
   --wg-action-soft: var(--accent-soft);
+  --wg-on-action: var(--accent-contrast);
   --wg-muted: var(--muted);
-  min-height: 100%;
+  min-height: 100vh;
+  min-height: 100dvh;
   box-sizing: border-box;
   padding: clamp(1rem, 4vw, 2rem) 0 clamp(3rem, 8vw, 5rem);
   background:
     radial-gradient(circle at 12% 0, var(--accent-soft), transparent 34rem),
     var(--bg);
   color: var(--text);
+}
+
+.wg-page--paper {
+  --wg-surface: color-mix(in srgb, var(--panel-solid) 96%, var(--accent));
 }
 
 .wg-page *,
@@ -43,7 +49,8 @@
   font-weight: 650;
 }
 
-.wg-back-link:hover {
+.wg-back-link:hover,
+.wg-back-link:focus-visible {
   color: var(--text);
 }
 
@@ -113,6 +120,13 @@
   font: inherit;
 }
 
+.wg-back-link:focus-visible,
+.wg-button:focus-visible,
+.wg-control:focus-visible {
+  outline: 3px solid var(--wg-action);
+  outline-offset: 2px;
+}
+
 textarea.wg-control {
   min-height: 8rem;
   resize: vertical;
@@ -156,7 +170,7 @@ textarea.wg-control {
 
 .wg-button--primary {
   background: var(--wg-action);
-  color: var(--bg);
+  color: var(--wg-on-action);
 }
 
 .wg-button--secondary {

--- a/apps/web/src/lib/styles/tokens.css
+++ b/apps/web/src/lib/styles/tokens.css
@@ -8,6 +8,7 @@
   --muted: #9aa4b2;
   --accent: #6aa6ff;
   --accent-soft: rgba(106, 166, 255, 0.18);
+  --accent-contrast: #0f1115;
   --primary: var(--accent);
   --fg: var(--text);
   --ghost: var(--muted);

--- a/apps/web/tests/context-panel-sheet.spec.ts
+++ b/apps/web/tests/context-panel-sheet.spec.ts
@@ -115,8 +115,81 @@ test.describe("ContextPanel mobile compact and full states", () => {
     await page.mouse.move(box!.x + box!.width / 2, box!.y - 360, { steps: 8 });
     await page.mouse.up();
     await expect(panel).toHaveAttribute("data-sheet-stage", "full");
-    await page.waitForTimeout(20);
+    await handle.dispatchEvent("click", { detail: 1 });
     await expect(panel).toHaveAttribute("data-sheet-stage", "full");
+  });
+
+  test("non-primary and secondary pointers cannot start a sheet drag", async ({
+    page,
+  }) => {
+    await page.locator(".map-marker").first().click();
+    const panel = page.getByTestId("context-panel");
+    const handle = page.getByTestId("sheet-handle");
+
+    for (const event of [
+      { pointerId: 23, pointerType: "touch", isPrimary: false, button: 0 },
+      { pointerId: 24, pointerType: "mouse", isPrimary: true, button: 1 },
+      { pointerId: 25, pointerType: "mouse", isPrimary: true, button: 2 },
+    ]) {
+      await handle.dispatchEvent("pointerdown", {
+        ...event,
+        clientY: 100,
+      });
+      await expect(panel).toHaveAttribute("data-sheet-stage", "compact");
+      await expect(panel).not.toHaveClass(/dragging/);
+      await expect(panel).not.toHaveAttribute("style");
+    }
+  });
+
+  test("collapsing preserves an unsaved edit draft for reopening", async ({
+    page,
+  }) => {
+    await page.locator(".map-marker:not(.marker-account)").first().click();
+    const panel = page.getByTestId("context-panel");
+    const handle = page.getByTestId("sheet-handle");
+    await handle.click();
+
+    await panel.getByRole("tab", { name: "Bearbeiten" }).click();
+    await panel.getByRole("button", { name: "Bearbeiten" }).click();
+    const titleInput = panel.getByLabel("Titel");
+    await titleInput.fill("Ungespeicherter Entwurf");
+
+    await panel.locator(".mobile-panel-title").click();
+    await expect(panel).toHaveAttribute("data-sheet-stage", "compact");
+    await expect(titleInput).toHaveCount(0);
+
+    await handle.click();
+    await expect(panel.getByLabel("Titel")).toHaveValue(
+      "Ungespeicherter Entwurf",
+    );
+  });
+
+  test("compact Garnrolle exposes its profile region and restores the selected tab", async ({
+    page,
+  }) => {
+    await page.locator(".map-marker.marker-account").first().click();
+    const panel = page.getByTestId("context-panel");
+    const handle = page.getByTestId("sheet-handle");
+
+    await expect(
+      panel.getByRole("region", { name: "Garnrollenprofil" }),
+    ).toBeVisible();
+    await expect(panel.locator(".tabs")).toHaveCount(0);
+
+    await handle.click();
+    await panel.getByRole("tab", { name: "Aktivität" }).click();
+    await expect(panel.locator("#panel-aktivitaet")).toBeVisible();
+
+    await panel.locator(".mobile-panel-title").click();
+    await expect(panel.getByTestId("account-compact-summary")).toBeVisible();
+    await expect(panel.locator("#panel-aktivitaet")).toHaveCount(0);
+
+    await handle.click();
+    await expect(panel.locator("#panel-aktivitaet")).toBeVisible();
+    await expect(panel.getByRole("tab", { name: "Aktivität" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
   });
 
   test("reduced motion removes the height transition", async ({ page }) => {
@@ -202,5 +275,33 @@ test.describe("ContextPanel desktop layout stays unchanged", () => {
 
     const box = await panel.boundingBox();
     expect(Math.round(box!.width)).toBe(400);
+  });
+});
+
+test.describe("ContextPanel touch input", () => {
+  test.use({ hasTouch: true, viewport: { width: 390, height: 844 } });
+
+  test.beforeEach(async ({ page }) => {
+    await mockApiResponses(page, {
+      auth: { authenticated: true, account_id: "e2e-weber", role: "weber" },
+    });
+    await page.goto("/map");
+    await page.waitForSelector(".map-marker", { timeout: 10000 });
+  });
+
+  test("one touch tap toggles the handle exactly once", async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.locator(".map-marker").first().click();
+    const panel = page.getByTestId("context-panel");
+    const handle = page.getByTestId("sheet-handle");
+    const box = await handle.boundingBox();
+    expect(box).not.toBeNull();
+
+    await page.touchscreen.tap(
+      box!.x + box!.width / 2,
+      box!.y + box!.height / 2,
+    );
+
+    await expect(panel).toHaveAttribute("data-sheet-stage", "full");
   });
 });

--- a/apps/web/tests/context-panel-sheet.spec.ts
+++ b/apps/web/tests/context-panel-sheet.spec.ts
@@ -23,7 +23,11 @@ test.describe("ContextPanel mobile compact and full states", () => {
     await expect(panel.locator(".panel-header h2")).toHaveCount(1);
     await expect(panel).toHaveAttribute("data-sheet-stage", "compact");
     await expect(handle).toHaveAttribute("aria-expanded", "false");
+    await expect(
+      panel.getByRole("region", { name: "Knotenübersicht" }),
+    ).toBeVisible();
     await expect(panel.locator(".tabs")).toBeHidden();
+    await expect(panel.getByRole("tab")).toHaveCount(0);
     await expect(page.getByLabel("Panelgröße")).toHaveCount(0);
     expect((await handle.boundingBox())?.height).toBeGreaterThanOrEqual(44);
   });
@@ -65,14 +69,39 @@ test.describe("ContextPanel mobile compact and full states", () => {
     await panel.locator(".mobile-panel-title").click();
     await expect(panel).toHaveAttribute("data-sheet-stage", "compact");
     await expect(panel.getByTestId("node-compact-summary")).toBeVisible();
-    await expect(panel.locator("#panel-gespraech")).toHaveCount(0);
+    await expect(panel.locator("#panel-gespraech")).toHaveCount(1);
+    await expect(panel.locator("#panel-gespraech")).toBeHidden();
 
     await handle.click();
+    await expect(panel.getByTestId("node-compact-summary")).toBeHidden();
     await expect(panel.locator("#panel-gespraech")).toBeVisible();
     await expect(panel.getByRole("tab", { name: "Gespräch" })).toHaveAttribute(
       "aria-selected",
       "true",
     );
+  });
+
+  test("collapsing preserves an unsaved edit draft", async ({ page }) => {
+    await page.locator(".map-marker").first().click();
+    const panel = page.getByTestId("context-panel");
+    const handle = page.getByTestId("sheet-handle");
+
+    await handle.click();
+    await panel.getByRole("tab", { name: "Bearbeiten" }).click();
+    await panel
+      .getByRole("button", { name: "Bearbeiten", exact: true })
+      .click();
+    const titleInput = panel.getByLabel("Titel");
+    await titleInput.fill("Ungespeicherter Entwurf");
+
+    await panel.locator(".mobile-panel-title").click();
+    await expect(panel).toHaveAttribute("data-sheet-stage", "compact");
+    await expect(titleInput).toBeHidden();
+    await expect(panel.getByTestId("node-compact-summary")).toBeVisible();
+
+    await handle.click();
+    await expect(titleInput).toBeVisible();
+    await expect(titleInput).toHaveValue("Ungespeicherter Entwurf");
   });
 
   test("Komposition starts full and can collapse through the same handle", async ({
@@ -90,7 +119,7 @@ test.describe("ContextPanel mobile compact and full states", () => {
     await expect(panel).toHaveAttribute("data-sheet-stage", "compact");
   });
 
-  test("keyboard and dragging select the two states without a post-drag double toggle", async ({
+  test("keyboard, taps and dragging change state exactly once", async ({
     page,
   }) => {
     await page.emulateMedia({ reducedMotion: "reduce" });
@@ -99,6 +128,11 @@ test.describe("ContextPanel mobile compact and full states", () => {
     const handle = page.getByTestId("sheet-handle");
 
     await handle.focus();
+    await handle.press("Enter");
+    await expect(panel).toHaveAttribute("data-sheet-stage", "full");
+    await handle.press(" ");
+    await expect(panel).toHaveAttribute("data-sheet-stage", "compact");
+
     await handle.press("ArrowUp");
     await expect(panel).toHaveAttribute("data-sheet-stage", "full");
     await handle.press("ArrowDown");
@@ -127,44 +161,108 @@ test.describe("ContextPanel mobile compact and full states", () => {
     const handle = page.getByTestId("sheet-handle");
 
     for (const event of [
-      { pointerId: 23, pointerType: "touch", isPrimary: false, button: 0 },
-      { pointerId: 24, pointerType: "mouse", isPrimary: true, button: 1 },
-      { pointerId: 25, pointerType: "mouse", isPrimary: true, button: 2 },
+      { pointerId: 40, pointerType: "touch", isPrimary: false, button: 0 },
+      { pointerId: 41, pointerType: "mouse", isPrimary: true, button: 1 },
+      { pointerId: 42, pointerType: "mouse", isPrimary: true, button: 2 },
     ]) {
       await handle.dispatchEvent("pointerdown", {
         ...event,
-        clientY: 100,
+        clientY: 700,
       });
-      await expect(panel).toHaveAttribute("data-sheet-stage", "compact");
       await expect(panel).not.toHaveClass(/dragging/);
+      await expect(panel).toHaveAttribute("data-sheet-stage", "compact");
       await expect(panel).not.toHaveAttribute("style");
     }
   });
 
-  test("collapsing preserves an unsaved edit draft for reopening", async ({
+  test("foreign pointer ids and pointercancel leave no drag state", async ({
     page,
   }) => {
-    await page.locator(".map-marker:not(.marker-account)").first().click();
+    await page.locator(".map-marker").first().click();
     const panel = page.getByTestId("context-panel");
     const handle = page.getByTestId("sheet-handle");
-    await handle.click();
+    const box = await handle.boundingBox();
+    expect(box).not.toBeNull();
 
-    await panel.getByRole("tab", { name: "Bearbeiten" }).click();
-    await panel.getByRole("button", { name: "Bearbeiten" }).click();
-    const titleInput = panel.getByLabel("Titel");
-    await titleInput.fill("Ungespeicherter Entwurf");
+    await handle.evaluate((element) => {
+      element.addEventListener(
+        "pointerdown",
+        (event) =>
+          element.setAttribute(
+            "data-test-pointer-id",
+            String((event as PointerEvent).pointerId),
+          ),
+        { once: true },
+      );
+    });
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+    await page.mouse.down();
+    const pointerId = Number(await handle.getAttribute("data-test-pointer-id"));
+    expect(Number.isFinite(pointerId)).toBe(true);
+    await expect(panel).toHaveClass(/dragging/);
 
-    await panel.locator(".mobile-panel-title").click();
+    await handle.dispatchEvent("pointermove", {
+      pointerId: pointerId + 1,
+      pointerType: "mouse",
+      isPrimary: true,
+      clientY: box!.y - 300,
+    });
+    await handle.dispatchEvent("pointerup", {
+      pointerId: pointerId + 1,
+      pointerType: "mouse",
+      isPrimary: true,
+      button: 0,
+    });
+    await expect(panel).toHaveClass(/dragging/);
     await expect(panel).toHaveAttribute("data-sheet-stage", "compact");
-    await expect(titleInput).toHaveCount(0);
 
-    await handle.click();
-    await expect(panel.getByLabel("Titel")).toHaveValue(
-      "Ungespeicherter Entwurf",
-    );
+    await handle.dispatchEvent("pointercancel", {
+      pointerId,
+      pointerType: "mouse",
+      isPrimary: true,
+      button: 0,
+    });
+    await expect(panel).not.toHaveClass(/dragging/);
+    await expect(panel).not.toHaveAttribute("style");
+    await page.mouse.up();
   });
 
-  test("compact Garnrolle exposes its profile region and restores the selected tab", async ({
+  test("lostpointercapture deterministically clears an active drag", async ({
+    page,
+  }) => {
+    await page.locator(".map-marker").first().click();
+    const panel = page.getByTestId("context-panel");
+    const handle = page.getByTestId("sheet-handle");
+    const box = await handle.boundingBox();
+    expect(box).not.toBeNull();
+
+    await handle.evaluate((element) => {
+      element.addEventListener(
+        "pointerdown",
+        (event) =>
+          element.setAttribute(
+            "data-test-pointer-id",
+            String((event as PointerEvent).pointerId),
+          ),
+        { once: true },
+      );
+    });
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+    await page.mouse.down();
+    const pointerId = Number(await handle.getAttribute("data-test-pointer-id"));
+    await expect(panel).toHaveClass(/dragging/);
+
+    await handle.dispatchEvent("lostpointercapture", {
+      pointerId,
+      pointerType: "mouse",
+      isPrimary: true,
+    });
+    await expect(panel).not.toHaveClass(/dragging/);
+    await expect(panel).not.toHaveAttribute("style");
+    await page.mouse.up();
+  });
+
+  test("compact Garnrolle keeps tabs and the selected panel in the DOM", async ({
     page,
   }) => {
     await page.locator(".map-marker.marker-account").first().click();
@@ -174,7 +272,8 @@ test.describe("ContextPanel mobile compact and full states", () => {
     await expect(
       panel.getByRole("region", { name: "Garnrollenprofil" }),
     ).toBeVisible();
-    await expect(panel.locator(".tabs")).toHaveCount(0);
+    await expect(panel.locator('[role="tab"]')).toHaveCount(3);
+    await expect(panel.getByRole("tab")).toHaveCount(0);
 
     await handle.click();
     await panel.getByRole("tab", { name: "Aktivität" }).click();
@@ -182,9 +281,12 @@ test.describe("ContextPanel mobile compact and full states", () => {
 
     await panel.locator(".mobile-panel-title").click();
     await expect(panel.getByTestId("account-compact-summary")).toBeVisible();
-    await expect(panel.locator("#panel-aktivitaet")).toHaveCount(0);
+    await expect(panel.locator('[role="tablist"]')).toBeHidden();
+    await expect(panel.locator("#panel-aktivitaet")).toHaveCount(1);
+    await expect(panel.locator("#panel-aktivitaet")).toBeHidden();
 
     await handle.click();
+    await expect(panel.getByTestId("account-compact-summary")).toBeHidden();
     await expect(panel.locator("#panel-aktivitaet")).toBeVisible();
     await expect(panel.getByRole("tab", { name: "Aktivität" })).toHaveAttribute(
       "aria-selected",
@@ -201,11 +303,11 @@ test.describe("ContextPanel mobile compact and full states", () => {
     expect(transitionDuration).toBe("0s");
   });
 
-  test("a coarse-pointer phone keeps the mobile sheet in landscape", async ({
+  test("rotating a coarse-pointer phone keeps the live panel mobile", async ({
     browser,
   }) => {
     const context = await browser.newContext({
-      viewport: { width: 844, height: 390 },
+      viewport: { width: 390, height: 844 },
       hasTouch: true,
       isMobile: true,
     });
@@ -226,6 +328,12 @@ test.describe("ContextPanel mobile compact and full states", () => {
     const handle = landscapePage.getByTestId("sheet-handle");
     await expect(handle).toBeVisible();
     await expect(panel).toHaveAttribute("data-sheet-stage", "compact");
+    await expect(panel.getByTestId("node-compact-summary")).toBeVisible();
+
+    await landscapePage.setViewportSize({ width: 844, height: 390 });
+    await expect(handle).toBeVisible();
+    await expect(panel).toHaveAttribute("data-sheet-stage", "compact");
+    await expect(panel.getByTestId("node-compact-summary")).toBeVisible();
     await handle.click();
     await expect(panel).toHaveAttribute("data-sheet-stage", "full");
 
@@ -269,9 +377,12 @@ test.describe("ContextPanel desktop layout stays unchanged", () => {
     await page.locator(".map-marker").first().click();
     const panel = page.getByTestId("context-panel");
     await expect(panel).toBeVisible();
-    await expect(page.getByTestId("sheet-handle")).toBeHidden();
+    const handle = page.getByTestId("sheet-handle");
+    await expect(handle).toBeHidden();
     await expect(panel.locator(".mobile-panel-title")).toBeHidden();
     await expect(panel.locator(".tabs")).toBeVisible();
+    await handle.dispatchEvent("click", { detail: 0 });
+    await expect(panel).toHaveAttribute("data-sheet-stage", "compact");
 
     const box = await panel.boundingBox();
     expect(Math.round(box!.width)).toBe(400);
@@ -289,7 +400,9 @@ test.describe("ContextPanel touch input", () => {
     await page.waitForSelector(".map-marker", { timeout: 10000 });
   });
 
-  test("one touch tap toggles the handle exactly once", async ({ page }) => {
+  test("one real touch tap toggles the handle exactly once", async ({
+    page,
+  }) => {
     await page.emulateMedia({ reducedMotion: "reduce" });
     await page.locator(".map-marker").first().click();
     const panel = page.getByTestId("context-panel");

--- a/apps/web/tests/page-design-system.spec.ts
+++ b/apps/web/tests/page-design-system.spec.ts
@@ -77,9 +77,17 @@ test("application overview uses the same surfaces, controls and empty-state cont
   await expect(
     page.getByLabel("Kurze Vorstellung oder Begründung"),
   ).toHaveClass(/wg-control/);
-  await expect(
-    page.getByRole("button", { name: "Weberstatus beantragen" }),
-  ).toHaveClass(/wg-button--primary/);
+  const primaryAction = page.getByRole("button", {
+    name: "Weberstatus beantragen",
+  });
+  await expect(primaryAction).toHaveClass(/wg-button--primary/);
+  const primaryActionColors = await primaryAction.evaluate((element) => {
+    const style = getComputedStyle(element);
+    return { foreground: style.color, background: style.backgroundColor };
+  });
+  expect(primaryActionColors.foreground).not.toBe(
+    primaryActionColors.background,
+  );
   await expect(page.getByText("Noch liegen keine Anträge vor.")).toHaveClass(
     /wg-state/,
   );
@@ -90,7 +98,7 @@ test("application overview uses the same surfaces, controls and empty-state cont
   await expect(filters.getByRole("link")).toHaveCount(5);
   await expect(filters.getByRole("link", { name: "Alle" })).toHaveAttribute(
     "aria-current",
-    "page",
+    "true",
   );
 });
 

--- a/apps/web/tests/page-design-system.spec.ts
+++ b/apps/web/tests/page-design-system.spec.ts
@@ -27,7 +27,8 @@ test("login uses the shared page, form and state contracts without changing the 
   );
 
   const emailInput = page.getByLabel("E-Mail");
-  await emailInput.focus();
+  await page.keyboard.press("Tab");
+  await expect(emailInput).toBeFocused();
   await expect
     .poll(() =>
       emailInput.evaluate((element) => getComputedStyle(element).outlineWidth),

--- a/apps/web/tests/page-design-system.spec.ts
+++ b/apps/web/tests/page-design-system.spec.ts
@@ -21,8 +21,20 @@ test("login uses the shared page, form and state contracts without changing the 
   await expect(loginPage.locator(".wg-card")).toHaveCount(1);
   await expect(loginPage.locator("[style]")).toHaveCount(0);
   await expect(loginPage).toHaveCSS("background-image", /radial-gradient/);
+  const loginBox = await loginPage.boundingBox();
+  expect(loginBox?.height).toBeGreaterThanOrEqual(
+    await page.evaluate(() => window.innerHeight),
+  );
 
-  await page.getByLabel("E-Mail").fill("person@example.org");
+  const emailInput = page.getByLabel("E-Mail");
+  await emailInput.focus();
+  await expect
+    .poll(() =>
+      emailInput.evaluate((element) => getComputedStyle(element).outlineWidth),
+    )
+    .toBe("3px");
+
+  await emailInput.fill("person@example.org");
   await page.getByRole("button", { name: "Login-Link senden" }).click();
 
   expect(requestBody).toEqual({ email: "person@example.org" });
@@ -51,6 +63,13 @@ test("application overview uses the same surfaces, controls and empty-state cont
 
   const applicationsPage = page.getByTestId("applications-page");
   await expect(applicationsPage).toHaveClass(/wg-page--paper/);
+  await expect
+    .poll(() =>
+      applicationsPage.evaluate((element) =>
+        getComputedStyle(element).getPropertyValue("--wg-surface").trim(),
+      ),
+    )
+    .toContain("color-mix");
   await expect(
     page.getByRole("heading", { name: "Anträge", exact: true }),
   ).toBeVisible();


### PR DESCRIPTION
<!-- weltgewebe-risk: R2 -->

## Ausgangslage

Dieser PR setzt die zwei externen Reviews zum konfliktbehafteten PR #1580 fort und ist inzwischen auf den aktuellen `main`-Stand `b043a86dbf4e0e0868feb5177745a0f32a3264c0` konfliktbereinigt. Der exakte konfliktfreie PR-Head ist `352b410fc151521957ac389f750674d5631dc97b`.

Die Konfliktauflösung kombiniert beide Seiten bewusst:

- `main` behält seine neuere DOM- und Zustandsarchitektur.
- Der PR ergänzt darauf robuste Pointer-, Responsive- und Accessibility-Verträge.
- Ungespeicherte Eingaben und Tabzustände bleiben beim Ein- und Ausklappen erhalten.
- Die Konfliktbereinigung wurde nicht als bloßes „unsere/theirs“ übernommen, sondern gegen Diff, Tests und Renderverhalten geprüft.

Die ursprünglichen Reviews wurden ebenfalls nicht blind übernommen:

- Der behauptete schwere SSR-Hydration-Fehler ist für dieses Panel nicht in dieser Form reproduzierbar, weil die Auswahl serverseitig `null` ist und das Kontextpanel daher nicht im initialen SSR-HTML erscheint.
- Die zugrunde liegende Architekturfrage war dennoch berechtigt: CSS und JavaScript müssen denselben Mobilvertrag verwenden.
- Das vorgeschlagene Zurücksetzen von `editing` beim Einklappen wurde verworfen, weil es ungespeicherte Eingaben gefährden würde. Der verlustfreie Wiederöffnungsweg ist nun explizit browsergetestet.

## Änderungen

### Mobiles Kontextpanel

- Der bestehende hybride Mobilvertrag bleibt erhalten: Breite bis 768 px **oder** geringe Höhe bis 500 px bei grobem Pointer. Damit bleibt ein Telefon mit 844×390 px im Querformat ein Bottom-Sheet.
- Pointer-Eingaben sind an genau einen primären Kontakt und die linke Taste gebunden.
- Nichtprimäre Berührungen, Mittel- und Rechtsklick starten keine Bewegung.
- `lostpointercapture` räumt einen abgebrochenen Vorgang deterministisch auf.
- Der 0-ms-Timer zur Klickunterdrückung entfällt.
- Pointer-Taps werden im Pointer-Abschluss einmalig verarbeitet; `click.detail === 0` bleibt ausdrücklich Tastatur- und synthetischen Aktivierungen vorbehalten.
- Knoten- und Garnrollen-Kompaktansichten besitzen passende `region`-Semantik.
- Der aktive Tab und ungespeicherte Bearbeitung bleiben beim Ein- und Ausklappen erhalten.

### Gemeinsames Seitensystem

- Seiten füllen mindestens `100vh` beziehungsweise `100dvh`.
- Eingaben, Buttons und Rücklinks erhalten einen klaren `:focus-visible`-Ring.
- Primäraktionen verwenden einen ausdrücklichen Vordergrundtoken statt der Seitenhintergrundfarbe.
- `wg-page--paper` erhält eine wirksame Oberflächenvariante.
- Das bestehende CSS-Performancebudget wurde **nicht** angehoben.
- Die aktuellen `aria-current`-Filter und die korrekte Fehlerdarstellung der Antragsseite bleiben erhalten; die entsprechenden veralteten Teile aus #1580 wurden nicht übernommen.

## Prüfungen auf Head `352b410f`

- `git diff --check` — grün
- `pnpm check:ci` — 0 Fehler, 0 Warnungen
- `pnpm lint` — grün
- `pnpm test:unit` — 26 Dateien, 212 Tests grün
- Playwright — 18/18 relevante Tests grün
  - mobiles Hochformat
  - 844×390-Querformat mit grobem Pointer
  - echter Touch-Tap
  - Drag, Tastatur und Klick-Deduplizierung
  - Nichtprimär-, Mittel- und Rechtsklick
  - fremde Pointer-IDs, `pointercancel` und `lostpointercapture`
  - ungespeicherter Bearbeitungsentwurf
  - Garnrollen-Kompaktregion und Tabwiederherstellung
  - Fokus, dynamische Viewport-Höhe, Paper-Surface
  - Antragsfilter und API-Fehlerzustand
- `pnpm build` — grün
- finale gzip-Routenbudgets:
  - `/login`: 44.660 B JS / 3.058 B CSS
  - `/antraege`: 54.023 B JS / 4.907 B CSS
  - `/settings`: 56.150 B JS / 3.528 B CSS
  - `/map`: 80.013 B JS / 17.084 B CSS
- Codex-Review auf exakt `352b410fc1` — keine größeren Befunde
- GitHub-Pflichtprüfungen einschließlich Core, PostgreSQL, Web-E2E, CodeQL, Kubernetes-, HA- und GitOps-Proof — grün

## Abgrenzung und Folgetasks

Der bekannte große Client-Chunk blockiert diesen PR nicht: Build und Routenbudgets sind grün. Die frühere Zuordnung zu `WELTGEWEBE-OS-V1-T046` war falsch; T046 behandelt Moderation. Der Befund ist nun korrekt als `WELTGEWEBE-OS-V1-T049` über Bureau-PR #1047 registriert und von der kanonischen Performanceaufgabe T048 abhängig.

Die auf diesem Host nicht ausgeführte WebKit-Spur ist separat als `WELTGEWEBE-OS-V1-T050` über Bureau-PR #1045 registriert. Vor Umsetzung muss die vermutete `libavif13`-Ursache frisch reproduziert werden.

Supersedes #1580. Der Merge ist durch die aktuelle Nutzeranweisung autorisiert und erfolgt nur revisionsgebunden nach bestandenem Review-Evidence-Gate und unverändert grünen Pflichtchecks.