### PR TITLE
fix(nodes): explain protected conversation deletes

### DIFF
--- a/apps/api/src/routes/nodes.rs
+++ b/apps/api/src/routes/nodes.rs
@@ -61,6 +61,11 @@ pub enum NodeMutationError {
     Status(StatusCode),
     DomainReadSourceReadOnly,
     Message(StatusCode, String),
+    Problem {
+        status: StatusCode,
+        code: &'static str,
+        message: &'static str,
+    },
 }
 
 impl IntoResponse for NodeMutationError {
@@ -74,6 +79,11 @@ impl IntoResponse for NodeMutationError {
                 (StatusCode::CONFLICT, body).into_response()
             }
             NodeMutationError::Message(status, body) => (status, body).into_response(),
+            NodeMutationError::Problem {
+                status,
+                code,
+                message,
+            } => (status, Json(json!({ "code": code, "message": message }))).into_response(),
         }
     }
 }
@@ -2652,6 +2662,26 @@ pub async fn replace_node(
     Ok(Json(node))
 }
 
+fn map_postgres_node_delete_error(error: NodeWriteError, id: &str) -> NodeMutationError {
+    match error {
+        NodeWriteError::NotFound => NodeMutationError::Status(StatusCode::NOT_FOUND),
+        NodeWriteError::InvalidEdgeReference(_) => NodeMutationError::Message(
+            StatusCode::CONFLICT,
+            "node deletion blocked by ambiguous edge endpoint".to_string(),
+        ),
+        NodeWriteError::ConversationNotEmpty => NodeMutationError::Problem {
+            status: StatusCode::CONFLICT,
+            code: "node_conversation_not_empty",
+            message:
+                "node deletion is blocked because its public conversation contains contributions",
+        },
+        other => {
+            tracing::error!(%other, node_id = %id, "failed to delete node in PostgreSQL");
+            NodeMutationError::Status(StatusCode::INTERNAL_SERVER_ERROR)
+        }
+    }
+}
+
 pub async fn delete_node(
     State(state): State<ApiState>,
     Path(id): Path<String>,
@@ -2744,21 +2774,9 @@ pub async fn delete_node(
                 .db_pool
                 .as_ref()
                 .ok_or(NodeMutationError::Status(StatusCode::INTERNAL_SERVER_ERROR))?;
-            delete_node_with_edges_in_postgres(pool, &id).await.map_err(|error| match error {
-                NodeWriteError::NotFound => NodeMutationError::Status(StatusCode::NOT_FOUND),
-                NodeWriteError::InvalidEdgeReference(_) => NodeMutationError::Message(
-                    StatusCode::CONFLICT,
-                    "node deletion blocked by ambiguous edge endpoint".to_string(),
-                ),
-                NodeWriteError::ConversationNotEmpty => NodeMutationError::Message(
-                    StatusCode::CONFLICT,
-                    "node deletion blocked because its public conversation contains contributions".to_string(),
-                ),
-                other => {
-                    tracing::error!(%other, node_id = %id, "failed to delete node in PostgreSQL");
-                    NodeMutationError::Status(StatusCode::INTERNAL_SERVER_ERROR)
-                }
-            })?
+            delete_node_with_edges_in_postgres(pool, &id)
+                .await
+                .map_err(|error| map_postgres_node_delete_error(error, &id))?
         }
     };
 
@@ -3087,6 +3105,37 @@ pub async fn list_nodes(
             .cloned()
             .collect();
         Ok(Json(ListResponse::Legacy(out)))
+    }
+}
+
+#[cfg(test)]
+mod node_mutation_error_response_tests {
+    use super::*;
+    use axum::body;
+
+    #[tokio::test]
+    async fn conversation_history_guard_has_a_stable_json_problem_code() {
+        let response = map_postgres_node_delete_error(NodeWriteError::ConversationNotEmpty, "n1")
+            .into_response();
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        assert_eq!(
+            response
+                .headers()
+                .get(axum::http::header::CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok()),
+            Some("application/json")
+        );
+
+        let body = body::to_bytes(response.into_body(), 4096)
+            .await
+            .expect("problem body");
+        let payload: Value = serde_json::from_slice(&body).expect("problem JSON");
+        assert_eq!(payload["code"], "node_conversation_not_empty");
+        assert_eq!(
+            payload["message"],
+            "node deletion is blocked because its public conversation contains contributions"
+        );
     }
 }
 

--- a/apps/web/src/lib/api/domainWrites.test.ts
+++ b/apps/web/src/lib/api/domainWrites.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { deleteNode, replaceNode } from "./domainWrites";
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("domain writes", () => {
+  it("keeps the structured delete conflict from JSON responses", async () => {
+    const body = {
+      code: "node_conversation_not_empty",
+      message:
+        "node deletion is blocked because its public conversation contains contributions",
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(body), {
+          status: 409,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    await expect(deleteNode("node-a", "version-a")).rejects.toMatchObject({
+      status: 409,
+      body,
+    });
+  });
+
+  it("keeps a plain-text conflict reason during rolling deployments", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response(
+            "node deletion blocked because its public conversation contains contributions",
+            { status: 409 },
+          ),
+        ),
+    );
+
+    await expect(deleteNode("node-a", "version-a")).rejects.toMatchObject({
+      status: 409,
+      body: "node deletion blocked because its public conversation contains contributions",
+    });
+  });
+
+  it("keeps structured version-conflict evidence from JSON responses", async () => {
+    const current = {
+      id: "node-a",
+      title: "Aktuell",
+      updated_at: "2026-07-26T08:00:00Z",
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            code: "node_version_conflict",
+            message: "conflict",
+            current,
+          }),
+          {
+            status: 412,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      ),
+    );
+
+    await expect(
+      replaceNode(
+        "node-a",
+        {
+          title: "Entwurf",
+          kind: "Ort",
+          address: "Testweg 1",
+          location: { lat: 54, lon: 8 },
+          tags: [],
+        },
+        "stale",
+      ),
+    ).rejects.toMatchObject({
+      status: 412,
+      body: {
+        code: "node_version_conflict",
+        message: "conflict",
+        current,
+      },
+    });
+  });
+});

--- a/apps/web/src/lib/api/domainWrites.test.ts
+++ b/apps/web/src/lib/api/domainWrites.test.ts
@@ -3,6 +3,20 @@ import { deleteNode, replaceNode } from "./domainWrites";
 
 afterEach(() => vi.unstubAllGlobals());
 
+function replaceWithStaleVersion() {
+  return replaceNode(
+    "node-a",
+    {
+      title: "Entwurf",
+      kind: "Ort",
+      address: "Testweg 1",
+      location: { lat: 54, lon: 8 },
+      tags: [],
+    },
+    "stale",
+  );
+}
+
 describe("domain writes", () => {
   it("keeps the structured delete conflict from JSON responses", async () => {
     const body = {
@@ -65,21 +79,27 @@ describe("domain writes", () => {
       ),
     );
 
-    await expect(
-      replaceNode(
-        "node-a",
-        {
-          title: "Entwurf",
-          kind: "Ort",
-          address: "Testweg 1",
-          location: { lat: 54, lon: 8 },
-          tags: [],
-        },
-        "stale",
-      ),
-    ).rejects.toMatchObject({
+    await expect(replaceWithStaleVersion()).rejects.toMatchObject({
       status: 412,
       body: current,
+    });
+  });
+
+  it.each([
+    ["plain text", "stale precondition"],
+    [
+      "a non-node JSON problem",
+      JSON.stringify({ code: "node_version_conflict", message: "conflict" }),
+    ],
+  ])("drops %s from 412 responses", async (_label, body) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(body, { status: 412 })),
+    );
+
+    await expect(replaceWithStaleVersion()).rejects.toMatchObject({
+      status: 412,
+      body: undefined,
     });
   });
 });

--- a/apps/web/src/lib/api/domainWrites.test.ts
+++ b/apps/web/src/lib/api/domainWrites.test.ts
@@ -45,26 +45,23 @@ describe("domain writes", () => {
     });
   });
 
-  it("keeps structured version-conflict evidence from JSON responses", async () => {
+  it("keeps the current node from direct 412 JSON responses", async () => {
     const current = {
       id: "node-a",
       title: "Aktuell",
+      kind: "Ort",
+      address: "Testweg 1",
+      location: { lat: 54, lon: 8 },
+      tags: [],
       updated_at: "2026-07-26T08:00:00Z",
     };
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue(
-        new Response(
-          JSON.stringify({
-            code: "node_version_conflict",
-            message: "conflict",
-            current,
-          }),
-          {
-            status: 412,
-            headers: { "Content-Type": "application/json" },
-          },
-        ),
+        new Response(JSON.stringify(current), {
+          status: 412,
+          headers: { "Content-Type": "application/json" },
+        }),
       ),
     );
 
@@ -82,11 +79,7 @@ describe("domain writes", () => {
       ),
     ).rejects.toMatchObject({
       status: 412,
-      body: {
-        code: "node_version_conflict",
-        message: "conflict",
-        current,
-      },
+      body: current,
     });
   });
 });

--- a/apps/web/src/lib/api/domainWrites.ts
+++ b/apps/web/src/lib/api/domainWrites.ts
@@ -15,6 +15,17 @@ export class ApiRequestError extends Error {
   }
 }
 
+async function readErrorBody(response: Response): Promise<unknown> {
+  const text = await response.text().catch(() => "");
+  if (!text) return undefined;
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
 async function requestJson<T>(
   path: string,
   method: "POST" | "PATCH" | "PUT",
@@ -34,9 +45,7 @@ async function requestJson<T>(
     signal,
   });
   if (!res.ok) {
-    const body =
-      res.status === 412 ? await res.json().catch(() => undefined) : undefined;
-    throw new ApiRequestError(res.status, body);
+    throw new ApiRequestError(res.status, await readErrorBody(res));
   }
   return res.json();
 }
@@ -73,16 +82,14 @@ async function deleteResource(path: string, etag?: string): Promise<void> {
     credentials: "include",
   });
   if (!res.ok) {
-    const body =
-      res.status === 412 ? await res.json().catch(() => undefined) : undefined;
-    throw new ApiRequestError(res.status, body);
+    throw new ApiRequestError(res.status, await readErrorBody(res));
   }
 }
 
 async function getJson<T>(path: string, signal?: AbortSignal): Promise<T> {
   const res = await fetch(path, { credentials: "include", signal });
   if (!res.ok) {
-    throw new ApiRequestError(res.status);
+    throw new ApiRequestError(res.status, await readErrorBody(res));
   }
   return res.json();
 }

--- a/apps/web/src/lib/api/domainWrites.ts
+++ b/apps/web/src/lib/api/domainWrites.ts
@@ -15,14 +15,29 @@ export class ApiRequestError extends Error {
   }
 }
 
+function isNodeVersionConflictBody(body: unknown): boolean {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return false;
+  }
+  const node = body as Record<string, unknown>;
+  return (
+    typeof node.id === "string" &&
+    typeof node.title === "string" &&
+    typeof node.updated_at === "string"
+  );
+}
+
 async function readErrorBody(response: Response): Promise<unknown> {
   const text = await response.text().catch(() => "");
   if (!text) return undefined;
 
   try {
-    return JSON.parse(text) as unknown;
+    const body = JSON.parse(text) as unknown;
+    return response.status === 412 && !isNodeVersionConflictBody(body)
+      ? undefined
+      : body;
   } catch {
-    return text;
+    return response.status === 412 ? undefined : text;
   }
 }
 

--- a/apps/web/src/lib/components/panels/NodePanel.svelte
+++ b/apps/web/src/lib/components/panels/NodePanel.svelte
@@ -15,6 +15,7 @@
   import { nodeKindLabel } from "$lib/ui/productLanguage";
   import type { MapEntityViewModel } from "$lib/map/types";
   import NodeConversation from "./NodeConversation.svelte";
+  import { nodeMutationMessage } from "./nodeMutationMessage";
 
   type DomainChanged = {
     kind: "node";
@@ -189,25 +190,6 @@
     void focusAfterRender(() => editTab);
   }
 
-  function mutationMessage(error: unknown): string {
-    if (error instanceof ApiRequestError) {
-      if (error.status === 401 || error.status === 403) {
-        return "Diese Garnrolle darf derzeit nicht schreiben.";
-      }
-      if (error.status === 404) return "Der Knoten existiert nicht mehr.";
-      if (error.status === 400) {
-        return "Die Eingaben sind ungültig. Bitte prüfe alle Felder.";
-      }
-      if (error.status === 409) {
-        return "Der Knoten konnte wegen eines Datenkonflikts nicht geändert werden. Es wurde nichts verändert.";
-      }
-      if (error.status === 428) {
-        return "Die geladene Knotenversion ist unvollständig. Bitte öffne den Knoten erneut und versuche es noch einmal.";
-      }
-    }
-    return "Die Änderung konnte nicht gespeichert werden.";
-  }
-
   async function saveNode() {
     const id = nodeDetails?.id || $selection?.id;
     const lat = Number(formLat);
@@ -276,7 +258,7 @@
           ...currentNode,
         } as NodeDetails);
       } else {
-        mutationError = mutationMessage(error);
+        mutationError = nodeMutationMessage(error, "save");
       }
     } finally {
       saving = false;
@@ -309,7 +291,7 @@
           ...(error.body as object),
         } as NodeDetails);
       } else {
-        mutationError = mutationMessage(error);
+        mutationError = nodeMutationMessage(error, "delete");
       }
     } finally {
       deleting = false;

--- a/apps/web/src/lib/components/panels/NodePanel.svelte
+++ b/apps/web/src/lib/components/panels/NodePanel.svelte
@@ -15,7 +15,6 @@
   import { nodeKindLabel } from "$lib/ui/productLanguage";
   import type { MapEntityViewModel } from "$lib/map/types";
   import NodeConversation from "./NodeConversation.svelte";
-  import { nodeMutationMessage } from "./nodeMutationMessage";
 
   type DomainChanged = {
     kind: "node";
@@ -143,6 +142,14 @@
     resolveTarget()?.focus();
   }
 
+  async function describeMutationError(
+    error: unknown,
+    action: "save" | "delete",
+  ): Promise<string> {
+    const { nodeMutationMessage } = await import("./nodeMutationMessage");
+    return nodeMutationMessage(error, action);
+  }
+
   function setTab(tab: NodeTab) {
     activeTab = tab;
   }
@@ -258,7 +265,7 @@
           ...currentNode,
         } as NodeDetails);
       } else {
-        mutationError = nodeMutationMessage(error, "save");
+        mutationError = await describeMutationError(error, "save");
       }
     } finally {
       saving = false;
@@ -291,7 +298,7 @@
           ...(error.body as object),
         } as NodeDetails);
       } else {
-        mutationError = nodeMutationMessage(error, "delete");
+        mutationError = await describeMutationError(error, "delete");
       }
     } finally {
       deleting = false;

--- a/apps/web/src/lib/components/panels/nodeMutationMessage.test.ts
+++ b/apps/web/src/lib/components/panels/nodeMutationMessage.test.ts
@@ -26,6 +26,15 @@ describe("node mutation messages", () => {
     expect(nodeMutationMessage(error, "save")).toContain("nicht geändert");
   });
 
+  it("ignores malformed structured codes", () => {
+    const error = new ApiRequestError(409, {
+      code: 42,
+      message: "protected",
+    });
+
+    expect(nodeMutationMessage(error, "delete")).toContain("nicht gelöscht");
+  });
+
   it("keeps generic save and delete conflicts distinct", () => {
     const error = new ApiRequestError(409, "other conflict");
 

--- a/apps/web/src/lib/components/panels/nodeMutationMessage.test.ts
+++ b/apps/web/src/lib/components/panels/nodeMutationMessage.test.ts
@@ -10,7 +10,7 @@ describe("node mutation messages", () => {
     );
 
     expect(nodeMutationMessage(error, "delete")).toBe(
-      "Dieser Knoten kann nicht gelöscht werden, weil sein öffentliches Gespräch Beiträge enthält. Das Gespräch bleibt als Teil der öffentlichen Geschichte geschützt; du kannst den Knoten weiterhin bearbeiten.",
+      "Dieser Knoten kann nicht gelöscht werden, weil sein öffentliches Gespräch Beiträge enthält. Die öffentliche Geschichte bleibt geschützt; du kannst ihn weiter bearbeiten.",
     );
   });
 
@@ -31,16 +31,5 @@ describe("node mutation messages", () => {
 
     expect(nodeMutationMessage(error, "save")).toContain("nicht geändert");
     expect(nodeMutationMessage(error, "delete")).toContain("nicht gelöscht");
-  });
-
-  it("explains ambiguous edge protection without exposing backend wording", () => {
-    const error = new ApiRequestError(
-      409,
-      "node deletion blocked by ambiguous edge endpoint",
-    );
-
-    expect(nodeMutationMessage(error, "delete")).toContain(
-      "Verbindung nicht eindeutig zugeordnet",
-    );
   });
 });

--- a/apps/web/src/lib/components/panels/nodeMutationMessage.test.ts
+++ b/apps/web/src/lib/components/panels/nodeMutationMessage.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { ApiRequestError } from "$lib/api/domainWrites";
+import { nodeMutationMessage } from "./nodeMutationMessage";
+
+describe("node mutation messages", () => {
+  it("explains the protected public conversation instead of claiming a data conflict", () => {
+    const error = new ApiRequestError(
+      409,
+      "node deletion blocked because its public conversation contains contributions",
+    );
+
+    expect(nodeMutationMessage(error, "delete")).toBe(
+      "Dieser Knoten kann nicht gelöscht werden, weil sein öffentliches Gespräch Beiträge enthält. Das Gespräch bleibt als Teil der öffentlichen Geschichte geschützt; du kannst den Knoten weiterhin bearbeiten.",
+    );
+  });
+
+  it("uses the stable structured error code only for delete actions", () => {
+    const error = new ApiRequestError(409, {
+      code: "node_conversation_not_empty",
+      message: "protected",
+    });
+
+    expect(nodeMutationMessage(error, "delete")).toContain(
+      "öffentliches Gespräch Beiträge enthält",
+    );
+    expect(nodeMutationMessage(error, "save")).toContain("nicht geändert");
+  });
+
+  it("keeps generic save and delete conflicts distinct", () => {
+    const error = new ApiRequestError(409, "other conflict");
+
+    expect(nodeMutationMessage(error, "save")).toContain("nicht geändert");
+    expect(nodeMutationMessage(error, "delete")).toContain("nicht gelöscht");
+  });
+
+  it("explains ambiguous edge protection without exposing backend wording", () => {
+    const error = new ApiRequestError(
+      409,
+      "node deletion blocked by ambiguous edge endpoint",
+    );
+
+    expect(nodeMutationMessage(error, "delete")).toContain(
+      "Verbindung nicht eindeutig zugeordnet",
+    );
+  });
+});

--- a/apps/web/src/lib/components/panels/nodeMutationMessage.ts
+++ b/apps/web/src/lib/components/panels/nodeMutationMessage.ts
@@ -2,6 +2,13 @@ import { ApiRequestError } from "$lib/api/domainWrites";
 
 export type NodeMutationAction = "save" | "delete";
 
+function problemCode(body: unknown): string | undefined {
+  if (typeof body !== "object" || body === null || !("code" in body)) {
+    return undefined;
+  }
+  return typeof body.code === "string" ? body.code : undefined;
+}
+
 export function nodeMutationMessage(
   error: unknown,
   action: NodeMutationAction,
@@ -17,9 +24,7 @@ export function nodeMutationMessage(
     }
     if (error.status === 409) {
       const reason =
-        typeof error.body === "string"
-          ? error.body
-          : (error.body as { code?: unknown } | undefined)?.code;
+        typeof error.body === "string" ? error.body : problemCode(error.body);
       if (
         deleting &&
         (reason === "node_conversation_not_empty" ||

--- a/apps/web/src/lib/components/panels/nodeMutationMessage.ts
+++ b/apps/web/src/lib/components/panels/nodeMutationMessage.ts
@@ -2,26 +2,11 @@ import { ApiRequestError } from "$lib/api/domainWrites";
 
 export type NodeMutationAction = "save" | "delete";
 
-function errorBodyParts(body: unknown): string[] {
-  if (typeof body === "string") return [body];
-  if (!body || typeof body !== "object") return [];
-
-  const record = body as Record<string, unknown>;
-  return [record.code, record.message, record.error].filter(
-    (value): value is string => typeof value === "string",
-  );
-}
-
-function hasErrorReason(error: ApiRequestError, reason: string): boolean {
-  return errorBodyParts(error.body).some(
-    (part) => part === reason || part.includes(reason),
-  );
-}
-
 export function nodeMutationMessage(
   error: unknown,
   action: NodeMutationAction,
 ): string {
+  const deleting = action === "delete";
   if (error instanceof ApiRequestError) {
     if (error.status === 401 || error.status === 403) {
       return "Diese Garnrolle darf derzeit nicht schreiben.";
@@ -31,46 +16,25 @@ export function nodeMutationMessage(
       return "Die Eingaben sind ungültig. Bitte prüfe alle Felder.";
     }
     if (error.status === 409) {
-      if (action === "delete") {
-        if (
-          hasErrorReason(error, "node_conversation_not_empty") ||
-          hasErrorReason(
-            error,
-            "node deletion blocked because its public conversation contains contributions",
-          ) ||
-          hasErrorReason(
-            error,
-            "node deletion blocked by existing conversation messages",
-          )
-        ) {
-          return "Dieser Knoten kann nicht gelöscht werden, weil sein öffentliches Gespräch Beiträge enthält. Das Gespräch bleibt als Teil der öffentlichen Geschichte geschützt; du kannst den Knoten weiterhin bearbeiten.";
-        }
-        if (
-          hasErrorReason(
-            error,
-            "node deletion requires matching node and edge write sources",
-          )
-        ) {
-          return "Der Knoten kann derzeit wegen einer technischen Inkonsistenz nicht gelöscht werden. Es wurde nichts verändert.";
-        }
-        if (
-          hasErrorReason(
-            error,
-            "node deletion blocked by ambiguous edge endpoint",
-          )
-        ) {
-          return "Der Knoten kann derzeit nicht sicher gelöscht werden, weil mindestens eine Verbindung nicht eindeutig zugeordnet ist. Es wurde nichts verändert.";
-        }
+      const reason =
+        typeof error.body === "string"
+          ? error.body
+          : (error.body as { code?: unknown } | undefined)?.code;
+      if (
+        deleting &&
+        (reason === "node_conversation_not_empty" ||
+          (typeof reason === "string" &&
+            reason.includes("conversation contains contributions")))
+      ) {
+        return "Dieser Knoten kann nicht gelöscht werden, weil sein öffentliches Gespräch Beiträge enthält. Die öffentliche Geschichte bleibt geschützt; du kannst ihn weiter bearbeiten.";
       }
-      return action === "delete"
-        ? "Der Knoten konnte wegen eines Datenkonflikts nicht gelöscht werden. Es wurde nichts verändert."
-        : "Der Knoten konnte wegen eines Datenkonflikts nicht geändert werden. Es wurde nichts verändert.";
+      return `Der Knoten konnte wegen eines Datenkonflikts nicht ${deleting ? "gelöscht" : "geändert"} werden. Es wurde nichts verändert.`;
     }
     if (error.status === 428) {
       return "Die geladene Knotenversion ist unvollständig. Bitte öffne den Knoten erneut und versuche es noch einmal.";
     }
   }
-  return action === "delete"
+  return deleting
     ? "Der Knoten konnte nicht gelöscht werden."
     : "Die Änderung konnte nicht gespeichert werden.";
 }

--- a/apps/web/src/lib/components/panels/nodeMutationMessage.ts
+++ b/apps/web/src/lib/components/panels/nodeMutationMessage.ts
@@ -1,0 +1,76 @@
+import { ApiRequestError } from "$lib/api/domainWrites";
+
+export type NodeMutationAction = "save" | "delete";
+
+function errorBodyParts(body: unknown): string[] {
+  if (typeof body === "string") return [body];
+  if (!body || typeof body !== "object") return [];
+
+  const record = body as Record<string, unknown>;
+  return [record.code, record.message, record.error].filter(
+    (value): value is string => typeof value === "string",
+  );
+}
+
+function hasErrorReason(error: ApiRequestError, reason: string): boolean {
+  return errorBodyParts(error.body).some(
+    (part) => part === reason || part.includes(reason),
+  );
+}
+
+export function nodeMutationMessage(
+  error: unknown,
+  action: NodeMutationAction,
+): string {
+  if (error instanceof ApiRequestError) {
+    if (error.status === 401 || error.status === 403) {
+      return "Diese Garnrolle darf derzeit nicht schreiben.";
+    }
+    if (error.status === 404) return "Der Knoten existiert nicht mehr.";
+    if (error.status === 400) {
+      return "Die Eingaben sind ungültig. Bitte prüfe alle Felder.";
+    }
+    if (error.status === 409) {
+      if (action === "delete") {
+        if (
+          hasErrorReason(error, "node_conversation_not_empty") ||
+          hasErrorReason(
+            error,
+            "node deletion blocked because its public conversation contains contributions",
+          ) ||
+          hasErrorReason(
+            error,
+            "node deletion blocked by existing conversation messages",
+          )
+        ) {
+          return "Dieser Knoten kann nicht gelöscht werden, weil sein öffentliches Gespräch Beiträge enthält. Das Gespräch bleibt als Teil der öffentlichen Geschichte geschützt; du kannst den Knoten weiterhin bearbeiten.";
+        }
+        if (
+          hasErrorReason(
+            error,
+            "node deletion requires matching node and edge write sources",
+          )
+        ) {
+          return "Der Knoten kann derzeit wegen einer technischen Inkonsistenz nicht gelöscht werden. Es wurde nichts verändert.";
+        }
+        if (
+          hasErrorReason(
+            error,
+            "node deletion blocked by ambiguous edge endpoint",
+          )
+        ) {
+          return "Der Knoten kann derzeit nicht sicher gelöscht werden, weil mindestens eine Verbindung nicht eindeutig zugeordnet ist. Es wurde nichts verändert.";
+        }
+      }
+      return action === "delete"
+        ? "Der Knoten konnte wegen eines Datenkonflikts nicht gelöscht werden. Es wurde nichts verändert."
+        : "Der Knoten konnte wegen eines Datenkonflikts nicht geändert werden. Es wurde nichts verändert.";
+    }
+    if (error.status === 428) {
+      return "Die geladene Knotenversion ist unvollständig. Bitte öffne den Knoten erneut und versuche es noch einmal.";
+    }
+  }
+  return action === "delete"
+    ? "Der Knoten konnte nicht gelöscht werden."
+    : "Die Änderung konnte nicht gespeichert werden.";
+}


### PR DESCRIPTION
<!-- weltgewebe-risk: R2 -->

## Problem
Beim Löschen eines Knotens mit öffentlichen Gesprächsbeiträgen verwirft die Webschicht den konkreten API-Grund und meldet irreführend einen allgemeinen Datenkonflikt.

## Lösung
- stabile JSON-Problemkennung `node_conversation_not_empty` für die bestehende Schutzsperre
- Fehlerkörper für Domain-Write-Fehler erhalten
- getrennte, handlungsbezogene Meldungen für Bearbeiten und Löschen
- rollout-kompatibler Fallback für den bisherigen Klartextfehler
- Schutz der öffentlichen Gesprächshistorie bleibt unverändert
- Fehlerzuordnung wird bei Bedarf dynamisch geladen; das `/map`-Routenbudget bleibt grün

## Nachreview-Härtung
- Der 412-Vertrag entspricht dem Backend: Die aktuelle Knotenversion wird direkt als JSON geliefert.
- Ein 412-Körper wird nur übernommen, wenn er ein Objekt und kein Array ist und `id`, `title` sowie `updated_at` als Strings enthält.
- 412-Klartext und nicht knotenkonforme JSON-Problemkörper werden verworfen, statt als Knotendetails in den UI-Zustand zu gelangen.
- Regressionstests decken den gültigen direkten Knoten, Klartext und einen falschen JSON-Umschlag ab.

## Finaler Prüfstand
- Base: `9ca1fba682e6b2419fd544709639d744c5ceebaa`
- Head: `e0bae9e91535f97eebebd2d305d2c76e50cf2176`
- GitHub-PR-Diff SHA-256: `a4ba037ddda729aced9bcdd1c2bd27a44923dca3faf45505b9d8ee5d359eefa5`
- Correctness-Review: PASS, exakt revisionsgebunden
- Regression-/Nutzererlebnis-Review: PASS, exakt revisionsgebunden
- Review evidence gate: PASS, Run `30200122286`
- Keine offenen Review-Threads

## CI-Beleg
- CI: PASS
- API: PASS
- API-Smoke: PASS
- Web Check (Gate A): PASS
  - Typecheck
  - Lint
  - Produktionsbuild und `/map`-Routenbudget
  - Vitest
  - Playwright
- Kubernetes Platform: PASS
- Auth Passkey Register Proof: PASS
- Deploy Check: PASS
- Policies und SEO Archive: PASS
- Vercel- und Cloudflare-Preview: PASS

## Restrisiken
- Der konkrete Löschgrund wird erst nach dem autoritativen Serverversuch sichtbar. Eine künftig serverseitig projizierte Löschfähigkeit kann früher informieren, darf aber die finale Backendprüfung nicht ersetzen.
- Fehlerkörper werden clientseitig vollständig gelesen; die aktuellen same-origin API-Fehlerkörper sind klein. Eine explizite Größenobergrenze ist ein allgemeiner Resilienzpfad, aber kein Blocker dieses R2-Fixes.