### PR TITLE
fix(web): scope node conflict validation to node writes

### DIFF
--- a/apps/web/src/lib/api/domainWrites.test.ts
+++ b/apps/web/src/lib/api/domainWrites.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { deleteNode, replaceNode } from "./domainWrites";
+import { deleteNode, replaceNode, updateOwnGarnrolle } from "./domainWrites";
 
 afterEach(() => vi.unstubAllGlobals());
 
@@ -91,6 +91,14 @@ describe("domain writes", () => {
       "a non-node JSON problem",
       JSON.stringify({ code: "node_version_conflict", message: "conflict" }),
     ],
+    [
+      "a node-shaped response for another id",
+      JSON.stringify({
+        id: "node-b",
+        title: "Andere Version",
+        updated_at: "2026-07-26T08:00:00Z",
+      }),
+    ],
   ])("drops %s from 412 responses", async (_label, body) => {
     vi.stubGlobal(
       "fetch",
@@ -101,5 +109,26 @@ describe("domain writes", () => {
       status: 412,
       body: undefined,
     });
+  });
+
+  it("keeps non-node 412 bodies on non-node write paths", async () => {
+    const body = { code: "profile_version_conflict", message: "conflict" };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(body), {
+          status: 412,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    await expect(
+      updateOwnGarnrolle({
+        title: "Garnrolle",
+        tags: [],
+        map_state: "not_on_map",
+      }),
+    ).rejects.toMatchObject({ status: 412, body });
   });
 });

--- a/apps/web/src/lib/api/domainWrites.ts
+++ b/apps/web/src/lib/api/domainWrites.ts
@@ -15,13 +15,13 @@ export class ApiRequestError extends Error {
   }
 }
 
-function isNodeVersionConflictBody(body: unknown): boolean {
+function isNodeVersionConflictBody(body: unknown, expectedId: string): boolean {
   if (typeof body !== "object" || body === null || Array.isArray(body)) {
     return false;
   }
   const node = body as Record<string, unknown>;
   return (
-    typeof node.id === "string" &&
+    node.id === expectedId &&
     typeof node.title === "string" &&
     typeof node.updated_at === "string"
   );
@@ -32,13 +32,24 @@ async function readErrorBody(response: Response): Promise<unknown> {
   if (!text) return undefined;
 
   try {
-    const body = JSON.parse(text) as unknown;
-    return response.status === 412 && !isNodeVersionConflictBody(body)
-      ? undefined
-      : body;
+    return JSON.parse(text) as unknown;
   } catch {
-    return response.status === 412 ? undefined : text;
+    return text;
   }
+}
+
+function preserveOnlyMatchingNodeConflict(
+  error: unknown,
+  expectedId: string,
+): never {
+  if (
+    error instanceof ApiRequestError &&
+    error.status === 412 &&
+    !isNodeVersionConflictBody(error.body, expectedId)
+  ) {
+    error.body = undefined;
+  }
+  throw error;
 }
 
 async function requestJson<T>(
@@ -183,10 +194,16 @@ export function replaceNode(
   payload: ReplaceNodePayload,
   etag?: string,
 ): Promise<Node> {
-  return putJson<Node>(`/api/nodes/${encodeURIComponent(id)}`, payload, etag);
+  return putJson<Node>(
+    `/api/nodes/${encodeURIComponent(id)}`,
+    payload,
+    etag,
+  ).catch((error) => preserveOnlyMatchingNodeConflict(error, id));
 }
 
 /** DELETE /api/nodes/:id — delete a node and its derived connected edges. */
 export function deleteNode(id: string, etag?: string): Promise<void> {
-  return deleteResource(`/api/nodes/${encodeURIComponent(id)}`, etag);
+  return deleteResource(`/api/nodes/${encodeURIComponent(id)}`, etag).catch(
+    (error) => preserveOnlyMatchingNodeConflict(error, id),
+  );
 }

--- a/apps/web/tests/node-mutations.spec.ts
+++ b/apps/web/tests/node-mutations.spec.ts
@@ -190,13 +190,17 @@ test.describe("Knoten bearbeiten und löschen", () => {
         return;
       }
       observedIfMatch.push(request.headers()["if-match"] ?? "");
+      const requestedNodeId = decodeURIComponent(
+        new URL(request.url()).pathname.split("/").pop() ?? "",
+      );
+      expect(requestedNodeId).not.toBe("");
       putAttempt += 1;
       if (putAttempt === 1) {
         await route.fulfill({
           status: 412,
           contentType: "application/json",
           body: JSON.stringify({
-            id: "fake-id",
+            id: requestedNodeId,
             title: "Neuer Titel vom Server",
             kind: "Ort",
             summary: "Neue Kurzbeschreibung vom Server",
@@ -214,7 +218,7 @@ test.describe("Knoten bearbeiten und löschen", () => {
         status: 200,
         contentType: "application/json",
         body: JSON.stringify({
-          id: "fake-id",
+          id: requestedNodeId,
           ...payload,
           created_at: "2026-01-01T00:00:00Z",
           updated_at: "2026-07-18T10:01:00Z",


### PR DESCRIPTION
## Problem

PR #1583 wurde auf Head `e0bae9e91535f97eebebd2d305d2c76e50cf2176` gemergt, während ein anschließendes Selbstreview noch einen Correctness-Seiteneffekt fand: Die neue 412-Filterung saß im gemeinsamen Fehlertransport und verwarf dadurch nichtknotenförmige 412-Payloads anderer Domain-Schreibpfade. Außerdem war ein knotengeformter Payload nicht an die angefragte ID gebunden.

## Änderung

- allgemeines JSON-/Klartextlesen bleibt für alle Domain-Schreibpfade unverändert
- 412-Knotenvalidierung erfolgt ausschließlich in `replaceNode` und `deleteNode`
- akzeptiert wird nur ein Payload mit derselben erwarteten Knoten-ID sowie Stringwerten für `title` und `updated_at`
- Klartext, Problemobjekte und knotengeformte Antworten für eine andere ID werden verworfen
- nichtknotenförmige 412-Payloads anderer Domain-Schreibpfade bleiben erhalten

## Belege auf Head `aeb8fd16`

- 7/7 fokussierte Domain-Write-Tests grün
- vollständiger Web-CI-Pfad grün
- Prettier und ESLint grün
- Svelte-Check: 0 Fehler, 0 Warnungen
- Produktionsbuild und Routenbudget grün
- `/map`: 80.078 B JS gzip bei 80.500 B Grenze

Dieser PR enthält gegenüber dem gemergten `main` ausschließlich zwei Dateien mit +56/−10 Zeilen.

<!-- weltgewebe-risk: R2 -->