### PR TITLE
fix(platform): retire primary cluster before HA restore

### DIFF
--- a/scripts/ci/tests/test_kubernetes_ha_contract.py
+++ b/scripts/ci/tests/test_kubernetes_ha_contract.py
@@ -106,9 +106,7 @@ class KubernetesHaContractTests(unittest.TestCase):
             )
         )
         container = job["spec"]["template"]["spec"]["containers"][0]
-        database = next(
-            item for item in container["env"] if item["name"] == "DATABASE_URL"
-        )
+        database = next(item for item in container["env"] if item["name"] == "DATABASE_URL")
         self.assertEqual(
             database["valueFrom"].get("secretKeyRef"),
             {"name": "weltgewebe-ha-runtime", "key": "database-url"},
@@ -140,7 +138,9 @@ class KubernetesHaContractTests(unittest.TestCase):
                 {
                     "name": "barman-cloud.cloudnative-pg.io",
                     "isWALArchiver": True,
-                    "parameters": {"barmanObjectName": "weltgewebe-ha-backup"},
+                    "parameters": {
+                        "barmanObjectName": "weltgewebe-ha-backup"
+                    },
                 }
             ],
         )
@@ -159,7 +159,9 @@ class KubernetesHaContractTests(unittest.TestCase):
                 {
                     "name": "barman-cloud.cloudnative-pg.io",
                     "isWALArchiver": True,
-                    "parameters": {"barmanObjectName": "weltgewebe-ha-backup"},
+                    "parameters": {
+                        "barmanObjectName": "weltgewebe-ha-backup"
+                    },
                 }
             ],
         )
@@ -198,9 +200,7 @@ class KubernetesHaContractTests(unittest.TestCase):
         proof_workflow = yaml.safe_load(proof_text)
         self.assertEqual(set(pr_workflow["on"]), {"pull_request"})
         self.assertEqual(set(proof_workflow["on"]), {"push", "workflow_dispatch"})
-        expected_head = proof_workflow["on"]["workflow_dispatch"]["inputs"][
-            "expected_head"
-        ]
+        expected_head = proof_workflow["on"]["workflow_dispatch"]["inputs"]["expected_head"]
         self.assertIs(expected_head["required"], True)
         self.assertEqual(expected_head["type"], "string")
         self.assertNotIn("packages: read", pr_text)
@@ -334,13 +334,11 @@ class KubernetesHaContractTests(unittest.TestCase):
             "coredns-b": {"node": "node-b", "zone": "zone-b"},
             "coredns-c": {"node": "node-c", "zone": "zone-c"},
         }
-        with (
-            mock.patch.object(self.ha.ref, "run") as run,
-            mock.patch.object(self.ha.ref, "wait_rollout") as wait_rollout,
-            mock.patch.object(
-                self.ha, "pod_topology", return_value=topology
-            ) as pod_topology,
-        ):
+        with mock.patch.object(self.ha.ref, "run") as run, mock.patch.object(
+            self.ha.ref, "wait_rollout"
+        ) as wait_rollout, mock.patch.object(
+            self.ha, "pod_topology", return_value=topology
+        ) as pod_topology:
             observed = self.ha.configure_cluster_dns_ha("kubectl")
 
         self.assertEqual(observed, topology)
@@ -373,7 +371,9 @@ class KubernetesHaContractTests(unittest.TestCase):
             required,
             [
                 {
-                    "labelSelector": {"matchLabels": {"k8s-app": "kube-dns"}},
+                    "labelSelector": {
+                        "matchLabels": {"k8s-app": "kube-dns"}
+                    },
                     "topologyKey": "topology.kubernetes.io/zone",
                 }
             ],
@@ -391,17 +391,13 @@ class KubernetesHaContractTests(unittest.TestCase):
             "coredns-b": {"node": "node-a", "zone": "zone-a"},
             "coredns-c": {"node": "node-b", "zone": "zone-b"},
         }
-        with (
-            mock.patch.object(self.ha.ref, "run"),
-            mock.patch.object(self.ha.ref, "wait_rollout"),
-            mock.patch.object(self.ha, "pod_topology", return_value=topology),
-        ):
+        with mock.patch.object(self.ha.ref, "run"), mock.patch.object(
+            self.ha.ref, "wait_rollout"
+        ), mock.patch.object(self.ha, "pod_topology", return_value=topology):
             with self.assertRaisesRegex(self.ha.ref.ProofError, "not spread"):
                 self.ha.configure_cluster_dns_ha("kubectl")
 
-    def test_external_object_store_missing_volume_is_absent_case_insensitively(
-        self,
-    ) -> None:
+    def test_external_object_store_missing_volume_is_absent_case_insensitively(self) -> None:
         result = mock.Mock(
             returncode=1,
             stdout="",
@@ -412,7 +408,9 @@ class KubernetesHaContractTests(unittest.TestCase):
         )
         with mock.patch.object(self.ha.subprocess, "run", return_value=result):
             self.assertIsNone(
-                self.ha._object_store_labels("volume", "proof-object-store-data")
+                self.ha._object_store_labels(
+                    "volume", "proof-object-store-data"
+                )
             )
 
     def test_strict_external_object_store_uses_verified_local_mirror_ref(self) -> None:
@@ -425,10 +423,9 @@ class KubernetesHaContractTests(unittest.TestCase):
                 }
             }
         }
-        with (
-            mock.patch.object(self.ha.ref, "controlled_oci_strict", return_value=True),
-            mock.patch.object(self.ha.ref, "_oci_mirror_lock", return_value=lock),
-        ):
+        with mock.patch.object(
+            self.ha.ref, "controlled_oci_strict", return_value=True
+        ), mock.patch.object(self.ha.ref, "_oci_mirror_lock", return_value=lock):
             self.assertEqual(self.ha.external_object_store_runtime_image(), local_ref)
 
     def test_strict_external_object_store_rejects_mirror_binding_drift(self) -> None:
@@ -440,23 +437,19 @@ class KubernetesHaContractTests(unittest.TestCase):
                 }
             }
         }
-        with (
-            mock.patch.object(self.ha.ref, "controlled_oci_strict", return_value=True),
-            mock.patch.object(self.ha.ref, "_oci_mirror_lock", return_value=lock),
-        ):
-            with self.assertRaisesRegex(
-                self.ha.ref.ProofError, "canonical reference drift"
-            ):
+        with mock.patch.object(
+            self.ha.ref, "controlled_oci_strict", return_value=True
+        ), mock.patch.object(self.ha.ref, "_oci_mirror_lock", return_value=lock):
+            with self.assertRaisesRegex(self.ha.ref.ProofError, "canonical reference drift"):
                 self.ha.external_object_store_runtime_image()
 
     def test_external_object_store_cleanup_is_ownership_bound(self) -> None:
         foreign = self.ha.external_object_store_binding(
             "proof", "a" * 40, "owner-foreign"
         )
-        with (
-            mock.patch.object(self.ha, "_object_store_labels", return_value=foreign),
-            mock.patch.object(self.ha.ref, "run") as delete,
-        ):
+        with mock.patch.object(
+            self.ha, "_object_store_labels", return_value=foreign
+        ), mock.patch.object(self.ha.ref, "run") as delete:
             with self.assertRaisesRegex(self.ha.ref.ProofError, "foreign"):
                 self.ha.delete_external_object_store(
                     "proof", "a" * 40, "owner-expected"
@@ -464,25 +457,18 @@ class KubernetesHaContractTests(unittest.TestCase):
         delete.assert_not_called()
 
     def test_external_object_store_start_cleans_partial_owned_resources(self) -> None:
-        with (
-            mock.patch.object(
-                self.ha, "_object_store_labels", side_effect=[None, None]
-            ),
-            mock.patch.object(self.ha.ref, "run"),
-            mock.patch.object(
-                self.ha,
-                "run_with_environment",
-                side_effect=self.ha.ref.ProofError("container start failed"),
-            ),
-            mock.patch.object(
-                self.ha,
-                "reconcile_external_object_store",
-                return_value={"resources": {}, "errors": {}},
-            ) as cleanup,
-        ):
-            with self.assertRaisesRegex(
-                self.ha.ref.ProofError, "container start failed"
-            ):
+        with mock.patch.object(
+            self.ha, "_object_store_labels", side_effect=[None, None]
+        ), mock.patch.object(self.ha.ref, "run"), mock.patch.object(
+            self.ha,
+            "run_with_environment",
+            side_effect=self.ha.ref.ProofError("container start failed"),
+        ), mock.patch.object(
+            self.ha,
+            "reconcile_external_object_store",
+            return_value={"resources": {}, "errors": {}},
+        ) as cleanup:
+            with self.assertRaisesRegex(self.ha.ref.ProofError, "container start failed"):
                 self.ha.start_external_object_store(
                     "proof", "a" * 40, "owner-proof", "secret"
                 )
@@ -492,15 +478,12 @@ class KubernetesHaContractTests(unittest.TestCase):
         reservation_context = mock.MagicMock()
         reservation_context.__enter__.return_value = None
         reservation_context.__exit__.return_value = False
-        with (
-            mock.patch.object(
-                self.ha.ref,
-                "cluster_creation_reservation",
-                return_value=reservation_context,
-            ) as reservation,
-            mock.patch.object(
-                self.ha.ref, "run", side_effect=self.ha.ref.ProofError("kind failed")
-            ),
+        with mock.patch.object(
+            self.ha.ref,
+            "cluster_creation_reservation",
+            return_value=reservation_context,
+        ) as reservation, mock.patch.object(
+            self.ha.ref, "run", side_effect=self.ha.ref.ProofError("kind failed")
         ):
             with self.assertRaisesRegex(self.ha.ref.ProofError, "kind failed"):
                 self.ha.create_kind_cluster(
@@ -511,27 +494,26 @@ class KubernetesHaContractTests(unittest.TestCase):
                     "b" * 40,
                     "owner-proof",
                 )
-        reservation.assert_called_once_with("kind", "proof", "b" * 40, "owner-proof")
+        reservation.assert_called_once_with(
+            "kind", "proof", "b" * 40, "owner-proof"
+        )
 
     def test_ha_cleanup_continues_after_one_cluster_failure(self) -> None:
-        with (
-            mock.patch.object(
-                self.ha.ref,
-                "delete_owned_cluster_if_present",
-                side_effect=[self.ha.ref.ProofError("restore marker unreadable"), True],
-            ) as delete_cluster,
-            mock.patch.object(
-                self.ha,
-                "reconcile_external_object_store",
-                return_value={
-                    "resources": {
-                        "object_store_container": "deleted",
-                        "object_store_volume": "absent",
-                    },
-                    "errors": {},
+        with mock.patch.object(
+            self.ha.ref,
+            "delete_owned_cluster_if_present",
+            side_effect=[self.ha.ref.ProofError("restore marker unreadable"), True],
+        ) as delete_cluster, mock.patch.object(
+            self.ha,
+            "reconcile_external_object_store",
+            return_value={
+                "resources": {
+                    "object_store_container": "deleted",
+                    "object_store_volume": "absent",
                 },
-            ) as object_store,
-        ):
+                "errors": {},
+            },
+        ) as object_store:
             result = self.ha.reconcile_owned_ha_resources(
                 "kind", "proof", "a" * 40, "owner-proof"
             )
@@ -557,21 +539,18 @@ class KubernetesHaContractTests(unittest.TestCase):
         )
 
     def test_ha_cleanup_reports_absent_when_nothing_exists(self) -> None:
-        with (
-            mock.patch.object(
-                self.ha.ref, "delete_owned_cluster_if_present", return_value=False
-            ),
-            mock.patch.object(
-                self.ha,
-                "reconcile_external_object_store",
-                return_value={
-                    "resources": {
-                        "object_store_container": "absent",
-                        "object_store_volume": "absent",
-                    },
-                    "errors": {},
+        with mock.patch.object(
+            self.ha.ref, "delete_owned_cluster_if_present", return_value=False
+        ), mock.patch.object(
+            self.ha,
+            "reconcile_external_object_store",
+            return_value={
+                "resources": {
+                    "object_store_container": "absent",
+                    "object_store_volume": "absent",
                 },
-            ),
+                "errors": {},
+            },
         ):
             result = self.ha.reconcile_owned_ha_resources(
                 "kind", "proof", "a" * 40, "owner-proof"
@@ -627,15 +606,11 @@ class KubernetesHaContractTests(unittest.TestCase):
             ({"status": "invalid"}, "got None"),
         )
         for result, expected_state in cases:
-            with (
-                self.subTest(result=result),
-                mock.patch.object(
-                    self.ha, "reconcile_owned_ha_resources", return_value=result
-                ),
+            with self.subTest(result=result), mock.patch.object(
+                self.ha, "reconcile_owned_ha_resources", return_value=result
             ):
                 with self.assertRaisesRegex(
-                    self.ha.ref.ProofError,
-                    expected_state,
+                    self.ha.ref.ProofError, expected_state
                 ):
                     self.ha.retire_primary_cluster_before_restore(
                         "kind", "proof", "a" * 40, "owner-proof"
@@ -653,10 +628,9 @@ class KubernetesHaContractTests(unittest.TestCase):
         create = mock.Mock()
         calls.attach_mock(retire, "retire")
         calls.attach_mock(create, "create")
-        with (
-            mock.patch.object(self.ha, "retire_primary_cluster_before_restore", retire),
-            mock.patch.object(self.ha, "create_kind_cluster", create),
-        ):
+        with mock.patch.object(
+            self.ha, "retire_primary_cluster_before_restore", retire
+        ), mock.patch.object(self.ha, "create_kind_cluster", create):
             result = self.ha.create_blank_restore_cluster(
                 "kind",
                 "proof",
@@ -688,12 +662,9 @@ class KubernetesHaContractTests(unittest.TestCase):
 
     def test_blank_restore_keep_mode_skips_primary_retirement(self) -> None:
         lifecycle = self.ha.ClusterLifecycle(primary_created=True)
-        with (
-            mock.patch.object(
-                self.ha, "retire_primary_cluster_before_restore"
-            ) as retire,
-            mock.patch.object(self.ha, "create_kind_cluster") as create,
-        ):
+        with mock.patch.object(
+            self.ha, "retire_primary_cluster_before_restore"
+        ) as retire, mock.patch.object(self.ha, "create_kind_cluster") as create:
             result = self.ha.create_blank_restore_cluster(
                 "kind",
                 "proof",
@@ -720,17 +691,14 @@ class KubernetesHaContractTests(unittest.TestCase):
 
     def test_blank_restore_creation_failure_preserves_cleanup_truth(self) -> None:
         lifecycle = self.ha.ClusterLifecycle(primary_created=True)
-        with (
-            mock.patch.object(
-                self.ha,
-                "retire_primary_cluster_before_restore",
-                return_value={"status": "deleted"},
-            ),
-            mock.patch.object(
-                self.ha,
-                "create_kind_cluster",
-                side_effect=self.ha.ref.ProofError("restore create failed"),
-            ),
+        with mock.patch.object(
+            self.ha,
+            "retire_primary_cluster_before_restore",
+            return_value={"status": "deleted"},
+        ), mock.patch.object(
+            self.ha,
+            "create_kind_cluster",
+            side_effect=self.ha.ref.ProofError("restore create failed"),
         ):
             with self.assertRaisesRegex(
                 self.ha.ref.ProofError, "restore create failed"
@@ -751,10 +719,8 @@ class KubernetesHaContractTests(unittest.TestCase):
 
     def test_digest_locked_manifest_replaces_each_release_image_once(self) -> None:
         tagged = {
-            "registry.example/controller:v1": "registry.example/controller@sha256:"
-            + "a" * 64,
-            "registry.example/webhook:v1": "registry.example/webhook@sha256:"
-            + "b" * 64,
+            "registry.example/controller:v1": "registry.example/controller@sha256:" + "a" * 64,
+            "registry.example/webhook:v1": "registry.example/webhook@sha256:" + "b" * 64,
         }
         with tempfile.TemporaryDirectory() as directory:
             artifact = Path(directory) / "release.yaml"
@@ -775,14 +741,16 @@ class KubernetesHaContractTests(unittest.TestCase):
 
     def test_cert_manager_install_waits_and_verifies_digest_images(self) -> None:
         expected = list(self.ha.CERT_MANAGER_IMAGES.values())
-        with (
-            mock.patch.object(
-                self.ha, "apply_digest_locked_manifest"
-            ) as apply_manifest,
-            mock.patch.object(self.ha.ref, "run") as run,
-            mock.patch.object(self.ha.ref, "wait_rollout") as wait_rollout,
-            mock.patch.object(self.ha, "wait_until") as wait_until,
-            mock.patch.object(self.ha.ref, "output", side_effect=expected),
+        with mock.patch.object(
+            self.ha, "apply_digest_locked_manifest"
+        ) as apply_manifest, mock.patch.object(
+            self.ha.ref, "run"
+        ) as run, mock.patch.object(
+            self.ha.ref, "wait_rollout"
+        ) as wait_rollout, mock.patch.object(
+            self.ha, "wait_until"
+        ) as wait_until, mock.patch.object(
+            self.ha.ref, "output", side_effect=expected
         ):
             self.ha.install_cert_manager("kubectl", "cert-manager.yaml")
         apply_manifest.assert_called_once_with(
@@ -793,7 +761,9 @@ class KubernetesHaContractTests(unittest.TestCase):
         wait_until.assert_called_once()
 
     def test_barman_manifest_pins_operator_and_sidecar_images(self) -> None:
-        sidecar_tag = "ghcr.io/cloudnative-pg/plugin-barman-cloud-sidecar:v0.13.0"
+        sidecar_tag = (
+            "ghcr.io/cloudnative-pg/plugin-barman-cloud-sidecar:v0.13.0"
+        )
         encoded = self.ha.base64.b64encode(sidecar_tag.encode()).decode()
         source = (
             "apiVersion: v1\nkind: Secret\nmetadata:\n  name: sidecar\n"
@@ -858,7 +828,9 @@ class KubernetesHaContractTests(unittest.TestCase):
                                     "name": "barman-cloud",
                                     "ready": index == leader_index,
                                     "state": {
-                                        "running": {"startedAt": "2026-07-18T11:32:39Z"}
+                                        "running": {
+                                            "startedAt": "2026-07-18T11:32:39Z"
+                                        }
                                     },
                                 }
                             ],
@@ -904,17 +876,21 @@ class KubernetesHaContractTests(unittest.TestCase):
                 self.barman_plugin_endpoint_payload(2),
             ],
         ):
-            state = self.ha.barman_plugin_state("kubectl", require_three_nodes=True)
+            state = self.ha.barman_plugin_state(
+                "kubectl", require_three_nodes=True
+            )
         self.assertEqual(state["nodes"], ["worker-1", "worker-2", "worker-3"])
-        self.assertEqual(state["leader"], {"pod": "barman-cloud-2", "node": "worker-2"})
+        self.assertEqual(
+            state["leader"], {"pod": "barman-cloud-2", "node": "worker-2"}
+        )
 
-    def test_barman_plugin_state_ignores_stale_container_ready_after_node_loss(
-        self,
-    ) -> None:
+    def test_barman_plugin_state_ignores_stale_container_ready_after_node_loss(self) -> None:
         pods = json.loads(self.barman_plugin_pod_payload(2))
         old_leader = pods["items"][0]
         old_leader["status"]["containerStatuses"][0]["ready"] = True
-        old_leader["status"]["conditions"] = [{"type": "Ready", "status": "False"}]
+        old_leader["status"]["conditions"] = [
+            {"type": "Ready", "status": "False"}
+        ]
         with mock.patch.object(
             self.ha.ref,
             "output",
@@ -923,8 +899,12 @@ class KubernetesHaContractTests(unittest.TestCase):
                 self.barman_plugin_endpoint_payload(2),
             ],
         ):
-            state = self.ha.barman_plugin_state("kubectl", require_three_nodes=False)
-        self.assertEqual(state["leader"], {"pod": "barman-cloud-2", "node": "worker-2"})
+            state = self.ha.barman_plugin_state(
+                "kubectl", require_three_nodes=False
+            )
+        self.assertEqual(
+            state["leader"], {"pod": "barman-cloud-2", "node": "worker-2"}
+        )
 
     def test_barman_plugin_install_waits_and_verifies_digest_images(self) -> None:
         secret_payload = json.dumps(
@@ -949,20 +929,22 @@ class KubernetesHaContractTests(unittest.TestCase):
             },
             "leader": {"pod": "barman-cloud-1", "node": "worker-1"},
         }
-        with (
-            mock.patch.object(self.ha, "apply_barman_cloud_manifest") as apply_manifest,
-            mock.patch.object(self.ha.ref, "run") as run,
-            mock.patch.object(self.ha.ref, "wait_condition") as wait_condition,
-            mock.patch.object(
-                self.ha, "verify_barman_plugin_ha", return_value=state
-            ) as verify_ha,
-            mock.patch.object(
-                self.ha.ref,
-                "output",
-                side_effect=[secret_payload, self.ha.BARMAN_CLOUD_PLUGIN_IMAGE],
-            ),
+        with mock.patch.object(
+            self.ha, "apply_barman_cloud_manifest"
+        ) as apply_manifest, mock.patch.object(
+            self.ha.ref, "run"
+        ) as run, mock.patch.object(
+            self.ha.ref, "wait_condition"
+        ) as wait_condition, mock.patch.object(
+            self.ha, "verify_barman_plugin_ha", return_value=state
+        ) as verify_ha, mock.patch.object(
+            self.ha.ref,
+            "output",
+            side_effect=[secret_payload, self.ha.BARMAN_CLOUD_PLUGIN_IMAGE],
         ):
-            observed = self.ha.install_barman_cloud_plugin("kubectl", "barman.yaml")
+            observed = self.ha.install_barman_cloud_plugin(
+                "kubectl", "barman.yaml"
+            )
         apply_manifest.assert_called_once_with("kubectl", "barman.yaml")
         self.assertIn("crd/objectstores.barmancloud.cnpg.io", run.call_args.args[0])
         self.assertEqual(wait_condition.call_count, 2)
@@ -981,7 +963,9 @@ class KubernetesHaContractTests(unittest.TestCase):
             with self.assertRaisesRegex(
                 self.ha.ref.ProofError, "exactly its elected ready leader"
             ):
-                self.ha.barman_plugin_state("kubectl", require_three_nodes=True)
+                self.ha.barman_plugin_state(
+                    "kubectl", require_three_nodes=True
+                )
 
     def test_barman_plugin_backup_proves_completed_plugin_rpc(self) -> None:
         completed = {
@@ -991,12 +975,9 @@ class KubernetesHaContractTests(unittest.TestCase):
                 "instanceID": {"podName": "postgres-ha-2"},
             }
         }
-        with (
-            mock.patch.object(self.ha.ref, "apply_yaml") as apply_yaml,
-            mock.patch.object(
-                self.ha, "wait_backup_complete", return_value=completed
-            ) as wait_backup,
-        ):
+        with mock.patch.object(self.ha.ref, "apply_yaml") as apply_yaml, mock.patch.object(
+            self.ha, "wait_backup_complete", return_value=completed
+        ) as wait_backup:
             result = self.ha.prove_barman_plugin_backup(
                 "kubectl", "postgres-ha", "probe-backup"
             )
@@ -1018,9 +999,7 @@ class KubernetesHaContractTests(unittest.TestCase):
             },
         )
 
-    def test_postgres_primary_alignment_promotes_to_existing_barman_leader(
-        self,
-    ) -> None:
+    def test_postgres_primary_alignment_promotes_to_existing_barman_leader(self) -> None:
         plugin_state = {
             "nodes": ["worker-1", "worker-2", "worker-3"],
             "pods": {
@@ -1041,26 +1020,17 @@ class KubernetesHaContractTests(unittest.TestCase):
             "method": "plugin",
             "pod": "postgres-ha-2",
         }
-        with (
-            mock.patch.object(
-                self.ha,
-                "verify_barman_plugin_ha",
-                side_effect=[plugin_state, plugin_state],
-            ),
-            mock.patch.object(
-                self.ha,
-                "current_primary",
-                side_effect=["postgres-ha-1", "postgres-ha-2"],
-            ),
-            mock.patch.object(
-                self.ha, "wait_until", return_value="postgres-ha-2"
-            ) as wait_until,
-            mock.patch.object(self.ha, "wait_cluster_ready") as wait_ready,
-            mock.patch.object(
-                self.ha, "prove_barman_plugin_backup", return_value=communication
-            ) as prove_backup,
-            mock.patch.object(self.ha.ref, "run") as run,
-        ):
+        with mock.patch.object(
+            self.ha, "verify_barman_plugin_ha", side_effect=[plugin_state, plugin_state]
+        ), mock.patch.object(
+            self.ha, "current_primary", side_effect=["postgres-ha-1", "postgres-ha-2"]
+        ), mock.patch.object(
+            self.ha, "wait_until", return_value="postgres-ha-2"
+        ) as wait_until, mock.patch.object(
+            self.ha, "wait_cluster_ready"
+        ) as wait_ready, mock.patch.object(
+            self.ha, "prove_barman_plugin_backup", return_value=communication
+        ) as prove_backup, mock.patch.object(self.ha.ref, "run") as run:
             result = self.ha.align_postgres_primary_with_barman_leader(
                 "kubectl-cnpg",
                 "kubectl",
@@ -1082,7 +1052,9 @@ class KubernetesHaContractTests(unittest.TestCase):
         self.assertNotIn("delete", run.call_args.args[0])
         wait_until.assert_called_once()
         wait_ready.assert_called_once_with("kubectl", "postgres-ha", "10m")
-        prove_backup.assert_called_once_with("kubectl", "postgres-ha", "probe-backup")
+        prove_backup.assert_called_once_with(
+            "kubectl", "postgres-ha", "probe-backup"
+        )
         self.assertEqual(result["target_node"], "worker-2")
         self.assertEqual(result["postgres_primary_before"], "postgres-ha-1")
         self.assertEqual(result["postgres_primary_aligned"], "postgres-ha-2")
@@ -1097,7 +1069,9 @@ class KubernetesHaContractTests(unittest.TestCase):
             },
             "leader": {"pod": "barman-cloud-2", "node": "worker-2"},
         }
-        with mock.patch.object(self.ha, "barman_plugin_state", return_value=surviving):
+        with mock.patch.object(
+            self.ha, "barman_plugin_state", return_value=surviving
+        ):
             leader = self.ha.wait_barman_plugin_leader_after_node_loss(
                 "kubectl", "worker-3"
             )
@@ -1124,7 +1098,9 @@ class KubernetesHaContractTests(unittest.TestCase):
                             "name": "plugin-barman-cloud",
                             "imageID": f"ghcr.io/cloudnative-pg/sidecar@{digest}",
                             "ready": True,
-                            "state": {"running": {"startedAt": "2026-07-18T08:00:00Z"}},
+                            "state": {
+                                "running": {"startedAt": "2026-07-18T08:00:00Z"}
+                            },
                         }
                     ]
                 },
@@ -1137,13 +1113,13 @@ class KubernetesHaContractTests(unittest.TestCase):
                 {"items": [pod("postgres-1"), pod("postgres-2"), pod("postgres-3")]}
             ),
         ):
-            observed = self.ha.verify_barman_sidecar_images("kubectl", "postgres-ha")
+            observed = self.ha.verify_barman_sidecar_images(
+                "kubectl", "postgres-ha"
+            )
         self.assertEqual(sorted(observed), ["postgres-1", "postgres-2", "postgres-3"])
         self.assertTrue(all(item["ready"] is True for item in observed.values()))
 
-    def test_barman_instance_sidecar_validation_fails_closed_when_not_ready(
-        self,
-    ) -> None:
+    def test_barman_instance_sidecar_validation_fails_closed_when_not_ready(self) -> None:
         payload = {
             "items": [
                 {
@@ -1169,10 +1145,10 @@ class KubernetesHaContractTests(unittest.TestCase):
                 }
             ]
         }
-        with mock.patch.object(self.ha.ref, "output", return_value=json.dumps(payload)):
-            with self.assertRaisesRegex(
-                self.ha.ref.ProofError, "not running and ready"
-            ):
+        with mock.patch.object(
+            self.ha.ref, "output", return_value=json.dumps(payload)
+        ):
+            with self.assertRaisesRegex(self.ha.ref.ProofError, "not running and ready"):
                 self.ha.verify_barman_sidecar_images("kubectl", "postgres-ha")
 
     def cnpg_release_fixture(self) -> str:
@@ -1227,14 +1203,14 @@ spec:
             required,
             [
                 {
-                    "labelSelector": {
-                        "matchLabels": {"app.kubernetes.io/name": "cloudnative-pg"}
-                    },
+                    "labelSelector": {"matchLabels": {"app.kubernetes.io/name": "cloudnative-pg"}},
                     "topologyKey": "kubernetes.io/hostname",
                 }
             ],
         )
-        self.assertNotIn("ghcr.io/cloudnative-pg/cloudnative-pg:1.30.0", rendered)
+        self.assertNotIn(
+            "ghcr.io/cloudnative-pg/cloudnative-pg:1.30.0", rendered
+        )
         self.assertEqual(rendered.count(self.ha.CNPG_OPERATOR_IMAGE), 2)
 
     def test_cnpg_release_uses_server_side_apply(self) -> None:
@@ -1242,17 +1218,14 @@ spec:
         artifact.parent.mkdir(parents=True, exist_ok=True)
         artifact.write_text(self.cnpg_release_fixture())
         try:
-            with (
-                mock.patch.object(self.ha.ref, "run") as run,
-                mock.patch.object(
-                    self.ha,
-                    "verify_cnpg_operator_ha",
-                    return_value=["node-a", "node-b", "node-c"],
-                ) as verify_ha,
-                mock.patch.object(self.ha, "wait_until"),
-                mock.patch.object(
-                    self.ha.ref, "output", return_value=self.ha.CNPG_OPERATOR_IMAGE
-                ),
+            with mock.patch.object(self.ha.ref, "run") as run, mock.patch.object(
+                self.ha,
+                "verify_cnpg_operator_ha",
+                return_value=["node-a", "node-b", "node-c"],
+            ) as verify_ha, mock.patch.object(
+                self.ha, "wait_until"
+            ), mock.patch.object(
+                self.ha.ref, "output", return_value=self.ha.CNPG_OPERATOR_IMAGE
             ):
                 observed_nodes = self.ha.install_cnpg("kubectl", str(artifact))
             verify_ha.assert_called_once_with("kubectl")
@@ -1290,9 +1263,10 @@ spec:
                 ]
             }
         )
-        with (
-            mock.patch.object(self.ha.ref, "wait_rollout") as wait_rollout,
-            mock.patch.object(self.ha.ref, "output", side_effect=["3", pods]),
+        with mock.patch.object(
+            self.ha.ref, "wait_rollout"
+        ) as wait_rollout, mock.patch.object(
+            self.ha.ref, "output", side_effect=["3", pods]
         ):
             observed_nodes = self.ha.verify_cnpg_operator_ha("kubectl")
         self.assertEqual(observed_nodes, ["node-a", "node-b", "node-c"])
@@ -1302,12 +1276,8 @@ spec:
 
     def test_cnpg_webhook_probe_requires_endpoint_and_server_dry_run(self) -> None:
         endpoint = mock.Mock(returncode=0, stdout="10.0.0.12")
-        dry_run = mock.Mock(
-            returncode=0, stdout="cluster.postgresql.cnpg.io/probe serverside-applied"
-        )
-        with mock.patch.object(
-            self.ha.subprocess, "run", side_effect=[endpoint, dry_run]
-        ) as run:
+        dry_run = mock.Mock(returncode=0, stdout="cluster.postgresql.cnpg.io/probe serverside-applied")
+        with mock.patch.object(self.ha.subprocess, "run", side_effect=[endpoint, dry_run]) as run:
             self.assertTrue(self.ha.cnpg_webhook_ready("kubectl"))
         endpoint_argv = run.call_args_list[0].args[0]
         dry_run_argv = run.call_args_list[1].args[0]
@@ -1326,11 +1296,11 @@ spec:
 
     def test_ha_diagnostic_snapshot_captures_cnpg_and_storage_evidence(self) -> None:
         completed = mock.Mock(stdout="evidence\n", stderr="")
-        with (
-            tempfile.TemporaryDirectory() as directory,
-            mock.patch.object(self.ha, "CACHE", Path(directory)),
-            mock.patch.object(self.ha.subprocess, "run", return_value=completed) as run,
-        ):
+        with tempfile.TemporaryDirectory() as directory, mock.patch.object(
+            self.ha, "CACHE", Path(directory)
+        ), mock.patch.object(
+            self.ha.subprocess, "run", return_value=completed
+        ) as run:
             self.ha.ha_diagnostic_snapshot("kubectl", "proof")
             target = Path(directory) / "failures" / "proof"
             self.assertEqual(
@@ -1386,7 +1356,8 @@ spec:
         documents = list(
             self.ha.yaml.safe_load_all(
                 (
-                    ROOT / "platform/apps/weltgewebe/overlays/ha/deployment-patch.yaml"
+                    ROOT
+                    / "platform/apps/weltgewebe/overlays/ha/deployment-patch.yaml"
                 ).read_text()
             )
         )
@@ -1399,10 +1370,12 @@ spec:
         self.assertEqual(spec["replicas"], 3)
         self.assertEqual(spec["strategy"]["type"], "RollingUpdate")
         self.assertEqual(spec["strategy"]["rollingUpdate"]["maxSurge"], 1)
-        self.assertEqual(spec["strategy"]["rollingUpdate"]["maxUnavailable"], 0)
-        preferred = spec["template"]["spec"]["affinity"]["podAntiAffinity"][
-            "preferredDuringSchedulingIgnoredDuringExecution"
-        ]
+        self.assertEqual(
+            spec["strategy"]["rollingUpdate"]["maxUnavailable"], 0
+        )
+        preferred = spec["template"]["spec"]["affinity"][
+            "podAntiAffinity"
+        ]["preferredDuringSchedulingIgnoredDuringExecution"]
         self.assertEqual(preferred[0]["weight"], 100)
         self.assertEqual(
             preferred[0]["podAffinityTerm"]["topologyKey"],
@@ -1415,11 +1388,12 @@ spec:
     def test_upgrade_candidate_is_distinct_and_loaded_into_kind(self) -> None:
         baseline = "sha256:" + "a" * 64
         candidate = "sha256:" + "b" * 64
-        with (
-            mock.patch.object(self.ha.ref, "run") as run,
-            mock.patch.object(self.ha.ref, "output", side_effect=[baseline, candidate]),
+        with mock.patch.object(self.ha.ref, "run") as run, mock.patch.object(
+            self.ha.ref, "output", side_effect=[baseline, candidate]
         ):
-            observed = self.ha.prepare_api_upgrade_candidate("kind", "proof", "c" * 40)
+            observed = self.ha.prepare_api_upgrade_candidate(
+                "kind", "proof", "c" * 40
+            )
         self.assertEqual(
             observed,
             {
@@ -1428,12 +1402,8 @@ spec:
             },
         )
         build = run.call_args_list[0]
-        self.assertEqual(
-            build.args[0][:5], ["docker", "build", "--pull=false", "--file", "-"]
-        )
-        self.assertIn(
-            "org.opencontainers.image.revision=" + "c" * 40, build.kwargs["input_text"]
-        )
+        self.assertEqual(build.args[0][:5], ["docker", "build", "--pull=false", "--file", "-"])
+        self.assertIn("org.opencontainers.image.revision=" + "c" * 40, build.kwargs["input_text"])
         self.assertEqual(
             run.call_args_list[1].args[0],
             [
@@ -1483,9 +1453,7 @@ spec:
         self.assertEqual(run.call_args.kwargs["timeout"], 5)
         self.assertFalse(run.call_args.kwargs["check"])
 
-    def test_gateway_owner_sample_tolerates_one_failed_advertised_listener(
-        self,
-    ) -> None:
+    def test_gateway_owner_sample_tolerates_one_failed_advertised_listener(self) -> None:
         node_addresses = {
             "node-a": "10.0.0.1",
             "node-b": "10.0.0.2",
@@ -1504,12 +1472,12 @@ spec:
                 "returncode": 0 if available else 28,
             }
 
-        with (
-            mock.patch.object(
-                self.ha.ref, "kind_nodes", return_value=["node-a", "node-b"]
-            ),
-            mock.patch.object(self.ha.ref, "output", side_effect=output),
-            mock.patch.object(self.ha, "gateway_projection_sample", side_effect=sample),
+        with mock.patch.object(
+            self.ha.ref, "kind_nodes", return_value=["node-a", "node-b"]
+        ), mock.patch.object(
+            self.ha.ref, "output", side_effect=output
+        ), mock.patch.object(
+            self.ha, "gateway_projection_sample", side_effect=sample
         ):
             observed = self.ha.gateway_owner_sample(
                 "kind", "proof", ["10.0.0.1", "10.0.0.2"], 80, "marker"
@@ -1518,30 +1486,26 @@ spec:
         self.assertTrue(observed["available"])
         self.assertEqual(observed["failed_paths"], 1)
         self.assertEqual(observed["successful_addresses"], ["10.0.0.2"])
-        self.assertEqual(observed["probe_mode"], "owner-node-any-advertised-address")
+        self.assertEqual(
+            observed["probe_mode"], "owner-node-any-advertised-address"
+        )
 
-    def test_gateway_owner_sample_fails_when_all_advertised_listeners_fail(
-        self,
-    ) -> None:
+    def test_gateway_owner_sample_fails_when_all_advertised_listeners_fail(self) -> None:
         node_addresses = {
             "node-a": "10.0.0.1",
             "node-b": "10.0.0.2",
         }
 
-        with (
-            mock.patch.object(
-                self.ha.ref, "kind_nodes", return_value=["node-a", "node-b"]
-            ),
-            mock.patch.object(
-                self.ha.ref,
-                "output",
-                side_effect=lambda argv: node_addresses[argv[-1]],
-            ),
-            mock.patch.object(
-                self.ha,
-                "gateway_projection_sample",
-                return_value={"available": False, "returncode": 28},
-            ),
+        with mock.patch.object(
+            self.ha.ref, "kind_nodes", return_value=["node-a", "node-b"]
+        ), mock.patch.object(
+            self.ha.ref,
+            "output",
+            side_effect=lambda argv: node_addresses[argv[-1]],
+        ), mock.patch.object(
+            self.ha,
+            "gateway_projection_sample",
+            return_value={"available": False, "returncode": 28},
         ):
             observed = self.ha.gateway_owner_sample(
                 "kind", "proof", ["10.0.0.1", "10.0.0.2"], 80, "marker"
@@ -1552,9 +1516,10 @@ spec:
         self.assertEqual(observed["failed_paths"], 2)
 
     def test_gateway_owner_sample_rejects_unowned_advertised_address(self) -> None:
-        with (
-            mock.patch.object(self.ha.ref, "kind_nodes", return_value=["node-a"]),
-            mock.patch.object(self.ha.ref, "output", return_value="10.0.0.1"),
+        with mock.patch.object(
+            self.ha.ref, "kind_nodes", return_value=["node-a"]
+        ), mock.patch.object(
+            self.ha.ref, "output", return_value="10.0.0.1"
         ):
             with self.assertRaisesRegex(
                 self.ha.ref.ProofError, "exactly one kind node owner"
@@ -1569,7 +1534,9 @@ spec:
             stdout="",
             stderr="curl: (28) Operation timed out",
         )
-        with mock.patch.object(self.ha.subprocess, "run", return_value=completed):
+        with mock.patch.object(
+            self.ha.subprocess, "run", return_value=completed
+        ):
             sample = self.ha.gateway_projection_sample(
                 "kind-worker", "10.0.0.10", 80, "marker"
             )
@@ -1584,7 +1551,9 @@ spec:
             stdout=json.dumps(42),
             stderr="",
         )
-        with mock.patch.object(self.ha.subprocess, "run", return_value=completed):
+        with mock.patch.object(
+            self.ha.subprocess, "run", return_value=completed
+        ):
             sample = self.ha.gateway_projection_sample(
                 "kind-worker", "10.0.0.10", 80, "marker"
             )
@@ -1604,17 +1573,21 @@ spec:
             },
         )
         self.assertEqual(budget["measurement_window_seconds"], 50.0)
-        self.assertEqual(budget["objective"], self.ha.REFERENCE_AVAILABILITY_OBJECTIVE)
+        self.assertEqual(
+            budget["objective"], self.ha.REFERENCE_AVAILABILITY_OBJECTIVE
+        )
         self.assertEqual(budget["consumed_ratio"], 0.0)
         self.assertTrue(budget["within_budget"])
 
-    def test_change_management_contract_uses_rollout_undo_and_receipt_fields(
-        self,
-    ) -> None:
+    def test_change_management_contract_uses_rollout_undo_and_receipt_fields(self) -> None:
         source = (ROOT / "scripts/platform/ha_reference.py").read_text()
-        self.assertIn('"rollout",\n            "undo"', source)
+        self.assertIn(
+            '"rollout",\n            "undo"', source
+        )
         self.assertIn('"change_management": change_management', source)
-        self.assertIn("kubectl, kind, args.cluster, marker, gateway_before", source)
+        self.assertIn(
+            "kubectl, kind, args.cluster, marker, gateway_before", source
+        )
         self.assertIn('probe_node = gateway_probe["probe_node"]', source)
         self.assertIn('probe_address = gateway_probe["address"]', source)
         self.assertIn("gateway_owner_sample(", source)
@@ -1636,11 +1609,15 @@ spec:
         ready = source.index(
             'wait_cluster_ready(restore_kubectl, "postgres-restore", "20m")'
         )
-        rto = source.index("restore_rto = time.monotonic() - restore_started", ready)
+        rto = source.index(
+            "restore_rto = time.monotonic() - restore_started", ready
+        )
         sidecars = source.index(
             "restore_barman_sidecars = verify_barman_sidecar_images(", rto
         )
-        archive = source.index('restore_kubectl, cluster="postgres-restore"', sidecars)
+        archive = source.index(
+            'restore_kubectl, cluster="postgres-restore"', sidecars
+        )
         self.assertLess(ready, rto)
         self.assertLess(rto, sidecars)
         self.assertLess(sidecars, archive)
@@ -1648,11 +1625,9 @@ spec:
 
     def test_zone_rejoin_waits_for_cilium_before_database_readiness(self) -> None:
         source = (ROOT / "scripts/platform/ha_reference.py").read_text()
-        node_ready = source.index("f\"node/{primary_topology['node']}\"")
+        node_ready = source.index('f"node/{primary_topology[\'node\']}"')
         cilium_ready = source.index('"daemonset/cilium"', node_ready)
-        postgres_ready = source.index(
-            'wait_cluster_ready(kubectl, "postgres-ha", "15m")', cilium_ready
-        )
+        postgres_ready = source.index('wait_cluster_ready(kubectl, "postgres-ha", "15m")', cilium_ready)
         self.assertLess(node_ready, cilium_ready)
         self.assertLess(cilium_ready, postgres_ready)
         self.assertIn('["docker", "stop", "--timeout", "10", stopped_node]', source)
@@ -1661,15 +1636,9 @@ spec:
         required = "000000020000000A000000FE"
         self.assertEqual(self.ha.wal_segment_position(required), (2, 10, 254))
         self.assertTrue(self.ha.wal_archived_at_or_after(required, required))
-        self.assertTrue(
-            self.ha.wal_archived_at_or_after("000000020000000A000000FF", required)
-        )
-        self.assertTrue(
-            self.ha.wal_archived_at_or_after("000000030000000000000001", required)
-        )
-        self.assertFalse(
-            self.ha.wal_archived_at_or_after("000000020000000A000000FD", required)
-        )
+        self.assertTrue(self.ha.wal_archived_at_or_after("000000020000000A000000FF", required))
+        self.assertTrue(self.ha.wal_archived_at_or_after("000000030000000000000001", required))
+        self.assertFalse(self.ha.wal_archived_at_or_after("000000020000000A000000FD", required))
         with self.assertRaisesRegex(self.ha.ref.ProofError, "invalid PostgreSQL WAL"):
             self.ha.wal_segment_position("not-a-wal")
         source = (ROOT / "scripts/platform/ha_reference.py").read_text()
@@ -1688,29 +1657,21 @@ spec:
         self.assertNotIn("status.lastArchivedWAL", source)
 
     def test_ha_diagnostics_are_bounded_and_do_not_raise_on_timeout(self) -> None:
-        with (
-            tempfile.TemporaryDirectory() as directory,
-            mock.patch.object(self.ha, "CACHE", Path(directory)),
-            mock.patch.object(
-                self.ha.subprocess,
-                "run",
-                side_effect=self.ha.subprocess.TimeoutExpired(["kubectl"], 30),
-            ) as run,
-        ):
+        with tempfile.TemporaryDirectory() as directory, mock.patch.object(
+            self.ha, "CACHE", Path(directory)
+        ), mock.patch.object(
+            self.ha.subprocess, "run", side_effect=self.ha.subprocess.TimeoutExpired(["kubectl"], 30)
+        ) as run:
             self.ha.ha_diagnostic_snapshot("kubectl", "timeout")
             target = Path(directory) / "failures" / "timeout"
             for evidence in target.iterdir():
                 self.assertIn("diagnostic command failed", evidence.read_text())
         self.assertTrue(run.call_args_list)
-        self.assertTrue(
-            all(call.kwargs["timeout"] == 30 for call in run.call_args_list)
-        )
+        self.assertTrue(all(call.kwargs["timeout"] == 30 for call in run.call_args_list))
 
     def test_sensitive_environment_values_never_enter_argv(self) -> None:
         completed = mock.Mock(returncode=0)
-        with mock.patch.object(
-            self.ha.subprocess, "run", return_value=completed
-        ) as run:
+        with mock.patch.object(self.ha.subprocess, "run", return_value=completed) as run:
             self.ha.run_with_environment(
                 ["docker", "run", "--env", "PROOF_SECRET"],
                 {"PROOF_SECRET": "ephemeral-sensitive-value"},
@@ -1722,7 +1683,9 @@ spec:
 
     def test_pitr_boundary_uses_and_verifies_postgres_clock(self) -> None:
         with mock.patch.object(self.ha, "psql", side_effect=["", "t"]) as psql:
-            self.ha.wait_for_pitr_boundary("kubectl", "2026-07-18T08:00:00.000000Z")
+            self.ha.wait_for_pitr_boundary(
+                "kubectl", "2026-07-18T08:00:00.000000Z"
+            )
         self.assertEqual(psql.call_args_list[0].args[1], "SELECT pg_sleep(2)")
         self.assertIn("clock_timestamp()", psql.call_args_list[1].args[1])
 
@@ -1731,7 +1694,9 @@ spec:
             with self.assertRaisesRegex(
                 self.ha.ref.ProofError, "did not cross PITR target"
             ):
-                self.ha.wait_for_pitr_boundary("kubectl", "2026-07-18T08:00:00.000000Z")
+                self.ha.wait_for_pitr_boundary(
+                    "kubectl", "2026-07-18T08:00:00.000000Z"
+                )
 
     def test_cluster_context_binding_uses_cluster_specific_kubeconfig(self) -> None:
         path = ROOT / ".cache/test-restore-kubeconfig.yaml"
@@ -1789,9 +1754,7 @@ spec:
         image = self.ha.POSTGRES_IMAGE
         self.assertIn(":16.14@sha256:", image)
         self.assertNotIn("postgresql@sha256:", image)
-        catalog = (
-            ROOT / "platform/infrastructure/ha-data/postgres-image-catalog.yaml"
-        ).read_text()
+        catalog = (ROOT / "platform/infrastructure/ha-data/postgres-image-catalog.yaml").read_text()
         self.assertIn(image, catalog)
         manifest = (ROOT / "platform/infrastructure/ha-data/postgres.yaml").read_text()
         self.assertNotIn("imageName:", manifest)

--- a/scripts/ci/tests/test_kubernetes_ha_contract.py
+++ b/scripts/ci/tests/test_kubernetes_ha_contract.py
@@ -106,7 +106,9 @@ class KubernetesHaContractTests(unittest.TestCase):
             )
         )
         container = job["spec"]["template"]["spec"]["containers"][0]
-        database = next(item for item in container["env"] if item["name"] == "DATABASE_URL")
+        database = next(
+            item for item in container["env"] if item["name"] == "DATABASE_URL"
+        )
         self.assertEqual(
             database["valueFrom"].get("secretKeyRef"),
             {"name": "weltgewebe-ha-runtime", "key": "database-url"},
@@ -138,9 +140,7 @@ class KubernetesHaContractTests(unittest.TestCase):
                 {
                     "name": "barman-cloud.cloudnative-pg.io",
                     "isWALArchiver": True,
-                    "parameters": {
-                        "barmanObjectName": "weltgewebe-ha-backup"
-                    },
+                    "parameters": {"barmanObjectName": "weltgewebe-ha-backup"},
                 }
             ],
         )
@@ -159,9 +159,7 @@ class KubernetesHaContractTests(unittest.TestCase):
                 {
                     "name": "barman-cloud.cloudnative-pg.io",
                     "isWALArchiver": True,
-                    "parameters": {
-                        "barmanObjectName": "weltgewebe-ha-backup"
-                    },
+                    "parameters": {"barmanObjectName": "weltgewebe-ha-backup"},
                 }
             ],
         )
@@ -200,7 +198,9 @@ class KubernetesHaContractTests(unittest.TestCase):
         proof_workflow = yaml.safe_load(proof_text)
         self.assertEqual(set(pr_workflow["on"]), {"pull_request"})
         self.assertEqual(set(proof_workflow["on"]), {"push", "workflow_dispatch"})
-        expected_head = proof_workflow["on"]["workflow_dispatch"]["inputs"]["expected_head"]
+        expected_head = proof_workflow["on"]["workflow_dispatch"]["inputs"][
+            "expected_head"
+        ]
         self.assertIs(expected_head["required"], True)
         self.assertEqual(expected_head["type"], "string")
         self.assertNotIn("packages: read", pr_text)
@@ -334,11 +334,13 @@ class KubernetesHaContractTests(unittest.TestCase):
             "coredns-b": {"node": "node-b", "zone": "zone-b"},
             "coredns-c": {"node": "node-c", "zone": "zone-c"},
         }
-        with mock.patch.object(self.ha.ref, "run") as run, mock.patch.object(
-            self.ha.ref, "wait_rollout"
-        ) as wait_rollout, mock.patch.object(
-            self.ha, "pod_topology", return_value=topology
-        ) as pod_topology:
+        with (
+            mock.patch.object(self.ha.ref, "run") as run,
+            mock.patch.object(self.ha.ref, "wait_rollout") as wait_rollout,
+            mock.patch.object(
+                self.ha, "pod_topology", return_value=topology
+            ) as pod_topology,
+        ):
             observed = self.ha.configure_cluster_dns_ha("kubectl")
 
         self.assertEqual(observed, topology)
@@ -371,9 +373,7 @@ class KubernetesHaContractTests(unittest.TestCase):
             required,
             [
                 {
-                    "labelSelector": {
-                        "matchLabels": {"k8s-app": "kube-dns"}
-                    },
+                    "labelSelector": {"matchLabels": {"k8s-app": "kube-dns"}},
                     "topologyKey": "topology.kubernetes.io/zone",
                 }
             ],
@@ -391,13 +391,17 @@ class KubernetesHaContractTests(unittest.TestCase):
             "coredns-b": {"node": "node-a", "zone": "zone-a"},
             "coredns-c": {"node": "node-b", "zone": "zone-b"},
         }
-        with mock.patch.object(self.ha.ref, "run"), mock.patch.object(
-            self.ha.ref, "wait_rollout"
-        ), mock.patch.object(self.ha, "pod_topology", return_value=topology):
+        with (
+            mock.patch.object(self.ha.ref, "run"),
+            mock.patch.object(self.ha.ref, "wait_rollout"),
+            mock.patch.object(self.ha, "pod_topology", return_value=topology),
+        ):
             with self.assertRaisesRegex(self.ha.ref.ProofError, "not spread"):
                 self.ha.configure_cluster_dns_ha("kubectl")
 
-    def test_external_object_store_missing_volume_is_absent_case_insensitively(self) -> None:
+    def test_external_object_store_missing_volume_is_absent_case_insensitively(
+        self,
+    ) -> None:
         result = mock.Mock(
             returncode=1,
             stdout="",
@@ -408,9 +412,7 @@ class KubernetesHaContractTests(unittest.TestCase):
         )
         with mock.patch.object(self.ha.subprocess, "run", return_value=result):
             self.assertIsNone(
-                self.ha._object_store_labels(
-                    "volume", "proof-object-store-data"
-                )
+                self.ha._object_store_labels("volume", "proof-object-store-data")
             )
 
     def test_strict_external_object_store_uses_verified_local_mirror_ref(self) -> None:
@@ -423,9 +425,10 @@ class KubernetesHaContractTests(unittest.TestCase):
                 }
             }
         }
-        with mock.patch.object(
-            self.ha.ref, "controlled_oci_strict", return_value=True
-        ), mock.patch.object(self.ha.ref, "_oci_mirror_lock", return_value=lock):
+        with (
+            mock.patch.object(self.ha.ref, "controlled_oci_strict", return_value=True),
+            mock.patch.object(self.ha.ref, "_oci_mirror_lock", return_value=lock),
+        ):
             self.assertEqual(self.ha.external_object_store_runtime_image(), local_ref)
 
     def test_strict_external_object_store_rejects_mirror_binding_drift(self) -> None:
@@ -437,19 +440,23 @@ class KubernetesHaContractTests(unittest.TestCase):
                 }
             }
         }
-        with mock.patch.object(
-            self.ha.ref, "controlled_oci_strict", return_value=True
-        ), mock.patch.object(self.ha.ref, "_oci_mirror_lock", return_value=lock):
-            with self.assertRaisesRegex(self.ha.ref.ProofError, "canonical reference drift"):
+        with (
+            mock.patch.object(self.ha.ref, "controlled_oci_strict", return_value=True),
+            mock.patch.object(self.ha.ref, "_oci_mirror_lock", return_value=lock),
+        ):
+            with self.assertRaisesRegex(
+                self.ha.ref.ProofError, "canonical reference drift"
+            ):
                 self.ha.external_object_store_runtime_image()
 
     def test_external_object_store_cleanup_is_ownership_bound(self) -> None:
         foreign = self.ha.external_object_store_binding(
             "proof", "a" * 40, "owner-foreign"
         )
-        with mock.patch.object(
-            self.ha, "_object_store_labels", return_value=foreign
-        ), mock.patch.object(self.ha.ref, "run") as delete:
+        with (
+            mock.patch.object(self.ha, "_object_store_labels", return_value=foreign),
+            mock.patch.object(self.ha.ref, "run") as delete,
+        ):
             with self.assertRaisesRegex(self.ha.ref.ProofError, "foreign"):
                 self.ha.delete_external_object_store(
                     "proof", "a" * 40, "owner-expected"
@@ -457,18 +464,25 @@ class KubernetesHaContractTests(unittest.TestCase):
         delete.assert_not_called()
 
     def test_external_object_store_start_cleans_partial_owned_resources(self) -> None:
-        with mock.patch.object(
-            self.ha, "_object_store_labels", side_effect=[None, None]
-        ), mock.patch.object(self.ha.ref, "run"), mock.patch.object(
-            self.ha,
-            "run_with_environment",
-            side_effect=self.ha.ref.ProofError("container start failed"),
-        ), mock.patch.object(
-            self.ha,
-            "reconcile_external_object_store",
-            return_value={"resources": {}, "errors": {}},
-        ) as cleanup:
-            with self.assertRaisesRegex(self.ha.ref.ProofError, "container start failed"):
+        with (
+            mock.patch.object(
+                self.ha, "_object_store_labels", side_effect=[None, None]
+            ),
+            mock.patch.object(self.ha.ref, "run"),
+            mock.patch.object(
+                self.ha,
+                "run_with_environment",
+                side_effect=self.ha.ref.ProofError("container start failed"),
+            ),
+            mock.patch.object(
+                self.ha,
+                "reconcile_external_object_store",
+                return_value={"resources": {}, "errors": {}},
+            ) as cleanup,
+        ):
+            with self.assertRaisesRegex(
+                self.ha.ref.ProofError, "container start failed"
+            ):
                 self.ha.start_external_object_store(
                     "proof", "a" * 40, "owner-proof", "secret"
                 )
@@ -478,12 +492,15 @@ class KubernetesHaContractTests(unittest.TestCase):
         reservation_context = mock.MagicMock()
         reservation_context.__enter__.return_value = None
         reservation_context.__exit__.return_value = False
-        with mock.patch.object(
-            self.ha.ref,
-            "cluster_creation_reservation",
-            return_value=reservation_context,
-        ) as reservation, mock.patch.object(
-            self.ha.ref, "run", side_effect=self.ha.ref.ProofError("kind failed")
+        with (
+            mock.patch.object(
+                self.ha.ref,
+                "cluster_creation_reservation",
+                return_value=reservation_context,
+            ) as reservation,
+            mock.patch.object(
+                self.ha.ref, "run", side_effect=self.ha.ref.ProofError("kind failed")
+            ),
         ):
             with self.assertRaisesRegex(self.ha.ref.ProofError, "kind failed"):
                 self.ha.create_kind_cluster(
@@ -494,26 +511,27 @@ class KubernetesHaContractTests(unittest.TestCase):
                     "b" * 40,
                     "owner-proof",
                 )
-        reservation.assert_called_once_with(
-            "kind", "proof", "b" * 40, "owner-proof"
-        )
+        reservation.assert_called_once_with("kind", "proof", "b" * 40, "owner-proof")
 
     def test_ha_cleanup_continues_after_one_cluster_failure(self) -> None:
-        with mock.patch.object(
-            self.ha.ref,
-            "delete_owned_cluster_if_present",
-            side_effect=[self.ha.ref.ProofError("restore marker unreadable"), True],
-        ) as delete_cluster, mock.patch.object(
-            self.ha,
-            "reconcile_external_object_store",
-            return_value={
-                "resources": {
-                    "object_store_container": "deleted",
-                    "object_store_volume": "absent",
+        with (
+            mock.patch.object(
+                self.ha.ref,
+                "delete_owned_cluster_if_present",
+                side_effect=[self.ha.ref.ProofError("restore marker unreadable"), True],
+            ) as delete_cluster,
+            mock.patch.object(
+                self.ha,
+                "reconcile_external_object_store",
+                return_value={
+                    "resources": {
+                        "object_store_container": "deleted",
+                        "object_store_volume": "absent",
+                    },
+                    "errors": {},
                 },
-                "errors": {},
-            },
-        ) as object_store:
+            ) as object_store,
+        ):
             result = self.ha.reconcile_owned_ha_resources(
                 "kind", "proof", "a" * 40, "owner-proof"
             )
@@ -539,18 +557,21 @@ class KubernetesHaContractTests(unittest.TestCase):
         )
 
     def test_ha_cleanup_reports_absent_when_nothing_exists(self) -> None:
-        with mock.patch.object(
-            self.ha.ref, "delete_owned_cluster_if_present", return_value=False
-        ), mock.patch.object(
-            self.ha,
-            "reconcile_external_object_store",
-            return_value={
-                "resources": {
-                    "object_store_container": "absent",
-                    "object_store_volume": "absent",
+        with (
+            mock.patch.object(
+                self.ha.ref, "delete_owned_cluster_if_present", return_value=False
+            ),
+            mock.patch.object(
+                self.ha,
+                "reconcile_external_object_store",
+                return_value={
+                    "resources": {
+                        "object_store_container": "absent",
+                        "object_store_volume": "absent",
+                    },
+                    "errors": {},
                 },
-                "errors": {},
-            },
+            ),
         ):
             result = self.ha.reconcile_owned_ha_resources(
                 "kind", "proof", "a" * 40, "owner-proof"
@@ -587,46 +608,153 @@ class KubernetesHaContractTests(unittest.TestCase):
 
     def test_primary_cluster_retirement_fails_closed_on_drift(self) -> None:
         cases = (
-            {
-                "status": "absent",
-                "resources": {"primary_cluster": "absent"},
-                "errors": {},
-            },
-            {
-                "status": "error",
-                "resources": {"primary_cluster": "error"},
-                "errors": {"primary_cluster": "ownership mismatch"},
-            },
+            (
+                {
+                    "status": "absent",
+                    "resources": {"primary_cluster": "absent"},
+                    "errors": {},
+                },
+                "got 'absent'",
+            ),
+            (
+                {
+                    "status": "error",
+                    "resources": {"primary_cluster": "error"},
+                    "errors": {"primary_cluster": "ownership mismatch"},
+                },
+                "got 'error'",
+            ),
+            ({"status": "invalid"}, "got None"),
         )
-        for result in cases:
-            with self.subTest(result=result), mock.patch.object(
-                self.ha, "reconcile_owned_ha_resources", return_value=result
+        for result, expected_state in cases:
+            with (
+                self.subTest(result=result),
+                mock.patch.object(
+                    self.ha, "reconcile_owned_ha_resources", return_value=result
+                ),
             ):
                 with self.assertRaisesRegex(
                     self.ha.ref.ProofError,
-                    "primary cluster retirement before blank restore failed",
+                    expected_state,
                 ):
                     self.ha.retire_primary_cluster_before_restore(
                         "kind", "proof", "a" * 40, "owner-proof"
                     )
 
-    def test_primary_cluster_is_retired_before_restore_cluster_creation(self) -> None:
-        source = (self.ha.ROOT / "scripts/platform/ha_reference.py").read_text()
-        retirement = source.index(
-            "primary_cluster_retirement = retire_primary_cluster_before_restore("
+    def test_blank_restore_retires_primary_before_cluster_creation(self) -> None:
+        retirement = {
+            "status": "deleted",
+            "resources": {"primary_cluster": "deleted"},
+            "errors": {},
+        }
+        lifecycle = self.ha.ClusterLifecycle(primary_created=True)
+        calls = mock.Mock()
+        retire = mock.Mock(return_value=retirement)
+        create = mock.Mock()
+        calls.attach_mock(retire, "retire")
+        calls.attach_mock(create, "create")
+        with (
+            mock.patch.object(self.ha, "retire_primary_cluster_before_restore", retire),
+            mock.patch.object(self.ha, "create_kind_cluster", create),
+        ):
+            result = self.ha.create_blank_restore_cluster(
+                "kind",
+                "proof",
+                "proof-restore",
+                "node-image",
+                "a" * 40,
+                "owner-proof",
+                keep_primary=False,
+                lifecycle=lifecycle,
+            )
+
+        self.assertIs(result, retirement)
+        self.assertEqual(
+            calls.mock_calls,
+            [
+                mock.call.retire("kind", "proof", "a" * 40, "owner-proof"),
+                mock.call.create(
+                    "kind",
+                    "proof-restore",
+                    "node-image",
+                    "platform/clusters/ha/restore-kind.yaml",
+                    "a" * 40,
+                    "owner-proof",
+                ),
+            ],
         )
-        restore_creation = source.index(
-            "create_kind_cluster(\n            kind, restore_name", retirement
+        self.assertFalse(lifecycle.primary_created)
+        self.assertTrue(lifecycle.restore_created)
+
+    def test_blank_restore_keep_mode_skips_primary_retirement(self) -> None:
+        lifecycle = self.ha.ClusterLifecycle(primary_created=True)
+        with (
+            mock.patch.object(
+                self.ha, "retire_primary_cluster_before_restore"
+            ) as retire,
+            mock.patch.object(self.ha, "create_kind_cluster") as create,
+        ):
+            result = self.ha.create_blank_restore_cluster(
+                "kind",
+                "proof",
+                "proof-restore",
+                "node-image",
+                "a" * 40,
+                "owner-proof",
+                keep_primary=True,
+                lifecycle=lifecycle,
+            )
+
+        self.assertIsNone(result)
+        retire.assert_not_called()
+        create.assert_called_once_with(
+            "kind",
+            "proof-restore",
+            "node-image",
+            "platform/clusters/ha/restore-kind.yaml",
+            "a" * 40,
+            "owner-proof",
         )
-        self.assertLess(retirement, restore_creation)
-        transition = source[retirement:restore_creation]
-        self.assertIn("created_primary = False", transition)
-        self.assertIn("if not args.keep:", source[retirement - 40 : retirement])
+        self.assertTrue(lifecycle.primary_created)
+        self.assertTrue(lifecycle.restore_created)
+
+    def test_blank_restore_creation_failure_preserves_cleanup_truth(self) -> None:
+        lifecycle = self.ha.ClusterLifecycle(primary_created=True)
+        with (
+            mock.patch.object(
+                self.ha,
+                "retire_primary_cluster_before_restore",
+                return_value={"status": "deleted"},
+            ),
+            mock.patch.object(
+                self.ha,
+                "create_kind_cluster",
+                side_effect=self.ha.ref.ProofError("restore create failed"),
+            ),
+        ):
+            with self.assertRaisesRegex(
+                self.ha.ref.ProofError, "restore create failed"
+            ):
+                self.ha.create_blank_restore_cluster(
+                    "kind",
+                    "proof",
+                    "proof-restore",
+                    "node-image",
+                    "a" * 40,
+                    "owner-proof",
+                    keep_primary=False,
+                    lifecycle=lifecycle,
+                )
+
+        self.assertFalse(lifecycle.primary_created)
+        self.assertFalse(lifecycle.restore_created)
 
     def test_digest_locked_manifest_replaces_each_release_image_once(self) -> None:
         tagged = {
-            "registry.example/controller:v1": "registry.example/controller@sha256:" + "a" * 64,
-            "registry.example/webhook:v1": "registry.example/webhook@sha256:" + "b" * 64,
+            "registry.example/controller:v1": "registry.example/controller@sha256:"
+            + "a" * 64,
+            "registry.example/webhook:v1": "registry.example/webhook@sha256:"
+            + "b" * 64,
         }
         with tempfile.TemporaryDirectory() as directory:
             artifact = Path(directory) / "release.yaml"
@@ -647,16 +775,14 @@ class KubernetesHaContractTests(unittest.TestCase):
 
     def test_cert_manager_install_waits_and_verifies_digest_images(self) -> None:
         expected = list(self.ha.CERT_MANAGER_IMAGES.values())
-        with mock.patch.object(
-            self.ha, "apply_digest_locked_manifest"
-        ) as apply_manifest, mock.patch.object(
-            self.ha.ref, "run"
-        ) as run, mock.patch.object(
-            self.ha.ref, "wait_rollout"
-        ) as wait_rollout, mock.patch.object(
-            self.ha, "wait_until"
-        ) as wait_until, mock.patch.object(
-            self.ha.ref, "output", side_effect=expected
+        with (
+            mock.patch.object(
+                self.ha, "apply_digest_locked_manifest"
+            ) as apply_manifest,
+            mock.patch.object(self.ha.ref, "run") as run,
+            mock.patch.object(self.ha.ref, "wait_rollout") as wait_rollout,
+            mock.patch.object(self.ha, "wait_until") as wait_until,
+            mock.patch.object(self.ha.ref, "output", side_effect=expected),
         ):
             self.ha.install_cert_manager("kubectl", "cert-manager.yaml")
         apply_manifest.assert_called_once_with(
@@ -667,9 +793,7 @@ class KubernetesHaContractTests(unittest.TestCase):
         wait_until.assert_called_once()
 
     def test_barman_manifest_pins_operator_and_sidecar_images(self) -> None:
-        sidecar_tag = (
-            "ghcr.io/cloudnative-pg/plugin-barman-cloud-sidecar:v0.13.0"
-        )
+        sidecar_tag = "ghcr.io/cloudnative-pg/plugin-barman-cloud-sidecar:v0.13.0"
         encoded = self.ha.base64.b64encode(sidecar_tag.encode()).decode()
         source = (
             "apiVersion: v1\nkind: Secret\nmetadata:\n  name: sidecar\n"
@@ -734,9 +858,7 @@ class KubernetesHaContractTests(unittest.TestCase):
                                     "name": "barman-cloud",
                                     "ready": index == leader_index,
                                     "state": {
-                                        "running": {
-                                            "startedAt": "2026-07-18T11:32:39Z"
-                                        }
+                                        "running": {"startedAt": "2026-07-18T11:32:39Z"}
                                     },
                                 }
                             ],
@@ -782,21 +904,17 @@ class KubernetesHaContractTests(unittest.TestCase):
                 self.barman_plugin_endpoint_payload(2),
             ],
         ):
-            state = self.ha.barman_plugin_state(
-                "kubectl", require_three_nodes=True
-            )
+            state = self.ha.barman_plugin_state("kubectl", require_three_nodes=True)
         self.assertEqual(state["nodes"], ["worker-1", "worker-2", "worker-3"])
-        self.assertEqual(
-            state["leader"], {"pod": "barman-cloud-2", "node": "worker-2"}
-        )
+        self.assertEqual(state["leader"], {"pod": "barman-cloud-2", "node": "worker-2"})
 
-    def test_barman_plugin_state_ignores_stale_container_ready_after_node_loss(self) -> None:
+    def test_barman_plugin_state_ignores_stale_container_ready_after_node_loss(
+        self,
+    ) -> None:
         pods = json.loads(self.barman_plugin_pod_payload(2))
         old_leader = pods["items"][0]
         old_leader["status"]["containerStatuses"][0]["ready"] = True
-        old_leader["status"]["conditions"] = [
-            {"type": "Ready", "status": "False"}
-        ]
+        old_leader["status"]["conditions"] = [{"type": "Ready", "status": "False"}]
         with mock.patch.object(
             self.ha.ref,
             "output",
@@ -805,12 +923,8 @@ class KubernetesHaContractTests(unittest.TestCase):
                 self.barman_plugin_endpoint_payload(2),
             ],
         ):
-            state = self.ha.barman_plugin_state(
-                "kubectl", require_three_nodes=False
-            )
-        self.assertEqual(
-            state["leader"], {"pod": "barman-cloud-2", "node": "worker-2"}
-        )
+            state = self.ha.barman_plugin_state("kubectl", require_three_nodes=False)
+        self.assertEqual(state["leader"], {"pod": "barman-cloud-2", "node": "worker-2"})
 
     def test_barman_plugin_install_waits_and_verifies_digest_images(self) -> None:
         secret_payload = json.dumps(
@@ -835,22 +949,20 @@ class KubernetesHaContractTests(unittest.TestCase):
             },
             "leader": {"pod": "barman-cloud-1", "node": "worker-1"},
         }
-        with mock.patch.object(
-            self.ha, "apply_barman_cloud_manifest"
-        ) as apply_manifest, mock.patch.object(
-            self.ha.ref, "run"
-        ) as run, mock.patch.object(
-            self.ha.ref, "wait_condition"
-        ) as wait_condition, mock.patch.object(
-            self.ha, "verify_barman_plugin_ha", return_value=state
-        ) as verify_ha, mock.patch.object(
-            self.ha.ref,
-            "output",
-            side_effect=[secret_payload, self.ha.BARMAN_CLOUD_PLUGIN_IMAGE],
+        with (
+            mock.patch.object(self.ha, "apply_barman_cloud_manifest") as apply_manifest,
+            mock.patch.object(self.ha.ref, "run") as run,
+            mock.patch.object(self.ha.ref, "wait_condition") as wait_condition,
+            mock.patch.object(
+                self.ha, "verify_barman_plugin_ha", return_value=state
+            ) as verify_ha,
+            mock.patch.object(
+                self.ha.ref,
+                "output",
+                side_effect=[secret_payload, self.ha.BARMAN_CLOUD_PLUGIN_IMAGE],
+            ),
         ):
-            observed = self.ha.install_barman_cloud_plugin(
-                "kubectl", "barman.yaml"
-            )
+            observed = self.ha.install_barman_cloud_plugin("kubectl", "barman.yaml")
         apply_manifest.assert_called_once_with("kubectl", "barman.yaml")
         self.assertIn("crd/objectstores.barmancloud.cnpg.io", run.call_args.args[0])
         self.assertEqual(wait_condition.call_count, 2)
@@ -869,9 +981,7 @@ class KubernetesHaContractTests(unittest.TestCase):
             with self.assertRaisesRegex(
                 self.ha.ref.ProofError, "exactly its elected ready leader"
             ):
-                self.ha.barman_plugin_state(
-                    "kubectl", require_three_nodes=True
-                )
+                self.ha.barman_plugin_state("kubectl", require_three_nodes=True)
 
     def test_barman_plugin_backup_proves_completed_plugin_rpc(self) -> None:
         completed = {
@@ -881,9 +991,12 @@ class KubernetesHaContractTests(unittest.TestCase):
                 "instanceID": {"podName": "postgres-ha-2"},
             }
         }
-        with mock.patch.object(self.ha.ref, "apply_yaml") as apply_yaml, mock.patch.object(
-            self.ha, "wait_backup_complete", return_value=completed
-        ) as wait_backup:
+        with (
+            mock.patch.object(self.ha.ref, "apply_yaml") as apply_yaml,
+            mock.patch.object(
+                self.ha, "wait_backup_complete", return_value=completed
+            ) as wait_backup,
+        ):
             result = self.ha.prove_barman_plugin_backup(
                 "kubectl", "postgres-ha", "probe-backup"
             )
@@ -905,7 +1018,9 @@ class KubernetesHaContractTests(unittest.TestCase):
             },
         )
 
-    def test_postgres_primary_alignment_promotes_to_existing_barman_leader(self) -> None:
+    def test_postgres_primary_alignment_promotes_to_existing_barman_leader(
+        self,
+    ) -> None:
         plugin_state = {
             "nodes": ["worker-1", "worker-2", "worker-3"],
             "pods": {
@@ -926,17 +1041,26 @@ class KubernetesHaContractTests(unittest.TestCase):
             "method": "plugin",
             "pod": "postgres-ha-2",
         }
-        with mock.patch.object(
-            self.ha, "verify_barman_plugin_ha", side_effect=[plugin_state, plugin_state]
-        ), mock.patch.object(
-            self.ha, "current_primary", side_effect=["postgres-ha-1", "postgres-ha-2"]
-        ), mock.patch.object(
-            self.ha, "wait_until", return_value="postgres-ha-2"
-        ) as wait_until, mock.patch.object(
-            self.ha, "wait_cluster_ready"
-        ) as wait_ready, mock.patch.object(
-            self.ha, "prove_barman_plugin_backup", return_value=communication
-        ) as prove_backup, mock.patch.object(self.ha.ref, "run") as run:
+        with (
+            mock.patch.object(
+                self.ha,
+                "verify_barman_plugin_ha",
+                side_effect=[plugin_state, plugin_state],
+            ),
+            mock.patch.object(
+                self.ha,
+                "current_primary",
+                side_effect=["postgres-ha-1", "postgres-ha-2"],
+            ),
+            mock.patch.object(
+                self.ha, "wait_until", return_value="postgres-ha-2"
+            ) as wait_until,
+            mock.patch.object(self.ha, "wait_cluster_ready") as wait_ready,
+            mock.patch.object(
+                self.ha, "prove_barman_plugin_backup", return_value=communication
+            ) as prove_backup,
+            mock.patch.object(self.ha.ref, "run") as run,
+        ):
             result = self.ha.align_postgres_primary_with_barman_leader(
                 "kubectl-cnpg",
                 "kubectl",
@@ -958,9 +1082,7 @@ class KubernetesHaContractTests(unittest.TestCase):
         self.assertNotIn("delete", run.call_args.args[0])
         wait_until.assert_called_once()
         wait_ready.assert_called_once_with("kubectl", "postgres-ha", "10m")
-        prove_backup.assert_called_once_with(
-            "kubectl", "postgres-ha", "probe-backup"
-        )
+        prove_backup.assert_called_once_with("kubectl", "postgres-ha", "probe-backup")
         self.assertEqual(result["target_node"], "worker-2")
         self.assertEqual(result["postgres_primary_before"], "postgres-ha-1")
         self.assertEqual(result["postgres_primary_aligned"], "postgres-ha-2")
@@ -975,9 +1097,7 @@ class KubernetesHaContractTests(unittest.TestCase):
             },
             "leader": {"pod": "barman-cloud-2", "node": "worker-2"},
         }
-        with mock.patch.object(
-            self.ha, "barman_plugin_state", return_value=surviving
-        ):
+        with mock.patch.object(self.ha, "barman_plugin_state", return_value=surviving):
             leader = self.ha.wait_barman_plugin_leader_after_node_loss(
                 "kubectl", "worker-3"
             )
@@ -1004,9 +1124,7 @@ class KubernetesHaContractTests(unittest.TestCase):
                             "name": "plugin-barman-cloud",
                             "imageID": f"ghcr.io/cloudnative-pg/sidecar@{digest}",
                             "ready": True,
-                            "state": {
-                                "running": {"startedAt": "2026-07-18T08:00:00Z"}
-                            },
+                            "state": {"running": {"startedAt": "2026-07-18T08:00:00Z"}},
                         }
                     ]
                 },
@@ -1019,13 +1137,13 @@ class KubernetesHaContractTests(unittest.TestCase):
                 {"items": [pod("postgres-1"), pod("postgres-2"), pod("postgres-3")]}
             ),
         ):
-            observed = self.ha.verify_barman_sidecar_images(
-                "kubectl", "postgres-ha"
-            )
+            observed = self.ha.verify_barman_sidecar_images("kubectl", "postgres-ha")
         self.assertEqual(sorted(observed), ["postgres-1", "postgres-2", "postgres-3"])
         self.assertTrue(all(item["ready"] is True for item in observed.values()))
 
-    def test_barman_instance_sidecar_validation_fails_closed_when_not_ready(self) -> None:
+    def test_barman_instance_sidecar_validation_fails_closed_when_not_ready(
+        self,
+    ) -> None:
         payload = {
             "items": [
                 {
@@ -1051,10 +1169,10 @@ class KubernetesHaContractTests(unittest.TestCase):
                 }
             ]
         }
-        with mock.patch.object(
-            self.ha.ref, "output", return_value=json.dumps(payload)
-        ):
-            with self.assertRaisesRegex(self.ha.ref.ProofError, "not running and ready"):
+        with mock.patch.object(self.ha.ref, "output", return_value=json.dumps(payload)):
+            with self.assertRaisesRegex(
+                self.ha.ref.ProofError, "not running and ready"
+            ):
                 self.ha.verify_barman_sidecar_images("kubectl", "postgres-ha")
 
     def cnpg_release_fixture(self) -> str:
@@ -1109,14 +1227,14 @@ spec:
             required,
             [
                 {
-                    "labelSelector": {"matchLabels": {"app.kubernetes.io/name": "cloudnative-pg"}},
+                    "labelSelector": {
+                        "matchLabels": {"app.kubernetes.io/name": "cloudnative-pg"}
+                    },
                     "topologyKey": "kubernetes.io/hostname",
                 }
             ],
         )
-        self.assertNotIn(
-            "ghcr.io/cloudnative-pg/cloudnative-pg:1.30.0", rendered
-        )
+        self.assertNotIn("ghcr.io/cloudnative-pg/cloudnative-pg:1.30.0", rendered)
         self.assertEqual(rendered.count(self.ha.CNPG_OPERATOR_IMAGE), 2)
 
     def test_cnpg_release_uses_server_side_apply(self) -> None:
@@ -1124,14 +1242,17 @@ spec:
         artifact.parent.mkdir(parents=True, exist_ok=True)
         artifact.write_text(self.cnpg_release_fixture())
         try:
-            with mock.patch.object(self.ha.ref, "run") as run, mock.patch.object(
-                self.ha,
-                "verify_cnpg_operator_ha",
-                return_value=["node-a", "node-b", "node-c"],
-            ) as verify_ha, mock.patch.object(
-                self.ha, "wait_until"
-            ), mock.patch.object(
-                self.ha.ref, "output", return_value=self.ha.CNPG_OPERATOR_IMAGE
+            with (
+                mock.patch.object(self.ha.ref, "run") as run,
+                mock.patch.object(
+                    self.ha,
+                    "verify_cnpg_operator_ha",
+                    return_value=["node-a", "node-b", "node-c"],
+                ) as verify_ha,
+                mock.patch.object(self.ha, "wait_until"),
+                mock.patch.object(
+                    self.ha.ref, "output", return_value=self.ha.CNPG_OPERATOR_IMAGE
+                ),
             ):
                 observed_nodes = self.ha.install_cnpg("kubectl", str(artifact))
             verify_ha.assert_called_once_with("kubectl")
@@ -1169,10 +1290,9 @@ spec:
                 ]
             }
         )
-        with mock.patch.object(
-            self.ha.ref, "wait_rollout"
-        ) as wait_rollout, mock.patch.object(
-            self.ha.ref, "output", side_effect=["3", pods]
+        with (
+            mock.patch.object(self.ha.ref, "wait_rollout") as wait_rollout,
+            mock.patch.object(self.ha.ref, "output", side_effect=["3", pods]),
         ):
             observed_nodes = self.ha.verify_cnpg_operator_ha("kubectl")
         self.assertEqual(observed_nodes, ["node-a", "node-b", "node-c"])
@@ -1182,8 +1302,12 @@ spec:
 
     def test_cnpg_webhook_probe_requires_endpoint_and_server_dry_run(self) -> None:
         endpoint = mock.Mock(returncode=0, stdout="10.0.0.12")
-        dry_run = mock.Mock(returncode=0, stdout="cluster.postgresql.cnpg.io/probe serverside-applied")
-        with mock.patch.object(self.ha.subprocess, "run", side_effect=[endpoint, dry_run]) as run:
+        dry_run = mock.Mock(
+            returncode=0, stdout="cluster.postgresql.cnpg.io/probe serverside-applied"
+        )
+        with mock.patch.object(
+            self.ha.subprocess, "run", side_effect=[endpoint, dry_run]
+        ) as run:
             self.assertTrue(self.ha.cnpg_webhook_ready("kubectl"))
         endpoint_argv = run.call_args_list[0].args[0]
         dry_run_argv = run.call_args_list[1].args[0]
@@ -1202,11 +1326,11 @@ spec:
 
     def test_ha_diagnostic_snapshot_captures_cnpg_and_storage_evidence(self) -> None:
         completed = mock.Mock(stdout="evidence\n", stderr="")
-        with tempfile.TemporaryDirectory() as directory, mock.patch.object(
-            self.ha, "CACHE", Path(directory)
-        ), mock.patch.object(
-            self.ha.subprocess, "run", return_value=completed
-        ) as run:
+        with (
+            tempfile.TemporaryDirectory() as directory,
+            mock.patch.object(self.ha, "CACHE", Path(directory)),
+            mock.patch.object(self.ha.subprocess, "run", return_value=completed) as run,
+        ):
             self.ha.ha_diagnostic_snapshot("kubectl", "proof")
             target = Path(directory) / "failures" / "proof"
             self.assertEqual(
@@ -1262,8 +1386,7 @@ spec:
         documents = list(
             self.ha.yaml.safe_load_all(
                 (
-                    ROOT
-                    / "platform/apps/weltgewebe/overlays/ha/deployment-patch.yaml"
+                    ROOT / "platform/apps/weltgewebe/overlays/ha/deployment-patch.yaml"
                 ).read_text()
             )
         )
@@ -1276,12 +1399,10 @@ spec:
         self.assertEqual(spec["replicas"], 3)
         self.assertEqual(spec["strategy"]["type"], "RollingUpdate")
         self.assertEqual(spec["strategy"]["rollingUpdate"]["maxSurge"], 1)
-        self.assertEqual(
-            spec["strategy"]["rollingUpdate"]["maxUnavailable"], 0
-        )
-        preferred = spec["template"]["spec"]["affinity"][
-            "podAntiAffinity"
-        ]["preferredDuringSchedulingIgnoredDuringExecution"]
+        self.assertEqual(spec["strategy"]["rollingUpdate"]["maxUnavailable"], 0)
+        preferred = spec["template"]["spec"]["affinity"]["podAntiAffinity"][
+            "preferredDuringSchedulingIgnoredDuringExecution"
+        ]
         self.assertEqual(preferred[0]["weight"], 100)
         self.assertEqual(
             preferred[0]["podAffinityTerm"]["topologyKey"],
@@ -1294,12 +1415,11 @@ spec:
     def test_upgrade_candidate_is_distinct_and_loaded_into_kind(self) -> None:
         baseline = "sha256:" + "a" * 64
         candidate = "sha256:" + "b" * 64
-        with mock.patch.object(self.ha.ref, "run") as run, mock.patch.object(
-            self.ha.ref, "output", side_effect=[baseline, candidate]
+        with (
+            mock.patch.object(self.ha.ref, "run") as run,
+            mock.patch.object(self.ha.ref, "output", side_effect=[baseline, candidate]),
         ):
-            observed = self.ha.prepare_api_upgrade_candidate(
-                "kind", "proof", "c" * 40
-            )
+            observed = self.ha.prepare_api_upgrade_candidate("kind", "proof", "c" * 40)
         self.assertEqual(
             observed,
             {
@@ -1308,8 +1428,12 @@ spec:
             },
         )
         build = run.call_args_list[0]
-        self.assertEqual(build.args[0][:5], ["docker", "build", "--pull=false", "--file", "-"])
-        self.assertIn("org.opencontainers.image.revision=" + "c" * 40, build.kwargs["input_text"])
+        self.assertEqual(
+            build.args[0][:5], ["docker", "build", "--pull=false", "--file", "-"]
+        )
+        self.assertIn(
+            "org.opencontainers.image.revision=" + "c" * 40, build.kwargs["input_text"]
+        )
         self.assertEqual(
             run.call_args_list[1].args[0],
             [
@@ -1359,7 +1483,9 @@ spec:
         self.assertEqual(run.call_args.kwargs["timeout"], 5)
         self.assertFalse(run.call_args.kwargs["check"])
 
-    def test_gateway_owner_sample_tolerates_one_failed_advertised_listener(self) -> None:
+    def test_gateway_owner_sample_tolerates_one_failed_advertised_listener(
+        self,
+    ) -> None:
         node_addresses = {
             "node-a": "10.0.0.1",
             "node-b": "10.0.0.2",
@@ -1378,12 +1504,12 @@ spec:
                 "returncode": 0 if available else 28,
             }
 
-        with mock.patch.object(
-            self.ha.ref, "kind_nodes", return_value=["node-a", "node-b"]
-        ), mock.patch.object(
-            self.ha.ref, "output", side_effect=output
-        ), mock.patch.object(
-            self.ha, "gateway_projection_sample", side_effect=sample
+        with (
+            mock.patch.object(
+                self.ha.ref, "kind_nodes", return_value=["node-a", "node-b"]
+            ),
+            mock.patch.object(self.ha.ref, "output", side_effect=output),
+            mock.patch.object(self.ha, "gateway_projection_sample", side_effect=sample),
         ):
             observed = self.ha.gateway_owner_sample(
                 "kind", "proof", ["10.0.0.1", "10.0.0.2"], 80, "marker"
@@ -1392,26 +1518,30 @@ spec:
         self.assertTrue(observed["available"])
         self.assertEqual(observed["failed_paths"], 1)
         self.assertEqual(observed["successful_addresses"], ["10.0.0.2"])
-        self.assertEqual(
-            observed["probe_mode"], "owner-node-any-advertised-address"
-        )
+        self.assertEqual(observed["probe_mode"], "owner-node-any-advertised-address")
 
-    def test_gateway_owner_sample_fails_when_all_advertised_listeners_fail(self) -> None:
+    def test_gateway_owner_sample_fails_when_all_advertised_listeners_fail(
+        self,
+    ) -> None:
         node_addresses = {
             "node-a": "10.0.0.1",
             "node-b": "10.0.0.2",
         }
 
-        with mock.patch.object(
-            self.ha.ref, "kind_nodes", return_value=["node-a", "node-b"]
-        ), mock.patch.object(
-            self.ha.ref,
-            "output",
-            side_effect=lambda argv: node_addresses[argv[-1]],
-        ), mock.patch.object(
-            self.ha,
-            "gateway_projection_sample",
-            return_value={"available": False, "returncode": 28},
+        with (
+            mock.patch.object(
+                self.ha.ref, "kind_nodes", return_value=["node-a", "node-b"]
+            ),
+            mock.patch.object(
+                self.ha.ref,
+                "output",
+                side_effect=lambda argv: node_addresses[argv[-1]],
+            ),
+            mock.patch.object(
+                self.ha,
+                "gateway_projection_sample",
+                return_value={"available": False, "returncode": 28},
+            ),
         ):
             observed = self.ha.gateway_owner_sample(
                 "kind", "proof", ["10.0.0.1", "10.0.0.2"], 80, "marker"
@@ -1422,10 +1552,9 @@ spec:
         self.assertEqual(observed["failed_paths"], 2)
 
     def test_gateway_owner_sample_rejects_unowned_advertised_address(self) -> None:
-        with mock.patch.object(
-            self.ha.ref, "kind_nodes", return_value=["node-a"]
-        ), mock.patch.object(
-            self.ha.ref, "output", return_value="10.0.0.1"
+        with (
+            mock.patch.object(self.ha.ref, "kind_nodes", return_value=["node-a"]),
+            mock.patch.object(self.ha.ref, "output", return_value="10.0.0.1"),
         ):
             with self.assertRaisesRegex(
                 self.ha.ref.ProofError, "exactly one kind node owner"
@@ -1440,9 +1569,7 @@ spec:
             stdout="",
             stderr="curl: (28) Operation timed out",
         )
-        with mock.patch.object(
-            self.ha.subprocess, "run", return_value=completed
-        ):
+        with mock.patch.object(self.ha.subprocess, "run", return_value=completed):
             sample = self.ha.gateway_projection_sample(
                 "kind-worker", "10.0.0.10", 80, "marker"
             )
@@ -1457,9 +1584,7 @@ spec:
             stdout=json.dumps(42),
             stderr="",
         )
-        with mock.patch.object(
-            self.ha.subprocess, "run", return_value=completed
-        ):
+        with mock.patch.object(self.ha.subprocess, "run", return_value=completed):
             sample = self.ha.gateway_projection_sample(
                 "kind-worker", "10.0.0.10", 80, "marker"
             )
@@ -1479,21 +1604,17 @@ spec:
             },
         )
         self.assertEqual(budget["measurement_window_seconds"], 50.0)
-        self.assertEqual(
-            budget["objective"], self.ha.REFERENCE_AVAILABILITY_OBJECTIVE
-        )
+        self.assertEqual(budget["objective"], self.ha.REFERENCE_AVAILABILITY_OBJECTIVE)
         self.assertEqual(budget["consumed_ratio"], 0.0)
         self.assertTrue(budget["within_budget"])
 
-    def test_change_management_contract_uses_rollout_undo_and_receipt_fields(self) -> None:
+    def test_change_management_contract_uses_rollout_undo_and_receipt_fields(
+        self,
+    ) -> None:
         source = (ROOT / "scripts/platform/ha_reference.py").read_text()
-        self.assertIn(
-            '"rollout",\n            "undo"', source
-        )
+        self.assertIn('"rollout",\n            "undo"', source)
         self.assertIn('"change_management": change_management', source)
-        self.assertIn(
-            "kubectl, kind, args.cluster, marker, gateway_before", source
-        )
+        self.assertIn("kubectl, kind, args.cluster, marker, gateway_before", source)
         self.assertIn('probe_node = gateway_probe["probe_node"]', source)
         self.assertIn('probe_address = gateway_probe["address"]', source)
         self.assertIn("gateway_owner_sample(", source)
@@ -1515,15 +1636,11 @@ spec:
         ready = source.index(
             'wait_cluster_ready(restore_kubectl, "postgres-restore", "20m")'
         )
-        rto = source.index(
-            "restore_rto = time.monotonic() - restore_started", ready
-        )
+        rto = source.index("restore_rto = time.monotonic() - restore_started", ready)
         sidecars = source.index(
             "restore_barman_sidecars = verify_barman_sidecar_images(", rto
         )
-        archive = source.index(
-            'restore_kubectl, cluster="postgres-restore"', sidecars
-        )
+        archive = source.index('restore_kubectl, cluster="postgres-restore"', sidecars)
         self.assertLess(ready, rto)
         self.assertLess(rto, sidecars)
         self.assertLess(sidecars, archive)
@@ -1531,9 +1648,11 @@ spec:
 
     def test_zone_rejoin_waits_for_cilium_before_database_readiness(self) -> None:
         source = (ROOT / "scripts/platform/ha_reference.py").read_text()
-        node_ready = source.index('f"node/{primary_topology[\'node\']}"')
+        node_ready = source.index("f\"node/{primary_topology['node']}\"")
         cilium_ready = source.index('"daemonset/cilium"', node_ready)
-        postgres_ready = source.index('wait_cluster_ready(kubectl, "postgres-ha", "15m")', cilium_ready)
+        postgres_ready = source.index(
+            'wait_cluster_ready(kubectl, "postgres-ha", "15m")', cilium_ready
+        )
         self.assertLess(node_ready, cilium_ready)
         self.assertLess(cilium_ready, postgres_ready)
         self.assertIn('["docker", "stop", "--timeout", "10", stopped_node]', source)
@@ -1542,9 +1661,15 @@ spec:
         required = "000000020000000A000000FE"
         self.assertEqual(self.ha.wal_segment_position(required), (2, 10, 254))
         self.assertTrue(self.ha.wal_archived_at_or_after(required, required))
-        self.assertTrue(self.ha.wal_archived_at_or_after("000000020000000A000000FF", required))
-        self.assertTrue(self.ha.wal_archived_at_or_after("000000030000000000000001", required))
-        self.assertFalse(self.ha.wal_archived_at_or_after("000000020000000A000000FD", required))
+        self.assertTrue(
+            self.ha.wal_archived_at_or_after("000000020000000A000000FF", required)
+        )
+        self.assertTrue(
+            self.ha.wal_archived_at_or_after("000000030000000000000001", required)
+        )
+        self.assertFalse(
+            self.ha.wal_archived_at_or_after("000000020000000A000000FD", required)
+        )
         with self.assertRaisesRegex(self.ha.ref.ProofError, "invalid PostgreSQL WAL"):
             self.ha.wal_segment_position("not-a-wal")
         source = (ROOT / "scripts/platform/ha_reference.py").read_text()
@@ -1563,21 +1688,29 @@ spec:
         self.assertNotIn("status.lastArchivedWAL", source)
 
     def test_ha_diagnostics_are_bounded_and_do_not_raise_on_timeout(self) -> None:
-        with tempfile.TemporaryDirectory() as directory, mock.patch.object(
-            self.ha, "CACHE", Path(directory)
-        ), mock.patch.object(
-            self.ha.subprocess, "run", side_effect=self.ha.subprocess.TimeoutExpired(["kubectl"], 30)
-        ) as run:
+        with (
+            tempfile.TemporaryDirectory() as directory,
+            mock.patch.object(self.ha, "CACHE", Path(directory)),
+            mock.patch.object(
+                self.ha.subprocess,
+                "run",
+                side_effect=self.ha.subprocess.TimeoutExpired(["kubectl"], 30),
+            ) as run,
+        ):
             self.ha.ha_diagnostic_snapshot("kubectl", "timeout")
             target = Path(directory) / "failures" / "timeout"
             for evidence in target.iterdir():
                 self.assertIn("diagnostic command failed", evidence.read_text())
         self.assertTrue(run.call_args_list)
-        self.assertTrue(all(call.kwargs["timeout"] == 30 for call in run.call_args_list))
+        self.assertTrue(
+            all(call.kwargs["timeout"] == 30 for call in run.call_args_list)
+        )
 
     def test_sensitive_environment_values_never_enter_argv(self) -> None:
         completed = mock.Mock(returncode=0)
-        with mock.patch.object(self.ha.subprocess, "run", return_value=completed) as run:
+        with mock.patch.object(
+            self.ha.subprocess, "run", return_value=completed
+        ) as run:
             self.ha.run_with_environment(
                 ["docker", "run", "--env", "PROOF_SECRET"],
                 {"PROOF_SECRET": "ephemeral-sensitive-value"},
@@ -1589,9 +1722,7 @@ spec:
 
     def test_pitr_boundary_uses_and_verifies_postgres_clock(self) -> None:
         with mock.patch.object(self.ha, "psql", side_effect=["", "t"]) as psql:
-            self.ha.wait_for_pitr_boundary(
-                "kubectl", "2026-07-18T08:00:00.000000Z"
-            )
+            self.ha.wait_for_pitr_boundary("kubectl", "2026-07-18T08:00:00.000000Z")
         self.assertEqual(psql.call_args_list[0].args[1], "SELECT pg_sleep(2)")
         self.assertIn("clock_timestamp()", psql.call_args_list[1].args[1])
 
@@ -1600,9 +1731,7 @@ spec:
             with self.assertRaisesRegex(
                 self.ha.ref.ProofError, "did not cross PITR target"
             ):
-                self.ha.wait_for_pitr_boundary(
-                    "kubectl", "2026-07-18T08:00:00.000000Z"
-                )
+                self.ha.wait_for_pitr_boundary("kubectl", "2026-07-18T08:00:00.000000Z")
 
     def test_cluster_context_binding_uses_cluster_specific_kubeconfig(self) -> None:
         path = ROOT / ".cache/test-restore-kubeconfig.yaml"
@@ -1660,7 +1789,9 @@ spec:
         image = self.ha.POSTGRES_IMAGE
         self.assertIn(":16.14@sha256:", image)
         self.assertNotIn("postgresql@sha256:", image)
-        catalog = (ROOT / "platform/infrastructure/ha-data/postgres-image-catalog.yaml").read_text()
+        catalog = (
+            ROOT / "platform/infrastructure/ha-data/postgres-image-catalog.yaml"
+        ).read_text()
         self.assertIn(image, catalog)
         manifest = (ROOT / "platform/infrastructure/ha-data/postgres.yaml").read_text()
         self.assertNotIn("imageName:", manifest)

--- a/scripts/ci/tests/test_kubernetes_ha_contract.py
+++ b/scripts/ci/tests/test_kubernetes_ha_contract.py
@@ -559,6 +559,70 @@ class KubernetesHaContractTests(unittest.TestCase):
         self.assertEqual(set(result["resources"].values()), {"absent"})
         self.assertEqual(result["errors"], {})
 
+    def test_primary_cluster_retirement_deletes_only_the_primary_cluster(self) -> None:
+        expected = {
+            "status": "deleted",
+            "cluster": "proof",
+            "commit": "a" * 40,
+            "owner_id": "owner-proof",
+            "resources": {"primary_cluster": "deleted"},
+            "errors": {},
+        }
+        with mock.patch.object(
+            self.ha, "reconcile_owned_ha_resources", return_value=expected
+        ) as reconcile:
+            result = self.ha.retire_primary_cluster_before_restore(
+                "kind", "proof", "a" * 40, "owner-proof"
+            )
+        self.assertIs(result, expected)
+        reconcile.assert_called_once_with(
+            "kind",
+            "proof",
+            "a" * 40,
+            "owner-proof",
+            include_restore=False,
+            include_primary=True,
+            include_object_store=False,
+        )
+
+    def test_primary_cluster_retirement_fails_closed_on_drift(self) -> None:
+        cases = (
+            {
+                "status": "absent",
+                "resources": {"primary_cluster": "absent"},
+                "errors": {},
+            },
+            {
+                "status": "error",
+                "resources": {"primary_cluster": "error"},
+                "errors": {"primary_cluster": "ownership mismatch"},
+            },
+        )
+        for result in cases:
+            with self.subTest(result=result), mock.patch.object(
+                self.ha, "reconcile_owned_ha_resources", return_value=result
+            ):
+                with self.assertRaisesRegex(
+                    self.ha.ref.ProofError,
+                    "primary cluster retirement before blank restore failed",
+                ):
+                    self.ha.retire_primary_cluster_before_restore(
+                        "kind", "proof", "a" * 40, "owner-proof"
+                    )
+
+    def test_primary_cluster_is_retired_before_restore_cluster_creation(self) -> None:
+        source = (self.ha.ROOT / "scripts/platform/ha_reference.py").read_text()
+        retirement = source.index(
+            "primary_cluster_retirement = retire_primary_cluster_before_restore("
+        )
+        restore_creation = source.index(
+            "create_kind_cluster(\n            kind, restore_name", retirement
+        )
+        self.assertLess(retirement, restore_creation)
+        transition = source[retirement:restore_creation]
+        self.assertIn("created_primary = False", transition)
+        self.assertIn("if not args.keep:", source[retirement - 40 : retirement])
+
     def test_digest_locked_manifest_replaces_each_release_image_once(self) -> None:
         tagged = {
             "registry.example/controller:v1": "registry.example/controller@sha256:" + "a" * 64,

--- a/scripts/platform/ha_reference.py
+++ b/scripts/platform/ha_reference.py
@@ -444,6 +444,27 @@ def reconcile_owned_ha_resources(
     }
 
 
+def retire_primary_cluster_before_restore(
+    kind: str, cluster: str, commit: str, owner_id: str
+) -> dict[str, Any]:
+    result = reconcile_owned_ha_resources(
+        kind,
+        cluster,
+        commit,
+        owner_id,
+        include_restore=False,
+        include_primary=True,
+        include_object_store=False,
+    )
+    primary_state = result["resources"].get("primary_cluster")
+    if result["errors"] or primary_state != "deleted":
+        raise ref.ProofError(
+            "primary cluster retirement before blank restore failed: "
+            f"{json.dumps(result, sort_keys=True)}"
+        )
+    return result
+
+
 def apply_object_store_endpoint(kubectl: str, address: str) -> None:
     ref.apply_yaml(
         kubectl,
@@ -2368,6 +2389,7 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
         node_image = oci_host["kind_node_image"]
     primary_oci_cluster: dict[str, Any] | None = None
     restore_oci_cluster: dict[str, Any] | None = None
+    primary_cluster_retirement: dict[str, Any] | None = None
     created_primary = created_restore = object_store_created = False
     stopped_node = ""
     object_store_address = ""
@@ -2528,6 +2550,12 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
             kubectl, cluster="postgres-ha"
         )
 
+        if not args.keep:
+            primary_cluster_retirement = retire_primary_cluster_before_restore(
+                kind, args.cluster, commit, owner_id
+            )
+            created_primary = False
+
         create_kind_cluster(
             kind, restore_name, node_image,
             "platform/clusters/ha/restore-kind.yaml", commit, owner_id
@@ -2591,6 +2619,10 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
         result = {
             "schema_version": 1, "status": "pass", "commit": commit,
             "primary_cluster": args.cluster, "restore_cluster": restore_name,
+            "primary_cluster_retired_before_restore": (
+                primary_cluster_retirement is not None
+            ),
+            "primary_cluster_retirement": primary_cluster_retirement,
             "tool_lock_sha256": receipt["lock_sha256"], "image_ids": image_ids,
             "oci_controlled_source": {
                 "strict": ref.controlled_oci_strict(),

--- a/scripts/platform/ha_reference.py
+++ b/scripts/platform/ha_reference.py
@@ -52,20 +52,14 @@ def sha256_text(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
-def run_with_environment(
-    argv: list[str], values: dict[str, str], *, timeout: int | None = None
-) -> None:
+def run_with_environment(argv: list[str], values: dict[str, str], *, timeout: int | None = None) -> None:
     print("+", " ".join(argv), f"[env: {','.join(sorted(values))}]", flush=True)
     environment = os.environ.copy()
     environment.update(values)
-    subprocess.run(
-        argv, cwd=ROOT, check=True, text=True, env=environment, timeout=timeout
-    )
+    subprocess.run(argv, cwd=ROOT, check=True, text=True, env=environment, timeout=timeout)
 
 
-def wait_until(
-    description: str, probe, *, timeout_seconds: int = 600, interval: float = 2.0
-):
+def wait_until(description: str, probe, *, timeout_seconds: int = 600, interval: float = 2.0):
     deadline = time.monotonic() + timeout_seconds
     last: Any = None
     while time.monotonic() < deadline:
@@ -121,23 +115,14 @@ def apply_secret_contracts(kubectl: str, app_password: str, s3_secret_key: str) 
             {
                 "apiVersion": "v1",
                 "kind": "Secret",
-                "metadata": {
-                    "name": "weltgewebe-ha-s3",
-                    "namespace": "weltgewebe-data",
-                },
+                "metadata": {"name": "weltgewebe-ha-s3", "namespace": "weltgewebe-data"},
                 "type": "Opaque",
-                "stringData": {
-                    "ACCESS_KEY_ID": S3_ACCESS_KEY,
-                    "ACCESS_SECRET_KEY": s3_secret_key,
-                },
+                "stringData": {"ACCESS_KEY_ID": S3_ACCESS_KEY, "ACCESS_SECRET_KEY": s3_secret_key},
             },
             {
                 "apiVersion": "v1",
                 "kind": "Secret",
-                "metadata": {
-                    "name": "weltgewebe-ha-app",
-                    "namespace": "weltgewebe-data",
-                },
+                "metadata": {"name": "weltgewebe-ha-app", "namespace": "weltgewebe-data"},
                 "type": "kubernetes.io/basic-auth",
                 "stringData": {"username": APP_USER, "password": app_password},
             },
@@ -145,10 +130,10 @@ def apply_secret_contracts(kubectl: str, app_password: str, s3_secret_key: str) 
     )
 
 
-def apply_runtime_secret(
-    kubectl: str, app_password: str, *, postgres_service: str = "postgres-ha-rw"
-) -> None:
-    database_url = f"postgres://{APP_USER}:{app_password}@{postgres_service}.weltgewebe-data.svc.cluster.local:5432/weltgewebe"
+def apply_runtime_secret(kubectl: str, app_password: str, *, postgres_service: str = "postgres-ha-rw") -> None:
+    database_url = (
+        f"postgres://{APP_USER}:{app_password}@{postgres_service}.weltgewebe-data.svc.cluster.local:5432/weltgewebe"
+    )
     ref.apply_yaml(
         kubectl,
         {
@@ -207,7 +192,9 @@ def _object_store_labels(resource_kind: str, name: str) -> dict[str, str] | None
         ]
     else:
         raise ValueError(f"unsupported object-store resource kind: {resource_kind}")
-    result = subprocess.run(argv, cwd=ROOT, text=True, capture_output=True, timeout=30)
+    result = subprocess.run(
+        argv, cwd=ROOT, text=True, capture_output=True, timeout=30
+    )
     if result.returncode != 0:
         detail = (result.stderr or result.stdout).strip()
         missing_markers = (
@@ -274,12 +261,12 @@ def start_external_object_store(
     container, volume = external_object_store_names(cluster)
     binding = external_object_store_binding(cluster, commit, owner_id)
     if _object_store_labels("container", container) is not None:
-        raise ref.ProofError(
-            f"external object-store container already exists: {container}"
-        )
+        raise ref.ProofError(f"external object-store container already exists: {container}")
     if _object_store_labels("volume", volume) is not None:
         raise ref.ProofError(f"external object-store volume already exists: {volume}")
-    ref.run(["docker", "volume", "create", *_docker_label_args(binding), volume])
+    ref.run(
+        ["docker", "volume", "create", *_docker_label_args(binding), volume]
+    )
     try:
         run_with_environment(
             [
@@ -318,7 +305,7 @@ def start_external_object_store(
                     "docker",
                     "inspect",
                     "--format",
-                    '{{(index .NetworkSettings.Networks "kind").IPAddress}}',
+                    "{{(index .NetworkSettings.Networks \"kind\").IPAddress}}",
                     container,
                 ]
             )
@@ -591,7 +578,9 @@ def cnpg_webhook_ready(kubectl: str) -> bool:
 def _load_yaml_documents(source: str, release_name: str) -> list[Any]:
     try:
         documents = [
-            document for document in yaml.safe_load_all(source) if document is not None
+            document
+            for document in yaml.safe_load_all(source)
+            if document is not None
         ]
     except yaml.YAMLError as error:
         raise ref.ProofError(f"{release_name} is not valid YAML") from error
@@ -665,11 +654,14 @@ def render_cnpg_manifest(source: str) -> str:
         for document in documents
         if isinstance(document, dict)
         and document.get("kind") == "Deployment"
-        and document.get("metadata", {}).get("name") == "cnpg-controller-manager"
+        and document.get("metadata", {}).get("name")
+        == "cnpg-controller-manager"
         and document.get("metadata", {}).get("namespace") == "cnpg-system"
     ]
     if len(deployments) != 1:
-        raise ref.ProofError("CloudNativePG controller deployment changed unexpectedly")
+        raise ref.ProofError(
+            "CloudNativePG controller deployment changed unexpectedly"
+        )
     deployment = deployments[0]
     spec = deployment.setdefault("spec", {})
     spec["replicas"] = 3
@@ -697,7 +689,6 @@ def render_cnpg_manifest(source: str) -> str:
     )
     documents = ref.enforce_controlled_oci_pull_policy(documents)
     return yaml.safe_dump_all(documents, sort_keys=False, explicit_start=True)
-
 
 def verify_cnpg_operator_ha(kubectl: str) -> list[str]:
     ref.wait_rollout(
@@ -750,7 +741,9 @@ def verify_cnpg_operator_ha(kubectl: str) -> list[str]:
 
 
 def install_cnpg(kubectl: str, artifact: str) -> list[str]:
-    source = render_cnpg_manifest(Path(artifact).read_text(encoding="utf-8"))
+    source = render_cnpg_manifest(
+        Path(artifact).read_text(encoding="utf-8")
+    )
     ref.run(
         [
             kubectl,
@@ -822,7 +815,6 @@ def apply_digest_locked_manifest(
         ],
         input_text=source,
     )
-
 
 def install_cert_manager(kubectl: str, artifact: str) -> None:
     apply_digest_locked_manifest(kubectl, artifact, CERT_MANAGER_IMAGES)
@@ -908,12 +900,16 @@ def render_barman_cloud_manifest(source: str) -> str:
         raise ref.ProofError(
             "Barman Cloud sidecar secret is not valid UTF-8 base64"
         ) from error
-    sidecar_tagged = "ghcr.io/cloudnative-pg/plugin-barman-cloud-sidecar:v0.13.0"
+    sidecar_tagged = (
+        "ghcr.io/cloudnative-pg/plugin-barman-cloud-sidecar:v0.13.0"
+    )
     if decoded != sidecar_tagged:
         raise ref.ProofError(
             f"Barman Cloud sidecar reference changed unexpectedly: {decoded}"
         )
-    sidecar_runtime_image = ref.controlled_oci_runtime_image(BARMAN_CLOUD_SIDECAR_IMAGE)
+    sidecar_runtime_image = ref.controlled_oci_runtime_image(
+        BARMAN_CLOUD_SIDECAR_IMAGE
+    )
     secret["data"]["SIDECAR_IMAGE"] = base64.b64encode(
         sidecar_runtime_image.encode("utf-8")
     ).decode("ascii")
@@ -954,9 +950,10 @@ def render_barman_cloud_manifest(source: str) -> str:
     documents = ref.enforce_controlled_oci_pull_policy(documents)
     return yaml.safe_dump_all(documents, sort_keys=False, explicit_start=True)
 
-
 def apply_barman_cloud_manifest(kubectl: str, artifact: str) -> None:
-    source = render_barman_cloud_manifest(Path(artifact).read_text(encoding="utf-8"))
+    source = render_barman_cloud_manifest(
+        Path(artifact).read_text(encoding="utf-8")
+    )
     ref.run(
         [
             kubectl,
@@ -974,17 +971,7 @@ def apply_barman_cloud_manifest(kubectl: str, artifact: str) -> None:
 def barman_plugin_state(kubectl: str, *, require_three_nodes: bool) -> dict[str, Any]:
     payload = json.loads(
         ref.output(
-            [
-                kubectl,
-                "-n",
-                "cnpg-system",
-                "get",
-                "pods",
-                "-l",
-                "app=barman-cloud",
-                "-o",
-                "json",
-            ]
+            [kubectl, "-n", "cnpg-system", "get", "pods", "-l", "app=barman-cloud", "-o", "json"]
         )
     )
     observed: dict[str, str] = {}
@@ -1028,22 +1015,16 @@ def barman_plugin_state(kubectl: str, *, require_three_nodes: bool) -> dict[str,
         observed[name] = node
         if pod_conditions.get("Ready") == "True":
             ready_pods.add(name)
-    if require_three_nodes and (len(observed) != 3 or len(set(observed.values())) != 3):
+    if require_three_nodes and (
+        len(observed) != 3 or len(set(observed.values())) != 3
+    ):
         raise ref.ProofError(
             "Barman Cloud plugin processes are not running on three distinct nodes: "
             f"{observed}"
         )
     endpoints = json.loads(
         ref.output(
-            [
-                kubectl,
-                "-n",
-                "cnpg-system",
-                "get",
-                "endpoints/barman-cloud",
-                "-o",
-                "json",
-            ]
+            [kubectl, "-n", "cnpg-system", "get", "endpoints/barman-cloud", "-o", "json"]
         )
     )
     endpoint_pods = {
@@ -1095,7 +1076,9 @@ def prove_barman_plugin_backup(
                 "method": "plugin",
                 "target": "primary",
                 "cluster": {"name": cluster},
-                "pluginConfiguration": {"name": "barman-cloud.cloudnative-pg.io"},
+                "pluginConfiguration": {
+                    "name": "barman-cloud.cloudnative-pg.io"
+                },
             },
         },
     )
@@ -1148,11 +1131,9 @@ def align_postgres_primary_with_barman_leader(
         )
         wait_until(
             f"PostgreSQL primary {target_primary} on Barman Cloud leader node",
-            lambda: (
-                target_primary
-                if current_primary(kubectl, cluster) == target_primary
-                else False
-            ),
+            lambda: target_primary
+            if current_primary(kubectl, cluster) == target_primary
+            else False,
             timeout_seconds=240,
         )
     wait_cluster_ready(kubectl, cluster, "10m")
@@ -1195,7 +1176,6 @@ def wait_barman_plugin_leader_after_node_loss(
             timeout_seconds=180,
         )
     )
-
 
 def install_barman_cloud_plugin(kubectl: str, artifact: str) -> dict[str, Any]:
     apply_barman_cloud_manifest(kubectl, artifact)
@@ -1248,7 +1228,8 @@ def install_barman_cloud_plugin(kubectl: str, artifact: str) -> dict[str, Any]:
     )
     if sidecar_images != [expected_sidecar_image]:
         raise ref.ProofError(
-            f"Barman Cloud sidecar image is not digest-bound: {sidecar_images}"
+            "Barman Cloud sidecar image is not digest-bound: "
+            f"{sidecar_images}"
         )
     observed = ref.output(
         [
@@ -1261,11 +1242,11 @@ def install_barman_cloud_plugin(kubectl: str, artifact: str) -> dict[str, Any]:
             "jsonpath={.spec.template.spec.containers[0].image}",
         ]
     )
-    expected_plugin_image = ref.controlled_oci_runtime_image(BARMAN_CLOUD_PLUGIN_IMAGE)
+    expected_plugin_image = ref.controlled_oci_runtime_image(
+        BARMAN_CLOUD_PLUGIN_IMAGE
+    )
     if observed != expected_plugin_image:
-        raise ref.ProofError(
-            f"Barman Cloud plugin image is not runtime-bound: {observed}"
-        )
+        raise ref.ProofError(f"Barman Cloud plugin image is not runtime-bound: {observed}")
     return plugin_nodes
 
 
@@ -1312,14 +1293,17 @@ def verify_barman_sidecar_images(
         declared_image = str(sidecars[0].get("image", ""))
         if declared_image != expected_sidecar_image:
             raise ref.ProofError(
-                f"PostgreSQL pod {name} has an unbound Barman sidecar: {declared_image}"
+                f"PostgreSQL pod {name} has an unbound Barman sidecar: "
+                f"{declared_image}"
             )
         statuses = [
             *pod.get("status", {}).get("initContainerStatuses", []),
             *pod.get("status", {}).get("containerStatuses", []),
         ]
         sidecar_statuses = [
-            status for status in statuses if status.get("name") == "plugin-barman-cloud"
+            status
+            for status in statuses
+            if status.get("name") == "plugin-barman-cloud"
         ]
         if len(sidecar_statuses) != 1:
             raise ref.ProofError(
@@ -1350,192 +1334,66 @@ def verify_barman_sidecar_images(
         )
     return observed
 
-
 def current_primary(kubectl: str, cluster: str = "postgres-ha") -> str:
-    return ref.output(
-        [
-            kubectl,
-            "-n",
-            "weltgewebe-data",
-            "get",
-            f"cluster/{cluster}",
-            "-o",
-            "jsonpath={.status.currentPrimary}",
-        ]
-    )
+    return ref.output([kubectl, "-n", "weltgewebe-data", "get", f"cluster/{cluster}", "-o", "jsonpath={.status.currentPrimary}"])
 
 
 def wait_cluster_ready(kubectl: str, cluster: str, timeout: str = "15m") -> None:
-    ref.wait_condition(
-        kubectl, "weltgewebe-data", f"cluster/{cluster}", "Ready", timeout
-    )
+    ref.wait_condition(kubectl, "weltgewebe-data", f"cluster/{cluster}", "Ready", timeout)
 
 
 def ha_diagnostic_snapshot(kubectl: str, name: str) -> None:
     target = CACHE / "failures" / name
     target.mkdir(parents=True, exist_ok=True)
     commands = {
-        "cnpg-clusters.yaml": [
-            kubectl,
-            "get",
-            "clusters.postgresql.cnpg.io",
-            "-A",
-            "-o",
-            "yaml",
-        ],
-        "cnpg-pods-describe.txt": [
-            kubectl,
-            "-n",
-            "weltgewebe-data",
-            "describe",
-            "pods",
-            "-l",
-            "cnpg.io/cluster",
-        ],
-        "cnpg-pods-logs.txt": [
-            kubectl,
-            "-n",
-            "weltgewebe-data",
-            "logs",
-            "-l",
-            "cnpg.io/cluster",
-            "--all-containers=true",
-            "--prefix=true",
-            "--tail=2000",
-        ],
-        "cnpg-pods-previous-logs.txt": [
-            kubectl,
-            "-n",
-            "weltgewebe-data",
-            "logs",
-            "-l",
-            "cnpg.io/cluster",
-            "--all-containers=true",
-            "--prefix=true",
-            "--previous=true",
-            "--tail=2000",
-        ],
+        "cnpg-clusters.yaml": [kubectl, "get", "clusters.postgresql.cnpg.io", "-A", "-o", "yaml"],
+        "cnpg-pods-describe.txt": [kubectl, "-n", "weltgewebe-data", "describe", "pods", "-l", "cnpg.io/cluster"],
+        "cnpg-pods-logs.txt": [kubectl, "-n", "weltgewebe-data", "logs", "-l", "cnpg.io/cluster", "--all-containers=true", "--prefix=true", "--tail=2000"],
+        "cnpg-pods-previous-logs.txt": [kubectl, "-n", "weltgewebe-data", "logs", "-l", "cnpg.io/cluster", "--all-containers=true", "--prefix=true", "--previous=true", "--tail=2000"],
         "cnpg-operator-deployment.yaml": [
-            kubectl,
-            "-n",
-            "cnpg-system",
-            "get",
-            "deployment/cnpg-controller-manager",
-            "-o",
-            "yaml",
+            kubectl, "-n", "cnpg-system", "get",
+            "deployment/cnpg-controller-manager", "-o", "yaml",
         ],
         "cnpg-operator-replicasets.yaml": [
-            kubectl,
-            "-n",
-            "cnpg-system",
-            "get",
-            "replicasets",
-            "-l",
-            "app.kubernetes.io/name=cloudnative-pg",
-            "-o",
-            "yaml",
+            kubectl, "-n", "cnpg-system", "get",
+            "replicasets", "-l", "app.kubernetes.io/name=cloudnative-pg",
+            "-o", "yaml",
         ],
         "cnpg-operator-logs.txt": [
-            kubectl,
-            "-n",
-            "cnpg-system",
-            "logs",
-            "-l",
-            "app.kubernetes.io/name=cloudnative-pg",
-            "--all-containers=true",
-            "--prefix=true",
-            "--tail=2000",
+            kubectl, "-n", "cnpg-system", "logs",
+            "-l", "app.kubernetes.io/name=cloudnative-pg",
+            "--all-containers=true", "--prefix=true", "--tail=2000",
         ],
         "barman-plugin-deployment.yaml": [
-            kubectl,
-            "-n",
-            "cnpg-system",
-            "get",
-            "deployment/barman-cloud",
-            "-o",
-            "yaml",
+            kubectl, "-n", "cnpg-system", "get", "deployment/barman-cloud", "-o", "yaml",
         ],
         "barman-plugin-pods-describe.txt": [
-            kubectl,
-            "-n",
-            "cnpg-system",
-            "describe",
-            "pods",
-            "-l",
-            "app=barman-cloud",
+            kubectl, "-n", "cnpg-system", "describe", "pods", "-l", "app=barman-cloud",
         ],
         "barman-plugin-endpoints.yaml": [
-            kubectl,
-            "-n",
-            "cnpg-system",
-            "get",
-            "endpoints/barman-cloud",
-            "-o",
-            "yaml",
+            kubectl, "-n", "cnpg-system", "get", "endpoints/barman-cloud", "-o", "yaml",
         ],
         "barman-plugin-logs.txt": [
-            kubectl,
-            "-n",
-            "cnpg-system",
-            "logs",
-            "-l",
-            "app=barman-cloud",
-            "--all-containers=true",
-            "--prefix=true",
-            "--tail=2000",
+            kubectl, "-n", "cnpg-system", "logs", "-l", "app=barman-cloud",
+            "--all-containers=true", "--prefix=true", "--tail=2000",
         ],
-        "barman-objectstores.yaml": [
-            kubectl,
-            "get",
-            "objectstores.barmancloud.cnpg.io",
-            "-A",
-            "-o",
-            "yaml",
-        ],
-        "certificates.yaml": [
-            kubectl,
-            "get",
-            "certificates.cert-manager.io",
-            "-A",
-            "-o",
-            "yaml",
-        ],
+        "barman-objectstores.yaml": [kubectl, "get", "objectstores.barmancloud.cnpg.io", "-A", "-o", "yaml"],
+        "certificates.yaml": [kubectl, "get", "certificates.cert-manager.io", "-A", "-o", "yaml"],
         "cluster-dns-deployment.yaml": [
-            kubectl,
-            "-n",
-            "kube-system",
-            "get",
-            "deployment/coredns",
-            "-o",
-            "yaml",
+            kubectl, "-n", "kube-system", "get", "deployment/coredns", "-o", "yaml",
         ],
         "cluster-dns-pods-describe.txt": [
-            kubectl,
-            "-n",
-            "kube-system",
-            "describe",
-            "pods",
-            "-l",
-            "k8s-app=kube-dns",
+            kubectl, "-n", "kube-system", "describe", "pods", "-l", "k8s-app=kube-dns",
         ],
         "cluster-dns-logs.txt": [
-            kubectl,
-            "-n",
-            "kube-system",
-            "logs",
-            "-l",
-            "k8s-app=kube-dns",
-            "--all-containers=true",
-            "--prefix=true",
-            "--tail=2000",
+            kubectl, "-n", "kube-system", "logs", "-l", "k8s-app=kube-dns",
+            "--all-containers=true", "--prefix=true", "--tail=2000",
         ],
         "storage.txt": [kubectl, "get", "pv,pvc", "-A", "-o", "wide"],
     }
     for filename, argv in commands.items():
         try:
-            result = subprocess.run(
-                argv, cwd=ROOT, text=True, capture_output=True, timeout=30
-            )
+            result = subprocess.run(argv, cwd=ROOT, text=True, capture_output=True, timeout=30)
             evidence = result.stdout + result.stderr
         except (OSError, subprocess.TimeoutExpired) as error:
             evidence = f"diagnostic command failed: {error}\n"
@@ -1544,9 +1402,7 @@ def ha_diagnostic_snapshot(kubectl: str, name: str) -> None:
 
 def wal_segment_position(name: str) -> tuple[int, int, int]:
     normalized = name.strip().upper()
-    if len(normalized) != 24 or any(
-        character not in "0123456789ABCDEF" for character in normalized
-    ):
+    if len(normalized) != 24 or any(character not in "0123456789ABCDEF" for character in normalized):
         raise ref.ProofError(f"invalid PostgreSQL WAL segment name: {name!r}")
     return tuple(int(normalized[offset : offset + 8], 16) for offset in (0, 8, 16))
 
@@ -1559,21 +1415,7 @@ def psql(kubectl: str, sql: str, *, cluster: str = "postgres-ha") -> str:
     primary = current_primary(kubectl, cluster)
     if not primary:
         raise ref.ProofError(f"PostgreSQL cluster {cluster} has no current primary")
-    return ref.output(
-        [
-            kubectl,
-            "-n",
-            "weltgewebe-data",
-            "exec",
-            primary,
-            "--",
-            "psql",
-            "-d",
-            "weltgewebe",
-            "-Atqc",
-            sql,
-        ]
-    )
+    return ref.output([kubectl, "-n", "weltgewebe-data", "exec", primary, "--", "psql", "-d", "weltgewebe", "-Atqc", sql])
 
 
 def wait_for_pitr_boundary(kubectl: str, target_time: str) -> None:
@@ -1589,21 +1431,10 @@ def wait_for_pitr_boundary(kubectl: str, target_time: str) -> None:
         )
 
 
-def pod_topology(
-    kubectl: str, namespace: str, selector: str
-) -> dict[str, dict[str, str]]:
-    pods = json.loads(
-        ref.output(
-            [kubectl, "-n", namespace, "get", "pods", "-l", selector, "-o", "json"]
-        )
-    )
+def pod_topology(kubectl: str, namespace: str, selector: str) -> dict[str, dict[str, str]]:
+    pods = json.loads(ref.output([kubectl, "-n", namespace, "get", "pods", "-l", selector, "-o", "json"]))
     nodes = json.loads(ref.output([kubectl, "get", "nodes", "-o", "json"]))
-    zones = {
-        item["metadata"]["name"]: item["metadata"]
-        .get("labels", {})
-        .get("topology.kubernetes.io/zone", "")
-        for item in nodes["items"]
-    }
+    zones = {item["metadata"]["name"]: item["metadata"].get("labels", {}).get("topology.kubernetes.io/zone", "") for item in nodes["items"]}
     result: dict[str, dict[str, str]] = {}
     for item in pods["items"]:
         metadata = item.get("metadata", {})
@@ -1622,14 +1453,10 @@ def pod_topology(
     return result
 
 
-def require_zones(
-    topology: dict[str, dict[str, str]], expected: int, component: str
-) -> None:
+def require_zones(topology: dict[str, dict[str, str]], expected: int, component: str) -> None:
     zones = {item["zone"] for item in topology.values() if item["zone"]}
     if len(topology) < expected or len(zones) != expected:
-        raise ref.ProofError(
-            f"{component} is not spread across {expected} zones: {topology}"
-        )
+        raise ref.ProofError(f"{component} is not spread across {expected} zones: {topology}")
 
 
 def configure_cluster_dns_ha(kubectl: str) -> dict[str, dict[str, str]]:
@@ -1674,28 +1501,18 @@ def configure_cluster_dns_ha(kubectl: str) -> dict[str, dict[str, str]]:
     ref.wait_rollout(kubectl, "kube-system", "deployment/coredns", "8m")
     topology = pod_topology(kubectl, "kube-system", "k8s-app=kube-dns")
     if len(topology) != 3:
-        raise ref.ProofError(f"cluster DNS requires exactly three replicas: {topology}")
+        raise ref.ProofError(
+            f"cluster DNS requires exactly three replicas: {topology}"
+        )
     require_zones(topology, 3, "cluster DNS")
     return topology
 
 
 def wait_api_replicas(kubectl: str, expected: int = 3) -> None:
     ref.wait_rollout(kubectl, "weltgewebe", "deployment/weltgewebe-api", "10m")
-    available = ref.output(
-        [
-            kubectl,
-            "-n",
-            "weltgewebe",
-            "get",
-            "deployment/weltgewebe-api",
-            "-o",
-            "jsonpath={.status.availableReplicas}",
-        ]
-    )
+    available = ref.output([kubectl, "-n", "weltgewebe", "get", "deployment/weltgewebe-api", "-o", "jsonpath={.status.availableReplicas}"])
     if available != str(expected):
-        raise ref.ProofError(
-            f"expected {expected} available API replicas, got {available!r}"
-        )
+        raise ref.ProofError(f"expected {expected} available API replicas, got {available!r}")
     ref.wait_rollout(kubectl, "weltgewebe", "deployment/weltgewebe-web", "10m")
 
 
@@ -1786,7 +1603,7 @@ def api_deployment_image(kubectl: str) -> str:
             "get",
             "deployment/weltgewebe-api",
             "-o",
-            'jsonpath={.spec.template.spec.containers[?(@.name=="api")].image}',
+            "jsonpath={.spec.template.spec.containers[?(@.name==\"api\")].image}",
         ]
     )
 
@@ -1810,7 +1627,9 @@ def api_rollout_complete(kubectl: str, expected_image: str) -> bool:
     status = deployment.get("status", {})
     images = {
         container.get("name"): container.get("image")
-        for container in spec.get("template", {}).get("spec", {}).get("containers", [])
+        for container in spec.get("template", {})
+        .get("spec", {})
+        .get("containers", [])
     }
     return (
         images.get("api") == expected_image
@@ -1872,13 +1691,17 @@ def projection_sample_url(node: str, url: str, marker: str) -> dict[str, Any]:
 def gateway_projection_sample(
     node: str, address: str, port: int, marker: str
 ) -> dict[str, Any]:
-    return projection_sample_url(node, f"http://{address}:{port}/api/nodes", marker)
+    return projection_sample_url(
+        node, f"http://{address}:{port}/api/nodes", marker
+    )
 
 
 def gateway_projection_available(
     node: str, address: str, port: int, marker: str
 ) -> bool:
-    return bool(gateway_projection_sample(node, address, port, marker)["available"])
+    return bool(
+        gateway_projection_sample(node, address, port, marker)["available"]
+    )
 
 
 def gateway_owner_sample(
@@ -1918,7 +1741,8 @@ def gateway_owner_sample(
         )
 
     targets = [
-        (owners_by_address[address][0], address) for address in gateway_addresses
+        (owners_by_address[address][0], address)
+        for address in gateway_addresses
     ]
 
     def run_target(target: tuple[str, str]) -> dict[str, Any]:
@@ -1938,7 +1762,9 @@ def gateway_owner_sample(
 
     failed_paths = [probe for probe in probes if probe.get("available") is not True]
     successful_addresses = [
-        str(probe["address"]) for probe in probes if probe.get("available") is True
+        str(probe["address"])
+        for probe in probes
+        if probe.get("available") is True
     ]
     return {
         "available": bool(successful_addresses),
@@ -1986,7 +1812,8 @@ def projection_path_diagnostic(
         {
             address
             for endpoint in endpoint_state
-            if endpoint.get("ready") is True and endpoint.get("terminating") is not True
+            if endpoint.get("ready") is True
+            and endpoint.get("terminating") is not True
             for address in endpoint.get("addresses", [])
             if isinstance(address, str) and address
         }
@@ -2002,7 +1829,9 @@ def projection_path_diagnostic(
             )
         )
     for pod_ip in ready_pod_ips:
-        targets.append(("pod", probe_node, pod_ip, f"http://{pod_ip}:8080/nodes"))
+        targets.append(
+            ("pod", probe_node, pod_ip, f"http://{pod_ip}:8080/nodes")
+        )
     gateway_addresses = sorted(set(ref.gateway_addresses(kubectl)))
     gateway_nodes = sorted(set(ref.kind_nodes(kind, cluster)))
     for node in gateway_nodes:
@@ -2121,11 +1950,15 @@ def api_transition_diagnostic(
                 "pod_ip": item.get("status", {}).get("podIP"),
                 "phase": item.get("status", {}).get("phase"),
                 "ready": conditions.get("Ready") == "True",
-                "deleting": bool(item.get("metadata", {}).get("deletionTimestamp")),
+                "deleting": bool(
+                    item.get("metadata", {}).get("deletionTimestamp")
+                ),
                 "image": next(
                     (
                         container.get("image")
-                        for container in item.get("spec", {}).get("containers", [])
+                        for container in item.get("spec", {}).get(
+                            "containers", []
+                        )
                         if container.get("name") == "api"
                     ),
                     None,
@@ -2142,7 +1975,9 @@ def api_transition_diagnostic(
                     "target": endpoint.get("targetRef", {}).get("name"),
                     "ready": endpoint.get("conditions", {}).get("ready"),
                     "serving": endpoint.get("conditions", {}).get("serving"),
-                    "terminating": endpoint.get("conditions", {}).get("terminating"),
+                    "terminating": endpoint.get("conditions", {}).get(
+                        "terminating"
+                    ),
                 }
             )
     status = deployment.get("status", {})
@@ -2219,7 +2054,9 @@ def measure_api_transition(
                     max_failed_gateway_paths, sample_failed_paths
                 )
             if available:
-                rollout_complete = api_rollout_complete(kubectl, expected_image)
+                rollout_complete = api_rollout_complete(
+                    kubectl, expected_image
+                )
         except (
             subprocess.CalledProcessError,
             subprocess.TimeoutExpired,
@@ -2237,7 +2074,9 @@ def measure_api_transition(
             if outage_started is not None:
                 outage = sampled_at - outage_started
                 unavailable_seconds += outage
-                longest_unavailable_seconds = max(longest_unavailable_seconds, outage)
+                longest_unavailable_seconds = max(
+                    longest_unavailable_seconds, outage
+                )
                 outage_started = None
         else:
             failed_samples += 1
@@ -2265,7 +2104,9 @@ def measure_api_transition(
                         "diagnostic_error": f"{type(error).__name__}: {error}",
                     }
                 diagnostic["sample"] = samples
-                diagnostic["elapsed_seconds"] = round(sampled_at - started, 3)
+                diagnostic["elapsed_seconds"] = round(
+                    sampled_at - started, 3
+                )
                 outage_diagnostics.append(diagnostic)
         if available and rollout_complete:
             break
@@ -2320,7 +2161,9 @@ def measure_api_transition(
 def compute_error_budget(
     upgrade: dict[str, Any], rollback: dict[str, Any]
 ) -> dict[str, Any]:
-    window = float(upgrade["duration_seconds"]) + float(rollback["duration_seconds"])
+    window = float(upgrade["duration_seconds"]) + float(
+        rollback["duration_seconds"]
+    )
     if window <= 0:
         raise ref.ProofError("change-management measurement window is empty")
     unavailable = float(upgrade["observed_unavailable_seconds"]) + float(
@@ -2417,9 +2260,13 @@ def prove_api_upgrade_and_rollback(
     }
 
 
-def measure_wal_archive(kubectl: str, *, cluster: str) -> dict[str, Any]:
+def measure_wal_archive(
+    kubectl: str, *, cluster: str
+) -> dict[str, Any]:
     started = time.monotonic()
-    required = psql(kubectl, "SELECT pg_walfile_name(pg_switch_wal())", cluster=cluster)
+    required = psql(
+        kubectl, "SELECT pg_walfile_name(pg_switch_wal())", cluster=cluster
+    )
     wal_segment_position(required)
 
     def archived_probe() -> str | bool:
@@ -2448,60 +2295,27 @@ def measure_wal_archive(kubectl: str, *, cluster: str) -> dict[str, Any]:
     }
 
 
-def insert_domain_node(
-    kubectl: str, node_id: str, title: str, *, cluster: str = "postgres-ha"
-) -> None:
-    payload = json.dumps(
-        {"summary": "HA recovery proof", "tags": ["ha-proof"]}, separators=(",", ":")
-    )
+def insert_domain_node(kubectl: str, node_id: str, title: str, *, cluster: str = "postgres-ha") -> None:
+    payload = json.dumps({"summary": "HA recovery proof", "tags": ["ha-proof"]}, separators=(",", ":"))
     sql = (
         "INSERT INTO domain_nodes (id,kind,title,lat,lon,created_at,updated_at,payload) VALUES ("
-        + "'"
-        + node_id
-        + "','Werkstatt','"
-        + title.replace("'", "''")
-        + "',53.55,9.99,clock_timestamp(),clock_timestamp(),'"
-        + payload.replace("'", "''")
-        + "'::jsonb) ON CONFLICT (id) DO NOTHING"
+        + "'" + node_id + "','Werkstatt','" + title.replace("'", "''") + "',53.55,9.99,clock_timestamp(),clock_timestamp(),'"
+        + payload.replace("'", "''") + "'::jsonb) ON CONFLICT (id) DO NOTHING"
     )
     psql(kubectl, sql, cluster=cluster)
 
 
 def node_exists(kubectl: str, node_id: str, *, cluster: str = "postgres-ha") -> bool:
-    return (
-        psql(
-            kubectl,
-            f"SELECT count(*) FROM domain_nodes WHERE id='{node_id}'",
-            cluster=cluster,
-        )
-        == "1"
-    )
+    return psql(kubectl, f"SELECT count(*) FROM domain_nodes WHERE id='{node_id}'", cluster=cluster) == "1"
 
 
 def gateway_contains_node(kubectl: str, kind: str, cluster: str, node_id: str) -> bool:
-    ref.wait_condition(
-        kubectl, "weltgewebe-gateway", "gateway/weltgewebe", "Programmed", "5m"
-    )
-    service = ref.output(
-        [
-            kubectl,
-            "-n",
-            "weltgewebe-gateway",
-            "get",
-            "service",
-            "-l",
-            "gateway.networking.k8s.io/gateway-name=weltgewebe",
-            "-o",
-            "jsonpath={.items[0].metadata.name}",
-        ]
-    )
+    ref.wait_condition(kubectl, "weltgewebe-gateway", "gateway/weltgewebe", "Programmed", "5m")
+    service = ref.output([kubectl, "-n", "weltgewebe-gateway", "get", "service", "-l", "gateway.networking.k8s.io/gateway-name=weltgewebe", "-o", "jsonpath={.items[0].metadata.name}"])
     port = ref.gateway_listener_port(kubectl)
     _, _, _, _, body = ref.probe_gateway_http(
-        kind,
-        cluster,
-        ref.gateway_addresses(kubectl),
-        ref.gateway_service_listener_port(kubectl, service, port),
-        timeout_seconds=30,
+        kind, cluster, ref.gateway_addresses(kubectl),
+        ref.gateway_service_listener_port(kubectl, service, port), timeout_seconds=30,
     )
     payload = json.loads(body)
     return any(isinstance(item, dict) and item.get("id") == node_id for item in payload)
@@ -2511,101 +2325,45 @@ def create_nats_box(kubectl: str, zone: str) -> None:
     ref.apply_yaml(
         kubectl,
         {
-            "apiVersion": "v1",
-            "kind": "Pod",
+            "apiVersion": "v1", "kind": "Pod",
             "metadata": {"name": "nats-box", "namespace": "weltgewebe-data"},
             "spec": {
                 "automountServiceAccountToken": False,
                 "nodeSelector": {"topology.kubernetes.io/zone": zone},
                 "restartPolicy": "Never",
-                "securityContext": {
-                    "runAsNonRoot": True,
-                    "runAsUser": 1000,
-                    "runAsGroup": 1000,
-                    "seccompProfile": {"type": "RuntimeDefault"},
-                },
-                "containers": [
-                    {
-                        "name": "nats-box",
-                        "image": NATS_BOX_IMAGE,
-                        "command": ["/bin/sh", "-c", "sleep 7200"],
-                        "securityContext": {
-                            "allowPrivilegeEscalation": False,
-                            "capabilities": {"drop": ["ALL"]},
-                        },
-                        "resources": {
-                            "requests": {"cpu": "20m", "memory": "32Mi"},
-                            "limits": {"cpu": "200m", "memory": "128Mi"},
-                        },
-                    }
-                ],
+                "securityContext": {"runAsNonRoot": True, "runAsUser": 1000, "runAsGroup": 1000, "seccompProfile": {"type": "RuntimeDefault"}},
+                "containers": [{
+                    "name": "nats-box", "image": NATS_BOX_IMAGE,
+                    "command": ["/bin/sh", "-c", "sleep 7200"],
+                    "securityContext": {"allowPrivilegeEscalation": False, "capabilities": {"drop": ["ALL"]}},
+                    "resources": {"requests": {"cpu": "20m", "memory": "32Mi"}, "limits": {"cpu": "200m", "memory": "128Mi"}},
+                }],
             },
         },
     )
     ref.wait_condition(kubectl, "weltgewebe-data", "pod/nats-box", "Ready", "5m")
 
 
-def nats(
-    kubectl: str, args: list[str], *, check: bool = True
-) -> subprocess.CompletedProcess[str]:
-    argv = [
-        kubectl,
-        "-n",
-        "weltgewebe-data",
-        "exec",
-        "nats-box",
-        "--",
-        "nats",
-        "--server",
-        "nats://nats:4222",
-        "--js-domain",
-        "weltgewebe-ha",
-        *args,
-    ]
-    return (
-        ref.run(argv, capture=True)
-        if check
-        else subprocess.run(argv, cwd=ROOT, text=True, capture_output=True)
-    )
+def nats(kubectl: str, args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    argv = [kubectl, "-n", "weltgewebe-data", "exec", "nats-box", "--", "nats", "--server", "nats://nats:4222", "--js-domain", "weltgewebe-ha", *args]
+    return ref.run(argv, capture=True) if check else subprocess.run(argv, cwd=ROOT, text=True, capture_output=True)
 
 
 def nats_message_count(kubectl: str) -> int:
-    document = json.loads(
-        nats(kubectl, ["stream", "info", "WG_PROOF", "--json"]).stdout
-    )
+    document = json.loads(nats(kubectl, ["stream", "info", "WG_PROOF", "--json"]).stdout)
     return int(document.get("state", {}).get("messages", -1))
 
 
 def wait_backup_complete(kubectl: str, name: str) -> dict[str, Any]:
     def probe():
-        document = json.loads(
-            ref.output(
-                [
-                    kubectl,
-                    "-n",
-                    "weltgewebe-data",
-                    "get",
-                    f"backup/{name}",
-                    "-o",
-                    "json",
-                ]
-            )
-        )
-        return (
-            document
-            if str(document.get("status", {}).get("phase", "")).lower() == "completed"
-            else False
-        )
-
-    return wait_until(
-        f"CloudNativePG backup {name}", probe, timeout_seconds=1200, interval=5
-    )
+        document = json.loads(ref.output([kubectl, "-n", "weltgewebe-data", "get", f"backup/{name}", "-o", "json"]))
+        return document if str(document.get("status", {}).get("phase", "")).lower() == "completed" else False
+    return wait_until(f"CloudNativePG backup {name}", probe, timeout_seconds=1200, interval=5)
 
 
 def restore_cluster_document(target_time: str) -> dict[str, Any]:
     return {
-        "apiVersion": "postgresql.cnpg.io/v1",
-        "kind": "Cluster",
+        "apiVersion": "postgresql.cnpg.io/v1", "kind": "Cluster",
         "metadata": {"name": "postgres-restore", "namespace": "weltgewebe-data"},
         "spec": {
             "instances": 3,
@@ -2618,39 +2376,32 @@ def restore_cluster_document(target_time: str) -> dict[str, Any]:
             "bootstrap": {
                 "recovery": {
                     "source": "postgres-ha",
-                    "database": "weltgewebe",
-                    "owner": APP_USER,
+                    "database": "weltgewebe", "owner": APP_USER,
                     "secret": {"name": "weltgewebe-ha-app"},
                     "recoveryTarget": {"targetTime": target_time, "exclusive": True},
                 }
             },
-            "externalClusters": [
-                {
-                    "name": "postgres-ha",
-                    "plugin": {
-                        "name": "barman-cloud.cloudnative-pg.io",
-                        "parameters": {
-                            "barmanObjectName": "weltgewebe-ha-backup",
-                            "serverName": "postgres-ha",
-                        },
-                    },
-                }
-            ],
-            "plugins": [
-                {
+            "externalClusters": [{
+                "name": "postgres-ha",
+                "plugin": {
                     "name": "barman-cloud.cloudnative-pg.io",
-                    "isWALArchiver": True,
-                    "parameters": {"barmanObjectName": "weltgewebe-ha-backup"},
-                }
-            ],
+                    "parameters": {
+                        "barmanObjectName": "weltgewebe-ha-backup",
+                        "serverName": "postgres-ha",
+                    },
+                },
+            }],
+            "plugins": [{
+                "name": "barman-cloud.cloudnative-pg.io",
+                "isWALArchiver": True,
+                "parameters": {
+                    "barmanObjectName": "weltgewebe-ha-backup"
+                },
+            }],
             "storage": {"size": "1Gi"},
-            "resources": {
-                "requests": {"cpu": "100m", "memory": "256Mi"},
-                "limits": {"cpu": "1", "memory": "1Gi"},
-            },
+            "resources": {"requests": {"cpu": "100m", "memory": "256Mi"}, "limits": {"cpu": "1", "memory": "1Gi"}},
             "affinity": {
-                "enablePodAntiAffinity": True,
-                "podAntiAffinityType": "required",
+                "enablePodAntiAffinity": True, "podAntiAffinityType": "required",
                 "topologyKey": "topology.kubernetes.io/zone",
                 "nodeSelector": {"weltgewebe.net/data-node": "true"},
             },
@@ -2660,9 +2411,7 @@ def restore_cluster_document(target_time: str) -> dict[str, Any]:
 
 def prove(args: argparse.Namespace) -> dict[str, Any]:
     if ref.output(["git", "status", "--porcelain"]):
-        raise ref.ProofError(
-            "HA recovery proof requires a clean, commit-bound worktree"
-        )
+        raise ref.ProofError("HA recovery proof requires a clean, commit-bound worktree")
     commit = ref.output(["git", "rev-parse", "HEAD"])
     timestamp = ref.output(["git", "show", "-s", "--format=%cI", "HEAD"])
     ref.require_host_tools()
@@ -2697,12 +2446,8 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
     s3_secret_key = secrets.token_urlsafe(32)
     try:
         create_kind_cluster(
-            kind,
-            args.cluster,
-            node_image,
-            "platform/clusters/ha/kind.yaml",
-            commit,
-            owner_id,
+            kind, args.cluster, node_image,
+            "platform/clusters/ha/kind.yaml", commit, owner_id
         )
         lifecycle.primary_created = True
         if ref.controlled_oci_strict():
@@ -2711,17 +2456,11 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
             )
         kubectl = require_active_cluster_context(kind, kubectl, args.cluster)
         image_ids = ref.build_images(kind, args.cluster, commit, timestamp)
-        image_ids.update(prepare_api_upgrade_candidate(kind, args.cluster, commit))
-        ref.install_platform_components(
-            kubectl,
-            flux,
-            helm,
-            receipt["artifacts"],
-            ref.control_plane_address(args.cluster),
+        image_ids.update(
+            prepare_api_upgrade_candidate(kind, args.cluster, commit)
         )
-        ref.run(
-            [kubectl, "wait", "--for=condition=Ready", "nodes", "--all", "--timeout=8m"]
-        )
+        ref.install_platform_components(kubectl, flux, helm, receipt["artifacts"], ref.control_plane_address(args.cluster))
+        ref.run([kubectl, "wait", "--for=condition=Ready", "nodes", "--all", "--timeout=8m"])
         primary_dns_topology = configure_cluster_dns_ha(kubectl)
         _, _, object_store_address = start_external_object_store(
             args.cluster, commit, owner_id, s3_secret_key
@@ -2729,9 +2468,7 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
         object_store_created = True
         ref.apply_file(kubectl, ROOT / "platform/infrastructure/ha-data/namespace.yaml")
         apply_secret_contracts(kubectl, app_password, s3_secret_key)
-        ref.apply_file(
-            kubectl, ROOT / "platform/infrastructure/ha-data/object-store.yaml"
-        )
+        ref.apply_file(kubectl, ROOT / "platform/infrastructure/ha-data/object-store.yaml")
         apply_object_store_endpoint(kubectl, object_store_address)
         install_cert_manager(kubectl, receipt["artifacts"]["cert_manager"])
         primary_operator_nodes = install_cnpg(
@@ -2744,41 +2481,29 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
         ref.apply_direct(kubectl, kustomize, "platform/infrastructure/ha-data")
         ref.wait_rollout(kubectl, "weltgewebe-data", "statefulset/nats", "12m")
         wait_cluster_ready(kubectl, "postgres-ha", "15m")
-        primary_barman_sidecars = verify_barman_sidecar_images(kubectl, "postgres-ha")
-        ref.apply_file(
-            kubectl, ROOT / "platform/apps/weltgewebe/migration/ha/namespace.yaml"
+        primary_barman_sidecars = verify_barman_sidecar_images(
+            kubectl, "postgres-ha"
         )
+        ref.apply_file(kubectl, ROOT / "platform/apps/weltgewebe/migration/ha/namespace.yaml")
         apply_runtime_secret(kubectl, app_password)
         ref.apply_direct(kubectl, kustomize, "platform/apps/weltgewebe/migration/ha")
-        ref.wait_condition(
-            kubectl, "weltgewebe", "job/weltgewebe-migration", "Complete", "10m"
-        )
+        ref.wait_condition(kubectl, "weltgewebe", "job/weltgewebe-migration", "Complete", "10m")
         ref.apply_direct(kubectl, kustomize, "platform/apps/weltgewebe/overlays/ha")
         ref.apply_direct(kubectl, kustomize, "platform/infrastructure/gateway")
         wait_api_replicas(kubectl)
         gateway_before = ref.prove_gateway(kubectl, kind, args.cluster)
 
         topology = {
-            "postgres": pod_topology(
-                kubectl, "weltgewebe-data", "cnpg.io/cluster=postgres-ha"
-            ),
-            "nats": pod_topology(
-                kubectl, "weltgewebe-data", "app.kubernetes.io/name=nats"
-            ),
-            "api": pod_topology(
-                kubectl, "weltgewebe", "app.kubernetes.io/name=weltgewebe-api"
-            ),
+            "postgres": pod_topology(kubectl, "weltgewebe-data", "cnpg.io/cluster=postgres-ha"),
+            "nats": pod_topology(kubectl, "weltgewebe-data", "app.kubernetes.io/name=nats"),
+            "api": pod_topology(kubectl, "weltgewebe", "app.kubernetes.io/name=weltgewebe-api"),
         }
         for component, observed in topology.items():
             require_zones(observed, 3, component)
 
         marker = "00000000-0000-4000-8000-00000000a004"
         insert_domain_node(kubectl, marker, "T004 acknowledged domain mutation")
-        wait_until(
-            "domain mutation in API projection",
-            lambda: gateway_contains_node(kubectl, kind, args.cluster, marker),
-            timeout_seconds=180,
-        )
+        wait_until("domain mutation in API projection", lambda: gateway_contains_node(kubectl, kind, args.cluster, marker), timeout_seconds=180)
         change_management = prove_api_upgrade_and_rollback(
             kubectl, kind, args.cluster, marker, gateway_before
         )
@@ -2801,29 +2526,9 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
                 "PostgreSQL primary and Barman Cloud leader are not co-located "
                 f"before failure: {barman_leader_alignment}"
             )
-        alternate_zone = next(
-            zone for zone in ("zone-a", "zone-b", "zone-c") if zone != failure_zone
-        )
+        alternate_zone = next(zone for zone in ("zone-a", "zone-b", "zone-c") if zone != failure_zone)
         create_nats_box(kubectl, alternate_zone)
-        nats(
-            kubectl,
-            [
-                "stream",
-                "add",
-                "WG_PROOF",
-                "--subjects",
-                "wg.proof",
-                "--storage",
-                "file",
-                "--replicas",
-                "3",
-                "--retention",
-                "limits",
-                "--max-msgs",
-                "100",
-                "--defaults",
-            ],
-        )
+        nats(kubectl, ["stream", "add", "WG_PROOF", "--subjects", "wg.proof", "--storage", "file", "--replicas", "3", "--retention", "limits", "--max-msgs", "100", "--defaults"])
         nats(kubectl, ["pub", "wg.proof", "before-zone-failure"])
         if nats_message_count(kubectl) != 1:
             raise ref.ProofError("JetStream did not acknowledge the baseline message")
@@ -2834,16 +2539,10 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
             kubectl, stopped_node
         )
         barman_leader_rto = time.monotonic() - failure_started
-
         def new_primary_probe():
             candidate = current_primary(kubectl)
             return candidate if candidate and candidate != primary_before else False
-
-        primary_after = str(
-            wait_until(
-                "PostgreSQL primary failover", new_primary_probe, timeout_seconds=180
-            )
-        )
+        primary_after = str(wait_until("PostgreSQL primary failover", new_primary_probe, timeout_seconds=180))
         postgres_rto = time.monotonic() - failure_started
         barman_communication_after_failure = prove_barman_plugin_backup(
             kubectl,
@@ -2851,47 +2550,20 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
             f"t004-failover-{commit[:8]}",
         )
         barman_rto = time.monotonic() - failure_started
-        wait_until(
-            "acknowledged domain mutation after failover",
-            lambda: node_exists(kubectl, marker),
-            timeout_seconds=60,
-        )
-        wait_until(
-            "API projection after zone failure",
-            lambda: gateway_contains_node(kubectl, kind, args.cluster, marker),
-            timeout_seconds=180,
-        )
+        wait_until("acknowledged domain mutation after failover", lambda: node_exists(kubectl, marker), timeout_seconds=60)
+        wait_until("API projection after zone failure", lambda: gateway_contains_node(kubectl, kind, args.cluster, marker), timeout_seconds=180)
         api_rto = time.monotonic() - failure_started
-
         def nats_publish_probe():
-            result = nats(
-                kubectl, ["pub", "wg.proof", "after-zone-failure"], check=False
-            )
+            result = nats(kubectl, ["pub", "wg.proof", "after-zone-failure"], check=False)
             return result.returncode == 0
-
-        wait_until(
-            "JetStream publish after zone failure",
-            nats_publish_probe,
-            timeout_seconds=120,
-            interval=1,
-        )
+        wait_until("JetStream publish after zone failure", nats_publish_probe, timeout_seconds=120, interval=1)
         nats_rto = time.monotonic() - failure_started
         if nats_message_count(kubectl) != 2:
-            raise ref.ProofError(
-                "JetStream lost an acknowledged message during zone failure"
-            )
+            raise ref.ProofError("JetStream lost an acknowledged message during zone failure")
 
         ref.run(["docker", "start", stopped_node], timeout=60)
         stopped_node = ""
-        ref.run(
-            [
-                kubectl,
-                "wait",
-                "--for=condition=Ready",
-                f"node/{primary_topology['node']}",
-                "--timeout=8m",
-            ]
-        )
+        ref.run([kubectl, "wait", "--for=condition=Ready", f"node/{primary_topology['node']}", "--timeout=8m"])
         ref.wait_rollout(kubectl, "kube-system", "daemonset/cilium", "8m")
         ref.wait_rollout(kubectl, "kube-system", "daemonset/cilium-envoy", "8m")
         primary_barman_plugin_recovered = verify_barman_plugin_ha(kubectl)
@@ -2913,18 +2585,19 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
                     "method": "plugin",
                     "target": "prefer-standby",
                     "cluster": {"name": "postgres-ha"},
-                    "pluginConfiguration": {"name": "barman-cloud.cloudnative-pg.io"},
+                    "pluginConfiguration": {
+                        "name": "barman-cloud.cloudnative-pg.io"
+                    },
                 },
             },
         )
         backup = wait_backup_complete(kubectl, backup_name)
-        target_time = psql(
-            kubectl,
-            "SELECT to_char(clock_timestamp() AT TIME ZONE 'UTC','YYYY-MM-DD\"T\"HH24:MI:SS.US\"Z\"')",
-        )
+        target_time = psql(kubectl, "SELECT to_char(clock_timestamp() AT TIME ZONE 'UTC','YYYY-MM-DD\"T\"HH24:MI:SS.US\"Z\"')")
         wait_for_pitr_boundary(kubectl, target_time)
         insert_domain_node(kubectl, after_id, "T004 after PITR target")
-        primary_wal_archive = measure_wal_archive(kubectl, cluster="postgres-ha")
+        primary_wal_archive = measure_wal_archive(
+            kubectl, cluster="postgres-ha"
+        )
 
         primary_cluster_retirement = create_blank_restore_cluster(
             kind,
@@ -2940,25 +2613,14 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
             restore_oci_cluster = ref.load_controlled_oci_into_kind(
                 kind, restore_name, "ha-recovery"
             )
-        restore_kubectl = require_active_cluster_context(kind, kubectl, restore_name)
-        ref.run(
-            [
-                restore_kubectl,
-                "wait",
-                "--for=condition=Ready",
-                "nodes",
-                "--all",
-                "--timeout=8m",
-            ]
+        restore_kubectl = require_active_cluster_context(
+            kind, kubectl, restore_name
         )
+        ref.run([restore_kubectl, "wait", "--for=condition=Ready", "nodes", "--all", "--timeout=8m"])
         restore_dns_topology = configure_cluster_dns_ha(restore_kubectl)
-        ref.apply_file(
-            restore_kubectl, ROOT / "platform/infrastructure/ha-data/namespace.yaml"
-        )
+        ref.apply_file(restore_kubectl, ROOT / "platform/infrastructure/ha-data/namespace.yaml")
         apply_secret_contracts(restore_kubectl, app_password, s3_secret_key)
-        ref.apply_file(
-            restore_kubectl, ROOT / "platform/infrastructure/ha-data/object-store.yaml"
-        )
+        ref.apply_file(restore_kubectl, ROOT / "platform/infrastructure/ha-data/object-store.yaml")
         apply_object_store_endpoint(restore_kubectl, object_store_address)
         install_cert_manager(
             restore_kubectl,
@@ -2992,34 +2654,24 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
             restore_kubectl, cluster="postgres-restore"
         )
         continuity_validation_seconds = time.monotonic() - continuity_started
-        restored_topology = pod_topology(
-            restore_kubectl, "weltgewebe-data", "cnpg.io/cluster=postgres-restore"
-        )
+        restored_topology = pod_topology(restore_kubectl, "weltgewebe-data", "cnpg.io/cluster=postgres-restore")
         require_zones(restored_topology, 3, "restored postgres")
         preserved = {
             marker: node_exists(restore_kubectl, marker, cluster="postgres-restore"),
-            before_id: node_exists(
-                restore_kubectl, before_id, cluster="postgres-restore"
-            ),
-            after_id: node_exists(
-                restore_kubectl, after_id, cluster="postgres-restore"
-            ),
+            before_id: node_exists(restore_kubectl, before_id, cluster="postgres-restore"),
+            after_id: node_exists(restore_kubectl, after_id, cluster="postgres-restore"),
         }
         if preserved != {marker: True, before_id: True, after_id: False}:
             raise ref.ProofError(f"PITR data comparison failed: {preserved}")
 
         result = {
-            "schema_version": 1,
-            "status": "pass",
-            "commit": commit,
-            "primary_cluster": args.cluster,
-            "restore_cluster": restore_name,
+            "schema_version": 1, "status": "pass", "commit": commit,
+            "primary_cluster": args.cluster, "restore_cluster": restore_name,
             "primary_cluster_retired_before_restore": (
                 primary_cluster_retirement is not None
             ),
             "primary_cluster_retirement": primary_cluster_retirement,
-            "tool_lock_sha256": receipt["lock_sha256"],
-            "image_ids": image_ids,
+            "tool_lock_sha256": receipt["lock_sha256"], "image_ids": image_ids,
             "oci_controlled_source": {
                 "strict": ref.controlled_oci_strict(),
                 "host": oci_host,
@@ -3046,18 +2698,14 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
                 "primary": primary_barman_sidecars,
                 "restore": restore_barman_sidecars,
             },
-            "topology": topology,
-            "restored_topology": restored_topology,
+            "topology": topology, "restored_topology": restored_topology,
             "zone_failure": {
-                "zone": failure_zone,
-                "node": primary_topology["node"],
-                "postgres_primary_before": primary_before,
-                "postgres_primary_after": primary_after,
+                "zone": failure_zone, "node": primary_topology["node"],
+                "postgres_primary_before": primary_before, "postgres_primary_after": primary_after,
                 "barman_leader_rto_seconds": round(barman_leader_rto, 3),
                 "barman_plugin_rto_seconds": round(barman_rto, 3),
                 "postgres_rto_seconds": round(postgres_rto, 3),
-                "api_rto_seconds": round(api_rto, 3),
-                "nats_rto_seconds": round(nats_rto, 3),
+                "api_rto_seconds": round(api_rto, 3), "nats_rto_seconds": round(nats_rto, 3),
                 "acknowledged_domain_mutation_preserved": True,
                 "acknowledged_jetstream_messages": 2,
             },
@@ -3089,22 +2737,16 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
                     "maximum observed forced-WAL archive latency under the "
                     "reference-cell workload"
                 ),
-                "primary_wal_archive_latency_seconds": primary_wal_archive[
-                    "latency_seconds"
-                ],
-                "restore_wal_archive_latency_seconds": restore_wal_archive[
-                    "latency_seconds"
-                ],
+                "primary_wal_archive_latency_seconds": primary_wal_archive["latency_seconds"],
+                "restore_wal_archive_latency_seconds": restore_wal_archive["latency_seconds"],
             },
             "change_management": change_management,
             "gateway_before": gateway_before,
             "proof_owner_id": owner_id,
             "production_changed": False,
             "does_not_establish": [
-                "production rollout",
-                "managed multi-region object-store durability",
-                "RTO or RPO under production load",
-                "survival of two simultaneous failure domains",
+                "production rollout", "managed multi-region object-store durability",
+                "RTO or RPO under production load", "survival of two simultaneous failure domains",
                 "semantic compatibility of a distinct application release",
                 "production error-budget consumption under representative traffic",
                 "external load-balancer reachability from outside the kind bridge",
@@ -3151,7 +2793,9 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
             if cleanup["errors"]:
                 detail = json.dumps(cleanup, sort_keys=True)
                 if active_error is None:
-                    raise ref.ProofError(f"HA proof cleanup incomplete: {detail}")
+                    raise ref.ProofError(
+                        f"HA proof cleanup incomplete: {detail}"
+                    )
                 print(
                     f"HA proof cleanup incomplete while preserving original failure: {detail}",
                     file=sys.stderr,
@@ -3207,11 +2851,7 @@ def main() -> int:
             print(json.dumps(cleanup_receipt, sort_keys=True))
             return 1 if cleanup["errors"] else 0
         prove(args)
-    except (
-        ref.ProofError,
-        subprocess.CalledProcessError,
-        subprocess.TimeoutExpired,
-    ) as error:
+    except (ref.ProofError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as error:
         if isinstance(error, subprocess.CalledProcessError):
             detail = f"subprocess exited with status {error.returncode}"
             evidence = _captured_subprocess_evidence(error)
@@ -3225,7 +2865,6 @@ def main() -> int:
         return 1
     print(json.dumps({"status": "pass"}, sort_keys=True))
     return 0
-
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/scripts/platform/ha_reference.py
+++ b/scripts/platform/ha_reference.py
@@ -40,18 +40,32 @@ UPGRADE_API_IMAGE = "weltgewebe-api:ha-upgrade-candidate"
 REFERENCE_AVAILABILITY_OBJECTIVE = 0.999
 
 
+class ClusterLifecycle:
+    def __init__(
+        self, *, primary_created: bool = False, restore_created: bool = False
+    ) -> None:
+        self.primary_created = primary_created
+        self.restore_created = restore_created
+
+
 def sha256_text(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
-def run_with_environment(argv: list[str], values: dict[str, str], *, timeout: int | None = None) -> None:
+def run_with_environment(
+    argv: list[str], values: dict[str, str], *, timeout: int | None = None
+) -> None:
     print("+", " ".join(argv), f"[env: {','.join(sorted(values))}]", flush=True)
     environment = os.environ.copy()
     environment.update(values)
-    subprocess.run(argv, cwd=ROOT, check=True, text=True, env=environment, timeout=timeout)
+    subprocess.run(
+        argv, cwd=ROOT, check=True, text=True, env=environment, timeout=timeout
+    )
 
 
-def wait_until(description: str, probe, *, timeout_seconds: int = 600, interval: float = 2.0):
+def wait_until(
+    description: str, probe, *, timeout_seconds: int = 600, interval: float = 2.0
+):
     deadline = time.monotonic() + timeout_seconds
     last: Any = None
     while time.monotonic() < deadline:
@@ -107,14 +121,23 @@ def apply_secret_contracts(kubectl: str, app_password: str, s3_secret_key: str) 
             {
                 "apiVersion": "v1",
                 "kind": "Secret",
-                "metadata": {"name": "weltgewebe-ha-s3", "namespace": "weltgewebe-data"},
+                "metadata": {
+                    "name": "weltgewebe-ha-s3",
+                    "namespace": "weltgewebe-data",
+                },
                 "type": "Opaque",
-                "stringData": {"ACCESS_KEY_ID": S3_ACCESS_KEY, "ACCESS_SECRET_KEY": s3_secret_key},
+                "stringData": {
+                    "ACCESS_KEY_ID": S3_ACCESS_KEY,
+                    "ACCESS_SECRET_KEY": s3_secret_key,
+                },
             },
             {
                 "apiVersion": "v1",
                 "kind": "Secret",
-                "metadata": {"name": "weltgewebe-ha-app", "namespace": "weltgewebe-data"},
+                "metadata": {
+                    "name": "weltgewebe-ha-app",
+                    "namespace": "weltgewebe-data",
+                },
                 "type": "kubernetes.io/basic-auth",
                 "stringData": {"username": APP_USER, "password": app_password},
             },
@@ -122,10 +145,10 @@ def apply_secret_contracts(kubectl: str, app_password: str, s3_secret_key: str) 
     )
 
 
-def apply_runtime_secret(kubectl: str, app_password: str, *, postgres_service: str = "postgres-ha-rw") -> None:
-    database_url = (
-        f"postgres://{APP_USER}:{app_password}@{postgres_service}.weltgewebe-data.svc.cluster.local:5432/weltgewebe"
-    )
+def apply_runtime_secret(
+    kubectl: str, app_password: str, *, postgres_service: str = "postgres-ha-rw"
+) -> None:
+    database_url = f"postgres://{APP_USER}:{app_password}@{postgres_service}.weltgewebe-data.svc.cluster.local:5432/weltgewebe"
     ref.apply_yaml(
         kubectl,
         {
@@ -184,9 +207,7 @@ def _object_store_labels(resource_kind: str, name: str) -> dict[str, str] | None
         ]
     else:
         raise ValueError(f"unsupported object-store resource kind: {resource_kind}")
-    result = subprocess.run(
-        argv, cwd=ROOT, text=True, capture_output=True, timeout=30
-    )
+    result = subprocess.run(argv, cwd=ROOT, text=True, capture_output=True, timeout=30)
     if result.returncode != 0:
         detail = (result.stderr or result.stdout).strip()
         missing_markers = (
@@ -253,12 +274,12 @@ def start_external_object_store(
     container, volume = external_object_store_names(cluster)
     binding = external_object_store_binding(cluster, commit, owner_id)
     if _object_store_labels("container", container) is not None:
-        raise ref.ProofError(f"external object-store container already exists: {container}")
+        raise ref.ProofError(
+            f"external object-store container already exists: {container}"
+        )
     if _object_store_labels("volume", volume) is not None:
         raise ref.ProofError(f"external object-store volume already exists: {volume}")
-    ref.run(
-        ["docker", "volume", "create", *_docker_label_args(binding), volume]
-    )
+    ref.run(["docker", "volume", "create", *_docker_label_args(binding), volume])
     try:
         run_with_environment(
             [
@@ -297,7 +318,7 @@ def start_external_object_store(
                     "docker",
                     "inspect",
                     "--format",
-                    "{{(index .NetworkSettings.Networks \"kind\").IPAddress}}",
+                    '{{(index .NetworkSettings.Networks "kind").IPAddress}}',
                     container,
                 ]
             )
@@ -447,6 +468,8 @@ def reconcile_owned_ha_resources(
 def retire_primary_cluster_before_restore(
     kind: str, cluster: str, commit: str, owner_id: str
 ) -> dict[str, Any]:
+    # Retire only the ownership-bound primary. The future restore cluster and the
+    # external object store must remain untouched so the blank restore can start.
     result = reconcile_owned_ha_resources(
         kind,
         cluster,
@@ -456,13 +479,51 @@ def retire_primary_cluster_before_restore(
         include_primary=True,
         include_object_store=False,
     )
-    primary_state = result["resources"].get("primary_cluster")
-    if result["errors"] or primary_state != "deleted":
+    resources = result.get("resources")
+    primary_state = (
+        resources.get("primary_cluster") if isinstance(resources, dict) else None
+    )
+    # "absent" is not enough: this proof must establish that this exact run
+    # deleted the ownership-bound primary instead of merely observing it gone.
+    if result.get("errors") or primary_state != "deleted":
         raise ref.ProofError(
-            "primary cluster retirement before blank restore failed: "
+            "primary cluster retirement before blank restore failed "
+            f"(expected primary_cluster='deleted', got {primary_state!r}): "
             f"{json.dumps(result, sort_keys=True)}"
         )
     return result
+
+
+def create_blank_restore_cluster(
+    kind: str,
+    primary_name: str,
+    restore_name: str,
+    node_image: str,
+    commit: str,
+    owner_id: str,
+    *,
+    keep_primary: bool,
+    lifecycle: ClusterLifecycle,
+) -> dict[str, Any] | None:
+    retirement: dict[str, Any] | None = None
+    if not keep_primary:
+        retirement = retire_primary_cluster_before_restore(
+            kind, primary_name, commit, owner_id
+        )
+        # The primary is gone now. Exception cleanup must not diagnose or delete
+        # it again if creation of the blank restore cluster fails afterwards.
+        lifecycle.primary_created = False
+
+    create_kind_cluster(
+        kind,
+        restore_name,
+        node_image,
+        "platform/clusters/ha/restore-kind.yaml",
+        commit,
+        owner_id,
+    )
+    lifecycle.restore_created = True
+    return retirement
 
 
 def apply_object_store_endpoint(kubectl: str, address: str) -> None:
@@ -530,9 +591,7 @@ def cnpg_webhook_ready(kubectl: str) -> bool:
 def _load_yaml_documents(source: str, release_name: str) -> list[Any]:
     try:
         documents = [
-            document
-            for document in yaml.safe_load_all(source)
-            if document is not None
+            document for document in yaml.safe_load_all(source) if document is not None
         ]
     except yaml.YAMLError as error:
         raise ref.ProofError(f"{release_name} is not valid YAML") from error
@@ -606,14 +665,11 @@ def render_cnpg_manifest(source: str) -> str:
         for document in documents
         if isinstance(document, dict)
         and document.get("kind") == "Deployment"
-        and document.get("metadata", {}).get("name")
-        == "cnpg-controller-manager"
+        and document.get("metadata", {}).get("name") == "cnpg-controller-manager"
         and document.get("metadata", {}).get("namespace") == "cnpg-system"
     ]
     if len(deployments) != 1:
-        raise ref.ProofError(
-            "CloudNativePG controller deployment changed unexpectedly"
-        )
+        raise ref.ProofError("CloudNativePG controller deployment changed unexpectedly")
     deployment = deployments[0]
     spec = deployment.setdefault("spec", {})
     spec["replicas"] = 3
@@ -641,6 +697,7 @@ def render_cnpg_manifest(source: str) -> str:
     )
     documents = ref.enforce_controlled_oci_pull_policy(documents)
     return yaml.safe_dump_all(documents, sort_keys=False, explicit_start=True)
+
 
 def verify_cnpg_operator_ha(kubectl: str) -> list[str]:
     ref.wait_rollout(
@@ -693,9 +750,7 @@ def verify_cnpg_operator_ha(kubectl: str) -> list[str]:
 
 
 def install_cnpg(kubectl: str, artifact: str) -> list[str]:
-    source = render_cnpg_manifest(
-        Path(artifact).read_text(encoding="utf-8")
-    )
+    source = render_cnpg_manifest(Path(artifact).read_text(encoding="utf-8"))
     ref.run(
         [
             kubectl,
@@ -767,6 +822,7 @@ def apply_digest_locked_manifest(
         ],
         input_text=source,
     )
+
 
 def install_cert_manager(kubectl: str, artifact: str) -> None:
     apply_digest_locked_manifest(kubectl, artifact, CERT_MANAGER_IMAGES)
@@ -852,16 +908,12 @@ def render_barman_cloud_manifest(source: str) -> str:
         raise ref.ProofError(
             "Barman Cloud sidecar secret is not valid UTF-8 base64"
         ) from error
-    sidecar_tagged = (
-        "ghcr.io/cloudnative-pg/plugin-barman-cloud-sidecar:v0.13.0"
-    )
+    sidecar_tagged = "ghcr.io/cloudnative-pg/plugin-barman-cloud-sidecar:v0.13.0"
     if decoded != sidecar_tagged:
         raise ref.ProofError(
             f"Barman Cloud sidecar reference changed unexpectedly: {decoded}"
         )
-    sidecar_runtime_image = ref.controlled_oci_runtime_image(
-        BARMAN_CLOUD_SIDECAR_IMAGE
-    )
+    sidecar_runtime_image = ref.controlled_oci_runtime_image(BARMAN_CLOUD_SIDECAR_IMAGE)
     secret["data"]["SIDECAR_IMAGE"] = base64.b64encode(
         sidecar_runtime_image.encode("utf-8")
     ).decode("ascii")
@@ -902,10 +954,9 @@ def render_barman_cloud_manifest(source: str) -> str:
     documents = ref.enforce_controlled_oci_pull_policy(documents)
     return yaml.safe_dump_all(documents, sort_keys=False, explicit_start=True)
 
+
 def apply_barman_cloud_manifest(kubectl: str, artifact: str) -> None:
-    source = render_barman_cloud_manifest(
-        Path(artifact).read_text(encoding="utf-8")
-    )
+    source = render_barman_cloud_manifest(Path(artifact).read_text(encoding="utf-8"))
     ref.run(
         [
             kubectl,
@@ -923,7 +974,17 @@ def apply_barman_cloud_manifest(kubectl: str, artifact: str) -> None:
 def barman_plugin_state(kubectl: str, *, require_three_nodes: bool) -> dict[str, Any]:
     payload = json.loads(
         ref.output(
-            [kubectl, "-n", "cnpg-system", "get", "pods", "-l", "app=barman-cloud", "-o", "json"]
+            [
+                kubectl,
+                "-n",
+                "cnpg-system",
+                "get",
+                "pods",
+                "-l",
+                "app=barman-cloud",
+                "-o",
+                "json",
+            ]
         )
     )
     observed: dict[str, str] = {}
@@ -967,16 +1028,22 @@ def barman_plugin_state(kubectl: str, *, require_three_nodes: bool) -> dict[str,
         observed[name] = node
         if pod_conditions.get("Ready") == "True":
             ready_pods.add(name)
-    if require_three_nodes and (
-        len(observed) != 3 or len(set(observed.values())) != 3
-    ):
+    if require_three_nodes and (len(observed) != 3 or len(set(observed.values())) != 3):
         raise ref.ProofError(
             "Barman Cloud plugin processes are not running on three distinct nodes: "
             f"{observed}"
         )
     endpoints = json.loads(
         ref.output(
-            [kubectl, "-n", "cnpg-system", "get", "endpoints/barman-cloud", "-o", "json"]
+            [
+                kubectl,
+                "-n",
+                "cnpg-system",
+                "get",
+                "endpoints/barman-cloud",
+                "-o",
+                "json",
+            ]
         )
     )
     endpoint_pods = {
@@ -1028,9 +1095,7 @@ def prove_barman_plugin_backup(
                 "method": "plugin",
                 "target": "primary",
                 "cluster": {"name": cluster},
-                "pluginConfiguration": {
-                    "name": "barman-cloud.cloudnative-pg.io"
-                },
+                "pluginConfiguration": {"name": "barman-cloud.cloudnative-pg.io"},
             },
         },
     )
@@ -1083,9 +1148,11 @@ def align_postgres_primary_with_barman_leader(
         )
         wait_until(
             f"PostgreSQL primary {target_primary} on Barman Cloud leader node",
-            lambda: target_primary
-            if current_primary(kubectl, cluster) == target_primary
-            else False,
+            lambda: (
+                target_primary
+                if current_primary(kubectl, cluster) == target_primary
+                else False
+            ),
             timeout_seconds=240,
         )
     wait_cluster_ready(kubectl, cluster, "10m")
@@ -1128,6 +1195,7 @@ def wait_barman_plugin_leader_after_node_loss(
             timeout_seconds=180,
         )
     )
+
 
 def install_barman_cloud_plugin(kubectl: str, artifact: str) -> dict[str, Any]:
     apply_barman_cloud_manifest(kubectl, artifact)
@@ -1180,8 +1248,7 @@ def install_barman_cloud_plugin(kubectl: str, artifact: str) -> dict[str, Any]:
     )
     if sidecar_images != [expected_sidecar_image]:
         raise ref.ProofError(
-            "Barman Cloud sidecar image is not digest-bound: "
-            f"{sidecar_images}"
+            f"Barman Cloud sidecar image is not digest-bound: {sidecar_images}"
         )
     observed = ref.output(
         [
@@ -1194,11 +1261,11 @@ def install_barman_cloud_plugin(kubectl: str, artifact: str) -> dict[str, Any]:
             "jsonpath={.spec.template.spec.containers[0].image}",
         ]
     )
-    expected_plugin_image = ref.controlled_oci_runtime_image(
-        BARMAN_CLOUD_PLUGIN_IMAGE
-    )
+    expected_plugin_image = ref.controlled_oci_runtime_image(BARMAN_CLOUD_PLUGIN_IMAGE)
     if observed != expected_plugin_image:
-        raise ref.ProofError(f"Barman Cloud plugin image is not runtime-bound: {observed}")
+        raise ref.ProofError(
+            f"Barman Cloud plugin image is not runtime-bound: {observed}"
+        )
     return plugin_nodes
 
 
@@ -1245,17 +1312,14 @@ def verify_barman_sidecar_images(
         declared_image = str(sidecars[0].get("image", ""))
         if declared_image != expected_sidecar_image:
             raise ref.ProofError(
-                f"PostgreSQL pod {name} has an unbound Barman sidecar: "
-                f"{declared_image}"
+                f"PostgreSQL pod {name} has an unbound Barman sidecar: {declared_image}"
             )
         statuses = [
             *pod.get("status", {}).get("initContainerStatuses", []),
             *pod.get("status", {}).get("containerStatuses", []),
         ]
         sidecar_statuses = [
-            status
-            for status in statuses
-            if status.get("name") == "plugin-barman-cloud"
+            status for status in statuses if status.get("name") == "plugin-barman-cloud"
         ]
         if len(sidecar_statuses) != 1:
             raise ref.ProofError(
@@ -1286,66 +1350,192 @@ def verify_barman_sidecar_images(
         )
     return observed
 
+
 def current_primary(kubectl: str, cluster: str = "postgres-ha") -> str:
-    return ref.output([kubectl, "-n", "weltgewebe-data", "get", f"cluster/{cluster}", "-o", "jsonpath={.status.currentPrimary}"])
+    return ref.output(
+        [
+            kubectl,
+            "-n",
+            "weltgewebe-data",
+            "get",
+            f"cluster/{cluster}",
+            "-o",
+            "jsonpath={.status.currentPrimary}",
+        ]
+    )
 
 
 def wait_cluster_ready(kubectl: str, cluster: str, timeout: str = "15m") -> None:
-    ref.wait_condition(kubectl, "weltgewebe-data", f"cluster/{cluster}", "Ready", timeout)
+    ref.wait_condition(
+        kubectl, "weltgewebe-data", f"cluster/{cluster}", "Ready", timeout
+    )
 
 
 def ha_diagnostic_snapshot(kubectl: str, name: str) -> None:
     target = CACHE / "failures" / name
     target.mkdir(parents=True, exist_ok=True)
     commands = {
-        "cnpg-clusters.yaml": [kubectl, "get", "clusters.postgresql.cnpg.io", "-A", "-o", "yaml"],
-        "cnpg-pods-describe.txt": [kubectl, "-n", "weltgewebe-data", "describe", "pods", "-l", "cnpg.io/cluster"],
-        "cnpg-pods-logs.txt": [kubectl, "-n", "weltgewebe-data", "logs", "-l", "cnpg.io/cluster", "--all-containers=true", "--prefix=true", "--tail=2000"],
-        "cnpg-pods-previous-logs.txt": [kubectl, "-n", "weltgewebe-data", "logs", "-l", "cnpg.io/cluster", "--all-containers=true", "--prefix=true", "--previous=true", "--tail=2000"],
+        "cnpg-clusters.yaml": [
+            kubectl,
+            "get",
+            "clusters.postgresql.cnpg.io",
+            "-A",
+            "-o",
+            "yaml",
+        ],
+        "cnpg-pods-describe.txt": [
+            kubectl,
+            "-n",
+            "weltgewebe-data",
+            "describe",
+            "pods",
+            "-l",
+            "cnpg.io/cluster",
+        ],
+        "cnpg-pods-logs.txt": [
+            kubectl,
+            "-n",
+            "weltgewebe-data",
+            "logs",
+            "-l",
+            "cnpg.io/cluster",
+            "--all-containers=true",
+            "--prefix=true",
+            "--tail=2000",
+        ],
+        "cnpg-pods-previous-logs.txt": [
+            kubectl,
+            "-n",
+            "weltgewebe-data",
+            "logs",
+            "-l",
+            "cnpg.io/cluster",
+            "--all-containers=true",
+            "--prefix=true",
+            "--previous=true",
+            "--tail=2000",
+        ],
         "cnpg-operator-deployment.yaml": [
-            kubectl, "-n", "cnpg-system", "get",
-            "deployment/cnpg-controller-manager", "-o", "yaml",
+            kubectl,
+            "-n",
+            "cnpg-system",
+            "get",
+            "deployment/cnpg-controller-manager",
+            "-o",
+            "yaml",
         ],
         "cnpg-operator-replicasets.yaml": [
-            kubectl, "-n", "cnpg-system", "get",
-            "replicasets", "-l", "app.kubernetes.io/name=cloudnative-pg",
-            "-o", "yaml",
+            kubectl,
+            "-n",
+            "cnpg-system",
+            "get",
+            "replicasets",
+            "-l",
+            "app.kubernetes.io/name=cloudnative-pg",
+            "-o",
+            "yaml",
         ],
         "cnpg-operator-logs.txt": [
-            kubectl, "-n", "cnpg-system", "logs",
-            "-l", "app.kubernetes.io/name=cloudnative-pg",
-            "--all-containers=true", "--prefix=true", "--tail=2000",
+            kubectl,
+            "-n",
+            "cnpg-system",
+            "logs",
+            "-l",
+            "app.kubernetes.io/name=cloudnative-pg",
+            "--all-containers=true",
+            "--prefix=true",
+            "--tail=2000",
         ],
         "barman-plugin-deployment.yaml": [
-            kubectl, "-n", "cnpg-system", "get", "deployment/barman-cloud", "-o", "yaml",
+            kubectl,
+            "-n",
+            "cnpg-system",
+            "get",
+            "deployment/barman-cloud",
+            "-o",
+            "yaml",
         ],
         "barman-plugin-pods-describe.txt": [
-            kubectl, "-n", "cnpg-system", "describe", "pods", "-l", "app=barman-cloud",
+            kubectl,
+            "-n",
+            "cnpg-system",
+            "describe",
+            "pods",
+            "-l",
+            "app=barman-cloud",
         ],
         "barman-plugin-endpoints.yaml": [
-            kubectl, "-n", "cnpg-system", "get", "endpoints/barman-cloud", "-o", "yaml",
+            kubectl,
+            "-n",
+            "cnpg-system",
+            "get",
+            "endpoints/barman-cloud",
+            "-o",
+            "yaml",
         ],
         "barman-plugin-logs.txt": [
-            kubectl, "-n", "cnpg-system", "logs", "-l", "app=barman-cloud",
-            "--all-containers=true", "--prefix=true", "--tail=2000",
+            kubectl,
+            "-n",
+            "cnpg-system",
+            "logs",
+            "-l",
+            "app=barman-cloud",
+            "--all-containers=true",
+            "--prefix=true",
+            "--tail=2000",
         ],
-        "barman-objectstores.yaml": [kubectl, "get", "objectstores.barmancloud.cnpg.io", "-A", "-o", "yaml"],
-        "certificates.yaml": [kubectl, "get", "certificates.cert-manager.io", "-A", "-o", "yaml"],
+        "barman-objectstores.yaml": [
+            kubectl,
+            "get",
+            "objectstores.barmancloud.cnpg.io",
+            "-A",
+            "-o",
+            "yaml",
+        ],
+        "certificates.yaml": [
+            kubectl,
+            "get",
+            "certificates.cert-manager.io",
+            "-A",
+            "-o",
+            "yaml",
+        ],
         "cluster-dns-deployment.yaml": [
-            kubectl, "-n", "kube-system", "get", "deployment/coredns", "-o", "yaml",
+            kubectl,
+            "-n",
+            "kube-system",
+            "get",
+            "deployment/coredns",
+            "-o",
+            "yaml",
         ],
         "cluster-dns-pods-describe.txt": [
-            kubectl, "-n", "kube-system", "describe", "pods", "-l", "k8s-app=kube-dns",
+            kubectl,
+            "-n",
+            "kube-system",
+            "describe",
+            "pods",
+            "-l",
+            "k8s-app=kube-dns",
         ],
         "cluster-dns-logs.txt": [
-            kubectl, "-n", "kube-system", "logs", "-l", "k8s-app=kube-dns",
-            "--all-containers=true", "--prefix=true", "--tail=2000",
+            kubectl,
+            "-n",
+            "kube-system",
+            "logs",
+            "-l",
+            "k8s-app=kube-dns",
+            "--all-containers=true",
+            "--prefix=true",
+            "--tail=2000",
         ],
         "storage.txt": [kubectl, "get", "pv,pvc", "-A", "-o", "wide"],
     }
     for filename, argv in commands.items():
         try:
-            result = subprocess.run(argv, cwd=ROOT, text=True, capture_output=True, timeout=30)
+            result = subprocess.run(
+                argv, cwd=ROOT, text=True, capture_output=True, timeout=30
+            )
             evidence = result.stdout + result.stderr
         except (OSError, subprocess.TimeoutExpired) as error:
             evidence = f"diagnostic command failed: {error}\n"
@@ -1354,7 +1544,9 @@ def ha_diagnostic_snapshot(kubectl: str, name: str) -> None:
 
 def wal_segment_position(name: str) -> tuple[int, int, int]:
     normalized = name.strip().upper()
-    if len(normalized) != 24 or any(character not in "0123456789ABCDEF" for character in normalized):
+    if len(normalized) != 24 or any(
+        character not in "0123456789ABCDEF" for character in normalized
+    ):
         raise ref.ProofError(f"invalid PostgreSQL WAL segment name: {name!r}")
     return tuple(int(normalized[offset : offset + 8], 16) for offset in (0, 8, 16))
 
@@ -1367,7 +1559,21 @@ def psql(kubectl: str, sql: str, *, cluster: str = "postgres-ha") -> str:
     primary = current_primary(kubectl, cluster)
     if not primary:
         raise ref.ProofError(f"PostgreSQL cluster {cluster} has no current primary")
-    return ref.output([kubectl, "-n", "weltgewebe-data", "exec", primary, "--", "psql", "-d", "weltgewebe", "-Atqc", sql])
+    return ref.output(
+        [
+            kubectl,
+            "-n",
+            "weltgewebe-data",
+            "exec",
+            primary,
+            "--",
+            "psql",
+            "-d",
+            "weltgewebe",
+            "-Atqc",
+            sql,
+        ]
+    )
 
 
 def wait_for_pitr_boundary(kubectl: str, target_time: str) -> None:
@@ -1383,10 +1589,21 @@ def wait_for_pitr_boundary(kubectl: str, target_time: str) -> None:
         )
 
 
-def pod_topology(kubectl: str, namespace: str, selector: str) -> dict[str, dict[str, str]]:
-    pods = json.loads(ref.output([kubectl, "-n", namespace, "get", "pods", "-l", selector, "-o", "json"]))
+def pod_topology(
+    kubectl: str, namespace: str, selector: str
+) -> dict[str, dict[str, str]]:
+    pods = json.loads(
+        ref.output(
+            [kubectl, "-n", namespace, "get", "pods", "-l", selector, "-o", "json"]
+        )
+    )
     nodes = json.loads(ref.output([kubectl, "get", "nodes", "-o", "json"]))
-    zones = {item["metadata"]["name"]: item["metadata"].get("labels", {}).get("topology.kubernetes.io/zone", "") for item in nodes["items"]}
+    zones = {
+        item["metadata"]["name"]: item["metadata"]
+        .get("labels", {})
+        .get("topology.kubernetes.io/zone", "")
+        for item in nodes["items"]
+    }
     result: dict[str, dict[str, str]] = {}
     for item in pods["items"]:
         metadata = item.get("metadata", {})
@@ -1405,10 +1622,14 @@ def pod_topology(kubectl: str, namespace: str, selector: str) -> dict[str, dict[
     return result
 
 
-def require_zones(topology: dict[str, dict[str, str]], expected: int, component: str) -> None:
+def require_zones(
+    topology: dict[str, dict[str, str]], expected: int, component: str
+) -> None:
     zones = {item["zone"] for item in topology.values() if item["zone"]}
     if len(topology) < expected or len(zones) != expected:
-        raise ref.ProofError(f"{component} is not spread across {expected} zones: {topology}")
+        raise ref.ProofError(
+            f"{component} is not spread across {expected} zones: {topology}"
+        )
 
 
 def configure_cluster_dns_ha(kubectl: str) -> dict[str, dict[str, str]]:
@@ -1453,18 +1674,28 @@ def configure_cluster_dns_ha(kubectl: str) -> dict[str, dict[str, str]]:
     ref.wait_rollout(kubectl, "kube-system", "deployment/coredns", "8m")
     topology = pod_topology(kubectl, "kube-system", "k8s-app=kube-dns")
     if len(topology) != 3:
-        raise ref.ProofError(
-            f"cluster DNS requires exactly three replicas: {topology}"
-        )
+        raise ref.ProofError(f"cluster DNS requires exactly three replicas: {topology}")
     require_zones(topology, 3, "cluster DNS")
     return topology
 
 
 def wait_api_replicas(kubectl: str, expected: int = 3) -> None:
     ref.wait_rollout(kubectl, "weltgewebe", "deployment/weltgewebe-api", "10m")
-    available = ref.output([kubectl, "-n", "weltgewebe", "get", "deployment/weltgewebe-api", "-o", "jsonpath={.status.availableReplicas}"])
+    available = ref.output(
+        [
+            kubectl,
+            "-n",
+            "weltgewebe",
+            "get",
+            "deployment/weltgewebe-api",
+            "-o",
+            "jsonpath={.status.availableReplicas}",
+        ]
+    )
     if available != str(expected):
-        raise ref.ProofError(f"expected {expected} available API replicas, got {available!r}")
+        raise ref.ProofError(
+            f"expected {expected} available API replicas, got {available!r}"
+        )
     ref.wait_rollout(kubectl, "weltgewebe", "deployment/weltgewebe-web", "10m")
 
 
@@ -1555,7 +1786,7 @@ def api_deployment_image(kubectl: str) -> str:
             "get",
             "deployment/weltgewebe-api",
             "-o",
-            "jsonpath={.spec.template.spec.containers[?(@.name==\"api\")].image}",
+            'jsonpath={.spec.template.spec.containers[?(@.name=="api")].image}',
         ]
     )
 
@@ -1579,9 +1810,7 @@ def api_rollout_complete(kubectl: str, expected_image: str) -> bool:
     status = deployment.get("status", {})
     images = {
         container.get("name"): container.get("image")
-        for container in spec.get("template", {})
-        .get("spec", {})
-        .get("containers", [])
+        for container in spec.get("template", {}).get("spec", {}).get("containers", [])
     }
     return (
         images.get("api") == expected_image
@@ -1643,17 +1872,13 @@ def projection_sample_url(node: str, url: str, marker: str) -> dict[str, Any]:
 def gateway_projection_sample(
     node: str, address: str, port: int, marker: str
 ) -> dict[str, Any]:
-    return projection_sample_url(
-        node, f"http://{address}:{port}/api/nodes", marker
-    )
+    return projection_sample_url(node, f"http://{address}:{port}/api/nodes", marker)
 
 
 def gateway_projection_available(
     node: str, address: str, port: int, marker: str
 ) -> bool:
-    return bool(
-        gateway_projection_sample(node, address, port, marker)["available"]
-    )
+    return bool(gateway_projection_sample(node, address, port, marker)["available"])
 
 
 def gateway_owner_sample(
@@ -1693,8 +1918,7 @@ def gateway_owner_sample(
         )
 
     targets = [
-        (owners_by_address[address][0], address)
-        for address in gateway_addresses
+        (owners_by_address[address][0], address) for address in gateway_addresses
     ]
 
     def run_target(target: tuple[str, str]) -> dict[str, Any]:
@@ -1714,9 +1938,7 @@ def gateway_owner_sample(
 
     failed_paths = [probe for probe in probes if probe.get("available") is not True]
     successful_addresses = [
-        str(probe["address"])
-        for probe in probes
-        if probe.get("available") is True
+        str(probe["address"]) for probe in probes if probe.get("available") is True
     ]
     return {
         "available": bool(successful_addresses),
@@ -1764,8 +1986,7 @@ def projection_path_diagnostic(
         {
             address
             for endpoint in endpoint_state
-            if endpoint.get("ready") is True
-            and endpoint.get("terminating") is not True
+            if endpoint.get("ready") is True and endpoint.get("terminating") is not True
             for address in endpoint.get("addresses", [])
             if isinstance(address, str) and address
         }
@@ -1781,9 +2002,7 @@ def projection_path_diagnostic(
             )
         )
     for pod_ip in ready_pod_ips:
-        targets.append(
-            ("pod", probe_node, pod_ip, f"http://{pod_ip}:8080/nodes")
-        )
+        targets.append(("pod", probe_node, pod_ip, f"http://{pod_ip}:8080/nodes"))
     gateway_addresses = sorted(set(ref.gateway_addresses(kubectl)))
     gateway_nodes = sorted(set(ref.kind_nodes(kind, cluster)))
     for node in gateway_nodes:
@@ -1902,15 +2121,11 @@ def api_transition_diagnostic(
                 "pod_ip": item.get("status", {}).get("podIP"),
                 "phase": item.get("status", {}).get("phase"),
                 "ready": conditions.get("Ready") == "True",
-                "deleting": bool(
-                    item.get("metadata", {}).get("deletionTimestamp")
-                ),
+                "deleting": bool(item.get("metadata", {}).get("deletionTimestamp")),
                 "image": next(
                     (
                         container.get("image")
-                        for container in item.get("spec", {}).get(
-                            "containers", []
-                        )
+                        for container in item.get("spec", {}).get("containers", [])
                         if container.get("name") == "api"
                     ),
                     None,
@@ -1927,9 +2142,7 @@ def api_transition_diagnostic(
                     "target": endpoint.get("targetRef", {}).get("name"),
                     "ready": endpoint.get("conditions", {}).get("ready"),
                     "serving": endpoint.get("conditions", {}).get("serving"),
-                    "terminating": endpoint.get("conditions", {}).get(
-                        "terminating"
-                    ),
+                    "terminating": endpoint.get("conditions", {}).get("terminating"),
                 }
             )
     status = deployment.get("status", {})
@@ -2006,9 +2219,7 @@ def measure_api_transition(
                     max_failed_gateway_paths, sample_failed_paths
                 )
             if available:
-                rollout_complete = api_rollout_complete(
-                    kubectl, expected_image
-                )
+                rollout_complete = api_rollout_complete(kubectl, expected_image)
         except (
             subprocess.CalledProcessError,
             subprocess.TimeoutExpired,
@@ -2026,9 +2237,7 @@ def measure_api_transition(
             if outage_started is not None:
                 outage = sampled_at - outage_started
                 unavailable_seconds += outage
-                longest_unavailable_seconds = max(
-                    longest_unavailable_seconds, outage
-                )
+                longest_unavailable_seconds = max(longest_unavailable_seconds, outage)
                 outage_started = None
         else:
             failed_samples += 1
@@ -2056,9 +2265,7 @@ def measure_api_transition(
                         "diagnostic_error": f"{type(error).__name__}: {error}",
                     }
                 diagnostic["sample"] = samples
-                diagnostic["elapsed_seconds"] = round(
-                    sampled_at - started, 3
-                )
+                diagnostic["elapsed_seconds"] = round(sampled_at - started, 3)
                 outage_diagnostics.append(diagnostic)
         if available and rollout_complete:
             break
@@ -2113,9 +2320,7 @@ def measure_api_transition(
 def compute_error_budget(
     upgrade: dict[str, Any], rollback: dict[str, Any]
 ) -> dict[str, Any]:
-    window = float(upgrade["duration_seconds"]) + float(
-        rollback["duration_seconds"]
-    )
+    window = float(upgrade["duration_seconds"]) + float(rollback["duration_seconds"])
     if window <= 0:
         raise ref.ProofError("change-management measurement window is empty")
     unavailable = float(upgrade["observed_unavailable_seconds"]) + float(
@@ -2212,13 +2417,9 @@ def prove_api_upgrade_and_rollback(
     }
 
 
-def measure_wal_archive(
-    kubectl: str, *, cluster: str
-) -> dict[str, Any]:
+def measure_wal_archive(kubectl: str, *, cluster: str) -> dict[str, Any]:
     started = time.monotonic()
-    required = psql(
-        kubectl, "SELECT pg_walfile_name(pg_switch_wal())", cluster=cluster
-    )
+    required = psql(kubectl, "SELECT pg_walfile_name(pg_switch_wal())", cluster=cluster)
     wal_segment_position(required)
 
     def archived_probe() -> str | bool:
@@ -2247,27 +2448,60 @@ def measure_wal_archive(
     }
 
 
-def insert_domain_node(kubectl: str, node_id: str, title: str, *, cluster: str = "postgres-ha") -> None:
-    payload = json.dumps({"summary": "HA recovery proof", "tags": ["ha-proof"]}, separators=(",", ":"))
+def insert_domain_node(
+    kubectl: str, node_id: str, title: str, *, cluster: str = "postgres-ha"
+) -> None:
+    payload = json.dumps(
+        {"summary": "HA recovery proof", "tags": ["ha-proof"]}, separators=(",", ":")
+    )
     sql = (
         "INSERT INTO domain_nodes (id,kind,title,lat,lon,created_at,updated_at,payload) VALUES ("
-        + "'" + node_id + "','Werkstatt','" + title.replace("'", "''") + "',53.55,9.99,clock_timestamp(),clock_timestamp(),'"
-        + payload.replace("'", "''") + "'::jsonb) ON CONFLICT (id) DO NOTHING"
+        + "'"
+        + node_id
+        + "','Werkstatt','"
+        + title.replace("'", "''")
+        + "',53.55,9.99,clock_timestamp(),clock_timestamp(),'"
+        + payload.replace("'", "''")
+        + "'::jsonb) ON CONFLICT (id) DO NOTHING"
     )
     psql(kubectl, sql, cluster=cluster)
 
 
 def node_exists(kubectl: str, node_id: str, *, cluster: str = "postgres-ha") -> bool:
-    return psql(kubectl, f"SELECT count(*) FROM domain_nodes WHERE id='{node_id}'", cluster=cluster) == "1"
+    return (
+        psql(
+            kubectl,
+            f"SELECT count(*) FROM domain_nodes WHERE id='{node_id}'",
+            cluster=cluster,
+        )
+        == "1"
+    )
 
 
 def gateway_contains_node(kubectl: str, kind: str, cluster: str, node_id: str) -> bool:
-    ref.wait_condition(kubectl, "weltgewebe-gateway", "gateway/weltgewebe", "Programmed", "5m")
-    service = ref.output([kubectl, "-n", "weltgewebe-gateway", "get", "service", "-l", "gateway.networking.k8s.io/gateway-name=weltgewebe", "-o", "jsonpath={.items[0].metadata.name}"])
+    ref.wait_condition(
+        kubectl, "weltgewebe-gateway", "gateway/weltgewebe", "Programmed", "5m"
+    )
+    service = ref.output(
+        [
+            kubectl,
+            "-n",
+            "weltgewebe-gateway",
+            "get",
+            "service",
+            "-l",
+            "gateway.networking.k8s.io/gateway-name=weltgewebe",
+            "-o",
+            "jsonpath={.items[0].metadata.name}",
+        ]
+    )
     port = ref.gateway_listener_port(kubectl)
     _, _, _, _, body = ref.probe_gateway_http(
-        kind, cluster, ref.gateway_addresses(kubectl),
-        ref.gateway_service_listener_port(kubectl, service, port), timeout_seconds=30,
+        kind,
+        cluster,
+        ref.gateway_addresses(kubectl),
+        ref.gateway_service_listener_port(kubectl, service, port),
+        timeout_seconds=30,
     )
     payload = json.loads(body)
     return any(isinstance(item, dict) and item.get("id") == node_id for item in payload)
@@ -2277,45 +2511,101 @@ def create_nats_box(kubectl: str, zone: str) -> None:
     ref.apply_yaml(
         kubectl,
         {
-            "apiVersion": "v1", "kind": "Pod",
+            "apiVersion": "v1",
+            "kind": "Pod",
             "metadata": {"name": "nats-box", "namespace": "weltgewebe-data"},
             "spec": {
                 "automountServiceAccountToken": False,
                 "nodeSelector": {"topology.kubernetes.io/zone": zone},
                 "restartPolicy": "Never",
-                "securityContext": {"runAsNonRoot": True, "runAsUser": 1000, "runAsGroup": 1000, "seccompProfile": {"type": "RuntimeDefault"}},
-                "containers": [{
-                    "name": "nats-box", "image": NATS_BOX_IMAGE,
-                    "command": ["/bin/sh", "-c", "sleep 7200"],
-                    "securityContext": {"allowPrivilegeEscalation": False, "capabilities": {"drop": ["ALL"]}},
-                    "resources": {"requests": {"cpu": "20m", "memory": "32Mi"}, "limits": {"cpu": "200m", "memory": "128Mi"}},
-                }],
+                "securityContext": {
+                    "runAsNonRoot": True,
+                    "runAsUser": 1000,
+                    "runAsGroup": 1000,
+                    "seccompProfile": {"type": "RuntimeDefault"},
+                },
+                "containers": [
+                    {
+                        "name": "nats-box",
+                        "image": NATS_BOX_IMAGE,
+                        "command": ["/bin/sh", "-c", "sleep 7200"],
+                        "securityContext": {
+                            "allowPrivilegeEscalation": False,
+                            "capabilities": {"drop": ["ALL"]},
+                        },
+                        "resources": {
+                            "requests": {"cpu": "20m", "memory": "32Mi"},
+                            "limits": {"cpu": "200m", "memory": "128Mi"},
+                        },
+                    }
+                ],
             },
         },
     )
     ref.wait_condition(kubectl, "weltgewebe-data", "pod/nats-box", "Ready", "5m")
 
 
-def nats(kubectl: str, args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
-    argv = [kubectl, "-n", "weltgewebe-data", "exec", "nats-box", "--", "nats", "--server", "nats://nats:4222", "--js-domain", "weltgewebe-ha", *args]
-    return ref.run(argv, capture=True) if check else subprocess.run(argv, cwd=ROOT, text=True, capture_output=True)
+def nats(
+    kubectl: str, args: list[str], *, check: bool = True
+) -> subprocess.CompletedProcess[str]:
+    argv = [
+        kubectl,
+        "-n",
+        "weltgewebe-data",
+        "exec",
+        "nats-box",
+        "--",
+        "nats",
+        "--server",
+        "nats://nats:4222",
+        "--js-domain",
+        "weltgewebe-ha",
+        *args,
+    ]
+    return (
+        ref.run(argv, capture=True)
+        if check
+        else subprocess.run(argv, cwd=ROOT, text=True, capture_output=True)
+    )
 
 
 def nats_message_count(kubectl: str) -> int:
-    document = json.loads(nats(kubectl, ["stream", "info", "WG_PROOF", "--json"]).stdout)
+    document = json.loads(
+        nats(kubectl, ["stream", "info", "WG_PROOF", "--json"]).stdout
+    )
     return int(document.get("state", {}).get("messages", -1))
 
 
 def wait_backup_complete(kubectl: str, name: str) -> dict[str, Any]:
     def probe():
-        document = json.loads(ref.output([kubectl, "-n", "weltgewebe-data", "get", f"backup/{name}", "-o", "json"]))
-        return document if str(document.get("status", {}).get("phase", "")).lower() == "completed" else False
-    return wait_until(f"CloudNativePG backup {name}", probe, timeout_seconds=1200, interval=5)
+        document = json.loads(
+            ref.output(
+                [
+                    kubectl,
+                    "-n",
+                    "weltgewebe-data",
+                    "get",
+                    f"backup/{name}",
+                    "-o",
+                    "json",
+                ]
+            )
+        )
+        return (
+            document
+            if str(document.get("status", {}).get("phase", "")).lower() == "completed"
+            else False
+        )
+
+    return wait_until(
+        f"CloudNativePG backup {name}", probe, timeout_seconds=1200, interval=5
+    )
 
 
 def restore_cluster_document(target_time: str) -> dict[str, Any]:
     return {
-        "apiVersion": "postgresql.cnpg.io/v1", "kind": "Cluster",
+        "apiVersion": "postgresql.cnpg.io/v1",
+        "kind": "Cluster",
         "metadata": {"name": "postgres-restore", "namespace": "weltgewebe-data"},
         "spec": {
             "instances": 3,
@@ -2328,32 +2618,39 @@ def restore_cluster_document(target_time: str) -> dict[str, Any]:
             "bootstrap": {
                 "recovery": {
                     "source": "postgres-ha",
-                    "database": "weltgewebe", "owner": APP_USER,
+                    "database": "weltgewebe",
+                    "owner": APP_USER,
                     "secret": {"name": "weltgewebe-ha-app"},
                     "recoveryTarget": {"targetTime": target_time, "exclusive": True},
                 }
             },
-            "externalClusters": [{
-                "name": "postgres-ha",
-                "plugin": {
-                    "name": "barman-cloud.cloudnative-pg.io",
-                    "parameters": {
-                        "barmanObjectName": "weltgewebe-ha-backup",
-                        "serverName": "postgres-ha",
+            "externalClusters": [
+                {
+                    "name": "postgres-ha",
+                    "plugin": {
+                        "name": "barman-cloud.cloudnative-pg.io",
+                        "parameters": {
+                            "barmanObjectName": "weltgewebe-ha-backup",
+                            "serverName": "postgres-ha",
+                        },
                     },
-                },
-            }],
-            "plugins": [{
-                "name": "barman-cloud.cloudnative-pg.io",
-                "isWALArchiver": True,
-                "parameters": {
-                    "barmanObjectName": "weltgewebe-ha-backup"
-                },
-            }],
+                }
+            ],
+            "plugins": [
+                {
+                    "name": "barman-cloud.cloudnative-pg.io",
+                    "isWALArchiver": True,
+                    "parameters": {"barmanObjectName": "weltgewebe-ha-backup"},
+                }
+            ],
             "storage": {"size": "1Gi"},
-            "resources": {"requests": {"cpu": "100m", "memory": "256Mi"}, "limits": {"cpu": "1", "memory": "1Gi"}},
+            "resources": {
+                "requests": {"cpu": "100m", "memory": "256Mi"},
+                "limits": {"cpu": "1", "memory": "1Gi"},
+            },
             "affinity": {
-                "enablePodAntiAffinity": True, "podAntiAffinityType": "required",
+                "enablePodAntiAffinity": True,
+                "podAntiAffinityType": "required",
                 "topologyKey": "topology.kubernetes.io/zone",
                 "nodeSelector": {"weltgewebe.net/data-node": "true"},
             },
@@ -2363,7 +2660,9 @@ def restore_cluster_document(target_time: str) -> dict[str, Any]:
 
 def prove(args: argparse.Namespace) -> dict[str, Any]:
     if ref.output(["git", "status", "--porcelain"]):
-        raise ref.ProofError("HA recovery proof requires a clean, commit-bound worktree")
+        raise ref.ProofError(
+            "HA recovery proof requires a clean, commit-bound worktree"
+        )
     commit = ref.output(["git", "rev-parse", "HEAD"])
     timestamp = ref.output(["git", "show", "-s", "--format=%cI", "HEAD"])
     ref.require_host_tools()
@@ -2390,28 +2689,39 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
     primary_oci_cluster: dict[str, Any] | None = None
     restore_oci_cluster: dict[str, Any] | None = None
     primary_cluster_retirement: dict[str, Any] | None = None
-    created_primary = created_restore = object_store_created = False
+    lifecycle = ClusterLifecycle()
+    object_store_created = False
     stopped_node = ""
     object_store_address = ""
     app_password = secrets.token_urlsafe(24)
     s3_secret_key = secrets.token_urlsafe(32)
     try:
         create_kind_cluster(
-            kind, args.cluster, node_image,
-            "platform/clusters/ha/kind.yaml", commit, owner_id
+            kind,
+            args.cluster,
+            node_image,
+            "platform/clusters/ha/kind.yaml",
+            commit,
+            owner_id,
         )
-        created_primary = True
+        lifecycle.primary_created = True
         if ref.controlled_oci_strict():
             primary_oci_cluster = ref.load_controlled_oci_into_kind(
                 kind, args.cluster, "ha-recovery"
             )
         kubectl = require_active_cluster_context(kind, kubectl, args.cluster)
         image_ids = ref.build_images(kind, args.cluster, commit, timestamp)
-        image_ids.update(
-            prepare_api_upgrade_candidate(kind, args.cluster, commit)
+        image_ids.update(prepare_api_upgrade_candidate(kind, args.cluster, commit))
+        ref.install_platform_components(
+            kubectl,
+            flux,
+            helm,
+            receipt["artifacts"],
+            ref.control_plane_address(args.cluster),
         )
-        ref.install_platform_components(kubectl, flux, helm, receipt["artifacts"], ref.control_plane_address(args.cluster))
-        ref.run([kubectl, "wait", "--for=condition=Ready", "nodes", "--all", "--timeout=8m"])
+        ref.run(
+            [kubectl, "wait", "--for=condition=Ready", "nodes", "--all", "--timeout=8m"]
+        )
         primary_dns_topology = configure_cluster_dns_ha(kubectl)
         _, _, object_store_address = start_external_object_store(
             args.cluster, commit, owner_id, s3_secret_key
@@ -2419,7 +2729,9 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
         object_store_created = True
         ref.apply_file(kubectl, ROOT / "platform/infrastructure/ha-data/namespace.yaml")
         apply_secret_contracts(kubectl, app_password, s3_secret_key)
-        ref.apply_file(kubectl, ROOT / "platform/infrastructure/ha-data/object-store.yaml")
+        ref.apply_file(
+            kubectl, ROOT / "platform/infrastructure/ha-data/object-store.yaml"
+        )
         apply_object_store_endpoint(kubectl, object_store_address)
         install_cert_manager(kubectl, receipt["artifacts"]["cert_manager"])
         primary_operator_nodes = install_cnpg(
@@ -2432,29 +2744,41 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
         ref.apply_direct(kubectl, kustomize, "platform/infrastructure/ha-data")
         ref.wait_rollout(kubectl, "weltgewebe-data", "statefulset/nats", "12m")
         wait_cluster_ready(kubectl, "postgres-ha", "15m")
-        primary_barman_sidecars = verify_barman_sidecar_images(
-            kubectl, "postgres-ha"
+        primary_barman_sidecars = verify_barman_sidecar_images(kubectl, "postgres-ha")
+        ref.apply_file(
+            kubectl, ROOT / "platform/apps/weltgewebe/migration/ha/namespace.yaml"
         )
-        ref.apply_file(kubectl, ROOT / "platform/apps/weltgewebe/migration/ha/namespace.yaml")
         apply_runtime_secret(kubectl, app_password)
         ref.apply_direct(kubectl, kustomize, "platform/apps/weltgewebe/migration/ha")
-        ref.wait_condition(kubectl, "weltgewebe", "job/weltgewebe-migration", "Complete", "10m")
+        ref.wait_condition(
+            kubectl, "weltgewebe", "job/weltgewebe-migration", "Complete", "10m"
+        )
         ref.apply_direct(kubectl, kustomize, "platform/apps/weltgewebe/overlays/ha")
         ref.apply_direct(kubectl, kustomize, "platform/infrastructure/gateway")
         wait_api_replicas(kubectl)
         gateway_before = ref.prove_gateway(kubectl, kind, args.cluster)
 
         topology = {
-            "postgres": pod_topology(kubectl, "weltgewebe-data", "cnpg.io/cluster=postgres-ha"),
-            "nats": pod_topology(kubectl, "weltgewebe-data", "app.kubernetes.io/name=nats"),
-            "api": pod_topology(kubectl, "weltgewebe", "app.kubernetes.io/name=weltgewebe-api"),
+            "postgres": pod_topology(
+                kubectl, "weltgewebe-data", "cnpg.io/cluster=postgres-ha"
+            ),
+            "nats": pod_topology(
+                kubectl, "weltgewebe-data", "app.kubernetes.io/name=nats"
+            ),
+            "api": pod_topology(
+                kubectl, "weltgewebe", "app.kubernetes.io/name=weltgewebe-api"
+            ),
         }
         for component, observed in topology.items():
             require_zones(observed, 3, component)
 
         marker = "00000000-0000-4000-8000-00000000a004"
         insert_domain_node(kubectl, marker, "T004 acknowledged domain mutation")
-        wait_until("domain mutation in API projection", lambda: gateway_contains_node(kubectl, kind, args.cluster, marker), timeout_seconds=180)
+        wait_until(
+            "domain mutation in API projection",
+            lambda: gateway_contains_node(kubectl, kind, args.cluster, marker),
+            timeout_seconds=180,
+        )
         change_management = prove_api_upgrade_and_rollback(
             kubectl, kind, args.cluster, marker, gateway_before
         )
@@ -2477,9 +2801,29 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
                 "PostgreSQL primary and Barman Cloud leader are not co-located "
                 f"before failure: {barman_leader_alignment}"
             )
-        alternate_zone = next(zone for zone in ("zone-a", "zone-b", "zone-c") if zone != failure_zone)
+        alternate_zone = next(
+            zone for zone in ("zone-a", "zone-b", "zone-c") if zone != failure_zone
+        )
         create_nats_box(kubectl, alternate_zone)
-        nats(kubectl, ["stream", "add", "WG_PROOF", "--subjects", "wg.proof", "--storage", "file", "--replicas", "3", "--retention", "limits", "--max-msgs", "100", "--defaults"])
+        nats(
+            kubectl,
+            [
+                "stream",
+                "add",
+                "WG_PROOF",
+                "--subjects",
+                "wg.proof",
+                "--storage",
+                "file",
+                "--replicas",
+                "3",
+                "--retention",
+                "limits",
+                "--max-msgs",
+                "100",
+                "--defaults",
+            ],
+        )
         nats(kubectl, ["pub", "wg.proof", "before-zone-failure"])
         if nats_message_count(kubectl) != 1:
             raise ref.ProofError("JetStream did not acknowledge the baseline message")
@@ -2490,10 +2834,16 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
             kubectl, stopped_node
         )
         barman_leader_rto = time.monotonic() - failure_started
+
         def new_primary_probe():
             candidate = current_primary(kubectl)
             return candidate if candidate and candidate != primary_before else False
-        primary_after = str(wait_until("PostgreSQL primary failover", new_primary_probe, timeout_seconds=180))
+
+        primary_after = str(
+            wait_until(
+                "PostgreSQL primary failover", new_primary_probe, timeout_seconds=180
+            )
+        )
         postgres_rto = time.monotonic() - failure_started
         barman_communication_after_failure = prove_barman_plugin_backup(
             kubectl,
@@ -2501,20 +2851,47 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
             f"t004-failover-{commit[:8]}",
         )
         barman_rto = time.monotonic() - failure_started
-        wait_until("acknowledged domain mutation after failover", lambda: node_exists(kubectl, marker), timeout_seconds=60)
-        wait_until("API projection after zone failure", lambda: gateway_contains_node(kubectl, kind, args.cluster, marker), timeout_seconds=180)
+        wait_until(
+            "acknowledged domain mutation after failover",
+            lambda: node_exists(kubectl, marker),
+            timeout_seconds=60,
+        )
+        wait_until(
+            "API projection after zone failure",
+            lambda: gateway_contains_node(kubectl, kind, args.cluster, marker),
+            timeout_seconds=180,
+        )
         api_rto = time.monotonic() - failure_started
+
         def nats_publish_probe():
-            result = nats(kubectl, ["pub", "wg.proof", "after-zone-failure"], check=False)
+            result = nats(
+                kubectl, ["pub", "wg.proof", "after-zone-failure"], check=False
+            )
             return result.returncode == 0
-        wait_until("JetStream publish after zone failure", nats_publish_probe, timeout_seconds=120, interval=1)
+
+        wait_until(
+            "JetStream publish after zone failure",
+            nats_publish_probe,
+            timeout_seconds=120,
+            interval=1,
+        )
         nats_rto = time.monotonic() - failure_started
         if nats_message_count(kubectl) != 2:
-            raise ref.ProofError("JetStream lost an acknowledged message during zone failure")
+            raise ref.ProofError(
+                "JetStream lost an acknowledged message during zone failure"
+            )
 
         ref.run(["docker", "start", stopped_node], timeout=60)
         stopped_node = ""
-        ref.run([kubectl, "wait", "--for=condition=Ready", f"node/{primary_topology['node']}", "--timeout=8m"])
+        ref.run(
+            [
+                kubectl,
+                "wait",
+                "--for=condition=Ready",
+                f"node/{primary_topology['node']}",
+                "--timeout=8m",
+            ]
+        )
         ref.wait_rollout(kubectl, "kube-system", "daemonset/cilium", "8m")
         ref.wait_rollout(kubectl, "kube-system", "daemonset/cilium-envoy", "8m")
         primary_barman_plugin_recovered = verify_barman_plugin_ha(kubectl)
@@ -2536,43 +2913,52 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
                     "method": "plugin",
                     "target": "prefer-standby",
                     "cluster": {"name": "postgres-ha"},
-                    "pluginConfiguration": {
-                        "name": "barman-cloud.cloudnative-pg.io"
-                    },
+                    "pluginConfiguration": {"name": "barman-cloud.cloudnative-pg.io"},
                 },
             },
         )
         backup = wait_backup_complete(kubectl, backup_name)
-        target_time = psql(kubectl, "SELECT to_char(clock_timestamp() AT TIME ZONE 'UTC','YYYY-MM-DD\"T\"HH24:MI:SS.US\"Z\"')")
+        target_time = psql(
+            kubectl,
+            "SELECT to_char(clock_timestamp() AT TIME ZONE 'UTC','YYYY-MM-DD\"T\"HH24:MI:SS.US\"Z\"')",
+        )
         wait_for_pitr_boundary(kubectl, target_time)
         insert_domain_node(kubectl, after_id, "T004 after PITR target")
-        primary_wal_archive = measure_wal_archive(
-            kubectl, cluster="postgres-ha"
-        )
+        primary_wal_archive = measure_wal_archive(kubectl, cluster="postgres-ha")
 
-        if not args.keep:
-            primary_cluster_retirement = retire_primary_cluster_before_restore(
-                kind, args.cluster, commit, owner_id
-            )
-            created_primary = False
-
-        create_kind_cluster(
-            kind, restore_name, node_image,
-            "platform/clusters/ha/restore-kind.yaml", commit, owner_id
+        primary_cluster_retirement = create_blank_restore_cluster(
+            kind,
+            args.cluster,
+            restore_name,
+            node_image,
+            commit,
+            owner_id,
+            keep_primary=args.keep,
+            lifecycle=lifecycle,
         )
-        created_restore = True
         if ref.controlled_oci_strict():
             restore_oci_cluster = ref.load_controlled_oci_into_kind(
                 kind, restore_name, "ha-recovery"
             )
-        restore_kubectl = require_active_cluster_context(
-            kind, kubectl, restore_name
+        restore_kubectl = require_active_cluster_context(kind, kubectl, restore_name)
+        ref.run(
+            [
+                restore_kubectl,
+                "wait",
+                "--for=condition=Ready",
+                "nodes",
+                "--all",
+                "--timeout=8m",
+            ]
         )
-        ref.run([restore_kubectl, "wait", "--for=condition=Ready", "nodes", "--all", "--timeout=8m"])
         restore_dns_topology = configure_cluster_dns_ha(restore_kubectl)
-        ref.apply_file(restore_kubectl, ROOT / "platform/infrastructure/ha-data/namespace.yaml")
+        ref.apply_file(
+            restore_kubectl, ROOT / "platform/infrastructure/ha-data/namespace.yaml"
+        )
         apply_secret_contracts(restore_kubectl, app_password, s3_secret_key)
-        ref.apply_file(restore_kubectl, ROOT / "platform/infrastructure/ha-data/object-store.yaml")
+        ref.apply_file(
+            restore_kubectl, ROOT / "platform/infrastructure/ha-data/object-store.yaml"
+        )
         apply_object_store_endpoint(restore_kubectl, object_store_address)
         install_cert_manager(
             restore_kubectl,
@@ -2606,24 +2992,34 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
             restore_kubectl, cluster="postgres-restore"
         )
         continuity_validation_seconds = time.monotonic() - continuity_started
-        restored_topology = pod_topology(restore_kubectl, "weltgewebe-data", "cnpg.io/cluster=postgres-restore")
+        restored_topology = pod_topology(
+            restore_kubectl, "weltgewebe-data", "cnpg.io/cluster=postgres-restore"
+        )
         require_zones(restored_topology, 3, "restored postgres")
         preserved = {
             marker: node_exists(restore_kubectl, marker, cluster="postgres-restore"),
-            before_id: node_exists(restore_kubectl, before_id, cluster="postgres-restore"),
-            after_id: node_exists(restore_kubectl, after_id, cluster="postgres-restore"),
+            before_id: node_exists(
+                restore_kubectl, before_id, cluster="postgres-restore"
+            ),
+            after_id: node_exists(
+                restore_kubectl, after_id, cluster="postgres-restore"
+            ),
         }
         if preserved != {marker: True, before_id: True, after_id: False}:
             raise ref.ProofError(f"PITR data comparison failed: {preserved}")
 
         result = {
-            "schema_version": 1, "status": "pass", "commit": commit,
-            "primary_cluster": args.cluster, "restore_cluster": restore_name,
+            "schema_version": 1,
+            "status": "pass",
+            "commit": commit,
+            "primary_cluster": args.cluster,
+            "restore_cluster": restore_name,
             "primary_cluster_retired_before_restore": (
                 primary_cluster_retirement is not None
             ),
             "primary_cluster_retirement": primary_cluster_retirement,
-            "tool_lock_sha256": receipt["lock_sha256"], "image_ids": image_ids,
+            "tool_lock_sha256": receipt["lock_sha256"],
+            "image_ids": image_ids,
             "oci_controlled_source": {
                 "strict": ref.controlled_oci_strict(),
                 "host": oci_host,
@@ -2650,14 +3046,18 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
                 "primary": primary_barman_sidecars,
                 "restore": restore_barman_sidecars,
             },
-            "topology": topology, "restored_topology": restored_topology,
+            "topology": topology,
+            "restored_topology": restored_topology,
             "zone_failure": {
-                "zone": failure_zone, "node": primary_topology["node"],
-                "postgres_primary_before": primary_before, "postgres_primary_after": primary_after,
+                "zone": failure_zone,
+                "node": primary_topology["node"],
+                "postgres_primary_before": primary_before,
+                "postgres_primary_after": primary_after,
                 "barman_leader_rto_seconds": round(barman_leader_rto, 3),
                 "barman_plugin_rto_seconds": round(barman_rto, 3),
                 "postgres_rto_seconds": round(postgres_rto, 3),
-                "api_rto_seconds": round(api_rto, 3), "nats_rto_seconds": round(nats_rto, 3),
+                "api_rto_seconds": round(api_rto, 3),
+                "nats_rto_seconds": round(nats_rto, 3),
                 "acknowledged_domain_mutation_preserved": True,
                 "acknowledged_jetstream_messages": 2,
             },
@@ -2689,16 +3089,22 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
                     "maximum observed forced-WAL archive latency under the "
                     "reference-cell workload"
                 ),
-                "primary_wal_archive_latency_seconds": primary_wal_archive["latency_seconds"],
-                "restore_wal_archive_latency_seconds": restore_wal_archive["latency_seconds"],
+                "primary_wal_archive_latency_seconds": primary_wal_archive[
+                    "latency_seconds"
+                ],
+                "restore_wal_archive_latency_seconds": restore_wal_archive[
+                    "latency_seconds"
+                ],
             },
             "change_management": change_management,
             "gateway_before": gateway_before,
             "proof_owner_id": owner_id,
             "production_changed": False,
             "does_not_establish": [
-                "production rollout", "managed multi-region object-store durability",
-                "RTO or RPO under production load", "survival of two simultaneous failure domains",
+                "production rollout",
+                "managed multi-region object-store durability",
+                "RTO or RPO under production load",
+                "survival of two simultaneous failure domains",
                 "semantic compatibility of a distinct application release",
                 "production error-budget consumption under representative traffic",
                 "external load-balancer reachability from outside the kind bridge",
@@ -2715,11 +3121,11 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
         result["receipt_sha256"] = hashlib.sha256(path.read_bytes()).hexdigest()
         return result
     except Exception:
-        if created_primary:
+        if lifecycle.primary_created:
             ref.configure_cluster_access(kind, args.cluster)
             ha_diagnostic_snapshot(kubectl, args.cluster)
             ref.diagnostic_snapshot(kubectl, args.cluster)
-        if created_restore:
+        if lifecycle.restore_created:
             ref.configure_cluster_access(kind, restore_name)
             ha_diagnostic_snapshot(kubectl, restore_name)
             ref.diagnostic_snapshot(kubectl, restore_name)
@@ -2728,22 +3134,24 @@ def prove(args: argparse.Namespace) -> dict[str, Any]:
         active_error = sys.exc_info()[1]
         if stopped_node:
             subprocess.run(["docker", "start", stopped_node], capture_output=True)
-        if not args.keep and (created_restore or created_primary or object_store_created):
+        if not args.keep and (
+            lifecycle.restore_created
+            or lifecycle.primary_created
+            or object_store_created
+        ):
             cleanup = reconcile_owned_ha_resources(
                 kind,
                 args.cluster,
                 commit,
                 owner_id,
-                include_restore=created_restore,
-                include_primary=created_primary,
+                include_restore=lifecycle.restore_created,
+                include_primary=lifecycle.primary_created,
                 include_object_store=object_store_created,
             )
             if cleanup["errors"]:
                 detail = json.dumps(cleanup, sort_keys=True)
                 if active_error is None:
-                    raise ref.ProofError(
-                        f"HA proof cleanup incomplete: {detail}"
-                    )
+                    raise ref.ProofError(f"HA proof cleanup incomplete: {detail}")
                 print(
                     f"HA proof cleanup incomplete while preserving original failure: {detail}",
                     file=sys.stderr,
@@ -2799,7 +3207,11 @@ def main() -> int:
             print(json.dumps(cleanup_receipt, sort_keys=True))
             return 1 if cleanup["errors"] else 0
         prove(args)
-    except (ref.ProofError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as error:
+    except (
+        ref.ProofError,
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+    ) as error:
         if isinstance(error, subprocess.CalledProcessError):
             detail = f"subprocess exited with status {error.returncode}"
             evidence = _captured_subprocess_evidence(error)
@@ -2813,6 +3225,7 @@ def main() -> int:
         return 1
     print(json.dumps({"status": "pass"}, sort_keys=True))
     return 0
+
 
 if __name__ == "__main__":
     raise SystemExit(main())


### PR DESCRIPTION
<!-- weltgewebe-risk: R3 -->

## Problem

The main-bound Kubernetes HA proof failed in Actions run 30233668401, job 89877199319. During blank-cluster recovery, the controlled OCI import into the second four-node kind cluster reached the fixed 900-second timeout while the still-running primary cluster consumed host resources. The restore software was never installed; diagnostics contained only kind base components and no `cnpg-system` namespace.

## Change

- retire the ownership-bound primary kind cluster after backup and WAL evidence are complete, before creating the blank restore cluster
- preserve the external object store and all backup evidence
- fail closed if the exact primary cluster cannot be proven deleted
- retain existing `--keep` behavior for interactive diagnostics
- record the early retirement receipt in the HA proof result
- add contract tests for scope, failure behavior, and operation ordering

This models disaster recovery more faithfully: the source cluster is gone before restoration begins, while reducing simultaneous CPU, memory, disk, and containerd pressure.

## Evidence

- `python3 -m unittest scripts.ci.tests.test_kubernetes_ha_contract` — 70 PASS
- platform/HA/Trivy contract suite — 180 PASS
- platform Python compilation — PASS
- `python3 scripts/platform/validate_platform.py --render` — PASS
- `git diff --check` — PASS

## Coordination

- Bureau task: `WELTGEWEBE-SEMANTIC-SEARCH-V1-T008`
- Bureau candidate: `candidate-196ed6b5b0338fda77307c2e`, event 1294
- source failure head: `f77873b7acd26ab25de6a19687da5df829b0c651`

No production mutation is performed by this PR.