### PR TITLE
ci(links): update lychee mail flag

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -24,7 +24,7 @@ jobs:
           args: >
             --accept 200,429
             --max-redirects 5
-            --exclude-mail
+            --include-mail=false
             --no-progress
             --config .lychee.toml
             --exclude "https?://(localhost|127\.0\.0\.1|0\.0\.0\.0)(:\d+)?(/.*)?"


### PR DESCRIPTION
<!-- weltgewebe-risk: R3 -->

## Ursache

Der geplante `links`-Workflow scheitert mit Lychee v0.24.2 bereits beim Argument-Parsing, weil `--exclude-mail` nicht mehr unterstützt wird.

## Änderung

- `--exclude-mail` durch `--include-mail=false` ersetzt
- bisheriges Verhalten bleibt erhalten: Mail-Links werden nicht geprüft

## Prüfung

- Workflow-YAML erfolgreich geparst
- `git diff --check` erfolgreich
- keine verbleibenden `--exclude-mail`-Vorkommen
- exakter Basis-Commit: `579d7efbc9044b5f4d5544a0130624f5670ffaf4`
- exakter Head: `d7c0941afcd67146f7b97bd228d1c0281ef0244a`

Bezug: fehlgeschlagener geplanter Lauf 30246421261.