### PR TITLE
fix(map): PMTiles-Protokoll bei überlappenden Kartenstarts erhalten

### DIFF
--- a/apps/web/src/lib/map/pmtilesProtocol.test.ts
+++ b/apps/web/src/lib/map/pmtilesProtocol.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+import { registerPmtilesProtocol } from "./pmtilesProtocol";
+
+type MapLibreProtocolRegistry = Pick<
+  typeof import("maplibre-gl"),
+  "addProtocol" | "removeProtocol"
+>;
+type ProtocolLoadFunction = Parameters<
+  MapLibreProtocolRegistry["addProtocol"]
+>[1];
+
+function loadFunction(label: string): ProtocolLoadFunction {
+  return vi.fn(async () => ({
+    data: new TextEncoder().encode(label),
+  })) as ProtocolLoadFunction;
+}
+
+function fakeRegistry() {
+  let active: ProtocolLoadFunction | null = null;
+  const addProtocol = vi.fn((_name: string, load: ProtocolLoadFunction) => {
+    active = load;
+  });
+  const removeProtocol = vi.fn(() => {
+    active = null;
+  });
+  const registry = {
+    addProtocol,
+    removeProtocol,
+  } as unknown as MapLibreProtocolRegistry;
+
+  return {
+    registry,
+    addProtocol,
+    removeProtocol,
+    active: () => active,
+  };
+}
+
+describe("registerPmtilesProtocol", () => {
+  it("keeps a newer mount active when an older map cleans up later", () => {
+    const fake = fakeRegistry();
+    const first = loadFunction("first");
+    const second = loadFunction("second");
+
+    const releaseFirst = registerPmtilesProtocol(fake.registry, first);
+    const releaseSecond = registerPmtilesProtocol(fake.registry, second);
+
+    expect(fake.active()).toBe(second);
+    releaseFirst();
+
+    expect(fake.active()).toBe(second);
+    expect(fake.removeProtocol).not.toHaveBeenCalled();
+
+    releaseSecond();
+    expect(fake.active()).toBeNull();
+    expect(fake.removeProtocol).toHaveBeenCalledOnce();
+  });
+
+  it("restores the previous live map when the newest mount leaves first", () => {
+    const fake = fakeRegistry();
+    const first = loadFunction("first");
+    const second = loadFunction("second");
+
+    const releaseFirst = registerPmtilesProtocol(fake.registry, first);
+    const releaseSecond = registerPmtilesProtocol(fake.registry, second);
+
+    releaseSecond();
+
+    expect(fake.active()).toBe(first);
+    expect(fake.addProtocol).toHaveBeenLastCalledWith("pmtiles", first);
+    expect(fake.removeProtocol).not.toHaveBeenCalled();
+
+    releaseFirst();
+    expect(fake.active()).toBeNull();
+  });
+
+  it("makes cleanup idempotent", () => {
+    const fake = fakeRegistry();
+    const release = registerPmtilesProtocol(
+      fake.registry,
+      loadFunction("only"),
+    );
+
+    release();
+    release();
+
+    expect(fake.removeProtocol).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/lib/map/pmtilesProtocol.ts
+++ b/apps/web/src/lib/map/pmtilesProtocol.ts
@@ -1,0 +1,58 @@
+type MapLibreProtocolRegistry = Pick<
+  typeof import("maplibre-gl"),
+  "addProtocol" | "removeProtocol"
+>;
+
+type ProtocolLoadFunction = Parameters<
+  MapLibreProtocolRegistry["addProtocol"]
+>[1];
+
+interface ProtocolRegistration {
+  load: ProtocolLoadFunction;
+}
+
+const registrations = new WeakMap<
+  MapLibreProtocolRegistry,
+  ProtocolRegistration[]
+>();
+
+/**
+ * Register one component-owned PMTiles handler without letting an older map
+ * teardown remove the handler of a newer overlapping map mount.
+ *
+ * MapLibre's custom-protocol registry is module-global. addProtocol replaces the
+ * current handler and removeProtocol deletes it unconditionally, so component
+ * cleanup needs stack semantics rather than a blind global removal.
+ */
+export function registerPmtilesProtocol(
+  maplibre: MapLibreProtocolRegistry,
+  load: ProtocolLoadFunction,
+): () => void {
+  const stack = registrations.get(maplibre) ?? [];
+  const registration = { load };
+  stack.push(registration);
+  registrations.set(maplibre, stack);
+  maplibre.addProtocol("pmtiles", load);
+
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+
+    const index = stack.indexOf(registration);
+    if (index === -1) return;
+
+    const wasActive = index === stack.length - 1;
+    stack.splice(index, 1);
+    if (!wasActive) return;
+
+    const previous = stack.at(-1);
+    if (previous) {
+      maplibre.addProtocol("pmtiles", previous.load);
+      return;
+    }
+
+    registrations.delete(maplibre);
+    maplibre.removeProtocol("pmtiles");
+  };
+}

--- a/apps/web/src/routes/map/+page.svelte
+++ b/apps/web/src/routes/map/+page.svelte
@@ -66,6 +66,7 @@
 
   import { currentBasemap } from "$lib/map/config/basemap.current";
   import { resolveBasemapStyle, rewritePmtilesUrl } from "$lib/map/basemap";
+  import { registerPmtilesProtocol } from "$lib/map/pmtilesProtocol";
   import { getGarnrolleMarkerScale } from "$lib/map/markerScale";
   import { buildMapScene } from "$lib/map/scene";
 
@@ -675,7 +676,7 @@
 
   onMount(() => {
     void preloadSearchOverlay();
-    let maplibreModule: any = null;
+    let releasePmtilesProtocol: (() => void) | undefined;
     // onMount returns its cleanup synchronously while the initialiser below is
     // still suspended on `await import('maplibre-gl')`. If the component is
     // destroyed in that window the cleanup finds `map`/`nodesOverlay` still
@@ -733,20 +734,17 @@
         | ((url: string, resourceType?: any) => { url: string })
         | undefined = undefined;
 
-      // PMTiles dev infrastructure is intentionally prepared now, including the runtime
-      // dependency 'pmtiles'. The current runtime stays strictly on 'remote-style', since
-      // real local artifact proof is still missing. This setup exists solely to reduce later
-      // activation cost and does NOT claim that 'local-sovereign' is already working end-to-end.
+      // MapLibre keeps custom protocols in a module-global registry. A fresh
+      // Protocol per map mount avoids sharing stale PMTiles header/directory
+      // caches, while the lease prevents an older overlapping teardown from
+      // deleting the handler that a newer map already installed.
       if (currentBasemap.mode === "local-sovereign") {
         const pmtiles = await import("pmtiles");
         if (destroyed) return;
-        try {
-          maplibregl.addProtocol("pmtiles", new pmtiles.Protocol().tile);
-        } catch (e: any) {
-          if (!e.message?.includes("already registered")) {
-            console.warn("Unexpected error registering PMTiles protocol:", e);
-          }
-        }
+        releasePmtilesProtocol = registerPmtilesProtocol(
+          maplibregl,
+          new pmtiles.Protocol().tile,
+        );
 
         transformRequestFn = (url: string, resourceType?: any) => {
           return { url: rewritePmtilesUrl(url, window.location.origin) };
@@ -754,10 +752,7 @@
       }
 
       // Past the last await boundary: from here on the cleanup below observes
-      // every resource this initialiser creates. `maplibreModule` gates the
-      // pmtiles protocol removal, so it must not be published before the
-      // protocol is actually registered.
-      maplibreModule = maplibregl;
+      // every resource this initialiser creates, including the protocol lease.
       container.addEventListener("click", handleMarkerClick);
 
       const initialUrlState = parseMapUrlState(get(page).url.searchParams);
@@ -867,15 +862,8 @@
         if (typeof map.remove === "function") map.remove();
       }
       mapContainer?.removeEventListener("click", handleMarkerClick);
-      if (currentBasemap.mode === "local-sovereign" && maplibreModule) {
-        try {
-          maplibreModule.removeProtocol("pmtiles");
-        } catch (e: any) {
-          if (!e.message?.includes("not registered")) {
-            console.warn("Unexpected error removing PMTiles protocol:", e);
-          }
-        }
-      }
+      releasePmtilesProtocol?.();
+      releasePmtilesProtocol = undefined;
     };
   });
 </script>


### PR DESCRIPTION
<!-- weltgewebe-risk: R2 -->

## Problem

Nach einer Aktualisierung kann MapLibre bereits laufen und die Weltgewebe-Marker anzeigen, während die eigentliche Basiskarte grau bleibt. Ein weiterer Browser-Refresh behebt den Zustand.

## Belegter Fehlmechanismus

MapLibre verwaltet benutzerdefinierte Protokolle global im geladenen Modul. Die Kartenseite registrierte bei jedem Start einen neuen `pmtiles`-Handler, entfernte beim Abbau aber stets blind den globalen Handler. Überschneiden sich alter Abbau und neuer Kartenstart, kann der alte Abbau daher den bereits installierten Handler der neuen Karte löschen. Dann bleiben Hintergrund, Steuerelemente und Weltgewebe-Marker sichtbar, während die PMTiles-Vektorkacheln ausfallen.

MapLibre 4.7.1 ersetzt den globalen Handler bei `addProtocol`; die bisherige Annahme eines Fehlers „already registered“ trifft auf die eingesetzte Version nicht zu.

## Änderung

- neue gestapelte PMTiles-Protokoll-Lease pro MapLibre-Modul
- jeder Kartenstart erhält weiterhin eine frische `Protocol`-Instanz und damit frische Header-/Verzeichnis-Caches
- ein verspäteter alter Abbau kann den neueren Handler nicht mehr löschen
- verlässt die neueste Karte zuerst, wird der noch lebende vorherige Handler wiederhergestellt
- idempotenter Abbau

## Prüfung

- `pnpm --dir apps/web test:unit`: 29 Dateien, 226 Tests bestanden
- `pnpm --dir apps/web check`: 0 Fehler, 0 Warnungen
- `pnpm --dir apps/web lint`: bestanden
- `pnpm --dir apps/web build`: bestanden; Kartenbudget 80.079 B gzip JavaScript / 17.084 B gzip CSS
- `make validate-guards`: Repository-, Dokumentrelations-, Generated- und Coverage-Guard bestanden
- auf aktuellen `main` (`5dd0fcaa91378fc172705d16d5cd5e6437598e40`) aktualisiert

## Grenze der Aussage

Der konkrete Browserlauf aus dem Nutzerprofil war nachträglich nicht reproduzierbar. Öffentlicher Style-Endpunkt und PMTiles-Range-Antwort waren beim Audit gesund. Der Patch beseitigt deshalb den im Code nachgewiesenen globalen Lebenszykluskonflikt, der exakt den beobachteten Zustand erzeugen kann; die endgültige Produktionsbestätigung erfolgt erst nach Merge, Rollout und erneutem Aktualisierungsversuch.