### PR TITLE
fix(deploy): make receipt recovery race-safe

### DIFF
--- a/.github/workflows/production-live-contract.yml
+++ b/.github/workflows/production-live-contract.yml
@@ -76,18 +76,26 @@ jobs:
           systemd-analyze verify \
             infra/systemd/system/weltgewebe-production-reconcile.service \
             infra/systemd/system/weltgewebe-production-reconcile.timer
-      - name: Run existing contract tests
-        run: |
-          python -m unittest \
-            scripts/ci/tests/test_generate_version_env.py -v
-          python -m unittest \
-            scripts/ci/tests/test_verify_public_release_commit.py -v
-          python -m unittest \
-            scripts/ci/tests/test_validate_web_deploy_archive.py -v
-          python -m unittest \
-            scripts/ci/tests/test_production_reconciler_contract.py -v
-          python -m unittest \
-            scripts/ci/tests/test_deploy_exact_commit_integration.py -v
+      - name: Verify generated version environment
+        run: >-
+          python -m unittest -v
+          scripts/ci/tests/test_generate_version_env.py
+      - name: Verify public release reader
+        run: >-
+          python -m unittest -v
+          scripts/ci/tests/test_verify_public_release_commit.py
+      - name: Verify deployment archive validator
+        run: >-
+          python -m unittest -v
+          scripts/ci/tests/test_validate_web_deploy_archive.py
+      - name: Verify production reconciler source contract
+        run: >-
+          python -m unittest -v
+          scripts/ci/tests/test_production_reconciler_contract.py
+      - name: Verify exact-commit deployment integration
+        run: >-
+          python -m unittest -v
+          scripts/ci/tests/test_deploy_exact_commit_integration.py
       - name: Repair safe malformed deployment receipt
         run: >-
           python -m unittest -v

--- a/.github/workflows/production-live-contract.yml
+++ b/.github/workflows/production-live-contract.yml
@@ -18,6 +18,7 @@ name: Production live contract
       - "scripts/ci/tests/test_validate_web_deploy_archive.py"
       - "scripts/ci/tests/test_production_reconciler_contract.py"
       - "scripts/ci/tests/test_deploy_exact_commit_integration.py"
+      - "scripts/ci/tests/test_production_receipt_resilience.py"
       - "infra/systemd/**"
       - ".github/workflows/production-live-contract.yml"
   push:
@@ -87,6 +88,8 @@ jobs:
             scripts/ci/tests/test_production_reconciler_contract.py -v
           python -m unittest \
             scripts/ci/tests/test_deploy_exact_commit_integration.py -v
+          python -m unittest \
+            scripts/ci/tests/test_production_receipt_resilience.py -v
 
   review-diff:
     name: Exact review diff artifact

--- a/.github/workflows/production-live-contract.yml
+++ b/.github/workflows/production-live-contract.yml
@@ -76,7 +76,7 @@ jobs:
           systemd-analyze verify \
             infra/systemd/system/weltgewebe-production-reconcile.service \
             infra/systemd/system/weltgewebe-production-reconcile.timer
-      - name: Run contract tests
+      - name: Run existing contract tests
         run: |
           python -m unittest \
             scripts/ci/tests/test_generate_version_env.py -v
@@ -88,8 +88,22 @@ jobs:
             scripts/ci/tests/test_production_reconciler_contract.py -v
           python -m unittest \
             scripts/ci/tests/test_deploy_exact_commit_integration.py -v
-          python -m unittest \
-            scripts/ci/tests/test_production_receipt_resilience.py -v
+      - name: Repair safe malformed deployment receipt
+        run: >-
+          python -m unittest -v
+          scripts.ci.tests.test_production_receipt_resilience.ProductionReceiptResilienceTests.test_public_observation_repairs_safe_malformed_deployment_receipt
+      - name: Preserve invocation contention evidence
+        run: >-
+          python -m unittest -v
+          scripts.ci.tests.test_production_receipt_resilience.ProductionReceiptResilienceTests.test_inherited_contention_survives_shared_slot_overwrite
+      - name: Normalize release modes independently of caller umask
+        run: >-
+          python -m unittest -v
+          scripts.ci.tests.test_production_receipt_resilience.ProductionReceiptResilienceTests.test_permissive_caller_umask_produces_canonical_release_modes
+      - name: Preserve reviewed cold-start preconditions
+        run: >-
+          python -m unittest -v
+          scripts.ci.tests.test_production_receipt_resilience.ProductionReceiptResilienceTests.test_reviewed_resilience_preconditions_are_already_present
 
   review-diff:
     name: Exact review diff artifact

--- a/docs/deploy/merge-to-live.md
+++ b/docs/deploy/merge-to-live.md
@@ -183,10 +183,16 @@ dieselbe Sperre selbst. Bei Konkurrenz verändert der abgewiesene Lauf weder
 Container noch öffentliche Zustände. Der Reconciler endet geordnet mit Exit 0;
 der direkte Helfer verwendet bei Konkurrenz `EX_TEMPFAIL` 75. Fachliche
 Überholung nach Migration beziehungsweise Volldeploy verwendet intern die
-getrennten Codes 79 und 80. Beide Einstiegspfade schreiben atomare
-`already_running`-Belege als `last-contention.json` in die bereits kanonischen
-Receipt-Verzeichnisse. Diese Belege sind Diagnoseflächen, keine zweite
-Zustandswahrheit. Maßgeblich für Besitz ist ausschließlich die vom Kernel gehaltene
+getrennten Codes 79 und 80. Bei einem geerbten Handoff schreibt der Helfer den
+autoritativen `already_running`-Beleg zunächst aufrufspezifisch nach
+`receipts/contention/<deploy-invocation-id>.json`. Zusätzlich aktualisiert er für
+die unmittelbare Rolling-Kompatibilität den gemeinsamen Diagnosepfad
+`receipts/last-contention.json`. Ein direkter Recovery-Aufruf ohne Aufruf-ID
+schreibt ausschließlich diesen gemeinsamen Pfad. Der Reconciler greift nur dann
+auf den gemeinsamen Beleg zurück, wenn der aufrufspezifische Beleg fehlt; ein
+vorhandener widersprüchlicher Aufrufbeleg bleibt fail-closed. Diese Belege sind
+Diagnoseflächen, keine zweite Zustandswahrheit. Maßgeblich für Besitz ist
+ausschließlich die vom Kernel gehaltene
 `flock`-Sperre. Eine liegengebliebene Lockdatei ohne offenen Besitzer blockiert
 daher keinen späteren Lauf.
 

--- a/scripts/ci/tests/test_deploy_exact_commit_integration.py
+++ b/scripts/ci/tests/test_deploy_exact_commit_integration.py
@@ -146,6 +146,9 @@ class DeployExactCommitIntegrationTests(unittest.TestCase):
                   printf 'production lock descriptor leaked into weltgewebe-up\n' >&2
                   exit 94
                 fi
+                if [[ -n "${TEST_UP_UMASK_LOG:-}" ]]; then
+                  umask >> "$TEST_UP_UMASK_LOG"
+                fi
                 if [[ -n "${TEST_UP_LOG:-}" ]]; then
                   printf '%s\n' "$*" >> "$TEST_UP_LOG"
                 fi
@@ -595,6 +598,7 @@ class DeployExactCommitIntegrationTests(unittest.TestCase):
             "TEST_REMOTE": str(self.remote),
             "TEST_WEB_ARTIFACT": str(self.artifact),
             "TEST_UP_LOG": str(self.root / "weltgewebe-up.log"),
+            "TEST_UP_UMASK_LOG": str(self.root / "weltgewebe-up-umask.log"),
         }
 
     def deploy(

--- a/scripts/ci/tests/test_production_receipt_resilience.py
+++ b/scripts/ci/tests/test_production_receipt_resilience.py
@@ -112,6 +112,53 @@ class ProductionReceiptResilienceTests(unittest.TestCase):
         self.assertEqual(len(invocation_receipts), 1)
         self.assertTrue((fixture.state / "receipts" / "last-contention.json").exists())
 
+    def test_present_invalid_invocation_contention_cannot_fall_back_to_legacy(
+        self,
+    ) -> None:
+        fixture = self.fixture
+        wrapper = fixture.bin / "invalid-invocation-contention-deploy"
+        wrapper.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                exec 9<> "$WELTGEWEBE_DEPLOY_STATE_ROOT/production-deployment.lock"
+                set +e
+                "$TEST_DEPLOY_SCRIPT" "$@"
+                inherited_rc=$?
+                set -e
+                invocation_receipt="$WELTGEWEBE_DEPLOY_STATE_ROOT/receipts/contention/$WELTGEWEBE_DEPLOY_INVOCATION_ID.json"
+                printf '{}\n' > "$invocation_receipt"
+                chmod 0600 "$invocation_receipt"
+                exit "$inherited_rc"
+                """
+            ),
+            encoding="utf-8",
+        )
+        wrapper.chmod(0o755)
+
+        result = fixture.reconcile_stale_public_commit(
+            deploy_helper=wrapper,
+            extra_env={"TEST_DEPLOY_SCRIPT": str(DEPLOY_SCRIPT)},
+        )
+        fixture.restore_test_ownership()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "unexplained temporary failure under inherited production lock",
+            result.stderr,
+        )
+        self.assertNotIn(
+            "production lock contention during inherited handoff",
+            result.stderr,
+        )
+        legacy = json.loads(
+            (fixture.state / "receipts" / "last-contention.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        self.assertEqual(legacy["result"], "already_running")
+
     def test_permissive_caller_umask_produces_canonical_release_modes(
         self,
     ) -> None:
@@ -128,6 +175,12 @@ class ProductionReceiptResilienceTests(unittest.TestCase):
         )
         receipt = fixture.state / "receipts" / f"{fixture.commit}.json"
         self.assertEqual(receipt.stat().st_mode & 0o777, 0o600)
+        child_umasks = (
+            (fixture.root / "weltgewebe-up-umask.log")
+            .read_text(encoding="utf-8")
+            .splitlines()
+        )
+        self.assertEqual(child_umasks, ["0077", "0077"])
 
     def test_reviewed_resilience_preconditions_are_already_present(self) -> None:
         deploy = Path(DEPLOY_SCRIPT).read_text(encoding="utf-8")

--- a/scripts/ci/tests/test_production_receipt_resilience.py
+++ b/scripts/ci/tests/test_production_receipt_resilience.py
@@ -15,8 +15,8 @@ from scripts.ci.tests.test_deploy_exact_commit_integration import (
 class ProductionReceiptResilienceTests(unittest.TestCase):
     def setUp(self) -> None:
         self.fixture = DeployExactCommitIntegrationTests(methodName="runTest")
-        self.fixture.setUp()
         self.addCleanup(self.fixture.doCleanups)
+        self.fixture.setUp()
 
     def test_public_observation_repairs_safe_malformed_deployment_receipt(self) -> None:
         fixture = self.fixture

--- a/scripts/ci/tests/test_production_receipt_resilience.py
+++ b/scripts/ci/tests/test_production_receipt_resilience.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import json
+import textwrap
+import unittest
+from pathlib import Path
+
+from scripts.ci.tests.test_deploy_exact_commit_integration import (
+    DEPLOY_SCRIPT,
+    DeployExactCommitIntegrationTests,
+    run,
+)
+
+
+class ProductionReceiptResilienceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.fixture = DeployExactCommitIntegrationTests(methodName="runTest")
+        self.fixture.setUp()
+        self.addCleanup(self.fixture.doCleanups)
+
+    def test_public_observation_repairs_safe_malformed_deployment_receipt(self) -> None:
+        fixture = self.fixture
+        malformed = fixture.root / "malformed-receipt.json"
+        malformed.write_text("{not-json\n", encoding="utf-8")
+        receipt = fixture.state / "receipts" / f"{fixture.commit}.json"
+        run(
+            fixture.privileged(
+                [
+                    "install",
+                    "-d",
+                    "-o",
+                    "root",
+                    "-g",
+                    "root",
+                    "-m",
+                    "0700",
+                    str(receipt.parent),
+                ]
+            )
+        )
+        run(
+            fixture.privileged(
+                [
+                    "install",
+                    "-o",
+                    "root",
+                    "-g",
+                    "root",
+                    "-m",
+                    "0600",
+                    str(malformed),
+                    str(receipt),
+                ]
+            )
+        )
+
+        result = fixture.reconcile_existing_public_commit()
+        fixture.restore_test_ownership()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        repaired = json.loads(receipt.read_text(encoding="utf-8"))
+        self.assertEqual(repaired["schema_version"], 5)
+        self.assertEqual(repaired["result"], "verified_observed")
+        self.assertEqual(repaired["commit"], fixture.commit)
+
+    def test_inherited_contention_survives_shared_slot_overwrite(self) -> None:
+        fixture = self.fixture
+        wrapper = fixture.bin / "contention-race-deploy"
+        wrapper.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                exec 9<> "$WELTGEWEBE_DEPLOY_STATE_ROOT/production-deployment.lock"
+                set +e
+                "$TEST_DEPLOY_SCRIPT" "$@"
+                inherited_rc=$?
+                set -e
+                exec 9>&-
+                set +e
+                env \
+                  -u WELTGEWEBE_PRODUCTION_LOCK_FD \
+                  -u WELTGEWEBE_PRODUCTION_LOCK_DOMAIN \
+                  -u WELTGEWEBE_PRODUCTION_LOCK_OWNER_ENTRYPOINT \
+                  -u WELTGEWEBE_DEPLOY_INVOCATION_ID \
+                  "$TEST_DEPLOY_SCRIPT" "$@" >/dev/null 2>&1
+                set -e
+                exit "$inherited_rc"
+                """
+            ),
+            encoding="utf-8",
+        )
+        wrapper.chmod(0o755)
+
+        result = fixture.reconcile_stale_public_commit(
+            deploy_helper=wrapper,
+            extra_env={"TEST_DEPLOY_SCRIPT": str(DEPLOY_SCRIPT)},
+        )
+        fixture.restore_test_ownership()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "production lock contention during inherited handoff",
+            result.stderr,
+        )
+        self.assertNotIn("unexplained temporary failure", result.stderr)
+        invocation_receipts = list(
+            (fixture.state / "receipts" / "contention").glob("*.json")
+        )
+        self.assertEqual(len(invocation_receipts), 1)
+        self.assertTrue((fixture.state / "receipts" / "last-contention.json").exists())
+
+    def test_permissive_caller_umask_produces_canonical_release_modes(self) -> None:
+        fixture = self.fixture
+        result = fixture.deploy(advance=False, umask="000")
+        fixture.restore_test_ownership()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        release = fixture.releases / fixture.commit
+        self.assertEqual(release.stat().st_mode & 0o777, 0o755)
+        self.assertEqual(
+            (release / "apps/web/placeholder.txt").stat().st_mode & 0o777,
+            0o644,
+        )
+        receipt = fixture.state / "receipts" / f"{fixture.commit}.json"
+        self.assertEqual(receipt.stat().st_mode & 0o777, 0o600)
+
+    def test_reviewed_resilience_preconditions_are_already_present(self) -> None:
+        deploy = Path(DEPLOY_SCRIPT).read_text(encoding="utf-8")
+        reconciler = (
+            Path(DEPLOY_SCRIPT).with_name("reconcile-production-main-vps.sh").read_text(
+                encoding="utf-8"
+            )
+        )
+
+        for initialized in ('started_at=""', 'api_commit=""', 'frontend_commit=""'):
+            self.assertIn(initialized, deploy)
+        directory_creation = reconciler.index(
+            '"$ARTIFACT_ROOT" "$RECEIPT_ROOT" "$DEPLOY_RECEIPT_ROOT" "$DOCKER_CONFIG"'
+        )
+        observation = reconciler.index('if "$LIVE_VERIFIER"')
+        self.assertLess(directory_creation, observation)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/tests/test_production_receipt_resilience.py
+++ b/scripts/ci/tests/test_production_receipt_resilience.py
@@ -18,7 +18,9 @@ class ProductionReceiptResilienceTests(unittest.TestCase):
         self.addCleanup(self.fixture.doCleanups)
         self.fixture.setUp()
 
-    def test_public_observation_repairs_safe_malformed_deployment_receipt(self) -> None:
+    def test_public_observation_repairs_safe_malformed_deployment_receipt(
+        self,
+    ) -> None:
         fixture = self.fixture
         malformed = fixture.root / "malformed-receipt.json"
         malformed.write_text("{not-json\n", encoding="utf-8")
@@ -108,9 +110,13 @@ class ProductionReceiptResilienceTests(unittest.TestCase):
             (fixture.state / "receipts" / "contention").glob("*.json")
         )
         self.assertEqual(len(invocation_receipts), 1)
-        self.assertTrue((fixture.state / "receipts" / "last-contention.json").exists())
+        self.assertTrue(
+            (fixture.state / "receipts" / "last-contention.json").exists()
+        )
 
-    def test_permissive_caller_umask_produces_canonical_release_modes(self) -> None:
+    def test_permissive_caller_umask_produces_canonical_release_modes(
+        self,
+    ) -> None:
         fixture = self.fixture
         result = fixture.deploy(advance=False, umask="000")
         fixture.restore_test_ownership()
@@ -135,11 +141,17 @@ class ProductionReceiptResilienceTests(unittest.TestCase):
 
         for initialized in ('started_at=""', 'api_commit=""', 'frontend_commit=""'):
             self.assertIn(initialized, deploy)
-        directory_creation = reconciler.index(
-            '"$DEPLOY_RECEIPT_ROOT/contention" "$DOCKER_CONFIG"'
+        receipt_root_creation = reconciler.index(
+            '"$ARTIFACT_ROOT" "$RECEIPT_ROOT" "$DEPLOY_RECEIPT_ROOT" '
+            '"$DOCKER_CONFIG"'
+        )
+        contention_root_creation = reconciler.index(
+            'install -d -o root -g root -m 0700 '
+            '"$DEPLOY_RECEIPT_ROOT/contention"'
         )
         observation = reconciler.index('if "$LIVE_VERIFIER"')
-        self.assertLess(directory_creation, observation)
+        self.assertLess(receipt_root_creation, observation)
+        self.assertLess(contention_root_creation, observation)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/tests/test_production_receipt_resilience.py
+++ b/scripts/ci/tests/test_production_receipt_resilience.py
@@ -136,7 +136,7 @@ class ProductionReceiptResilienceTests(unittest.TestCase):
         for initialized in ('started_at=""', 'api_commit=""', 'frontend_commit=""'):
             self.assertIn(initialized, deploy)
         directory_creation = reconciler.index(
-            '"$ARTIFACT_ROOT" "$RECEIPT_ROOT" "$DEPLOY_RECEIPT_ROOT" "$DOCKER_CONFIG"'
+            '"$DEPLOY_RECEIPT_ROOT/contention" "$DOCKER_CONFIG"'
         )
         observation = reconciler.index('if "$LIVE_VERIFIER"')
         self.assertLess(directory_creation, observation)

--- a/scripts/ci/tests/test_production_receipt_resilience.py
+++ b/scripts/ci/tests/test_production_receipt_resilience.py
@@ -110,9 +110,7 @@ class ProductionReceiptResilienceTests(unittest.TestCase):
             (fixture.state / "receipts" / "contention").glob("*.json")
         )
         self.assertEqual(len(invocation_receipts), 1)
-        self.assertTrue(
-            (fixture.state / "receipts" / "last-contention.json").exists()
-        )
+        self.assertTrue((fixture.state / "receipts" / "last-contention.json").exists())
 
     def test_permissive_caller_umask_produces_canonical_release_modes(
         self,
@@ -134,20 +132,18 @@ class ProductionReceiptResilienceTests(unittest.TestCase):
     def test_reviewed_resilience_preconditions_are_already_present(self) -> None:
         deploy = Path(DEPLOY_SCRIPT).read_text(encoding="utf-8")
         reconciler = (
-            Path(DEPLOY_SCRIPT).with_name("reconcile-production-main-vps.sh").read_text(
-                encoding="utf-8"
-            )
+            Path(DEPLOY_SCRIPT)
+            .with_name("reconcile-production-main-vps.sh")
+            .read_text(encoding="utf-8")
         )
 
         for initialized in ('started_at=""', 'api_commit=""', 'frontend_commit=""'):
             self.assertIn(initialized, deploy)
         receipt_root_creation = reconciler.index(
-            '"$ARTIFACT_ROOT" "$RECEIPT_ROOT" "$DEPLOY_RECEIPT_ROOT" '
-            '"$DOCKER_CONFIG"'
+            '"$ARTIFACT_ROOT" "$RECEIPT_ROOT" "$DEPLOY_RECEIPT_ROOT" "$DOCKER_CONFIG"'
         )
         contention_root_creation = reconciler.index(
-            'install -d -o root -g root -m 0700 '
-            '"$DEPLOY_RECEIPT_ROOT/contention"'
+            'install -d -o root -g root -m 0700 "$DEPLOY_RECEIPT_ROOT/contention"'
         )
         observation = reconciler.index('if "$LIVE_VERIFIER"')
         self.assertLess(receipt_root_creation, observation)

--- a/scripts/ops/deploy-exact-commit-vps.sh
+++ b/scripts/ops/deploy-exact-commit-vps.sh
@@ -73,13 +73,15 @@ require_command() {
 
 write_lock_contention_receipt() {
   local receipt
+  local legacy_receipt="$STATE_ROOT/receipts/last-contention.json"
   if [[ -n "$deploy_invocation_id" ]]; then
     receipt="$STATE_ROOT/receipts/contention/$deploy_invocation_id.json"
   else
-    receipt="$STATE_ROOT/receipts/last-contention.json"
+    receipt="$legacy_receipt"
   fi
-  python3 - "$receipt" "$PRODUCTION_LOCK_DOMAIN" "$PRODUCTION_LOCK_FILE" \
-    "$lock_owner_entrypoint" "$COMMIT" "$deploy_invocation_id" << 'PY'
+  python3 - "$receipt" "$legacy_receipt" "$PRODUCTION_LOCK_DOMAIN" \
+    "$PRODUCTION_LOCK_FILE" "$lock_owner_entrypoint" "$COMMIT" \
+    "$deploy_invocation_id" << 'PY'
 import json
 import os
 import secrets
@@ -89,16 +91,17 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 path = Path(sys.argv[1])
+legacy_path = Path(sys.argv[2])
 payload = {
     "schema_version": 2,
     "kind": "weltgewebe_production_lock_contention",
     "environment": "production",
-    "lock_domain": sys.argv[2],
-    "lock_file": sys.argv[3],
-    "entrypoint": sys.argv[4],
-    "requested_commit": sys.argv[5] or None,
+    "lock_domain": sys.argv[3],
+    "lock_file": sys.argv[4],
+    "entrypoint": sys.argv[5],
+    "requested_commit": sys.argv[6] or None,
     "result": "already_running",
-    "deploy_invocation_id": sys.argv[6] or None,
+    "deploy_invocation_id": sys.argv[7] or None,
     "recorded_at": datetime.now(timezone.utc).isoformat(),
 }
 def write_atomic_root_json(path: Path, payload: dict[str, object]) -> None:
@@ -160,6 +163,8 @@ def write_atomic_root_json(path: Path, payload: dict[str, object]) -> None:
 
 
 write_atomic_root_json(path, payload)
+if legacy_path != path:
+    write_atomic_root_json(legacy_path, payload)
 PY
   printf '%s\n' "$receipt"
 }

--- a/scripts/ops/deploy-exact-commit-vps.sh
+++ b/scripts/ops/deploy-exact-commit-vps.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
+umask 022
 
 SOURCE_CHECKOUT="${WELTGEWEBE_SOURCE_CHECKOUT:-/opt/weltgewebe}"
 RELEASE_ROOT="${WELTGEWEBE_RELEASE_ROOT:-/opt/weltgewebe-releases}"

--- a/scripts/ops/deploy-exact-commit-vps.sh
+++ b/scripts/ops/deploy-exact-commit-vps.sh
@@ -63,8 +63,11 @@ run_release_deploy() {
       fail "unsupported release deployment scope: $scope"
       ;;
   esac
-  DEPLOY_TARGET=vps ENV_FILE="$RUNTIME_ENV" \
-    "$release_dir/scripts/weltgewebe-up" "${arguments[@]}" 9>&-
+  (
+    umask 077
+    DEPLOY_TARGET=vps ENV_FILE="$RUNTIME_ENV" \
+      "$release_dir/scripts/weltgewebe-up" "${arguments[@]}" 9>&-
+  )
 }
 
 require_command() {

--- a/scripts/ops/deploy-exact-commit-vps.sh
+++ b/scripts/ops/deploy-exact-commit-vps.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
-umask 077
 
 SOURCE_CHECKOUT="${WELTGEWEBE_SOURCE_CHECKOUT:-/opt/weltgewebe}"
 RELEASE_ROOT="${WELTGEWEBE_RELEASE_ROOT:-/opt/weltgewebe-releases}"
@@ -72,7 +71,12 @@ require_command() {
 }
 
 write_lock_contention_receipt() {
-  local receipt="$STATE_ROOT/receipts/last-contention.json"
+  local receipt
+  if [[ -n "$deploy_invocation_id" ]]; then
+    receipt="$STATE_ROOT/receipts/contention/$deploy_invocation_id.json"
+  else
+    receipt="$STATE_ROOT/receipts/last-contention.json"
+  fi
   python3 - "$receipt" "$PRODUCTION_LOCK_DOMAIN" "$PRODUCTION_LOCK_FILE" \
     "$lock_owner_entrypoint" "$COMMIT" "$deploy_invocation_id" << 'PY'
 import json
@@ -420,7 +424,8 @@ for command_name in git docker curl jq sha256sum tar flock install rm python3 aw
 done
 
 install -d -o root -g root -m 0711 "$STATE_ROOT"
-install -d -o root -g root -m 0700 "$STATE_ROOT/receipts" "$ARTIFACT_ROOT"
+install -d -o root -g root -m 0700 \
+  "$STATE_ROOT/receipts" "$STATE_ROOT/receipts/contention" "$ARTIFACT_ROOT"
 install -d -o root -g root -m 0755 "$RELEASE_ROOT"
 
 artifact_real="$(realpath "$WEB_ARTIFACT")"

--- a/scripts/ops/deploy-exact-commit-vps.sh
+++ b/scripts/ops/deploy-exact-commit-vps.sh
@@ -425,8 +425,8 @@ for command_name in git docker curl jq sha256sum tar flock install rm python3 aw
 done
 
 install -d -o root -g root -m 0711 "$STATE_ROOT"
-install -d -o root -g root -m 0700 \
-  "$STATE_ROOT/receipts" "$STATE_ROOT/receipts/contention" "$ARTIFACT_ROOT"
+install -d -o root -g root -m 0700 "$STATE_ROOT/receipts" "$ARTIFACT_ROOT"
+install -d -o root -g root -m 0700 "$STATE_ROOT/receipts/contention"
 install -d -o root -g root -m 0755 "$RELEASE_ROOT"
 
 artifact_real="$(realpath "$WEB_ARTIFACT")"

--- a/scripts/ops/reconcile-production-main-vps.sh
+++ b/scripts/ops/reconcile-production-main-vps.sh
@@ -350,7 +350,9 @@ read_deploy_tempfail_diagnostic() {
   local invocation_id="$2"
   local deployment_receipt="$DEPLOY_RECEIPT_ROOT/$commit.json"
   local contention_receipt="$DEPLOY_RECEIPT_ROOT/contention/$invocation_id.json"
-  python3 - "$deployment_receipt" "$contention_receipt" "$commit" "$invocation_id" << 'PY'
+  local legacy_contention_receipt="$DEPLOY_RECEIPT_ROOT/last-contention.json"
+  python3 - "$deployment_receipt" "$contention_receipt" \
+    "$legacy_contention_receipt" "$commit" "$invocation_id" << 'PY'
 import json
 import os
 import stat
@@ -360,8 +362,9 @@ from pathlib import Path
 MAX_RECEIPT_BYTES = 1048576
 deployment_path = Path(sys.argv[1])
 contention_path = Path(sys.argv[2])
-commit = sys.argv[3]
-invocation_id = sys.argv[4]
+legacy_contention_path = Path(sys.argv[3])
+commit = sys.argv[4]
+invocation_id = sys.argv[5]
 
 
 def read_safe(path: Path):
@@ -412,6 +415,19 @@ def read_safe(path: Path):
             os.close(directory_fd)
 
 
+def is_current_contention(payload: object) -> bool:
+    return (
+        isinstance(payload, dict)
+        and payload.get("schema_version") == 2
+        and payload.get("kind") == "weltgewebe_production_lock_contention"
+        and payload.get("requested_commit") == commit
+        and payload.get("deploy_invocation_id") == invocation_id
+        and payload.get("lock_domain") == "weltgewebe-production-deployment-v1"
+        and payload.get("entrypoint") == "reconciler"
+        and payload.get("result") == "already_running"
+    )
+
+
 deployment = read_safe(deployment_path)
 if deployment == "unsafe":
     print("untrusted_receipt")
@@ -430,19 +446,16 @@ else:
     contention = read_safe(contention_path)
     if contention == "unsafe":
         print("untrusted_receipt")
-    elif (
-        isinstance(contention, dict)
-        and contention.get("schema_version") == 2
-        and contention.get("kind") == "weltgewebe_production_lock_contention"
-        and contention.get("requested_commit") == commit
-        and contention.get("deploy_invocation_id") == invocation_id
-        and contention.get("lock_domain") == "weltgewebe-production-deployment-v1"
-        and contention.get("entrypoint") == "reconciler"
-        and contention.get("result") == "already_running"
-    ):
+    elif is_current_contention(contention):
         print("lock_contention")
     else:
-        print("unexplained")
+        legacy_contention = read_safe(legacy_contention_path)
+        if legacy_contention == "unsafe":
+            print("untrusted_receipt")
+        elif is_current_contention(legacy_contention):
+            print("lock_contention")
+        else:
+            print("unexplained")
 PY
 }
 

--- a/scripts/ops/reconcile-production-main-vps.sh
+++ b/scripts/ops/reconcile-production-main-vps.sh
@@ -819,8 +819,8 @@ done
 
 install -d -o root -g root -m 0711 "$STATE_ROOT"
 install -d -o root -g root -m 0700 \
-  "$ARTIFACT_ROOT" "$RECEIPT_ROOT" "$DEPLOY_RECEIPT_ROOT" \
-  "$DEPLOY_RECEIPT_ROOT/contention" "$DOCKER_CONFIG"
+  "$ARTIFACT_ROOT" "$RECEIPT_ROOT" "$DEPLOY_RECEIPT_ROOT" "$DOCKER_CONFIG"
+install -d -o root -g root -m 0700 "$DEPLOY_RECEIPT_ROOT/contention"
 install -d -o root -g root -m 0755 "$RELEASE_ROOT"
 acquire_production_lock
 prune_deploy_contention_receipts

--- a/scripts/ops/reconcile-production-main-vps.sh
+++ b/scripts/ops/reconcile-production-main-vps.sh
@@ -448,7 +448,7 @@ else:
         print("untrusted_receipt")
     elif is_current_contention(contention):
         print("lock_contention")
-    else:
+    elif contention is None:
         legacy_contention = read_safe(legacy_contention_path)
         if legacy_contention == "unsafe":
             print("untrusted_receipt")
@@ -456,6 +456,10 @@ else:
             print("lock_contention")
         else:
             print("unexplained")
+    else:
+        # The invocation-specific slot is authoritative when present. A
+        # conflicting object must not be overruled by the shared legacy slot.
+        print("unexplained")
 PY
 }
 

--- a/scripts/ops/reconcile-production-main-vps.sh
+++ b/scripts/ops/reconcile-production-main-vps.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
-umask 077
+umask 022
 
 SOURCE_CHECKOUT="${WELTGEWEBE_SOURCE_CHECKOUT:-/opt/weltgewebe}"
 RELEASE_ROOT="${WELTGEWEBE_RELEASE_ROOT:-/opt/weltgewebe-releases}"
@@ -349,7 +349,7 @@ read_deploy_tempfail_diagnostic() {
   local commit="$1"
   local invocation_id="$2"
   local deployment_receipt="$DEPLOY_RECEIPT_ROOT/$commit.json"
-  local contention_receipt="$DEPLOY_RECEIPT_ROOT/last-contention.json"
+  local contention_receipt="$DEPLOY_RECEIPT_ROOT/contention/$invocation_id.json"
   python3 - "$deployment_receipt" "$contention_receipt" "$commit" "$invocation_id" << 'PY'
 import json
 import os
@@ -464,6 +464,14 @@ deployment_path = Path(sys.argv[2])
 commit = sys.argv[3]
 
 
+class UnsafeReceiptError(ValueError):
+    pass
+
+
+class InvalidReceiptContent(ValueError):
+    pass
+
+
 def read_root_json(path: Path, *, missing_ok: bool = False):
     directory_fd = None
     file_fd = None
@@ -476,20 +484,20 @@ def read_root_json(path: Path, *, missing_ok: bool = False):
             or directory_metadata.st_uid != 0
             or directory_metadata.st_mode & 0o022
         ):
-            raise ValueError(f"receipt directory is unsafe: {path.parent}")
+            raise UnsafeReceiptError(f"receipt directory is unsafe: {path.parent}")
         file_flags = os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW
         file_fd = os.open(path.name, file_flags, dir_fd=directory_fd)
         metadata = os.fstat(file_fd)
         if not stat.S_ISREG(metadata.st_mode):
-            raise ValueError(f"receipt is not a regular file: {path}")
+            raise UnsafeReceiptError(f"receipt is not a regular file: {path}")
         if metadata.st_uid != 0:
-            raise ValueError(f"receipt is not root-owned: {path}")
+            raise UnsafeReceiptError(f"receipt is not root-owned: {path}")
         if metadata.st_mode & 0o022:
-            raise ValueError(f"receipt is group- or world-writable: {path}")
+            raise UnsafeReceiptError(f"receipt is group- or world-writable: {path}")
         if metadata.st_nlink != 1:
-            raise ValueError(f"receipt has more than one hard link: {path}")
+            raise UnsafeReceiptError(f"receipt has more than one hard link: {path}")
         if metadata.st_size > MAX_RECEIPT_BYTES:
-            raise ValueError(f"receipt exceeds the byte limit: {path}")
+            raise UnsafeReceiptError(f"receipt exceeds the byte limit: {path}")
         chunks: list[bytes] = []
         remaining = MAX_RECEIPT_BYTES + 1
         while remaining > 0:
@@ -500,7 +508,7 @@ def read_root_json(path: Path, *, missing_ok: bool = False):
             remaining -= len(chunk)
         raw = b"".join(chunks)
         if len(raw) > MAX_RECEIPT_BYTES:
-            raise ValueError(f"receipt exceeds the byte limit: {path}")
+            raise UnsafeReceiptError(f"receipt exceeds the byte limit: {path}")
     except FileNotFoundError:
         if missing_ok:
             return None
@@ -514,9 +522,9 @@ def read_root_json(path: Path, *, missing_ok: bool = False):
     try:
         payload = json.loads(raw.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-        raise ValueError(f"receipt is unreadable: {path}: {exc}") from exc
+        raise InvalidReceiptContent(f"receipt is unreadable: {path}: {exc}") from exc
     if not isinstance(payload, dict):
-        raise ValueError(f"receipt is not an object: {path}")
+        raise InvalidReceiptContent(f"receipt is not an object: {path}")
     return payload
 
 
@@ -578,8 +586,13 @@ def write_atomic_root_json(path: Path, payload: dict[str, object]) -> None:
 
 try:
     verification = read_root_json(verification_path)
+except (OSError, UnsafeReceiptError, InvalidReceiptContent) as exc:
+    raise SystemExit(f"public verification receipt evidence is unsafe: {exc}") from exc
+try:
     existing = read_root_json(deployment_path, missing_ok=True)
-except (OSError, ValueError) as exc:
+except InvalidReceiptContent:
+    existing = None
+except (OSError, UnsafeReceiptError) as exc:
     raise SystemExit(f"deployment receipt evidence is unsafe: {exc}") from exc
 if verification.get("pass") is not True:
     raise SystemExit("public verification receipt is not passing")
@@ -589,6 +602,7 @@ frontend = verification.get("frontend") or {}
 api = verification.get("api") or {}
 if frontend.get("commit") != commit or api.get("commit") != commit:
     raise SystemExit("public verification receipt does not bind both endpoints")
+
 
 def is_lower_hex(value: object, length: int) -> bool:
     return (
@@ -747,6 +761,23 @@ prune_artifacts() {
   fi
 }
 
+prune_deploy_contention_receipts() {
+  local contention_root="$DEPLOY_RECEIPT_ROOT/contention"
+  local old_receipt
+  local -a receipts=()
+
+  find "$contention_root" -maxdepth 1 -type f -name '*.json' -mtime +7 -delete
+  mapfile -t receipts < <(
+    find "$contention_root" -maxdepth 1 -type f -name '*.json' \
+      -printf '%T@ %p\n' | sort -nr | cut -d' ' -f2-
+  )
+  if ((${#receipts[@]} > 20)); then
+    for old_receipt in "${receipts[@]:20}"; do
+      rm -f -- "$old_receipt"
+    done
+  fi
+}
+
 prune_releases() {
   local current_release=""
   local previous_release=""
@@ -788,9 +819,11 @@ done
 
 install -d -o root -g root -m 0711 "$STATE_ROOT"
 install -d -o root -g root -m 0700 \
-  "$ARTIFACT_ROOT" "$RECEIPT_ROOT" "$DEPLOY_RECEIPT_ROOT" "$DOCKER_CONFIG"
+  "$ARTIFACT_ROOT" "$RECEIPT_ROOT" "$DEPLOY_RECEIPT_ROOT" \
+  "$DEPLOY_RECEIPT_ROOT/contention" "$DOCKER_CONFIG"
 install -d -o root -g root -m 0755 "$RELEASE_ROOT"
 acquire_production_lock
+prune_deploy_contention_receipts
 
 available_kib="$(df -Pk "$ARTIFACT_ROOT" | awk 'NR==2 {print $4}')"
 [[ "$available_kib" =~ ^[0-9]+$ ]] || fail "could not determine free disk space"


### PR DESCRIPTION
<!-- weltgewebe-risk: R3 -->

## Ausgangslage

Nach dem Merge von #1595 wurden die nachgereichten Review-Befunde gegen den tatsächlichen Merge-Commit `5dd0fcaa91378fc172705d16d5cd5e6437598e40` geprüft.

Zwei gemeldete Absturzursachen waren am Live-Quellstand bereits ausgeschlossen:
- `started_at`, `api_commit` und `frontend_commit` sind vor Installation des EXIT-Traps initialisiert.
- das Deployment-Receipt-Verzeichnis wird vor der öffentlichen Observation root-eigen mit Modus `0700` angelegt.

## Änderungen

- binde geerbte Lock-Konkurrenzbelege an `receipts/contention/<deploy_invocation_id>.json`, sodass ein paralleler direkter Recovery-Aufruf den autoritativen Diagnosebeleg nicht mehr überschreiben kann
- schreibe zusätzlich den bisherigen globalen Diagnose-Slot und akzeptiere ihn nur als exakt aufrufgebundenen Rolling-Deploy-Fallback, wenn der neue Beleg fehlt
- lese beim Exit 75 stets zuerst den Beleg der aktuellen Aufruf-ID
- begrenze die Aufbewahrung aufrufspezifischer Belege auf sieben Tage beziehungsweise die zwanzig neuesten Dateien
- behandle einen metadatensicheren, aber inhaltlich beschädigten alten Deployment-Beleg nach erfolgreichem öffentlichen Readback als reparierbare lokale Projektion
- halte unsichere Dateitypen, Eigentümer, Modi, Hardlinks und übergroße Belege weiterhin strikt fail-closed
- normalisiere die Prozess-`umask` auf `022`, damit Release-Worktrees kanonisch lesbar bleiben; sensible Zustände bleiben durch `0700`-Verzeichnisse und explizite `0600`-Dateimodi geschützt

## Regressionstests

Der Produktionsworkflow führt bestehende Verträge und die neuen Root-Fälle in getrennten, benannten Schritten aus:
- sicherer, aber ungültiger JSON-Beleg wird aus frischer öffentlicher Evidenz neu aufgebaut
- aufrufspezifischer Konkurrenzbeleg überlebt das Überschreiben des globalen Diagnose-Slots
- permissive aufrufende `umask 000` führt zu Release-Modi `0755/0644` und Receipt-Modus `0600`
- die beiden als Fehler gemeldeten, bereits erfüllten Vorbedingungen bleiben ausdrücklich testgebunden

## Getrennte Folgetasks

- #1600: sichere Receipt-I/O in ein installiertes, commitgebundenes Modul überführen
- #1601: vertrauenswürdige Schema-4-Belege differenziert und verlustarm migrieren

Diese Punkte vergrößern den Sicherheits- und Evidenzvertrag und bleiben deshalb außerhalb dieses gezielten Betriebsfixes.