### PR TITLE
fix(ci): run web unit tests in local contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,6 +405,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: SvelteKit prepare
+        run: pnpm sync
+
       - name: Cache Playwright browser binaries
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # tag: v6.1.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,11 +354,9 @@ jobs:
           just --version
 
       # CI Test Architecture:
-      #   ci.yml — build, lint, typecheck (web + API), cargo test, cargo-deny (via just ci),
-      #            plus always-on Core Guard Tests in the independent guard-tests job.
-      #   web.yml (Gate A) — web unit tests (vitest) + Playwright E2E. Path-scoped to apps/web/**.
-      #   Vitest deliberately runs only in web.yml to avoid double execution on PRs
-      #   that trigger both workflows. See also: Justfile ci recipe, web.yml header.
+      #   just ci — canonical web unit tests, build/lint/typecheck, API tests and cargo-deny.
+      #   ci.yml / web.yml browser jobs — Playwright E2E only.
+      #   Core Guard Tests remain in the independent guard-tests job.
       - name: Validate project
         env:
           CARGO_TERM_COLOR: always
@@ -405,9 +403,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Run web unit tests
-        run: pnpm test:unit
 
       - name: Cache Playwright browser binaries
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # tag: v6.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,8 +354,9 @@ jobs:
           just --version
 
       # CI Test Architecture:
-      #   just ci — canonical web unit tests, build/lint/typecheck, API tests and cargo-deny.
-      #   ci.yml / web.yml browser jobs — Playwright E2E only.
+      #   just ci — canonical web unit tests for pull requests and main pushes,
+      #             plus build/lint/typecheck, API tests and cargo-deny.
+      #   web.yml — push-only unit fallback for non-main web branches, plus Playwright E2E.
       #   Core Guard Tests remain in the independent guard-tests job.
       - name: Validate project
         env:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1,7 +1,6 @@
 ---
-# Web Check (Gate A) — canonical location for web unit tests (vitest) and Playwright E2E.
-# ci.yml does NOT run vitest; it handles build/lint/typecheck + API tests + guard tests.
-# This split avoids double vitest execution when both workflows trigger on the same PR.
+# Web Check (Gate A) — path-scoped web build, lint, typecheck and Playwright E2E.
+# The canonical Vitest execution lives in `just ci`, invoked by ci.yml.
 name: Web Check (Gate A)
 
 env:
@@ -87,9 +86,6 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-playwright-
-
-      - name: Unit tests (Vitest)
-        run: pnpm test:unit
 
       - name: "Playwright: setup browsers (CI)"
         # WICHTIG: Nicht "0" setzen – jede nicht-leere Zeichenkette gilt als truthy

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1,6 +1,7 @@
 ---
 # Web Check (Gate A) — path-scoped web build, lint, typecheck and Playwright E2E.
-# The canonical Vitest execution lives in `just ci`, invoked by ci.yml.
+# Pull requests and main pushes receive Vitest through `just ci`; non-main branch
+# pushes use the conditional fallback below because ci.yml does not cover them.
 name: Web Check (Gate A)
 
 env:
@@ -62,6 +63,10 @@ jobs:
 
       - name: SvelteKit prepare
         run: pnpm sync
+
+      - name: Unit tests (non-main branch pushes)
+        if: github.event_name == 'push' && github.ref != 'refs/heads/main'
+        run: pnpm test:unit
 
       - name: Typecheck
         run: pnpm check

--- a/Justfile
+++ b/Justfile
@@ -25,16 +25,13 @@ alias c := ci
 ci:
 	# Web: unit tests, build, lint and typecheck. Run Vitest directly so the
 	# package pretest generator hook is not repeated after the explicit sync.
-	# GitHub Actions already runs Vitest; this extra invocation is local-only.
-	# Browser E2E remains the separate complete profile in web.yml.
+	# Hosted workflows delegate unit tests here; browser jobs keep E2E separate.
 	@echo "==> Web: install, sync, unit tests, build, typecheck"
 	if [ -d apps/web ]; then \
 		pushd apps/web >/dev/null; \
 		pnpm install --frozen-lockfile; \
 		pnpm sync; \
-		if [ "${GITHUB_ACTIONS:-false}" != "true" ]; then \
-			pnpm exec vitest run; \
-		fi; \
+		pnpm exec vitest run; \
 		pnpm build; \
 		pnpm run ci; \
 		popd >/dev/null; \

--- a/Justfile
+++ b/Justfile
@@ -23,15 +23,15 @@ reset-web:
 alias c := ci
 
 ci:
-	# Web: build, lint, typecheck (budget + prettier + eslint + svelte-check).
-	# Unit tests (vitest) run canonically in web.yml, not here, to avoid
-	# double execution when both ci.yml and web.yml trigger on the same PR.
-	# web.yml is path-scoped to apps/web/** and runs test:unit before Playwright.
-	@echo "==> Web: install, sync, build, typecheck"
+	# Web: unit tests, build, lint and typecheck. Run Vitest directly so the
+	# package pretest generator hook is not repeated after the explicit sync.
+	# Browser E2E remains the separate complete profile in web.yml.
+	@echo "==> Web: install, sync, unit tests, build, typecheck"
 	if [ -d apps/web ]; then \
 		pushd apps/web >/dev/null; \
 		pnpm install --frozen-lockfile; \
 		pnpm sync; \
+		pnpm exec vitest run; \
 		pnpm build; \
 		pnpm run ci; \
 		popd >/dev/null; \
@@ -45,6 +45,8 @@ ci:
 		cargo test --locked; \
 		popd >/dev/null; \
 	fi
+	@echo "==> Root: local CI contract"
+	python3 -m unittest scripts.ci.tests.test_justfile_contract -v
 	@echo "==> Root: dependency check"
 	cargo deny check
 

--- a/Justfile
+++ b/Justfile
@@ -25,13 +25,16 @@ alias c := ci
 ci:
 	# Web: unit tests, build, lint and typecheck. Run Vitest directly so the
 	# package pretest generator hook is not repeated after the explicit sync.
+	# GitHub Actions already runs Vitest; this extra invocation is local-only.
 	# Browser E2E remains the separate complete profile in web.yml.
 	@echo "==> Web: install, sync, unit tests, build, typecheck"
 	if [ -d apps/web ]; then \
 		pushd apps/web >/dev/null; \
 		pnpm install --frozen-lockfile; \
 		pnpm sync; \
-		pnpm exec vitest run; \
+		if [ "${GITHUB_ACTIONS:-false}" != "true" ]; then \
+			pnpm exec vitest run; \
+		fi; \
 		pnpm build; \
 		pnpm run ci; \
 		popd >/dev/null; \

--- a/Justfile
+++ b/Justfile
@@ -25,7 +25,7 @@ alias c := ci
 ci:
 	# Web: unit tests, build, lint and typecheck. Run Vitest directly so the
 	# package pretest generator hook is not repeated after the explicit sync.
-	# Hosted workflows delegate unit tests here; browser jobs keep E2E separate.
+	# PRs and main pushes delegate unit tests here; non-main web pushes use the equivalent fallback.
 	@echo "==> Web: install, sync, unit tests, build, typecheck"
 	if [ -d apps/web ]; then \
 		pushd apps/web >/dev/null; \

--- a/scripts/ci/tests/test_justfile_contract.py
+++ b/scripts/ci/tests/test_justfile_contract.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+JUSTFILE = ROOT / "Justfile"
+
+
+class JustfileContractTests(unittest.TestCase):
+    def ci_recipe(self) -> str:
+        text = JUSTFILE.read_text(encoding="utf-8")
+        start = text.index("\nci:\n")
+        end = text.index("\n# ---------- Rust ----------", start)
+        return text[start:end]
+
+    def test_local_ci_runs_web_unit_tests_without_package_pretest_hook(self) -> None:
+        recipe = self.ci_recipe()
+        self.assertIn("pnpm exec vitest run", recipe)
+        self.assertNotIn("pnpm test:unit", recipe)
+        self.assertLess(recipe.index("pnpm sync"), recipe.index("pnpm exec vitest run"))
+        self.assertLess(
+            recipe.index("pnpm exec vitest run"), recipe.index("pnpm build")
+        )
+
+    def test_browser_e2e_remains_outside_local_ci_recipe(self) -> None:
+        recipe = self.ci_recipe()
+        self.assertNotIn("playwright", recipe.lower())
+        self.assertNotIn("test:e2e", recipe)
+
+    def test_rust_formatting_stays_check_only(self) -> None:
+        recipe = self.ci_recipe()
+        self.assertIn("cargo fmt -- --check", recipe)
+        self.assertNotIn("cargo fmt --all\n", recipe)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/tests/test_justfile_contract.py
+++ b/scripts/ci/tests/test_justfile_contract.py
@@ -1,36 +1,61 @@
+import re
 from pathlib import Path
 import unittest
 
 
 ROOT = Path(__file__).resolve().parents[3]
 JUSTFILE = ROOT / "Justfile"
+CONTINUATION = chr(92)
+
+
+def continued(command: str) -> str:
+    return f"{command}; {CONTINUATION}"
 
 
 class JustfileContractTests(unittest.TestCase):
-    def ci_recipe(self) -> str:
+    def ci_recipe_lines(self) -> list[str]:
         text = JUSTFILE.read_text(encoding="utf-8")
         start = text.index("\nci:\n")
         end = text.index("\n# ---------- Rust ----------", start)
-        return text[start:end]
+        return text[start:end].splitlines()
 
-    def test_local_ci_runs_web_unit_tests_without_package_pretest_hook(self) -> None:
-        recipe = self.ci_recipe()
-        self.assertIn("pnpm exec vitest run", recipe)
-        self.assertNotIn("pnpm test:unit", recipe)
-        self.assertLess(recipe.index("pnpm sync"), recipe.index("pnpm exec vitest run"))
-        self.assertLess(
-            recipe.index("pnpm exec vitest run"), recipe.index("pnpm build")
+    def executable_lines(self) -> list[str]:
+        return [
+            line.lstrip("\t")
+            for line in self.ci_recipe_lines()
+            if line.startswith("\t")
+            and not line.startswith("\t#")
+            and not line.startswith("\t@echo")
+        ]
+
+    def test_local_ci_runs_full_web_unit_suite_only_outside_github_actions(
+        self,
+    ) -> None:
+        lines = self.executable_lines()
+        vitest_line = continued("pnpm exec vitest run")
+        self.assertEqual(lines.count(vitest_line), 1)
+        index = lines.index(vitest_line)
+        self.assertEqual(
+            lines[index - 1],
+            f'if [ "${{GITHUB_ACTIONS:-false}}" != "true" ]; then {CONTINUATION}',
         )
+        self.assertEqual(lines[index + 1], continued("fi"))
+        self.assertLess(lines.index(continued("pnpm sync")), index)
+        self.assertLess(index, lines.index(continued("pnpm build")))
+        self.assertNotIn(continued("pnpm test:unit"), lines)
 
-    def test_browser_e2e_remains_outside_local_ci_recipe(self) -> None:
-        recipe = self.ci_recipe()
-        self.assertNotIn("playwright", recipe.lower())
-        self.assertNotIn("test:e2e", recipe)
+    def test_browser_e2e_commands_remain_outside_local_ci_recipe(self) -> None:
+        for line in self.executable_lines():
+            normalized = line.lower().rstrip(f"; {CONTINUATION}")
+            self.assertNotIn("playwright", normalized)
+            self.assertIsNone(
+                re.match(r"^pnpm (?:run )?test(?::(?:ci|e2e))?(?: |$)", normalized)
+            )
 
     def test_rust_formatting_stays_check_only(self) -> None:
-        recipe = self.ci_recipe()
-        self.assertIn("cargo fmt -- --check", recipe)
-        self.assertNotIn("cargo fmt --all\n", recipe)
+        lines = self.executable_lines()
+        self.assertIn(continued("cargo fmt -- --check"), lines)
+        self.assertNotIn(continued("cargo fmt --all"), lines)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/tests/test_justfile_contract.py
+++ b/scripts/ci/tests/test_justfile_contract.py
@@ -229,6 +229,13 @@ def trigger_block(path: Path) -> str:
     return text[start : min(candidates)]
 
 
+def job_block(path: Path, job: str, next_job: str) -> str:
+    text = path.read_text(encoding="utf-8")
+    start = text.index(f"\n  {job}:\n")
+    end = text.index(f"\n  {next_job}:\n", start)
+    return text[start:end]
+
+
 def workflow_steps(path: Path) -> list[dict[str, str]]:
     lines = path.read_text(encoding="utf-8").splitlines()
     steps: list[dict[str, str]] = []
@@ -369,6 +376,14 @@ class JustfileContractTests(unittest.TestCase):
                 for step in web_steps
             )
         )
+        ci_web_e2e = job_block(CI_WORKFLOW, "web-e2e", "web-runtime-proof")
+        install = ci_web_e2e.index(
+            "- name: Install dependencies\n        run: pnpm install --frozen-lockfile"
+        )
+        prepare = ci_web_e2e.index("- name: SvelteKit prepare\n        run: pnpm sync")
+        browser = ci_web_e2e.index("- name: Run Playwright tests\n        env:")
+        self.assertLess(install, prepare)
+        self.assertLess(prepare, browser)
 
     def test_local_package_scripts_do_not_reach_playwright(self) -> None:
         scripts = self.web_scripts()

--- a/scripts/ci/tests/test_justfile_contract.py
+++ b/scripts/ci/tests/test_justfile_contract.py
@@ -7,11 +7,72 @@ import unittest
 ROOT = Path(__file__).resolve().parents[3]
 JUSTFILE = ROOT / "Justfile"
 WEB_PACKAGE = ROOT / "apps" / "web" / "package.json"
+CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+WEB_WORKFLOW = ROOT / ".github" / "workflows" / "web.yml"
 CONTINUATION = chr(92)
+SHELL_OPERATORS = {";", "&&", "||", "|"}
 
 
 def continued(command: str) -> str:
     return f"{command}; {CONTINUATION}"
+
+
+def shell_commands(command: str) -> list[list[str]]:
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|")
+    lexer.whitespace_split = True
+    lexer.commenters = ""
+    commands: list[list[str]] = [[]]
+    for token in lexer:
+        if token in SHELL_OPERATORS:
+            if commands[-1]:
+                commands.append([])
+            continue
+        commands[-1].append(token)
+    return [tokens for tokens in commands if tokens]
+
+
+def package_script_reference(tokens: list[str], scripts: dict[str, str]) -> str | None:
+    if not tokens:
+        return None
+    executable_index = 0
+    while executable_index < len(tokens) and "=" in tokens[executable_index]:
+        executable_index += 1
+    if executable_index >= len(tokens):
+        return None
+    tool = tokens[executable_index]
+    if tool not in {"pnpm", "npm"}:
+        return None
+    index = executable_index + 1
+    while index < len(tokens) and tokens[index].startswith("-"):
+        index += 1
+    if index >= len(tokens):
+        return None
+    if tokens[index] == "run":
+        index += 1
+    return tokens[index] if index < len(tokens) and tokens[index] in scripts else None
+
+
+def command_invokes_playwright(tokens: list[str]) -> bool:
+    if not tokens:
+        return False
+    index = 0
+    while index < len(tokens) and "=" in tokens[index]:
+        index += 1
+    if index >= len(tokens):
+        return False
+    executable = tokens[index]
+    if executable == "playwright":
+        return True
+    if executable not in {"pnpm", "npm", "npx"}:
+        return False
+    index += 1
+    while index < len(tokens) and tokens[index].startswith("-"):
+        index += 1
+    if index < len(tokens) and tokens[index] in {"exec", "dlx"}:
+        index += 1
+        while index < len(tokens) and tokens[index].startswith("-"):
+            index += 1
+    return index < len(tokens) and tokens[index] == "playwright"
 
 
 def script_uses_playwright(
@@ -23,26 +84,20 @@ def script_uses_playwright(
     if script in seen:
         return False
     seen.add(script)
-    command = scripts.get(script)
-    if command is None:
-        return False
-    try:
-        tokens = shlex.split(command)
-    except ValueError:
-        return True
-    if "playwright" in tokens:
-        return True
-    for index, token in enumerate(tokens):
-        if token != "pnpm" or index + 1 >= len(tokens):
-            continue
-        next_token = tokens[index + 1]
-        nested = (
-            tokens[index + 2]
-            if next_token == "run" and index + 2 < len(tokens)
-            else next_token
-        )
-        if nested in scripts and script_uses_playwright(nested, scripts, seen):
+    lifecycle = [
+        name for name in (f"pre{script}", script, f"post{script}") if name in scripts
+    ]
+    for name in lifecycle:
+        try:
+            commands = shell_commands(scripts[name])
+        except ValueError:
             return True
+        for tokens in commands:
+            if command_invokes_playwright(tokens):
+                return True
+            nested = package_script_reference(tokens, scripts)
+            if nested is not None and script_uses_playwright(nested, scripts, seen):
+                return True
     return False
 
 
@@ -63,48 +118,56 @@ class JustfileContractTests(unittest.TestCase):
         ]
 
     def web_scripts(self) -> dict[str, str]:
-        payload = json.loads(WEB_PACKAGE.read_text(encoding="utf-8"))
-        scripts = payload.get("scripts")
+        scripts = json.loads(WEB_PACKAGE.read_text(encoding="utf-8")).get("scripts")
         self.assertIsInstance(scripts, dict)
         self.assertTrue(
             all(isinstance(k, str) and isinstance(v, str) for k, v in scripts.items())
         )
         return scripts
 
-    def test_local_ci_runs_full_web_unit_suite_only_outside_github_actions(
-        self,
-    ) -> None:
+    def test_just_ci_owns_one_exact_full_vitest_execution(self) -> None:
         lines = self.executable_lines()
-        vitest_line = continued("pnpm exec vitest run")
-        self.assertEqual(lines.count(vitest_line), 1)
-        index = lines.index(vitest_line)
-        self.assertEqual(
-            lines[index - 1],
-            f'if [ "${{GITHUB_ACTIONS:-false}}" != "true" ]; then {CONTINUATION}',
-        )
-        self.assertEqual(lines[index + 1], continued("fi"))
-        self.assertLess(lines.index(continued("pnpm sync")), index)
-        self.assertLess(index, lines.index(continued("pnpm build")))
-        self.assertNotIn(continued("pnpm test:unit"), lines)
+        expected_pnpm = {
+            continued("pnpm install --frozen-lockfile"),
+            continued("pnpm sync"),
+            continued("pnpm exec vitest run"),
+            continued("pnpm build"),
+            continued("pnpm run ci"),
+        }
+        actual_pnpm = {line for line in lines if line.startswith("pnpm ")}
+        self.assertEqual(actual_pnpm, expected_pnpm)
+        vitest = lines.index(continued("pnpm exec vitest run"))
+        self.assertLess(lines.index(continued("pnpm sync")), vitest)
+        self.assertLess(vitest, lines.index(continued("pnpm build")))
 
-    def test_browser_e2e_commands_remain_outside_local_ci_recipe(self) -> None:
+    def test_hosted_browser_workflows_do_not_repeat_unit_tests(self) -> None:
+        for workflow in (CI_WORKFLOW, WEB_WORKFLOW):
+            lines = [
+                line.strip()
+                for line in workflow.read_text(encoding="utf-8").splitlines()
+            ]
+            self.assertNotIn("run: pnpm test:unit", lines, workflow.name)
+            self.assertIn("run: pnpm test:ci", lines, workflow.name)
+
+    def test_local_package_scripts_do_not_reach_playwright(self) -> None:
         scripts = self.web_scripts()
-        for line in self.executable_lines():
-            normalized = line.rstrip(f"; {CONTINUATION}")
-            try:
-                tokens = shlex.split(normalized)
-            except ValueError as error:
-                self.fail(f"unparseable CI command {normalized!r}: {error}")
-            if "playwright" in tokens[:3]:
-                self.fail(f"direct Playwright command in local CI: {normalized}")
-            if len(tokens) < 2 or tokens[0] != "pnpm":
-                continue
-            script = tokens[2] if tokens[1] == "run" and len(tokens) > 2 else tokens[1]
-            if script in scripts:
-                self.assertFalse(
-                    script_uses_playwright(script, scripts),
-                    f"pnpm script {script!r} reaches Playwright",
-                )
+        for script in ("sync", "build", "ci"):
+            self.assertFalse(script_uses_playwright(script, scripts), script)
+
+    def test_resolver_handles_flags_hooks_cycles_and_harmless_names(self) -> None:
+        scripts = {
+            "browser": "playwright test",
+            "wrapper": "pnpm --silent run browser",
+            "ci": "echo ok",
+            "preci": "npm run wrapper",
+            "cycle-a": "pnpm cycle-b",
+            "cycle-b": "pnpm cycle-a",
+            "safe": "echo playwright && test -d playwright",
+        }
+        self.assertTrue(script_uses_playwright("wrapper", scripts))
+        self.assertTrue(script_uses_playwright("ci", scripts))
+        self.assertFalse(script_uses_playwright("cycle-a", scripts))
+        self.assertFalse(script_uses_playwright("safe", scripts))
 
     def test_rust_formatting_stays_check_only(self) -> None:
         lines = self.executable_lines()

--- a/scripts/ci/tests/test_justfile_contract.py
+++ b/scripts/ci/tests/test_justfile_contract.py
@@ -1,15 +1,49 @@
-import re
+import json
 from pathlib import Path
+import shlex
 import unittest
 
 
 ROOT = Path(__file__).resolve().parents[3]
 JUSTFILE = ROOT / "Justfile"
+WEB_PACKAGE = ROOT / "apps" / "web" / "package.json"
 CONTINUATION = chr(92)
 
 
 def continued(command: str) -> str:
     return f"{command}; {CONTINUATION}"
+
+
+def script_uses_playwright(
+    script: str,
+    scripts: dict[str, str],
+    seen: set[str] | None = None,
+) -> bool:
+    seen = set() if seen is None else seen
+    if script in seen:
+        return False
+    seen.add(script)
+    command = scripts.get(script)
+    if command is None:
+        return False
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return True
+    if "playwright" in tokens:
+        return True
+    for index, token in enumerate(tokens):
+        if token != "pnpm" or index + 1 >= len(tokens):
+            continue
+        next_token = tokens[index + 1]
+        nested = (
+            tokens[index + 2]
+            if next_token == "run" and index + 2 < len(tokens)
+            else next_token
+        )
+        if nested in scripts and script_uses_playwright(nested, scripts, seen):
+            return True
+    return False
 
 
 class JustfileContractTests(unittest.TestCase):
@@ -28,6 +62,15 @@ class JustfileContractTests(unittest.TestCase):
             and not line.startswith("\t@echo")
         ]
 
+    def web_scripts(self) -> dict[str, str]:
+        payload = json.loads(WEB_PACKAGE.read_text(encoding="utf-8"))
+        scripts = payload.get("scripts")
+        self.assertIsInstance(scripts, dict)
+        self.assertTrue(
+            all(isinstance(k, str) and isinstance(v, str) for k, v in scripts.items())
+        )
+        return scripts
+
     def test_local_ci_runs_full_web_unit_suite_only_outside_github_actions(
         self,
     ) -> None:
@@ -45,12 +88,23 @@ class JustfileContractTests(unittest.TestCase):
         self.assertNotIn(continued("pnpm test:unit"), lines)
 
     def test_browser_e2e_commands_remain_outside_local_ci_recipe(self) -> None:
+        scripts = self.web_scripts()
         for line in self.executable_lines():
-            normalized = line.lower().rstrip(f"; {CONTINUATION}")
-            self.assertNotIn("playwright", normalized)
-            self.assertIsNone(
-                re.match(r"^pnpm (?:run )?test(?::(?:ci|e2e))?(?: |$)", normalized)
-            )
+            normalized = line.rstrip(f"; {CONTINUATION}")
+            try:
+                tokens = shlex.split(normalized)
+            except ValueError as error:
+                self.fail(f"unparseable CI command {normalized!r}: {error}")
+            if "playwright" in tokens[:3]:
+                self.fail(f"direct Playwright command in local CI: {normalized}")
+            if len(tokens) < 2 or tokens[0] != "pnpm":
+                continue
+            script = tokens[2] if tokens[1] == "run" and len(tokens) > 2 else tokens[1]
+            if script in scripts:
+                self.assertFalse(
+                    script_uses_playwright(script, scripts),
+                    f"pnpm script {script!r} reaches Playwright",
+                )
 
     def test_rust_formatting_stays_check_only(self) -> None:
         lines = self.executable_lines()

--- a/scripts/ci/tests/test_justfile_contract.py
+++ b/scripts/ci/tests/test_justfile_contract.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import json
 from pathlib import Path
+import re
 import shlex
 import unittest
 
@@ -11,6 +14,60 @@ CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 WEB_WORKFLOW = ROOT / ".github" / "workflows" / "web.yml"
 CONTINUATION = chr(92)
 SHELL_OPERATORS = {";", "&&", "||", "|"}
+PACKAGE_MANAGERS = {"pnpm", "npm"}
+PACKAGE_OPTIONS_WITH_VALUE = {
+    "pnpm": {
+        "--config",
+        "--dir",
+        "--filter",
+        "--lockfile-dir",
+        "--network-concurrency",
+        "--reporter",
+        "--store-dir",
+        "--virtual-store-dir",
+        "--workspace-concurrency",
+        "-C",
+        "-F",
+    },
+    "npm": {
+        "--cache",
+        "--prefix",
+        "--registry",
+        "--userconfig",
+        "--workspace",
+        "-w",
+    },
+}
+PACKAGE_BOOLEAN_OPTIONS = {
+    "pnpm": {
+        "--if-present",
+        "--ignore-scripts",
+        "--offline",
+        "--prefer-offline",
+        "--recursive",
+        "--silent",
+        "--workspace-root",
+        "-r",
+        "-s",
+        "-w",
+    },
+    "npm": {
+        "--if-present",
+        "--ignore-scripts",
+        "--silent",
+        "-s",
+    },
+}
+PACKAGE_BUILTINS = {
+    "add",
+    "ci",
+    "config",
+    "install",
+    "list",
+    "remove",
+    "setup",
+    "update",
+}
 
 
 def continued(command: str) -> str:
@@ -18,6 +75,7 @@ def continued(command: str) -> str:
 
 
 def shell_commands(command: str) -> list[list[str]]:
+    command = command.replace("\n", " ; ")
     lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|")
     lexer.whitespace_split = True
     lexer.commenters = ""
@@ -31,74 +89,188 @@ def shell_commands(command: str) -> list[list[str]]:
     return [tokens for tokens in commands if tokens]
 
 
-def package_script_reference(tokens: list[str], scripts: dict[str, str]) -> str | None:
-    if not tokens:
-        return None
-    executable_index = 0
-    while executable_index < len(tokens) and "=" in tokens[executable_index]:
-        executable_index += 1
-    if executable_index >= len(tokens):
-        return None
-    tool = tokens[executable_index]
-    if tool not in {"pnpm", "npm"}:
-        return None
-    index = executable_index + 1
-    while index < len(tokens) and tokens[index].startswith("-"):
+def skip_environment_assignments(tokens: list[str], index: int = 0) -> int:
+    while index < len(tokens) and re.fullmatch(
+        r"[A-Za-z_][A-Za-z0-9_]*=.*", tokens[index]
+    ):
         index += 1
-    if index >= len(tokens):
-        return None
-    if tokens[index] == "run":
-        index += 1
-    return tokens[index] if index < len(tokens) and tokens[index] in scripts else None
+    return index
 
 
-def command_invokes_playwright(tokens: list[str]) -> bool:
-    if not tokens:
-        return False
-    index = 0
-    while index < len(tokens) and "=" in tokens[index]:
-        index += 1
-    if index >= len(tokens):
-        return False
-    executable = tokens[index]
-    if executable == "playwright":
-        return True
-    if executable not in {"pnpm", "npm", "npx"}:
-        return False
-    index += 1
+def skip_package_options(tokens: list[str], index: int, tool: str) -> int:
     while index < len(tokens) and tokens[index].startswith("-"):
-        index += 1
-    if index < len(tokens) and tokens[index] in {"exec", "dlx"}:
-        index += 1
-        while index < len(tokens) and tokens[index].startswith("-"):
+        option = tokens[index]
+        if option == "--":
+            return index + 1
+        if option.startswith("--") and "=" in option:
             index += 1
-    return index < len(tokens) and tokens[index] == "playwright"
+            continue
+        if option in PACKAGE_OPTIONS_WITH_VALUE[tool]:
+            if index + 1 >= len(tokens) or tokens[index + 1].startswith("-"):
+                raise ValueError(f"missing value for {tool} option {option}")
+            index += 2
+            continue
+        if option in PACKAGE_BOOLEAN_OPTIONS[tool]:
+            index += 1
+            continue
+        raise ValueError(f"unsupported {tool} option {option}")
+    return index
 
 
-def script_uses_playwright(
+def package_invocation(
+    tokens: list[str], scripts: dict[str, str]
+) -> tuple[str, str] | None:
+    index = skip_environment_assignments(tokens)
+    if index >= len(tokens) or tokens[index] not in PACKAGE_MANAGERS:
+        return None
+    tool = tokens[index]
+    index = skip_package_options(tokens, index + 1, tool)
+    if index >= len(tokens):
+        raise ValueError(f"{tool} command is missing")
+    command = tokens[index]
+    index += 1
+
+    if command in {"exec", "dlx"}:
+        index = skip_package_options(tokens, index, tool)
+        if index >= len(tokens):
+            raise ValueError(f"{tool} {command} target is missing")
+        return ("binary", tokens[index])
+
+    if command == "run":
+        index = skip_package_options(tokens, index, tool)
+        if index >= len(tokens):
+            raise ValueError(f"{tool} run script is missing")
+        return ("script", tokens[index])
+
+    if command in scripts:
+        return ("script", command)
+    if command in PACKAGE_BUILTINS:
+        return ("builtin", command)
+    return ("builtin", command)
+
+
+def direct_binary(tokens: list[str]) -> str | None:
+    index = skip_environment_assignments(tokens)
+    if index >= len(tokens):
+        return None
+    return tokens[index]
+
+
+def script_uses_binary(
     script: str,
     scripts: dict[str, str],
-    seen: set[str] | None = None,
+    binary: str,
+    visiting: set[str] | None = None,
+    memo: dict[str, bool] | None = None,
 ) -> bool:
-    seen = set() if seen is None else seen
-    if script in seen:
+    visiting = set() if visiting is None else visiting
+    memo = {} if memo is None else memo
+    if script in memo:
+        return memo[script]
+    if script in visiting:
         return False
-    seen.add(script)
+    visiting.add(script)
     lifecycle = [
         name for name in (f"pre{script}", script, f"post{script}") if name in scripts
     ]
-    for name in lifecycle:
-        try:
-            commands = shell_commands(scripts[name])
-        except ValueError:
-            return True
-        for tokens in commands:
-            if command_invokes_playwright(tokens):
-                return True
-            nested = package_script_reference(tokens, scripts)
-            if nested is not None and script_uses_playwright(nested, scripts, seen):
-                return True
+    try:
+        for name in lifecycle:
+            for tokens in shell_commands(scripts[name]):
+                if direct_binary(tokens) == binary:
+                    memo[script] = True
+                    return True
+                invocation = package_invocation(tokens, scripts)
+                if invocation is None:
+                    continue
+                kind, target = invocation
+                if kind == "binary" and target == binary:
+                    memo[script] = True
+                    return True
+                if kind == "script" and script_uses_binary(
+                    target, scripts, binary, visiting, memo
+                ):
+                    memo[script] = True
+                    return True
+    except ValueError:
+        memo[script] = True
+        return True
+    finally:
+        visiting.discard(script)
+    memo[script] = False
     return False
+
+
+def run_uses_binary(run: str, scripts: dict[str, str], binary: str) -> bool:
+    try:
+        for tokens in shell_commands(run):
+            if direct_binary(tokens) == binary:
+                return True
+            invocation = package_invocation(tokens, scripts)
+            if invocation is None:
+                continue
+            kind, target = invocation
+            if kind == "binary" and target == binary:
+                return True
+            if kind == "script" and script_uses_binary(target, scripts, binary):
+                return True
+    except ValueError:
+        return True
+    return False
+
+
+def trigger_block(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    start = text.index('"on":\n')
+    candidates = [
+        position
+        for marker in ("\njobs:\n", "\nconcurrency:\n")
+        if (position := text.find(marker, start)) != -1
+    ]
+    return text[start : min(candidates)]
+
+
+def workflow_steps(path: Path) -> list[dict[str, str]]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    steps: list[dict[str, str]] = []
+    index = 0
+    while index < len(lines):
+        match = re.match(r"^(\s*)- name:\s*(.+)$", lines[index])
+        if match is None:
+            index += 1
+            continue
+        indent = len(match.group(1))
+        step: dict[str, str] = {"name": match.group(2).strip("\"'")}
+        index += 1
+        while index < len(lines):
+            next_step = re.match(r"^(\s*)- name:\s*(.+)$", lines[index])
+            if next_step is not None and len(next_step.group(1)) == indent:
+                break
+            stripped = lines[index].strip()
+            current_indent = len(lines[index]) - len(lines[index].lstrip())
+            if stripped and current_indent <= indent:
+                break
+            if stripped.startswith("if:"):
+                step["if"] = stripped.removeprefix("if:").strip()
+            elif stripped.startswith("run:"):
+                value = stripped.removeprefix("run:").strip()
+                if value in {"|", ">"}:
+                    run_indent = len(lines[index]) - len(lines[index].lstrip())
+                    block: list[str] = []
+                    index += 1
+                    while index < len(lines):
+                        raw = lines[index]
+                        current_indent = len(raw) - len(raw.lstrip())
+                        if raw.strip() and current_indent <= run_indent:
+                            index -= 1
+                            break
+                        block.append(raw[run_indent + 2 :] if raw.strip() else "")
+                        index += 1
+                    step["run"] = "\n".join(block)
+                else:
+                    step["run"] = value
+            index += 1
+        steps.append(step)
+    return steps
 
 
 class JustfileContractTests(unittest.TestCase):
@@ -121,53 +293,128 @@ class JustfileContractTests(unittest.TestCase):
         scripts = json.loads(WEB_PACKAGE.read_text(encoding="utf-8")).get("scripts")
         self.assertIsInstance(scripts, dict)
         self.assertTrue(
-            all(isinstance(k, str) and isinstance(v, str) for k, v in scripts.items())
+            all(
+                isinstance(key, str) and isinstance(value, str)
+                for key, value in scripts.items()
+            )
         )
         return scripts
 
-    def test_just_ci_owns_one_exact_full_vitest_execution(self) -> None:
+    def test_just_ci_web_block_is_exact_and_unconditional(self) -> None:
         lines = self.executable_lines()
-        expected_pnpm = {
-            continued("pnpm install --frozen-lockfile"),
-            continued("pnpm sync"),
-            continued("pnpm exec vitest run"),
-            continued("pnpm build"),
-            continued("pnpm run ci"),
-        }
-        actual_pnpm = {line for line in lines if line.startswith("pnpm ")}
-        self.assertEqual(actual_pnpm, expected_pnpm)
-        vitest = lines.index(continued("pnpm exec vitest run"))
-        self.assertLess(lines.index(continued("pnpm sync")), vitest)
-        self.assertLess(vitest, lines.index(continued("pnpm build")))
+        start = lines.index(f"if [ -d apps/web ]; then {CONTINUATION}")
+        end = lines.index("fi", start)
+        self.assertEqual(
+            lines[start : end + 1],
+            [
+                f"if [ -d apps/web ]; then {CONTINUATION}",
+                continued("pushd apps/web >/dev/null"),
+                continued("pnpm install --frozen-lockfile"),
+                continued("pnpm sync"),
+                continued("pnpm exec vitest run"),
+                continued("pnpm build"),
+                continued("pnpm run ci"),
+                continued("popd >/dev/null"),
+                "fi",
+            ],
+        )
 
-    def test_hosted_browser_workflows_do_not_repeat_unit_tests(self) -> None:
-        for workflow in (CI_WORKFLOW, WEB_WORKFLOW):
-            lines = [
-                line.strip()
-                for line in workflow.read_text(encoding="utf-8").splitlines()
-            ]
-            self.assertNotIn("run: pnpm test:unit", lines, workflow.name)
-            self.assertIn("run: pnpm test:ci", lines, workflow.name)
+    def test_hosted_events_cover_unit_tests_without_pr_or_main_duplication(
+        self,
+    ) -> None:
+        scripts = self.web_scripts()
+        ci_triggers = trigger_block(CI_WORKFLOW)
+        web_triggers = trigger_block(WEB_WORKFLOW)
+        self.assertIn("branches: [main]", ci_triggers)
+        self.assertIn("pull_request:", ci_triggers)
+        self.assertIn("branches: [main, dev, 'feat/**', 'fix/**']", web_triggers)
+        self.assertIn("pull_request:", web_triggers)
+
+        ci_steps = workflow_steps(CI_WORKFLOW)
+        web_steps = workflow_steps(WEB_WORKFLOW)
+        self.assertTrue(
+            any(
+                any(tokens == ["just", "ci"] for tokens in shell_commands(step["run"]))
+                for step in ci_steps
+                if "run" in step
+            )
+        )
+        self.assertFalse(
+            any(
+                run_uses_binary(step["run"], scripts, "vitest")
+                for step in ci_steps
+                if "run" in step
+            )
+        )
+        unit_steps = [
+            step
+            for step in web_steps
+            if "run" in step and run_uses_binary(step["run"], scripts, "vitest")
+        ]
+        self.assertEqual(
+            unit_steps,
+            [
+                {
+                    "name": "Unit tests (non-main branch pushes)",
+                    "if": "github.event_name == 'push' && github.ref != 'refs/heads/main'",
+                    "run": "pnpm test:unit",
+                }
+            ],
+        )
+        self.assertTrue(
+            any(
+                step.get("name") == "Test (CI)"
+                and step.get("run") == "pnpm test:ci"
+                and run_uses_binary(step["run"], scripts, "playwright")
+                for step in web_steps
+            )
+        )
 
     def test_local_package_scripts_do_not_reach_playwright(self) -> None:
         scripts = self.web_scripts()
         for script in ("sync", "build", "ci"):
-            self.assertFalse(script_uses_playwright(script, scripts), script)
+            self.assertFalse(script_uses_binary(script, scripts, "playwright"), script)
 
-    def test_resolver_handles_flags_hooks_cycles_and_harmless_names(self) -> None:
+    def test_resolver_handles_option_values_hooks_cycles_and_malformed_scripts(
+        self,
+    ) -> None:
+        direct_cases = {
+            "pnpm-dir": "pnpm --dir . run browser",
+            "pnpm-filter": "pnpm --filter weltgewebe-web run browser",
+            "npm-prefix": "npm --prefix . run browser",
+            "pnpm-exec": "pnpm --dir . exec playwright test",
+            "npm-exec": "npm --prefix . exec playwright test",
+        }
+        for name, command in direct_cases.items():
+            scripts = {"root": command, "browser": "playwright test"}
+            self.assertTrue(script_uses_binary("root", scripts, "playwright"), name)
+
         scripts = {
             "browser": "playwright test",
             "wrapper": "pnpm --silent run browser",
             "ci": "echo ok",
             "preci": "npm run wrapper",
             "cycle-a": "pnpm cycle-b",
-            "cycle-b": "pnpm cycle-a",
+            "cycle-b": "pnpm cycle-a && pnpm browser",
+            "broken-root": "pnpm broken",
+            "broken": "echo '",
             "safe": "echo playwright && test -d playwright",
         }
-        self.assertTrue(script_uses_playwright("wrapper", scripts))
-        self.assertTrue(script_uses_playwright("ci", scripts))
-        self.assertFalse(script_uses_playwright("cycle-a", scripts))
-        self.assertFalse(script_uses_playwright("safe", scripts))
+        self.assertTrue(script_uses_binary("wrapper", scripts, "playwright"))
+        self.assertTrue(script_uses_binary("ci", scripts, "playwright"))
+        self.assertTrue(script_uses_binary("cycle-a", scripts, "playwright"))
+        self.assertTrue(script_uses_binary("broken-root", scripts, "playwright"))
+        self.assertFalse(script_uses_binary("safe", scripts, "playwright"))
+
+    def test_workflow_run_parser_detects_unit_command_variants(self) -> None:
+        scripts = self.web_scripts()
+        for command in (
+            "pnpm test:unit",
+            "pnpm run test:unit",
+            "pnpm exec vitest run",
+            "echo prepare\npnpm test:unit",
+        ):
+            self.assertTrue(run_uses_binary(command, scripts, "vitest"), command)
 
     def test_rust_formatting_stays_check_only(self) -> None:
         lines = self.executable_lines()


### PR DESCRIPTION
<!-- weltgewebe-risk: R3 -->

## Summary
- run one full Vitest suite through `just ci` for pull requests and `main` pushes
- retain one conditional unit-test fallback for non-`main` `dev`, `feat/**` and `fix/**` web pushes that `ci.yml` does not cover
- keep Playwright E2E in the browser workflows
- restore explicit `pnpm sync` before the independent CI browser job so SvelteKit aliases exist without a duplicate unit run
- enforce the event matrix, command ordering and package-script indirection with a fail-closed contract test

## Validation
- exact head: `83d47839cef5060bf2c42aa95fe8e34cf1e9a699`
- exact prior-head disposable clone: 29 Vitest files, 226 tests passed; final head adds only the CI `pnpm sync` prerequisite and its contract assertion
- `python3 -m unittest scripts.ci.tests.test_justfile_contract -v`: 6 tests passed
- `ruff check` and `ruff format --check`
- workflow YAML parsing, `just --dry-run ci`, `git diff --check`
- independent operations review: PASS
- GitHub Web E2E and Required merge gate: PASS
- complete UTF-8 diff: 19,768 bytes, SHA-256 `7ed2ab5c785997ddbe232606c86d85ae5b3e1493f800723902de01759adf42f8`

Risk is R3 because the diff changes GitHub workflow execution paths.

Leaf slice of #1474. This PR does not close the broader CI proof-graph consolidation issue.