### PR TITLE
fix(compose): require API readiness for container health

### DIFF
--- a/docs/deploy/vps.md
+++ b/docs/deploy/vps.md
@@ -172,11 +172,15 @@ Wenn API-Healthchecks fehlschlagen, prüfe im Container:
 
 ```bash
 wg-compose logs api
-# Teste im Container
+# Der Container-Healthcheck verwendet ausschließlich Readiness.
 wg-compose exec api wget -qO- http://localhost:8080/health/ready
-# Oder Fallback
+# Liveness ist nur eine getrennte Diagnose für Prozesslebendigkeit.
 wg-compose exec api wget -qO- http://localhost:8080/health/live
 ```
+
+Ein erfolgreicher Liveness-Aufruf darf einen fehlgeschlagenen Readiness-Aufruf
+nicht überstimmen: Der Container bleibt ungesund, solange die API ihre
+Abhängigkeiten und Policy-Verträge nicht als bereit meldet.
 
 Startet die API gar nicht und meldet `AUTH_TRUSTED_PROXIES is not set`, dann
 läuft der Stack ohne `compose.vps.override.yml` (siehe oben) oder die

--- a/infra/compose/compose.prod.yml
+++ b/infra/compose/compose.prod.yml
@@ -56,9 +56,7 @@ services:
       test:
         - CMD-SHELL
         - >
-          wget -qO- http://localhost:8080/health/ready >/dev/null 2>&1 ||
-          wget -qO- http://localhost:8080/health/live >/dev/null 2>&1 ||
-          exit 1
+          wget -qO- http://localhost:8080/health/ready >/dev/null 2>&1
       interval: 10s
       timeout: 3s
       retries: 10

--- a/scripts/ci/tests/test_compose_readiness_contract.py
+++ b/scripts/ci/tests/test_compose_readiness_contract.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+import yaml
+
+
+REPO = Path(__file__).resolve().parents[3]
+COMPOSE = REPO / "infra" / "compose" / "compose.prod.yml"
+
+
+def _api_healthcheck_command() -> str:
+    payload = yaml.safe_load(COMPOSE.read_text(encoding="utf-8"))
+    test = payload["services"]["api"]["healthcheck"]["test"]
+    assert test[0] == "CMD-SHELL"
+    assert len(test) == 2
+    return test[1]
+
+
+def test_production_api_healthcheck_requires_readiness() -> None:
+    command = _api_healthcheck_command()
+    assert command.count("/health/ready") == 1
+    assert "/health/live" not in command
+    assert "||" not in command
+
+
+def test_production_api_healthcheck_preserves_failure_status() -> None:
+    command = _api_healthcheck_command().strip()
+    assert command.startswith("wget -qO-")
+    assert command.endswith(">/dev/null 2>&1")

--- a/scripts/ci/tests/test_compose_readiness_contract.py
+++ b/scripts/ci/tests/test_compose_readiness_contract.py
@@ -1,3 +1,4 @@
+import unittest
 from pathlib import Path
 
 import yaml
@@ -10,19 +11,23 @@ COMPOSE = REPO / "infra" / "compose" / "compose.prod.yml"
 def _api_healthcheck_command() -> str:
     payload = yaml.safe_load(COMPOSE.read_text(encoding="utf-8"))
     test = payload["services"]["api"]["healthcheck"]["test"]
-    assert test[0] == "CMD-SHELL"
-    assert len(test) == 2
+    if test[0] != "CMD-SHELL" or len(test) != 2:
+        raise AssertionError("API healthcheck must be one CMD-SHELL command")
     return test[1]
 
 
-def test_production_api_healthcheck_requires_readiness() -> None:
-    command = _api_healthcheck_command()
-    assert command.count("/health/ready") == 1
-    assert "/health/live" not in command
-    assert "||" not in command
+class ComposeReadinessContractTests(unittest.TestCase):
+    def test_production_api_healthcheck_requires_readiness(self) -> None:
+        command = _api_healthcheck_command()
+        self.assertEqual(command.count("/health/ready"), 1)
+        self.assertNotIn("/health/live", command)
+        self.assertNotIn("||", command)
+
+    def test_production_api_healthcheck_preserves_failure_status(self) -> None:
+        command = _api_healthcheck_command().strip()
+        self.assertTrue(command.startswith("wget -qO-"))
+        self.assertTrue(command.endswith(">/dev/null 2>&1"))
 
 
-def test_production_api_healthcheck_preserves_failure_status() -> None:
-    command = _api_healthcheck_command().strip()
-    assert command.startswith("wget -qO-")
-    assert command.endswith(">/dev/null 2>&1")
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- remove the `/health/live` fallback from the production API container healthcheck
- keep liveness and readiness semantics separate
- add a focused contract test that rejects future readiness bypasses
- document that liveness is diagnostic only and never overrides failed readiness

This implements the production-Compose leaf of #1467; the broader worker, queue and JetStream readiness work remains separate.

## Validation

- `python3 -m pytest -q scripts/ci/tests/test_compose_readiness_contract.py scripts/ci/tests/test_observability_compose_contract.py scripts/ci/tests/test_proxy_trust_defaults.py` — 15 passed
- `git diff --check` — pass

## Binding

- base: `7b4c347b87e0deb75315d59acd264a2f24130084`
- head: `6ed61117bfd65c3ada7a08d9ae19979467812b3a`

<!-- weltgewebe-risk: R3 -->