### PR TITLE
fix(auth): validate open-registration email shape

### DIFF
--- a/apps/api/src/routes/auth.rs
+++ b/apps/api/src/routes/auth.rs
@@ -54,6 +54,23 @@ pub const GENERIC_LOGIN_MSG: &str = "If your email is registered, you will recei
 /// Maximum email length in bytes (RFC 5321 forward path limit).
 pub const MAX_EMAIL_LEN: usize = 254;
 
+fn normalize_login_email(input: &str) -> Option<String> {
+    if input.is_empty()
+        || input.len() > MAX_EMAIL_LEN
+        || input.chars().any(|c| c.is_whitespace() || c.is_control())
+        || input.matches('@').count() != 1
+    {
+        return None;
+    }
+
+    let (local, domain) = input.split_once('@')?;
+    if local.is_empty() || domain.is_empty() {
+        return None;
+    }
+
+    Some(input.to_ascii_lowercase())
+}
+
 fn shared_auth_backend_json_response(
     store: &'static str,
     error: &impl std::fmt::Display,
@@ -839,33 +856,22 @@ pub async fn request_login(
         message: GENERIC_LOGIN_MSG.to_string(),
     };
 
-    // 1. Validate email format (simple check)
-    if !payload.email.contains('@') {
-        tracing::warn!(%request_id, %client_ip, "Invalid email format in login request");
-        return (StatusCode::OK, Json(generic_response)).into_response();
-    }
-
-    // Normalize email input for semantic checks and downstream processing.
-    let email_raw = payload.email.trim();
-
-    // 1a. Reject overly long emails before any further processing (hashing, rate limiting,
-    // mailing). Bounds the work an unauthenticated client can force per request and matches
-    // RFC 5321 mailbox semantics after trimming surrounding whitespace. Response stays
-    // identical for Anti-Enumeration parity.
-    if email_raw.len() > MAX_EMAIL_LEN {
-        tracing::warn!(
-            event = "login.email_too_long",
-            request_id = %request_id,
-            client_ip = %client_ip,
-            email_len = email_raw.len(),
-            max_len = MAX_EMAIL_LEN,
-            "Email exceeds maximum length in login request"
-        );
-        return (StatusCode::OK, Json(generic_response)).into_response();
-    }
-
-    // Normalize email: lowercase
-    let email_norm = email_raw.to_ascii_lowercase();
+    // Validate and normalize before hashing, rate limiting, account lookup, provisioning,
+    // token creation, or mail delivery. The generic response preserves anti-enumeration.
+    let email_norm = match normalize_login_email(&payload.email) {
+        Some(email) => email,
+        None => {
+            tracing::warn!(
+                event = "login.email_invalid",
+                request_id = %request_id,
+                client_ip = %client_ip,
+                email_len = payload.email.len(),
+                max_len = MAX_EMAIL_LEN,
+                "Invalid email format in login request"
+            );
+            return (StatusCode::OK, Json(generic_response)).into_response();
+        }
+    };
 
     // Compute hash for privacy-preserving logging
     let mut hasher = Sha256::new();

--- a/apps/api/src/routes/auth.rs
+++ b/apps/api/src/routes/auth.rs
@@ -58,17 +58,15 @@ fn normalize_login_email(input: &str) -> Option<String> {
     if input.is_empty()
         || input.len() > MAX_EMAIL_LEN
         || input.chars().any(|c| c.is_whitespace() || c.is_control())
-        || input.matches('@').count() != 1
     {
         return None;
     }
 
-    let (local, domain) = input.split_once('@')?;
-    if local.is_empty() || domain.is_empty() {
-        return None;
-    }
-
-    Some(input.to_ascii_lowercase())
+    // Use the same address parser as the delivery layer before any account,
+    // token, rate-limit, or mailer side effect can occur.
+    let normalized = input.to_ascii_lowercase();
+    normalized.parse::<lettre::Address>().ok()?;
+    Some(normalized)
 }
 
 fn shared_auth_backend_json_response(

--- a/apps/api/tests/api_auth.rs
+++ b/apps/api/tests/api_auth.rs
@@ -1797,8 +1797,8 @@ async fn request_login_provisioning_email_normalization_works() -> Result<()> {
 
     let app = app(state.clone());
 
-    // Input has whitespace and mixed case
-    let input_email = "  Allowed@EXAMPLE.com  ";
+    // Input has mixed case; semantic normalization remains lowercase.
+    let input_email = "Allowed@EXAMPLE.com";
     let normalized_email = "allowed@example.com";
 
     let req = Request::post("/auth/magic-link/request")

--- a/apps/api/tests/auth_open_registration.rs
+++ b/apps/api/tests/auth_open_registration.rs
@@ -153,3 +153,59 @@ async fn test_open_registration_flow_auto_provisions_unknown_email() -> Result<(
 
     Ok(())
 }
+
+#[tokio::test]
+#[serial]
+async fn test_open_registration_rejects_invalid_email_shapes_without_side_effects() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let _env = set_gewebe_in_dir(tmp.path());
+
+    let state = test_state_open_reg()?;
+    let app = app(state.clone());
+    let invalid_emails = [
+        "a@b@c",
+        "@example.org",
+        "user@",
+        "user name@example.org",
+        " user@example.org",
+        "user@example.org ",
+        "user@example.org\n",
+    ];
+
+    for email in invalid_emails {
+        let req = Request::post("/auth/magic-link/request")
+            .header("Content-Type", "application/json")
+            .body(body::Body::from(
+                serde_json::json!({"email": email}).to_string(),
+            ))?;
+
+        let res = app.clone().oneshot(req).await?;
+        assert_eq!(res.status(), StatusCode::OK, "email={email:?}");
+
+        let response_body = body::to_bytes(res.into_body(), usize::MAX).await?;
+        let body_val: serde_json::Value = serde_json::from_slice(&response_body)?;
+        assert_eq!(body_val["ok"], true, "email={email:?}");
+        assert_eq!(body_val["message"], GENERIC_LOGIN_MSG, "email={email:?}");
+
+        let accounts = state.accounts.read().await;
+        assert!(accounts.values().next().is_none(), "email={email:?}");
+        drop(accounts);
+        #[cfg(feature = "integration-testing")]
+        {
+            assert!(
+                state.tokens.latest_raw_for_email(email).is_none(),
+                "invalid email must not create a token: {email:?}"
+            );
+            let legacy_normalized = email.trim().to_ascii_lowercase();
+            assert!(
+                state
+                    .tokens
+                    .latest_raw_for_email(&legacy_normalized)
+                    .is_none(),
+                "invalid email must not create a normalized token: {email:?}"
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/apps/api/tests/auth_open_registration.rs
+++ b/apps/api/tests/auth_open_registration.rs
@@ -170,6 +170,8 @@ async fn test_open_registration_rejects_invalid_email_shapes_without_side_effect
         " user@example.org",
         "user@example.org ",
         "user@example.org\n",
+        "foo..bar@example.org",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@example.org",
     ];
 
     for email in invalid_emails {


### PR DESCRIPTION
<!-- weltgewebe-risk: R3 -->

## Summary

- validate magic-link email syntax before hashing, rate limiting, account lookup, auto-provisioning, token creation, or mail delivery
- use `lettre::Address`, the same delivery-compatible parser used by the mailer
- reject malformed mailboxes including multiple `@`, empty parts, whitespace/control characters, consecutive dots and local parts over 64 bytes
- preserve the generic HTTP 200 anti-enumeration response and lowercase normalization for valid addresses
- prove invalid inputs create neither accounts nor integration-test tokens

## Validation

- `cargo test --manifest-path apps/api/Cargo.toml --test auth_open_registration` — 2 passed
- `cargo test --manifest-path apps/api/Cargo.toml --features integration-testing --test auth_open_registration` — 2 passed
- `cargo test --manifest-path apps/api/Cargo.toml --features integration-testing --test api_auth request_login` — 16 passed
- `cargo clippy --manifest-path apps/api/Cargo.toml --all-targets --features integration-testing -- -D warnings` — passed
- `cargo fmt --all -- --check`, `git diff --check` — passed

## Revision binding

- base: `c52aaa716ce3d043d29c6c9e57548b00bc624de3`
- head: `67d1c8969b766474b4d413140c04df83dd2ac86d`
- full diff SHA-256: `75e0af906b19d88bc5e01b4af557767ca293014395e7a35741c3f3ca4afa76d9`
- immutable diff artifact: `293ff8ae767042a085eb2a4e9f52caf8`
- artifact receipt SHA-256: `b4ebbbfb3d1d3ab70b607f703b4fb2032d4449ec9d391b5ac491684bf2db6c14`
- Bureau candidate: `candidate-786ba0bd57b13f0631d5d7ac`
