### PR TITLE
fix(api): enforce node info limit on patch

### DIFF
--- a/apps/api/src/routes/nodes.rs
+++ b/apps/api/src/routes/nodes.rs
@@ -248,12 +248,72 @@ where
     Deserialize::deserialize(deserializer).map(Some)
 }
 
+/// Mirrors `contracts/domain/node.schema.json` (`info.maxLength`) for every
+/// node write path, including partial updates.
+const NODE_INFO_MAX_LEN: usize = 20_000;
+
 #[derive(Deserialize)]
 pub struct UpdateNode {
     #[serde(default, deserialize_with = "deserialize_some")]
     pub info: Option<Option<String>>,
     #[serde(default, deserialize_with = "deserialize_some")]
     pub search_visibility: Option<Option<SearchVisibility>>,
+}
+
+#[derive(Debug, PartialEq)]
+enum NodePatchValidationError {
+    InfoTooLong { max: usize },
+}
+
+impl UpdateNode {
+    fn validate(&self) -> Result<(), NodePatchValidationError> {
+        if let Some(Some(info)) = &self.info {
+            if info.chars().count() > NODE_INFO_MAX_LEN {
+                return Err(NodePatchValidationError::InfoTooLong {
+                    max: NODE_INFO_MAX_LEN,
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+fn node_patch_error_message(error: &NodePatchValidationError) -> String {
+    match error {
+        NodePatchValidationError::InfoTooLong { max } => {
+            format!("info exceeds the maximum length of {max}")
+        }
+    }
+}
+
+#[cfg(test)]
+mod node_patch_validation_tests {
+    use super::{NodePatchValidationError, SearchVisibility, UpdateNode, NODE_INFO_MAX_LEN};
+
+    #[test]
+    fn accepts_absent_null_and_exact_limit_info() {
+        for info in [None, Some(None), Some(Some("a".repeat(NODE_INFO_MAX_LEN)))] {
+            let request = UpdateNode {
+                info,
+                search_visibility: Some(Some(SearchVisibility::Public)),
+            };
+            assert_eq!(request.validate(), Ok(()));
+        }
+    }
+
+    #[test]
+    fn rejects_info_over_limit() {
+        let request = UpdateNode {
+            info: Some(Some("a".repeat(NODE_INFO_MAX_LEN + 1))),
+            search_visibility: None,
+        };
+        assert_eq!(
+            request.validate(),
+            Err(NodePatchValidationError::InfoTooLong {
+                max: NODE_INFO_MAX_LEN,
+            })
+        );
+    }
 }
 
 /// Lightweight struct for fast-path ID checking during node rewrites.
@@ -1376,7 +1436,7 @@ pub async fn create_node(
 /// can safely replay the same account-scoped create action when the derived
 /// Faden projection fails after the node itself became durable.
 mod node_create {
-    use super::SearchVisibility;
+    use super::{SearchVisibility, NODE_INFO_MAX_LEN};
     use serde::{de, Deserialize, Deserializer};
     use uuid::Uuid;
 
@@ -1401,8 +1461,6 @@ mod node_create {
     const NODE_ADDRESS_MAX_LEN: usize = 500;
     /// Mirrors `contracts/domain/node.schema.json` (`summary.maxLength`).
     const NODE_SUMMARY_MAX_LEN: usize = 500;
-    /// Mirrors `contracts/domain/node.schema.json` (`info.maxLength`).
-    const NODE_INFO_MAX_LEN: usize = 20_000;
     /// Mirrors `contracts/domain/node.schema.json` (`tags.items.maxLength`).
     const NODE_TAG_MAX_LEN: usize = 64;
     /// The domain contract does not cap the number of tags; this bound exists
@@ -2801,6 +2859,15 @@ pub async fn patch_node(
 ) -> Result<Json<Node>, NodeMutationError> {
     reject_node_patch_unless_writable(&state)
         .map_err(|(status, body)| NodeMutationError::Message(status, body))?;
+    payload.validate().map_err(|error| {
+        NodeMutationError::Message(
+            StatusCode::BAD_REQUEST,
+            format!(
+                "invalid node patch request: {}",
+                node_patch_error_message(&error)
+            ),
+        )
+    })?;
 
     if state.config.domain_node_write_source == DomainNodeWriteSource::Postgres {
         return patch_node_postgres(&state, &id, payload).await;

--- a/apps/api/tests/api_nodes.rs
+++ b/apps/api/tests/api_nodes.rs
@@ -443,6 +443,84 @@ async fn nodes_patch_info_lifecycle() -> anyhow::Result<()> {
 
 #[tokio::test]
 #[serial]
+async fn nodes_patch_rejects_oversized_info_without_side_effects() -> anyhow::Result<()> {
+    const INFO_MAX_LEN: usize = 20_000;
+    let tmp = make_tmp_dir();
+    let in_dir = tmp.path().join("in");
+    let nodes_path = in_dir.join("demo.nodes.jsonl");
+    let original_line = r#"{"id":"n1","location":{"lon":10.0,"lat":53.5},"title":"A","info":"Old Info","updated_at":"2026-01-01T00:00:00Z"}"#;
+    write_lines(&nodes_path, &[original_line]);
+    let _env = set_gewebe_in_dir(&in_dir);
+
+    let mut account_map = AccountStore::new();
+    account_map.insert(AccountInternal {
+        public: AccountPublic {
+            id: "cccccccc-cccc-4ccc-8ccc-000000000001".to_string(),
+            kind: "garnrolle".to_string(),
+            title: "Weber".to_string(),
+            summary: None,
+            public_pos: None,
+            map_state: weltgewebe_api::routes::accounts::GarnrolleMapState::NotOnMap,
+            radius_m: 0,
+            disabled: false,
+            tags: vec![],
+        },
+        role: Role::Weber,
+        email: Some("cccccccc-cccc-4ccc-8ccc-000000000001@example.com".to_string()),
+        webauthn_user_id: uuid::Uuid::new_v4(),
+    });
+
+    let mut state = test_state().await?;
+    state.accounts = Arc::new(RwLock::new(account_map));
+    let session = create_session(&state, "cccccccc-cccc-4ccc-8ccc-000000000001", None).await;
+    let cookie = format!("gewebe_session={}", session.id);
+    let app = Router::new()
+        .merge(api_router())
+        .layer(from_fn_with_state(state.clone(), auth_middleware))
+        .layer(axum::middleware::from_fn(require_csrf))
+        .with_state(state.clone());
+
+    let current = app
+        .clone()
+        .oneshot(Request::get("/nodes/n1").body(body::Body::empty())?)
+        .await?;
+    assert_eq!(current.status(), StatusCode::OK);
+    let current_body = body::to_bytes(current.into_body(), usize::MAX).await?;
+    let current_node: serde_json::Value = serde_json::from_slice(&current_body)?;
+    let etag = node_etag(&current_node);
+
+    let request_body = serde_json::json!({ "info": "a".repeat(INFO_MAX_LEN + 1) }).to_string();
+    let response = app
+        .oneshot(
+            Request::patch("/nodes/n1")
+                .header("Content-Type", "application/json")
+                .header("Cookie", cookie)
+                .header("Host", "localhost")
+                .header("Origin", "http://localhost")
+                .header("If-Match", etag)
+                .body(body::Body::from(request_body))?,
+        )
+        .await?;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let response_body = body::to_bytes(response.into_body(), usize::MAX).await?;
+    assert_eq!(
+        String::from_utf8(response_body.to_vec())?,
+        "invalid node patch request: info exceeds the maximum length of 20000"
+    );
+
+    assert_eq!(fs::read_to_string(&nodes_path)?, original_line);
+    let cached_info = state
+        .nodes
+        .read()
+        .await
+        .get("n1")
+        .and_then(|node| node.info.clone());
+    assert_eq!(cached_info.as_deref(), Some("Old Info"));
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
 async fn postgres_read_source_blocks_node_patch_without_persisting() -> anyhow::Result<()> {
     let tmp = make_tmp_dir();
     let in_dir = tmp.path().join("in");

--- a/apps/api/tests/db_domain_node_write_path.rs
+++ b/apps/api/tests/db_domain_node_write_path.rs
@@ -423,6 +423,57 @@ async fn postgres_node_patch_persists_and_reload_sees_change() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+#[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
+#[serial]
+async fn postgres_node_patch_rejects_oversized_info_without_side_effects() -> Result<()> {
+    const INFO_MAX_LEN: usize = 20_000;
+    let pool = connect_pool().await;
+    run_migrations(&pool).await;
+    clean(&pool).await;
+    seed_node(&pool, NODE_A, Some("initial"), None).await;
+
+    let tmp = tempfile::tempdir()?;
+    let in_dir = tmp.path().join("in");
+    std::fs::create_dir_all(&in_dir)?;
+    let _env = set_gewebe_in_dir(&in_dir);
+
+    let (app, cookie, state) =
+        postgres_write_app(pool.clone(), "10000000-0000-0000-0000-000000000099").await?;
+    let request_body = serde_json::json!({ "info": "a".repeat(INFO_MAX_LEN + 1) }).to_string();
+    let response = app
+        .oneshot(patch_node_req(
+            &cookie,
+            NODE_A,
+            &request_body,
+            SEEDED_NODE_ETAG,
+        ))
+        .await?;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let response_body = body::to_bytes(response.into_body(), usize::MAX).await?;
+    assert_eq!(
+        String::from_utf8(response_body.to_vec())?,
+        "invalid node patch request: info exceeds the maximum length of 20000"
+    );
+
+    let persisted_info: Option<String> =
+        sqlx::query_scalar("SELECT payload->>'info' FROM domain_nodes WHERE id = $1")
+            .bind(NODE_A)
+            .fetch_one(&pool)
+            .await?;
+    assert_eq!(persisted_info.as_deref(), Some("initial"));
+    let cached_info = state
+        .nodes
+        .read()
+        .await
+        .get(NODE_A)
+        .and_then(|node| node.info.clone());
+    assert_eq!(cached_info.as_deref(), Some("initial"));
+
+    clean(&pool).await;
+    Ok(())
+}
+
 /// B. No JSONL side-effect in PostgreSQL mode.
 #[tokio::test]
 #[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]


### PR DESCRIPTION
## Problem

`POST /nodes` enforces the schema-bound 20,000-character limit for `info`, while `PATCH /nodes/{id}` previously accepted larger values and could persist them through JSONL or PostgreSQL.

## Change

- share the canonical `NODE_INFO_MAX_LEN` across create and patch validation
- reject oversized patch values before selecting or mutating either persistence backend
- preserve absent and explicit-null patch semantics
- prove JSONL file/cache and PostgreSQL row/cache remain unchanged after rejection

## Validation

- `cargo test -p weltgewebe-api --lib node_patch_validation_tests`
- `cargo test -p weltgewebe-api --test api_nodes` — 22/22 passed
- PostgreSQL regression target compiled with `--no-run`
- `cargo clippy -p weltgewebe-api --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Revision binding

- base: `c16953c6f0a23299da37804d1650601ffb675012`
- head: `ff3f4ddef9a9f96f928af3b4ecf3c8b28583de47`
- diff SHA-256: `1f91abd26337f5f38caa4d4c5b7fbf845f8d94afa7039b55f935acde0aebfefb`
- Bureau evidence: `candidate-dcd423a307ba3ebea875674d`

<!-- weltgewebe-risk: R3 -->