### PR TITLE
fix(api): persist step-up email updates in JSONL

### DIFF
--- a/apps/api/src/routes/accounts.rs
+++ b/apps/api/src/routes/accounts.rs
@@ -737,7 +737,13 @@ fn profile_response(
     }
 }
 
-async fn latest_jsonl_account_record(account_id: &str) -> std::io::Result<Option<Value>> {
+/// Return the latest append-only JSONL record for one account.
+///
+/// Shared with the step-up email update path so every successful JSONL-mode
+/// account mutation is durable before the in-memory cache is changed.
+pub(crate) async fn latest_jsonl_account_record(
+    account_id: &str,
+) -> std::io::Result<Option<Value>> {
     let file = match File::open(accounts_path()).await {
         Ok(file) => file,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),

--- a/apps/api/src/routes/accounts.rs
+++ b/apps/api/src/routes/accounts.rs
@@ -501,21 +501,7 @@ pub async fn load_all_accounts() -> std::io::Result<AccountStore> {
     let mut line_number = 0usize;
     while let Some(line) = lines.next_line().await? {
         line_number += 1;
-        let value: Value = serde_json::from_str(&line).map_err(|error| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("invalid JSONL account record at {path:?} line {line_number}: {error}"),
-            )
-        })?;
-
-        let public = map_json_to_public_account(&value).ok_or_else(|| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!(
-                    "account record at {path:?} line {line_number} violates the canonical Garnrolle contract"
-                ),
-            )
-        })?;
+        let (value, public) = parse_jsonl_account_record(&path, line_number, &line)?;
 
         let role = value
             .get("role")
@@ -737,25 +723,50 @@ fn profile_response(
     }
 }
 
+fn parse_jsonl_account_record(
+    path: &std::path::Path,
+    line_number: usize,
+    line: &str,
+) -> std::io::Result<(Value, AccountPublic)> {
+    let value: Value = serde_json::from_str(line).map_err(|error| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("invalid JSONL account record at {path:?} line {line_number}: {error}"),
+        )
+    })?;
+    let public = map_json_to_public_account(&value).ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "account record at {path:?} line {line_number} violates the canonical Garnrolle contract"
+            ),
+        )
+    })?;
+    Ok((value, public))
+}
+
 /// Return the latest append-only JSONL record for one account.
 ///
 /// Shared with the step-up email update path so every successful JSONL-mode
-/// account mutation is durable before the in-memory cache is changed.
+/// account mutation is durable before the in-memory cache is changed. The
+/// complete source is validated with the same strict contract as startup before
+/// a caller may append another record.
 pub(crate) async fn latest_jsonl_account_record(
     account_id: &str,
 ) -> std::io::Result<Option<Value>> {
-    let file = match File::open(accounts_path()).await {
+    let path = accounts_path();
+    let file = match File::open(&path).await {
         Ok(file) => file,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => return Err(error),
     };
     let mut lines = BufReader::new(file).lines();
+    let mut line_number = 0usize;
     let mut latest = None;
     while let Some(line) = lines.next_line().await? {
-        let Ok(value) = serde_json::from_str::<Value>(&line) else {
-            continue;
-        };
-        if value.get("id").and_then(Value::as_str) == Some(account_id) {
+        line_number += 1;
+        let (value, public) = parse_jsonl_account_record(&path, line_number, &line)?;
+        if public.id == account_id {
             latest = Some(value);
         }
     }

--- a/apps/api/src/routes/auth.rs
+++ b/apps/api/src/routes/auth.rs
@@ -38,7 +38,10 @@ use crate::{
         update_account_email_in_postgres, AccountEmailUpdateError, AccountWriteError,
     },
     middleware::auth::AuthContext,
-    routes::accounts::{append_account_line, map_json_to_public_account, AccountInternal},
+    routes::accounts::{
+        append_account_line, latest_jsonl_account_record, map_json_to_public_account,
+        AccountInternal,
+    },
     state::ApiState,
 };
 use webauthn_rs::prelude::{PublicKeyCredential, RegisterPublicKeyCredential};
@@ -2178,40 +2181,92 @@ pub async fn consume_step_up(
                 return (StatusCode::NO_CONTENT, jar).into_response();
             }
 
-            let mut accounts = state.accounts.write().await;
-            // JSONL-mode behaviour remains cache-local, but conflict checking and
-            // mutation stay under the same write lock so concurrent in-memory
-            // email updates cannot bypass the duplicate guard.
-            if let Some(existing) = accounts.get_by_email(&new_email) {
-                if existing.public.id != account_id {
-                    tracing::warn!(
-                        event = "auth.step_up.consume.update_email.conflict",
+            let _persist_guard = state.accounts_persist.lock().await;
+            // The persistence guard serializes every JSONL account write. Keep the
+            // cache lock out of filesystem awaits while preserving an atomic
+            // conflict-check/read snapshot for this mutation.
+            let mut account = {
+                let accounts = state.accounts.read().await;
+                if let Some(existing) = accounts.get_by_email(&new_email) {
+                    if existing.public.id != account_id {
+                        tracing::warn!(
+                            event = "auth.step_up.consume.update_email.conflict",
+                            request_id = %request_id,
+                            account_id = %account_id,
+                            "Email was taken by another account before step-up was consumed"
+                        );
+                        let err = serde_json::json!({
+                            "error": "CONFLICT",
+                            "message": "Email already in use"
+                        });
+                        return (StatusCode::CONFLICT, jar, Json(err)).into_response();
+                    }
+                }
+
+                let Some(account) = accounts.get(&account_id).cloned() else {
+                    tracing::error!(
+                        event = "auth.step_up.consume.update_email.missing_account",
                         request_id = %request_id,
                         account_id = %account_id,
-                        "Email was taken by another account before step-up was consumed"
+                        "Account missing during email update step-up consume"
                     );
-                    let err = serde_json::json!({
-                        "error": "CONFLICT",
-                        "message": "Email already in use"
-                    });
-                    return (StatusCode::CONFLICT, jar, Json(err)).into_response();
-                }
-            }
+                    let err = serde_json::json!({"error": "ACCOUNT_INVALID"});
+                    return (StatusCode::BAD_REQUEST, jar, Json(err)).into_response();
+                };
+                account
+            };
 
-            if let Some(mut account) = accounts.get(&account_id).cloned() {
-                account.email = Some(new_email);
-                accounts.insert(account);
-                (StatusCode::NO_CONTENT, jar).into_response()
-            } else {
+            let mut record = match latest_jsonl_account_record(&account_id).await {
+                Ok(Some(record)) => record,
+                Ok(None) => {
+                    tracing::error!(
+                        event = "auth.step_up.consume.update_email.jsonl_missing_record",
+                        request_id = %request_id,
+                        account_id = %account_id,
+                        "Account cache entry has no durable JSONL record"
+                    );
+                    let err = serde_json::json!({"error": "INTERNAL_SERVER_ERROR"});
+                    return (StatusCode::INTERNAL_SERVER_ERROR, jar, Json(err)).into_response();
+                }
+                Err(error) => {
+                    tracing::error!(
+                        event = "auth.step_up.consume.update_email.jsonl_read_failed",
+                        request_id = %request_id,
+                        account_id = %account_id,
+                        error = %error,
+                        "Failed to read durable JSONL account before email update"
+                    );
+                    let err = serde_json::json!({"error": "INTERNAL_SERVER_ERROR"});
+                    return (StatusCode::INTERNAL_SERVER_ERROR, jar, Json(err)).into_response();
+                }
+            };
+            let Some(record_object) = record.as_object_mut() else {
                 tracing::error!(
-                    event = "auth.step_up.consume.update_email.missing_account",
+                    event = "auth.step_up.consume.update_email.jsonl_invalid_record",
                     request_id = %request_id,
                     account_id = %account_id,
-                    "Account missing during email update step-up consume"
+                    "Latest durable JSONL account record is not an object"
                 );
-                let err = serde_json::json!({"error": "ACCOUNT_INVALID"});
-                (StatusCode::BAD_REQUEST, jar, Json(err)).into_response()
+                let err = serde_json::json!({"error": "INTERNAL_SERVER_ERROR"});
+                return (StatusCode::INTERNAL_SERVER_ERROR, jar, Json(err)).into_response();
+            };
+            record_object.insert("email".to_string(), json!(new_email));
+            if let Err(error) = append_account_line(&record).await {
+                tracing::error!(
+                    event = "auth.step_up.consume.update_email.jsonl_persist_failed",
+                    request_id = %request_id,
+                    account_id = %account_id,
+                    error = %error,
+                    "Failed to persist step-up email update to JSONL"
+                );
+                let err = serde_json::json!({"error": "INTERNAL_SERVER_ERROR"});
+                return (StatusCode::INTERNAL_SERVER_ERROR, jar, Json(err)).into_response();
             }
+
+            account.email = Some(new_email);
+            let mut accounts = state.accounts.write().await;
+            accounts.insert(account);
+            (StatusCode::NO_CONTENT, jar).into_response()
         }
         ChallengeIntent::BeginPasskeyRegistration => {
             let grant_id = match state

--- a/apps/api/tests/api_auth.rs
+++ b/apps/api/tests/api_auth.rs
@@ -4204,6 +4204,101 @@ async fn test_update_email_consume_session_rotation() -> Result<()> {
 
 #[tokio::test]
 #[serial]
+async fn test_update_email_jsonl_invalid_source_leaves_cache_unchanged() -> Result<()> {
+    for corrupt_tail in ["{not-json", r#"{"id":"u1"}"#] {
+        let tmp = tempfile::tempdir()?;
+        let _env = weltgewebe_api::test_helpers::EnvGuard::set(
+            "GEWEBE_IN_DIR",
+            tmp.path().to_str().expect("tempdir path is valid utf-8"),
+        );
+        let initial_record = serde_json::json!({
+            "id": "u1",
+            "type": "garnrolle",
+            "title": "User One",
+            "summary": "Summary 1",
+            "map_state": "not_on_map",
+            "radius_m": 0,
+            "disabled": false,
+            "tags": [],
+            "role": "gast",
+            "email": "u1@example.com",
+            "webauthn_user_id": uuid::Uuid::new_v4().to_string(),
+        });
+        tokio::fs::write(
+            tmp.path().join("demo.accounts.jsonl"),
+            format!(
+                "{}\n{}\n",
+                serde_json::to_string(&initial_record)?,
+                corrupt_tail
+            ),
+        )
+        .await?;
+
+        let mut state = test_state_with_accounts()?;
+        state.config.auth_public_login = true;
+
+        let session = create_session(&state, "u1", Some("dev1")).await;
+        let cookie = format!("{}={}", SESSION_COOKIE_NAME, session.id);
+
+        use weltgewebe_api::auth::challenges::ChallengeIntent;
+        let challenge = state.challenges.create(
+            session.account_id.clone(),
+            session.device_id.clone(),
+            ChallengeIntent::UpdateEmail {
+                new_email: "must-not-stick@example.com".to_string(),
+            },
+        );
+        let token = state.step_up_tokens.create(
+            challenge.id.clone(),
+            session.account_id.clone(),
+            session.device_id.clone(),
+        );
+
+        let app = Router::new()
+            .merge(weltgewebe_api::routes::api_router())
+            .route_layer(axum::middleware::from_fn_with_state(
+                state.clone(),
+                weltgewebe_api::middleware::auth::auth_middleware,
+            ))
+            .with_state(state.clone());
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/auth/step-up/magic-link/consume")
+            .header("Cookie", cookie)
+            .header("Content-Type", "application/json")
+            .header("Origin", "http://localhost")
+            .header("X-Forwarded-For", "127.0.0.1")
+            .body(body::Body::from(
+                serde_json::json!({
+                    "token": token,
+                    "challenge_id": challenge.id
+                })
+                .to_string(),
+            ))?;
+
+        let res = app.oneshot(req).await?;
+        assert_eq!(
+            res.status(),
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "invalid JSONL tail must fail closed: {corrupt_tail}"
+        );
+
+        let accounts = state.accounts.read().await;
+        assert_eq!(
+            accounts
+                .get("u1")
+                .and_then(|account| account.email.as_deref()),
+            Some("u1@example.com"),
+            "an invalid JSONL source must not leave a cache-only email update"
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
 async fn test_update_email_jsonl_read_failure_leaves_cache_unchanged() -> Result<()> {
     let tmp = tempfile::tempdir()?;
     let invalid_in_dir = tmp.path().join("not-a-directory");

--- a/apps/api/tests/api_auth.rs
+++ b/apps/api/tests/api_auth.rs
@@ -3664,6 +3664,30 @@ async fn test_update_email_no_op_returns_204() -> Result<()> {
 #[tokio::test]
 #[serial]
 async fn test_update_email_full_e2e_flow() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let _env = weltgewebe_api::test_helpers::EnvGuard::set(
+        "GEWEBE_IN_DIR",
+        tmp.path().to_str().expect("tempdir path is valid utf-8"),
+    );
+    let initial_record = serde_json::json!({
+        "id": "u1",
+        "type": "garnrolle",
+        "title": "User One",
+        "summary": "Summary 1",
+        "map_state": "not_on_map",
+        "radius_m": 0,
+        "disabled": false,
+        "tags": [],
+        "role": "gast",
+        "email": "u1@example.com",
+        "webauthn_user_id": uuid::Uuid::new_v4().to_string(),
+    });
+    tokio::fs::write(
+        tmp.path().join("demo.accounts.jsonl"),
+        format!("{}\n", serde_json::to_string(&initial_record)?),
+    )
+    .await?;
+
     let mut state = test_state_with_accounts()?;
     state.config.auth_public_login = true;
     state.config.app_base_url = Some("http://localhost".to_string());
@@ -3771,10 +3795,19 @@ async fn test_update_email_full_e2e_flow() -> Result<()> {
     let res3 = app.oneshot(req3).await?;
     assert_eq!(res3.status(), StatusCode::NO_CONTENT);
 
-    // 5. Assert the database email has changed
-    let accounts = state.accounts.read().await;
-    let acc = accounts.get("u1").unwrap();
-    assert_eq!(acc.email, Some("e2e@example.com".to_string()));
+    // 5. Assert both the live cache and a fresh JSONL reload see the new email.
+    {
+        let accounts = state.accounts.read().await;
+        let acc = accounts.get("u1").unwrap();
+        assert_eq!(acc.email.as_deref(), Some("e2e@example.com"));
+    }
+    let reloaded = weltgewebe_api::routes::accounts::load_all_accounts().await?;
+    assert_eq!(
+        reloaded
+            .get("u1")
+            .and_then(|account| account.email.as_deref()),
+        Some("e2e@example.com")
+    );
 
     // Ensure challenge is consumed and gone
     assert!(state.challenges.get(&challenge_id).is_none());
@@ -4072,6 +4105,30 @@ async fn test_update_email_consume_wrong_session() -> Result<()> {
 #[tokio::test]
 #[serial]
 async fn test_update_email_consume_session_rotation() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let _env = weltgewebe_api::test_helpers::EnvGuard::set(
+        "GEWEBE_IN_DIR",
+        tmp.path().to_str().expect("tempdir path is valid utf-8"),
+    );
+    let initial_record = serde_json::json!({
+        "id": "u1",
+        "type": "garnrolle",
+        "title": "User One",
+        "summary": "Summary 1",
+        "map_state": "not_on_map",
+        "radius_m": 0,
+        "disabled": false,
+        "tags": [],
+        "role": "gast",
+        "email": "u1@example.com",
+        "webauthn_user_id": uuid::Uuid::new_v4().to_string(),
+    });
+    tokio::fs::write(
+        tmp.path().join("demo.accounts.jsonl"),
+        format!("{}\n", serde_json::to_string(&initial_record)?),
+    )
+    .await?;
+
     let mut state = test_state_with_accounts()?;
     state.config.auth_public_login = true;
 
@@ -4128,10 +4185,90 @@ async fn test_update_email_consume_session_rotation() -> Result<()> {
     // The binding matches because account_id and device_id match, despite the different session_id
     assert_eq!(res.status(), StatusCode::NO_CONTENT);
 
-    // Ensure the email was updated
+    // Ensure both the cache and a fresh JSONL reload observe the rotated email.
+    {
+        let accounts = state.accounts.read().await;
+        let acc = accounts.get("u1").unwrap();
+        assert_eq!(acc.email.as_deref(), Some("rotated@example.com"));
+    }
+    let reloaded = weltgewebe_api::routes::accounts::load_all_accounts().await?;
+    assert_eq!(
+        reloaded
+            .get("u1")
+            .and_then(|account| account.email.as_deref()),
+        Some("rotated@example.com")
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn test_update_email_jsonl_read_failure_leaves_cache_unchanged() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let invalid_in_dir = tmp.path().join("not-a-directory");
+    tokio::fs::write(&invalid_in_dir, b"not a directory").await?;
+    let _env = weltgewebe_api::test_helpers::EnvGuard::set(
+        "GEWEBE_IN_DIR",
+        invalid_in_dir
+            .to_str()
+            .expect("temporary path is valid utf-8"),
+    );
+
+    let mut state = test_state_with_accounts()?;
+    state.config.auth_public_login = true;
+
+    let session = create_session(&state, "u1", Some("dev1")).await;
+    let cookie = format!("{}={}", SESSION_COOKIE_NAME, session.id);
+
+    use weltgewebe_api::auth::challenges::ChallengeIntent;
+    let challenge = state.challenges.create(
+        session.account_id.clone(),
+        session.device_id.clone(),
+        ChallengeIntent::UpdateEmail {
+            new_email: "must-not-stick@example.com".to_string(),
+        },
+    );
+    let token = state.step_up_tokens.create(
+        challenge.id.clone(),
+        session.account_id.clone(),
+        session.device_id.clone(),
+    );
+
+    let app = Router::new()
+        .merge(weltgewebe_api::routes::api_router())
+        .route_layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            weltgewebe_api::middleware::auth::auth_middleware,
+        ))
+        .with_state(state.clone());
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/auth/step-up/magic-link/consume")
+        .header("Cookie", cookie)
+        .header("Content-Type", "application/json")
+        .header("Origin", "http://localhost")
+        .header("X-Forwarded-For", "127.0.0.1")
+        .body(body::Body::from(
+            serde_json::json!({
+                "token": token,
+                "challenge_id": challenge.id
+            })
+            .to_string(),
+        ))?;
+
+    let res = app.oneshot(req).await?;
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
     let accounts = state.accounts.read().await;
-    let acc = accounts.get("u1").unwrap();
-    assert_eq!(acc.email, Some("rotated@example.com".to_string()));
+    assert_eq!(
+        accounts
+            .get("u1")
+            .and_then(|account| account.email.as_deref()),
+        Some("u1@example.com"),
+        "a failed durable JSONL read must not leave a cache-only email update"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
<!-- weltgewebe-risk: R3 -->

## Problem

In JSONL account-write mode, successful step-up email changes only updated the in-memory account cache. A restart reloaded the previous email from `demo.accounts.jsonl`, despite the API having returned 204.

## Change

- serialize JSONL account mutations with the existing account persistence guard
- validate the full JSONL source with the same strict parser and account projection used at startup
- load the latest append-only account record, update its normalized email and fsync a new record before changing the cache
- fail closed when the durable source is missing, malformed, non-canonical or unreadable
- prove normal and rotated-session flows survive a fresh JSONL reload
- prove durable-source failures leave both file and cache unchanged

## Verification

- `cargo test -p weltgewebe-api --test api_auth`: 109 passed
- `cargo test -p weltgewebe-api --lib`: 442 passed, 1 ignored
- `cargo clippy -p weltgewebe-api --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Revision binding

- Base: `277a4cf4b51f05bad8e921ebf7134b13f8e142f8`
- Head: `3c08293764d6112ea878a97126d99cfeb91d89f2`
- Canonical binary diff SHA-256: `73d2c7f6c55717f7f114832866c4f05c9b8e119d83ca967101160697d4c10a2c`
- Canonical GitHub diff SHA-256 used by the review gate: `f617e44390ae7f49ec7484ee52bbb22cbac9a3623063716e738d695a2fd74653`

The independent Codex review on the exact head found no major issues after the prior data-integrity finding was fixed. Two exact R3 review reports are attached below. Merge remains gated by the repository review-evidence contract and an authoritative final readback.