### PR TITLE
fix(ops): bound runtime evidence claims

### DIFF
--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -274,20 +274,23 @@ python3 scripts/ops/collect_production_runtime_evidence.py \
   --output /var/lib/weltgewebe/evidence/production-runtime.json
 ```
 
-Ein optionales `--offhost-backup-manifest` muss auf ein kopiertes Manifest
-zeigen, dessen Dump im selben Verzeichnis liegt. Nur wenn dieses Abbild
-hashgleich zum ausgewählten Produktionsbackup ist, erhält der Gesamtbeleg
-`status=pass`. Ohne Off-host-Beleg lautet der Zustand `partial` und der Prozess
-endet mit Code `2`; ein gebrochener Pflichtbeweis liefert `fail` und Code `1`.
-Damit kann ein lokaler Backup-/Restore-Beleg nicht versehentlich als
-Off-host-Recovery ausgegeben werden.
+Ein optionales `--secondary-copy-manifest` muss auf ein kopiertes Manifest
+zeigen, dessen Dump im selben Verzeichnis liegt. Ein hashgleiches Abbild wird
+nur als `secondary_copy` ausgewiesen. Es beweist weder einen anderen Host noch
+eine getrennte Ausfallzone und hebt den Gesamtbeleg deshalb nicht über
+`status=partial`. Ein gebrochener Pflichtbeweis oder eine widersprüchliche
+Zweitkopie liefert `fail` und Code `1`; `partial` endet mit Code `2`.
+`evidence_boundary.does_not_prove` nennt die fehlende Off-host- und
+Disaster-Recovery-Grenze unabhängig davon, ob eine lokale Zweitkopie vorliegt.
 
-Die JSON-Ausgabe besitzt Schema-Version, UTC-Prüfzeitpunkt, explizite
-Read-only-/Redaktionsmarker und eine `evidence_boundary` mit bewiesenen und nicht
-bewiesenen Aussagen. Bei `--output` wird sie atomar mit Dateimodus `0600`
-geschrieben; diese ausdrücklich gewählte Berichtdatei ist die einzige Mutation
-des Sammlers. Der Bericht beweist den beobachteten Zeitpunkt, nicht zukünftige
-Verfügbarkeit oder die fachliche Richtigkeit jeder Datenbankzeile.
+Die JSON-Ausgabe verwendet für diesen korrigierten Vertrag Schema-Version 2,
+enthält UTC-Prüfzeitpunkt, explizite Read-only-/Redaktionsmarker und eine
+`evidence_boundary` mit bewiesenen und nicht bewiesenen Aussagen. Bei
+`--output` muss das Elternverzeichnis bereits existieren und darf kein Symlink
+sein. Nur die Berichtdatei selbst wird atomar mit Dateimodus `0600` geschrieben;
+der Sammler erzeugt keine Verzeichnisse. Der Bericht beweist den beobachteten
+Zeitpunkt, nicht zukünftige Verfügbarkeit oder die fachliche Richtigkeit jeder
+Datenbankzeile.
 
 
 ---

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -283,6 +283,14 @@ Zweitkopie liefert `fail` und Code `1`; `partial` endet mit Code `2`.
 `evidence_boundary.does_not_prove` nennt die fehlende Off-host- und
 Disaster-Recovery-Grenze unabhängig davon, ob eine lokale Zweitkopie vorliegt.
 
+Zur Migration bleibt `--offhost-backup-manifest` vorübergehend als veralteter,
+in der CLI-Hilfe verborgener Alias für `--secondary-copy-manifest` erhalten;
+beide Namen gleichzeitig sind unzulässig. Der Alias ändert keine Aussage:
+Auch damit ist die Zweitkopie nur lokal/hashgleich und niemals ein Off-host-
+oder Vollpass-Beleg. Nachgelagerte Aufrufer müssen Code `2` ausdrücklich als
+intentionale gesunde Obergrenze behandeln und dürfen ihn nicht in einen Fehler
+oder einen Vollpass umdeuten.
+
 Die JSON-Ausgabe verwendet für diesen korrigierten Vertrag Schema-Version 2,
 enthält UTC-Prüfzeitpunkt, explizite Read-only-/Redaktionsmarker und eine
 `evidence_boundary` mit bewiesenen und nicht bewiesenen Aussagen. Bei

--- a/scripts/ci/tests/test_production_runtime_evidence.py
+++ b/scripts/ci/tests/test_production_runtime_evidence.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
 import argparse
+import errno
 import hashlib
+import io
 import json
 import os
 import stat
 import tempfile
 import unittest
+from contextlib import redirect_stderr, redirect_stdout
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from unittest import mock
 
 from scripts.ops import collect_production_runtime_evidence as evidence
 from scripts.ops.check_public_live_readiness import FetchResult
@@ -390,6 +394,81 @@ class ProductionRuntimeEvidenceTest(unittest.TestCase):
             self.assertEqual(actual.read_text(encoding="utf-8"), "unchanged\n")
             self.assertTrue(target.is_symlink())
 
+    def test_atomic_json_output_wraps_temporary_file_permission_error(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            target = Path(temp) / "evidence.json"
+            real_open = os.open
+
+            def fail_temporary_open(path, flags, mode=0o777, *, dir_fd=None):
+                if dir_fd is not None:
+                    raise PermissionError(errno.EACCES, "permission denied")
+                return real_open(path, flags, mode)
+
+            with mock.patch.object(evidence.os, "open", side_effect=fail_temporary_open):
+                with self.assertRaisesRegex(
+                    evidence.EvidenceError,
+                    "could not atomically write output",
+                ) as caught:
+                    evidence.write_json_atomic(target, {"status": "partial"})
+
+            self.assertIsInstance(caught.exception.__cause__, PermissionError)
+            self.assertFalse(target.exists())
+            self.assertEqual(list(target.parent.glob(f".{target.name}.*")), [])
+
+    def test_atomic_json_output_replace_enospc_is_bounded_at_cli(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            target = Path(temp) / "evidence.json"
+            passing = {"status": "pass"}
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+
+            with (
+                mock.patch.object(evidence, "collect_public_evidence", return_value=passing),
+                mock.patch.object(evidence, "collect_runtime_modes", return_value=passing),
+                mock.patch.object(evidence, "collect_backup_evidence", return_value=passing),
+                mock.patch.object(evidence, "collect_restore_evidence", return_value=passing),
+                mock.patch.object(
+                    evidence,
+                    "collect_secondary_copy_evidence",
+                    return_value={"status": "not-provided"},
+                ),
+                mock.patch.object(
+                    evidence.os,
+                    "replace",
+                    side_effect=OSError(errno.ENOSPC, "no space left on device"),
+                ),
+                redirect_stdout(stdout),
+                redirect_stderr(stderr),
+            ):
+                result = evidence.main(
+                    [
+                        "--backup-manifest",
+                        "unused-backup.manifest",
+                        "--restore-proof",
+                        "unused-restore.proof",
+                        "--output",
+                        str(target),
+                    ]
+                )
+
+            self.assertEqual(result, 1)
+            self.assertEqual(stdout.getvalue(), "")
+            self.assertEqual(
+                stderr.getvalue(),
+                f"runtime evidence output failed: could not atomically write output: {target}\n",
+            )
+            self.assertNotIn("Traceback", stderr.getvalue())
+            self.assertNotIn('"status": "partial"', stderr.getvalue())
+            self.assertFalse(target.exists())
+            self.assertEqual(list(target.parent.glob(f".{target.name}.*")), [])
+
+    def test_atomic_json_output_keeps_programmer_errors_visible(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            target = Path(temp) / "evidence.json"
+            with self.assertRaises(TypeError):
+                evidence.write_json_atomic(target, {"not-json-serializable": object()})
+            self.assertFalse(target.exists())
+            self.assertEqual(list(target.parent.glob(f".{target.name}.*")), [])
 
     def test_deploy_docs_preserve_redaction_and_partial_status_contract(self) -> None:
         repo = Path(__file__).resolve().parents[3]

--- a/scripts/ci/tests/test_production_runtime_evidence.py
+++ b/scripts/ci/tests/test_production_runtime_evidence.py
@@ -309,6 +309,89 @@ class ProductionRuntimeEvidenceTest(unittest.TestCase):
         self.assertEqual(result["status"], "not-provided")
         self.assertFalse(result["required_for_overall_pass"])
 
+    def test_legacy_offhost_option_is_hidden_alias_for_secondary_copy(self) -> None:
+        parser = evidence.build_parser()
+        args = parser.parse_args(
+            [
+                "--backup-manifest",
+                "backup.manifest",
+                "--restore-proof",
+                "restore.proof",
+                "--offhost-backup-manifest",
+                "secondary.manifest",
+            ]
+        )
+
+        self.assertEqual(args.secondary_copy_manifest, Path("secondary.manifest"))
+        self.assertNotIn("--offhost-backup-manifest", parser.format_help())
+
+    def test_secondary_copy_option_and_legacy_alias_are_mutually_exclusive(self) -> None:
+        stderr = io.StringIO()
+        with redirect_stderr(stderr), self.assertRaises(SystemExit) as caught:
+            evidence.build_parser().parse_args(
+                [
+                    "--backup-manifest",
+                    "backup.manifest",
+                    "--restore-proof",
+                    "restore.proof",
+                    "--secondary-copy-manifest",
+                    "secondary.manifest",
+                    "--offhost-backup-manifest",
+                    "legacy.manifest",
+                ]
+            )
+
+        self.assertEqual(caught.exception.code, 2)
+        self.assertIn("--offhost-backup-manifest", stderr.getvalue())
+        self.assertIn("--secondary-copy-manifest", stderr.getvalue())
+
+    def test_legacy_alias_cli_writes_partial_schema_v2_and_exits_two(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            production = root / "production"
+            secondary = root / "secondary"
+            production.mkdir()
+            secondary.mkdir()
+            manifest, backup_file, digest = self.make_backup_fixture(production)
+            proof = self.make_restore_fixture(production, backup_file, digest)
+            secondary_backup = secondary / backup_file.name
+            secondary_backup.write_bytes(backup_file.read_bytes())
+            secondary_manifest = secondary / manifest.name
+            secondary_manifest.write_bytes(manifest.read_bytes())
+            output = root / "runtime-evidence.json"
+            passing = {"status": "pass"}
+
+            with (
+                mock.patch.object(evidence, "utc_now", return_value=NOW),
+                mock.patch.object(evidence, "collect_public_evidence", return_value=passing),
+                mock.patch.object(evidence, "collect_runtime_modes", return_value=passing),
+            ):
+                result = evidence.main(
+                    [
+                        "--backup-manifest",
+                        str(manifest),
+                        "--restore-proof",
+                        str(proof),
+                        "--offhost-backup-manifest",
+                        str(secondary_manifest),
+                        "--output",
+                        str(output),
+                    ]
+                )
+
+            payload = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(result, 2)
+            self.assertEqual(payload["schema_version"], 2)
+            self.assertEqual(payload["status"], "partial")
+            self.assertEqual(payload["secondary_copy"]["status"], "pass")
+            self.assertEqual(payload["secondary_copy"]["kind"], "secondary_copy")
+            self.assertFalse(payload["secondary_copy"]["proves_offhost_boundary"])
+            self.assertNotIn("offhost_backup", payload)
+            self.assertIn(
+                "off-host storage or recovery boundary",
+                payload["evidence_boundary"]["does_not_prove"],
+            )
+
     def test_evidence_envelope_states_scope_and_secondary_copy_boundary(self) -> None:
         passing = {"status": "pass"}
         payload = evidence.build_evidence(
@@ -478,6 +561,8 @@ class ProductionRuntimeEvidenceTest(unittest.TestCase):
             "vollständige Containerumgebung wird weder",
             "`status=partial`",
             "`secondary_copy`",
+            "`--offhost-backup-manifest`",
+            "gesunde Obergrenze",
             "Schema-Version 2",
             "Elternverzeichnis bereits existieren",
             "Code `2`",

--- a/scripts/ci/tests/test_production_runtime_evidence.py
+++ b/scripts/ci/tests/test_production_runtime_evidence.py
@@ -202,19 +202,19 @@ class ProductionRuntimeEvidenceTest(unittest.TestCase):
         )
         return proof
 
-    def test_backup_restore_and_offhost_evidence_bind_same_artifact(self) -> None:
+    def test_backup_restore_and_secondary_copy_bind_same_artifact(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             production = root / "production"
-            offhost = root / "offhost"
+            secondary = root / "secondary"
             production.mkdir()
-            offhost.mkdir()
+            secondary.mkdir()
             manifest, backup_file, digest = self.make_backup_fixture(production)
             proof = self.make_restore_fixture(production, backup_file, digest)
-            offhost_backup = offhost / backup_file.name
-            offhost_backup.write_bytes(backup_file.read_bytes())
-            offhost_manifest = offhost / manifest.name
-            offhost_manifest.write_bytes(manifest.read_bytes())
+            secondary_backup = secondary / backup_file.name
+            secondary_backup.write_bytes(backup_file.read_bytes())
+            secondary_manifest = secondary / manifest.name
+            secondary_manifest.write_bytes(manifest.read_bytes())
 
             backup = evidence.collect_backup_evidence(
                 manifest_path=manifest,
@@ -227,8 +227,8 @@ class ProductionRuntimeEvidenceTest(unittest.TestCase):
                 now=NOW,
                 max_age=timedelta(hours=192),
             )
-            copied = evidence.collect_offhost_evidence(
-                manifest_path=offhost_manifest,
+            copied = evidence.collect_secondary_copy_evidence(
+                manifest_path=secondary_manifest,
                 backup=backup,
             )
 
@@ -238,6 +238,8 @@ class ProductionRuntimeEvidenceTest(unittest.TestCase):
             self.assertTrue(restore["backup_matches_manifest"])
             self.assertEqual(copied["status"], "pass")
             self.assertTrue(copied["copied_file_hash_matches"])
+            self.assertEqual(copied["kind"], "secondary_copy")
+            self.assertFalse(copied["proves_offhost_boundary"])
 
     def test_stale_backup_is_reported_without_inflating_the_claim(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
@@ -298,19 +300,19 @@ class ProductionRuntimeEvidenceTest(unittest.TestCase):
             self.assertEqual(restore["status"], "fail")
             self.assertFalse(restore["not_before_backup"])
 
-    def test_offhost_is_explicitly_not_proven_when_omitted(self) -> None:
-        result = evidence.collect_offhost_evidence(manifest_path=None, backup={})
+    def test_secondary_copy_is_explicitly_not_proven_when_omitted(self) -> None:
+        result = evidence.collect_secondary_copy_evidence(manifest_path=None, backup={})
         self.assertEqual(result["status"], "not-provided")
         self.assertFalse(result["required_for_overall_pass"])
 
-    def test_evidence_envelope_states_scope_and_optional_offhost_boundary(self) -> None:
+    def test_evidence_envelope_states_scope_and_secondary_copy_boundary(self) -> None:
         passing = {"status": "pass"}
         payload = evidence.build_evidence(
             public=passing,
             runtime=passing,
             backup=passing,
             restore=passing,
-            offhost={"status": "not-provided", "required_for_overall_pass": False},
+            secondary_copy={"status": "not-provided", "required_for_overall_pass": False},
             generated_at=NOW,
         )
         self.assertEqual(payload["status"], "partial")
@@ -319,32 +321,74 @@ class ProductionRuntimeEvidenceTest(unittest.TestCase):
         self.assertTrue(payload["report_write_is_only_mutation"])
         self.assertTrue(payload["values_redacted"])
         self.assertIn(
-            "off-host recovery when no off-host manifest is supplied",
+            "off-host storage or recovery boundary",
             payload["evidence_boundary"]["does_not_prove"],
         )
 
 
-    def test_evidence_requires_verified_offhost_copy_for_full_pass(self) -> None:
+    def test_secondary_copy_never_claims_offhost_or_full_pass(self) -> None:
         passing = {"status": "pass"}
         payload = evidence.build_evidence(
             public=passing,
             runtime=passing,
             backup=passing,
             restore=passing,
-            offhost={"status": "pass", "required_for_overall_pass": True},
+            secondary_copy={
+                "status": "pass",
+                "kind": "secondary_copy",
+                "proves_offhost_boundary": False,
+            },
             generated_at=NOW,
         )
-        self.assertEqual(payload["status"], "pass")
+        self.assertEqual(payload["status"], "partial")
+        self.assertEqual(payload["schema_version"], 2)
+        self.assertNotIn("offhost_backup", payload)
+        self.assertIn("secondary_copy", payload)
+        self.assertIn(
+            "off-host storage or recovery boundary",
+            payload["evidence_boundary"]["does_not_prove"],
+        )
 
     def test_atomic_json_output_is_private_and_complete(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
-            target = Path(temp) / "nested" / "evidence.json"
-            payload = {"status": "pass", "schema_version": 1}
+            target = Path(temp) / "evidence.json"
+            payload = {"status": "partial", "schema_version": 2}
             evidence.write_json_atomic(target, payload)
             self.assertEqual(json.loads(target.read_text(encoding="utf-8")), payload)
             mode = stat.S_IMODE(os.stat(target).st_mode)
             self.assertEqual(mode, 0o600)
             self.assertEqual(list(target.parent.glob(f".{target.name}.*")), [])
+
+    def test_atomic_json_output_requires_existing_parent(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            missing_parent = Path(temp) / "missing"
+            target = missing_parent / "evidence.json"
+            with self.assertRaisesRegex(evidence.EvidenceError, "parent directory does not exist"):
+                evidence.write_json_atomic(target, {"status": "partial"})
+            self.assertFalse(missing_parent.exists())
+
+    def test_atomic_json_output_rejects_symlink_parent(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            actual = root / "actual"
+            actual.mkdir()
+            linked = root / "linked"
+            linked.symlink_to(actual, target_is_directory=True)
+            with self.assertRaisesRegex(evidence.EvidenceError, "non-symlink directory"):
+                evidence.write_json_atomic(linked / "evidence.json", {"status": "partial"})
+            self.assertEqual(list(actual.iterdir()), [])
+
+    def test_atomic_json_output_rejects_symlink_target(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            actual = root / "actual.json"
+            actual.write_text("unchanged\n", encoding="utf-8")
+            target = root / "evidence.json"
+            target.symlink_to(actual.name)
+            with self.assertRaisesRegex(evidence.EvidenceError, "regular non-symlink file"):
+                evidence.write_json_atomic(target, {"status": "partial"})
+            self.assertEqual(actual.read_text(encoding="utf-8"), "unchanged\n")
+            self.assertTrue(target.is_symlink())
 
 
     def test_deploy_docs_preserve_redaction_and_partial_status_contract(self) -> None:
@@ -353,8 +397,10 @@ class ProductionRuntimeEvidenceTest(unittest.TestCase):
         for phrase in (
             "collect_production_runtime_evidence.py",
             "vollständige Containerumgebung wird weder",
-            "status=pass",
-            "Zustand `partial`",
+            "`status=partial`",
+            "`secondary_copy`",
+            "Schema-Version 2",
+            "Elternverzeichnis bereits existieren",
             "Code `2`",
             "Dateimodus `0600`",
             "evidence_boundary",

--- a/scripts/ops/collect_production_runtime_evidence.py
+++ b/scripts/ops/collect_production_runtime_evidence.py
@@ -627,29 +627,32 @@ def write_json_atomic(path: Path, payload: Mapping[str, Any]) -> None:
     name = path.name
     if name in {"", ".", ".."}:
         raise EvidenceError("output target must have a regular filename")
-    directory_fd = open_output_directory(path)
-    temp_name = f".{name}.{uuid.uuid4().hex}.tmp"
-    temp_fd: int | None = None
     try:
-        validate_existing_output_target(directory_fd, name, path)
-        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
-        temp_fd = os.open(temp_name, flags, 0o600, dir_fd=directory_fd)
-        encoded = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
-        with os.fdopen(temp_fd, "wb") as handle:
-            temp_fd = None
-            handle.write(encoded)
-            handle.flush()
-            os.fsync(handle.fileno())
-        os.replace(temp_name, name, src_dir_fd=directory_fd, dst_dir_fd=directory_fd)
-        os.fsync(directory_fd)
-    finally:
-        if temp_fd is not None:
-            os.close(temp_fd)
+        directory_fd = open_output_directory(path)
+        temp_name = f".{name}.{uuid.uuid4().hex}.tmp"
+        temp_fd: int | None = None
         try:
-            os.unlink(temp_name, dir_fd=directory_fd)
-        except FileNotFoundError:
-            pass
-        os.close(directory_fd)
+            validate_existing_output_target(directory_fd, name, path)
+            flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+            temp_fd = os.open(temp_name, flags, 0o600, dir_fd=directory_fd)
+            encoded = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+            with os.fdopen(temp_fd, "wb") as handle:
+                temp_fd = None
+                handle.write(encoded)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temp_name, name, src_dir_fd=directory_fd, dst_dir_fd=directory_fd)
+            os.fsync(directory_fd)
+        finally:
+            if temp_fd is not None:
+                os.close(temp_fd)
+            try:
+                os.unlink(temp_name, dir_fd=directory_fd)
+            except FileNotFoundError:
+                pass
+            os.close(directory_fd)
+    except OSError as exc:
+        raise EvidenceError(f"could not atomically write output: {path}") from exc
 
 
 def positive_hours(value: str) -> float:

--- a/scripts/ops/collect_production_runtime_evidence.py
+++ b/scripts/ops/collect_production_runtime_evidence.py
@@ -684,7 +684,14 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--service", default="api")
     parser.add_argument("--backup-manifest", type=Path, required=True)
     parser.add_argument("--restore-proof", type=Path, required=True)
-    parser.add_argument("--secondary-copy-manifest", type=Path)
+    secondary_copy_group = parser.add_mutually_exclusive_group()
+    secondary_copy_group.add_argument("--secondary-copy-manifest", type=Path)
+    secondary_copy_group.add_argument(
+        "--offhost-backup-manifest",
+        dest="secondary_copy_manifest",
+        type=Path,
+        help=argparse.SUPPRESS,
+    )
     parser.add_argument("--backup-max-age-hours", type=positive_hours, default=26.0)
     parser.add_argument("--restore-max-age-hours", type=positive_hours, default=192.0)
     parser.add_argument("--output", type=Path)

--- a/scripts/ops/collect_production_runtime_evidence.py
+++ b/scripts/ops/collect_production_runtime_evidence.py
@@ -17,7 +17,8 @@ import os
 import re
 import stat
 import subprocess
-import tempfile
+import sys
+import uuid
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -29,7 +30,7 @@ try:
 except ModuleNotFoundError:  # direct execution from scripts/ops
     from check_public_live_readiness import FetchResult, fetch_url
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 EVIDENCE_KIND = "weltgewebe.production-runtime-evidence"
 EXPECTED_TABLES = (
     "domain_accounts",
@@ -487,7 +488,7 @@ def collect_restore_evidence(
     }
 
 
-def collect_offhost_evidence(
+def collect_secondary_copy_evidence(
     *,
     manifest_path: Path | None,
     backup: Mapping[str, Any],
@@ -495,45 +496,49 @@ def collect_offhost_evidence(
     if manifest_path is None:
         return {
             "status": "not-provided",
+            "kind": "secondary_copy",
             "required_for_overall_pass": False,
-            "detail": "no off-host manifest was supplied",
+            "proves_offhost_boundary": False,
+            "detail": "no secondary-copy manifest was supplied",
         }
     values = read_key_value_file(manifest_path, allowed_keys=BACKUP_MANIFEST_KEYS)
     if values.get("contract") != "weltgewebe-postgres-backup-v1":
-        raise EvidenceError("off-host manifest contract is not supported")
-    offhost_name = values.get("file", "")
-    offhost_sha_expected = values.get("sha256", "")
-    if not SAFE_BACKUP_FILE_RE.fullmatch(offhost_name) or Path(offhost_name).name != offhost_name:
-        raise EvidenceError("off-host manifest file must be a safe .sql.gz basename")
-    if not SHA256_RE.fullmatch(offhost_sha_expected):
-        raise EvidenceError("off-host manifest sha256 is invalid")
+        raise EvidenceError("secondary-copy manifest contract is not supported")
+    copy_name = values.get("file", "")
+    copy_sha_expected = values.get("sha256", "")
+    if not SAFE_BACKUP_FILE_RE.fullmatch(copy_name) or Path(copy_name).name != copy_name:
+        raise EvidenceError("secondary-copy manifest file must be a safe .sql.gz basename")
+    if not SHA256_RE.fullmatch(copy_sha_expected):
+        raise EvidenceError("secondary-copy manifest sha256 is invalid")
     try:
-        offhost_bytes_expected = int(values.get("bytes", ""))
+        copy_bytes_expected = int(values.get("bytes", ""))
     except ValueError as exc:
-        raise EvidenceError("off-host manifest bytes is invalid") from exc
-    require_exact_tables(values.get("tables", ""), source="off-host manifest")
+        raise EvidenceError("secondary-copy manifest bytes is invalid") from exc
+    require_exact_tables(values.get("tables", ""), source="secondary-copy manifest")
     same_artifact = (
-        offhost_name == backup.get("file")
-        and offhost_sha_expected == backup.get("sha256")
-        and offhost_bytes_expected == backup.get("bytes")
+        copy_name == backup.get("file")
+        and copy_sha_expected == backup.get("sha256")
+        and copy_bytes_expected == backup.get("bytes")
         and values.get("created_at") == backup.get("created_at")
     )
     try:
-        offhost_sha, offhost_bytes = sha256_and_size(manifest_path.parent / offhost_name)
+        copy_sha, copy_bytes = sha256_and_size(manifest_path.parent / copy_name)
     except EvidenceError:
         hash_matches = False
     else:
         hash_matches = (
-            offhost_sha == offhost_sha_expected
-            and offhost_bytes == offhost_bytes_expected
+            copy_sha == copy_sha_expected
+            and copy_bytes == copy_bytes_expected
         )
     ok = same_artifact and hash_matches
     return {
         "status": "pass" if ok else "fail",
-        "required_for_overall_pass": True,
-        "file": offhost_name,
-        "sha256": offhost_sha_expected,
-        "bytes": offhost_bytes_expected,
+        "kind": "secondary_copy",
+        "required_for_overall_pass": False,
+        "proves_offhost_boundary": False,
+        "file": copy_name,
+        "sha256": copy_sha_expected,
+        "bytes": copy_bytes_expected,
         "same_artifact_as_production_manifest": same_artifact,
         "copied_file_hash_matches": hash_matches,
     }
@@ -545,15 +550,13 @@ def build_evidence(
     runtime: Mapping[str, Any],
     backup: Mapping[str, Any],
     restore: Mapping[str, Any],
-    offhost: Mapping[str, Any],
+    secondary_copy: Mapping[str, Any],
     generated_at: datetime,
 ) -> dict[str, Any]:
     required_sections = (public, runtime, backup, restore)
     required_ok = all(section.get("status") == "pass" for section in required_sections)
-    if not required_ok or offhost.get("status") == "fail":
+    if not required_ok or secondary_copy.get("status") == "fail":
         overall_status = "fail"
-    elif offhost.get("status") == "pass":
-        overall_status = "pass"
     else:
         overall_status = "partial"
     return {
@@ -569,7 +572,7 @@ def build_evidence(
         "runtime_configuration": dict(runtime),
         "backup": dict(backup),
         "restore": dict(restore),
-        "offhost_backup": dict(offhost),
+        "secondary_copy": dict(secondary_copy),
         "evidence_boundary": {
             "proves": [
                 "public API readiness at collection time",
@@ -577,39 +580,76 @@ def build_evidence(
                 "allowlisted persistence and migration modes in the running API container",
                 "integrity and freshness of the explicitly selected local backup",
                 "fresh successful restore proof bound to that backup",
-                "off-host copy identity only when an off-host manifest is supplied",
+                "hash-identical secondary copy when a secondary-copy manifest is supplied",
             ],
             "does_not_prove": [
                 "future availability",
                 "absence of latent application defects",
                 "completeness or semantic correctness of every database row",
-                "off-host recovery when no off-host manifest is supplied",
+                "off-host storage or recovery boundary",
                 "disaster recovery for infrastructure outside the selected PostgreSQL artifacts",
             ],
         },
     }
 
 
-def write_json_atomic(path: Path, payload: Mapping[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    encoded = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
-    fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
-    temp_path = Path(temp_name)
+def open_output_directory(path: Path) -> int:
+    flags = os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_NOFOLLOW", 0)
     try:
-        os.fchmod(fd, 0o600)
-        with os.fdopen(fd, "wb") as handle:
+        directory_fd = os.open(path.parent, flags)
+    except FileNotFoundError as exc:
+        raise EvidenceError(f"output parent directory does not exist: {path.parent}") from exc
+    except OSError as exc:
+        raise EvidenceError(
+            f"output parent must be an existing non-symlink directory: {path.parent}"
+        ) from exc
+    directory_stat = os.fstat(directory_fd)
+    if not stat.S_ISDIR(directory_stat.st_mode):
+        os.close(directory_fd)
+        raise EvidenceError(
+            f"output parent must be an existing non-symlink directory: {path.parent}"
+        )
+    return directory_fd
+
+
+def validate_existing_output_target(directory_fd: int, name: str, path: Path) -> None:
+    try:
+        target_stat = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        raise EvidenceError(f"could not inspect output target: {path}") from exc
+    if stat.S_ISLNK(target_stat.st_mode) or not stat.S_ISREG(target_stat.st_mode):
+        raise EvidenceError(f"output target must be absent or a regular non-symlink file: {path}")
+
+
+def write_json_atomic(path: Path, payload: Mapping[str, Any]) -> None:
+    name = path.name
+    if name in {"", ".", ".."}:
+        raise EvidenceError("output target must have a regular filename")
+    directory_fd = open_output_directory(path)
+    temp_name = f".{name}.{uuid.uuid4().hex}.tmp"
+    temp_fd: int | None = None
+    try:
+        validate_existing_output_target(directory_fd, name, path)
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+        temp_fd = os.open(temp_name, flags, 0o600, dir_fd=directory_fd)
+        encoded = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+        with os.fdopen(temp_fd, "wb") as handle:
+            temp_fd = None
             handle.write(encoded)
             handle.flush()
             os.fsync(handle.fileno())
-        os.replace(temp_path, path)
-        directory_fd = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
-        try:
-            os.fsync(directory_fd)
-        finally:
-            os.close(directory_fd)
+        os.replace(temp_name, name, src_dir_fd=directory_fd, dst_dir_fd=directory_fd)
+        os.fsync(directory_fd)
     finally:
-        if temp_path.exists():
-            temp_path.unlink()
+        if temp_fd is not None:
+            os.close(temp_fd)
+        try:
+            os.unlink(temp_name, dir_fd=directory_fd)
+        except FileNotFoundError:
+            pass
+        os.close(directory_fd)
 
 
 def positive_hours(value: str) -> float:
@@ -641,7 +681,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--service", default="api")
     parser.add_argument("--backup-manifest", type=Path, required=True)
     parser.add_argument("--restore-proof", type=Path, required=True)
-    parser.add_argument("--offhost-backup-manifest", type=Path)
+    parser.add_argument("--secondary-copy-manifest", type=Path)
     parser.add_argument("--backup-max-age-hours", type=positive_hours, default=26.0)
     parser.add_argument("--restore-max-age-hours", type=positive_hours, default=192.0)
     parser.add_argument("--output", type=Path)
@@ -681,8 +721,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             now=now,
             max_age=timedelta(hours=args.restore_max_age_hours),
         )
-        offhost = collect_offhost_evidence(
-            manifest_path=args.offhost_backup_manifest,
+        secondary_copy = collect_secondary_copy_evidence(
+            manifest_path=args.secondary_copy_manifest,
             backup=backup,
         )
         payload = build_evidence(
@@ -690,7 +730,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             runtime=runtime,
             backup=backup,
             restore=restore,
-            offhost=offhost,
+            secondary_copy=secondary_copy,
             generated_at=now,
         )
     except EvidenceError as exc:
@@ -707,7 +747,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         }
 
     if args.output:
-        write_json_atomic(args.output, payload)
+        try:
+            write_json_atomic(args.output, payload)
+        except EvidenceError as exc:
+            print(f"runtime evidence output failed: {exc}", file=sys.stderr)
+            return 1
     else:
         print(json.dumps(payload, indent=2, sort_keys=True))
     if payload["status"] == "pass":


### PR DESCRIPTION
## Zusammenfassung

- klassifiziert eine hashgleiche lokale Kopie nur noch als `secondary_copy`
- verhindert, dass eine lokale Zweitkopie einen Off-host- oder Vollpass-Claim erzeugt
- veröffentlicht den korrigierten Vertrag als Schema-Version 2
- schreibt Berichte nur in ein bereits vorhandenes, nicht als Symlink geöffnetes Elternverzeichnis
- lehnt Symlink-Ziele und implizite Verzeichniserzeugung fail-closed ab
- begrenzt atomare Schreibfehler auf einen kontrollierten CLI-Fehler ohne Traceback oder partiellen Erfolgszustand

Closes #1434

## Prüfungen

- `python3 -m unittest scripts.ci.tests.test_production_runtime_evidence` — 27/27 bestanden
- `python3 -m unittest discover scripts/ci/tests/` — 571 bestanden, 64 übersprungen
- `ruff check scripts/ops/collect_production_runtime_evidence.py scripts/ci/tests/test_production_runtime_evidence.py`
- `python3 -m py_compile scripts/ops/collect_production_runtime_evidence.py scripts/ci/tests/test_production_runtime_evidence.py`
- Agent-Contract-Validator und vier verpflichtende Repository-Guards
- `git diff --check`

## Begrenzung

`make validate` scheitert außerhalb dieses Diffs auf dem lokalen Python-3.10-Interpreter, weil `scripts/agent/validate_agent_tooling_lock.py` das erst ab Python 3.11 enthaltene `tomllib` importiert. Die vollständige CI-Testfläche `scripts/ci/tests/` ist auf dem exakten Head grün.

<!-- weltgewebe-risk: R3 -->