### PR TITLE
fix(dev): bind compose web to exact commit

### DIFF
--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -2,6 +2,7 @@
 name: compose-smoke
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  GIT_COMMIT_SHA: ${{ github.sha }}
 
 permissions:
   contents: read

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ diagnose: generate
 prepare-commit: validate
 
 up:
-	docker compose -f infra/compose/compose.core.yml --profile dev up -d --build
+	GIT_COMMIT_SHA="$$(git rev-parse HEAD)" docker compose -f infra/compose/compose.core.yml --profile dev up -d --build
 
 down:
 	docker compose -f infra/compose/compose.core.yml --profile dev down -v

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -101,6 +101,14 @@ Der Guard listet alle blockierenden Container mit Name, Projekt-Label und Config
   - `compose.observ.yml` – Observability / Zusatzdienste
   - `compose.ops.override.yml` – Lokale Entwicklungs-/Ops-Umgebung (NATS + API-Port-Mapping für Debugging)
 
+Der Web-Service des `dev`-Profils besitzt absichtlich kein eigenes `git` und
+leitet deshalb keine Versionsidentität aus dem Containerdateisystem ab. Der
+Aufrufer muss den vollständigen Quellcommit als `GIT_COMMIT_SHA` binden:
+`make up` verwendet `git rev-parse HEAD`, der GitHub-Compose-Smoke den exakten
+`github.sha`. Direkte Compose-Aufrufe müssen denselben Wert ausdrücklich
+setzen. Fehlt er, bleibt die Client-Buildidentität fail-closed; ein erfundener
+oder zeitabhängiger Ersatzcommit ist unzulässig.
+
 Der nur im `dev`-Profil verwendete PgBouncer-Container ist in
 `compose.core.yml` sowohl auf eine veröffentlichte Version als auch auf den
 OCI-Manifest-Digest gepinnt. Bei Aktualisierungen müssen Registry-Existenz,

--- a/infra/compose/compose.core.yml
+++ b/infra/compose/compose.core.yml
@@ -23,6 +23,7 @@ services:
         condition: service_healthy
     environment:
       NODE_ENV: development
+      GIT_COMMIT_SHA: ${GIT_COMMIT_SHA:-}
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:5173 >/dev/null"]
       interval: 5s

--- a/scripts/ci/tests/test_compose_dev_build_identity.py
+++ b/scripts/ci/tests/test_compose_dev_build_identity.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+class ComposeDevBuildIdentityContractTests(unittest.TestCase):
+    def test_web_service_receives_caller_bound_git_commit(self) -> None:
+        compose = (ROOT / "infra/compose/compose.core.yml").read_text(encoding="utf-8")
+        self.assertIn("GIT_COMMIT_SHA: ${GIT_COMMIT_SHA:-}", compose)
+
+    def test_compose_smoke_binds_the_exact_github_revision(self) -> None:
+        workflow = (ROOT / ".github/workflows/compose-smoke.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("GIT_COMMIT_SHA: ${{ github.sha }}", workflow)
+        self.assertIn(
+            "docker compose -f infra/compose/compose.core.yml --profile dev up -d --build",
+            workflow,
+        )
+
+    def test_make_up_derives_the_exact_local_head(self) -> None:
+        makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+        self.assertIn(
+            'GIT_COMMIT_SHA="$$(git rev-parse HEAD)" docker compose '
+            "-f infra/compose/compose.core.yml --profile dev up -d --build",
+            makefile,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- weltgewebe-risk: R3 -->

## Ursache

Der Post-Merge-Lauf von PR #1619 zeigte einen roten `compose-smoke`: Das Web-Dev-Image enthält kein `git`, während `generate-version.js` inzwischen zu Recht eine kanonische Commitidentität verlangt. Der Web-Container wurde deshalb ungesund, obwohl Produkt-CI und Produktionsvertrag grün waren.

## Korrektur

- `compose.core.yml` reicht `GIT_COMMIT_SHA` explizit an den Web-Service weiter.
- GitHub Actions bindet den Wert an `${{ github.sha }}`.
- `make up` bindet lokale Starts an `git rev-parse HEAD`.
- Ein CI-Vertrag schützt alle drei Übergaben gegen erneuten Drift.

Es wird kein erfundener Fallback-Commit eingeführt; fehlt die Identität bei einem direkten, ungebundenen Compose-Aufruf, bleibt der bestehende fail-closed Buildvertrag erhalten.

## Prüfung

- fokussierte Vertragsprüfung: 3/3 PASS
- vollständige Python-CI-Sammlung: 588 PASS, 64 SKIP
- gerendertes Compose-Modell: Web erhält exakt `72f88e55460cfb051ecab4aa70ed4ce69e9ffa7b`
- Workflow- und Compose-YAML: parsebar
- Ruff: PASS
- `git diff --check`: PASS
- `make -n up`: exakte Commitableitung sichtbar
