### PR TITLE
Fade dated legacy Fäden retroactively

### DIFF
--- a/apps/api/src/domain_db.rs
+++ b/apps/api/src/domain_db.rs
@@ -102,19 +102,21 @@ fn payload_string(payload: &Value, key: &str) -> Option<String> {
 /// Read a lifecycle timestamp field while preserving the distinction between
 /// an omitted key (`None`) and an explicit `null` (`Some(None)`), matching
 /// `Edge::expires_at`'s tri-state deserialization. A present non-string,
-/// non-null value is malformed and is treated the same as an explicit `null`
-/// so it fails closed instead of silently deriving an expiry from garbage
-/// payload data.
+/// non-null value is structurally malformed payload data — returning `Err`
+/// lets the caller reject the whole row instead of coercing it into the
+/// explicit-null state, which would let a corrupted value pass as the
+/// legitimate fully-undated legacy pairing when `created_at` is also absent.
 fn payload_lifecycle_field(
     payload: &Value,
     key: &str,
-) -> Option<Option<crate::routes::edges::LifecycleTimestamp>> {
+) -> Result<Option<Option<crate::routes::edges::LifecycleTimestamp>>, ()> {
     match payload.get(key) {
-        None => None,
-        Some(Value::String(s)) => Some(Some(crate::routes::edges::LifecycleTimestamp::from(
+        None => Ok(None),
+        Some(Value::Null) => Ok(Some(None)),
+        Some(Value::String(s)) => Ok(Some(Some(crate::routes::edges::LifecycleTimestamp::from(
             s.as_str(),
-        ))),
-        Some(_) => Some(None),
+        )))),
+        Some(_) => Err(()),
     }
 }
 
@@ -187,6 +189,7 @@ pub async fn load_edges_from_postgres(pool: &PgPool) -> Result<OrderedCache<Edge
 
     let mut cache = OrderedCache::new();
     let mut seen = 0usize;
+    let mut skipped = 0usize;
     let mut truncated = false;
     while let Some((id, source_id, target_id, edge_kind, created_at, payload_text)) = rows
         .try_next()
@@ -199,6 +202,11 @@ pub async fn load_edges_from_postgres(pool: &PgPool) -> Result<OrderedCache<Edge
         }
 
         let payload = parse_payload(&payload_text);
+        let Ok(expires_at) = payload_lifecycle_field(&payload, "expires_at") else {
+            tracing::warn!(edge_id = %id, "skipping domain edge with malformed expires_at payload");
+            skipped += 1;
+            continue;
+        };
         let edge = Edge {
             id: id.clone(),
             source_id,
@@ -208,7 +216,7 @@ pub async fn load_edges_from_postgres(pool: &PgPool) -> Result<OrderedCache<Edge
             edge_kind,
             note: payload_string(&payload, "note"),
             created_at: created_at.map(LifecycleTimestamp::from_datetime),
-            expires_at: payload_lifecycle_field(&payload, "expires_at"),
+            expires_at,
         };
         cache.insert(id, edge);
         seen += 1;
@@ -221,6 +229,7 @@ pub async fn load_edges_from_postgres(pool: &PgPool) -> Result<OrderedCache<Edge
     }
     tracing::info!(
         count = cache.len(),
+        skipped,
         truncated,
         "Loaded edges from PostgreSQL"
     );
@@ -625,6 +634,8 @@ fn node_from_row(row: NodeRow) -> Result<Node, anyhow::Error> {
 fn edge_from_row(row: EdgeRow) -> Result<Edge, anyhow::Error> {
     let (id, source_id, target_id, edge_kind, created_at, payload_text) = row;
     let payload = parse_payload(&payload_text);
+    let expires_at = payload_lifecycle_field(&payload, "expires_at")
+        .map_err(|()| anyhow::anyhow!("edge {id} has malformed expires_at payload value"))?;
     Ok(Edge {
         id,
         source_id,
@@ -634,7 +645,7 @@ fn edge_from_row(row: EdgeRow) -> Result<Edge, anyhow::Error> {
         edge_kind,
         note: payload_string(&payload, "note"),
         created_at: created_at.map(LifecycleTimestamp::from_datetime),
-        expires_at: payload_lifecycle_field(&payload, "expires_at"),
+        expires_at,
     })
 }
 
@@ -2094,6 +2105,55 @@ mod edge_write_path_tests {
         edge.created_at = Some("yesterday".into());
         let err = NewDomainEdgeRow::from_edge(&edge).unwrap_err();
         assert!(err.to_string().contains("not RFC3339"));
+    }
+
+    #[test]
+    fn payload_lifecycle_field_distinguishes_omitted_null_and_value() {
+        let omitted = serde_json::json!({});
+        assert_eq!(payload_lifecycle_field(&omitted, "expires_at"), Ok(None));
+
+        let explicit_null = serde_json::json!({ "expires_at": null });
+        assert_eq!(
+            payload_lifecycle_field(&explicit_null, "expires_at"),
+            Ok(Some(None))
+        );
+
+        let dated = serde_json::json!({ "expires_at": "2026-06-19T10:00:00+00:00" });
+        assert_eq!(
+            payload_lifecycle_field(&dated, "expires_at"),
+            Ok(Some(Some("2026-06-19T10:00:00+00:00".into())))
+        );
+    }
+
+    /// A structurally malformed `expires_at` (neither absent, `null`, nor a
+    /// string) must not be silently coerced into the explicit-null state.
+    /// Doing so would let it pass as the legitimate fully-undated legacy
+    /// pairing whenever `created_at` is also absent, defeating fail-closed
+    /// handling of corrupted payload data.
+    #[test]
+    fn payload_lifecycle_field_rejects_structurally_malformed_value() {
+        for malformed in [
+            serde_json::json!({ "expires_at": 12345 }),
+            serde_json::json!({ "expires_at": true }),
+            serde_json::json!({ "expires_at": {} }),
+            serde_json::json!({ "expires_at": [] }),
+        ] {
+            assert_eq!(payload_lifecycle_field(&malformed, "expires_at"), Err(()));
+        }
+    }
+
+    #[test]
+    fn edge_from_row_rejects_row_with_malformed_expires_at_payload() {
+        let row: EdgeRow = (
+            "edge-malformed".to_string(),
+            "source".to_string(),
+            "target".to_string(),
+            "reference".to_string(),
+            None,
+            r#"{"expires_at": 12345}"#.to_string(),
+        );
+        let err = edge_from_row(row).unwrap_err();
+        assert!(err.to_string().contains("malformed expires_at"));
     }
 }
 

--- a/apps/api/src/domain_db.rs
+++ b/apps/api/src/domain_db.rs
@@ -2002,6 +2002,18 @@ pub async fn insert_domain_edge(
     // of the `->` operator's SQL NULL silently propagating through equality
     // checks (as an earlier version of this condition did).
     //
+    // The whole exclusion is additionally guarded on the payload actually
+    // being a JSON object. `?` matches array *elements*, not just object
+    // keys, so a non-object payload such as `["expires_at"]` would otherwise
+    // make `payload ? 'expires_at'` true while `payload -> 'expires_at'`
+    // returns SQL NULL — `jsonb_typeof(NULL)` is itself NULL, propagating
+    // through the same three-valued-logic trap the `?` operator was meant to
+    // avoid. `payload_string`/`payload_lifecycle_field` only ever look up
+    // keys via `Value::get`, which returns `None` for any non-object value
+    // regardless of its contents, so the loader treats a non-object payload
+    // exactly like `{}` (a reachable, omitted-expiry edge) — the capacity
+    // count must agree instead of quietly excluding it.
+    //
     // Deliberately not covered: a dated `created_at` with a present string
     // `expires_at` that is unparseable or not exactly the canonical 168-hour
     // duration. Validating that would require casting the payload string to
@@ -2016,7 +2028,8 @@ pub async fn insert_domain_edge(
     let (limit_reached,): (bool,) = sqlx::query_as(
         "SELECT COUNT(*) >= $1 FROM domain_edges \
          WHERE NOT (\
-             payload ? 'expires_at' \
+             jsonb_typeof(payload) = 'object' \
+             AND payload ? 'expires_at' \
              AND (\
                  jsonb_typeof(payload -> 'expires_at') NOT IN ('null', 'string') \
                  OR (created_at IS NOT NULL AND jsonb_typeof(payload -> 'expires_at') = 'null') \

--- a/apps/api/src/domain_db.rs
+++ b/apps/api/src/domain_db.rs
@@ -19,7 +19,7 @@ use crate::routes::accounts::{
     MIN_RADIUS_M, RADIUS_PROJECTION_KEY,
 };
 use crate::routes::auth::MAX_EMAIL_LEN;
-use crate::routes::edges::{Edge, LifecycleTimestamp};
+use crate::routes::edges::{edge_is_permanently_unreachable, Edge, LifecycleTimestamp};
 use crate::routes::nodes::{normalize_account_id, Location, Node, SearchVisibility};
 use crate::state::OrderedCache;
 
@@ -205,11 +205,6 @@ pub async fn load_edges_from_postgres(pool: &PgPool) -> Result<OrderedCache<Edge
             continue;
         };
 
-        if seen >= max_edges {
-            truncated = true;
-            break;
-        }
-
         let edge = Edge {
             id: id.clone(),
             source_id,
@@ -221,6 +216,24 @@ pub async fn load_edges_from_postgres(pool: &PgPool) -> Result<OrderedCache<Edge
             created_at: created_at.map(LifecycleTimestamp::from_datetime),
             expires_at,
         };
+        // Checked before the cache-limit gate for the same reason as the
+        // malformed-payload check above: a row that can never be active for
+        // any `now` must never consume one of the `max_edges` slots that a
+        // genuinely reachable edge would need.
+        if edge_is_permanently_unreachable(&edge) {
+            tracing::warn!(
+                edge_id = %edge.id,
+                "skipping domain edge that can never be active under any lifecycle rule"
+            );
+            skipped += 1;
+            continue;
+        }
+
+        if seen >= max_edges {
+            truncated = true;
+            break;
+        }
+
         cache.insert(id, edge);
         seen += 1;
     }

--- a/apps/api/src/domain_db.rs
+++ b/apps/api/src/domain_db.rs
@@ -1989,26 +1989,39 @@ pub async fn insert_domain_edge(
     let max_edges = crate::routes::edges::max_edges_cache_limit();
     let max_edges_i64 = i64::try_from(max_edges).unwrap_or(i64::MAX);
 
-    // A dated row whose payload carries an explicit `expires_at: null` is
-    // exactly the state `edge_is_permanently_unreachable` excludes from the
-    // loader's cache: it can never be active for any `now`, so it never
-    // occupies a cache slot and must not count against write capacity
-    // either. This mirrors only that concrete, cheaply-indexable case rather
-    // than the full Rust-side lifecycle predicate (which would need a full
-    // per-row payload fetch on every create); the rarer cases already left
-    // unhandled by simple existence-based counting before this fix (an
-    // invalid timestamp string, or a non-canonical explicit duration) remain
-    // out of scope here, unchanged from prior behavior.
+    // Mirrors `edge_is_permanently_unreachable` for every case that is safe
+    // to check without parsing the payload's `expires_at` string as a
+    // timestamp (which `jsonb_typeof` never needs to do, so this can never
+    // throw regardless of what a corrupted row contains):
+    //   - a present `expires_at` that is neither `null` nor a string is
+    //     malformed and never becomes a valid `Edge` at all;
+    //   - a dated `created_at` paired with an explicit `expires_at: null`;
+    //   - an absent `created_at` paired with a concrete `expires_at` string.
     // `payload ? 'expires_at'` is a definite boolean (never SQL NULL), so a
-    // missing key short-circuits the AND chain to a definite `false` instead
-    // of the `->` operator's SQL NULL propagating through `= 'null'::jsonb`
-    // and silently excluding every row that merely omits the key.
+    // missing key short-circuits every branch to a definite `false` instead
+    // of the `->` operator's SQL NULL silently propagating through equality
+    // checks (as an earlier version of this condition did).
+    //
+    // Deliberately not covered: a dated `created_at` with a present string
+    // `expires_at` that is unparseable or not exactly the canonical 168-hour
+    // duration. Validating that would require casting the payload string to
+    // a timestamp, which raises a hard error for any non-timestamp string
+    // anywhere in the table instead of evaluating to a boolean — turning a
+    // conservative over-count into a query failure that blocks every create.
+    // Closing that gap needs a safe-cast SQL helper (a schema migration),
+    // not a WHERE clause; the loader already fails such rows closed at read
+    // time, so at worst a persisted row that could never occur through this
+    // API's own write path (which always emits a canonical duration) counts
+    // toward capacity a little too eagerly.
     let (limit_reached,): (bool,) = sqlx::query_as(
         "SELECT COUNT(*) >= $1 FROM domain_edges \
          WHERE NOT (\
-             created_at IS NOT NULL \
-             AND payload ? 'expires_at' \
-             AND payload -> 'expires_at' = 'null'::jsonb\
+             payload ? 'expires_at' \
+             AND (\
+                 jsonb_typeof(payload -> 'expires_at') NOT IN ('null', 'string') \
+                 OR (created_at IS NOT NULL AND jsonb_typeof(payload -> 'expires_at') = 'null') \
+                 OR (created_at IS NULL AND jsonb_typeof(payload -> 'expires_at') = 'string')\
+             )\
          )",
     )
     .bind(max_edges_i64)

--- a/apps/api/src/domain_db.rs
+++ b/apps/api/src/domain_db.rs
@@ -179,12 +179,14 @@ pub async fn load_nodes_from_postgres(pool: &PgPool) -> Result<OrderedCache<Node
 
 pub async fn load_edges_from_postgres(pool: &PgPool) -> Result<OrderedCache<Edge>> {
     let max_edges = crate::routes::edges::max_edges_cache_limit();
-    let fetch_limit = max_edges.saturating_add(1).min(i64::MAX as usize) as i64;
+    // No SQL-side LIMIT: rejected rows must not consume a physical row slot
+    // that a later valid row would need. The loop below bounds physical reads
+    // itself, breaking as soon as it has examined `max_edges + 1` *accepted*
+    // rows (the `+ 1` only confirms truncation; it is never cached).
     let mut rows = sqlx::query_as::<_, EdgeRow>(
         "SELECT id, source_id, target_id, edge_kind, created_at, payload::text \
-         FROM domain_edges ORDER BY id ASC LIMIT $1",
+         FROM domain_edges ORDER BY id ASC",
     )
-    .bind(fetch_limit)
     .fetch(pool);
 
     let mut cache = OrderedCache::new();
@@ -196,17 +198,18 @@ pub async fn load_edges_from_postgres(pool: &PgPool) -> Result<OrderedCache<Edge
         .await
         .context("failed to load edges from domain_edges")?
     {
-        if seen >= max_edges {
-            truncated = true;
-            break;
-        }
-
         let payload = parse_payload(&payload_text);
         let Ok(expires_at) = payload_lifecycle_field(&payload, "expires_at") else {
             tracing::warn!(edge_id = %id, "skipping domain edge with malformed expires_at payload");
             skipped += 1;
             continue;
         };
+
+        if seen >= max_edges {
+            truncated = true;
+            break;
+        }
+
         let edge = Edge {
             id: id.clone(),
             source_id,

--- a/apps/api/src/domain_db.rs
+++ b/apps/api/src/domain_db.rs
@@ -99,6 +99,25 @@ fn payload_string(payload: &Value, key: &str) -> Option<String> {
         .map(|s| s.to_string())
 }
 
+/// Read a lifecycle timestamp field while preserving the distinction between
+/// an omitted key (`None`) and an explicit `null` (`Some(None)`), matching
+/// `Edge::expires_at`'s tri-state deserialization. A present non-string,
+/// non-null value is malformed and is treated the same as an explicit `null`
+/// so it fails closed instead of silently deriving an expiry from garbage
+/// payload data.
+fn payload_lifecycle_field(
+    payload: &Value,
+    key: &str,
+) -> Option<Option<crate::routes::edges::LifecycleTimestamp>> {
+    match payload.get(key) {
+        None => None,
+        Some(Value::String(s)) => Some(Some(crate::routes::edges::LifecycleTimestamp::from(
+            s.as_str(),
+        ))),
+        Some(_) => Some(None),
+    }
+}
+
 fn payload_string_array(payload: &Value, key: &str) -> Vec<String> {
     payload
         .get(key)
@@ -189,7 +208,7 @@ pub async fn load_edges_from_postgres(pool: &PgPool) -> Result<OrderedCache<Edge
             edge_kind,
             note: payload_string(&payload, "note"),
             created_at: created_at.map(LifecycleTimestamp::from_datetime),
-            expires_at: payload_string(&payload, "expires_at").map(LifecycleTimestamp::from),
+            expires_at: payload_lifecycle_field(&payload, "expires_at"),
         };
         cache.insert(id, edge);
         seen += 1;
@@ -615,7 +634,7 @@ fn edge_from_row(row: EdgeRow) -> Result<Edge, anyhow::Error> {
         edge_kind,
         note: payload_string(&payload, "note"),
         created_at: created_at.map(LifecycleTimestamp::from_datetime),
-        expires_at: payload_string(&payload, "expires_at").map(LifecycleTimestamp::from),
+        expires_at: payload_lifecycle_field(&payload, "expires_at"),
     })
 }
 
@@ -1847,7 +1866,7 @@ impl NewDomainEdgeRow {
         if let Some(note) = &edge.note {
             payload_map.insert("note".to_string(), Value::String(note.clone()));
         }
-        if let Some(expires_at) = &edge.expires_at {
+        if let Some(Some(expires_at)) = &edge.expires_at {
             payload_map.insert(
                 "expires_at".to_string(),
                 Value::String(expires_at.as_str().to_owned()),
@@ -2020,7 +2039,7 @@ mod edge_write_path_tests {
             edge_kind: "reference".to_string(),
             note: None,
             created_at: Some("2026-06-12T10:00:00+00:00".into()),
-            expires_at: Some("2026-06-19T10:00:00+00:00".into()),
+            expires_at: Some(Some("2026-06-19T10:00:00+00:00".into())),
         }
     }
 

--- a/apps/api/src/domain_db.rs
+++ b/apps/api/src/domain_db.rs
@@ -1989,11 +1989,32 @@ pub async fn insert_domain_edge(
     let max_edges = crate::routes::edges::max_edges_cache_limit();
     let max_edges_i64 = i64::try_from(max_edges).unwrap_or(i64::MAX);
 
-    let (limit_reached,): (bool,) = sqlx::query_as("SELECT COUNT(*) >= $1 FROM domain_edges")
-        .bind(max_edges_i64)
-        .fetch_one(&mut *tx)
-        .await
-        .map_err(EdgeWriteError::Database)?;
+    // A dated row whose payload carries an explicit `expires_at: null` is
+    // exactly the state `edge_is_permanently_unreachable` excludes from the
+    // loader's cache: it can never be active for any `now`, so it never
+    // occupies a cache slot and must not count against write capacity
+    // either. This mirrors only that concrete, cheaply-indexable case rather
+    // than the full Rust-side lifecycle predicate (which would need a full
+    // per-row payload fetch on every create); the rarer cases already left
+    // unhandled by simple existence-based counting before this fix (an
+    // invalid timestamp string, or a non-canonical explicit duration) remain
+    // out of scope here, unchanged from prior behavior.
+    // `payload ? 'expires_at'` is a definite boolean (never SQL NULL), so a
+    // missing key short-circuits the AND chain to a definite `false` instead
+    // of the `->` operator's SQL NULL propagating through `= 'null'::jsonb`
+    // and silently excluding every row that merely omits the key.
+    let (limit_reached,): (bool,) = sqlx::query_as(
+        "SELECT COUNT(*) >= $1 FROM domain_edges \
+         WHERE NOT (\
+             created_at IS NOT NULL \
+             AND payload ? 'expires_at' \
+             AND payload -> 'expires_at' = 'null'::jsonb\
+         )",
+    )
+    .bind(max_edges_i64)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(EdgeWriteError::Database)?;
 
     if limit_reached {
         tx.rollback().await.ok();

--- a/apps/api/src/routes/edges.rs
+++ b/apps/api/src/routes/edges.rs
@@ -2053,6 +2053,24 @@ mod tests {
         ));
     }
 
+    /// Undated legacy edges must project as an explicit JSON null/null pair
+    /// (keys present, values null), not omit the fields. Clients and AJV
+    /// couple the two nulls; omitted keys would look like "derive expires_at".
+    #[test]
+    fn public_undated_legacy_serializes_explicit_null_lifecycle_pair() {
+        let edge = lifecycle_edge_with_null_expiry(None);
+        let projected = PublicEdge::from(&edge);
+        assert_eq!(projected.created_at, None);
+        assert_eq!(projected.expires_at, None);
+
+        let value = serde_json::to_value(&projected).expect("serialize public edge");
+        assert_eq!(value.get("created_at"), Some(&serde_json::Value::Null));
+        assert_eq!(value.get("expires_at"), Some(&serde_json::Value::Null));
+        // Keys must be present; absence would violate the schema coupling.
+        assert!(value.as_object().expect("object").contains_key("created_at"));
+        assert!(value.as_object().expect("object").contains_key("expires_at"));
+    }
+
     #[test]
     fn expiry_filter_precedes_pagination() {
         let now = Utc.with_ymd_and_hms(2026, 7, 24, 10, 0, 0).unwrap();

--- a/apps/api/src/routes/edges.rs
+++ b/apps/api/src/routes/edges.rs
@@ -2067,8 +2067,14 @@ mod tests {
         assert_eq!(value.get("created_at"), Some(&serde_json::Value::Null));
         assert_eq!(value.get("expires_at"), Some(&serde_json::Value::Null));
         // Keys must be present; absence would violate the schema coupling.
-        assert!(value.as_object().expect("object").contains_key("created_at"));
-        assert!(value.as_object().expect("object").contains_key("expires_at"));
+        assert!(value
+            .as_object()
+            .expect("object")
+            .contains_key("created_at"));
+        assert!(value
+            .as_object()
+            .expect("object")
+            .contains_key("expires_at"));
     }
 
     #[test]

--- a/apps/api/src/routes/edges.rs
+++ b/apps/api/src/routes/edges.rs
@@ -151,10 +151,7 @@ impl From<&Edge> for PublicEdge {
                 .created_at
                 .as_ref()
                 .map(|timestamp| timestamp.as_str().to_owned()),
-            expires_at: edge
-                .expires_at
-                .as_ref()
-                .map(|timestamp| timestamp.as_str().to_owned()),
+            expires_at: projected_faden_expires_at(edge),
         }
     }
 }
@@ -181,57 +178,101 @@ pub(crate) const DEFAULT_MAX_EDGES_CACHE: usize = 500_000;
 /// Canonical lifetime of a newly derived, unverzwirnter Faden.
 ///
 /// The durable Webungsaktion remains the source of truth; only this active
-/// projection expires. Legacy records without `expires_at` remain visible until
-/// a later, explicit Garn/legacy migration can classify them without guessing.
+/// projection expires. Legacy records with a valid `created_at` use the same
+/// deterministic boundary even when the record predates the lifecycle feature.
+/// Only fully undated legacy records remain visible because their age cannot be
+/// reconstructed without guessing.
 pub(crate) const FADEN_LIFETIME_HOURS: i64 = FIXED_FADEN_FADE_DAYS as i64 * 24;
 
+fn checked_faden_expires_at(created_at: DateTime<Utc>) -> Option<DateTime<Utc>> {
+    created_at.checked_add_signed(Duration::hours(FADEN_LIFETIME_HOURS))
+}
+
 fn faden_expires_at(created_at: DateTime<Utc>) -> DateTime<Utc> {
-    created_at + Duration::hours(FADEN_LIFETIME_HOURS)
+    checked_faden_expires_at(created_at)
+        .expect("server-owned creation timestamps always permit a 168-hour lifetime")
+}
+
+/// Publicly project the canonical expiry without rewriting persisted legacy
+/// records. Explicit values retain their original wire representation; a
+/// missing value is deterministically derived only from a valid `created_at`.
+fn projected_faden_expires_at(edge: &Edge) -> Option<String> {
+    if let Some(expires_at) = edge.expires_at.as_ref() {
+        return Some(expires_at.as_str().to_owned());
+    }
+
+    let created_at = edge.created_at.as_ref()?.parsed()?;
+    let expires_at = checked_faden_expires_at(*created_at)?;
+    Some(expires_at.to_rfc3339_opts(SecondsFormat::AutoSi, true))
 }
 
 /// Active-read predicate for Faden projections.
 ///
-/// `None` is the compatibility state for legacy records and a future explicit
-/// Garn representation. A present but malformed timestamp fails closed: it is
-/// never projected as an active Faden. The exact boundary is exclusive, so a
-/// Faden is gone at `now == expires_at`.
+/// A missing `expires_at` is derived from a valid `created_at`, so Fäden created
+/// before the lifecycle feature age exactly like new projections. Only records
+/// with neither timestamp remain visible as undated legacy data. Malformed or
+/// non-canonical lifecycle data fails closed. The exact boundary is exclusive,
+/// so a Faden is gone at `now == expires_at`.
 pub(crate) fn edge_is_active_at(edge: &Edge, now: DateTime<Utc>) -> bool {
-    let Some(expires_at) = edge.expires_at.as_ref() else {
-        return true;
-    };
     let Some(created_at) = edge.created_at.as_ref() else {
+        if edge.expires_at.is_none() {
+            return true;
+        }
         tracing::debug!(
             edge_id = %edge.id,
-            expires_at = %expires_at,
+            expires_at = %edge.expires_at.as_ref().expect("checked above"),
             "hiding expiring edge without created_at from active projection"
         );
         return false;
     };
 
-    let (Some(created_at_value), Some(expires_at_value)) =
-        (created_at.parsed(), expires_at.parsed())
-    else {
+    let Some(created_at_value) = created_at.parsed() else {
         tracing::debug!(
             edge_id = %edge.id,
             created_at_raw = %created_at,
-            expires_at_raw = %expires_at,
-            "hiding edge with invalid lifecycle timestamp from active projection"
+            "hiding edge with invalid created_at from active projection"
         );
         return false;
     };
-    if expires_at_value.signed_duration_since(created_at_value)
-        != Duration::hours(FADEN_LIFETIME_HOURS)
-    {
-        tracing::debug!(
-            edge_id = %edge.id,
-            created_at = %created_at_value,
-            expires_at = %expires_at_value,
-            "hiding edge with non-canonical Faden lifetime from active projection"
-        );
-        return false;
-    }
 
-    now >= *created_at_value && now < *expires_at_value
+    let expires_at_value = match edge.expires_at.as_ref() {
+        Some(expires_at) => {
+            let Some(expires_at_value) = expires_at.parsed() else {
+                tracing::debug!(
+                    edge_id = %edge.id,
+                    created_at_raw = %created_at,
+                    expires_at_raw = %expires_at,
+                    "hiding edge with invalid lifecycle timestamp from active projection"
+                );
+                return false;
+            };
+            if expires_at_value.signed_duration_since(created_at_value)
+                != Duration::hours(FADEN_LIFETIME_HOURS)
+            {
+                tracing::debug!(
+                    edge_id = %edge.id,
+                    created_at = %created_at_value,
+                    expires_at = %expires_at_value,
+                    "hiding edge with non-canonical Faden lifetime from active projection"
+                );
+                return false;
+            }
+            *expires_at_value
+        }
+        None => {
+            let Some(expires_at_value) = checked_faden_expires_at(*created_at_value) else {
+                tracing::debug!(
+                    edge_id = %edge.id,
+                    created_at = %created_at_value,
+                    "hiding legacy edge whose derived expiry exceeds the supported timestamp range"
+                );
+                return false;
+            };
+            expires_at_value
+        }
+    };
+
+    now >= *created_at_value && now < expires_at_value
 }
 
 fn edge_matches_list_at(
@@ -1788,8 +1829,8 @@ mod edge_create {
 mod tests {
     use super::{
         build_edge_record, edge_create::ValidatedCreateEdge, edge_is_active_at,
-        edge_matches_list_at, faden_expires_at, max_edges_cache_limit, Edge, LifecycleTimestamp,
-        DEFAULT_MAX_EDGES_CACHE, FADEN_LIFETIME_HOURS,
+        edge_matches_list_at, faden_expires_at, max_edges_cache_limit, projected_faden_expires_at,
+        Edge, LifecycleTimestamp, PublicEdge, DEFAULT_MAX_EDGES_CACHE, FADEN_LIFETIME_HOURS,
     };
     use crate::test_helpers::EnvGuard;
     use chrono::{DateTime, Duration, TimeZone, Utc};
@@ -1871,8 +1912,31 @@ mod tests {
     }
 
     #[test]
-    fn active_projection_uses_exact_boundary_and_legacy_compatibility() {
+    fn public_projection_derives_missing_legacy_expiry_without_mutating_storage() {
+        let edge = lifecycle_edge(Some("2026-07-17T10:00:00Z"), None);
+        let projected = PublicEdge::from(&edge);
+
+        assert_eq!(
+            projected.expires_at.as_deref(),
+            Some("2026-07-24T10:00:00Z")
+        );
+        assert!(edge.expires_at.is_none());
+    }
+
+    #[test]
+    fn legacy_projection_preserves_submicrosecond_timestamp_precision() {
+        let precise = lifecycle_edge(Some("2026-07-17T10:00:00.123456789Z"), None);
+
+        assert_eq!(
+            projected_faden_expires_at(&precise).as_deref(),
+            Some("2026-07-24T10:00:00.123456789Z")
+        );
+    }
+
+    #[test]
+    fn active_projection_uses_exact_boundary_and_retroactive_legacy_expiry() {
         let edge = lifecycle_edge(Some("2026-07-17T10:00:00Z"), Some("2026-07-24T10:00:00Z"));
+        let legacy_with_created_at = lifecycle_edge(Some("2026-07-17T10:00:00Z"), None);
         let before_creation = Utc.with_ymd_and_hms(2026, 7, 17, 9, 59, 59).unwrap();
         let created = Utc.with_ymd_and_hms(2026, 7, 17, 10, 0, 0).unwrap();
         let before_expiry = Utc.with_ymd_and_hms(2026, 7, 24, 9, 59, 59).unwrap();
@@ -1881,6 +1945,9 @@ mod tests {
         assert!(edge_is_active_at(&edge, created));
         assert!(edge_is_active_at(&edge, before_expiry));
         assert!(!edge_is_active_at(&edge, at_expiry));
+        assert!(edge_is_active_at(&legacy_with_created_at, created));
+        assert!(edge_is_active_at(&legacy_with_created_at, before_expiry));
+        assert!(!edge_is_active_at(&legacy_with_created_at, at_expiry));
         assert!(edge_is_active_at(&lifecycle_edge(None, None), at_expiry));
     }
 
@@ -1889,6 +1956,10 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2026, 7, 18, 10, 0, 0).unwrap();
         assert!(!edge_is_active_at(
             &lifecycle_edge(Some("invalid"), Some("2026-07-24T10:00:00Z")),
+            now
+        ));
+        assert!(!edge_is_active_at(
+            &lifecycle_edge(Some("invalid"), None),
             now
         ));
         assert!(!edge_is_active_at(

--- a/apps/api/src/routes/edges.rs
+++ b/apps/api/src/routes/edges.rs
@@ -110,6 +110,21 @@ impl<'de> Deserialize<'de> for LifecycleTimestamp {
     }
 }
 
+/// Deserialize a present field (including an explicit JSON `null`) as `Some`,
+/// so pairing this with `#[serde(default)]` distinguishes an omitted key
+/// (`None`, via the `default`) from an explicit `null` (`Some(None)`). Used for
+/// `Edge::expires_at`, where that distinction is load-bearing: an omitted key
+/// means "derive the canonical expiry retroactively", while an explicit `null`
+/// paired with a dated `created_at` is a non-canonical state that must fail
+/// closed instead of being silently treated as omitted.
+fn deserialize_some<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    T: Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    Deserialize::deserialize(deserializer).map(Some)
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Edge {
     pub id: String,
@@ -121,7 +136,16 @@ pub struct Edge {
     pub edge_kind: String,
     pub note: Option<String>,
     pub created_at: Option<LifecycleTimestamp>,
-    pub expires_at: Option<LifecycleTimestamp>,
+    /// `None` means the JSONL/PostgreSQL record omitted the key (legacy dated
+    /// Fäden predating the lifecycle feature); `Some(None)` means the record
+    /// carried an explicit `null`. Only the omitted state derives a retroactive
+    /// expiry — see [`edge_is_active_at`].
+    #[serde(
+        default,
+        deserialize_with = "deserialize_some",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub expires_at: Option<Option<LifecycleTimestamp>>,
 }
 
 /// Public edge projection. Free-text notes remain persisted authoring metadata
@@ -197,8 +221,13 @@ fn faden_expires_at(created_at: DateTime<Utc>) -> DateTime<Utc> {
 /// records. Explicit values retain their original wire representation; a
 /// missing value is deterministically derived only from a valid `created_at`.
 fn projected_faden_expires_at(edge: &Edge) -> Option<String> {
-    if let Some(expires_at) = edge.expires_at.as_ref() {
-        return Some(expires_at.as_str().to_owned());
+    match edge.expires_at.as_ref() {
+        Some(Some(expires_at)) => return Some(expires_at.as_str().to_owned()),
+        // Explicit `null` paired with a dated `created_at` is non-canonical;
+        // `edge_is_active_at` already hides such records from every read
+        // surface that reaches this projection, so there is nothing to derive.
+        Some(None) => return None,
+        None => {}
     }
 
     let created_at = edge.created_at.as_ref()?.parsed()?;
@@ -215,12 +244,12 @@ fn projected_faden_expires_at(edge: &Edge) -> Option<String> {
 /// so a Faden is gone at `now == expires_at`.
 pub(crate) fn edge_is_active_at(edge: &Edge, now: DateTime<Utc>) -> bool {
     let Some(created_at) = edge.created_at.as_ref() else {
-        if edge.expires_at.is_none() {
+        let Some(Some(expires_at)) = edge.expires_at.as_ref() else {
             return true;
-        }
+        };
         tracing::debug!(
             edge_id = %edge.id,
-            expires_at = %edge.expires_at.as_ref().expect("checked above"),
+            expires_at = %expires_at,
             "hiding expiring edge without created_at from active projection"
         );
         return false;
@@ -236,7 +265,7 @@ pub(crate) fn edge_is_active_at(edge: &Edge, now: DateTime<Utc>) -> bool {
     };
 
     let expires_at_value = match edge.expires_at.as_ref() {
-        Some(expires_at) => {
+        Some(Some(expires_at)) => {
             let Some(expires_at_value) = expires_at.parsed() else {
                 tracing::debug!(
                     edge_id = %edge.id,
@@ -258,6 +287,19 @@ pub(crate) fn edge_is_active_at(edge: &Edge, now: DateTime<Utc>) -> bool {
                 return false;
             }
             *expires_at_value
+        }
+        // An explicit `null` paired with a dated `created_at` is exactly the
+        // pairing the domain contract rejects: readers must not be able to
+        // tell a dated Faden with an intentionally unbounded lifetime apart
+        // from one whose expiry was simply never persisted. Fail closed
+        // instead of silently treating it as the omitted/derive case.
+        Some(None) => {
+            tracing::debug!(
+                edge_id = %edge.id,
+                created_at = %created_at_value,
+                "hiding edge with explicit null expires_at paired with a dated created_at from active projection"
+            );
+            return false;
         }
         None => {
             let Some(expires_at_value) = checked_faden_expires_at(*created_at_value) else {
@@ -801,7 +843,7 @@ fn build_edge_record(
         edge_kind: validated.edge_kind,
         note: validated.note,
         created_at: Some(LifecycleTimestamp::from_datetime(created_at)),
-        expires_at: Some(LifecycleTimestamp::from_datetime(expires_at)),
+        expires_at: Some(Some(LifecycleTimestamp::from_datetime(expires_at))),
     };
 
     let mut record = serde_json::Map::new();
@@ -812,7 +854,15 @@ fn build_edge_record(
     record.insert("target_type".into(), json!(edge.target_type));
     record.insert("edge_kind".into(), json!(edge.edge_kind));
     record.insert("created_at".into(), json!(edge.created_at));
-    record.insert("expires_at".into(), json!(edge.expires_at));
+    // `json!` serializes the bare `Option<Option<_>>` value directly rather
+    // than through `Edge`'s field-level `skip_serializing_if`, so both the
+    // omitted and explicit-null states would otherwise collapse to a literal
+    // `null` here. A freshly created edge always carries a concrete server-
+    // derived expiry, so flatten to the inner timestamp before serializing.
+    record.insert(
+        "expires_at".into(),
+        json!(edge.expires_at.clone().flatten()),
+    );
     if let Some(note) = &edge.note {
         record.insert("note".into(), json!(note));
     }
@@ -1836,6 +1886,8 @@ mod tests {
     use chrono::{DateTime, Duration, TimeZone, Utc};
     use serial_test::serial;
 
+    /// `expires_at: None` models an omitted key (legacy dated Fäden); use
+    /// [`lifecycle_edge_with_null_expiry`] to model an explicit `null`.
     fn lifecycle_edge(created_at: Option<&str>, expires_at: Option<&str>) -> Edge {
         Edge {
             id: "00000000-0000-0000-0000-0000000000e1".to_string(),
@@ -1846,8 +1898,16 @@ mod tests {
             edge_kind: "reference".to_string(),
             note: None,
             created_at: created_at.map(LifecycleTimestamp::from),
-            expires_at: expires_at.map(LifecycleTimestamp::from),
+            expires_at: expires_at.map(|value| Some(LifecycleTimestamp::from(value))),
         }
+    }
+
+    /// Models a persisted record carrying an explicit `expires_at: null`,
+    /// distinct from the omitted key that [`lifecycle_edge`] produces.
+    fn lifecycle_edge_with_null_expiry(created_at: Option<&str>) -> Edge {
+        let mut edge = lifecycle_edge(created_at, None);
+        edge.expires_at = Some(None);
+        edge
     }
 
     #[test]
@@ -1896,7 +1956,7 @@ mod tests {
             Some("2026-07-17T10:00:00.123456Z")
         );
         assert_eq!(
-            edge.expires_at.as_deref(),
+            edge.expires_at.clone().flatten().as_deref(),
             Some("2026-07-24T10:00:00.123456Z")
         );
         assert_eq!(
@@ -1905,7 +1965,7 @@ mod tests {
         );
         assert_eq!(
             record.get("expires_at"),
-            Some(&serde_json::json!(edge.expires_at))
+            Some(&serde_json::json!(edge.expires_at.clone().flatten()))
         );
         let round_trip: Edge = serde_json::from_value(record).expect("JSONL round trip");
         assert_eq!(round_trip.expires_at, edge.expires_at);
@@ -1968,6 +2028,27 @@ mod tests {
         ));
         assert!(!edge_is_active_at(
             &lifecycle_edge(Some("2026-07-17T10:00:00Z"), Some("2026-07-25T10:00:00Z"),),
+            now
+        ));
+    }
+
+    /// A JSONL/PostgreSQL record whose stored `expires_at` is an explicit
+    /// `null` — as opposed to the field simply being omitted — must not be
+    /// treated as "no stored expiry, derive one". That noncanonical pairing
+    /// is exactly what the domain schema rejects, so it has to fail closed
+    /// instead of silently reusing the omitted-key derivation path.
+    #[test]
+    fn dated_edge_with_explicit_null_expiry_fails_closed() {
+        let now = Utc.with_ymd_and_hms(2026, 7, 18, 10, 0, 0).unwrap();
+        let dated_explicit_null = lifecycle_edge_with_null_expiry(Some("2026-07-17T10:00:00Z"));
+        assert_eq!(dated_explicit_null.expires_at, Some(None));
+        assert!(!edge_is_active_at(&dated_explicit_null, now));
+        assert_eq!(projected_faden_expires_at(&dated_explicit_null), None);
+
+        // Paired with an equally undated `created_at`, an explicit null
+        // expiry remains the accepted fully-undated legacy state.
+        assert!(edge_is_active_at(
+            &lifecycle_edge_with_null_expiry(None),
             now
         ));
     }

--- a/apps/api/src/routes/edges.rs
+++ b/apps/api/src/routes/edges.rs
@@ -375,6 +375,27 @@ pub async fn load_edges() -> OrderedCache<Edge> {
     let max_edges = max_edges_cache_limit();
 
     while let Ok(Some(line)) = lines.next_line().await {
+        let edge: Edge = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(e) => {
+                // Secure logging: avoid logging full payload, just length and error
+                tracing::warn!(error = %e, line_len = line.len(), "failed to parse edge JSON");
+                continue;
+            }
+        };
+
+        // Checked before the cache-limit gate, mirroring the PostgreSQL
+        // loader: a record that can never be active for any `now` must not
+        // consume one of the `max_edges` slots that a genuinely reachable
+        // edge would need.
+        if edge_is_permanently_unreachable(&edge) {
+            tracing::warn!(
+                edge_id = %edge.id,
+                "skipping domain edge that can never be active under any lifecycle rule"
+            );
+            continue;
+        }
+
         if records_read >= max_edges {
             tracing::warn!(
                 ?path,
@@ -385,14 +406,6 @@ pub async fn load_edges() -> OrderedCache<Edge> {
         }
         records_read += 1;
 
-        let edge: Edge = match serde_json::from_str(&line) {
-            Ok(v) => v,
-            Err(e) => {
-                // Secure logging: avoid logging full payload, just length and error
-                tracing::warn!(error = %e, line_len = line.len(), "failed to parse edge JSON");
-                continue;
-            }
-        };
         if edges.insert(edge.id.clone(), edge) {
             duplicates_count += 1;
         }
@@ -754,10 +767,14 @@ struct EdgePersistenceStatus {
 }
 
 /// Scan the persisted edges file once before an append, mirroring
-/// [`load_edges`] semantics: every line counts toward the cache limit,
-/// unparseable lines are skipped, and a final unterminated line is still read.
-/// The whole file is scanned — also beyond the limit — so duplicate ids and an
-/// earlier operation result in an unmaterialized suffix remain detectable. A
+/// [`load_edges`] semantics: a line counts toward the cache limit only if it
+/// parses into an edge that could ever be active (matching
+/// [`edge_is_permanently_unreachable`]); unparseable lines are skipped, and a
+/// final unterminated line is still read. The whole file is scanned — also
+/// beyond the limit — so duplicate ids and an earlier operation result in an
+/// unmaterialized suffix remain detectable regardless of lifecycle validity:
+/// an id must never be reusable just because the record that first claimed
+/// it later became lifecycle-invalid or fell out of cache capacity. A
 /// missing file means an empty persistence source. Callers MUST hold the
 /// `edge_create_persist_lock`.
 async fn inspect_edge_persistence_for_create(
@@ -784,7 +801,6 @@ async fn inspect_edge_persistence_for_create(
     let mut existing_operation = None;
 
     while let Some(line) = lines.next_line().await? {
-        lines_read += 1;
         let value: Value = match serde_json::from_str(&line) {
             Ok(value) => value,
             // The loader skips unparseable lines; mirror that instead of
@@ -809,6 +825,11 @@ async fn inspect_edge_persistence_for_create(
             Err(_) => continue,
         };
 
+        // Duplicate-id and operation-replay detection must see every
+        // parseable line regardless of lifecycle validity: an id must stay
+        // permanently claimed even if the record that claimed it can never
+        // be active. Only the cache-limit accounting below mirrors the
+        // loader's admission rule.
         if edge.id == id {
             duplicate_id = true;
         }
@@ -819,7 +840,11 @@ async fn inspect_edge_persistence_for_create(
                     "duplicate edge create operation metadata",
                 ));
             }
-            existing_operation = Some(edge);
+            existing_operation = Some(edge.clone());
+        }
+
+        if !edge_is_permanently_unreachable(&edge) {
+            lines_read += 1;
         }
     }
 

--- a/apps/api/src/routes/edges.rs
+++ b/apps/api/src/routes/edges.rs
@@ -235,56 +235,46 @@ fn projected_faden_expires_at(edge: &Edge) -> Option<String> {
     Some(expires_at.to_rfc3339_opts(SecondsFormat::AutoSi, true))
 }
 
-/// Active-read predicate for Faden projections.
+/// The time-bound window during which an edge is active, or [`Unbounded`]
+/// for the fully undated legacy state that has no expiry at all.
 ///
-/// A missing `expires_at` is derived from a valid `created_at`, so Fäden created
-/// before the lifecycle feature age exactly like new projections. Only records
-/// with neither timestamp remain visible as undated legacy data. Malformed or
-/// non-canonical lifecycle data fails closed. The exact boundary is exclusive,
-/// so a Faden is gone at `now == expires_at`.
-pub(crate) fn edge_is_active_at(edge: &Edge, now: DateTime<Utc>) -> bool {
+/// [`Unbounded`]: EdgeLifecycleWindow::Unbounded
+enum EdgeLifecycleWindow {
+    Unbounded,
+    Bounded {
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+    },
+}
+
+/// Resolve an edge's lifecycle window, or `Err` with a short reason when the
+/// edge is invalid or non-canonical and therefore can never be active for
+/// *any* `now`. Shared by [`edge_is_active_at`] (the per-request read gate)
+/// and [`edge_is_permanently_unreachable`] (the PostgreSQL loader's
+/// cache-admission gate), so both agree on exactly which persisted rows can
+/// never surface through any read endpoint.
+fn edge_lifecycle_window(edge: &Edge) -> Result<EdgeLifecycleWindow, &'static str> {
     let Some(created_at) = edge.created_at.as_ref() else {
-        let Some(Some(expires_at)) = edge.expires_at.as_ref() else {
-            return true;
+        return if matches!(edge.expires_at, Some(Some(_))) {
+            Err("expiring edge without created_at")
+        } else {
+            Ok(EdgeLifecycleWindow::Unbounded)
         };
-        tracing::debug!(
-            edge_id = %edge.id,
-            expires_at = %expires_at,
-            "hiding expiring edge without created_at from active projection"
-        );
-        return false;
     };
 
     let Some(created_at_value) = created_at.parsed() else {
-        tracing::debug!(
-            edge_id = %edge.id,
-            created_at_raw = %created_at,
-            "hiding edge with invalid created_at from active projection"
-        );
-        return false;
+        return Err("invalid created_at");
     };
 
     let expires_at_value = match edge.expires_at.as_ref() {
         Some(Some(expires_at)) => {
             let Some(expires_at_value) = expires_at.parsed() else {
-                tracing::debug!(
-                    edge_id = %edge.id,
-                    created_at_raw = %created_at,
-                    expires_at_raw = %expires_at,
-                    "hiding edge with invalid lifecycle timestamp from active projection"
-                );
-                return false;
+                return Err("invalid lifecycle timestamp");
             };
-            if expires_at_value.signed_duration_since(created_at_value)
+            if expires_at_value.signed_duration_since(*created_at_value)
                 != Duration::hours(FADEN_LIFETIME_HOURS)
             {
-                tracing::debug!(
-                    edge_id = %edge.id,
-                    created_at = %created_at_value,
-                    expires_at = %expires_at_value,
-                    "hiding edge with non-canonical Faden lifetime from active projection"
-                );
-                return false;
+                return Err("non-canonical Faden lifetime");
             }
             *expires_at_value
         }
@@ -293,28 +283,47 @@ pub(crate) fn edge_is_active_at(edge: &Edge, now: DateTime<Utc>) -> bool {
         // tell a dated Faden with an intentionally unbounded lifetime apart
         // from one whose expiry was simply never persisted. Fail closed
         // instead of silently treating it as the omitted/derive case.
-        Some(None) => {
-            tracing::debug!(
-                edge_id = %edge.id,
-                created_at = %created_at_value,
-                "hiding edge with explicit null expires_at paired with a dated created_at from active projection"
-            );
-            return false;
-        }
+        Some(None) => return Err("explicit null expires_at paired with a dated created_at"),
         None => {
             let Some(expires_at_value) = checked_faden_expires_at(*created_at_value) else {
-                tracing::debug!(
-                    edge_id = %edge.id,
-                    created_at = %created_at_value,
-                    "hiding legacy edge whose derived expiry exceeds the supported timestamp range"
-                );
-                return false;
+                return Err("derived expiry exceeds the supported timestamp range");
             };
             expires_at_value
         }
     };
 
-    now >= *created_at_value && now < expires_at_value
+    Ok(EdgeLifecycleWindow::Bounded {
+        start: *created_at_value,
+        end: expires_at_value,
+    })
+}
+
+/// Active-read predicate for Faden projections.
+///
+/// A missing `expires_at` is derived from a valid `created_at`, so Fäden created
+/// before the lifecycle feature age exactly like new projections. Only records
+/// with neither timestamp remain visible as undated legacy data. Malformed or
+/// non-canonical lifecycle data fails closed. The exact boundary is exclusive,
+/// so a Faden is gone at `now == expires_at`.
+pub(crate) fn edge_is_active_at(edge: &Edge, now: DateTime<Utc>) -> bool {
+    match edge_lifecycle_window(edge) {
+        Err(reason) => {
+            tracing::debug!(edge_id = %edge.id, reason, "hiding edge from active projection");
+            false
+        }
+        Ok(EdgeLifecycleWindow::Unbounded) => true,
+        Ok(EdgeLifecycleWindow::Bounded { start, end }) => now >= start && now < end,
+    }
+}
+
+/// `true` when an edge can never be active for *any* `now` — invalid or
+/// non-canonical lifecycle data (for example a dated `created_at` paired
+/// with an explicit `expires_at: null`). Such a row can never be surfaced by
+/// any read endpoint, so the PostgreSQL loader excludes it from the
+/// fixed-size edge cache instead of letting it occupy a slot that a
+/// genuinely reachable edge would need.
+pub(crate) fn edge_is_permanently_unreachable(edge: &Edge) -> bool {
+    edge_lifecycle_window(edge).is_err()
 }
 
 fn edge_matches_list_at(
@@ -1879,8 +1888,9 @@ mod edge_create {
 mod tests {
     use super::{
         build_edge_record, edge_create::ValidatedCreateEdge, edge_is_active_at,
-        edge_matches_list_at, faden_expires_at, max_edges_cache_limit, projected_faden_expires_at,
-        Edge, LifecycleTimestamp, PublicEdge, DEFAULT_MAX_EDGES_CACHE, FADEN_LIFETIME_HOURS,
+        edge_is_permanently_unreachable, edge_matches_list_at, faden_expires_at,
+        max_edges_cache_limit, projected_faden_expires_at, Edge, LifecycleTimestamp, PublicEdge,
+        DEFAULT_MAX_EDGES_CACHE, FADEN_LIFETIME_HOURS,
     };
     use crate::test_helpers::EnvGuard;
     use chrono::{DateTime, Duration, TimeZone, Utc};
@@ -2051,6 +2061,37 @@ mod tests {
             &lifecycle_edge_with_null_expiry(None),
             now
         ));
+    }
+
+    /// `edge_is_permanently_unreachable` must agree with `edge_is_active_at`
+    /// on exactly which edges can never be active for any `now`. A loader
+    /// that used a different rule could admit a permanently-invalid row into
+    /// a fixed-size cache, wasting a slot a genuinely reachable edge needs.
+    #[test]
+    fn permanently_unreachable_matches_every_always_inactive_shape() {
+        let now = Utc.with_ymd_and_hms(2026, 7, 18, 10, 0, 0).unwrap();
+
+        let always_unreachable = [
+            lifecycle_edge_with_null_expiry(Some("2026-07-17T10:00:00Z")),
+            lifecycle_edge(Some("invalid"), Some("2026-07-24T10:00:00Z")),
+            lifecycle_edge(Some("invalid"), None),
+            lifecycle_edge(None, Some("2026-07-24T10:00:00Z")),
+            lifecycle_edge(Some("2026-07-17T10:00:00Z"), Some("2026-07-25T10:00:00Z")),
+        ];
+        for edge in always_unreachable {
+            assert!(edge_is_permanently_unreachable(&edge));
+            assert!(!edge_is_active_at(&edge, now));
+        }
+
+        let reachable = [
+            lifecycle_edge(None, None),
+            lifecycle_edge_with_null_expiry(None),
+            lifecycle_edge(Some("2026-07-17T10:00:00Z"), None),
+            lifecycle_edge(Some("2026-07-17T10:00:00Z"), Some("2026-07-24T10:00:00Z")),
+        ];
+        for edge in reachable {
+            assert!(!edge_is_permanently_unreachable(&edge));
+        }
     }
 
     /// Undated legacy edges must project as an explicit JSON null/null pair

--- a/apps/api/tests/api_accounts.rs
+++ b/apps/api/tests/api_accounts.rs
@@ -4,6 +4,7 @@ use axum::{
     http::{Request, StatusCode},
     Router,
 };
+use chrono::{Duration, SecondsFormat, Utc};
 mod helpers;
 
 use helpers::{assert_account_has_single_node_relation, read_account_details, test_node};
@@ -23,6 +24,15 @@ use weltgewebe_api::{
     state::{ApiState, OrderedCache},
     telemetry::{BuildInfo, Metrics},
 };
+
+fn active_faden_timestamps() -> (String, String) {
+    let created_at = Utc::now() - Duration::hours(1);
+    let expires_at = created_at + Duration::hours(168);
+    (
+        created_at.to_rfc3339_opts(SecondsFormat::Micros, true),
+        expires_at.to_rfc3339_opts(SecondsFormat::Micros, true),
+    )
+}
 
 async fn test_state() -> Result<ApiState> {
     let metrics = Metrics::try_new(BuildInfo {
@@ -432,7 +442,7 @@ async fn accounts_cursor_limit_zero_is_bad_request() -> Result<()> {
 async fn account_details_project_outgoing_relation_without_public_note() -> Result<()> {
     const ACCOUNT_ID: &str = "account-1";
     const NODE_ID: &str = "node-1";
-    const CREATED_AT: &str = "2026-07-11T11:11:50.322307+00:00";
+    let (created_at, expires_at) = active_faden_timestamps();
 
     let mut state = test_state().await?;
     let mut accounts = AccountStore::new();
@@ -460,8 +470,8 @@ async fn account_details_project_outgoing_relation_without_public_note() -> Resu
             target_type: Some("node".to_string()),
             edge_kind: "reference".to_string(),
             note: Some("nicht öffentlich".to_string()),
-            created_at: Some(CREATED_AT.to_string().into()),
-            expires_at: None,
+            created_at: Some(created_at.clone().into()),
+            expires_at: Some(expires_at.into()),
         },
     );
     state.edges = Arc::new(RwLock::new(edges));
@@ -478,7 +488,7 @@ async fn account_details_project_outgoing_relation_without_public_note() -> Resu
         "reference",
         "Hat den Knoten \"fairschenkbox\" geknüpft.",
     );
-    assert_eq!(projected_at, CREATED_AT);
+    assert_eq!(projected_at, created_at);
 
     Ok(())
 }
@@ -529,7 +539,7 @@ async fn account_details_omit_expired_faden_projection() -> Result<()> {
 async fn account_details_attribute_incoming_admin_relation_neutrally() -> Result<()> {
     const ACCOUNT_ID: &str = "account-incoming";
     const NODE_ID: &str = "node-incoming";
-    const CREATED_AT: &str = "2026-07-12T12:00:00+00:00";
+    let (created_at, expires_at) = active_faden_timestamps();
 
     let mut state = test_state().await?;
     let mut accounts = AccountStore::new();
@@ -554,8 +564,8 @@ async fn account_details_attribute_incoming_admin_relation_neutrally() -> Result
             target_type: Some("account".to_string()),
             edge_kind: "reference".to_string(),
             note: Some("interne Importnotiz".to_string()),
-            created_at: Some(CREATED_AT.to_string().into()),
-            expires_at: None,
+            created_at: Some(created_at.clone().into()),
+            expires_at: Some(expires_at.into()),
         },
     );
     state.edges = Arc::new(RwLock::new(edges));
@@ -570,7 +580,7 @@ async fn account_details_attribute_incoming_admin_relation_neutrally() -> Result
         "reference",
         "Wurde über einen Faden mit dem Knoten \"Importknoten\" verknüpft.",
     );
-    assert_eq!(projected_at, CREATED_AT);
+    assert_eq!(projected_at, created_at);
 
     Ok(())
 }

--- a/apps/api/tests/api_accounts.rs
+++ b/apps/api/tests/api_accounts.rs
@@ -471,7 +471,7 @@ async fn account_details_project_outgoing_relation_without_public_note() -> Resu
             edge_kind: "reference".to_string(),
             note: Some("nicht öffentlich".to_string()),
             created_at: Some(created_at.clone().into()),
-            expires_at: Some(expires_at.into()),
+            expires_at: Some(Some(expires_at.into())),
         },
     );
     state.edges = Arc::new(RwLock::new(edges));
@@ -522,7 +522,7 @@ async fn account_details_omit_expired_faden_projection() -> Result<()> {
             edge_kind: "reference".to_string(),
             note: None,
             created_at: Some("2020-01-01T00:00:00Z".to_string().into()),
-            expires_at: Some("2020-01-08T00:00:00Z".to_string().into()),
+            expires_at: Some(Some("2020-01-08T00:00:00Z".to_string().into())),
         },
     );
     state.edges = Arc::new(RwLock::new(edges));
@@ -565,7 +565,7 @@ async fn account_details_attribute_incoming_admin_relation_neutrally() -> Result
             edge_kind: "reference".to_string(),
             note: Some("interne Importnotiz".to_string()),
             created_at: Some(created_at.clone().into()),
-            expires_at: Some(expires_at.into()),
+            expires_at: Some(Some(expires_at.into())),
         },
     );
     state.edges = Arc::new(RwLock::new(edges));

--- a/apps/api/tests/api_edges.rs
+++ b/apps/api/tests/api_edges.rs
@@ -269,7 +269,8 @@ async fn edges_invalid_limit() -> anyhow::Result<()> {
 
 #[tokio::test]
 #[serial]
-async fn expired_edges_are_hidden_before_pagination_and_from_single_get() -> anyhow::Result<()> {
+async fn expired_and_pre_lifecycle_edges_are_hidden_before_pagination_and_single_get(
+) -> anyhow::Result<()> {
     let tmp = make_tmp_dir();
     let in_dir = tmp.path().join("in");
     let edges_path = in_dir.join("demo.edges.jsonl");
@@ -279,6 +280,7 @@ async fn expired_edges_are_hidden_before_pagination_and_from_single_get() -> any
         &edges_path,
         &[
             r#"{"id":"e-expired","source_id":"n1","target_id":"n2","edge_kind":"reference","created_at":"2020-01-01T00:00:00Z","expires_at":"2020-01-08T00:00:00Z"}"#,
+            r#"{"id":"e-pre-lifecycle","source_id":"n1","target_id":"n4","edge_kind":"reference","created_at":"2020-01-01T00:00:00Z"}"#,
             r#"{"id":"e-active","source_id":"n1","target_id":"n3","edge_kind":"reference"}"#,
         ],
     );
@@ -313,7 +315,13 @@ async fn expired_edges_are_hidden_before_pagination_and_from_single_get() -> any
     assert_eq!(items[0]["id"], "e-active");
 
     let res = app
+        .clone()
         .oneshot(Request::get("/edges/e-expired").body(body::Body::empty())?)
+        .await?;
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+
+    let res = app
+        .oneshot(Request::get("/edges/e-pre-lifecycle").body(body::Body::empty())?)
         .await?;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
 

--- a/apps/api/tests/api_edges.rs
+++ b/apps/api/tests/api_edges.rs
@@ -1416,6 +1416,40 @@ async fn post_edges_rejects_create_when_edge_cache_limit_reached() -> Result<()>
     Ok(())
 }
 
+/// A dated edge with an explicit `expires_at: null` is structurally
+/// well-formed but permanently unreachable per `edge_is_active_at` — it must
+/// not fill the cache-limit slot that a genuinely reachable edge would need,
+/// so a create must succeed instead of hitting the cache-limit gate.
+#[tokio::test]
+#[serial]
+async fn post_edges_admits_create_when_limit_filled_by_permanently_unreachable_row() -> Result<()> {
+    let tmp = make_tmp_dir();
+    let in_dir = tmp.path().join("in");
+    let edges_path = in_dir.join("demo.edges.jsonl");
+    let _env = set_gewebe_in_dir(&in_dir);
+    let _limit = EnvGuard::set("MAX_EDGES_CACHE", "1");
+
+    const UNREACHABLE_ID: &str = "00000000-0000-0000-0000-0000000000ad";
+    let unreachable_line = format!(
+        r#"{{"id":"{UNREACHABLE_ID}","source_id":"{CREATE_SOURCE_ID}","target_id":"{CREATE_TARGET_ID}","edge_kind":"reference","created_at":"2026-06-01T00:00:00Z","expires_at":null}}"#
+    );
+    write_lines(&edges_path, &[unreachable_line.as_str()]);
+
+    let (app, cookie, state) = app_with_session(Role::Weber, DomainReadSource::Jsonl).await?;
+    // The permanently unreachable row does not consume the single slot.
+    assert_eq!(state.edges.read().await.len(), 0);
+
+    let res = app
+        .oneshot(post_edges(Some(&cookie), &valid_create_body()))
+        .await?;
+    assert_eq!(res.status(), StatusCode::CREATED);
+
+    assert_eq!(jsonl_lines(&edges_path).len(), 2);
+    assert_eq!(state.edges.read().await.len(), 1);
+
+    Ok(())
+}
+
 #[tokio::test]
 #[serial]
 async fn post_edges_rejects_duplicate_id_in_unloaded_edge_suffix() -> Result<()> {

--- a/apps/api/tests/api_edges.rs
+++ b/apps/api/tests/api_edges.rs
@@ -867,7 +867,13 @@ async fn post_edges_creates_edge_in_jsonl_mode() -> Result<()> {
         let cache = state.edges.read().await;
         let cached = cache.get(&id).context("edge must be in cache")?;
         assert_eq!(cached.created_at.as_deref(), Some(created_at.as_str()));
-        assert_eq!(cached.expires_at.as_deref(), Some(expires_at.as_str()));
+        assert_eq!(
+            cached
+                .expires_at
+                .as_ref()
+                .and_then(|inner| inner.as_deref()),
+            Some(expires_at.as_str())
+        );
         assert_eq!(cached.source_type.as_deref(), Some("node"));
         assert_eq!(cached.target_type.as_deref(), Some("node"));
     }

--- a/apps/api/tests/db_domain_edge_write_path.rs
+++ b/apps/api/tests/db_domain_edge_write_path.rs
@@ -987,3 +987,114 @@ async fn postgres_edge_create_admits_when_limit_filled_by_permanently_unreachabl
     clean(&pool).await;
     Ok(())
 }
+
+/// Same as above, but the permanently unreachable row carries a malformed
+/// (non-string, non-null) `expires_at` payload value instead of an explicit
+/// `null` — `edge_is_permanently_unreachable` rejects this shape via the
+/// same `jsonb_typeof` check regardless of `created_at`.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
+#[serial]
+async fn postgres_edge_create_admits_when_limit_filled_by_malformed_expiry_row() -> Result<()> {
+    let pool = connect_pool().await;
+    run_migrations(&pool).await;
+    clean(&pool).await;
+
+    let (base_count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM domain_edges")
+        .fetch_one(&pool)
+        .await?;
+
+    let target_limit = base_count + 1;
+    let _env_guard = EnvVarGuard::set("MAX_EDGES_CACHE", target_limit.to_string());
+
+    sqlx::query(
+        "INSERT INTO domain_edges (id, source_id, target_id, edge_kind, created_at, payload) \
+         VALUES ($1, $2, $3, 'reference', '2026-06-01T00:00:00Z', '{\"expires_at\": 12345}'::jsonb)",
+    )
+    .bind(EDGE_ID_DUP)
+    .bind(NODE_ID)
+    .bind(ACCOUNT_ID)
+    .execute(&pool)
+    .await
+    .expect("seed malformed edge row");
+
+    let tmp = tempfile::tempdir()?;
+    let in_dir = tmp.path().join("in");
+    std::fs::create_dir_all(&in_dir)?;
+    let _env = set_gewebe_in_dir(&in_dir);
+
+    let (app, cookie, state) = edge_write_app(
+        pool.clone(),
+        "writepath-edge-writer-limit-malformed",
+        Role::Admin,
+        DomainReadSource::Postgres,
+        DomainEdgeWriteSource::Postgres,
+    )
+    .await?;
+    assert!(state.edges.read().await.get(EDGE_ID_DUP).is_none());
+
+    let res = app
+        .oneshot(post_edges_req(&cookie, &create_body(EDGE_ID_A, None)))
+        .await?;
+    assert_eq!(res.status(), StatusCode::CREATED);
+    assert!(state.edges.read().await.get(EDGE_ID_A).is_some());
+
+    clean(&pool).await;
+    Ok(())
+}
+
+/// Same as above, but the permanently unreachable row is undated
+/// (`created_at IS NULL`) with a concrete `expires_at` string — the
+/// "expiring edge without created_at" shape `edge_is_permanently_unreachable`
+/// also rejects.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
+#[serial]
+async fn postgres_edge_create_admits_when_limit_filled_by_undated_row_with_expiry() -> Result<()> {
+    let pool = connect_pool().await;
+    run_migrations(&pool).await;
+    clean(&pool).await;
+
+    let (base_count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM domain_edges")
+        .fetch_one(&pool)
+        .await?;
+
+    let target_limit = base_count + 1;
+    let _env_guard = EnvVarGuard::set("MAX_EDGES_CACHE", target_limit.to_string());
+
+    sqlx::query(
+        "INSERT INTO domain_edges (id, source_id, target_id, edge_kind, created_at, payload) \
+         VALUES ($1, $2, $3, 'reference', NULL, \
+         '{\"expires_at\": \"2026-06-08T00:00:00Z\"}'::jsonb)",
+    )
+    .bind(EDGE_ID_DUP)
+    .bind(NODE_ID)
+    .bind(ACCOUNT_ID)
+    .execute(&pool)
+    .await
+    .expect("seed undated edge row with a concrete expiry");
+
+    let tmp = tempfile::tempdir()?;
+    let in_dir = tmp.path().join("in");
+    std::fs::create_dir_all(&in_dir)?;
+    let _env = set_gewebe_in_dir(&in_dir);
+
+    let (app, cookie, state) = edge_write_app(
+        pool.clone(),
+        "writepath-edge-writer-limit-undated",
+        Role::Admin,
+        DomainReadSource::Postgres,
+        DomainEdgeWriteSource::Postgres,
+    )
+    .await?;
+    assert!(state.edges.read().await.get(EDGE_ID_DUP).is_none());
+
+    let res = app
+        .oneshot(post_edges_req(&cookie, &create_body(EDGE_ID_A, None)))
+        .await?;
+    assert_eq!(res.status(), StatusCode::CREATED);
+    assert!(state.edges.read().await.get(EDGE_ID_A).is_some());
+
+    clean(&pool).await;
+    Ok(())
+}

--- a/apps/api/tests/db_domain_edge_write_path.rs
+++ b/apps/api/tests/db_domain_edge_write_path.rs
@@ -1098,3 +1098,70 @@ async fn postgres_edge_create_admits_when_limit_filled_by_undated_row_with_expir
     clean(&pool).await;
     Ok(())
 }
+
+/// A dated row whose payload is a JSON *array* rather than an object (e.g.
+/// `["expires_at"]`) is not permanently unreachable: `payload_lifecycle_field`
+/// looks up keys via `Value::get`, which returns `None` for any non-object
+/// value regardless of content, so the loader treats it exactly like an
+/// empty object payload — a reachable dated legacy edge with an omitted
+/// expiry. The write-capacity check must count it too (unlike the
+/// permanently-unreachable rows above), so a create at capacity must still
+/// be rejected.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
+#[serial]
+async fn postgres_edge_create_rejects_when_limit_filled_by_non_object_payload_row() -> Result<()> {
+    let pool = connect_pool().await;
+    run_migrations(&pool).await;
+    clean(&pool).await;
+
+    let (base_count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM domain_edges")
+        .fetch_one(&pool)
+        .await?;
+
+    let target_limit = base_count + 1;
+    let _env_guard = EnvVarGuard::set("MAX_EDGES_CACHE", target_limit.to_string());
+
+    // A non-object payload happening to contain the string "expires_at" as
+    // an array element: PostgreSQL's `?` operator matches array elements as
+    // well as object keys, which is exactly the trap a naive exclusion falls
+    // into.
+    sqlx::query(
+        "INSERT INTO domain_edges (id, source_id, target_id, edge_kind, created_at, payload) \
+         VALUES ($1, $2, $3, 'reference', '2026-06-01T00:00:00Z', '[\"expires_at\"]'::jsonb)",
+    )
+    .bind(EDGE_ID_DUP)
+    .bind(NODE_ID)
+    .bind(ACCOUNT_ID)
+    .execute(&pool)
+    .await
+    .expect("seed non-object-payload edge row");
+
+    let tmp = tempfile::tempdir()?;
+    let in_dir = tmp.path().join("in");
+    std::fs::create_dir_all(&in_dir)?;
+    let _env = set_gewebe_in_dir(&in_dir);
+
+    let (app, cookie, state) = edge_write_app(
+        pool.clone(),
+        "writepath-edge-writer-limit-nonobject",
+        Role::Admin,
+        DomainReadSource::Postgres,
+        DomainEdgeWriteSource::Postgres,
+    )
+    .await?;
+    // The loader admits this row as a reachable dated legacy edge, occupying
+    // the single available slot.
+    assert!(state.edges.read().await.get(EDGE_ID_DUP).is_some());
+
+    let res = app
+        .oneshot(post_edges_req(&cookie, &create_body(EDGE_ID_A, None)))
+        .await?;
+    assert_eq!(res.status(), StatusCode::CONFLICT);
+    let text = read_text_body(res).await?;
+    assert!(text.contains("edge cache limit reached"), "body: {text}");
+    assert!(state.edges.read().await.get(EDGE_ID_A).is_none());
+
+    clean(&pool).await;
+    Ok(())
+}

--- a/apps/api/tests/db_domain_edge_write_path.rs
+++ b/apps/api/tests/db_domain_edge_write_path.rs
@@ -928,3 +928,62 @@ async fn postgres_edge_create_rejects_when_cache_limit_reached() -> Result<()> {
     clean(&pool).await;
     Ok(())
 }
+
+/// A dated row with an explicit `expires_at: null` payload is permanently
+/// unreachable per `edge_is_active_at` and the read loader excludes it from
+/// cache capacity; the write-capacity check must not still count it, or a
+/// row declared not to consume cache capacity would permanently block
+/// otherwise-valid creates.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
+#[serial]
+async fn postgres_edge_create_admits_when_limit_filled_by_permanently_unreachable_row() -> Result<()>
+{
+    let pool = connect_pool().await;
+    run_migrations(&pool).await;
+    clean(&pool).await;
+
+    let (base_count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM domain_edges")
+        .fetch_one(&pool)
+        .await?;
+
+    let target_limit = base_count + 1;
+    let _env_guard = EnvVarGuard::set("MAX_EDGES_CACHE", target_limit.to_string());
+
+    // Fill the "limit" with a permanently unreachable row instead of a
+    // genuinely reachable one.
+    sqlx::query(
+        "INSERT INTO domain_edges (id, source_id, target_id, edge_kind, created_at, payload) \
+         VALUES ($1, $2, $3, 'reference', '2026-06-01T00:00:00Z', '{\"expires_at\": null}'::jsonb)",
+    )
+    .bind(EDGE_ID_DUP)
+    .bind(NODE_ID)
+    .bind(ACCOUNT_ID)
+    .execute(&pool)
+    .await
+    .expect("seed permanently unreachable edge row");
+
+    let tmp = tempfile::tempdir()?;
+    let in_dir = tmp.path().join("in");
+    std::fs::create_dir_all(&in_dir)?;
+    let _env = set_gewebe_in_dir(&in_dir);
+
+    let (app, cookie, state) = edge_write_app(
+        pool.clone(),
+        "writepath-edge-writer-limit-unreachable",
+        Role::Admin,
+        DomainReadSource::Postgres,
+        DomainEdgeWriteSource::Postgres,
+    )
+    .await?;
+    assert!(state.edges.read().await.get(EDGE_ID_DUP).is_none());
+
+    let res = app
+        .oneshot(post_edges_req(&cookie, &create_body(EDGE_ID_A, None)))
+        .await?;
+    assert_eq!(res.status(), StatusCode::CREATED);
+    assert!(state.edges.read().await.get(EDGE_ID_A).is_some());
+
+    clean(&pool).await;
+    Ok(())
+}

--- a/apps/api/tests/db_domain_read_path.rs
+++ b/apps/api/tests/db_domain_read_path.rs
@@ -97,6 +97,49 @@ async fn edges_loader_respects_max_edges_cache_limit() {
 #[tokio::test]
 #[ignore]
 #[serial]
+async fn edges_loader_skips_malformed_rows_without_losing_later_valid_edges() {
+    let pool = prepare_pool().await;
+    let _limit = EnvGuard::set("MAX_EDGES_CACHE", "2");
+    // Sort before the valid rows (id ascending) and carry a structurally
+    // malformed expires_at payload (neither absent, null, nor a string).
+    for id in ["rp-edge-a", "rp-edge-b"] {
+        sqlx::query(
+            "INSERT INTO domain_edges (id, source_id, target_id, edge_kind, payload) \
+             VALUES ($1, 'rp-node-a', 'rp-node-b', 'relates', '{\"expires_at\": 12345}'::jsonb)",
+        )
+        .bind(id)
+        .execute(&pool)
+        .await
+        .expect("insert malformed edge");
+    }
+    for id in ["rp-edge-c", "rp-edge-d"] {
+        sqlx::query(
+            "INSERT INTO domain_edges (id, source_id, target_id, edge_kind, payload) \
+             VALUES ($1, 'rp-node-a', 'rp-node-b', 'relates', '{}'::jsonb)",
+        )
+        .bind(id)
+        .execute(&pool)
+        .await
+        .expect("insert valid edge");
+    }
+
+    let cache = load_edges_from_postgres(&pool).await.expect("load edges");
+
+    assert_eq!(
+        cache.len(),
+        2,
+        "two malformed rows sorting before two valid rows must not prevent \
+         both later valid edges from loading, even though the cache limit \
+         equals the number of valid edges"
+    );
+    assert!(cache.get("rp-edge-c").is_some());
+    assert!(cache.get("rp-edge-d").is_some());
+    clean(&pool).await;
+}
+
+#[tokio::test]
+#[ignore]
+#[serial]
 async fn accounts_loader_rebuilds_email_index_and_rejects_removed_fields() {
     let pool = prepare_pool().await;
     sqlx::query(

--- a/apps/api/tests/db_domain_read_path.rs
+++ b/apps/api/tests/db_domain_read_path.rs
@@ -140,6 +140,53 @@ async fn edges_loader_skips_malformed_rows_without_losing_later_valid_edges() {
 #[tokio::test]
 #[ignore]
 #[serial]
+async fn edges_loader_excludes_permanently_unreachable_rows_from_cache_capacity() {
+    let pool = prepare_pool().await;
+    let _limit = EnvGuard::set("MAX_EDGES_CACHE", "2");
+    // A dated created_at paired with an explicit `expires_at: null` is
+    // structurally well-formed (not caught by payload_lifecycle_field's
+    // malformed check) but non-canonical: edge_is_active_at rejects it for
+    // every `now`. It must not consume one of the two cache slots.
+    for id in ["rp-edge-a", "rp-edge-b"] {
+        sqlx::query(
+            "INSERT INTO domain_edges (id, source_id, target_id, edge_kind, created_at, payload) \
+             VALUES ($1, 'rp-node-a', 'rp-node-b', 'relates', '2026-06-01T00:00:00Z', \
+             '{\"expires_at\": null}'::jsonb)",
+        )
+        .bind(id)
+        .execute(&pool)
+        .await
+        .expect("insert permanently unreachable edge");
+    }
+    for id in ["rp-edge-c", "rp-edge-d"] {
+        sqlx::query(
+            "INSERT INTO domain_edges (id, source_id, target_id, edge_kind, payload) \
+             VALUES ($1, 'rp-node-a', 'rp-node-b', 'relates', '{}'::jsonb)",
+        )
+        .bind(id)
+        .execute(&pool)
+        .await
+        .expect("insert valid edge");
+    }
+
+    let cache = load_edges_from_postgres(&pool).await.expect("load edges");
+
+    assert_eq!(
+        cache.len(),
+        2,
+        "permanently unreachable rows sorting before valid rows must not \
+         prevent both later valid edges from loading"
+    );
+    assert!(cache.get("rp-edge-c").is_some());
+    assert!(cache.get("rp-edge-d").is_some());
+    assert!(cache.get("rp-edge-a").is_none());
+    assert!(cache.get("rp-edge-b").is_none());
+    clean(&pool).await;
+}
+
+#[tokio::test]
+#[ignore]
+#[serial]
 async fn accounts_loader_rebuilds_email_index_and_rejects_removed_fields() {
     let pool = prepare_pool().await;
     sqlx::query(

--- a/apps/web/src/lib/demo/resolvers.test.ts
+++ b/apps/web/src/lib/demo/resolvers.test.ts
@@ -13,6 +13,7 @@ import {
   getEdgeEntries,
 } from "./resolvers";
 import { demoAccounts, demoEdges, demoNodes } from "./demoData";
+import { normalizeEdgeLifecycle } from "../map/edgeLifecycle";
 
 describe("Demo Resolvers", () => {
   describe("Invariant Checks (Edge Index Safety)", () => {
@@ -75,6 +76,16 @@ describe("Demo Resolvers", () => {
       expect(nodeParticipants.every((relation) => !("note" in relation))).toBe(
         true,
       );
+    });
+
+    it("keeps the static public demo relation visible without fabricating recent activity", () => {
+      const [edge] = listPublicEdges();
+      expect(edge).toEqual(
+        expect.objectContaining({ created_at: null, expires_at: null }),
+      );
+      expect(normalizeEdgeLifecycle(edge).lifecycle).toEqual({
+        kind: "legacy",
+      });
     });
 
     it("resolveEdgeParticipants remains consistent for existing and missing IDs", () => {

--- a/apps/web/src/lib/demo/resolvers.ts
+++ b/apps/web/src/lib/demo/resolvers.ts
@@ -69,7 +69,14 @@ export function resolveEdge(id: string) {
   return edgeMap.get(id);
 }
 
-/** Public edge shape used by prerendered preview endpoints. */
+/**
+ * Public edge shape used by prerendered preview endpoints.
+ *
+ * The static demo cannot truthfully claim that its relation was created within
+ * the last seven days: a build-time timestamp would eventually expire while a
+ * refreshed timestamp would fabricate activity. Project it explicitly as an
+ * undated, non-authoritative preview relation instead.
+ */
 export function toPublicEdge(edge: DemoEdge) {
   return {
     id: edge.id,
@@ -78,7 +85,8 @@ export function toPublicEdge(edge: DemoEdge) {
     target_id: edge.target_id,
     target_type: edge.target_type,
     edge_kind: edge.edge_kind,
-    created_at: edge.created_at,
+    created_at: null,
+    expires_at: null,
   };
 }
 

--- a/apps/web/src/lib/map/edgeLifecycle.test.ts
+++ b/apps/web/src/lib/map/edgeLifecycle.test.ts
@@ -86,6 +86,24 @@ describe("edge lifecycle", () => {
     }
   });
 
+  it("rejects an omitted created_at instead of treating it as undated legacy", () => {
+    const omittedCreatedAt = { ...rawEdge };
+    delete omittedCreatedAt.created_at;
+    delete omittedCreatedAt.expires_at;
+    expect(normalizeEdgeLifecycle(omittedCreatedAt).lifecycle).toEqual({
+      kind: "invalid",
+    });
+
+    const omittedCreatedAtWithNullExpiry = {
+      ...rawEdge,
+      expires_at: null,
+    };
+    delete omittedCreatedAtWithNullExpiry.created_at;
+    expect(
+      normalizeEdgeLifecycle(omittedCreatedAtWithNullExpiry).lifecycle,
+    ).toEqual({ kind: "invalid" });
+  });
+
   it("accepts signed offsets and rejects out-of-range offsets", () => {
     const offsetEdge = normalizeEdgeLifecycle({
       ...rawEdge,

--- a/apps/web/src/lib/map/edgeLifecycle.test.ts
+++ b/apps/web/src/lib/map/edgeLifecycle.test.ts
@@ -36,10 +36,9 @@ describe("edge lifecycle", () => {
   });
 
   it("retroactively ages dated legacy records and preserves only undated legacy", () => {
-    const datedLegacy = normalizeEdgeLifecycle({
-      ...rawEdge,
-      expires_at: null,
-    });
+    const datedLegacyEdge = { ...rawEdge };
+    delete datedLegacyEdge.expires_at;
+    const datedLegacy = normalizeEdgeLifecycle(datedLegacyEdge);
     expect(datedLegacy.lifecycle).toEqual({
       kind: "faden",
       createdAtMs: createdAt,
@@ -65,6 +64,7 @@ describe("edge lifecycle", () => {
         created_at: "invalid",
         expires_at: null,
       }),
+      normalizeEdgeLifecycle({ ...rawEdge, expires_at: null }),
       normalizeEdgeLifecycle({ ...rawEdge, created_at: "2026-07-17" }),
       normalizeEdgeLifecycle({
         ...rawEdge,

--- a/apps/web/src/lib/map/edgeLifecycle.test.ts
+++ b/apps/web/src/lib/map/edgeLifecycle.test.ts
@@ -35,13 +35,36 @@ describe("edge lifecycle", () => {
     expect(edgeOpacityAt(edge, createdAt + FADEN_LIFETIME_MS)).toBe(0);
   });
 
-  it("keeps legacy records visible and fails closed for invalid data", () => {
-    const legacy = normalizeEdgeLifecycle({ ...rawEdge, expires_at: null });
-    expect(legacy.lifecycle).toEqual({ kind: "legacy" });
-    expect(edgeOpacityAt(legacy, createdAt)).toBe(1);
+  it("retroactively ages dated legacy records and preserves only undated legacy", () => {
+    const datedLegacy = normalizeEdgeLifecycle({
+      ...rawEdge,
+      expires_at: null,
+    });
+    expect(datedLegacy.lifecycle).toEqual({
+      kind: "faden",
+      createdAtMs: createdAt,
+      expiresAtMs: createdAt + FADEN_LIFETIME_MS,
+    });
+    expect(edgeOpacityAt(datedLegacy, createdAt)).toBe(1);
+    expect(edgeOpacityAt(datedLegacy, createdAt + FADEN_LIFETIME_MS)).toBe(0);
 
+    const undatedLegacy = normalizeEdgeLifecycle({
+      ...rawEdge,
+      created_at: null,
+      expires_at: null,
+    });
+    expect(undatedLegacy.lifecycle).toEqual({ kind: "legacy" });
+    expect(edgeOpacityAt(undatedLegacy, createdAt)).toBe(1);
+  });
+
+  it("fails closed for invalid data", () => {
     for (const invalid of [
       normalizeEdgeLifecycle({ ...rawEdge, created_at: "invalid" }),
+      normalizeEdgeLifecycle({
+        ...rawEdge,
+        created_at: "invalid",
+        expires_at: null,
+      }),
       normalizeEdgeLifecycle({ ...rawEdge, created_at: "2026-07-17" }),
       normalizeEdgeLifecycle({
         ...rawEdge,

--- a/apps/web/src/lib/map/edgeLifecycle.ts
+++ b/apps/web/src/lib/map/edgeLifecycle.ts
@@ -44,18 +44,26 @@ function parseCanonicalRfc3339Ms(value: string): number | null {
 
 /** Parse lifecycle data once when an edge crosses the API/UI boundary. */
 export function normalizeEdgeLifecycle(edge: Edge): MapEdge {
-  if (edge.expires_at == null) {
-    return { ...edge, lifecycle: { kind: "legacy" } };
-  }
   if (edge.created_at == null) {
-    return { ...edge, lifecycle: { kind: "invalid" } };
+    return {
+      ...edge,
+      lifecycle:
+        edge.expires_at == null ? { kind: "legacy" } : { kind: "invalid" },
+    };
   }
 
   const createdAtMs = parseCanonicalRfc3339Ms(edge.created_at);
-  const expiresAtMs = parseCanonicalRfc3339Ms(edge.expires_at);
+  if (createdAtMs == null) {
+    return { ...edge, lifecycle: { kind: "invalid" } };
+  }
+
+  const expiresAtMs =
+    edge.expires_at == null
+      ? createdAtMs + FADEN_LIFETIME_MS
+      : parseCanonicalRfc3339Ms(edge.expires_at);
   if (
-    createdAtMs == null ||
     expiresAtMs == null ||
+    !Number.isFinite(expiresAtMs) ||
     expiresAtMs - createdAtMs !== FADEN_LIFETIME_MS
   ) {
     return { ...edge, lifecycle: { kind: "invalid" } };

--- a/apps/web/src/lib/map/edgeLifecycle.ts
+++ b/apps/web/src/lib/map/edgeLifecycle.ts
@@ -57,8 +57,12 @@ export function normalizeEdgeLifecycle(edge: Edge): MapEdge {
     return { ...edge, lifecycle: { kind: "invalid" } };
   }
 
+  if (edge.expires_at === null) {
+    return { ...edge, lifecycle: { kind: "invalid" } };
+  }
+
   const expiresAtMs =
-    edge.expires_at == null
+    edge.expires_at === undefined
       ? createdAtMs + FADEN_LIFETIME_MS
       : parseCanonicalRfc3339Ms(edge.expires_at);
   if (

--- a/apps/web/src/lib/map/edgeLifecycle.ts
+++ b/apps/web/src/lib/map/edgeLifecycle.ts
@@ -44,11 +44,20 @@ function parseCanonicalRfc3339Ms(value: string): number | null {
 
 /** Parse lifecycle data once when an edge crosses the API/UI boundary. */
 export function normalizeEdgeLifecycle(edge: Edge): MapEdge {
-  if (edge.created_at == null) {
+  // The canonical public contract always includes `created_at`; an omitted
+  // key is a noncanonical remote response, not the undated-legacy state,
+  // which requires an explicit `null` (paired with an explicit `expires_at:
+  // null`). Fail closed instead of conflating "absent" with "explicitly
+  // undated".
+  if (edge.created_at === undefined) {
+    return { ...edge, lifecycle: { kind: "invalid" } };
+  }
+
+  if (edge.created_at === null) {
     return {
       ...edge,
       lifecycle:
-        edge.expires_at == null ? { kind: "legacy" } : { kind: "invalid" },
+        edge.expires_at === null ? { kind: "legacy" } : { kind: "invalid" },
     };
   }
 

--- a/apps/web/src/lib/map/edgeLifecycle.ts
+++ b/apps/web/src/lib/map/edgeLifecycle.ts
@@ -16,8 +16,7 @@ function parseCanonicalRfc3339Ms(value: string): number | null {
   const hour = Number(match[4]);
   const minute = Number(match[5]);
   const second = Number(match[6]);
-  // The sign is intentionally left to Date.parse; these groups only enforce
-  // RFC3339 offset bounds.
+  // Offset groups only enforce RFC3339 bounds; Date.parse owns the sign.
   const offsetHour = match[7] == null ? 0 : Number(match[7]);
   const offsetMinute = match[8] == null ? 0 : Number(match[8]);
   const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate();
@@ -36,50 +35,38 @@ function parseCanonicalRfc3339Ms(value: string): number | null {
     return null;
   }
 
-  // The regex captures only the offset magnitude for bounds checking; the
-  // sign and absolute-instant calculation remain delegated to Date.parse.
   const parsed = Date.parse(value);
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+function invalid(edge: Edge): MapEdge {
+  return { ...edge, lifecycle: { kind: "invalid" } };
+}
+
 /** Parse lifecycle data once when an edge crosses the API/UI boundary. */
 export function normalizeEdgeLifecycle(edge: Edge): MapEdge {
-  // The canonical public contract always includes `created_at`; an omitted
-  // key is a noncanonical remote response, not the undated-legacy state,
-  // which requires an explicit `null` (paired with an explicit `expires_at:
-  // null`). Fail closed instead of conflating "absent" with "explicitly
-  // undated".
-  if (edge.created_at === undefined) {
-    return { ...edge, lifecycle: { kind: "invalid" } };
-  }
-
-  if (edge.created_at === null) {
+  // Public contract always includes created_at. Omitted ≠ undated legacy:
+  // undated requires explicit null/null. Fail closed on non-canonical pairs.
+  const created = edge.created_at;
+  const expires = edge.expires_at;
+  if (created === undefined) return invalid(edge);
+  if (created === null) {
     return {
       ...edge,
-      lifecycle:
-        edge.expires_at === null ? { kind: "legacy" } : { kind: "invalid" },
+      lifecycle: { kind: expires === null ? "legacy" : "invalid" },
     };
   }
 
-  const createdAtMs = parseCanonicalRfc3339Ms(edge.created_at);
-  if (createdAtMs == null) {
-    return { ...edge, lifecycle: { kind: "invalid" } };
-  }
-
-  if (edge.expires_at === null) {
-    return { ...edge, lifecycle: { kind: "invalid" } };
-  }
+  const createdAtMs = parseCanonicalRfc3339Ms(created);
+  if (createdAtMs == null || expires === null) return invalid(edge);
 
   const expiresAtMs =
-    edge.expires_at === undefined
+    expires === undefined
       ? createdAtMs + FADEN_LIFETIME_MS
-      : parseCanonicalRfc3339Ms(edge.expires_at);
-  if (
-    expiresAtMs == null ||
-    !Number.isFinite(expiresAtMs) ||
-    expiresAtMs - createdAtMs !== FADEN_LIFETIME_MS
-  ) {
-    return { ...edge, lifecycle: { kind: "invalid" } };
+      : parseCanonicalRfc3339Ms(expires);
+  // Derived path is finite when createdAtMs is; parse path already rejects NaN.
+  if (expiresAtMs == null || expiresAtMs - createdAtMs !== FADEN_LIFETIME_MS) {
+    return invalid(edge);
   }
 
   return {

--- a/apps/web/tests/fixtures/mockApi.ts
+++ b/apps/web/tests/fixtures/mockApi.ts
@@ -1,9 +1,6 @@
 import type { Page } from "@playwright/test";
-import {
-  demoNodes,
-  demoAccounts,
-  demoEdges,
-} from "../../src/lib/demo/demoData";
+import { demoNodes, demoAccounts } from "../../src/lib/demo/demoData";
+import { listPublicEdges } from "../../src/lib/demo/resolvers";
 import { FADEN_LIFETIME_MS } from "../../src/lib/map/edgeLifecycle";
 
 /**
@@ -99,14 +96,7 @@ export async function mockApiResponses(
   // the mock. There is deliberately no direct edge-create request surface.
   const createdNodes: Record<string, unknown>[] = [];
   const createdEdges: Record<string, unknown>[] = [];
-  const activeDemoCreatedAtMs = Date.now() - 60_000;
-  const activeDemoEdges = demoEdges.map((edge) => ({
-    ...edge,
-    created_at: new Date(activeDemoCreatedAtMs).toISOString(),
-    expires_at: new Date(
-      activeDemoCreatedAtMs + FADEN_LIFETIME_MS,
-    ).toISOString(),
-  }));
+  const publicDemoEdges = listPublicEdges();
   const mutableDemoNodes: Record<string, unknown>[] = demoNodes.map((node) => ({
     ...node,
     address: "Musterstraße 1",
@@ -458,7 +448,7 @@ export async function mockApiResponses(
     }
 
     if (new URL(url).pathname === "/api/edges" && method === "GET") {
-      const edges = [...activeDemoEdges, ...createdEdges].filter(
+      const edges = [...publicDemoEdges, ...createdEdges].filter(
         (edge) =>
           (typeof edge.source_id !== "string" ||
             !deletedNodeIds.has(edge.source_id)) &&

--- a/apps/web/tests/fixtures/mockApi.ts
+++ b/apps/web/tests/fixtures/mockApi.ts
@@ -4,6 +4,7 @@ import {
   demoAccounts,
   demoEdges,
 } from "../../src/lib/demo/demoData";
+import { FADEN_LIFETIME_MS } from "../../src/lib/map/edgeLifecycle";
 
 /**
  * Mock API responses for E2E tests.
@@ -98,6 +99,14 @@ export async function mockApiResponses(
   // the mock. There is deliberately no direct edge-create request surface.
   const createdNodes: Record<string, unknown>[] = [];
   const createdEdges: Record<string, unknown>[] = [];
+  const activeDemoCreatedAtMs = Date.now() - 60_000;
+  const activeDemoEdges = demoEdges.map((edge) => ({
+    ...edge,
+    created_at: new Date(activeDemoCreatedAtMs).toISOString(),
+    expires_at: new Date(
+      activeDemoCreatedAtMs + FADEN_LIFETIME_MS,
+    ).toISOString(),
+  }));
   const mutableDemoNodes: Record<string, unknown>[] = demoNodes.map((node) => ({
     ...node,
     address: "Musterstraße 1",
@@ -196,6 +205,9 @@ export async function mockApiResponses(
           target_type: "node",
           edge_kind: "reference",
           created_at: now,
+          expires_at: new Date(
+            Date.parse(now) + FADEN_LIFETIME_MS,
+          ).toISOString(),
         });
       }
       return route.fulfill({
@@ -446,7 +458,7 @@ export async function mockApiResponses(
     }
 
     if (new URL(url).pathname === "/api/edges" && method === "GET") {
-      const edges = [...demoEdges, ...createdEdges].filter(
+      const edges = [...activeDemoEdges, ...createdEdges].filter(
         (edge) =>
           (typeof edge.source_id !== "string" ||
             !deletedNodeIds.has(edge.source_id)) &&

--- a/contracts/domain/edge.schema.json
+++ b/contracts/domain/edge.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://weltgewebe.org/schemas/domain/edge.schema.json",
   "title": "Edge",
-  "description": "A derived Faden projection between two entities. Newly derived, unverzwirnte Fäden expire exactly 168 hours after their server-owned creation timestamp; durable Webungsaktionen remain outside this projection.",
+  "description": "A derived Faden projection between two entities. Dated, unverzwirnte Fäden expire exactly 168 hours after their server-owned creation timestamp; durable Webungsaktionen remain outside this projection. Fully undated legacy or non-authoritative preview projections explicitly carry a null lifecycle pair.",
   "type": "object",
   "properties": {
     "id": {
@@ -30,13 +30,13 @@
       "enum": ["delegation", "membership", "ownership", "reference"]
     },
     "created_at": {
-      "description": "Server-owned creation timestamp of the derived projection.",
-      "type": "string",
+      "description": "Server-owned creation timestamp of the derived projection. Null is permitted only for a fully undated legacy or non-authoritative preview projection and must be paired with expires_at null.",
+      "type": ["string", "null"],
       "format": "date-time"
     },
     "expires_at": {
-      "description": "Server-owned active-projection boundary. For every unverzwirnter Faden this is exactly 168 hours after created_at. When a legacy record has created_at but no persisted expires_at, readers derive the same boundary without rewriting history. Complete absence of lifecycle timestamps is reserved for undated legacy data; a future durable Garn requires an explicit representation.",
-      "type": "string",
+      "description": "Server-owned active-projection boundary. For every dated, unverzwirnter Faden this is exactly 168 hours after created_at. When a persisted legacy record has created_at but no expiry, readers derive the same boundary without rewriting history. A fully undated projection carries null together with created_at null.",
+      "type": ["string", "null"],
       "format": "date-time"
     },
     "note": {
@@ -46,5 +46,21 @@
     }
   },
   "required": ["id", "source_type", "source_id", "target_type", "target_id", "edge_kind", "created_at"],
-  "additionalProperties": false
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "created_at": { "type": "null" }
+        },
+        "required": ["created_at"]
+      },
+      "then": {
+        "properties": {
+          "expires_at": { "type": "null" }
+        },
+        "required": ["expires_at"]
+      }
+    }
+  ]
 }

--- a/contracts/domain/edge.schema.json
+++ b/contracts/domain/edge.schema.json
@@ -35,7 +35,7 @@
       "format": "date-time"
     },
     "expires_at": {
-      "description": "Server-owned active-projection boundary. For every newly derived, unverzwirnter Faden this is exactly 168 hours after created_at. Absence is reserved for legacy records or a future explicit durable Garn representation.",
+      "description": "Server-owned active-projection boundary. For every unverzwirnter Faden this is exactly 168 hours after created_at. When a legacy record has created_at but no persisted expires_at, readers derive the same boundary without rewriting history. Complete absence of lifecycle timestamps is reserved for undated legacy data; a future durable Garn requires an explicit representation.",
       "type": "string",
       "format": "date-time"
     },

--- a/contracts/domain/edge.schema.json
+++ b/contracts/domain/edge.schema.json
@@ -61,6 +61,19 @@
         },
         "required": ["expires_at"]
       }
+    },
+    {
+      "if": {
+        "properties": {
+          "expires_at": { "type": "null" }
+        },
+        "required": ["expires_at"]
+      },
+      "then": {
+        "properties": {
+          "created_at": { "type": "null" }
+        }
+      }
     }
   ]
 }

--- a/contracts/domain/examples/edge.undated-legacy.example.json
+++ b/contracts/domain/examples/edge.undated-legacy.example.json
@@ -1,0 +1,10 @@
+{
+  "id": "d3f6c9b1-4e2a-4d7f-8b1c-2a9e5f6d7c8b",
+  "source_type": "account",
+  "source_id": "7d97a42e-3704-4a33-a61f-0e0a6b4d65d8",
+  "target_type": "node",
+  "target_id": "b52be17c-4ab7-4434-98ce-520f86290cf0",
+  "edge_kind": "reference",
+  "created_at": null,
+  "expires_at": null
+}

--- a/docs/reports/domain-edge-faden-lifecycle-proof.md
+++ b/docs/reports/domain-edge-faden-lifecycle-proof.md
@@ -49,8 +49,8 @@ Lesen abgeleitet, ohne gespeicherte Daten oder die Chronik umzuschreiben.
 | Aktive Projektion | Filterung erfolgt vor Offset- und Cursor-Paginierung; Einzelabruf liefert nach Ablauf 404. |
 | Nebenprojektion | Account-Details verwenden denselben aktiven Fadenprädikat. |
 | Darstellung | Die lineare Deckkraft wird aus vorgeparsten Millisekunden berechnet und minütlich neu projiziert; ein separater Einmal-Timer entfernt den nächsten Faden exakt bei `expires_at`. |
-| Legacy | Fehlt nur `expires_at`, wird es aus einem gültigen `created_at` exakt abgeleitet. Vollständig undatierte Datensätze bleiben sichtbar; Persistenz und Chronik werden nicht verändert. |
-| Korruption | Ungültige vorhandene Zeitstempel sowie explizite, nicht exakt 168 Stunden auseinanderliegende Grenzen werden fail-closed ausgeblendet. |
+| Legacy | Fehlt das `expires_at`-Feld ganz, wird es aus einem gültigen `created_at` exakt abgeleitet. Vollständig undatierte Datensätze bleiben sichtbar; Persistenz und Chronik werden nicht verändert. |
+| Korruption | Ungültige vorhandene Zeitstempel, ein explizites `expires_at: null` bei datiertem `created_at`, strukturell fehlerhafte PostgreSQL-Payload-Werte sowie explizite, nicht exakt 168 Stunden auseinanderliegende Grenzen werden fail-closed ausgeblendet beziehungsweise beim Laden übersprungen — keiner dieser Fälle wird mit dem legitimen, fehlenden Feld verwechselt. |
 | Garn | Dauerhaft und ausgenommen, aber ohne geratenes Feld oder öffentliches CRUD; eigener Folgeauftrag. |
 
 ## Revalidierung 2026-07-29
@@ -68,6 +68,45 @@ Lesen abgeleitet, ohne gespeicherte Daten oder die Chronik umzuschreiben.
 Nicht als neue lokale Evidenz behauptet werden der vollständige Web-Build, das
 gesamte API-Testkorpus, `cargo deny` und die Remote-CI. Diese Prüfungen bleiben
 den repositoryweiten beziehungsweise PR-gebundenen Gates vorbehalten.
+
+## Revalidierung 2026-07-30
+
+Drei von Codex gemeldete Befunde auf dem vorherigen Head sind behoben:
+
+- P2: Die API unterschied beim JSONL- und PostgreSQL-Laden ein fehlendes
+  `expires_at` nicht von einem explizit gespeicherten `expires_at: null`,
+  wodurch ein datierter Legacy-Faden mit explizitem `null` fälschlich eine
+  rückwirkend abgeleitete Ablaufzeit erhielt statt fail-closed ausgeblendet zu
+  werden. `Edge.expires_at` ist jetzt ein Tri-State
+  (`Option<Option<LifecycleTimestamp>>`), rund-trip-fest für beide
+  Persistenzpfade.
+- P2: Die Kartengrenze (`edgeLifecycle.ts`) behandelte ein fehlendes
+  `created_at` wie den undatierten Legacy-Zustand statt es als nichtkonform
+  abzulehnen; sie unterscheidet jetzt `undefined` (immer ungültig) von einem
+  expliziten `null` (nur mit explizitem `expires_at: null` gültig).
+- P3: Eine strukturell fehlerhafte (weder fehlende, `null`- noch String-)
+  `expires_at`-Nutzlast im PostgreSQL-JSONB-Payload wurde zuvor stillschweigend
+  wie ein explizites `null` behandelt; bei fehlendem `created_at` hätte das
+  denselben Datensatz wie einen legitimen, dauerhaft sichtbaren undatierten
+  Altbestand erscheinen lassen. Der PostgreSQL-Ladepfad überspringt solche
+  Zeilen jetzt mit einer Warnung, statt sie zu maskieren.
+
+Aktualisierte lokale Prüfbelege:
+
+- API-Lifecycle-Unit-Tests (`routes::edges::tests`): 10 bestanden, 0
+  fehlgeschlagen (zuvor 9; neuer Test deckt das explizite `null` bei
+  datiertem `created_at` ab).
+- Neue PostgreSQL-Payload-Unit-Tests (`domain_db::edge_write_path_tests`): 3
+  zusätzliche Tests für die Tri-State-Unterscheidung und das Verwerfen
+  strukturell fehlerhafter Nutzlasten.
+- Karten-Lifecycle-Tests: 6 bestanden, 0 fehlgeschlagen (zuvor 5; neuer Test
+  deckt das fehlende `created_at` an der Kartengrenze ab).
+- Vollständige lokale Rust-Bibliothekstests (470 bestanden), `cargo clippy
+  --all-targets -- -D warnings` und `cargo fmt --check`: bestanden.
+- Vollständige lokale Web-Vitest-Suite (275 bestanden über 36 Dateien),
+  `svelte-check` (0 Fehler) und `pnpm lint`: bestanden.
+- `just contracts-domain-check`: alle sechs Schemata und Beispielinstanzen
+  weiterhin gültig; dieser Fix ändert kein Schema.
 
 ## Grenzen und Folgetasks
 

--- a/docs/reports/domain-edge-faden-lifecycle-proof.md
+++ b/docs/reports/domain-edge-faden-lifecycle-proof.md
@@ -194,6 +194,32 @@ dieser Datei weiterhin grün). Vollständige lokale Rust-Bibliothekstests (472
 bestanden), `cargo clippy --all-targets -- -D warnings` und
 `cargo fmt --check`: bestanden.
 
+Codex bemängelte anschließend zurecht, dass die gezielte SQL-Bedingung nur
+den einen konkreten Fall (datiert + explizites `null`) abdeckte, während
+`edge_is_permanently_unreachable` auch undatierte Zeilen mit konkretem
+`expires_at`-String sowie strukturell fehlerhafte (weder `null` noch
+String-)Werte ausschließt. Die Bedingung deckt jetzt zusätzlich beide sicher
+prüfbaren Fälle über `jsonb_typeof` ab (das nie einen Laufzeitfehler wirft,
+unabhängig vom Zellinhalt). Bewusst weiterhin nicht abgedeckt bleibt ein
+datiertes `created_at` mit einem vorhandenen, aber nicht exakt 168 Stunden
+entfernten oder unparsebaren `expires_at`-String: Eine Prüfung dieses Falls
+würde einen Cast des Payload-Strings auf einen Zeitstempel erfordern, der
+bei irgendeiner nicht-Zeitstempel-Zeichenkette in der gesamten Tabelle einen
+harten Datenbankfehler auslöst statt zu einem Boolean auszuwerten — aus einer
+konservativen Überzählung würde ein Query-Ausfall. Das Schließen dieser
+Lücke bräuchte eine sichere Cast-Funktion (eine Schemamigration), keine
+WHERE-Bedingung; der Leseweg weist einen solchen Datensatz ohnehin schon
+beim Laden fail-closed ab, sodass im schlimmsten Fall eine Zeile, die über
+diesen API-eigenen Schreibpfad (der stets eine kanonische Dauer erzeugt)
+gar nicht entstehen kann, die Kapazität etwas zu früh als erschöpft zählt.
+
+Zwei weitere Regressionstests: `postgres_edge_create_admits_when_limit_filled_by_malformed_expiry_row`
+und `postgres_edge_create_admits_when_limit_filled_by_undated_row_with_expiry`
+(`db_domain_edge_write_path`, jetzt 11 bestanden, gegen eine disponible
+lokale PostgreSQL-16-Instanz verifiziert). Vollständige lokale
+Rust-Bibliothekstests (472 bestanden), `cargo clippy --all-targets -- -D
+warnings` und `cargo fmt --check`: weiterhin bestanden.
+
 ## Grenzen und Folgetasks
 
 - Vollständig undatierte Legacy-Projektionen bleiben sichtbar, weil ihr Alter

--- a/docs/reports/domain-edge-faden-lifecycle-proof.md
+++ b/docs/reports/domain-edge-faden-lifecycle-proof.md
@@ -160,6 +160,40 @@ Cache-Kapazität bei sehr großen Edge-Beständen — bleibt als
 erfordert dort eine reproduzierbare 500k-Messung statt einer punktuellen
 Änderung der Admission-Reihenfolge in diesem PR.
 
+Codex fand denselben Konsistenzfehler danach an zwei weiteren Stellen, die
+`edge_is_permanently_unreachable` noch nicht berücksichtigten:
+
+- Der JSONL-Leseloader (`load_edges`) zählte dauerhaft unerreichbare Zeilen
+  weiterhin gegen `MAX_EDGES_CACHE`, bevor er sie verwarf — derselbe Fehler
+  wie zuvor im PostgreSQL-Loader, nur für den JSONL-Pfad. Behoben durch
+  dieselbe Umstellung der Prüfreihenfolge; die Duplicate-ID-/Operation-Scan-
+  Funktion `inspect_edge_persistence_for_create` zählt ebenfalls nur noch
+  erreichbare Zeilen gegen das Limit, erkennt Duplikate und Replays aber
+  weiterhin über die gesamte Datei unabhängig vom Erreichbarkeitsstatus.
+- Der PostgreSQL-Schreibpfad (`insert_domain_edge`) prüfte die Kapazität
+  weiterhin über ein rohes `SELECT COUNT(*)`, das dauerhaft unerreichbare
+  Zeilen mitzählte, obwohl sie keinen Cache-Slot mehr belegen — neue, gültige
+  Fäden wären dadurch dauerhaft blockiert geblieben, sobald die Tabelle genug
+  solcher Zeilen enthielt. Behoben durch eine gezielte SQL-Bedingung, die
+  genau den konkreten, günstig prüfbaren Fall ausschließt (datiertes
+  `created_at` mit explizitem `expires_at: null`) statt das volle
+  Rust-seitige Prädikat je Schreibzugriff nachzubilden (das einen
+  Payload-Volltabellenscan pro Create erfordern würde). Ein erster
+  Implementierungsversuch fiel selbst einer Drei-Werte-Logik-Falle zum Opfer
+  (`payload -> 'expires_at' = 'null'::jsonb` liefert SQL-`NULL`, nicht
+  `false`, wenn der Schlüssel fehlt, wodurch auch reguläre Zeilen ohne
+  `expires_at` fälschlich ausgeschlossen wurden); korrigiert über den
+  `payload ? 'expires_at'`-Existenzoperator, der immer einen definiten
+  Wahrheitswert liefert.
+
+Neue Regressionstests: `post_edges_admits_create_when_limit_filled_by_permanently_unreachable_row`
+(JSONL, `api_edges`), `postgres_edge_create_admits_when_limit_filled_by_permanently_unreachable_row`
+(PostgreSQL, `db_domain_edge_write_path`, gegen eine disponible lokale
+PostgreSQL-16-Instanz verifiziert, zusammen mit den bestehenden 9 Tests
+dieser Datei weiterhin grün). Vollständige lokale Rust-Bibliothekstests (472
+bestanden), `cargo clippy --all-targets -- -D warnings` und
+`cargo fmt --check`: bestanden.
+
 ## Grenzen und Folgetasks
 
 - Vollständig undatierte Legacy-Projektionen bleiben sichtbar, weil ihr Alter

--- a/docs/reports/domain-edge-faden-lifecycle-proof.md
+++ b/docs/reports/domain-edge-faden-lifecycle-proof.md
@@ -71,7 +71,7 @@ den repositoryweiten beziehungsweise PR-gebundenen Gates vorbehalten.
 
 ## Revalidierung 2026-07-30
 
-Drei von Codex gemeldete Befunde auf dem vorherigen Head sind behoben:
+Vier von Codex gemeldete Befunde auf vorherigen Heads sind behoben:
 
 - P2: Die API unterschied beim JSONL- und PostgreSQL-Laden ein fehlendes
   `expires_at` nicht von einem explizit gespeicherten `expires_at: null`,
@@ -90,6 +90,15 @@ Drei von Codex gemeldete Befunde auf dem vorherigen Head sind behoben:
   denselben Datensatz wie einen legitimen, dauerhaft sichtbaren undatierten
   Altbestand erscheinen lassen. Der PostgreSQL-Ladepfad überspringt solche
   Zeilen jetzt mit einer Warnung, statt sie zu maskieren.
+- P2: Der vorherige Fix für den obigen Befund führte selbst eine Paginierungs-
+  Regression ein: `load_edges_from_postgres` überspringt fehlerhafte Zeilen,
+  ohne `seen` zu erhöhen, während die SQL-Abfrage die physischen Zeilen
+  weiterhin fest auf `max_edges + 1` begrenzte. Sortierten mehrere fehlerhafte
+  Zeilen vor gültigen und überschritt die Tabelle das Cache-Limit, gingen
+  dadurch gültige Fäden stillschweigend verloren und `truncated` blieb
+  fälschlich `false`. Die Abfrage begrenzt die Zeilenzahl jetzt nicht mehr per
+  SQL; die Schleife selbst bricht erst ab, sobald `max_edges + 1` **gültige**
+  Zeilen untersucht wurden.
 
 Aktualisierte lokale Prüfbelege:
 
@@ -103,6 +112,13 @@ Aktualisierte lokale Prüfbelege:
   deckt das fehlende `created_at` an der Kartengrenze ab).
 - Vollständige lokale Rust-Bibliothekstests (470 bestanden), `cargo clippy
   --all-targets -- -D warnings` und `cargo fmt --check`: bestanden.
+- Neuer PostgreSQL-Integrationstest
+  `edges_loader_skips_malformed_rows_without_losing_later_valid_edges`
+  (`db_domain_read_path`) reproduziert exakt das von Codex beschriebene
+  Szenario (Cache-Limit 2, zwei fehlerhafte Zeilen vor zwei gültigen) gegen
+  eine disponible lokale PostgreSQL-16-Instanz; zusammen mit den bestehenden
+  `db_domain_read_path`- (10 bestanden) und `db_domain_edge_write_path`-Tests
+  (8 bestanden) grün.
 - Vollständige lokale Web-Vitest-Suite (275 bestanden über 36 Dateien),
   `svelte-check` (0 Fehler) und `pnpm lint`: bestanden.
 - `just contracts-domain-check`: alle sechs Schemata und Beispielinstanzen

--- a/docs/reports/domain-edge-faden-lifecycle-proof.md
+++ b/docs/reports/domain-edge-faden-lifecycle-proof.md
@@ -220,6 +220,33 @@ lokale PostgreSQL-16-Instanz verifiziert). Vollständige lokale
 Rust-Bibliothekstests (472 bestanden), `cargo clippy --all-targets -- -D
 warnings` und `cargo fmt --check`: weiterhin bestanden.
 
+Codex fand danach einen weiteren, subtilen Fall: Ein datiertes `payload`,
+das selbst kein JSON-Objekt ist (etwa das Array `["expires_at"]`), lässt
+PostgreSQLs `?`-Operator — der auch Array-Elemente statt nur Objektschlüssel
+matcht — fälschlich `true` liefern, während `payload -> 'expires_at'` dabei
+SQL-`NULL` zurückgibt; `jsonb_typeof(NULL)` ist wiederum `NULL`, wodurch die
+gesamte Ausschlussbedingung zu `NULL` auswertet und die Zeile fälschlich von
+der Kapazitätszählung ausgeschlossen wird. `payload_lifecycle_field` sucht
+Schlüssel dagegen über `Value::get`, das für jeden Nicht-Objekt-Wert
+unabhängig vom Inhalt `None` liefert — der Loader behandelt ein
+Nicht-Objekt-Payload also wie `{}` (eine erreichbare, datierte
+Legacy-Kante mit abgeleiteter Ablaufzeit) und zählt sie mit. Die
+Kapazitätsprüfung muss dasselbe tun, sonst kann ein Create trotz vollem
+Cache erfolgreich sein.
+
+Behoben durch eine äußere Bedingung `jsonb_typeof(payload) = 'object'`, die
+der gesamten Ausschlussklausel vorausgeht: Da die Spalte `payload` per
+Schema `NOT NULL` ist, liefert `jsonb_typeof(payload)` immer einen
+definiten Wahrheitswert, wodurch `FALSE AND …` für jeden Nicht-Objekt-Wert
+sicher zu `FALSE` auswertet, statt die SQL-`NULL`-Falle erneut auszulösen.
+Neuer Regressionstest: `postgres_edge_create_rejects_when_limit_filled_by_non_object_payload_row`
+(jetzt 12 Tests in `db_domain_edge_write_path`, gegen eine disponible
+lokale PostgreSQL-16-Instanz verifiziert; erwartet — anders als die
+vorherigen drei „admits“-Tests — eine Ablehnung, da diese Zeile tatsächlich
+einen Cache-Slot belegt). Vollständige lokale Rust-Bibliothekstests (472
+bestanden), `cargo clippy --all-targets -- -D warnings` und
+`cargo fmt --check`: weiterhin bestanden.
+
 ## Grenzen und Folgetasks
 
 - Vollständig undatierte Legacy-Projektionen bleiben sichtbar, weil ihr Alter

--- a/docs/reports/domain-edge-faden-lifecycle-proof.md
+++ b/docs/reports/domain-edge-faden-lifecycle-proof.md
@@ -124,6 +124,42 @@ Aktualisierte lokale Prüfbelege:
 - `just contracts-domain-check`: alle sechs Schemata und Beispielinstanzen
   weiterhin gültig; dieser Fix ändert kein Schema.
 
+Fünfter von Codex gemeldeter Befund, ebenfalls behoben: Der vorherige
+Paginierungs-Fix prüfte nur, ob eine Zeile strukturell ladbar war, nicht ob
+die daraus konstruierte Kante überhaupt jemals aktiv sein kann. Ein
+datiertes `created_at` mit explizitem `expires_at: null` ist strukturell
+gültig, aber laut `edge_is_active_at` für jedes `now` zurückgewiesen und
+hätte weiterhin einen Cache-Slot verbraucht. `edge_is_active_at`s Validierung
+ist jetzt in einen gemeinsamen `edge_lifecycle_window`-Helper extrahiert; die
+neue `edge_is_permanently_unreachable`-Funktion nutzt ihn, sodass Leseweg und
+PostgreSQL-Ladeweg exakt übereinstimmen, welche Zeilen niemals sichtbar
+werden können.
+
+- API-Lifecycle-Unit-Tests (`routes::edges::tests`): 12 bestanden, 0
+  fehlgeschlagen (zuvor 10; ein neuer Test prüft die Übereinstimmung von
+  `edge_is_active_at` und `edge_is_permanently_unreachable`, ein weiterer —
+  von @alexdermohr direkt beigetragen — die explizite null/null-Serialisierung
+  der undatierten Legacy-Projektion).
+- Neuer PostgreSQL-Integrationstest
+  `edges_loader_excludes_permanently_unreachable_rows_from_cache_capacity`
+  (`db_domain_read_path`, jetzt 11 bestanden) reproduziert das beschriebene
+  Szenario gegen eine disponible lokale PostgreSQL-16-Instanz.
+- Vollständige lokale Rust-Bibliothekstests: 472 bestanden.
+
+Ein sechster, in derselben Runde gemeldeter Befund ("Exclude already-expired
+rows from startup cache") wurde geprüft und **nicht** übernommen: Der
+PostgreSQL-Ladeweg hält bereits abgelaufene, aber strukturell gültige Fäden
+absichtlich im Cache — der Create-Pfad prüft `edges.get(&edge.id).is_some()`
+für Duplicate-ID-Erkennung und Operation-Replay explizit gegen den
+vollständigen Cache, unabhängig vom Aktivitätsstatus. Ein bereits abgelaufener
+Faden aus dem Cache auszuschließen würde diese Chronik-/Idempotenzgarantie
+brechen (siehe „Grenzen und Folgetasks“: abgelaufene Projektionen bleiben aus
+Chronik- und Idempotenzgründen persistiert). Das allgemeinere Problem — feste
+Cache-Kapazität bei sehr großen Edge-Beständen — bleibt als
+`WELTGEWEBE-EDGE-PROJECTION-INDEX-BENCH-V1` in Bureau-PR #649 registriert und
+erfordert dort eine reproduzierbare 500k-Messung statt einer punktuellen
+Änderung der Admission-Reihenfolge in diesem PR.
+
 ## Grenzen und Folgetasks
 
 - Vollständig undatierte Legacy-Projektionen bleiben sichtbar, weil ihr Alter

--- a/docs/reports/domain-edge-faden-lifecycle-proof.md
+++ b/docs/reports/domain-edge-faden-lifecycle-proof.md
@@ -12,9 +12,10 @@ canonicality: evidence
 lang: de
 summary: >
   Lokaler, diffgebundener Implementierungs- und Regressionstest für den
-  exakt 168 Stunden langen Lebenszyklus neu abgeleiteter, unverzwirnter Fäden.
-  Belegt sind servereigene Ablaufzeit, JSONL-/PostgreSQL-Mapping, Filterung vor
-  Paginierung, 404 nach Ablauf, Account-Projektion und kontinuierliches lineares Kartenverblassen.
+  exakt 168 Stunden langen Lebenszyklus unverzwirnter Fäden einschließlich
+  rückwirkender Ableitung für datierte Legacy-Projektionen ohne persistiertes
+  expires_at. Belegt sind servereigene Ablaufzeit, Filterung vor Paginierung,
+  404 nach Ablauf und kontinuierliches lineares Kartenverblassen.
   Garn und Verzwirnung bleiben ein eigener, noch zu spezifizierender Vertrag.
 relations:
   - type: supersedes
@@ -33,7 +34,9 @@ relations:
 `expires_at = created_at + 168 Stunden`. Clientwerte für `created_at` und
 `expires_at` bleiben verboten. Ab `now == expires_at` verschwindet der Faden
 aus aktiven Listen, Einzelabrufen, Account-Projektionen und der Karte. Seine
-persistierte Webungsaktion wird nicht gelöscht.
+persistierte Webungsaktion wird nicht gelöscht. Für bestehende Projektionen mit
+gültigem `created_at`, aber fehlendem `expires_at`, wird dieselbe Grenze beim
+Lesen abgeleitet, ohne gespeicherte Daten oder die Chronik umzuschreiben.
 
 ## Belegte Semantik
 
@@ -41,37 +44,47 @@ persistierte Webungsaktion wird nicht gelöscht.
 |---|---|
 | Zeitautorität | API-Server setzt `created_at` und leitet `expires_at` daraus ab. |
 | Dauer | Exakt 168 Stunden; keine Konfiguration und kein Refresh durch spätere Aktionen. |
-| JSONL | Beide Zeitstempel landen in derselben dauerhaften Zeile und im Cache. |
-| PostgreSQL | `created_at` bleibt Spalte; `expires_at` wird im bestehenden JSONB-Payload gespeichert und beim Reload rekonstruiert. |
-| Aktive Projektion | Filterung erfolgt vor Offset- und Cursor-Paginierung; Einzelabruf liefert nach Ablauf 404. Zeitstempel werden beim Laden oder Erzeugen einmal geparst; der Request-Hot-Path vergleicht nur vorgeparste Werte. |
+| JSONL | Neue Fäden speichern beide Zeitstempel. Datierte Legacy-Zeilen ohne `expires_at` bleiben unverändert. |
+| PostgreSQL | `created_at` bleibt Spalte; `expires_at` wird für neue Fäden im bestehenden JSONB-Payload gespeichert und beim Reload rekonstruiert. |
+| Aktive Projektion | Filterung erfolgt vor Offset- und Cursor-Paginierung; Einzelabruf liefert nach Ablauf 404. |
 | Nebenprojektion | Account-Details verwenden denselben aktiven Fadenprädikat. |
-| Darstellung | Die lineare Deckkraft wird aus vorgeparsten Millisekunden berechnet und minütlich als GeoJSON neu projiziert; der maximale Schritt beträgt weniger als 0,0001. Ein separater Einmal-Timer entfernt den nächsten Faden exakt bei `expires_at`. |
-| Legacy | Datensätze ohne `expires_at` bleiben sichtbar; es wird keine rückwirkende Ablaufzeit geraten. |
-| Korruption | Fehlende, ungültige oder nicht exakt 168 Stunden auseinanderliegende Zeitstempel werden fail-closed ausgeblendet. |
+| Darstellung | Die lineare Deckkraft wird aus vorgeparsten Millisekunden berechnet und minütlich neu projiziert; ein separater Einmal-Timer entfernt den nächsten Faden exakt bei `expires_at`. |
+| Legacy | Fehlt nur `expires_at`, wird es aus einem gültigen `created_at` exakt abgeleitet. Vollständig undatierte Datensätze bleiben sichtbar; Persistenz und Chronik werden nicht verändert. |
+| Korruption | Ungültige vorhandene Zeitstempel sowie explizite, nicht exakt 168 Stunden auseinanderliegende Grenzen werden fail-closed ausgeblendet. |
 | Garn | Dauerhaft und ausgenommen, aber ohne geratenes Feld oder öffentliches CRUD; eigener Folgeauftrag. |
 
-## Lokale Prüfbelege
+## Revalidierung 2026-07-29
 
-- Web-Produktionsbuild einschließlich Route-Performance-Budget: bestanden.
-- Web-CI: Budget-, Public-Asset-, Prettier-, ESLint- und Svelte-Checks bestanden.
-- Web-Unit-Tests: 160 bestanden, 0 fehlgeschlagen; Lifecycle-Normalisierung, minütlicher Refresh, Offsetgrenzen und exakte Ablaufplanung sind getrennt getestet.
-- API `cargo fmt`, `cargo clippy --all-targets --all-features -D warnings` und Build: bestanden.
-- API-Testkorpus: alle nicht ignorierten Unit- und Integrationstests bestanden;
-  darunter 370 Library-Tests, 28 Edge-Tests, 13 Account-Tests und die neuen
-  Ablauf-/Paginierungs-/Account-Projektionstests.
-- `cargo deny check`: Advisories, Bans, Lizenzen und Quellen bestanden.
-- Domain-Contracts: alle sechs Schemas sowie alle Beispiele bestanden.
-- Demo-Daten-Vertrag und Repository-Lint: bestanden.
+- API-Lifecycle-Unit-Tests: 9 bestanden, 0 fehlgeschlagen.
+- API-Edge-Integrationstests: 28 bestanden, 0 fehlgeschlagen. Enthalten ist ein
+  vor Einführung des Lifecycle-Vertrags erzeugter Faden mit `created_at`, aber
+  ohne `expires_at`, der vor Paginierung gefiltert wird und im Einzelabruf 404
+  liefert.
+- Karten-Lifecycle-Tests: 5 bestanden, 0 fehlgeschlagen.
+- Svelte-Typ- und Komponentenprüfung: 0 Fehler, 0 Warnungen.
+- Domain-Contracts: sechs Schemata und alle Beispielinstanzen bestanden.
+- Rust-Formatprüfung, Clippy mit Warnungen als Fehler und Web-Lint: bestanden.
+
+Nicht als neue lokale Evidenz behauptet werden der vollständige Web-Build, das
+gesamte API-Testkorpus, `cargo deny` und die Remote-CI. Diese Prüfungen bleiben
+den repositoryweiten beziehungsweise PR-gebundenen Gates vorbehalten.
 
 ## Grenzen und Folgetasks
 
+- Vollständig undatierte Legacy-Projektionen bleiben sichtbar, weil ihr Alter
+  nicht ohne Schätzung rekonstruiert werden kann.
 - Abgelaufene Projektionen bleiben aus Chronik- und Idempotenzgründen
-  persistiert; sichere Archivierung/Kompaktion ist separat registriert.
+  persistiert; sichere Archivierung oder Kompaktion ist separat registriert.
 - Die feste Sieben-Tage-Frist besitzt keine Runtime-Oberfläche mehr; AppConfig
   weist die entfernten Schlüssel `fade_days` und `HA_FADE_DAYS` fail-closed ab.
 - Garn und Verzwirnung benötigen einen eigenen Domänen-, Ereignis- und
   Persistenzvertrag.
-- Endpoint-/Ablaufindexierung für sehr große Edge-Bestände ist als `WELTGEWEBE-EDGE-PROJECTION-INDEX-BENCH-V1` in Bureau-PR #649 registriert; sie erfordert zuerst eine reproduzierbare 500k-Messung.
-- MapLibre-Feature-State ist als `WELTGEWEBE-MAP-EDGE-FEATURE-STATE-V1` in Bureau-PR #649 registriert und bleibt profilinggebunden, weil der auf 250 Fäden begrenzte minütliche `setData`-Pfad derzeit keinen belegten Engpass darstellt.
+- Endpoint- und Ablaufindexierung für sehr große Edge-Bestände ist als
+  `WELTGEWEBE-EDGE-PROJECTION-INDEX-BENCH-V1` in Bureau-PR #649 registriert; sie
+  erfordert zuerst eine reproduzierbare 500k-Messung.
+- MapLibre-Feature-State ist als `WELTGEWEBE-MAP-EDGE-FEATURE-STATE-V1` in
+  Bureau-PR #649 registriert und bleibt profilinggebunden, weil der auf 250
+  Fäden begrenzte minütliche `setData`-Pfad derzeit keinen belegten Engpass
+  darstellt.
 - Remote-CI- und Live-Evidence werden nach PR und Merge ergänzt; dieser Bericht
   behauptet bis dahin ausschließlich den lokal reproduzierten Stand.

--- a/docs/specs/garnrolle-knoten-faden.md
+++ b/docs/specs/garnrolle-knoten-faden.md
@@ -188,10 +188,15 @@ noch Ende vorgeben.
    sofern fachlich vorgesehen, eine neue Projektion mit eigener Uhr.
 4. Die zugrunde liegende Webungsaktion und ihre Chronik bleiben dauerhaft
    erhalten. Aufgelöst wird nur die abgeleitete Fadenprojektion.
-5. Bestehende Datensätze ohne `expires_at` bleiben aus Kompatibilitätsgründen
-   sichtbar. Sie dürfen nicht durch eine rückwirkend geratene Ablaufzeit gelöscht
-   werden.
-6. Ein vorhandener, aber ungültiger oder nicht exakt 168 Stunden langer
+5. Bei bestehenden Datensätzen mit gültigem `created_at`, aber ohne persistiertes
+   `expires_at`, leiten API und Karte die Ablaufgrenze rückwirkend und
+   deterministisch als `created_at + 168 Stunden` ab. Die Persistenz und Chronik
+   werden dabei nicht umgeschrieben.
+6. Vollständig undatierte Legacy-Datensätze ohne `created_at` und `expires_at`
+   bleiben sichtbar, weil ihr Alter nicht ohne Schätzung rekonstruiert werden
+   kann. Ein ungültiges vorhandenes `created_at` wird nicht als undatiert
+   behandelt, sondern fail-closed ausgeblendet.
+7. Ein vorhandener, aber ungültiger oder nicht exakt 168 Stunden langer
    Ablaufvertrag wird in aktiven Projektionen fail-closed ausgeblendet.
 
 Ein verzwirnter, dauerhafter Zusammenhang heißt **Garn** und ist vom Fadenverfall
@@ -200,7 +205,9 @@ nicht Bestandteil dieses Vertragsstands. Bis zu einer eigenen kanonischen
 Spezifikation darf dafür weder ein öffentliches CRUD noch ein geratenes Edge-Feld
 eingeführt werden. `expires_at = null` ist deshalb kein regulärer Erzeugungswert
 für neue Fäden, sondern ausschließlich ein Legacy- und späterer expliziter
-Garn-Kompatibilitätspfad.
+Speicherzustand. Eine künftige Garnrepräsentation muss sich explizit von einem
+unverzwirnten Faden unterscheiden und darf nicht allein aus `expires_at = null`
+abgeleitet werden.
 
 ## Gespräche
 

--- a/scripts/tests/json-schema-check.test.mjs
+++ b/scripts/tests/json-schema-check.test.mjs
@@ -58,6 +58,65 @@ test("compiles draft-07 and validates positive and negative data", () => {
   }
 });
 
+test("edge lifecycle schema couples explicit null timestamps", () => {
+  const directory = fixtureDirectory();
+  try {
+    const schema = join(
+      repositoryRoot,
+      "contracts",
+      "domain",
+      "edge.schema.json",
+    );
+    const baseEdge = {
+      id: "d3f6c9b1-4e2a-4d7f-8b1c-2a9e5f6d7c8b",
+      source_type: "account",
+      source_id: "7d97a42e-3704-4a33-a61f-0e0a6b4d65d8",
+      target_type: "node",
+      target_id: "b52be17c-4ab7-4434-98ce-520f86290cf0",
+      edge_kind: "reference",
+    };
+    const undated = join(directory, "undated.json");
+    const datedLegacy = join(directory, "dated-legacy.json");
+    const datedNullExpiry = join(directory, "dated-null-expiry.json");
+    writeFileSync(
+      undated,
+      JSON.stringify({ ...baseEdge, created_at: null, expires_at: null }),
+    );
+    writeFileSync(
+      datedLegacy,
+      JSON.stringify({ ...baseEdge, created_at: "2026-07-29T12:00:00Z" }),
+    );
+    writeFileSync(
+      datedNullExpiry,
+      JSON.stringify({
+        ...baseEdge,
+        created_at: "2026-07-29T12:00:00Z",
+        expires_at: null,
+      }),
+    );
+
+    assert.equal(
+      run("validate", "--schema", schema, "--data", undated).status,
+      0,
+    );
+    assert.equal(
+      run("validate", "--schema", schema, "--data", datedLegacy).status,
+      0,
+    );
+    const rejected = run(
+      "validate",
+      "--schema",
+      schema,
+      "--data",
+      datedNullExpiry,
+    );
+    assert.equal(rejected.status, 1);
+    assert.match(rejected.stderr, /invalid/);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
 test("auto-detects draft 2020-12 and loads formats", () => {
   const directory = fixtureDirectory();
   try {


### PR DESCRIPTION
## Änderung

- leitet für datierte Legacy-Fäden ohne persistiertes `expires_at` die kanonische Ablaufgrenze als `created_at + 168 Stunden` ab
- schreibt keine Altbestände um und löscht weder Knoten noch Fäden; die Webungsaktion bleibt dauerhaft erhalten
- blendet ungültige oder nichtkanonische Zeitpaare fail-closed aus
- erhält vollständig undatierte Altbestände als ausdrücklich modelliertes `created_at: null` / `expires_at: null`-Paar
- projiziert den statischen lokalen Demo-Faden als undatierte, nicht-authoritative Vorschau statt künstlich aktuelle Aktivität vorzutäuschen
- verwendet denselben Demo-Resolver in der Playwright-Mock-API
- hält API, Karte, Domänenschema, Beispiele und Spezifikation auf demselben Lebenszyklusvertrag

## Eingearbeitete Reviews

- P2: echter lokaler Demo-Faden verschwand nach rückwirkender Ablaufableitung — behoben in `b0e1f1d1`
- P2: vollständig undatierter öffentlicher Zustand war nicht schema-valid — behoben in `b0e1f1d1`
- ältere Dublette desselben Schemafehlers ebenfalls beantwortet und aufgelöst

## Prüfung

- `just ci`: bestanden; umfasst Web-Unit-Tests, Produktionsbuild, Lint, Typprüfung, Rust-Format, Clippy, Build, API-Tests, Root-Verträge und Abhängigkeitsprüfung
- vollständige Playwright-Suite: bestanden
- gezielte Demo-/Lifecycle-Unit-Tests: bestanden
- gezielter Edge-Visibility-Browsertest: bestanden
- gepinnter Domain-Contract-Check samt neuem `edge.undated-legacy.example.json`: bestanden
- AJV-Negativprüfung: `created_at: null` mit datiertem `expires_at` wird abgelehnt
- `git diff --check`: bestanden
- Remote-CI und erneuter Codex-Review laufen auf dem aktuellen Head

## Nicht behauptet

Der statische Demo-Faden besitzt bewusst keinen Hotspot-Zeitwert. Ein künstlich bei jedem Build erneuerter Zeitstempel würde Aktivität vortäuschen; ein realer Build-Zeitstempel würde die Demo nach sieben Tagen unbrauchbar machen.

<!-- weltgewebe-risk: R2 -->