### PR TITLE
feat(web): Erklärungen bei ähnlichen Knoten auf Abruf

### DIFF
--- a/apps/web/src/lib/components/InfoHeading.svelte
+++ b/apps/web/src/lib/components/InfoHeading.svelte
@@ -1,0 +1,130 @@
+<script lang="ts">
+  export let id: string;
+  export let label: string;
+  export let level: 2 | 3 | 4 | 5 | 6 = 3;
+
+  function openFromLongPress(event: MouseEvent) {
+    event.preventDefault();
+    (event.currentTarget as HTMLElement | null)?.parentElement?.setAttribute(
+      "open",
+      "",
+    );
+  }
+</script>
+
+<details class="info-heading">
+  <summary
+    aria-controls={`${id}-explanation`}
+    on:contextmenu={openFromLongPress}
+  >
+    <span {id} class="info-heading-title" role="heading" aria-level={level}
+      >{label}</span
+    >
+  </summary>
+
+  <div
+    id={`${id}-explanation`}
+    class="info-heading-panel"
+    role="dialog"
+    aria-labelledby={id}
+  >
+    <slot />
+  </div>
+</details>
+
+<style>
+  .info-heading {
+    position: relative;
+    anchor-scope: --info-heading-trigger;
+  }
+
+  summary {
+    min-height: 44px;
+    margin: -0.45rem 0;
+    padding: 0.45rem 0.1rem;
+    cursor: pointer;
+    list-style: none;
+    display: inline-flex;
+    align-items: center;
+    touch-action: manipulation;
+    -webkit-touch-callout: none;
+    anchor-name: --info-heading-trigger;
+  }
+
+  summary::-webkit-details-marker {
+    display: none;
+  }
+
+  summary:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+
+  .info-heading-title {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font: inherit;
+    font-weight: inherit;
+  }
+
+  .info-heading-title::after {
+    content: "ⓘ";
+    color: var(--muted);
+    font-size: 0.92em;
+    line-height: 1;
+  }
+
+  summary:hover .info-heading-title::after,
+  summary:focus-visible .info-heading-title::after {
+    color: var(--accent);
+  }
+
+  .info-heading-panel {
+    position: fixed;
+    z-index: 30;
+    top: 5rem;
+    right: 1rem;
+    width: min(24rem, calc(100vw - 2rem));
+    padding: 0.75rem;
+    border: 1px solid var(--panel-border-strong);
+    border-radius: 10px;
+    background: var(--panel-solid);
+    color: var(--text);
+    box-shadow: 0 10px 30px color-mix(in srgb, #000 22%, transparent);
+  }
+
+  .info-heading-panel :global(:first-child) {
+    margin-top: 0;
+  }
+
+  .info-heading-panel :global(:last-child) {
+    margin-bottom: 0;
+  }
+
+  @supports (top: anchor(bottom)) {
+    .info-heading-panel {
+      position-anchor: --info-heading-trigger;
+      top: anchor(bottom);
+      right: auto;
+      left: anchor(left);
+      margin-top: 0.4rem;
+      position-try-fallbacks: flip-block;
+    }
+  }
+
+  @media (max-width: 40rem) {
+    .info-heading-panel {
+      top: auto;
+      right: 0.75rem;
+      bottom: calc(0.75rem + env(safe-area-inset-bottom));
+      left: 0.75rem;
+      width: auto;
+      max-height: min(50vh, 24rem);
+      margin-top: 0;
+      overflow: auto;
+      border-radius: 14px;
+    }
+  }
+</style>

--- a/apps/web/src/lib/components/InfoHeading.svelte
+++ b/apps/web/src/lib/components/InfoHeading.svelte
@@ -10,9 +10,31 @@
       "",
     );
   }
+
+  function closeDetails(details: HTMLDetailsElement | null) {
+    if (!details) return;
+    details.removeAttribute("open");
+    details.querySelector<HTMLElement>("summary")?.focus();
+  }
+
+  function close(event: MouseEvent) {
+    closeDetails(
+      (event.currentTarget as HTMLElement | null)?.closest("details") ?? null,
+    );
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key !== "Escape" || event.repeat || event.defaultPrevented)
+      return;
+    const details = event.currentTarget as HTMLDetailsElement;
+    if (!details.open) return;
+    event.preventDefault();
+    event.stopPropagation();
+    closeDetails(details);
+  }
 </script>
 
-<details class="info-heading">
+<details class="info-heading" on:keydown={handleKeydown}>
   <summary
     aria-controls={`${id}-explanation`}
     on:contextmenu={openFromLongPress}
@@ -29,6 +51,7 @@
     aria-labelledby={id}
   >
     <slot />
+    <button type="button" on:click={close}>Schließen</button>
   </div>
 </details>
 
@@ -103,6 +126,24 @@
     margin-bottom: 0;
   }
 
+  button {
+    min-height: 36px;
+    margin: 0.7rem 0 0 auto;
+    padding: 0.4rem 0.65rem;
+    border: 1px solid var(--panel-border-strong);
+    border-radius: 7px;
+    background: var(--panel-solid);
+    color: var(--text);
+    font: inherit;
+    cursor: pointer;
+    display: block;
+  }
+
+  button:hover,
+  button:focus-visible {
+    border-color: var(--accent);
+  }
+
   @supports (top: anchor(bottom)) {
     .info-heading-panel {
       position-anchor: --info-heading-trigger;
@@ -110,7 +151,10 @@
       right: auto;
       left: anchor(left);
       margin-top: 0.4rem;
-      position-try-fallbacks: flip-block;
+      position-try-fallbacks:
+        flip-inline,
+        flip-block,
+        flip-inline flip-block;
     }
   }
 

--- a/apps/web/src/lib/components/panels/SimilarNodes.svelte
+++ b/apps/web/src/lib/components/panels/SimilarNodes.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { createEventDispatcher, onDestroy } from "svelte";
+  import InfoHeading from "$lib/components/InfoHeading.svelte";
   import { nodeKindLabel } from "$lib/ui/productLanguage";
   import {
     buildSimilarNodeQuery,
@@ -86,15 +87,15 @@
 <section
   class="similar-nodes"
   aria-labelledby="similar-nodes-heading"
-  aria-describedby="similar-nodes-explainer"
   aria-busy={requested && loading}
 >
-  <h4 id="similar-nodes-heading">Ähnliche Knoten</h4>
-  <p id="similar-nodes-explainer" class="similar-explainer">
-    Maschinell aus Inhalt und Schlagwörtern dieses Knotens berechnet. Das sind
-    Vorschläge – keine Fäden, keine kuratierten Beziehungen und keine Aussage
-    über gemeinsame Autorenschaft.
-  </p>
+  <InfoHeading id="similar-nodes-heading" label="Ähnliche Knoten" level={4}>
+    <p class="similar-explainer">
+      Maschinell aus Inhalt und Schlagwörtern dieses Knotens berechnet. Das sind
+      Vorschläge – keine Fäden, keine kuratierten Beziehungen und keine Aussage
+      über gemeinsame Autorenschaft.
+    </p>
+  </InfoHeading>
   {#if !requested}
     <button
       class="similar-trigger"
@@ -125,11 +126,10 @@
     {/if}
     {#if similarNodes.length > 0}
       <p class="similar-result-status" role="status" aria-live="polite">
-        {similarNodes.length} maschinell berechnete {similarNodes.length === 1
-          ? "Ähnlichkeit"
-          : "Ähnlichkeiten"} gefunden.
+        {similarNodes.length}
+        {similarNodes.length === 1 ? "Vorschlag" : "Vorschläge"}
       </p>
-      <ul aria-label="Maschinell berechnete ähnliche Knoten">
+      <ul aria-label="Vorgeschlagene ähnliche Knoten">
         {#each similarNodes as similar}
           <li>
             <button
@@ -161,8 +161,7 @@
     padding-top: 1rem;
     border-top: 1px solid var(--panel-border);
   }
-  h4 {
-    margin: 0;
+  .similar-nodes :global(.info-heading-title) {
     font-size: 1rem;
   }
   .similar-explainer,
@@ -175,7 +174,7 @@
     color: var(--muted);
   }
   .similar-result-status {
-    margin-top: 0;
+    margin-top: 0.65rem;
   }
   .similar-error {
     color: var(--text);

--- a/apps/web/tests/ui-search-t007.spec.ts
+++ b/apps/web/tests/ui-search-t007.spec.ts
@@ -162,6 +162,7 @@ test.describe("T007 authorized server search contract", () => {
   test("loads similar nodes only after explicit request and navigates without mutation", async ({
     page,
   }) => {
+    await page.setViewportSize({ width: 800, height: 900 });
     let mutationRequests = 0;
     let similarityRequests = 0;
     await page.route("**/api/search**", async (route) => {
@@ -222,17 +223,23 @@ test.describe("T007 authorized server search contract", () => {
     await expect(explanation).toContainText("keine Fäden");
     await expect(explanation).toContainText("keine kuratierten Beziehungen");
 
-    await headingTrigger.press("Enter");
+    await headingTrigger.press("Escape");
     await expect(disclosure).not.toHaveAttribute("open", "");
     await expect(explanation).not.toBeVisible();
+    await expect(page.getByTestId("context-panel")).toBeVisible();
     await expect(headingTrigger).toBeFocused();
 
     await headingTrigger.dispatchEvent("contextmenu");
     await expect(disclosure).toHaveAttribute("open", "");
     await expect(explanation).toBeVisible();
-    await headingTrigger.click();
+    const explanationBox = await explanation.boundingBox();
+    expect(explanationBox).not.toBeNull();
+    expect(explanationBox!.x).toBeGreaterThanOrEqual(0);
+    expect(explanationBox!.x + explanationBox!.width).toBeLessThanOrEqual(800);
+    await explanation.getByRole("button", { name: "Schließen" }).click();
     await expect(disclosure).not.toHaveAttribute("open", "");
     await expect(explanation).not.toBeVisible();
+    await expect(headingTrigger).toBeFocused();
 
     await page.waitForTimeout(SIMILARITY_QUIESCENCE_MS);
     expect(similarityRequests).toBe(0);

--- a/apps/web/tests/ui-search-t007.spec.ts
+++ b/apps/web/tests/ui-search-t007.spec.ts
@@ -193,23 +193,54 @@ test.describe("T007 authorized server search contract", () => {
     await page.getByRole("option").first().click();
 
     const section = page.locator("section.similar-nodes");
+    const disclosure = section.locator("details.info-heading");
+    const headingTrigger = disclosure.locator("summary");
+    const explanation = disclosure.getByRole("dialog", {
+      name: "Ähnliche Knoten",
+    });
+
     await expect(
       section.getByRole("heading", { name: "Ähnliche Knoten" }),
     ).toBeVisible();
-    await expect(section).toContainText(
-      "Maschinell aus Inhalt und Schlagwörtern dieses Knotens berechnet.",
+    await expect(headingTrigger).toHaveAttribute(
+      "aria-controls",
+      "similar-nodes-heading-explanation",
     );
-    await expect(section).toContainText("keine Fäden");
-    await expect(section).toContainText("keine kuratierten Beziehungen");
+    await expect(disclosure).not.toHaveAttribute("open", "");
+    await expect(explanation).not.toBeVisible();
     await expect(section).toContainText(
       "Erst beim Anklicken wird eine Suche an den Server gesendet.",
     );
+
+    await headingTrigger.focus();
+    await headingTrigger.press("Enter");
+    await expect(disclosure).toHaveAttribute("open", "");
+    await expect(explanation).toBeVisible();
+    await expect(explanation).toContainText(
+      "Maschinell aus Inhalt und Schlagwörtern dieses Knotens berechnet.",
+    );
+    await expect(explanation).toContainText("keine Fäden");
+    await expect(explanation).toContainText("keine kuratierten Beziehungen");
+
+    await headingTrigger.press("Enter");
+    await expect(disclosure).not.toHaveAttribute("open", "");
+    await expect(explanation).not.toBeVisible();
+    await expect(headingTrigger).toBeFocused();
+
+    await headingTrigger.dispatchEvent("contextmenu");
+    await expect(disclosure).toHaveAttribute("open", "");
+    await expect(explanation).toBeVisible();
+    await headingTrigger.click();
+    await expect(disclosure).not.toHaveAttribute("open", "");
+    await expect(explanation).not.toBeVisible();
+
     await page.waitForTimeout(SIMILARITY_QUIESCENCE_MS);
     expect(similarityRequests).toBe(0);
 
     await section
       .getByRole("button", { name: "Ähnliche Knoten suchen" })
       .click();
+    await expect(section.getByText("1 Vorschlag")).toBeVisible();
     await expect(
       section.getByRole("button", { name: /Gemeinschaftliche Radstation/ }),
     ).toBeVisible();


### PR DESCRIPTION
<!-- weltgewebe-risk: R2 -->

## Ziel

Methodische Erklärungen bei „Ähnliche Knoten“ standardmäßig verbergen und barrierefrei über die Überschrift zugänglich machen.

## Nicht-Ziele

- keine Änderung am Suchranking oder an der API
- keine automatische Suche beim Öffnen eines Knotens
- noch keine Migration weiterer Erklärungstexte

## Zu bewahrende Invarianten

- Fehler, Warnungen und die Information über die Serveranfrage bleiben sichtbar
- Tap/Klick sowie Tastatur bleiben vollständige Zugangswege; Longpress ist nur zusätzlich
- keine Schreibanfrage wird durch die Ähnlichkeitssuche ausgelöst

## Fehlerszenarien und Rückfallweg

Bei Darstellungsproblemen kann der einzelne Commit ohne Datenmigration zurückgenommen werden. Browser ohne CSS Anchor Positioning verwenden das feste Desktop-Fallback; mobil wird die Erklärung als kompaktes Bottom Sheet angezeigt.

## Prüfungen

- `pnpm check:ci`: 0 Fehler, 0 Warnungen
- zielgerichtetes ESLint: PASS
- `pnpm test -- tests/ui-search-t007.spec.ts`: 5/5 PASS
- Codex-Befunde auf dem Vorgänger-Head behoben: Escape schließt nur die Erklärung; Anchor-Fallback berücksichtigt horizontale Kollisionen
- Regressionstest bei 800 px prüft Panelgrenzen, Fokuswiederherstellung und den Erhalt des Kontextpanels
- vollständiger CI-Build einschließlich Routenbudget: PASS
- `/map`: 80.446 / 80.500 Byte initiales JavaScript gzip; sauberer main-Vergleich: 80.413 Byte

## Reviewevidenz

Zwei methodisch getrennte, nicht als unabhängig behauptete Self-Review-Pässe werden für den exakten Head und den kanonischen Diff-Digest attestiert.

## Veröffentlichung und Liveprüfung

Vercel- und Cloudflare-Vorschauen werden für Commit `a965ac40e8cdd41c321d26a383829a063e56fce2` neu bewertet. Ein Produktionsmerge erfolgt ausschließlich nach exakter Reviewevidenz, grüner Pflicht-CI und autoritativem Readback.

Bureau-Task: WELTGEWEBE-SEMANTIC-SEARCH-V1-T008
