### PR TITLE
fix(api): commit nodes and origin Fäden atomically

### DIFF
--- a/apps/api/src/domain_db.rs
+++ b/apps/api/src/domain_db.rs
@@ -2202,6 +2202,84 @@ where
     }
 }
 
+/// Holds the same cross-instance node-mutation lock used by edit and delete
+/// routes while the create handler reconciles and publishes its cache state.
+/// The snapshots are read only after the lock is acquired, so a deletion or
+/// guest exit that wins the post-commit gap is observed instead of overwritten
+/// by the stale create response.
+pub struct NodeFadenCachePublicationGuard {
+    transaction: Transaction<'static, Postgres>,
+    pub node: Option<Node>,
+    pub edge: Option<Edge>,
+}
+
+impl NodeFadenCachePublicationGuard {
+    pub async fn release(self) -> Result<(), sqlx::Error> {
+        self.transaction.commit().await
+    }
+}
+
+pub async fn lock_node_faden_cache_publication(
+    pool: &PgPool,
+    node_id: &str,
+    operation: &CreateOperationKey,
+    expected_edge: &Edge,
+) -> Result<NodeFadenCachePublicationGuard, NodeFadenCreateError> {
+    let mut transaction = pool
+        .begin()
+        .await
+        .map_err(NodeCreateError::Database)
+        .map_err(NodeFadenCreateError::Node)?;
+
+    sqlx::query("SELECT pg_advisory_xact_lock($1::bigint)")
+        .bind(crate::advisory_lock::node_mutation_lock_key(node_id))
+        .execute(&mut *transaction)
+        .await
+        .map_err(NodeCreateError::Database)?;
+
+    let node = sqlx::query_as::<_, NodeRow>(
+        "SELECT id, kind, title, lat, lon, created_at, updated_at, payload::text, search_visibility \
+         FROM domain_nodes WHERE id = $1",
+    )
+    .bind(node_id)
+    .fetch_optional(&mut *transaction)
+    .await
+    .map_err(NodeCreateError::Database)?
+    .map(node_from_row)
+    .transpose()
+    .map_err(NodeCreateError::Mapping)?;
+
+    let edge = if node.is_some() {
+        let edge = sqlx::query_as::<_, EdgeRow>(
+            "SELECT id, source_id, target_id, edge_kind, created_at, payload::text \
+             FROM domain_edges \
+             WHERE create_actor_id = $1 AND create_operation_id = $2",
+        )
+        .bind(&operation.actor_id)
+        .bind(&operation.operation_id)
+        .fetch_optional(&mut *transaction)
+        .await
+        .map_err(EdgeWriteError::Database)?
+        .map(edge_from_row)
+        .transpose()
+        .map_err(EdgeWriteError::Mapping)?;
+        if let Some(existing) = edge.as_ref() {
+            if !edge_matches_projection(existing, expected_edge) {
+                return Err(NodeFadenCreateError::EdgeOperationConflict);
+            }
+        }
+        edge
+    } else {
+        None
+    };
+
+    Ok(NodeFadenCachePublicationGuard {
+        transaction,
+        node,
+        edge,
+    })
+}
+
 #[cfg(test)]
 mod edge_write_path_tests {
     use super::*;

--- a/apps/api/src/domain_db.rs
+++ b/apps/api/src/domain_db.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result};
 use chrono::{DateTime, Timelike, Utc};
 use futures_util::TryStreamExt;
 use serde_json::{json, Map, Value};
-use sqlx::PgPool;
+use sqlx::{PgPool, Postgres, Transaction};
 use uuid::Uuid;
 
 use crate::auth::accounts::AccountStore;
@@ -1093,8 +1093,8 @@ pub async fn insert_domain_node(
 /// account row is locked `FOR UPDATE`, serializing the count-and-insert decision
 /// across all API instances. Operation replays are resolved before the limit so
 /// a successful prior create remains safely retryable even at the cap.
-pub async fn insert_domain_node_with_creator_limit(
-    pool: &PgPool,
+async fn insert_domain_node_in_transaction(
+    tx: &mut Transaction<'_, Postgres>,
     node: &Node,
     operation: Option<&CreateOperationKey>,
     creator_node_limit: Option<usize>,
@@ -1110,14 +1110,9 @@ pub async fn insert_domain_node_with_creator_limit(
         .map(|dt| dt.with_timezone(&Utc))
         .map_err(NodeCreateError::InvalidTimestamp)?;
 
-    let mut tx = pool.begin().await.map_err(NodeCreateError::Database)?;
-
     // Bind creator identity to a live canonical account for the full create
     // transaction. `FOR KEY SHARE` is compatible with unrelated account
     // updates, but conflicts with the `FOR UPDATE` lock taken by guest exit.
-    // Therefore exactly one ordering wins:
-    // - create commits first, then exit sees and anonymises the node;
-    // - exit commits first, then create observes no active account and fails.
     if let Some(creator_account_id) = node.created_by_account_id.as_deref() {
         let active_creator: Option<String> = if creator_node_limit.is_some() {
             sqlx::query_scalar(
@@ -1125,7 +1120,7 @@ pub async fn insert_domain_node_with_creator_limit(
                  WHERE id = $1 AND disabled = FALSE FOR UPDATE",
             )
             .bind(creator_account_id)
-            .fetch_optional(&mut *tx)
+            .fetch_optional(&mut **tx)
             .await
             .map_err(NodeCreateError::Database)?
         } else {
@@ -1134,12 +1129,11 @@ pub async fn insert_domain_node_with_creator_limit(
                  WHERE id = $1 AND disabled = FALSE FOR KEY SHARE",
             )
             .bind(creator_account_id)
-            .fetch_optional(&mut *tx)
+            .fetch_optional(&mut **tx)
             .await
             .map_err(NodeCreateError::Database)?
         };
         if active_creator.is_none() {
-            tx.rollback().await.ok();
             return Err(NodeCreateError::CreatorAccountUnavailable);
         }
     }
@@ -1151,7 +1145,7 @@ pub async fn insert_domain_node_with_creator_limit(
         );
         sqlx::query("SELECT pg_advisory_xact_lock($1::bigint)")
             .bind(lock_key)
-            .fetch_one(&mut *tx)
+            .fetch_one(&mut **tx)
             .await
             .map_err(NodeCreateError::Database)?;
 
@@ -1162,13 +1156,12 @@ pub async fn insert_domain_node_with_creator_limit(
         )
         .bind(&operation.actor_id)
         .bind(&operation.operation_id)
-        .fetch_optional(&mut *tx)
+        .fetch_optional(&mut **tx)
         .await
         .map_err(NodeCreateError::Database)?;
 
         if let Some(row) = existing {
             let existing = node_from_row(row).map_err(NodeCreateError::Mapping)?;
-            tx.commit().await.map_err(NodeCreateError::Database)?;
             return Ok(CreateWriteOutcome::Existing(existing));
         }
     }
@@ -1183,11 +1176,10 @@ pub async fn insert_domain_node_with_creator_limit(
                AND weltgewebe_search_node_owner_account_id(payload) = trim($1)",
         )
         .bind(creator_account_id)
-        .fetch_one(&mut *tx)
+        .fetch_one(&mut **tx)
         .await
         .map_err(NodeCreateError::Database)?;
         if owned_count >= max_i64 {
-            tx.rollback().await.ok();
             return Err(NodeCreateError::CreatorNodeLimitReached { max });
         }
     }
@@ -1209,38 +1201,35 @@ pub async fn insert_domain_node_with_creator_limit(
     .bind(operation.map(|value| value.actor_id.as_str()))
     .bind(operation.map(|value| value.operation_id.as_str()))
     .bind(node.search_visibility.as_str())
-    .execute(&mut *tx)
+    .execute(&mut **tx)
     .await;
 
     match result {
-        Ok(_) => {
-            tx.commit().await.map_err(NodeCreateError::Database)?;
-            Ok(CreateWriteOutcome::Created)
-        }
+        Ok(_) => Ok(CreateWriteOutcome::Created),
         Err(sqlx::Error::Database(db_err)) if db_err.is_unique_violation() => {
-            tx.rollback().await.ok();
-            if let Some(operation) = operation {
-                let existing: Option<NodeRow> = sqlx::query_as(
-                    "SELECT id, kind, title, lat, lon, created_at, updated_at, payload::text, search_visibility \
-                     FROM domain_nodes \
-                     WHERE create_actor_id = $1 AND create_operation_id = $2",
-                )
-                .bind(&operation.actor_id)
-                .bind(&operation.operation_id)
-                .fetch_optional(pool)
-                .await
-                .map_err(NodeCreateError::Database)?;
-                if let Some(row) = existing {
-                    return node_from_row(row)
-                        .map(CreateWriteOutcome::Existing)
-                        .map_err(NodeCreateError::Mapping);
-                }
-            }
             Err(NodeCreateError::DuplicateId)
         }
-        Err(e) => {
+        Err(error) => Err(NodeCreateError::Database(error)),
+    }
+}
+
+pub async fn insert_domain_node_with_creator_limit(
+    pool: &PgPool,
+    node: &Node,
+    operation: Option<&CreateOperationKey>,
+    creator_node_limit: Option<usize>,
+) -> Result<CreateWriteOutcome<Node>, NodeCreateError> {
+    let mut tx = pool.begin().await.map_err(NodeCreateError::Database)?;
+    let outcome =
+        insert_domain_node_in_transaction(&mut tx, node, operation, creator_node_limit).await;
+    match outcome {
+        Ok(outcome) => {
+            tx.commit().await.map_err(NodeCreateError::Database)?;
+            Ok(outcome)
+        }
+        Err(error) => {
             tx.rollback().await.ok();
-            Err(NodeCreateError::Database(e))
+            Err(error)
         }
     }
 }
@@ -1939,20 +1928,18 @@ pub enum EdgeWriteError {
 /// surface as a defensive fallback.
 ///
 /// This function performs no in-memory mutation and writes no JSONL.
-pub async fn insert_domain_edge(
-    pool: &PgPool,
+async fn insert_domain_edge_in_transaction(
+    tx: &mut Transaction<'_, Postgres>,
     edge: &crate::routes::edges::Edge,
     operation: Option<&CreateOperationKey>,
 ) -> Result<CreateWriteOutcome<Edge>, EdgeWriteError> {
     let row = NewDomainEdgeRow::from_edge(edge).map_err(EdgeWriteError::Mapping)?;
 
-    let mut tx = pool.begin().await.map_err(EdgeWriteError::Database)?;
-
-    // The existing edge path already serializes creates for cache-limit and
-    // duplicate-id semantics. The operation lookup belongs inside the same
-    // transaction so a replay cannot race the first insert.
+    // One transaction owns operation replay, duplicate detection, capacity and
+    // insertion. This helper deliberately does not commit so node creation can
+    // include its mandatory origin Faden in the same transaction.
     sqlx::query("LOCK TABLE domain_edges IN EXCLUSIVE MODE")
-        .execute(&mut *tx)
+        .execute(&mut **tx)
         .await
         .map_err(EdgeWriteError::Database)?;
 
@@ -1964,12 +1951,11 @@ pub async fn insert_domain_edge(
         )
         .bind(&operation.actor_id)
         .bind(&operation.operation_id)
-        .fetch_optional(&mut *tx)
+        .fetch_optional(&mut **tx)
         .await
         .map_err(EdgeWriteError::Database)?;
         if let Some(row) = existing {
             let existing = edge_from_row(row).map_err(EdgeWriteError::Mapping)?;
-            tx.commit().await.map_err(EdgeWriteError::Database)?;
             return Ok(CreateWriteOutcome::Existing(existing));
         }
     }
@@ -1977,18 +1963,15 @@ pub async fn insert_domain_edge(
     let (exists,): (bool,) =
         sqlx::query_as("SELECT EXISTS (SELECT 1 FROM domain_edges WHERE id = $1)")
             .bind(&row.id)
-            .fetch_one(&mut *tx)
+            .fetch_one(&mut **tx)
             .await
             .map_err(EdgeWriteError::Database)?;
-
     if exists {
-        tx.rollback().await.ok();
         return Err(EdgeWriteError::DuplicateId);
     }
 
     let max_edges = crate::routes::edges::max_edges_cache_limit();
     let max_edges_i64 = i64::try_from(max_edges).unwrap_or(i64::MAX);
-
     // Mirrors `edge_is_permanently_unreachable` for every case that is safe
     // to check without parsing the payload's `expires_at` string as a
     // timestamp (which `jsonb_typeof` never needs to do, so this can never
@@ -2038,12 +2021,10 @@ pub async fn insert_domain_edge(
          )",
     )
     .bind(max_edges_i64)
-    .fetch_one(&mut *tx)
+    .fetch_one(&mut **tx)
     .await
     .map_err(EdgeWriteError::Database)?;
-
     if limit_reached {
-        tx.rollback().await.ok();
         return Err(EdgeWriteError::CacheLimitReached);
     }
 
@@ -2062,38 +2043,161 @@ pub async fn insert_domain_edge(
     .bind(&row.payload)
     .bind(operation.map(|value| value.actor_id.as_str()))
     .bind(operation.map(|value| value.operation_id.as_str()))
-    .execute(&mut *tx)
+    .execute(&mut **tx)
     .await;
 
     match result {
-        Ok(_) => {
-            tx.commit().await.map_err(EdgeWriteError::Database)?;
-            Ok(CreateWriteOutcome::Created)
-        }
+        Ok(_) => Ok(CreateWriteOutcome::Created),
         Err(sqlx::Error::Database(db_err)) if db_err.is_unique_violation() => {
-            tx.rollback().await.ok();
-            if let Some(operation) = operation {
-                let existing: Option<EdgeRow> = sqlx::query_as(
-                    "SELECT id, source_id, target_id, edge_kind, created_at, payload::text \
-                     FROM domain_edges \
-                     WHERE create_actor_id = $1 AND create_operation_id = $2",
-                )
-                .bind(&operation.actor_id)
-                .bind(&operation.operation_id)
-                .fetch_optional(pool)
-                .await
-                .map_err(EdgeWriteError::Database)?;
-                if let Some(row) = existing {
-                    return edge_from_row(row)
-                        .map(CreateWriteOutcome::Existing)
-                        .map_err(EdgeWriteError::Mapping);
-                }
-            }
             Err(EdgeWriteError::DuplicateId)
         }
-        Err(e) => {
+        Err(error) => Err(EdgeWriteError::Database(error)),
+    }
+}
+
+pub async fn insert_domain_edge(
+    pool: &PgPool,
+    edge: &crate::routes::edges::Edge,
+    operation: Option<&CreateOperationKey>,
+) -> Result<CreateWriteOutcome<Edge>, EdgeWriteError> {
+    let mut tx = pool.begin().await.map_err(EdgeWriteError::Database)?;
+    let outcome = insert_domain_edge_in_transaction(&mut tx, edge, operation).await;
+    match outcome {
+        Ok(outcome) => {
+            tx.commit().await.map_err(EdgeWriteError::Database)?;
+            Ok(outcome)
+        }
+        Err(error) => {
             tx.rollback().await.ok();
-            Err(EdgeWriteError::Database(e))
+            Err(error)
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct NodeFadenCreateOutcome {
+    pub node: Node,
+    pub edge: Edge,
+    pub created: bool,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum NodeFadenCreateError {
+    #[error(transparent)]
+    Node(#[from] NodeCreateError),
+    #[error(transparent)]
+    Edge(#[from] EdgeWriteError),
+    #[error("node operation id was already used for different data")]
+    OperationConflict,
+    #[error("edge operation id was already used for different data")]
+    EdgeOperationConflict,
+    #[error("replayed node was deleted before its origin Faden could be repaired")]
+    ReplayedNodeDeleted,
+}
+
+fn edge_matches_projection(existing: &Edge, expected: &Edge) -> bool {
+    existing.source_id == expected.source_id
+        && existing.source_type == expected.source_type
+        && existing.target_id == expected.target_id
+        && existing.target_type == expected.target_type
+        && existing.edge_kind == expected.edge_kind
+        && existing.note == expected.note
+}
+
+/// Atomically persist a PostgreSQL node and its mandatory account→node origin
+/// Faden. Operation replays repair an older missing Faden in the same guarded
+/// transaction after validating the original node semantics.
+pub async fn insert_domain_node_and_faden_with_creator_limit<F, G>(
+    pool: &PgPool,
+    node: &Node,
+    operation: &CreateOperationKey,
+    creator_node_limit: Option<usize>,
+    existing_matches: F,
+    edge_for_node: G,
+) -> Result<NodeFadenCreateOutcome, NodeFadenCreateError>
+where
+    F: Fn(&Node) -> bool,
+    G: Fn(&str) -> Edge,
+{
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(NodeCreateError::Database)
+        .map_err(NodeFadenCreateError::Node)?;
+
+    let result: Result<NodeFadenCreateOutcome, NodeFadenCreateError> = async {
+        if let Some(account_id) = node.created_by_account_id.as_deref() {
+            sqlx::query("SELECT pg_advisory_xact_lock($1::bigint)")
+                .bind(crate::advisory_lock::account_lifecycle_lock_key(account_id))
+                .execute(&mut *tx)
+                .await
+                .map_err(NodeCreateError::Database)?;
+        }
+
+        let node_outcome =
+            insert_domain_node_in_transaction(&mut tx, node, Some(operation), creator_node_limit)
+                .await?;
+        let (actual_node, created) = match node_outcome {
+            CreateWriteOutcome::Created => (node.clone(), true),
+            CreateWriteOutcome::Existing(existing) => {
+                if !existing_matches(&existing) {
+                    return Err(NodeFadenCreateError::OperationConflict);
+                }
+                (existing, false)
+            }
+        };
+
+        sqlx::query("SELECT pg_advisory_xact_lock($1::bigint)")
+            .bind(crate::advisory_lock::node_mutation_lock_key(
+                &actual_node.id,
+            ))
+            .execute(&mut *tx)
+            .await
+            .map_err(NodeCreateError::Database)?;
+        if !created {
+            let node_still_exists: bool =
+                sqlx::query_scalar("SELECT EXISTS (SELECT 1 FROM domain_nodes WHERE id = $1)")
+                    .bind(&actual_node.id)
+                    .fetch_one(&mut *tx)
+                    .await
+                    .map_err(NodeCreateError::Database)?;
+            if !node_still_exists {
+                return Err(NodeFadenCreateError::ReplayedNodeDeleted);
+            }
+        }
+
+        let expected_edge = edge_for_node(&actual_node.id);
+        let edge_outcome =
+            insert_domain_edge_in_transaction(&mut tx, &expected_edge, Some(operation)).await?;
+        let actual_edge = match edge_outcome {
+            CreateWriteOutcome::Created => expected_edge,
+            CreateWriteOutcome::Existing(existing) => {
+                if !edge_matches_projection(&existing, &expected_edge) {
+                    return Err(NodeFadenCreateError::EdgeOperationConflict);
+                }
+                existing
+            }
+        };
+
+        Ok(NodeFadenCreateOutcome {
+            node: actual_node,
+            edge: actual_edge,
+            created,
+        })
+    }
+    .await;
+
+    match result {
+        Ok(outcome) => {
+            tx.commit()
+                .await
+                .map_err(NodeCreateError::Database)
+                .map_err(NodeFadenCreateError::Node)?;
+            Ok(outcome)
+        }
+        Err(error) => {
+            tx.rollback().await.ok();
+            Err(error)
         }
     }
 }

--- a/apps/api/src/routes/edges.rs
+++ b/apps/api/src/routes/edges.rs
@@ -904,6 +904,23 @@ fn build_edge_record(
     (edge, Value::Object(record))
 }
 
+/// Build the canonical account→node Faden for a successful node creation.
+/// PostgreSQL node creation persists this value in the same transaction as the
+/// node; JSONL callers continue through the regular projection writer.
+pub(crate) fn build_node_origin_faden(account_id: &str, node_id: &str) -> Edge {
+    let validated = edge_create::ValidatedCreateEdge {
+        id: None,
+        source_id: account_id.to_string(),
+        target_id: node_id.to_string(),
+        edge_kind: "reference".to_string(),
+        source_type: "account".to_string(),
+        target_type: "node".to_string(),
+        note: None,
+        operation_id: None,
+    };
+    build_edge_record(validated, Uuid::new_v4().to_string(), Utc::now()).0
+}
+
 /// Map an `EdgeCreateValidationError` onto a stable message for the 400 body.
 fn edge_create_error_message(err: &edge_create::EdgeCreateValidationError) -> String {
     use edge_create::EdgeCreateValidationError as E;

--- a/apps/api/src/routes/nodes.rs
+++ b/apps/api/src/routes/nodes.rs
@@ -1125,7 +1125,7 @@ async fn rollback_newly_created_node_after_faden_failure(
 /// JSONL (default): durable JSONL append (fsync), serialized against
 /// concurrent node persistence via `state.nodes_persist`.
 /// PostgreSQL (opt-in via `WELTGEWEBE_DOMAIN_NODE_WRITE_SOURCE=postgres`,
-/// requires the canonical PostgreSQL account/edge sources): one transaction
+/// requires PostgreSQL reads plus PostgreSQL node/edge writes): one transaction
 /// commits the node, its conversation trigger effects, idempotency binding and
 /// mandatory account→node origin Faden. No dual-write: JSONL mode never touches
 /// PostgreSQL, PostgreSQL mode never appends JSONL.
@@ -1198,8 +1198,11 @@ pub async fn create_node(
         build_node_record(validated, id.clone(), now, creator_account_id.clone());
     add_create_operation_metadata(&mut record, operation.as_ref());
 
-    let postgres_lifecycle_guarded = state.config.domain_read_source == DomainReadSource::Postgres
-        && state.config.domain_account_write_source == DomainAccountWriteSource::Postgres
+    // Account writes may deliberately remain JSONL/read-only during a staged
+    // migration. The creator account is nevertheless canonical PostgreSQL truth
+    // whenever domain reads are PostgreSQL, so atomic node creation depends only
+    // on the read, node-write and edge-write sources.
+    let postgres_atomic_create = state.config.domain_read_source == DomainReadSource::Postgres
         && state.config.domain_node_write_source == DomainNodeWriteSource::Postgres
         && state.config.domain_edge_write_source == DomainEdgeWriteSource::Postgres;
 
@@ -1207,7 +1210,7 @@ pub async fn create_node(
     // account→node origin Faden in one transaction. Cache state is published
     // only after commit. An operation replay can repair an older partial node,
     // but cannot attach a Faden when the original request semantics differ.
-    if postgres_lifecycle_guarded {
+    if postgres_atomic_create {
         let pool = state.db_pool.as_ref().ok_or_else(|| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -1427,7 +1430,7 @@ pub async fn create_node(
             // internally inconsistent; never fall back to a partial write.
             return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
-                "PostgreSQL node create requires canonical PostgreSQL account and edge sources"
+                "PostgreSQL node create requires PostgreSQL reads plus PostgreSQL node and edge writes"
                     .to_string(),
             ));
         }

--- a/apps/api/src/routes/nodes.rs
+++ b/apps/api/src/routes/nodes.rs
@@ -1302,23 +1302,25 @@ pub async fn create_node(
         let canonical_node = publication.node.clone();
         let canonical_edge = publication.edge.clone();
 
-        // Publish the Faden cache entry first. Removing the original ids before
-        // inserting the canonical snapshots also handles a deletion that won
-        // the post-commit gap.
+        // Acquire both cache writers before mutating either projection. Match
+        // `ApiState::refresh_domain_projection_if_stale` lock order (nodes,
+        // then edges) so refresh and create cannot deadlock. Once both guards
+        // are held, readers observe either the old pair or the new pair, never
+        // a Faden whose target node is not yet available from the node cache.
         {
+            let mut nodes = state.nodes.write().await;
             let mut edges = state.edges.write().await;
+
             edges.remove(&outcome.edge.id);
             if let Some(edge) = canonical_edge.as_ref() {
                 edges.insert(edge.id.clone(), edge.clone());
             }
-            state.metrics.set_edges_cache_count(edges.len() as i64);
-        }
-        {
-            let mut nodes = state.nodes.write().await;
             nodes.remove(&outcome.node.id);
             if let Some(node) = canonical_node.as_ref() {
                 nodes.insert(node.id.clone(), node.clone());
             }
+
+            state.metrics.set_edges_cache_count(edges.len() as i64);
             state.metrics.set_nodes_cache_count(nodes.len() as i64);
         }
         if let Err(error) = publication.release().await {

--- a/apps/api/src/routes/nodes.rs
+++ b/apps/api/src/routes/nodes.rs
@@ -1114,6 +1114,33 @@ async fn rollback_newly_created_node_after_faden_failure(
     Ok(())
 }
 
+const NODE_CREATE_PUBLICATION_DELETED_MESSAGE: &str =
+    "node was deleted before the create response could be published";
+
+fn published_node_or_conflict(canonical_node: Option<Node>) -> Result<Node, (StatusCode, String)> {
+    canonical_node.ok_or_else(|| {
+        (
+            StatusCode::CONFLICT,
+            NODE_CREATE_PUBLICATION_DELETED_MESSAGE.to_string(),
+        )
+    })
+}
+
+#[cfg(test)]
+mod node_create_publication_tests {
+    use super::{published_node_or_conflict, NODE_CREATE_PUBLICATION_DELETED_MESSAGE};
+    use axum::http::StatusCode;
+
+    #[test]
+    fn deleted_post_commit_node_is_not_reported_as_created() {
+        let (status, message) = published_node_or_conflict(None)
+            .expect_err("deleted canonical node must not fall back to stale create output");
+
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(message, NODE_CREATE_PUBLICATION_DELETED_MESSAGE);
+    }
+}
+
 /// Create a node.
 ///
 /// Write path: write gate ([`reject_node_create_unless_writable`]) -> contract
@@ -1332,7 +1359,17 @@ pub async fn create_node(
         } else {
             StatusCode::OK
         };
-        let response_node = canonical_node.unwrap_or_else(|| outcome.node.clone());
+        let response_node = match published_node_or_conflict(canonical_node) {
+            Ok(node) => node,
+            Err(error) => {
+                tracing::warn!(
+                    node_id = %outcome.node.id,
+                    replay = !outcome.created,
+                    "Node was deleted before its create response could be published"
+                );
+                return Err(error);
+            }
+        };
         tracing::info!(
             event = "node.created",
             node_id = %outcome.node.id,

--- a/apps/api/src/routes/nodes.rs
+++ b/apps/api/src/routes/nodes.rs
@@ -12,15 +12,15 @@ use super::{
         MAX_PAGE_SIZE,
     },
 };
-use crate::advisory_lock::{account_lifecycle_lock_key, node_mutation_lock_key};
 use crate::auth::role::Role;
 use crate::config::{
     DomainAccountWriteSource, DomainEdgeWriteSource, DomainNodeWriteSource, DomainReadSource,
 };
 use crate::domain_db::{
-    delete_node_with_edges_in_postgres, insert_domain_node_with_creator_limit,
-    patch_node_in_postgres, replace_node_in_postgres, CreateOperationKey, CreateWriteOutcome,
-    NodeConversationDeleteEffect, NodeCreateError, NodePatchInput, NodeWriteError,
+    delete_node_with_edges_in_postgres, insert_domain_node_and_faden_with_creator_limit,
+    patch_node_in_postgres, replace_node_in_postgres, CreateOperationKey,
+    NodeConversationDeleteEffect, NodeCreateError, NodeFadenCreateError, NodePatchInput,
+    NodeWriteError,
 };
 use crate::middleware::auth::AuthContext;
 use crate::state::{ApiState, OrderedCache};
@@ -35,27 +35,13 @@ use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::path::{Path as FsPath, PathBuf};
-use std::sync::OnceLock;
 use tokio::{
     fs::{File, OpenOptions},
     io::{
         AsyncBufReadExt, AsyncReadExt, AsyncSeekExt, AsyncWriteExt, BufReader, BufWriter, SeekFrom,
     },
-    sync::Semaphore,
 };
 use uuid::Uuid;
-
-fn node_create_faden_db_semaphore() -> &'static Semaphore {
-    static SEMAPHORE: OnceLock<Semaphore> = OnceLock::new();
-    SEMAPHORE.get_or_init(|| {
-        // Each projected PostgreSQL create temporarily needs two connections:
-        // one for the account guard and one for the edge transaction. Reserve
-        // one pool slot for unrelated work and admit only pairs that fit.
-        let permits =
-            (((crate::DATABASE_POOL_MAX_CONNECTIONS as usize).saturating_sub(1)) / 2).max(1);
-        Semaphore::new(permits)
-    })
-}
 
 pub enum NodeMutationError {
     Status(StatusCode),
@@ -1104,32 +1090,19 @@ async fn rollback_newly_created_node_after_faden_failure(
     state: &ApiState,
     node_id: &str,
 ) -> Result<(), String> {
-    let removed_edge_ids = match state.config.domain_node_write_source {
-        DomainNodeWriteSource::Jsonl => {
-            // Match normal JSONL create/delete lock order: node persistence
-            // before edge persistence. The journal-backed helper restores both
-            // files together after crashes during compensation.
-            let _node_guard = state.nodes_persist.lock().await;
-            let _edge_guard = edge_create_persist_lock().lock().await;
-            let outcome =
-                delete_node_and_edges_jsonl(node_id, EdgeEndpointCollisionEvidence::default())
-                    .await
-                    .map_err(|error| format!("failed to compensate JSONL node create: {error}"))?;
-            outcome.removed_edge_ids
-        }
-        DomainNodeWriteSource::Postgres => {
-            let pool = state.db_pool.as_ref().ok_or_else(|| {
-                "PostgreSQL pool unavailable during node compensation".to_string()
-            })?;
-            delete_node_with_edges_in_postgres(pool, node_id)
-                .await
-                .map_err(|error| format!("failed to compensate PostgreSQL node create: {error}"))?
-                .removed_edge_ids
-        }
-    };
+    // Only JSONL reaches compensation: PostgreSQL commits the node and its
+    // mandatory origin Faden in one transaction and returns before this path.
+    // Match normal JSONL create/delete lock order: node persistence before edge
+    // persistence. The journal-backed helper restores both files together after
+    // crashes during compensation.
+    let _node_guard = state.nodes_persist.lock().await;
+    let _edge_guard = edge_create_persist_lock().lock().await;
+    let outcome = delete_node_and_edges_jsonl(node_id, EdgeEndpointCollisionEvidence::default())
+        .await
+        .map_err(|error| format!("failed to compensate JSONL node create: {error}"))?;
 
     let mut edges = state.edges.write().await;
-    for edge_id in &removed_edge_ids {
+    for edge_id in &outcome.removed_edge_ids {
         edges.remove(edge_id);
     }
     state.metrics.set_edges_cache_count(edges.len() as i64);
@@ -1152,9 +1125,9 @@ async fn rollback_newly_created_node_after_faden_failure(
 /// JSONL (default): durable JSONL append (fsync), serialized against
 /// concurrent node persistence via `state.nodes_persist`.
 /// PostgreSQL (opt-in via `WELTGEWEBE_DOMAIN_NODE_WRITE_SOURCE=postgres`,
-/// requires the PostgreSQL read source): one transaction, a per-operation
-/// advisory lock when `operation_id` is present, an account-scoped partial
-/// unique index, and the final INSERT. No dual-write: JSONL mode never touches
+/// requires the canonical PostgreSQL account/edge sources): one transaction
+/// commits the node, its conversation trigger effects, idempotency binding and
+/// mandatory account→node origin Faden. No dual-write: JSONL mode never touches
 /// PostgreSQL, PostgreSQL mode never appends JSONL.
 pub async fn create_node(
     State(state): State<ApiState>,
@@ -1230,65 +1203,108 @@ pub async fn create_node(
         && state.config.domain_node_write_source == DomainNodeWriteSource::Postgres
         && state.config.domain_edge_write_source == DomainEdgeWriteSource::Postgres;
 
-    // The guard itself occupies one pool connection while node/edge persistence
-    // uses a second. Admit only as many complete create operations as the pool
-    // can sustain, leaving one connection available for unrelated work.
-    let _db_create_permit = if postgres_lifecycle_guarded {
-        Some(
-            node_create_faden_db_semaphore()
-                .acquire()
-                .await
-                .map_err(|_| {
-                    (
-                        StatusCode::SERVICE_UNAVAILABLE,
-                        "node create coordinator unavailable".to_string(),
-                    )
-                })?,
-        )
-    } else {
-        None
-    };
-
-    let mut node_create_lifecycle_guard = if postgres_lifecycle_guarded {
+    // The canonical PostgreSQL configuration writes the node and its mandatory
+    // account→node origin Faden in one transaction. Cache state is published
+    // only after commit. An operation replay can repair an older partial node,
+    // but cannot attach a Faden when the original request semantics differ.
+    if postgres_lifecycle_guarded {
         let pool = state.db_pool.as_ref().ok_or_else(|| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                "PostgreSQL pool unavailable for node lifecycle guard".to_string(),
+                "PostgreSQL pool unavailable for atomic node creation".to_string(),
             )
         })?;
-        let mut tx = pool.begin().await.map_err(|error| {
-            tracing::error!(%error, account_id = %creator_account_id, node_id = %node.id, "failed to begin node lifecycle guard");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "failed to guard node creation lifecycle".to_string(),
-            )
-        })?;
-        sqlx::query("SELECT pg_advisory_xact_lock($1::bigint)")
-            .bind(account_lifecycle_lock_key(&creator_account_id))
-            .execute(&mut *tx)
-            .await
-            .map_err(|error| {
-                tracing::error!(%error, account_id = %creator_account_id, node_id = %node.id, "failed to lock account lifecycle for node create");
-                (
+        let creator_node_limit =
+            (auth.role == Role::Gast).then_some(state.config.max_guest_owned_nodes);
+        let operation_key = operation
+            .as_ref()
+            .expect("validated node create always carries an operation id");
+        let outcome = insert_domain_node_and_faden_with_creator_limit(
+            pool,
+            &node,
+            operation_key,
+            creator_node_limit,
+            |existing| node_matches_create(existing, &semantic_request),
+            |actual_node_id| {
+                super::edges::build_node_origin_faden(&creator_account_id, actual_node_id)
+            },
+        )
+        .await;
+
+        let outcome = match outcome {
+            Ok(outcome) => outcome,
+            Err(NodeFadenCreateError::OperationConflict) => {
+                return Err((
+                    StatusCode::CONFLICT,
+                    "node operation id was already used for different data".to_string(),
+                ));
+            }
+            Err(NodeFadenCreateError::EdgeOperationConflict) => {
+                return Err((
+                    StatusCode::CONFLICT,
+                    "node operation id has an inconsistent origin Faden".to_string(),
+                ));
+            }
+            Err(NodeFadenCreateError::ReplayedNodeDeleted) => {
+                return Err((
+                    StatusCode::CONFLICT,
+                    "node operation result was deleted before replay completed".to_string(),
+                ));
+            }
+            Err(NodeFadenCreateError::Node(NodeCreateError::DuplicateId)) => {
+                return Err((StatusCode::CONFLICT, "node id already exists".to_string()));
+            }
+            Err(NodeFadenCreateError::Node(NodeCreateError::CreatorAccountUnavailable)) => {
+                return Err((
+                    StatusCode::UNAUTHORIZED,
+                    "creator account is no longer active".to_string(),
+                ));
+            }
+            Err(NodeFadenCreateError::Node(NodeCreateError::CreatorNodeLimitReached { max })) => {
+                return Err((
+                    StatusCode::TOO_MANY_REQUESTS,
+                    format!("guest node limit reached ({max})"),
+                ));
+            }
+            Err(error) => {
+                tracing::error!(%error, node_id = %node.id, "atomic node and origin Faden create failed");
+                return Err((
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    "failed to guard node creation lifecycle".to_string(),
-                )
-            })?;
-        sqlx::query("SELECT pg_advisory_xact_lock($1::bigint)")
-            .bind(node_mutation_lock_key(&node.id))
-            .execute(&mut *tx)
-            .await
-            .map_err(|error| {
-                tracing::error!(%error, account_id = %creator_account_id, node_id = %node.id, "failed to lock new node mutation lifecycle");
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "failed to guard node creation lifecycle".to_string(),
-                )
-            })?;
-        Some(tx)
-    } else {
-        None
-    };
+                    "failed to persist node and its origin Faden atomically".to_string(),
+                ));
+            }
+        };
+
+        // Publish the Faden cache entry first. Durable state is already atomic;
+        // this ordering also prevents an in-process reader from briefly seeing
+        // the node without its required origin Faden between the two cache locks.
+        {
+            let mut edges = state.edges.write().await;
+            edges.insert(outcome.edge.id.clone(), outcome.edge.clone());
+            state.metrics.set_edges_cache_count(edges.len() as i64);
+        }
+        {
+            let mut nodes = state.nodes.write().await;
+            nodes.insert(outcome.node.id.clone(), outcome.node.clone());
+            state.metrics.set_nodes_cache_count(nodes.len() as i64);
+        }
+
+        let status = if outcome.created {
+            StatusCode::CREATED
+        } else {
+            StatusCode::OK
+        };
+        tracing::info!(
+            event = "node.created",
+            node_id = %outcome.node.id,
+            write_source = ?state.config.domain_node_write_source,
+            operation_bound = true,
+            atomic_origin_faden = true,
+            replay = !outcome.created,
+            "Node and origin Faden committed atomically"
+        );
+        return Ok((status, Json(outcome.node)));
+    }
 
     match state.config.domain_node_write_source {
         DomainNodeWriteSource::Jsonl => {
@@ -1372,129 +1388,14 @@ pub async fn create_node(
             state.metrics.set_nodes_cache_count(nodes.len() as i64);
         }
         DomainNodeWriteSource::Postgres => {
-            // PostgreSQL mode never appends JSONL. The helper performs the
-            // operation lookup and insert in one transaction.
-            {
-                let nodes = state.nodes.read().await;
-                if nodes.get(&id).is_some() {
-                    return Err((StatusCode::CONFLICT, "node id already exists".to_string()));
-                }
-            }
-
-            // Startup validation normally guarantees this pool; missing
-            // state fails closed rather than falling back to JSONL.
-            let pool = state.db_pool.as_ref().ok_or_else(|| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "PostgreSQL pool unavailable for node write".to_string(),
-                )
-            })?;
-            let creator_node_limit =
-                (auth.role == Role::Gast).then_some(state.config.max_guest_owned_nodes);
-            match insert_domain_node_with_creator_limit(
-                pool,
-                &node,
-                operation.as_ref(),
-                creator_node_limit,
-            )
-            .await
-            {
-                Ok(CreateWriteOutcome::Created) => {}
-                Ok(CreateWriteOutcome::Existing(existing)) => {
-                    if !node_matches_create(&existing, &semantic_request) {
-                        return Err((
-                            StatusCode::CONFLICT,
-                            "node operation id was already used for different data".to_string(),
-                        ));
-                    }
-                    if postgres_lifecycle_guarded {
-                        let tx = node_create_lifecycle_guard.as_mut().ok_or_else(|| {
-                            (
-                                StatusCode::INTERNAL_SERVER_ERROR,
-                                "PostgreSQL node lifecycle guard disappeared during replay"
-                                    .to_string(),
-                            )
-                        })?;
-                        sqlx::query("SELECT pg_advisory_xact_lock($1::bigint)")
-                            .bind(node_mutation_lock_key(&existing.id))
-                            .execute(&mut **tx)
-                            .await
-                            .map_err(|error| {
-                                tracing::error!(%error, node_id = %existing.id, "failed to lock replayed node mutation lifecycle");
-                                (
-                                    StatusCode::INTERNAL_SERVER_ERROR,
-                                    "failed to guard replayed node creation lifecycle".to_string(),
-                                )
-                            })?;
-                        let node_still_exists: bool = sqlx::query_scalar(
-                            "SELECT EXISTS (SELECT 1 FROM domain_nodes WHERE id = $1)",
-                        )
-                        .bind(&existing.id)
-                        .fetch_one(&mut **tx)
-                        .await
-                        .map_err(|error| {
-                            tracing::error!(%error, node_id = %existing.id, "failed to recheck replayed node after acquiring mutation lock");
-                            (
-                                StatusCode::INTERNAL_SERVER_ERROR,
-                                "failed to verify replayed node creation lifecycle".to_string(),
-                            )
-                        })?;
-                        if !node_still_exists {
-                            return Err((
-                                StatusCode::CONFLICT,
-                                "node operation result was deleted before replay completed"
-                                    .to_string(),
-                            ));
-                        }
-                    }
-                    {
-                        let mut nodes = state.nodes.write().await;
-                        nodes.insert(existing.id.clone(), existing.clone());
-                        state.metrics.set_nodes_cache_count(nodes.len() as i64);
-                    }
-                    ensure_node_faden_with_operation_id(
-                        &state,
-                        &auth,
-                        &existing.id,
-                        semantic_request.operation_id.as_deref(),
-                        postgres_lifecycle_guarded,
-                        "node_create",
-                    )
-                    .await?;
-                    if let Some(tx) = node_create_lifecycle_guard.take() {
-                        if let Err(error) = tx.rollback().await {
-                            tracing::warn!(%error, node_id = %existing.id, "node lifecycle guard connection ended while releasing replay locks");
-                        }
-                    }
-                    return Ok((StatusCode::OK, Json(existing)));
-                }
-                Err(NodeCreateError::DuplicateId) => {
-                    return Err((StatusCode::CONFLICT, "node id already exists".to_string()));
-                }
-                Err(NodeCreateError::CreatorAccountUnavailable) => {
-                    return Err((
-                        StatusCode::UNAUTHORIZED,
-                        "creator account is no longer active".to_string(),
-                    ));
-                }
-                Err(NodeCreateError::CreatorNodeLimitReached { max }) => {
-                    return Err((
-                        StatusCode::TOO_MANY_REQUESTS,
-                        format!("guest node limit reached ({max})"),
-                    ));
-                }
-                Err(e) => {
-                    tracing::error!(error = %e, "failed to insert node into domain_nodes");
-                    return Err((
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        "failed to persist node".to_string(),
-                    ));
-                }
-            }
-
-            let mut nodes = state.nodes.write().await;
-            nodes.insert(id.clone(), node.clone());
-            state.metrics.set_nodes_cache_count(nodes.len() as i64);
+            // Any supported PostgreSQL configuration returned from the atomic
+            // branch above. Reaching this arm means the source contract is
+            // internally inconsistent; never fall back to a partial write.
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "PostgreSQL node create requires canonical PostgreSQL account and edge sources"
+                    .to_string(),
+            ));
         }
     }
 
@@ -1503,7 +1404,7 @@ pub async fn create_node(
         &auth,
         &node.id,
         semantic_request.operation_id.as_deref(),
-        postgres_lifecycle_guarded,
+        false,
         "node_create",
     )
     .await
@@ -1516,24 +1417,12 @@ pub async fn create_node(
                 %rollback_error,
                 "Derived Faden failed and compensating node rollback also failed"
             );
-            if let Some(tx) = node_create_lifecycle_guard.take() {
-                tx.rollback().await.ok();
-            }
             return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "derived Faden failed and node rollback could not be completed".to_string(),
             ));
         }
-        if let Some(tx) = node_create_lifecycle_guard.take() {
-            tx.rollback().await.ok();
-        }
         return Err(projection_error);
-    }
-
-    if let Some(tx) = node_create_lifecycle_guard.take() {
-        if let Err(error) = tx.rollback().await {
-            tracing::warn!(%error, node_id = %node.id, "node lifecycle guard connection ended while releasing locks");
-        }
     }
 
     tracing::info!(
@@ -1555,7 +1444,8 @@ pub async fn create_node(
 /// that supplies them gets a deterministic 400 instead of a silently dropped
 /// field. `operation_id` is required and must be a non-null UUID so a client
 /// can safely replay the same account-scoped create action when the derived
-/// Faden projection fails after the node itself became durable.
+/// Faden projection fails after a JSONL node itself became durable.
+/// PostgreSQL commits both records atomically and never enters this state.
 mod node_create {
     use super::{SearchVisibility, NODE_INFO_MAX_LEN};
     use serde::{de, Deserialize, Deserializer};

--- a/apps/api/src/routes/nodes.rs
+++ b/apps/api/src/routes/nodes.rs
@@ -18,9 +18,9 @@ use crate::config::{
 };
 use crate::domain_db::{
     delete_node_with_edges_in_postgres, insert_domain_node_and_faden_with_creator_limit,
-    patch_node_in_postgres, replace_node_in_postgres, CreateOperationKey,
-    NodeConversationDeleteEffect, NodeCreateError, NodeFadenCreateError, NodePatchInput,
-    NodeWriteError,
+    lock_node_faden_cache_publication, patch_node_in_postgres, replace_node_in_postgres,
+    CreateOperationKey, NodeConversationDeleteEffect, NodeCreateError, NodeFadenCreateError,
+    NodePatchInput, NodeWriteError,
 };
 use crate::middleware::auth::AuthContext;
 use crate::state::{ApiState, OrderedCache};
@@ -1275,18 +1275,51 @@ pub async fn create_node(
             }
         };
 
-        // Publish the Faden cache entry first. Durable state is already atomic;
-        // this ordering also prevents an in-process reader from briefly seeing
-        // the node without its required origin Faden between the two cache locks.
+        // Commit releases the transaction-scoped creation locks. Reacquire the
+        // canonical node-mutation lock before touching caches and read the
+        // post-commit truth under that lock. If delete or guest exit won the
+        // narrow gap, their state is preserved instead of being overwritten by
+        // the stale create outcome. The guard remains held through both cache
+        // writes, matching edit/delete serialization across API instances.
+        let publication = lock_node_faden_cache_publication(
+            pool,
+            &outcome.node.id,
+            operation_key,
+            &outcome.edge,
+        )
+        .await
+        .map_err(|error| {
+            tracing::error!(%error, node_id = %outcome.node.id, "failed to lock canonical node/Faden cache publication");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "node and origin Faden committed, but cache publication could not be reconciled; retry the same operation"
+                    .to_string(),
+            )
+        })?;
+        let canonical_node = publication.node.clone();
+        let canonical_edge = publication.edge.clone();
+
+        // Publish the Faden cache entry first. Removing the original ids before
+        // inserting the canonical snapshots also handles a deletion that won
+        // the post-commit gap.
         {
             let mut edges = state.edges.write().await;
-            edges.insert(outcome.edge.id.clone(), outcome.edge.clone());
+            edges.remove(&outcome.edge.id);
+            if let Some(edge) = canonical_edge.as_ref() {
+                edges.insert(edge.id.clone(), edge.clone());
+            }
             state.metrics.set_edges_cache_count(edges.len() as i64);
         }
         {
             let mut nodes = state.nodes.write().await;
-            nodes.insert(outcome.node.id.clone(), outcome.node.clone());
+            nodes.remove(&outcome.node.id);
+            if let Some(node) = canonical_node.as_ref() {
+                nodes.insert(node.id.clone(), node.clone());
+            }
             state.metrics.set_nodes_cache_count(nodes.len() as i64);
+        }
+        if let Err(error) = publication.release().await {
+            tracing::error!(%error, node_id = %outcome.node.id, "failed to release node/Faden cache publication lock");
         }
 
         let status = if outcome.created {
@@ -1294,6 +1327,7 @@ pub async fn create_node(
         } else {
             StatusCode::OK
         };
+        let response_node = canonical_node.unwrap_or_else(|| outcome.node.clone());
         tracing::info!(
             event = "node.created",
             node_id = %outcome.node.id,
@@ -1303,7 +1337,7 @@ pub async fn create_node(
             replay = !outcome.created,
             "Node and origin Faden committed atomically"
         );
-        return Ok((status, Json(outcome.node)));
+        return Ok((status, Json(response_node)));
     }
 
     match state.config.domain_node_write_source {

--- a/apps/api/tests/db_domain_node_write_path.rs
+++ b/apps/api/tests/db_domain_node_write_path.rs
@@ -2475,6 +2475,92 @@ async fn node_faden_cache_publication_is_delete_race_safe() -> Result<()> {
     Ok(())
 }
 
+/// K2i. Cache publication acquires both write guards before changing either
+/// projection. Holding a node-cache reader must therefore prevent the origin
+/// Faden from becoming visible on its own.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
+#[serial]
+async fn node_and_faden_caches_publish_in_one_critical_section() -> Result<()> {
+    const ACTOR_ID: &str = "20000000-0000-0000-0000-000000000096";
+
+    let pool = connect_pool().await;
+    run_migrations(&pool).await;
+    clean_all_nodes(&pool).await;
+
+    let tmp = tempfile::tempdir()?;
+    let in_dir = tmp.path().join("in");
+    std::fs::create_dir_all(&in_dir)?;
+    let _env = set_gewebe_in_dir(&in_dir);
+    let (app, cookie, state) = postgres_write_app(pool.clone(), ACTOR_ID).await?;
+
+    let edges_before = state.edges.read().await.len();
+    let nodes_before = state.nodes.read().await.len();
+    let node_reader = state.nodes.read().await;
+
+    let request = post_node_req(
+        &cookie,
+        r#"{"title":"Atomic Cache Pair","kind":"Werkstatt","address":"Cacheweg 1","location":{"lat":53.5,"lon":10.0},"operation_id":"30000000-0000-4000-8000-000000000097"}"#,
+    );
+    let create_app = app.clone();
+    let mut create_task = tokio::spawn(async move { create_app.oneshot(request).await });
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let durable: bool = sqlx::query_scalar(
+                "SELECT EXISTS (SELECT 1 FROM domain_nodes WHERE payload ->> 'created_by_account_id' = $1)",
+            )
+            .bind(ACTOR_ID)
+            .fetch_one(&pool)
+            .await
+            .expect("probe durable node");
+            if durable {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .context("node becomes durable before blocked cache publication")?;
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(150), &mut create_task)
+            .await
+            .is_err(),
+        "create response must wait while the node cache writer is blocked"
+    );
+    assert_eq!(
+        state.edges.read().await.len(),
+        edges_before,
+        "origin Faden must not publish before the node cache writer is acquired"
+    );
+    assert_eq!(node_reader.len(), nodes_before);
+    drop(node_reader);
+
+    let response = tokio::time::timeout(Duration::from_secs(5), create_task)
+        .await
+        .context("create completes after node cache reader release")?
+        .context("join cache-pair create")??;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let response_body = body::to_bytes(response.into_body(), usize::MAX).await?;
+    let created: serde_json::Value = serde_json::from_slice(&response_body)?;
+    let node_id = created["id"].as_str().context("cache-pair node id")?;
+
+    assert!(state.nodes.read().await.get(node_id).is_some());
+    assert!(
+        state
+            .edges
+            .read()
+            .await
+            .iter_in_order()
+            .any(|edge| edge.source_id == ACTOR_ID && edge.target_id == node_id),
+        "node and origin Faden must both be present after publication"
+    );
+
+    clean_all_nodes(&pool).await;
+    Ok(())
+}
+
 /// K3. The real PostgreSQL HTTP path keeps node and origin Faden in one
 /// transaction while holding the account-lifecycle lock. A concurrent reader
 /// cannot observe the node before the blocked Faden insert, and guest exit must

--- a/apps/api/tests/db_domain_node_write_path.rs
+++ b/apps/api/tests/db_domain_node_write_path.rs
@@ -43,8 +43,9 @@ use weltgewebe_api::{
     },
     domain_db::{
         delete_node_with_edges_in_postgres, insert_domain_node, load_nodes_from_postgres,
-        patch_node_in_postgres, replace_node_in_postgres, NodeConversationDeleteEffect,
-        NodeCreateError, NodePatchInput, NodeWriteError,
+        lock_node_faden_cache_publication, patch_node_in_postgres, replace_node_in_postgres,
+        CreateOperationKey, NodeConversationDeleteEffect, NodeCreateError, NodePatchInput,
+        NodeWriteError,
     },
     governance::delete_guest_account,
     middleware::{
@@ -2249,6 +2250,141 @@ async fn node_create_replay_locks_existing_node_before_faden_repair() -> Result<
         state.nodes.read().await.get(&node_id).is_none(),
         "conflicting replay must not leave a stale node in cache"
     );
+
+    clean_all_nodes(&pool).await;
+    Ok(())
+}
+
+/// K2h. Post-commit cache publication re-reads canonical state under the same
+/// node lock as edit/delete. A deletion that wins the commit→cache gap is
+/// observed, while a later deletion waits until publication releases the lock.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
+#[serial]
+async fn node_faden_cache_publication_is_delete_race_safe() -> Result<()> {
+    const ACTOR_ID: &str = "20000000-0000-0000-0000-000000000095";
+    const OPERATION_ONE: &str = "30000000-0000-4000-8000-000000000095";
+    const OPERATION_TWO: &str = "30000000-0000-4000-8000-000000000096";
+
+    let pool = connect_pool().await;
+    run_migrations(&pool).await;
+    clean_all_nodes(&pool).await;
+
+    let tmp = tempfile::tempdir()?;
+    let in_dir = tmp.path().join("in");
+    std::fs::create_dir_all(&in_dir)?;
+    let _env = set_gewebe_in_dir(&in_dir);
+    let (app, cookie, state) = postgres_write_app(pool.clone(), ACTOR_ID).await?;
+
+    let create = |title: &str, operation_id: &str| {
+        serde_json::json!({
+            "title": title,
+            "kind": "Werkstatt",
+            "address": "Publikationsweg 1",
+            "location": {"lat": 53.5, "lon": 10.0},
+            "operation_id": operation_id
+        })
+        .to_string()
+    };
+
+    let first_response = app
+        .clone()
+        .oneshot(post_node_req(
+            &cookie,
+            &create("Delete wins", OPERATION_ONE),
+        ))
+        .await?;
+    assert_eq!(first_response.status(), StatusCode::CREATED);
+    let first_body = body::to_bytes(first_response.into_body(), usize::MAX).await?;
+    let first: serde_json::Value = serde_json::from_slice(&first_body)?;
+    let first_node_id = first["id"].as_str().context("first node id")?.to_string();
+    let first_edge = state
+        .edges
+        .read()
+        .await
+        .iter_in_order()
+        .find(|edge| edge.source_id == ACTOR_ID && edge.target_id == first_node_id)
+        .cloned()
+        .context("first origin Faden")?;
+    let first_operation = CreateOperationKey {
+        actor_id: ACTOR_ID.to_string(),
+        operation_id: OPERATION_ONE.to_string(),
+    };
+
+    delete_node_with_edges_in_postgres(&pool, &first_node_id)
+        .await
+        .context("delete before cache publication readback")?;
+    let deleted_snapshot =
+        lock_node_faden_cache_publication(&pool, &first_node_id, &first_operation, &first_edge)
+            .await
+            .context("lock deleted publication snapshot")?;
+    assert!(deleted_snapshot.node.is_none());
+    assert!(deleted_snapshot.edge.is_none());
+    deleted_snapshot.release().await?;
+
+    let second_response = app
+        .clone()
+        .oneshot(post_node_req(
+            &cookie,
+            &create("Delete waits", OPERATION_TWO),
+        ))
+        .await?;
+    assert_eq!(second_response.status(), StatusCode::CREATED);
+    let second_body = body::to_bytes(second_response.into_body(), usize::MAX).await?;
+    let second: serde_json::Value = serde_json::from_slice(&second_body)?;
+    let second_node_id = second["id"].as_str().context("second node id")?.to_string();
+    let second_edge = state
+        .edges
+        .read()
+        .await
+        .iter_in_order()
+        .find(|edge| edge.source_id == ACTOR_ID && edge.target_id == second_node_id)
+        .cloned()
+        .context("second origin Faden")?;
+    let second_operation = CreateOperationKey {
+        actor_id: ACTOR_ID.to_string(),
+        operation_id: OPERATION_TWO.to_string(),
+    };
+
+    let publication =
+        lock_node_faden_cache_publication(&pool, &second_node_id, &second_operation, &second_edge)
+            .await
+            .context("lock live publication snapshot")?;
+    assert!(publication.node.is_some());
+    assert!(publication.edge.is_some());
+
+    let delete_pool = pool.clone();
+    let delete_id = second_node_id.clone();
+    let mut delete_task = tokio::spawn(async move {
+        let mut transaction = delete_pool.begin().await?;
+        sqlx::query("SELECT pg_advisory_xact_lock($1::bigint)")
+            .bind(node_mutation_lock_key(&delete_id))
+            .execute(&mut *transaction)
+            .await?;
+        sqlx::query("DELETE FROM domain_nodes WHERE id = $1")
+            .bind(&delete_id)
+            .execute(&mut *transaction)
+            .await?;
+        transaction.commit().await
+    });
+    assert!(
+        tokio::time::timeout(Duration::from_millis(150), &mut delete_task)
+            .await
+            .is_err(),
+        "node deletion must wait while cache publication owns the node lock"
+    );
+    publication.release().await?;
+    tokio::time::timeout(Duration::from_secs(5), delete_task)
+        .await
+        .context("delete completes after publication lock release")?
+        .context("join publication-race delete")??;
+
+    let second_exists: bool =
+        sqlx::query_scalar("SELECT EXISTS (SELECT 1 FROM domain_nodes WHERE id = $1)")
+            .bind(&second_node_id)
+            .fetch_one(&pool)
+            .await?;
+    assert!(!second_exists);
 
     clean_all_nodes(&pool).await;
     Ok(())

--- a/apps/api/tests/db_domain_node_write_path.rs
+++ b/apps/api/tests/db_domain_node_write_path.rs
@@ -1914,9 +1914,9 @@ async fn concurrent_node_creates_preserve_runtime_pool_headroom() -> Result<()> 
     Ok(())
 }
 
-/// K2d. A permanent derived-Faden capacity failure must not leave the newly
-/// created node durable. The create returns an error and compensation removes
-/// both persistence and cache state.
+/// K2d. A permanent derived-Faden capacity failure must roll back the complete
+/// PostgreSQL Webungsaktion: node, trigger-created conversation, domain outbox
+/// records and cache state remain unchanged.
 #[tokio::test]
 #[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
 #[serial]
@@ -1933,12 +1933,17 @@ async fn node_create_rolls_back_when_derived_faden_is_rejected() -> Result<()> {
     .execute(&pool)
     .await?;
     let _edge_limit = EnvVarGuard::set("MAX_EDGES_CACHE", "1");
-
     let tmp = tempfile::tempdir()?;
     let in_dir = tmp.path().join("in");
     std::fs::create_dir_all(&in_dir)?;
     let _env = set_gewebe_in_dir(&in_dir);
     let (app, cookie, state) = postgres_write_app(pool.clone(), ACTOR_ID).await?;
+    let conversations_before: i64 = sqlx::query_scalar("SELECT count(*) FROM domain_conversations")
+        .fetch_one(&pool)
+        .await?;
+    let outbox_before: i64 = sqlx::query_scalar("SELECT count(*) FROM domain_outbox")
+        .fetch_one(&pool)
+        .await?;
 
     let body = serde_json::json!({
         "title": "Rollback Node",
@@ -1959,7 +1964,21 @@ async fn node_create_rolls_back_when_derived_faden_is_rejected() -> Result<()> {
     .await?;
     assert_eq!(
         durable_nodes, 0,
-        "failed Faden projection must compensate node insert"
+        "failed Faden projection must roll back node insert"
+    );
+    let conversations_after: i64 = sqlx::query_scalar("SELECT count(*) FROM domain_conversations")
+        .fetch_one(&pool)
+        .await?;
+    let outbox_after: i64 = sqlx::query_scalar("SELECT count(*) FROM domain_outbox")
+        .fetch_one(&pool)
+        .await?;
+    assert_eq!(
+        conversations_after, conversations_before,
+        "node conversation trigger effects must roll back with the failed Faden"
+    );
+    assert_eq!(
+        outbox_after, outbox_before,
+        "node and conversation outbox effects must roll back with the failed Faden"
     );
     assert!(
         state
@@ -1968,7 +1987,7 @@ async fn node_create_rolls_back_when_derived_faden_is_rejected() -> Result<()> {
             .await
             .iter_in_order()
             .all(|node| node.created_by_account_id.as_deref() != Some(ACTOR_ID)),
-        "compensation must remove the failed node from cache"
+        "failed atomic create must not publish the node to cache"
     );
 
     sqlx::query("DELETE FROM domain_edges WHERE id = 'writepath-edge-capacity-sentinel'")
@@ -2235,9 +2254,10 @@ async fn node_create_replay_locks_existing_node_before_faden_repair() -> Result<
     Ok(())
 }
 
-/// K3. The real HTTP node-create path owns one account-lifecycle lock from
-/// before the node INSERT until its derived Faden is durable. A concurrent exit
-/// therefore cannot enter the historical gap between the two durable writes.
+/// K3. The real PostgreSQL HTTP path keeps node and origin Faden in one
+/// transaction while holding the account-lifecycle lock. A concurrent reader
+/// cannot observe the node before the blocked Faden insert, and guest exit must
+/// wait until the complete transaction commits.
 #[tokio::test]
 #[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
 #[serial]
@@ -2266,8 +2286,8 @@ async fn postgres_node_create_faden_projection_serializes_with_guest_exit() -> R
     guest.role = Role::Gast;
     state.accounts.write().await.insert(guest);
 
-    // Stop only the derived edge INSERT. Node persistence can complete first,
-    // reproducing the exact historical gap between the two durable writes.
+    // Stop the edge INSERT. Because node and Faden now share the same
+    // transaction, the node must remain invisible to every other connection.
     let mut edge_blocker = pool.begin().await.context("begin edge blocker")?;
     sqlx::query("LOCK TABLE domain_edges IN ACCESS EXCLUSIVE MODE")
         .execute(&mut *edge_blocker)
@@ -2279,29 +2299,26 @@ async fn postgres_node_create_faden_projection_serializes_with_guest_exit() -> R
         r#"{"title":"Exit Race Node","kind":"Werkstatt","address":"Race 1","location":{"lat":53.55,"lon":9.99}}"#,
     );
     let create_app = app.clone();
-    let create_task = tokio::spawn(async move { create_app.oneshot(request).await });
-
-    tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            let exists: bool = sqlx::query_scalar(
-                "SELECT EXISTS (SELECT 1 FROM domain_nodes WHERE payload ->> 'created_by_account_id' = $1)",
-            )
-            .bind(ACTOR_ID)
-            .fetch_one(&pool)
+    let mut create_task = tokio::spawn(async move { create_app.oneshot(request).await });
+    assert!(
+        tokio::time::timeout(Duration::from_millis(150), &mut create_task)
             .await
-            .expect("probe created node");
-            if exists {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(20)).await;
-        }
-    })
-    .await
-    .context("node must become durable before Faden blocker is released")?;
+            .is_err(),
+        "node create must wait while the edge table is blocked"
+    );
+    let visible_before_faden: bool = sqlx::query_scalar(
+        "SELECT EXISTS (SELECT 1 FROM domain_nodes WHERE payload ->> 'created_by_account_id' = $1)",
+    )
+    .bind(ACTOR_ID)
+    .fetch_one(&pool)
+    .await?;
+    assert!(
+        !visible_before_faden,
+        "atomic create must not expose the node before its origin Faden"
+    );
 
-    // Prove the lifecycle lock is already held immediately after the node is
-    // durable, before the blocked Faden INSERT can complete. This is the exact
-    // historical gap that previously allowed guest exit to win.
+    // The same transaction already owns the account lifecycle lock, so guest
+    // exit cannot overtake the blocked atomic create.
     let lifecycle_key = account_lifecycle_lock_key(ACTOR_ID);
     tokio::time::timeout(Duration::from_secs(5), async {
         loop {

--- a/apps/api/tests/db_domain_node_write_path.rs
+++ b/apps/api/tests/db_domain_node_write_path.rs
@@ -214,13 +214,34 @@ fn admin_operator(id: &str) -> AccountInternal {
 }
 
 async fn postgres_write_app(pool: PgPool, operator_id: &str) -> Result<(Router, String, ApiState)> {
-    postgres_write_app_with_guest_limit(pool, operator_id, 1_000).await
+    postgres_write_app_with_account_source(
+        pool,
+        operator_id,
+        1_000,
+        DomainAccountWriteSource::Postgres,
+    )
+    .await
 }
 
 async fn postgres_write_app_with_guest_limit(
     pool: PgPool,
     operator_id: &str,
     max_guest_owned_nodes: usize,
+) -> Result<(Router, String, ApiState)> {
+    postgres_write_app_with_account_source(
+        pool,
+        operator_id,
+        max_guest_owned_nodes,
+        DomainAccountWriteSource::Postgres,
+    )
+    .await
+}
+
+async fn postgres_write_app_with_account_source(
+    pool: PgPool,
+    operator_id: &str,
+    max_guest_owned_nodes: usize,
+    domain_account_write_source: DomainAccountWriteSource,
 ) -> Result<(Router, String, ApiState)> {
     let operator = admin_operator(operator_id);
     sqlx::query(
@@ -249,7 +270,7 @@ async fn postgres_write_app_with_guest_limit(
         delegation_expire_days: 28,
         max_guest_owned_nodes,
         domain_read_source: DomainReadSource::Postgres,
-        domain_account_write_source: DomainAccountWriteSource::Postgres,
+        domain_account_write_source,
         domain_node_write_source: DomainNodeWriteSource::Postgres,
         domain_edge_write_source: DomainEdgeWriteSource::Postgres,
         passkey_credential_source: weltgewebe_api::config::PasskeyCredentialSource::InMemory,
@@ -1099,6 +1120,70 @@ async fn postgres_node_create_persists_and_reload_sees_it() -> Result<()> {
     assert_eq!(node.tags, vec!["a".to_string(), "b".to_string()]);
     assert!((node.location.lat - 53.55).abs() < 1e-9);
     assert!((node.location.lon - 9.99).abs() < 1e-9);
+
+    clean_all_nodes(&pool).await;
+    Ok(())
+}
+
+/// I2. A staged migration may keep account writes on JSONL/read-only while
+/// PostgreSQL remains the canonical read source and owns node/edge writes.
+/// Node creation must still commit the node and origin Faden atomically.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL pointing to direct PostgreSQL"]
+#[serial]
+async fn postgres_node_create_allows_jsonl_account_write_source() -> Result<()> {
+    const ACTOR_ID: &str = "10000000-0000-0000-0000-000000000023";
+
+    let pool = connect_pool().await;
+    run_migrations(&pool).await;
+    clean_all_nodes(&pool).await;
+
+    let tmp = tempfile::tempdir()?;
+    let in_dir = tmp.path().join("in");
+    std::fs::create_dir_all(&in_dir)?;
+    let _env = set_gewebe_in_dir(&in_dir);
+
+    let (app, cookie, state) = postgres_write_app_with_account_source(
+        pool.clone(),
+        ACTOR_ID,
+        1_000,
+        DomainAccountWriteSource::Jsonl,
+    )
+    .await?;
+    assert_eq!(
+        state.config.domain_account_write_source,
+        DomainAccountWriteSource::Jsonl
+    );
+
+    let response = app
+        .oneshot(post_node_req(
+            &cookie,
+            r#"{"title":"Staged Migration Node","kind":"Werkstatt","address":"Migrationsweg 1","location":{"lat":53.55,"lon":9.99},"operation_id":"30000000-0000-4000-8000-000000000123"}"#,
+        ))
+        .await?;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let response_body = body::to_bytes(response.into_body(), usize::MAX).await?;
+    let created: serde_json::Value = serde_json::from_slice(&response_body)?;
+    let node_id = created["id"].as_str().context("staged migration node id")?;
+
+    let node_count: i64 = sqlx::query_scalar("SELECT count(*) FROM domain_nodes WHERE id = $1")
+        .bind(node_id)
+        .fetch_one(&pool)
+        .await?;
+    let edge_count: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM domain_edges WHERE source_id = $1 AND target_id = $2 \
+         AND payload ->> 'source_type' = 'account' AND payload ->> 'target_type' = 'node'",
+    )
+    .bind(ACTOR_ID)
+    .bind(node_id)
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(node_count, 1);
+    assert_eq!(edge_count, 1);
+    assert!(
+        !in_dir.join("demo.nodes.jsonl").exists(),
+        "PostgreSQL node writes must not append JSONL in the staged configuration"
+    );
 
     clean_all_nodes(&pool).await;
     Ok(())


### PR DESCRIPTION
<!-- weltgewebe-risk: R3 -->

## Problem

PostgreSQL-Knotenerzeugung schrieb den Knoten und den verpflichtenden Account→Knoten-Herkunftsfaden in getrennten Transaktionen. Scheiterte der Faden, musste eine zweite Kompensation den bereits dauerhaften Knoten entfernen. Ein weiterer Fehler in dieser Kompensation konnte einen verwaisten Knoten hinterlassen.

## Änderung

- schreibt Knoten und Herkunftsfaden in derselben PostgreSQL-Transaktion
- bindet Triggerfolgen wie Knotengespräch und Domain-Outbox an denselben Commit/Rollback
- erhält operation-id-gebundene Replays und repariert historische Teilzustände nur nach Semantikprüfung
- entfernt den nun unerreichbaren Zwei-Verbindungs-/Semaphore-Koordinator
- belässt JSONL beim journalgestützten Kompensations- und Retry-Vertrag
- schließt den Codex-P1 zum Commit→Cache-Fenster: Nach dem Commit wird derselbe Node-Lock wie bei Bearbeiten/Löschen erneut genommen, der kanonische Datenbankzustand gelesen und nur dieser in den Cache veröffentlicht

## Prüfungen

- `cargo fmt --check` — PASS
- `cargo clippy --all-targets -- -D warnings` — PASS
- API-Bibliothek: terminal erfolgreich; 472 Tests im unveränderten Bibliothekskorpus, 1 expliziter Ollama-Livetest ignoriert
- `api_nodes`: 22/22 bestanden
- PostgreSQL `db_domain_node_write_path`: 32/32 bestanden
- PostgreSQL `db_domain_edge_write_path`: 12/12 bestanden
- Fehlerinjektion belegt Rollback von Knoten, Gespräch, Outbox und Cache bei abgelehntem Faden
- Konkurrenztest belegt, dass der Knoten während blockierter Fadenpersistenz für andere Verbindungen unsichtbar bleibt und Gast-Austritt nicht überholt
- neuer Codex-P1-Test belegt beide Cache-Race-Richtungen: vorher abgeschlossenes Löschen wird beim Readback erkannt; späteres Löschen wartet bis zur Cache-Veröffentlichung

## Reviewbefund

Codex meldete auf Head `4c94b38e…` zurecht ein P1-Fenster zwischen Transaktionscommit und Cache-Veröffentlichung. Head `20eb8b8c…` schließt dieses Fenster revisionsgebunden und mit PostgreSQL-Regressionsbeweis.

## Wirkung und Grenzen

Die fachliche Webungsaktion ist im kanonischen PostgreSQL-Pfad atomar. Die Transaktion hält den bereits bestehenden exklusiven Edge-Tabellenlock nun gemeinsam mit dem Node-Insert; dafür entfallen eine zusätzliche Poolverbindung, ein Prozesssemaphore und die fehleranfällige PostgreSQL-Kompensation. Die nachgelagerte Cache-Veröffentlichung wird unter dem kanonischen Node-Lock aus frisch gelesener Datenbankwahrheit erzeugt.

Closes #1470