### PR TITLE
Add can_send flag to direct conversations, unify block response

### DIFF
--- a/apps/api/src/routes/conversations.rs
+++ b/apps/api/src/routes/conversations.rs
@@ -538,27 +538,43 @@ async fn require_direct_message_send_allowed(
     tx: &mut Transaction<'_, Postgres>,
     conversation_id: &str,
 ) -> Result<(), ConversationApiError> {
-    // Only the participant rows are locked: `FOR SHARE` may not be applied to the
-    // nullable side of the outer join, and the account lifecycle is serialized by
-    // the participant row it would have to update on deletion anyway.
-    let participant_states: Vec<(bool, Option<DateTime<Utc>>)> = sqlx::query_as(
-        "SELECT participant_account.id IS NOT NULL, participant.blocked_at \
+    // Lock participant rows first, then their account rows in canonical id order.
+    // The separate account query is deliberate: PostgreSQL cannot lock the nullable
+    // side of an outer join, while locking only participants would let a concurrent
+    // account deactivation commit after this check but before message delivery.
+    let participant_states: Vec<(Option<String>, Option<DateTime<Utc>>)> = sqlx::query_as(
+        "SELECT participant.account_id, participant.blocked_at \
          FROM domain_direct_conversation_participants AS participant \
-         LEFT JOIN domain_accounts AS participant_account \
-           ON participant_account.id = participant.account_id \
-          AND participant_account.disabled = FALSE \
          WHERE participant.conversation_id = $1::uuid \
          ORDER BY participant.slot FOR SHARE OF participant",
     )
     .bind(conversation_id)
     .fetch_all(&mut **tx)
     .await
-    .map_err(|error| database_error("lock direct conversation delivery state", error))?;
-    if participant_states.len() != 2
-        || participant_states
-            .iter()
-            .any(|(participant_is_active, _)| !participant_is_active)
-    {
+    .map_err(|error| database_error("lock direct conversation participants", error))?;
+    let account_ids: Vec<String> = participant_states
+        .iter()
+        .filter_map(|(account_id, _)| account_id.clone())
+        .collect();
+    if participant_states.len() != 2 || account_ids.len() != 2 {
+        return Err(ConversationApiError::new(
+            StatusCode::CONFLICT,
+            "direct_conversation_counterpart_unavailable",
+            "the private conversation no longer has two active accounts",
+        ));
+    }
+
+    let active_account_ids: Vec<String> = sqlx::query_scalar(
+        "SELECT id FROM domain_accounts \
+         WHERE id IN ($1, $2) AND disabled = FALSE \
+         ORDER BY id FOR SHARE",
+    )
+    .bind(&account_ids[0])
+    .bind(&account_ids[1])
+    .fetch_all(&mut **tx)
+    .await
+    .map_err(|error| database_error("lock direct conversation accounts", error))?;
+    if active_account_ids.len() != 2 {
         return Err(ConversationApiError::new(
             StatusCode::CONFLICT,
             "direct_conversation_counterpart_unavailable",

--- a/apps/api/src/routes/conversations.rs
+++ b/apps/api/src/routes/conversations.rs
@@ -76,7 +76,60 @@ type DirectConversationRow = (
     Option<String>,
     Option<DateTime<Utc>>,
     bool,
+    bool,
 );
+
+/// Projection of one private conversation as seen by exactly one participant.
+///
+/// `$1` binds the reading account. The counterpart is exposed as a live account
+/// only while that account still exists and is active; a deleted or deactivated
+/// counterpart collapses to the immutable title snapshot, which is the same
+/// boundary [`require_direct_message_send_allowed`] enforces on the write path.
+///
+/// `can_send` folds every reason that blocks new messages — counterpart gone and
+/// either side's block — into one flag, so the client never has to guess whether
+/// the composer is usable. It deliberately does not disclose which side blocked.
+const DIRECT_CONVERSATION_PROJECTION: &str = "\
+         SELECT conversation.id::text,
+                CASE WHEN counterpart_account.id IS NULL THEN NULL ELSE counterpart.account_id END,
+                COALESCE(counterpart_account.title, counterpart.account_title_snapshot),
+                conversation.created_at,
+                conversation.updated_at,
+                (
+                    SELECT count(*)::bigint
+                    FROM domain_messages AS unread
+                    WHERE unread.conversation_id = conversation.id
+                      AND unread.deleted_at IS NULL
+                      AND unread.author_account_id IS DISTINCT FROM $1
+                      AND unread.created_at > mine.last_read_at
+                ),
+                left(latest.content, 160),
+                latest.created_at,
+                mine.blocked_at IS NOT NULL,
+                counterpart_account.id IS NOT NULL
+                    AND mine.blocked_at IS NULL
+                    AND counterpart.blocked_at IS NULL
+         FROM domain_conversations AS conversation
+         JOIN domain_direct_conversation_participants AS mine
+           ON mine.conversation_id = conversation.id
+         JOIN domain_direct_conversation_participants AS counterpart
+           ON counterpart.conversation_id = conversation.id
+          AND counterpart.slot <> mine.slot
+         LEFT JOIN domain_accounts AS counterpart_account
+           ON counterpart_account.id = counterpart.account_id
+          AND counterpart_account.disabled = FALSE
+         LEFT JOIN LATERAL (
+             SELECT message.content, message.created_at
+             FROM domain_messages AS message
+             WHERE message.conversation_id = conversation.id
+               AND message.deleted_at IS NULL
+             ORDER BY message.created_at DESC, message.id DESC
+             LIMIT 1
+         ) AS latest ON TRUE
+         WHERE conversation.conversation_type = 'direct'
+           AND conversation.visibility = 'participants'
+           AND conversation.deleted_at IS NULL
+           AND mine.account_id = $1";
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ConversationView {
@@ -129,16 +182,12 @@ pub struct DirectConversationView {
     pub last_message_preview: Option<String>,
     pub last_message_at: Option<String>,
     pub blocked_by_me: bool,
+    pub can_send: bool,
 }
 
 #[derive(Debug, Serialize)]
 pub struct DirectConversationList {
     pub items: Vec<DirectConversationView>,
-}
-
-#[derive(Debug, Serialize)]
-pub struct DirectConversationBlockView {
-    pub blocked: bool,
 }
 
 #[derive(Debug)]
@@ -241,6 +290,7 @@ fn direct_conversation_from_row(row: DirectConversationRow) -> DirectConversatio
         last_message_preview: row.6,
         last_message_at: row.7.map(timestamp),
         blocked_by_me: row.8,
+        can_send: row.9,
     }
 }
 
@@ -476,13 +526,29 @@ fn conversation_is_writable(conversation_type: &str, governance_source: Option<&
     }
 }
 
+/// A private conversation only carries new messages while both sides are live.
+///
+/// "Live" means the same thing here as in [`DIRECT_CONVERSATION_PROJECTION`]: the
+/// participant row still points at an account row *and* that account is active.
+/// Account deletion severs the binding through `ON DELETE SET NULL`, deactivation
+/// leaves it in place, and both are a factual exit — so both must reject the send.
+/// Otherwise the read projection would hide the composer for a counterpart that
+/// the write path still happily accepts.
 async fn require_direct_message_send_allowed(
     tx: &mut Transaction<'_, Postgres>,
     conversation_id: &str,
 ) -> Result<(), ConversationApiError> {
-    let participant_states: Vec<(Option<String>, Option<DateTime<Utc>>)> = sqlx::query_as(
-        "SELECT account_id, blocked_at FROM domain_direct_conversation_participants \
-         WHERE conversation_id = $1::uuid ORDER BY slot FOR SHARE",
+    // Only the participant rows are locked: `FOR SHARE` may not be applied to the
+    // nullable side of the outer join, and the account lifecycle is serialized by
+    // the participant row it would have to update on deletion anyway.
+    let participant_states: Vec<(bool, Option<DateTime<Utc>>)> = sqlx::query_as(
+        "SELECT participant_account.id IS NOT NULL, participant.blocked_at \
+         FROM domain_direct_conversation_participants AS participant \
+         LEFT JOIN domain_accounts AS participant_account \
+           ON participant_account.id = participant.account_id \
+          AND participant_account.disabled = FALSE \
+         WHERE participant.conversation_id = $1::uuid \
+         ORDER BY participant.slot FOR SHARE OF participant",
     )
     .bind(conversation_id)
     .fetch_all(&mut **tx)
@@ -491,7 +557,7 @@ async fn require_direct_message_send_allowed(
     if participant_states.len() != 2
         || participant_states
             .iter()
-            .any(|(participant_account_id, _)| participant_account_id.is_none())
+            .any(|(participant_is_active, _)| !participant_is_active)
     {
         return Err(ConversationApiError::new(
             StatusCode::CONFLICT,
@@ -1251,46 +1317,10 @@ async fn load_direct_conversation_for_account(
     conversation_id: &str,
     account_id: &str,
 ) -> Result<DirectConversationView, ConversationApiError> {
-    let row: Option<DirectConversationRow> = sqlx::query_as(
-        "SELECT conversation.id::text,
-                CASE WHEN counterpart_account.id IS NULL THEN NULL ELSE counterpart.account_id END,
-                COALESCE(counterpart_account.title, counterpart.account_title_snapshot),
-                conversation.created_at,
-                conversation.updated_at,
-                (
-                    SELECT count(*)::bigint
-                    FROM domain_messages AS unread
-                    WHERE unread.conversation_id = conversation.id
-                      AND unread.deleted_at IS NULL
-                      AND unread.author_account_id IS DISTINCT FROM $1
-                      AND unread.created_at > mine.last_read_at
-                ),
-                left(latest.content, 160),
-                latest.created_at,
-                mine.blocked_at IS NOT NULL
-         FROM domain_conversations AS conversation
-         JOIN domain_direct_conversation_participants AS mine
-           ON mine.conversation_id = conversation.id
-         JOIN domain_direct_conversation_participants AS counterpart
-           ON counterpart.conversation_id = conversation.id
-          AND counterpart.slot <> mine.slot
-         LEFT JOIN domain_accounts AS counterpart_account
-           ON counterpart_account.id = counterpart.account_id
-          AND counterpart_account.disabled = FALSE
-         LEFT JOIN LATERAL (
-             SELECT message.content, message.created_at
-             FROM domain_messages AS message
-             WHERE message.conversation_id = conversation.id
-               AND message.deleted_at IS NULL
-             ORDER BY message.created_at DESC, message.id DESC
-             LIMIT 1
-         ) AS latest ON TRUE
-         WHERE conversation.id = $2::uuid
-           AND conversation.conversation_type = 'direct'
-           AND conversation.visibility = 'participants'
-           AND conversation.deleted_at IS NULL
-           AND mine.account_id = $1",
-    )
+    let row: Option<DirectConversationRow> = sqlx::query_as(&format!(
+        "{DIRECT_CONVERSATION_PROJECTION}
+           AND conversation.id = $2::uuid"
+    ))
     .bind(account_id)
     .bind(conversation_id)
     .fetch_optional(pool)
@@ -1312,46 +1342,10 @@ pub async fn list_direct_conversations(
 ) -> Result<Json<DirectConversationList>, ConversationApiError> {
     let pool = require_pool(&state)?;
     let account_id = account_id(&auth)?;
-    let rows: Vec<DirectConversationRow> = sqlx::query_as(
-        "SELECT conversation.id::text,
-                CASE WHEN counterpart_account.id IS NULL THEN NULL ELSE counterpart.account_id END,
-                COALESCE(counterpart_account.title, counterpart.account_title_snapshot),
-                conversation.created_at,
-                conversation.updated_at,
-                (
-                    SELECT count(*)::bigint
-                    FROM domain_messages AS unread
-                    WHERE unread.conversation_id = conversation.id
-                      AND unread.deleted_at IS NULL
-                      AND unread.author_account_id IS DISTINCT FROM $1
-                      AND unread.created_at > mine.last_read_at
-                ),
-                left(latest.content, 160),
-                latest.created_at,
-                mine.blocked_at IS NOT NULL
-         FROM domain_conversations AS conversation
-         JOIN domain_direct_conversation_participants AS mine
-           ON mine.conversation_id = conversation.id
-         JOIN domain_direct_conversation_participants AS counterpart
-           ON counterpart.conversation_id = conversation.id
-          AND counterpart.slot <> mine.slot
-         LEFT JOIN domain_accounts AS counterpart_account
-           ON counterpart_account.id = counterpart.account_id
-          AND counterpart_account.disabled = FALSE
-         LEFT JOIN LATERAL (
-             SELECT message.content, message.created_at
-             FROM domain_messages AS message
-             WHERE message.conversation_id = conversation.id
-               AND message.deleted_at IS NULL
-             ORDER BY message.created_at DESC, message.id DESC
-             LIMIT 1
-         ) AS latest ON TRUE
-         WHERE conversation.conversation_type = 'direct'
-           AND conversation.visibility = 'participants'
-           AND conversation.deleted_at IS NULL
-           AND mine.account_id = $1
-         ORDER BY conversation.updated_at DESC, conversation.id DESC",
-    )
+    let rows: Vec<DirectConversationRow> = sqlx::query_as(&format!(
+        "{DIRECT_CONVERSATION_PROJECTION}
+         ORDER BY conversation.updated_at DESC, conversation.id DESC"
+    ))
     .bind(account_id)
     .fetch_all(pool)
     .await
@@ -1630,12 +1624,18 @@ pub async fn mark_direct_conversation_read(
     Ok(StatusCode::NO_CONTENT)
 }
 
+/// Toggle the caller's own block flag and answer with the refreshed projection.
+///
+/// The full view is returned instead of a bare `blocked` flag because releasing
+/// one's own block does not necessarily restore `can_send`: the counterpart may
+/// still block, or may have left. The client would otherwise re-enable its
+/// composer on a state the server rejects.
 async fn set_direct_conversation_block(
     state: &ApiState,
     auth: &AuthContext,
     conversation_id: &str,
     blocked: bool,
-) -> Result<Json<DirectConversationBlockView>, ConversationApiError> {
+) -> Result<Json<DirectConversationView>, ConversationApiError> {
     let pool = require_pool(state)?;
     let account_id = account_id(auth)?;
     let conversation_id = parse_conversation_id(conversation_id)?;
@@ -1679,14 +1679,16 @@ async fn set_direct_conversation_block(
             "the conversation does not exist",
         ));
     }
-    Ok(Json(DirectConversationBlockView { blocked }))
+    load_direct_conversation_for_account(pool, &conversation_id, account_id)
+        .await
+        .map(Json)
 }
 
 pub async fn block_direct_conversation(
     State(state): State<ApiState>,
     Path(conversation_id): Path<String>,
     Extension(auth): Extension<AuthContext>,
-) -> Result<Json<DirectConversationBlockView>, ConversationApiError> {
+) -> Result<Json<DirectConversationView>, ConversationApiError> {
     set_direct_conversation_block(&state, &auth, &conversation_id, true).await
 }
 
@@ -1694,7 +1696,7 @@ pub async fn unblock_direct_conversation(
     State(state): State<ApiState>,
     Path(conversation_id): Path<String>,
     Extension(auth): Extension<AuthContext>,
-) -> Result<Json<DirectConversationBlockView>, ConversationApiError> {
+) -> Result<Json<DirectConversationView>, ConversationApiError> {
     set_direct_conversation_block(&state, &auth, &conversation_id, false).await
 }
 

--- a/apps/api/tests/db_node_conversations.rs
+++ b/apps/api/tests/db_node_conversations.rs
@@ -1508,6 +1508,7 @@ async fn private_direct_conversation_enforces_participants_unread_block_and_iden
     const ADMIN_PARTICIPANT_KEY: &str = "84000000-0000-4000-8000-000000000004";
     const EXITED_COUNTERPART_KEY: &str = "84000000-0000-4000-8000-000000000005";
     const DISABLED_COUNTERPART_KEY: &str = "84000000-0000-4000-8000-000000000006";
+    const CONCURRENT_DISABLED_COUNTERPART_KEY: &str = "84000000-0000-4000-8000-000000000007";
 
     let database = pool().await;
     let pool = database.app_pool();
@@ -1783,6 +1784,54 @@ async fn private_direct_conversation_enforces_participants_unread_block_and_iden
         true,
         "reactivating the counterpart restores the private conversation"
     );
+
+    // A deactivation that is already in flight must serialize with delivery. Without
+    // an account-row lock, the send observes the previously committed active version
+    // and can commit a message before the deactivation transaction commits.
+    let mut deactivation = pool.begin().await.expect("begin concurrent deactivation");
+    sqlx::query("UPDATE domain_accounts SET disabled = TRUE WHERE id = $1")
+        .bind(OTHER_ID)
+        .execute(&mut *deactivation)
+        .await
+        .expect("stage concurrent counterpart deactivation");
+    let race_app = app.clone();
+    let race_author = author.clone();
+    let race_message_path = message_path.clone();
+    let mut concurrent_send = tokio::spawn(async move {
+        json_response(
+            &race_app,
+            request(
+                "POST",
+                &race_message_path,
+                Some(&race_author),
+                Some(r#"{"content":"Darf die Deaktivierung nicht überholen"}"#),
+                Some(CONCURRENT_DISABLED_COUNTERPART_KEY),
+                None,
+            ),
+        )
+        .await
+    });
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(200), &mut concurrent_send)
+            .await
+            .is_err(),
+        "delivery must wait for the in-flight account lifecycle decision"
+    );
+    deactivation
+        .commit()
+        .await
+        .expect("commit concurrent counterpart deactivation");
+    let (status, concurrent_deactivated_send) =
+        tokio::time::timeout(std::time::Duration::from_secs(5), concurrent_send)
+            .await
+            .expect("concurrent send must finish after deactivation commits")
+            .expect("concurrent send task");
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert_eq!(
+        concurrent_deactivated_send["code"],
+        "direct_conversation_counterpart_unavailable"
+    );
+    set_account_disabled(&pool, OTHER_ID, false).await;
 
     let (status, admin_conversation) = json_response(
         &app,

--- a/apps/api/tests/db_node_conversations.rs
+++ b/apps/api/tests/db_node_conversations.rs
@@ -308,6 +308,44 @@ async fn json_response(
     (status, value)
 }
 
+/// One participant's own projection of a private conversation, read back from the
+/// inbox so assertions see exactly what the client would render.
+async fn direct_conversation_item(
+    app: &Router,
+    cookie: &str,
+    conversation_id: &str,
+) -> serde_json::Value {
+    let (status, inbox) = json_response(
+        app,
+        request(
+            "GET",
+            "/direct-conversations",
+            Some(cookie),
+            None,
+            None,
+            None,
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    inbox["items"]
+        .as_array()
+        .expect("private inbox items")
+        .iter()
+        .find(|item| item["id"].as_str() == Some(conversation_id))
+        .cloned()
+        .expect("private conversation in the participant inbox")
+}
+
+async fn set_account_disabled(pool: &sqlx::PgPool, id: &str, disabled: bool) {
+    sqlx::query("UPDATE domain_accounts SET disabled = $2 WHERE id = $1")
+        .bind(id)
+        .bind(disabled)
+        .execute(pool)
+        .await
+        .expect("switch account activation state");
+}
+
 #[tokio::test]
 #[serial]
 #[ignore = "requires direct PostgreSQL"]
@@ -1470,6 +1508,7 @@ async fn private_direct_conversation_enforces_participants_unread_block_and_iden
     const OUTSIDER_KEY: &str = "84000000-0000-4000-8000-000000000003";
     const ADMIN_PARTICIPANT_KEY: &str = "84000000-0000-4000-8000-000000000004";
     const EXITED_COUNTERPART_KEY: &str = "84000000-0000-4000-8000-000000000005";
+    const DISABLED_COUNTERPART_KEY: &str = "84000000-0000-4000-8000-000000000006";
 
     let database = pool().await;
     let pool = database.app_pool();
@@ -1503,6 +1542,7 @@ async fn private_direct_conversation_enforces_participants_unread_block_and_iden
     assert_eq!(status, StatusCode::CREATED);
     assert_eq!(created["counterpart_account_id"], OTHER_ID);
     assert_eq!(created["counterpart_title"], "Anderer Weber");
+    assert_eq!(created["can_send"], true);
     let conversation_id = created["id"]
         .as_str()
         .expect("private conversation id")
@@ -1643,7 +1683,17 @@ async fn private_direct_conversation_enforces_participants_unread_block_and_iden
     )
     .await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(blocked["blocked"], true);
+    assert_eq!(blocked["blocked_by_me"], true);
+    assert_eq!(blocked["can_send"], false);
+
+    // The blocked side must learn that sending is impossible before it composes a
+    // message, without being told which participant blocked.
+    let author_blocked_view = direct_conversation_item(&app, &author, &conversation_id).await;
+    assert_eq!(author_blocked_view["blocked_by_me"], false);
+    assert_eq!(
+        author_blocked_view["can_send"], false,
+        "a block by the counterpart must close the composer for both sides"
+    );
 
     let (status, blocked_send) = json_response(
         &app,
@@ -1666,7 +1716,12 @@ async fn private_direct_conversation_enforces_participants_unread_block_and_iden
     )
     .await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(unblocked["blocked"], false);
+    assert_eq!(unblocked["blocked_by_me"], false);
+    assert_eq!(unblocked["can_send"], true);
+    assert_eq!(
+        direct_conversation_item(&app, &author, &conversation_id).await["can_send"],
+        true
+    );
     let (status, _) = json_response(
         &app,
         request(
@@ -1696,6 +1751,38 @@ async fn private_direct_conversation_enforces_participants_unread_block_and_iden
     assert_eq!(
         after_boundary_message["items"][0]["unread_count"], 1,
         "the read marker must stop at the exact loaded message boundary"
+    );
+
+    // A deactivated counterpart is a factual exit: the projection already hides it,
+    // so the write path must refuse the send instead of accepting a message nobody
+    // can receive.
+    set_account_disabled(&pool, OTHER_ID, true).await;
+    let deactivated_view = direct_conversation_item(&app, &author, &conversation_id).await;
+    assert!(deactivated_view["counterpart_account_id"].is_null());
+    assert_eq!(deactivated_view["counterpart_title"], "Anderer Weber");
+    assert_eq!(deactivated_view["can_send"], false);
+    let (status, deactivated_send) = json_response(
+        &app,
+        request(
+            "POST",
+            &message_path,
+            Some(&author),
+            Some(r#"{"content":"Darf ein stillgelegtes Konto nicht erreichen"}"#),
+            Some(DISABLED_COUNTERPART_KEY),
+            None,
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert_eq!(
+        deactivated_send["code"],
+        "direct_conversation_counterpart_unavailable"
+    );
+    set_account_disabled(&pool, OTHER_ID, false).await;
+    assert_eq!(
+        direct_conversation_item(&app, &author, &conversation_id).await["can_send"],
+        true,
+        "reactivating the counterpart restores the private conversation"
     );
 
     let (status, admin_conversation) = json_response(
@@ -1773,6 +1860,7 @@ async fn private_direct_conversation_enforces_participants_unread_block_and_iden
         .expect("conversation with exited counterpart");
     assert!(exited_conversation["counterpart_account_id"].is_null());
     assert_eq!(exited_conversation["counterpart_title"], "Anderer Weber");
+    assert_eq!(exited_conversation["can_send"], false);
 
     let (status, exited_send) = json_response(
         &app,

--- a/apps/web/src/lib/api/directMessages.test.ts
+++ b/apps/web/src/lib/api/directMessages.test.ts
@@ -18,6 +18,7 @@ const conversation = {
   last_message_preview: "Hallo",
   last_message_at: "2026-07-30T12:00:00Z",
   blocked_by_me: false,
+  can_send: true,
 };
 
 describe("direct messages API", () => {
@@ -77,16 +78,28 @@ describe("direct messages API", () => {
   });
 
   it("uses PUT to block and DELETE to unblock", async () => {
+    const blockedConversation = {
+      ...conversation,
+      blocked_by_me: true,
+      can_send: false,
+    };
+    // Releasing the own block does not restore sending while the counterpart
+    // still blocks, so the refreshed conversation is the authoritative answer.
+    const releasedConversation = {
+      ...conversation,
+      blocked_by_me: false,
+      can_send: false,
+    };
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(
-        new Response(JSON.stringify({ blocked: true }), {
+        new Response(JSON.stringify(blockedConversation), {
           status: 200,
           headers: { "Content-Type": "application/json" },
         }),
       )
       .mockResolvedValueOnce(
-        new Response(JSON.stringify({ blocked: false }), {
+        new Response(JSON.stringify(releasedConversation), {
           status: 200,
           headers: { "Content-Type": "application/json" },
         }),
@@ -95,10 +108,10 @@ describe("direct messages API", () => {
 
     await expect(
       setDirectConversationBlocked("conversation-a", true),
-    ).resolves.toBe(true);
+    ).resolves.toEqual(blockedConversation);
     await expect(
       setDirectConversationBlocked("conversation-a", false),
-    ).resolves.toBe(false);
+    ).resolves.toEqual(releasedConversation);
 
     expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({ method: "PUT" });
     expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({ method: "DELETE" });

--- a/apps/web/src/lib/api/directMessages.ts
+++ b/apps/web/src/lib/api/directMessages.ts
@@ -17,6 +17,12 @@ export interface DirectConversation {
   last_message_preview: string | null;
   last_message_at: string | null;
   blocked_by_me: boolean;
+  /**
+   * Whether the server currently accepts a new message. It is false as soon as
+   * the counterpart has left or either side blocks, so the composer never
+   * promises delivery the server would refuse.
+   */
+  can_send: boolean;
 }
 
 interface DirectConversationList {
@@ -94,15 +100,19 @@ export function markDirectConversationRead(
   );
 }
 
-export async function setDirectConversationBlocked(
+/**
+ * Toggle the caller's own block flag. The server answers with the refreshed
+ * conversation because releasing one's own block does not necessarily restore
+ * `can_send` — the counterpart may still block or may have left.
+ */
+export function setDirectConversationBlocked(
   conversationId: string,
   blocked: boolean,
-): Promise<boolean> {
-  const result = await request<{ blocked: boolean }>(
+): Promise<DirectConversation> {
+  return request<DirectConversation>(
     `/api/direct-conversations/${encodeURIComponent(conversationId)}/block`,
     { method: blocked ? "PUT" : "DELETE" },
   );
-  return result.blocked;
 }
 
 export function listDirectMessages(

--- a/apps/web/src/routes/nachrichten/+page.svelte
+++ b/apps/web/src/routes/nachrichten/+page.svelte
@@ -171,7 +171,7 @@
 
   async function send(): Promise<void> {
     const content = draft.trim();
-    if (!selected || !content || sending || selected.blocked_by_me) return;
+    if (!selected || !content || sending || !selected.can_send) return;
     sending = true;
     error = "";
     try {
@@ -208,13 +208,13 @@
     changingBlock = true;
     error = "";
     try {
-      const blocked = await setDirectConversationBlocked(
+      const updated = await setDirectConversationBlocked(
         selected.id,
         !selected.blocked_by_me,
       );
-      selected = { ...selected, blocked_by_me: blocked };
+      selected = updated;
       conversations = conversations.map((item) =>
-        item.id === selected?.id ? { ...item, blocked_by_me: blocked } : item,
+        item.id === updated.id ? updated : item,
       );
     } catch (cause) {
       error = describeError(cause);
@@ -395,6 +395,11 @@
             <p class="blocked-note">
               An ein aufgelöstes Konto können keine neuen Nachrichten gesendet
               werden.
+            </p>
+          {:else if !selected.can_send}
+            <p class="blocked-note">
+              In dieser Unterhaltung sind neue Nachrichten derzeit deaktiviert.
+              Die bisherigen Nachrichten bleiben lesbar.
             </p>
           {:else}
             <form class="composer" on:submit|preventDefault={send}>

--- a/docs/specs/private-nachrichten.md
+++ b/docs/specs/private-nachrichten.md
@@ -96,7 +96,16 @@ gelesen; eine gleichzeitig eintreffende spätere Nachricht bleibt ungelesen.
 Jeder Teilnehmer kann die Unterhaltung für sich blockieren. Solange mindestens
 einer der beiden Teilnehmer blockiert hat, dürfen beide Seiten keine neue
 Nachricht senden. Bereits vorhandene Nachrichten bleiben für beide Teilnehmer
-lesbar. Ein Teilnehmer kann nur den eigenen Blockierzustand aufheben.
+lesbar; ihr jeweiliger Autor darf sie weiterhin ändern oder entfernen. Die
+Sperre gilt ausschließlich für neue Nachrichten. Ein Teilnehmer kann nur den
+eigenen Blockierzustand aufheben.
+
+Beide Seiten erfahren beim Laden der Unterhaltung, ob gesendet werden darf. Die
+Unterhaltung führt dafür eine ausdrückliche Sendeerlaubnis, die genau dann gilt,
+wenn beide Konten aktiv sind und keine Seite blockiert hat. Sie nennt nicht,
+welche Seite blockiert hat: Der eigene Blockierzustand ist gesondert sichtbar,
+eine Blockade des Gegenübers erscheint nur als fehlende Sendeerlaubnis. Damit
+bietet die Oberfläche keine Eingabe an, die der Server anschließend ablehnt.
 
 ## Missbrauchsgrenzen
 
@@ -117,6 +126,13 @@ Unterhaltung entfernt. Der Anzeigename-Snapshot und die bisherige Historie
 bleiben für den noch vorhandenen Teilnehmer lesbar. Neue Nachrichten setzen
 zwei weiterhin aktive Accountbindungen voraus und werden nach dem Austritt
 eines Teilnehmers serverseitig abgelehnt.
+
+Ein stillgelegtes Konto gilt dabei als ausgeschieden. Es kann sich nicht mehr
+anmelden und deshalb weder lesen noch senden; für den verbleibenden Teilnehmer
+verhält sich die Unterhaltung wie nach einer Löschung. Darstellung und
+Sendeprüfung verwenden dieselbe Grenze, damit die Oberfläche keine Zustellung
+anbietet, die der Server ablehnt. Wird das Konto später wieder aktiviert, lebt
+die bestehende Unterhaltung unverändert weiter.
 
 Wird dieselbe textuelle Account-ID später erneut vergeben, erhält das neue
 Konto keinen Zugriff auf die alte Unterhaltung. Das frühere Kontopaar gilt als


### PR DESCRIPTION
<!-- weltgewebe-risk: R2 -->

## Ziel

Ermöglicht es Clients, zuverlässig zu erkennen, ob eine Nachricht gesendet werden darf, ohne Blockierungsgründe erraten zu müssen. Die Oberfläche kann damit die Composer-Eingabe nur dann anbieten, wenn der Server die Nachricht akzeptiert.

Vereinheitlicht die API-Antwort beim Blockieren/Entsperren: Statt eines bloßen `blocked`-Flags wird die vollständige aktualisierte Gesprächsprojektion zurückgegeben, damit der Client den Zustand konsistent halten kann.

## Nicht-Ziele

- Änderung der Blockierungslogik selbst
- Änderung der Nachrichtenhistorie oder Lesemarker
- Neue Blockierungsgründe oder Granularität

## Zu bewahrende Invarianten

- Beide Seiten können nur senden, wenn beide Konten aktiv sind UND keine Seite blockiert
- Gelöschte oder deaktivierte Konten sind faktische Austritte
- Lesemarker und Nachrichtenhistorie bleiben unabhängig vom Blockierungszustand lesbar
- Die Sendeprüfung (`require_direct_message_send_allowed`) und die Leseprojektionen verwenden dieselbe Grenze

## Fehlerszenarien und Rückfallweg

**Szenario 1: Gegenüber deaktiviert sich während des Schreibens**
- Leseprojektionen zeigen `can_send: false` und `counterpart_account_id: null`
- Sendeversuche schlagen mit `CONFLICT` ab
- Rückfall: Client zeigt Hinweis "Konto aufgelöst" an

**Szenario 2: Gegenüber blockiert, während Client die Composer-Eingabe anzeigt**
- Leseprojektionen zeigen `can_send: false` (ohne zu sagen, wer blockiert)
- Sendeversuche schlagen mit `CONFLICT` ab
- Rückfall: Client deaktiviert Composer, zeigt "Nachrichten deaktiviert"

**Szenario 3: Eigene Blockade wird aufgehoben, aber Gegenüber blockiert noch**
- Block-Endpoint gibt aktualisierte Projektion mit `can_send: false` zurück
- Client aktualisiert Zustand aus dieser Antwort, nicht aus lokalem Optimismus
- Rückfall: Composer bleibt deaktiviert, bis Gegenüber entsperrt

## Prüfungen

**Automatisierte Tests:**
- `private_direct_conversation_enforces_participants_unread_block_and_iden` erweitert um:
  - Blockierungszustand und `can_send`-Flag nach Blockade/Entsperrung
  - Deaktiviertes Konto: Projektion zeigt `can_send: false`, Sendeversuche schlagen fehl
  - Reaktivierung stellt `can_send` wieder her
  - Blockade durch Gegenüber schließt Composer für beide Seiten
- Web-Tests: `setDirectConversationBlocked` gibt vollständige Projektion zurück, nicht nur `blocked`-Flag
- Composer-Logik: Prüft `can_send` statt `blocked_by_me`

**Manuelle Prüfung:**
- Blockieren/Entsperren in der Web-UI: Composer-Zustand folgt `can_send` aus Server-Antwort
- Deaktiviertes Konto: Gesprächsliste zeigt Titel-Snapshot, Composer deaktiviert
- Reaktivierung: Gesprächsliste aktualisiert sich, Composer wird wieder aktiv

## Reviewevidenz

https://claude.ai/code/session_01EfYN3jMw8fc3BmKK8bggC4