### PR TITLE
fix(config): remove inert delegation expiry control

### DIFF
--- a/.github/workflows/policycheck.yml
+++ b/.github/workflows/policycheck.yml
@@ -27,4 +27,5 @@ jobs:
         with:
           python-version-file: '.python-version'
       - run: python -m pip install pyyaml
+      - run: python -m unittest scripts.ci.tests.test_policycheck -v
       - run: python tools/py/policycheck.py

--- a/apps/api/src/auth/passkeys.rs
+++ b/apps/api/src/auth/passkeys.rs
@@ -920,9 +920,7 @@ mod tests {
     #[test]
     #[serial]
     fn build_webauthn_returns_none_when_unconfigured() {
-        let config =
-            AppConfig::load_from_str("anonymize_opt_in: true\ndelegation_expire_days: 28\n")
-                .unwrap();
+        let config = AppConfig::load_from_str("anonymize_opt_in: true\n").unwrap();
         let result = build_webauthn(&config).unwrap();
         assert!(
             result.is_none(),
@@ -935,7 +933,6 @@ mod tests {
     fn build_webauthn_succeeds_with_valid_config() {
         let yaml = "\
 anonymize_opt_in: true\n\
-delegation_expire_days: 28\n\
 webauthn_rp_id: localhost\n\
 webauthn_rp_origin: \"http://localhost:3000\"\n";
         let config = AppConfig::load_from_str(yaml).unwrap();
@@ -948,7 +945,6 @@ webauthn_rp_origin: \"http://localhost:3000\"\n";
     fn build_webauthn_fails_when_only_rp_id_set() {
         let yaml = "\
 anonymize_opt_in: true\n\
-delegation_expire_days: 28\n\
 webauthn_rp_id: example.com\n";
         // Config validation should catch this, but build_webauthn also guards:
         // load_from_str runs validate(), which bails on mismatch.

--- a/apps/api/src/config.rs
+++ b/apps/api/src/config.rs
@@ -294,7 +294,6 @@ impl AutoProvisionRole {
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 pub struct AppConfig {
     pub anonymize_opt_in: bool,
-    pub delegation_expire_days: u32,
 
     /// Maximum number of nodes a guest account may own at once. Loaded once
     /// at startup so request handlers never re-read process environment state.
@@ -391,7 +390,7 @@ impl AppConfig {
     fn parse_yaml(raw: &str) -> Result<Self> {
         let value: serde_yaml::Value =
             serde_yaml::from_str(raw).context("failed to parse YAML configuration")?;
-        for removed_key in ["fade_days", "ron_days"] {
+        for removed_key in ["fade_days", "ron_days", "delegation_expire_days"] {
             let key = serde_yaml::Value::String(removed_key.to_string());
             if value
                 .as_mapping()
@@ -406,6 +405,11 @@ impl AppConfig {
                     "ron_days" => anyhow::bail!(concat!(
                         "ron_days has been removed from runtime configuration; ",
                         "no runtime RON retention consumer exists, so the setting must not be ",
+                        "presented as operator-tunable"
+                    )),
+                    "delegation_expire_days" => anyhow::bail!(concat!(
+                        "delegation_expire_days has been removed from runtime configuration; ",
+                        "no runtime delegation-expiry consumer exists, so the setting must not be ",
                         "presented as operator-tunable"
                     )),
                     _ => unreachable!(),
@@ -464,8 +468,13 @@ impl AppConfig {
                 "no runtime RON retention consumer exists for this setting"
             ));
         }
+        if env::var_os("HA_DELEGATION_EXPIRE_DAYS").is_some() {
+            anyhow::bail!(concat!(
+                "HA_DELEGATION_EXPIRE_DAYS has been removed; ",
+                "no runtime delegation-expiry consumer exists for this setting"
+            ));
+        }
         apply_env_override!(self, anonymize_opt_in, "HA_ANONYMIZE_OPT_IN");
-        apply_env_override!(self, delegation_expire_days, "HA_DELEGATION_EXPIRE_DAYS");
         apply_env_override!(self, max_guest_owned_nodes, "MAX_GUEST_OWNED_NODES");
 
         if let Ok(val) = env::var("WELTGEWEBE_DOMAIN_READ_SOURCE") {
@@ -889,7 +898,6 @@ mod tests {
 
     const YAML: &str = r#"
 anonymize_opt_in: true
-delegation_expire_days: 28
 "#;
 
     #[test]
@@ -921,6 +929,33 @@ delegation_expire_days: 28
 
     #[test]
     #[serial]
+    fn delegation_expire_days_yaml_key_is_rejected_as_removed_setting() {
+        let _delegation = EnvGuard::unset("HA_DELEGATION_EXPIRE_DAYS");
+        let yaml = format!("delegation_expire_days: 28\n{YAML}");
+
+        let error = AppConfig::load_from_str(&yaml)
+            .expect_err("the removed delegation_expire_days YAML key must fail closed");
+        let error = format!("{error:#}");
+
+        assert!(error.contains("delegation_expire_days has been removed"));
+        assert!(error.contains("no runtime delegation-expiry consumer exists"));
+    }
+
+    #[test]
+    #[serial]
+    fn delegation_expire_days_env_override_is_rejected_as_removed_setting() {
+        let _delegation = EnvGuard::set("HA_DELEGATION_EXPIRE_DAYS", "28");
+
+        let error = AppConfig::load_from_str(YAML)
+            .expect_err("the removed HA_DELEGATION_EXPIRE_DAYS override must fail closed");
+        let error = format!("{error:#}");
+
+        assert!(error.contains("HA_DELEGATION_EXPIRE_DAYS has been removed"));
+        assert!(error.contains("no runtime delegation-expiry consumer exists"));
+    }
+
+    #[test]
+    #[serial]
     fn load_from_path_reads_defaults() -> Result<()> {
         let _fade = EnvGuard::unset("HA_FADE_DAYS");
         let file = NamedTempFile::new()?;
@@ -929,13 +964,11 @@ delegation_expire_days: 28
         let _config_path = EnvGuard::unset("APP_CONFIG_PATH");
         let _ron = EnvGuard::unset("HA_RON_DAYS");
         let _anonymize = EnvGuard::unset("HA_ANONYMIZE_OPT_IN");
-        let _delegation = EnvGuard::unset("HA_DELEGATION_EXPIRE_DAYS");
         let _guest_nodes = EnvGuard::unset("MAX_GUEST_OWNED_NODES");
         let _cookie_secure = EnvGuard::unset("AUTH_COOKIE_SECURE");
 
         let cfg = AppConfig::load_from_path(file.path())?;
         assert!(cfg.anonymize_opt_in);
-        assert_eq!(cfg.delegation_expire_days, 28);
         assert_eq!(cfg.max_guest_owned_nodes, 1_000);
         assert!(cfg.auth_cookie_secure);
 
@@ -1023,13 +1056,11 @@ delegation_expire_days: 28
         let _config_path = EnvGuard::unset("APP_CONFIG_PATH");
         let _ron = EnvGuard::unset("HA_RON_DAYS");
         let _anonymize = EnvGuard::set("HA_ANONYMIZE_OPT_IN", "false");
-        let _delegation = EnvGuard::set("HA_DELEGATION_EXPIRE_DAYS", "14");
         let _guest_nodes = EnvGuard::set("MAX_GUEST_OWNED_NODES", "321");
         let _cookie_secure = EnvGuard::set("AUTH_COOKIE_SECURE", "false");
 
         let cfg = AppConfig::load_from_path(file.path())?;
         assert!(!cfg.anonymize_opt_in);
-        assert_eq!(cfg.delegation_expire_days, 14);
         assert_eq!(cfg.max_guest_owned_nodes, 321);
         assert!(!cfg.auth_cookie_secure);
 
@@ -1046,7 +1077,6 @@ delegation_expire_days: 28
         let _config_path = EnvGuard::unset("APP_CONFIG_PATH");
         let _ron = EnvGuard::unset("HA_RON_DAYS");
         let _anonymize = EnvGuard::unset("HA_ANONYMIZE_OPT_IN");
-        let _delegation = EnvGuard::unset("HA_DELEGATION_EXPIRE_DAYS");
         let _read = EnvGuard::unset("WELTGEWEBE_DOMAIN_READ_SOURCE");
         let _account_write = EnvGuard::unset("WELTGEWEBE_DOMAIN_ACCOUNT_WRITE_SOURCE");
         let _node_write = EnvGuard::unset("WELTGEWEBE_DOMAIN_NODE_WRITE_SOURCE");
@@ -1054,7 +1084,6 @@ delegation_expire_days: 28
 
         let cfg = AppConfig::load()?;
         assert!(cfg.anonymize_opt_in);
-        assert_eq!(cfg.delegation_expire_days, 28);
         assert_eq!(cfg.domain_read_source, DomainReadSource::Jsonl);
 
         Ok(())
@@ -1137,7 +1166,6 @@ delegation_expire_days: 28
         let file = NamedTempFile::new()?;
         let invalid_yaml = r#"
 anonymize_opt_in: false
-delegation_expire_days: 365
 domain_read_source: jsonl
 domain_account_write_source: postgres
 "#;
@@ -1168,7 +1196,6 @@ domain_account_write_source: postgres
         let file = NamedTempFile::new()?;
         let valid_yaml = r#"
 anonymize_opt_in: true
-delegation_expire_days: 28
 "#;
         std::fs::write(file.path(), valid_yaml)?;
 
@@ -1178,7 +1205,6 @@ delegation_expire_days: 28
         );
         let _ron = EnvGuard::unset("HA_RON_DAYS");
         let _anonymize = EnvGuard::unset("HA_ANONYMIZE_OPT_IN");
-        let _delegation = EnvGuard::unset("HA_DELEGATION_EXPIRE_DAYS");
         let _read = EnvGuard::unset("WELTGEWEBE_DOMAIN_READ_SOURCE");
         let _account_write = EnvGuard::unset("WELTGEWEBE_DOMAIN_ACCOUNT_WRITE_SOURCE");
         let _node_write = EnvGuard::unset("WELTGEWEBE_DOMAIN_NODE_WRITE_SOURCE");
@@ -1186,7 +1212,6 @@ delegation_expire_days: 28
 
         let cfg = AppConfig::load()?;
         assert!(cfg.anonymize_opt_in);
-        assert_eq!(cfg.delegation_expire_days, 28);
         assert_eq!(cfg.domain_read_source, DomainReadSource::Jsonl);
         assert_eq!(
             cfg.domain_account_write_source,

--- a/apps/api/src/mailer.rs
+++ b/apps/api/src/mailer.rs
@@ -252,7 +252,6 @@ mod tests {
         let _smtp_auth = crate::test_helpers::EnvGuard::set("SMTP_AUTH", "on");
         let config = AppConfig {
             anonymize_opt_in: true,
-            delegation_expire_days: 28,
             max_guest_owned_nodes: 1_000,
             domain_read_source: crate::config::DomainReadSource::Jsonl,
             domain_account_write_source: crate::config::DomainAccountWriteSource::Jsonl,
@@ -295,7 +294,6 @@ mod tests {
     fn mailer_fails_with_invalid_from_address() {
         let config = AppConfig {
             anonymize_opt_in: true,
-            delegation_expire_days: 28,
             max_guest_owned_nodes: 1_000,
             domain_read_source: crate::config::DomainReadSource::Jsonl,
             domain_account_write_source: crate::config::DomainAccountWriteSource::Jsonl,

--- a/apps/api/src/routes/domain_write_guard.rs
+++ b/apps/api/src/routes/domain_write_guard.rs
@@ -204,7 +204,6 @@ mod tests {
 
         let config = AppConfig {
             anonymize_opt_in: true,
-            delegation_expire_days: 28,
             max_guest_owned_nodes: 1_000,
             domain_read_source,
             domain_account_write_source,

--- a/apps/api/src/routes/health.rs
+++ b/apps/api/src/routes/health.rs
@@ -482,7 +482,6 @@ mod tests {
 
         let config = AppConfig {
             anonymize_opt_in: true,
-            delegation_expire_days: 28,
             max_guest_owned_nodes: 1_000,
             domain_read_source: crate::config::DomainReadSource::Jsonl,
             domain_account_write_source: crate::config::DomainAccountWriteSource::Jsonl,

--- a/apps/api/src/search/service.rs
+++ b/apps/api/src/search/service.rs
@@ -413,7 +413,6 @@ mod tests {
 
         let config = AppConfig {
             anonymize_opt_in: true,
-            delegation_expire_days: 28,
             max_guest_owned_nodes: 1_000,
             domain_read_source: DomainReadSource::Jsonl,
             domain_account_write_source: crate::config::DomainAccountWriteSource::Jsonl,

--- a/apps/api/tests/api_accounts.rs
+++ b/apps/api/tests/api_accounts.rs
@@ -43,7 +43,6 @@ async fn test_state() -> Result<ApiState> {
 
     let config = AppConfig {
         anonymize_opt_in: true,
-        delegation_expire_days: 28,
         max_guest_owned_nodes: 1_000,
         domain_read_source: weltgewebe_api::config::DomainReadSource::Jsonl,
         domain_account_write_source: weltgewebe_api::config::DomainAccountWriteSource::Jsonl,

--- a/apps/api/tests/api_accounts_create.rs
+++ b/apps/api/tests/api_accounts_create.rs
@@ -38,7 +38,6 @@ async fn test_state() -> Result<ApiState> {
 
     let config = AppConfig {
         anonymize_opt_in: true,
-        delegation_expire_days: 28,
         max_guest_owned_nodes: 1_000,
         domain_read_source: DomainReadSource::Jsonl,
         domain_account_write_source: DomainAccountWriteSource::Jsonl,

--- a/apps/api/tests/api_auth.rs
+++ b/apps/api/tests/api_auth.rs
@@ -69,7 +69,6 @@ fn test_state() -> Result<ApiState> {
 
     let config = AppConfig {
         anonymize_opt_in: true,
-        delegation_expire_days: 28,
         max_guest_owned_nodes: 1_000,
         domain_read_source: weltgewebe_api::config::DomainReadSource::Jsonl,
         domain_account_write_source: weltgewebe_api::config::DomainAccountWriteSource::Jsonl,

--- a/apps/api/tests/api_collective_mutations.rs
+++ b/apps/api/tests/api_collective_mutations.rs
@@ -39,7 +39,6 @@ async fn state_for_role(role: Role) -> Result<ApiState> {
     })?;
     let config = AppConfig {
         anonymize_opt_in: true,
-        delegation_expire_days: 28,
         max_guest_owned_nodes: 1_000,
         domain_read_source: DomainReadSource::Jsonl,
         domain_account_write_source: DomainAccountWriteSource::Jsonl,

--- a/apps/api/tests/api_edges.rs
+++ b/apps/api/tests/api_edges.rs
@@ -41,7 +41,6 @@ async fn test_state() -> Result<ApiState> {
 
     let config = AppConfig {
         anonymize_opt_in: true,
-        delegation_expire_days: 28,
         max_guest_owned_nodes: 1_000,
         domain_read_source: weltgewebe_api::config::DomainReadSource::Jsonl,
         domain_account_write_source: weltgewebe_api::config::DomainAccountWriteSource::Jsonl,

--- a/apps/api/tests/api_governance_guards.rs
+++ b/apps/api/tests/api_governance_guards.rs
@@ -76,7 +76,6 @@ fn account(id: &str, role: Role) -> AccountInternal {
 fn test_config() -> AppConfig {
     AppConfig {
         anonymize_opt_in: true,
-        delegation_expire_days: 28,
         max_guest_owned_nodes: 1_000,
         domain_read_source: DomainReadSource::Jsonl,
         domain_account_write_source: DomainAccountWriteSource::Jsonl,

--- a/apps/api/tests/api_nodes.rs
+++ b/apps/api/tests/api_nodes.rs
@@ -54,7 +54,6 @@ async fn test_state() -> Result<ApiState> {
 
     let config = AppConfig {
         anonymize_opt_in: true,
-        delegation_expire_days: 28,
         max_guest_owned_nodes: 1_000,
         domain_read_source: DomainReadSource::Jsonl,
         domain_account_write_source: DomainAccountWriteSource::Jsonl,

--- a/apps/api/tests/auth_auto_provision_persistence.rs
+++ b/apps/api/tests/auth_auto_provision_persistence.rs
@@ -55,7 +55,6 @@ fn test_metrics() -> Metrics {
 fn provisioning_state(role: AutoProvisionRole, allow_emails: Vec<String>) -> Result<ApiState> {
     let config = AppConfig {
         anonymize_opt_in: true,
-        delegation_expire_days: 28,
         max_guest_owned_nodes: 1_000,
         domain_read_source: weltgewebe_api::config::DomainReadSource::Jsonl,
         domain_account_write_source: weltgewebe_api::config::DomainAccountWriteSource::Jsonl,

--- a/apps/api/tests/auth_handler_test.rs
+++ b/apps/api/tests/auth_handler_test.rs
@@ -34,7 +34,6 @@ mod tests {
 
         let config = AppConfig {
             anonymize_opt_in: true,
-            delegation_expire_days: 28,
             max_guest_owned_nodes: 1_000,
             domain_read_source: weltgewebe_api::config::DomainReadSource::Jsonl,
             domain_account_write_source: weltgewebe_api::config::DomainAccountWriteSource::Jsonl,

--- a/apps/api/tests/auth_open_registration.rs
+++ b/apps/api/tests/auth_open_registration.rs
@@ -35,7 +35,6 @@ fn test_state_open_reg() -> Result<ApiState> {
     // - Rate Limits: Set (> 0)
     let config = AppConfig {
         anonymize_opt_in: true,
-        delegation_expire_days: 28,
         max_guest_owned_nodes: 1_000,
         domain_read_source: weltgewebe_api::config::DomainReadSource::Jsonl,
         domain_account_write_source: weltgewebe_api::config::DomainAccountWriteSource::Jsonl,

--- a/apps/api/tests/auth_ratelimit.rs
+++ b/apps/api/tests/auth_ratelimit.rs
@@ -68,7 +68,6 @@ fn app(state: ApiState) -> Router {
 fn default_config() -> AppConfig {
     AppConfig {
         anonymize_opt_in: true,
-        delegation_expire_days: 28,
         max_guest_owned_nodes: 1_000,
         domain_read_source: weltgewebe_api::config::DomainReadSource::Jsonl,
         domain_account_write_source: weltgewebe_api::config::DomainAccountWriteSource::Jsonl,

--- a/apps/api/tests/auth_ratelimit_proxy_trusted.rs
+++ b/apps/api/tests/auth_ratelimit_proxy_trusted.rs
@@ -70,7 +70,6 @@ fn app(state: ApiState) -> Router {
 fn default_config() -> AppConfig {
     AppConfig {
         anonymize_opt_in: true,
-        delegation_expire_days: 28,
         max_guest_owned_nodes: 1_000,
         domain_read_source: weltgewebe_api::config::DomainReadSource::Jsonl,
         domain_account_write_source: weltgewebe_api::config::DomainAccountWriteSource::Jsonl,

--- a/apps/api/tests/auth_ratelimit_proxy_untrusted.rs
+++ b/apps/api/tests/auth_ratelimit_proxy_untrusted.rs
@@ -70,7 +70,6 @@ fn app(state: ApiState) -> Router {
 fn default_config() -> AppConfig {
     AppConfig {
         anonymize_opt_in: true,
-        delegation_expire_days: 28,
         max_guest_owned_nodes: 1_000,
         domain_read_source: weltgewebe_api::config::DomainReadSource::Jsonl,
         domain_account_write_source: weltgewebe_api::config::DomainAccountWriteSource::Jsonl,

--- a/apps/api/tests/auth_security_invariants.rs
+++ b/apps/api/tests/auth_security_invariants.rs
@@ -77,7 +77,6 @@ fn build_state() -> Result<ApiState> {
     // stays unknown instead of being auto-provisioned.
     let config = AppConfig {
         anonymize_opt_in: true,
-        delegation_expire_days: 28,
         max_guest_owned_nodes: 1_000,
         domain_read_source: weltgewebe_api::config::DomainReadSource::Jsonl,
         domain_account_write_source: weltgewebe_api::config::DomainAccountWriteSource::Jsonl,

--- a/apps/api/tests/db_auto_provision_write_path.rs
+++ b/apps/api/tests/db_auto_provision_write_path.rs
@@ -85,7 +85,6 @@ fn test_metrics() -> Metrics {
 fn provisioning_state_postgres(pool: PgPool, allow_emails: Vec<String>) -> ApiState {
     let config = AppConfig {
         anonymize_opt_in: true,
-        delegation_expire_days: 28,
         max_guest_owned_nodes: 1_000,
         domain_read_source: DomainReadSource::Postgres,
         domain_account_write_source: DomainAccountWriteSource::Postgres,

--- a/apps/api/tests/db_domain_account_write_path.rs
+++ b/apps/api/tests/db_domain_account_write_path.rs
@@ -159,7 +159,6 @@ async fn postgres_write_app(pool: PgPool, operator_id: &str) -> Result<(Router, 
 
     let config = AppConfig {
         anonymize_opt_in: true,
-        delegation_expire_days: 28,
         max_guest_owned_nodes: 1_000,
         domain_read_source: DomainReadSource::Postgres,
         domain_account_write_source: DomainAccountWriteSource::Postgres,

--- a/apps/api/tests/db_domain_edge_write_path.rs
+++ b/apps/api/tests/db_domain_edge_write_path.rs
@@ -161,7 +161,6 @@ fn write_path_config(
 ) -> AppConfig {
     AppConfig {
         anonymize_opt_in: true,
-        delegation_expire_days: 28,
         max_guest_owned_nodes: 1_000,
         domain_read_source,
         domain_account_write_source: DomainAccountWriteSource::Postgres,

--- a/apps/api/tests/db_domain_node_write_path.rs
+++ b/apps/api/tests/db_domain_node_write_path.rs
@@ -267,7 +267,6 @@ async fn postgres_write_app_with_account_source(
 
     let config = AppConfig {
         anonymize_opt_in: true,
-        delegation_expire_days: 28,
         max_guest_owned_nodes,
         domain_read_source: DomainReadSource::Postgres,
         domain_account_write_source,
@@ -589,7 +588,6 @@ async fn postgres_read_jsonl_node_write_is_blocked() -> Result<()> {
 
     let config = AppConfig {
         anonymize_opt_in: true,
-        delegation_expire_days: 28,
         max_guest_owned_nodes: 1_000,
         domain_read_source: DomainReadSource::Postgres,
         domain_account_write_source: DomainAccountWriteSource::Postgres,
@@ -769,7 +767,6 @@ async fn jsonl_default_node_patch_compiles_and_routes_correctly() -> Result<()> 
 
     let config = AppConfig {
         anonymize_opt_in: true,
-        delegation_expire_days: 28,
         max_guest_owned_nodes: 1_000,
         domain_read_source: DomainReadSource::Jsonl,
         domain_account_write_source: DomainAccountWriteSource::Jsonl,

--- a/apps/api/tests/db_multi_instance_foundation.rs
+++ b/apps/api/tests/db_multi_instance_foundation.rs
@@ -88,7 +88,6 @@ async fn reset(pool: &PgPool) {
 fn config() -> AppConfig {
     AppConfig {
         anonymize_opt_in: true,
-        delegation_expire_days: 28,
         max_guest_owned_nodes: 1_000,
         domain_read_source: DomainReadSource::Postgres,
         domain_account_write_source: DomainAccountWriteSource::Postgres,

--- a/apps/api/tests/db_node_conversations.rs
+++ b/apps/api/tests/db_node_conversations.rs
@@ -116,7 +116,6 @@ async fn pool() -> IsolatedTestDatabase {
 fn config() -> AppConfig {
     AppConfig {
         anonymize_opt_in: true,
-        delegation_expire_days: 28,
         max_guest_owned_nodes: 1_000,
         domain_read_source: DomainReadSource::Postgres,
         domain_account_write_source: DomainAccountWriteSource::Postgres,

--- a/apps/api/tests/db_passkey_store_persistence.rs
+++ b/apps/api/tests/db_passkey_store_persistence.rs
@@ -116,7 +116,6 @@ async fn cleanup_account(pool: &sqlx::PgPool, account_id: &str) {
 fn postgres_passkey_runtime_state(pool: sqlx::PgPool) -> ApiState {
     let config = AppConfig {
         anonymize_opt_in: true,
-        delegation_expire_days: 28,
         max_guest_owned_nodes: 1_000,
         domain_read_source: DomainReadSource::Postgres,
         domain_account_write_source: DomainAccountWriteSource::Jsonl,

--- a/apps/api/tests/db_semantic_search_projection_worker.rs
+++ b/apps/api/tests/db_semantic_search_projection_worker.rs
@@ -1968,7 +1968,6 @@ async fn t006_search_api_against_postgres_projections() {
         nats_configured: false,
         config: AppConfig {
             anonymize_opt_in: true,
-            delegation_expire_days: 28,
             max_guest_owned_nodes: 1000,
             domain_read_source: DomainReadSource::Postgres,
             domain_account_write_source: DomainAccountWriteSource::Postgres,

--- a/configs/README.md
+++ b/configs/README.md
@@ -2,8 +2,8 @@
 
 `configs/app.defaults.yml` liefert die Basiswerte für die API. Zur Laufzeit können
 Deployments eine alternative YAML-Datei via `APP_CONFIG_PATH` angeben oder einzelne
-Felder mit `HA_*`-Variablen überschreiben (`HA_ANONYMIZE_OPT_IN`,
-`HA_DELEGATION_EXPIRE_DAYS`).
+Felder mit dokumentierten Umgebungsvariablen überschreiben, etwa
+`HA_ANONYMIZE_OPT_IN`.
 
 Die Lebensdauer neu abgeleiteter, unverzwirnter Fäden ist verfassungsfest auf
 sieben Tage gebunden und deshalb kein Runtime-Feld. Die entfernten Oberflächen
@@ -13,3 +13,7 @@ Deployment-Konfiguration keine Scheinsteuerbarkeit erzeugt.
 `ron_days` und `HA_RON_DAYS` wurden ebenfalls entfernt und werden fail-closed
 abgewiesen. Für diese Oberfläche existiert kein Runtime-Verbraucher, der eine
 RON-Aufbewahrungswirkung umsetzt; ein ladbarer Wert wäre daher Scheinsteuerbarkeit.
+
+`delegation_expire_days` und `HA_DELEGATION_EXPIRE_DAYS` wurden entfernt und
+werden fail-closed abgewiesen. Es existiert kein Runtime-Verbraucher, der eine
+Delegationsablaufwirkung umsetzt; ein ladbarer Wert wäre daher Scheinsteuerbarkeit.

--- a/configs/app.defaults.yml
+++ b/configs/app.defaults.yml
@@ -1,4 +1,3 @@
 ---
 anonymize_opt_in: true
-delegation_expire_days: 28
 max_guest_owned_nodes: 1000

--- a/docs/policies/orientierung.md
+++ b/docs/policies/orientierung.md
@@ -99,9 +99,10 @@ Es beschreibt:
 - Ortsdaten (`ungenauigkeitsradius_m`)
   - Richtwert: individuell einstellbar.
   - Herkunft: zusammenstellung.md, Abschnitt III.
-- Delegation (`delegation_expire_days`)
+- Delegation
   - Richtwert: 28 Tage (4 Wochen).
-  - Herkunft: § IV Delegation.
+  - Kein Runtime-Schalter: `delegation_expire_days` und `HA_DELEGATION_EXPIRE_DAYS` werden als wirkungslose Scheinsteuerung abgewiesen.
+  - Herkunft: § IV Delegation; eine technische Frist benötigt zuerst einen eindeutigen Runtime-Verbraucher.
 
 > **Hinweis:** Die Fadenfrist von 7 Tagen ist verfassungsfest; das 7+7-Tage-Modell
 > für Anträge ist im kanonischen Governance-Vertrag normativ festgelegt. Die

--- a/policies/retention.yml
+++ b/policies/retention.yml
@@ -1,6 +1,5 @@
 ---
 data_lifecycle:
-  delegation_expire_days: 28
   anonymize_opt_in_default: true
 forget_pipeline:
   - name: primary_accounts

--- a/scripts/ci/tests/test_policycheck.py
+++ b/scripts/ci/tests/test_policycheck.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+POLICYCHECK = REPO_ROOT / "tools" / "py" / "policycheck.py"
+
+
+class PolicycheckTests(unittest.TestCase):
+    def _run(self, *, policy: str, defaults: str) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "policies").mkdir()
+            (root / "configs").mkdir()
+            (root / "policies" / "retention.yml").write_text(policy, encoding="utf-8")
+            (root / "configs" / "app.defaults.yml").write_text(defaults, encoding="utf-8")
+            return subprocess.run(
+                [sys.executable, str(POLICYCHECK)],
+                cwd=root,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+    def test_accepts_current_policy_surface(self) -> None:
+        result = self._run(
+            policy="data_lifecycle:\n  anonymize_opt_in_default: true\n",
+            defaults="anonymize_opt_in: true\n",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("policy ok", result.stdout)
+
+    def test_rejects_delegation_expire_days_in_retention_policy(self) -> None:
+        result = self._run(
+            policy=(
+                "data_lifecycle:\n"
+                "  delegation_expire_days: 28\n"
+                "  anonymize_opt_in_default: true\n"
+            ),
+            defaults="anonymize_opt_in: true\n",
+        )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("must not publish delegation_expire_days", result.stdout)
+
+    def test_rejects_delegation_expire_days_in_app_defaults(self) -> None:
+        result = self._run(
+            policy="data_lifecycle:\n  anonymize_opt_in_default: true\n",
+            defaults="anonymize_opt_in: true\ndelegation_expire_days: 28\n",
+        )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("must not publish delegation_expire_days", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/py/policycheck.py
+++ b/tools/py/policycheck.py
@@ -45,6 +45,12 @@ def main() -> int:
                 "no runtime RON retention consumer exists"
             )
             return 1
+        if "delegation_expire_days" in mapping:
+            print(
+                f"::error::{source} must not publish delegation_expire_days; "
+                "no runtime delegation-expiry consumer exists"
+            )
+            return 1
 
     print("policy ok")
     return 0


### PR DESCRIPTION
<!-- weltgewebe-risk: R3 -->

## Befund

`delegation_expire_days` und `HA_DELEGATION_EXPIRE_DAYS` wurden geladen und in der Betreiberoberfläche veröffentlicht, hatten aber keinen Runtime-Verbraucher. Änderungen des Werts konnten daher keine Delegationsablaufwirkung erzeugen.

## Änderung

- entfernt das wirkungslose Feld aus `AppConfig`, den Defaults und der Retention-Oberfläche
- weist alte YAML-Schlüssel und den alten Env-Override beim Start fail-closed ab
- ergänzt Contract-Tests für beide entfernten Konfigurationsoberflächen
- sperrt den entfernten Schlüssel zusätzlich im eigenständigen Policy-Guard für Retention und Defaults
- führt drei Policy-Regressionstests verpflichtend im `policycheck`-Workflow aus
- bereinigt alle AppConfig-Fixtures und dokumentiert den bewusst entfernten Schalter

## Prüfung

- `cargo fmt --all --check`
- `cargo test -p weltgewebe-api config::tests` — 81 bestanden
- `cargo test -p weltgewebe-api --lib` — 476 bestanden, 1 explizit ignorierter Live-Ollama-Test
- `python3 -m unittest scripts.ci.tests.test_policycheck -v` — 3 bestanden
- `python3 tools/py/policycheck.py` — `policy ok`
- Workflow-YAML strukturell geladen und neuer Testschritt verifiziert
- `git diff --check 0a6c60f...HEAD`

## Self-Review

PASS nach Einarbeitung des Codex-Befunds.

- Base: `0a6c60fd0d594533d9d3ef1479fadb56dcad4925`
- Head: `2225651ec9d66080a8aaddca1919f6fd03d24d7b`
- GitHub-Diff SHA-256: `b3e949207b3149210f89de4c7f166748885752cb7d3da3ed2bb770dbe9da41da`
- geprüft: kein Fachverbraucher entfernt; nur wirkungslose Konfigurationsannahme und Test-Fixture-Feld beseitigt
- Review-Fund geschlossen: `delegation_expire_days` kann weder über App-Konfiguration noch über die separate Policy-Oberfläche still zurückkehren
- bewusste Folge: bestehende Deployments mit dem alten Schlüssel brechen beim Start klar ab, statt weiter Scheinsteuerbarkeit zu akzeptieren

Refs #1468